### PR TITLE
Add native return types in tests/

### DIFF
--- a/tests/Fixture/AssertIntegrationTestCase.php
+++ b/tests/Fixture/AssertIntegrationTestCase.php
@@ -27,10 +27,8 @@ class AssertIntegrationTestCase extends TestCase
 
     /**
      * testBadAssertNoRedirect
-     *
-     * @return void
      */
-    public function testBadAssertNoRedirect()
+    public function testBadAssertNoRedirect(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withLocation('http://localhost/tasks/index');

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -32,30 +32,24 @@ class FixturizedTestCase extends TestCase
 
     /**
      * test that the shared fixture is correctly set
-     *
-     * @return void
      */
-    public function testFixturePresent()
+    public function testFixturePresent(): void
     {
         $this->assertInstanceOf(FixtureManager::class, $this->fixtureManager);
     }
 
     /**
      * test that it is possible to load fixtures on demand
-     *
-     * @return void
      */
-    public function testFixtureLoadOnDemand()
+    public function testFixtureLoadOnDemand(): void
     {
         $this->loadFixtures('Categories');
     }
 
     /**
      * test that calling loadFixtures without args loads all fixtures
-     *
-     * @return void
      */
-    public function testLoadAllFixtures()
+    public function testLoadAllFixtures(): void
     {
         $this->loadFixtures();
         $article = $this->getTableLocator()->get('Articles')->get(1);
@@ -66,20 +60,16 @@ class FixturizedTestCase extends TestCase
 
     /**
      * test that a test is marked as skipped using skipIf and its first parameter evaluates to true
-     *
-     * @return void
      */
-    public function testSkipIfTrue()
+    public function testSkipIfTrue(): void
     {
         $this->skipIf(true);
     }
 
     /**
      * test that a test is not marked as skipped using skipIf and its first parameter evaluates to false
-     *
-     * @return void
      */
-    public function testSkipIfFalse()
+    public function testSkipIfFalse(): void
     {
         $this->skipIf(false);
     }
@@ -87,10 +77,9 @@ class FixturizedTestCase extends TestCase
     /**
      * test that a fixtures are unloaded even if the test throws exceptions
      *
-     * @return void
      * @throws \Exception
      */
-    public function testThrowException()
+    public function testThrowException(): void
     {
         throw new Exception();
     }

--- a/tests/Fixture/OtherArticlesFixture.php
+++ b/tests/Fixture/OtherArticlesFixture.php
@@ -36,7 +36,7 @@ class OtherArticlesFixture implements FixtureInterface
         return true;
     }
 
-    public function insert(ConnectionInterface $connection)
+    public function insert(ConnectionInterface $connection): void
     {
     }
 

--- a/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
+++ b/tests/PHPStan/AssociationTableMixinClassReflectionExtension.php
@@ -22,16 +22,12 @@ class AssociationTableMixinClassReflectionExtension implements PropertiesClassRe
 
     /**
      * @param Broker $broker Class reflection broker
-     * @return void
      */
     public function setBroker(Broker $broker): void
     {
         $this->broker = $broker;
     }
 
-    /**
-     * @return ClassReflection
-     */
     protected function getTableReflection(): ClassReflection
     {
         return $this->broker->getClass(Table::class);
@@ -40,7 +36,6 @@ class AssociationTableMixinClassReflectionExtension implements PropertiesClassRe
     /**
      * @param ClassReflection $classReflection Class reflection
      * @param string $methodName Method name
-     * @return bool
      */
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
@@ -59,7 +54,6 @@ class AssociationTableMixinClassReflectionExtension implements PropertiesClassRe
     /**
      * @param ClassReflection $classReflection Class reflection
      * @param string $methodName Method name
-     * @return MethodReflection
      */
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
@@ -74,7 +68,6 @@ class AssociationTableMixinClassReflectionExtension implements PropertiesClassRe
     /**
      * @param ClassReflection $classReflection Class reflection
      * @param string $propertyName Method name
-     * @return bool
      */
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
@@ -88,7 +81,6 @@ class AssociationTableMixinClassReflectionExtension implements PropertiesClassRe
     /**
      * @param ClassReflection $classReflection Class reflection
      * @param string $propertyName Method name
-     * @return PropertyReflection
      */
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -48,8 +48,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -68,8 +66,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test applying settings in the constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -83,8 +79,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateNoData(): void
     {
@@ -95,8 +89,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateNoUsername(): void
     {
@@ -110,8 +102,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateNoPassword(): void
     {
@@ -125,8 +115,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateInjection(): void
     {
@@ -144,8 +132,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * Test that username of 0 works.
-     *
-     * @return void
      */
     public function testAuthenticateUsernameZero(): void
     {
@@ -175,8 +161,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test that challenge headers are sent when no credentials are found.
-     *
-     * @return void
      */
     public function testAuthenticateChallenge(): void
     {
@@ -196,8 +180,6 @@ class BasicAuthenticateTest extends TestCase
 
     /**
      * test authenticate success
-     *
-     * @return void
      */
     public function testAuthenticateSuccess(): void
     {

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -36,8 +36,6 @@ class ControllerAuthorizeTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,9 +49,6 @@ class ControllerAuthorizeTest extends TestCase
         $this->auth = new ControllerAuthorize($this->components);
     }
 
-    /**
-     * @return void
-     */
     public function testControllerErrorOnMissingMethod(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
@@ -63,8 +58,6 @@ class ControllerAuthorizeTest extends TestCase
 
     /**
      * test failure
-     *
-     * @return void
      */
     public function testAuthorizeFailure(): void
     {
@@ -75,8 +68,6 @@ class ControllerAuthorizeTest extends TestCase
 
     /**
      * test isAuthorized working.
-     *
-     * @return void
      */
     public function testAuthorizeSuccess(): void
     {

--- a/tests/TestCase/Auth/DefaultPasswordHasherTest.php
+++ b/tests/TestCase/Auth/DefaultPasswordHasherTest.php
@@ -27,8 +27,6 @@ class DefaultPasswordHasherTest extends TestCase
     /**
      * Tests that a password not produced by DefaultPasswordHasher needs
      * to be rehashed
-     *
-     * @return void
      */
     public function testNeedsRehash(): void
     {
@@ -41,8 +39,6 @@ class DefaultPasswordHasherTest extends TestCase
     /**
      * Tests that when the hash options change, the password needs
      * to be rehashed
-     *
-     * @return void
      */
     public function testNeedsRehashWithDifferentOptions(): void
     {

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -52,8 +52,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -75,8 +73,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test applying settings in the constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -93,8 +89,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateNoData(): void
     {
@@ -105,8 +99,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateWrongUsername(): void
     {
@@ -133,8 +125,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test that challenge headers are sent when no credentials are found.
-     *
-     * @return void
      */
     public function testAuthenticateChallenge(): void
     {
@@ -159,8 +149,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test that challenge headers include stale when the nonce is stale
-     *
-     * @return void
      */
     public function testAuthenticateChallengeIncludesStaleAttributeOnStaleNonce(): void
     {
@@ -190,8 +178,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * Test that authentication fails when a nonce is stale
-     *
-     * @return void
      */
     public function testAuthenticateFailsOnStaleNonce(): void
     {
@@ -215,8 +201,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * Test that nonces are required.
-     *
-     * @return void
      */
     public function testAuthenticateValidUsernamePasswordNoNonce(): void
     {
@@ -242,8 +226,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test authenticate success
-     *
-     * @return void
      */
     public function testAuthenticateSuccess(): void
     {
@@ -274,8 +256,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test authenticate success even when digest 'password' is a hidden field.
-     *
-     * @return void
      */
     public function testAuthenticateSuccessHiddenPasswordField(): void
     {
@@ -309,8 +289,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * test authenticate success
-     *
-     * @return void
      */
     public function testAuthenticateSuccessSimulatedRequestMethod(): void
     {
@@ -343,8 +321,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * testLoginHeaders method
-     *
-     * @return void
      */
     public function testLoginHeaders(): void
     {
@@ -364,8 +340,6 @@ class DigestAuthenticateTest extends TestCase
 
     /**
      * testParseDigestAuthData method
-     *
-     * @return void
      */
     public function testParseAuthData(): void
     {
@@ -400,8 +374,6 @@ DIGEST;
 
     /**
      * Test parsing a full URI. While not part of the spec some mobile clients will do it wrong.
-     *
-     * @return void
      */
     public function testParseAuthDataFullUri(): void
     {
@@ -424,8 +396,6 @@ DIGEST;
 
     /**
      * test parsing digest information with email addresses
-     *
-     * @return void
      */
     public function testParseAuthEmailAddress(): void
     {
@@ -457,8 +427,6 @@ DIGEST;
 
     /**
      * test password hashing
-     *
-     * @return void
      */
     public function testPassword(): void
     {
@@ -473,7 +441,6 @@ DIGEST;
      * @param string $secret The secret to use.
      * @param int $expires Time to live
      * @param int $time Current time in microseconds
-     * @return string
      */
     protected function generateNonce(?string $secret = null, ?int $expires = 300, ?int $time = null): string
     {
@@ -490,7 +457,6 @@ DIGEST;
      * Create a digest header string from an array of data.
      *
      * @param array $data the data to convert into a header.
-     * @return string
      */
     protected function digestHeader(array $data): string
     {

--- a/tests/TestCase/Auth/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/Auth/FallbackPasswordHasherTest.php
@@ -35,8 +35,6 @@ class FallbackPasswordHasherTest extends TestCase
 
     /**
      * Tests that only the first hasher is user for hashing a password
-     *
-     * @return void
      */
     public function testHash(): void
     {
@@ -52,8 +50,6 @@ class FallbackPasswordHasherTest extends TestCase
     /**
      * Tests that the check method will check with configured hashers until a match
      * is found
-     *
-     * @return void
      */
     public function testCheck(): void
     {
@@ -70,8 +66,6 @@ class FallbackPasswordHasherTest extends TestCase
     /**
      * Tests that the check method will work with configured hashers including different
      * configs per hasher.
-     *
-     * @return void
      */
     public function testCheckWithConfigs(): void
     {
@@ -88,8 +82,6 @@ class FallbackPasswordHasherTest extends TestCase
 
     /**
      * Tests that the password only needs to be re-built according to the first hasher
-     *
-     * @return void
      */
     public function testNeedsRehash(): void
     {

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -49,8 +49,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -73,8 +71,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test applying settings in the constructor
-     *
-     * @return void
      */
     public function testConstructor(): void
     {
@@ -88,10 +84,8 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
-    public function testAuthenticateNoData()
+    public function testAuthenticateNoData(): void
     {
         $request = new ServerRequest([
             'url' => 'posts/index',
@@ -102,8 +96,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateNoUsername(): void
     {
@@ -116,8 +108,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateNoPassword(): void
     {
@@ -130,8 +120,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test authenticate password is false method
-     *
-     * @return void
      */
     public function testAuthenticatePasswordIsFalse(): void
     {
@@ -148,8 +136,6 @@ class FormAuthenticateTest extends TestCase
     /**
      * Test for password as empty string with _checkFields() call skipped
      * Refs https://github.com/cakephp/cakephp/pull/2441
-     *
-     * @return void
      */
     public function testAuthenticatePasswordIsEmptyString(): void
     {
@@ -179,8 +165,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test authenticate field is not string
-     *
-     * @return void
      */
     public function testAuthenticateFieldsAreNotString(): void
     {
@@ -205,8 +189,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test the authenticate method
-     *
-     * @return void
      */
     public function testAuthenticateInjection(): void
     {
@@ -222,8 +204,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test authenticate success
-     *
-     * @return void
      */
     public function testAuthenticateSuccess(): void
     {
@@ -246,8 +226,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * Test that authenticate() includes virtual fields.
-     *
-     * @return void
      */
     public function testAuthenticateIncludesVirtualFields(): void
     {
@@ -274,8 +252,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test a model in a plugin.
-     *
-     * @return void
      */
     public function testPluginModel(): void
     {
@@ -310,8 +286,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * Test using custom finder
-     *
-     * @return void
      */
     public function testFinder(): void
     {
@@ -350,8 +324,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * Test using custom finder
-     *
-     * @return void
      */
     public function testFinderOptions(): void
     {
@@ -389,8 +361,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * test password hasher settings
-     *
-     * @return void
      */
     public function testPasswordHasherSettings(): void
     {
@@ -445,8 +415,6 @@ class FormAuthenticateTest extends TestCase
 
     /**
      * Tests that using default means password don't need to be rehashed
-     *
-     * @return void
      */
     public function testAuthenticateNoRehash(): void
     {
@@ -465,8 +433,6 @@ class FormAuthenticateTest extends TestCase
     /**
      * Tests that not using the Default password hasher means that the password
      * needs to be rehashed
-     *
-     * @return void
      */
     public function testAuthenticateRehash(): void
     {
@@ -492,7 +458,6 @@ class FormAuthenticateTest extends TestCase
     /**
      * Tests that password hasher function is called exactly once in all cases.
      *
-     * @return void
      * @dataProvider userList
      */
     public function testAuthenticateSingleHash(string $username, ?string $password): void

--- a/tests/TestCase/Auth/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/Auth/PasswordHasherFactoryTest.php
@@ -26,8 +26,6 @@ class PasswordHasherFactoryTest extends TestCase
 {
     /**
      * test passwordhasher instance building
-     *
-     * @return void
      */
     public function testBuild(): void
     {
@@ -49,8 +47,6 @@ class PasswordHasherFactoryTest extends TestCase
 
     /**
      * test build() throws exception for nonexistent hasher
-     *
-     * @return void
      */
     public function testBuildException(): void
     {

--- a/tests/TestCase/Auth/Storage/MemoryStorageTest.php
+++ b/tests/TestCase/Auth/Storage/MemoryStorageTest.php
@@ -36,8 +36,6 @@ class MemoryStorageTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class MemoryStorageTest extends TestCase
 
     /**
      * Test write.
-     *
-     * @return void
      */
     public function testWrite(): void
     {
@@ -60,8 +56,6 @@ class MemoryStorageTest extends TestCase
 
     /**
      * Test read.
-     *
-     * @return void
      */
     public function testRead(): void
     {
@@ -70,8 +64,6 @@ class MemoryStorageTest extends TestCase
 
     /**
      * Test delete.
-     *
-     * @return void
      */
     public function testDelete(): void
     {
@@ -83,8 +75,6 @@ class MemoryStorageTest extends TestCase
 
     /**
      * Test redirectUrl.
-     *
-     * @return void
      */
     public function testRedirectUrl(): void
     {

--- a/tests/TestCase/Auth/Storage/SessionStorageTest.php
+++ b/tests/TestCase/Auth/Storage/SessionStorageTest.php
@@ -34,8 +34,6 @@ class SessionStorageTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -50,8 +48,6 @@ class SessionStorageTest extends TestCase
 
     /**
      * Test write
-     *
-     * @return void
      */
     public function testWrite(): void
     {
@@ -65,8 +61,6 @@ class SessionStorageTest extends TestCase
 
     /**
      * Test read
-     *
-     * @return void
      */
     public function testRead(): void
     {
@@ -81,8 +75,6 @@ class SessionStorageTest extends TestCase
 
     /**
      * Test read from local var
-     *
-     * @return void
      */
     public function testGetFromLocalVar(): void
     {
@@ -97,8 +89,6 @@ class SessionStorageTest extends TestCase
 
     /**
      * Test delete
-     *
-     * @return void
      */
     public function testDelete(): void
     {
@@ -111,8 +101,6 @@ class SessionStorageTest extends TestCase
 
     /**
      * Test redirectUrl()
-     *
-     * @return void
      */
     public function redirectUrl(): void
     {

--- a/tests/TestCase/Auth/WeakPasswordHasherTest.php
+++ b/tests/TestCase/Auth/WeakPasswordHasherTest.php
@@ -27,8 +27,6 @@ class WeakPasswordHasherTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -40,8 +38,6 @@ class WeakPasswordHasherTest extends TestCase
     /**
      * Tests that any password not produced by WeakPasswordHasher needs
      * to be rehashed
-     *
-     * @return void
      */
     public function testNeedsRehash(): void
     {
@@ -53,8 +49,6 @@ class WeakPasswordHasherTest extends TestCase
 
     /**
      * Tests hash() and check()
-     *
-     * @return void
      */
     public function testHashAndCheck(): void
     {

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -33,10 +33,8 @@ class BasicsTest extends TestCase
 {
     /**
      * test the array_diff_key compatibility function.
-     *
-     * @return void
      */
-    public function testArrayDiffKey()
+    public function testArrayDiffKey(): void
     {
         $one = ['one' => 1, 'two' => 2, 'three' => 3];
         $two = ['one' => 'one', 'two' => 'two'];
@@ -69,10 +67,8 @@ class BasicsTest extends TestCase
 
     /**
      * testHttpBase method
-     *
-     * @return void
      */
-    public function testEnv()
+    public function testEnv(): void
     {
         $this->skipIf(!function_exists('ini_get') || ini_get('safe_mode') === '1', 'Safe mode is on.');
 
@@ -141,10 +137,8 @@ class BasicsTest extends TestCase
 
     /**
      * Test h()
-     *
-     * @return void
      */
-    public function testH()
+    public function testH(): void
     {
         $string = '<foo>';
         $result = h($string);
@@ -216,10 +210,8 @@ class BasicsTest extends TestCase
 
     /**
      * test debug()
-     *
-     * @return void
      */
-    public function testDebug()
+    public function testDebug(): void
     {
         ob_start();
         $this->assertSame('this-is-a-test', debug('this-is-a-test', false));
@@ -260,10 +252,8 @@ EXPECTED;
 
     /**
      * test pr()
-     *
-     * @return void
      */
-    public function testPr()
+    public function testPr(): void
     {
         ob_start();
         $this->assertTrue(pr(true));
@@ -310,10 +300,8 @@ EXPECTED;
 
     /**
      * test pj()
-     *
-     * @return void
      */
-    public function testPj()
+    public function testPj(): void
     {
         ob_start();
         $this->assertTrue(pj(true));
@@ -361,10 +349,8 @@ EXPECTED;
 
     /**
      * Test splitting plugin names.
-     *
-     * @return void
      */
-    public function testPluginSplit()
+    public function testPluginSplit(): void
     {
         $result = pluginSplit('Something.else');
         $this->assertSame(['Something', 'else'], $result);
@@ -390,10 +376,8 @@ EXPECTED;
 
     /**
      * test namespaceSplit
-     *
-     * @return void
      */
-    public function testNamespaceSplit()
+    public function testNamespaceSplit(): void
     {
         $result = namespaceSplit('Something');
         $this->assertSame(['', 'Something'], $result);
@@ -410,10 +394,8 @@ EXPECTED;
 
     /**
      * Tests that the stackTrace() method is a shortcut for Debugger::trace()
-     *
-     * @return void
      */
-    public function testStackTrace()
+    public function testStackTrace(): void
     {
         ob_start();
         // phpcs:ignore
@@ -431,10 +413,8 @@ EXPECTED;
 
     /**
      * Tests that the collection() method is a shortcut for new Collection
-     *
-     * @return void
      */
-    public function testCollection()
+    public function testCollection(): void
     {
         $items = [1, 2, 3];
         $collection = collection($items);
@@ -448,10 +428,8 @@ EXPECTED;
      *
      * The return value is passed to testEventManagerReset2 as
      * an arguments.
-     *
-     * @return \Cake\Event\EventManager
      */
-    public function testEventManagerReset1()
+    public function testEventManagerReset1(): EventManager
     {
         $eventManager = EventManager::instance();
         $this->assertInstanceOf(EventManager::class, $eventManager);
@@ -463,9 +441,8 @@ EXPECTED;
      * Test if the EventManager is reset between tests.
      *
      * @depends testEventManagerReset1
-     * @return void
      */
-    public function testEventManagerReset2(EventManager $prevEventManager)
+    public function testEventManagerReset2(EventManager $prevEventManager): void
     {
         $this->assertInstanceOf(EventManager::class, $prevEventManager);
         $this->assertNotSame($prevEventManager, EventManager::instance());

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -31,8 +31,6 @@ class CacheTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,8 +40,6 @@ class CacheTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,10 +50,8 @@ class CacheTest extends TestCase
 
     /**
      * Configure cache settings for test
-     *
-     * @return void
      */
-    protected function _configCache()
+    protected function _configCache(): void
     {
         Cache::setConfig('tests', [
             'engine' => 'File',
@@ -68,10 +62,8 @@ class CacheTest extends TestCase
 
     /**
      * tests Cache::pool() fallback
-     *
-     * @return void
      */
-    public function testCachePoolFallback()
+    public function testCachePoolFallback(): void
     {
         $filename = tempnam(CACHE, 'tmp_');
 
@@ -98,10 +90,8 @@ class CacheTest extends TestCase
 
     /**
      * tests you can disable Cache::pool() fallback
-     *
-     * @return void
      */
-    public function testCachePoolFallbackDisabled()
+    public function testCachePoolFallbackDisabled(): void
     {
         $filename = tempnam(CACHE, 'tmp_');
 
@@ -119,10 +109,8 @@ class CacheTest extends TestCase
 
     /**
      * tests handling misconfiguration of fallback
-     *
-     * @return void
      */
-    public function testCacheEngineFallbackToSelf()
+    public function testCacheEngineFallbackToSelf(): void
     {
         $filename = tempnam(CACHE, 'tmp_');
 
@@ -149,10 +137,8 @@ class CacheTest extends TestCase
 
     /**
      * tests Cache::pool() fallback when using groups
-     *
-     * @return void
      */
-    public function testCacheFallbackWithGroups()
+    public function testCacheFallbackWithGroups(): void
     {
         $filename = tempnam(CACHE, 'tmp_');
 
@@ -183,10 +169,8 @@ class CacheTest extends TestCase
 
     /**
      * tests cache fallback
-     *
-     * @return void
      */
-    public function testCacheFallbackIntegration()
+    public function testCacheFallbackIntegration(): void
     {
         $filename = tempnam(CACHE, 'tmp_');
 
@@ -227,10 +211,8 @@ class CacheTest extends TestCase
 
     /**
      * Check that no fatal errors are issued doing normal things when Cache.disable is true.
-     *
-     * @return void
      */
-    public function testNonFatalErrorsWithCacheDisable()
+    public function testNonFatalErrorsWithCacheDisable(): void
     {
         Cache::disable();
         $this->_configCache();
@@ -242,10 +224,8 @@ class CacheTest extends TestCase
 
     /**
      * Check that a null instance is returned from engine() when caching is disabled.
-     *
-     * @return void
      */
-    public function testNullEngineWhenCacheDisable()
+    public function testNullEngineWhenCacheDisable(): void
     {
         $this->_configCache();
         Cache::disable();
@@ -256,10 +236,8 @@ class CacheTest extends TestCase
 
     /**
      * Test configuring an invalid class fails
-     *
-     * @return void
      */
-    public function testConfigInvalidClassType()
+    public function testConfigInvalidClassType(): void
     {
         Cache::setConfig('tests', [
             'className' => '\stdClass',
@@ -273,10 +251,8 @@ class CacheTest extends TestCase
 
     /**
      * Test engine init failing triggers an error but falls back to NullEngine
-     *
-     * @return void
      */
-    public function testConfigFailedInit()
+    public function testConfigFailedInit(): void
     {
         $mock = $this->getMockForAbstractClass('Cake\Cache\CacheEngine', [], '', true, true, true, ['init']);
         $mock->method('init')->will($this->returnValue(false));
@@ -292,10 +268,8 @@ class CacheTest extends TestCase
 
     /**
      * test configuring CacheEngines in App/libs
-     *
-     * @return void
      */
-    public function testConfigWithLibAndPluginEngines()
+    public function testConfigWithLibAndPluginEngines(): void
     {
         static::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
@@ -318,10 +292,8 @@ class CacheTest extends TestCase
 
     /**
      * Test write from a config that is undefined.
-     *
-     * @return void
      */
-    public function testWriteNonExistentConfig()
+    public function testWriteNonExistentConfig(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -330,10 +302,8 @@ class CacheTest extends TestCase
 
     /**
      * Test write from a config that is undefined.
-     *
-     * @return void
      */
-    public function testIncrementNonExistentConfig()
+    public function testIncrementNonExistentConfig(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -342,10 +312,8 @@ class CacheTest extends TestCase
 
     /**
      * Test increment with value < 0
-     *
-     * @return void
      */
-    public function testIncrementSubZero()
+    public function testIncrementSubZero(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -354,10 +322,8 @@ class CacheTest extends TestCase
 
     /**
      * Test write from a config that is undefined.
-     *
-     * @return void
      */
-    public function testDecrementNonExistentConfig()
+    public function testDecrementNonExistentConfig(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -366,10 +332,8 @@ class CacheTest extends TestCase
 
     /**
      * Test decrement value < 0
-     *
-     * @return void
      */
-    public function testDecrementSubZero()
+    public function testDecrementSubZero(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -403,9 +367,8 @@ class CacheTest extends TestCase
      *
      * @dataProvider configProvider
      * @param \Cake\Cache\CacheEngine|array $config
-     * @return void
      */
-    public function testConfigVariants($config)
+    public function testConfigVariants($config): void
     {
         $this->assertNotContains('test', Cache::configured(), 'test config should not exist.');
         Cache::setConfig('tests', $config);
@@ -417,10 +380,8 @@ class CacheTest extends TestCase
 
     /**
      * testConfigInvalidEngine method
-     *
-     * @return void
      */
-    public function testConfigInvalidEngine()
+    public function testConfigInvalidEngine(): void
     {
         $config = ['engine' => 'Imaginary'];
         Cache::setConfig('test', $config);
@@ -432,10 +393,8 @@ class CacheTest extends TestCase
 
     /**
      * test that trying to configure classes that don't extend CacheEngine fail.
-     *
-     * @return void
      */
-    public function testConfigInvalidObject()
+    public function testConfigInvalidObject(): void
     {
         $this->getMockBuilder(\stdClass::class)
             ->setMockClassName('RubbishEngine')
@@ -450,10 +409,8 @@ class CacheTest extends TestCase
 
     /**
      * Ensure you cannot reconfigure a cache adapter.
-     *
-     * @return void
      */
-    public function testConfigErrorOnReconfigure()
+    public function testConfigErrorOnReconfigure(): void
     {
         Cache::setConfig('tests', ['engine' => 'File', 'path' => CACHE]);
 
@@ -464,10 +421,8 @@ class CacheTest extends TestCase
 
     /**
      * Test reading configuration.
-     *
-     * @return void
      */
-    public function testConfigRead()
+    public function testConfigRead(): void
     {
         $config = [
             'engine' => 'File',
@@ -483,10 +438,8 @@ class CacheTest extends TestCase
 
     /**
      * Test reading configuration with numeric string.
-     *
-     * @return void
      */
-    public function testConfigReadNumeric()
+    public function testConfigReadNumeric(): void
     {
         $config = [
             'engine' => 'File',
@@ -502,10 +455,8 @@ class CacheTest extends TestCase
 
     /**
      * test config() with dotted name
-     *
-     * @return void
      */
-    public function testConfigDottedAlias()
+    public function testConfigDottedAlias(): void
     {
         Cache::setConfig('cache.dotted', [
             'className' => 'File',
@@ -523,7 +474,7 @@ class CacheTest extends TestCase
     /**
      * testGroupConfigs method
      */
-    public function testGroupConfigs()
+    public function testGroupConfigs(): void
     {
         Cache::drop('test');
         Cache::setConfig('latest', [
@@ -579,7 +530,7 @@ class CacheTest extends TestCase
     /**
      * testGroupConfigsWithCacheInstance method
      */
-    public function testGroupConfigsWithCacheInstance()
+    public function testGroupConfigsWithCacheInstance(): void
     {
         Cache::drop('test');
         $cache = new FileEngine();
@@ -597,7 +548,7 @@ class CacheTest extends TestCase
     /**
      * testGroupConfigsThrowsException method
      */
-    public function testGroupConfigsThrowsException()
+    public function testGroupConfigsThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Cache::groupConfigs('bogus');
@@ -606,10 +557,8 @@ class CacheTest extends TestCase
     /**
      * test that configured returns an array of the currently configured cache
      * config
-     *
-     * @return void
      */
-    public function testConfigured()
+    public function testConfigured(): void
     {
         Cache::drop('default');
         $result = Cache::configured();
@@ -620,10 +569,8 @@ class CacheTest extends TestCase
     /**
      * test that drop removes cache configs, and that further attempts to use that config
      * do not work.
-     *
-     * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         static::setAppNamespace();
 
@@ -642,10 +589,8 @@ class CacheTest extends TestCase
 
     /**
      * testWriteEmptyValues method
-     *
-     * @return void
      */
-    public function testWriteEmptyValues()
+    public function testWriteEmptyValues(): void
     {
         $this->_configCache();
         Cache::write('App.falseTest', false, 'tests');
@@ -666,10 +611,8 @@ class CacheTest extends TestCase
 
     /**
      * testWriteEmptyValues method
-     *
-     * @return void
      */
-    public function testWriteEmptyKey()
+    public function testWriteEmptyKey(): void
     {
         $this->_configCache();
 
@@ -681,10 +624,8 @@ class CacheTest extends TestCase
 
     /**
      * testReadWriteMany method
-     *
-     * @return void
      */
-    public function testReadWriteMany()
+    public function testReadWriteMany(): void
     {
         $this->_configCache();
         $data = [
@@ -707,10 +648,8 @@ class CacheTest extends TestCase
 
     /**
      * testDeleteMany method
-     *
-     * @return void
      */
-    public function testDeleteMany()
+    public function testDeleteMany(): void
     {
         $this->_configCache();
         $data = [
@@ -735,10 +674,8 @@ class CacheTest extends TestCase
 
     /**
      * Test that failed writes cause errors to be triggered.
-     *
-     * @return void
      */
-    public function testWriteTriggerError()
+    public function testWriteTriggerError(): void
     {
         static::setAppNamespace();
         Cache::setConfig('test_trigger', [
@@ -756,10 +693,8 @@ class CacheTest extends TestCase
      *
      * Check that the "Cache.disable" configuration and a change to it
      * (even after a cache config has been setup) is taken into account.
-     *
-     * @return void
      */
-    public function testCacheDisable()
+    public function testCacheDisable(): void
     {
         Cache::enable();
         Cache::setConfig('test_cache_disable_1', [
@@ -805,10 +740,8 @@ class CacheTest extends TestCase
 
     /**
      * test clearAll() method
-     *
-     * @return void
      */
-    public function testClearAll()
+    public function testClearAll(): void
     {
         Cache::setConfig('configTest', [
             'engine' => 'File',
@@ -836,10 +769,8 @@ class CacheTest extends TestCase
 
     /**
      * Test toggling enabled state of cache.
-     *
-     * @return void
      */
-    public function testEnableDisableEnabled()
+    public function testEnableDisableEnabled(): void
     {
         Cache::enable();
         $this->assertTrue(Cache::enabled(), 'Should be on');
@@ -849,10 +780,8 @@ class CacheTest extends TestCase
 
     /**
      * test remember method.
-     *
-     * @return void
      */
-    public function testRemember()
+    public function testRemember(): void
     {
         $this->_configCache();
         $counter = 0;
@@ -871,10 +800,8 @@ class CacheTest extends TestCase
 
     /**
      * Test add method.
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $this->_configCache();
         Cache::delete('test_add_key', 'tests');
@@ -892,20 +819,16 @@ class CacheTest extends TestCase
 
     /**
      * Test getting the registry
-     *
-     * @return void
      */
-    public function testGetRegistry()
+    public function testGetRegistry(): void
     {
         $this->assertInstanceOf(CacheRegistry::class, Cache::getRegistry());
     }
 
     /**
      * Test setting the registry
-     *
-     * @return void
      */
-    public function testSetAndGetRegistry()
+    public function testSetAndGetRegistry(): void
     {
         $registry = new CacheRegistry();
         Cache::setRegistry($registry);
@@ -915,10 +838,8 @@ class CacheTest extends TestCase
 
     /**
      * Test getting instances with pool
-     *
-     * @return void
      */
-    public function testPool()
+    public function testPool(): void
     {
         $this->_configCache();
 
@@ -928,10 +849,8 @@ class CacheTest extends TestCase
 
     /**
      * Test getting instances with pool
-     *
-     * @return void
      */
-    public function testPoolCacheDisabled()
+    public function testPoolCacheDisabled(): void
     {
         Cache::disable();
         $pool = Cache::pool('tests');

--- a/tests/TestCase/Cache/Engine/ApcuEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcuEngineTest.php
@@ -56,8 +56,6 @@ class ApcuEngineTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -75,8 +73,6 @@ class ApcuEngineTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -89,9 +85,8 @@ class ApcuEngineTest extends TestCase
      * Helper method for testing.
      *
      * @param array $config
-     * @return void
      */
-    protected function _configCache(array $config = [])
+    protected function _configCache(array $config = []): void
     {
         $defaults = [
             'className' => 'Apcu',
@@ -104,10 +99,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * testReadAndWriteCache method
-     *
-     * @return void
      */
-    public function testReadAndWriteCache()
+    public function testReadAndWriteCache(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -127,10 +120,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * Writing cache entries with duration = 0 (forever) should work.
-     *
-     * @return void
      */
-    public function testReadWriteDurationZero()
+    public function testReadWriteDurationZero(): void
     {
         Cache::drop('apcu');
         Cache::setConfig('apcu', ['engine' => 'Apcu', 'duration' => 0, 'prefix' => 'cake_']);
@@ -143,10 +134,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * Test get with default value
-     *
-     * @return void
      */
-    public function testGetDefaultValue()
+    public function testGetDefaultValue(): void
     {
         $apcu = Cache::pool('apcu');
         $this->assertFalse($apcu->get('nope', false));
@@ -160,10 +149,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * testExpiry method
-     *
-     * @return void
      */
-    public function testExpiry()
+    public function testExpiry(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -182,10 +169,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * test set ttl parameter
-     *
-     * @return void
      */
-    public function testSetWithTtl()
+    public function testSetWithTtl(): void
     {
         $this->_configCache(['duration' => 99]);
         $engine = Cache::pool('apcu');
@@ -204,10 +189,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * testDeleteCache method
-     *
-     * @return void
      */
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('delete_test', $data, 'apcu');
@@ -219,10 +202,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * testDecrement method
-     *
-     * @return void
      */
-    public function testDecrement()
+    public function testDecrement(): void
     {
         $result = Cache::write('test_decrement', 5, 'apcu');
         $this->assertTrue($result);
@@ -242,10 +223,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * testIncrement method
-     *
-     * @return void
      */
-    public function testIncrement()
+    public function testIncrement(): void
     {
         $result = Cache::write('test_increment', 5, 'apcu');
         $this->assertTrue($result);
@@ -265,10 +244,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * test the clearing of cache keys
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         apcu_store('not_cake', 'survive');
         Cache::write('some_value', 'value', 'apcu');
@@ -284,10 +261,8 @@ class ApcuEngineTest extends TestCase
      * Tests that configuring groups for stored keys return the correct values when read/written
      * Shows that altering the group value is equivalent to deleting all keys under the same
      * group
-     *
-     * @return void
      */
-    public function testGroupsReadWrite()
+    public function testGroupsReadWrite(): void
     {
         Cache::setConfig('apcu_groups', [
             'engine' => 'Apcu',
@@ -312,10 +287,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * Tests that deleting from a groups-enabled config is possible
-     *
-     * @return void
      */
-    public function testGroupDelete()
+    public function testGroupDelete(): void
     {
         Cache::setConfig('apcu_groups', [
             'engine' => 'Apcu',
@@ -333,10 +306,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * Test clearing a cache group
-     *
-     * @return void
      */
-    public function testGroupClear()
+    public function testGroupClear(): void
     {
         Cache::setConfig('apcu_groups', [
             'engine' => 'Apcu',
@@ -357,10 +328,8 @@ class ApcuEngineTest extends TestCase
 
     /**
      * Test add
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         Cache::delete('test_add_key', 'apcu');
 

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -27,8 +27,6 @@ class ArrayEngineTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -41,8 +39,6 @@ class ArrayEngineTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -55,9 +51,8 @@ class ArrayEngineTest extends TestCase
      * Helper method for testing.
      *
      * @param array $config
-     * @return void
      */
-    protected function _configCache($config = [])
+    protected function _configCache($config = []): void
     {
         $defaults = [
             'className' => 'Array',
@@ -70,10 +65,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * testReadAndWriteCache method
-     *
-     * @return void
      */
-    public function testReadAndWriteCache()
+    public function testReadAndWriteCache(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -93,10 +86,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * testExpiry method
-     *
-     * @return void
      */
-    public function testExpiry()
+    public function testExpiry(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -114,10 +105,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * testDeleteCache method
-     *
-     * @return void
      */
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('delete_test', $data, 'array');
@@ -129,10 +118,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * testDecrement method
-     *
-     * @return void
      */
-    public function testDecrement()
+    public function testDecrement(): void
     {
         $result = Cache::write('test_decrement', 5, 'array');
         $this->assertTrue($result);
@@ -152,10 +139,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * testIncrement method
-     *
-     * @return void
      */
-    public function testIncrement()
+    public function testIncrement(): void
     {
         $result = Cache::write('test_increment', 5, 'array');
         $this->assertTrue($result);
@@ -175,10 +160,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * test the clearing of cache keys
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         Cache::write('some_value', 'value', 'array');
 
@@ -191,10 +174,8 @@ class ArrayEngineTest extends TestCase
      * Tests that configuring groups for stored keys return the correct values when read/written
      * Shows that altering the group value is equivalent to deleting all keys under the same
      * group
-     *
-     * @return void
      */
-    public function testGroupsReadWrite()
+    public function testGroupsReadWrite(): void
     {
         Cache::setConfig('array_groups', [
             'engine' => 'array',
@@ -219,10 +200,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Tests that deleting from a groups-enabled config is possible
-     *
-     * @return void
      */
-    public function testGroupDelete()
+    public function testGroupDelete(): void
     {
         Cache::setConfig('array_groups', [
             'engine' => 'array',
@@ -240,10 +219,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Test clearing a cache group
-     *
-     * @return void
      */
-    public function testGroupClear()
+    public function testGroupClear(): void
     {
         Cache::setConfig('array_groups', [
             'engine' => 'array',
@@ -264,10 +241,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Test add
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         Cache::delete('test_add_key', 'array');
 
@@ -284,10 +259,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Test writeMany() with Traversable
-     *
-     * @return void
      */
-    public function testWriteManyTraversable()
+    public function testWriteManyTraversable(): void
     {
         $data = new \ArrayObject([
             'a' => 1,
@@ -303,10 +276,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Test that passing a non iterable argument to setMultiple() throws exception.
-     *
-     * @return void
      */
-    public function testSetMultipleException()
+    public function testSetMultipleException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A cache set must be either an array or a Traversable.');
@@ -317,10 +288,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Test that passing a non iterable argument to getMultiple() throws exception.
-     *
-     * @return void
      */
-    public function testGetMultipleException()
+    public function testGetMultipleException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A cache key set must be either an array or a Traversable.');
@@ -331,10 +300,8 @@ class ArrayEngineTest extends TestCase
 
     /**
      * Test that passing a non iterable argument to deleteMultiple() throws exception.
-     *
-     * @return void
      */
-    public function testDeleteMultipleException()
+    public function testDeleteMultipleException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('A cache key set must be either an array or a Traversable.');

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -30,8 +30,6 @@ class FileEngineTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,8 +41,6 @@ class FileEngineTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -59,9 +55,8 @@ class FileEngineTest extends TestCase
      * Helper method for testing.
      *
      * @param array $config
-     * @return void
      */
-    protected function _configCache($config = [])
+    protected function _configCache($config = []): void
     {
         $defaults = [
             'className' => 'File',
@@ -73,10 +68,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test get with default value
-     *
-     * @return void
      */
-    public function testGetDefaultValue()
+    public function testGetDefaultValue(): void
     {
         $file = Cache::pool('file_test');
         $this->assertFalse($file->get('nope', false));
@@ -90,10 +83,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testReadAndWriteCache method
-     *
-     * @return void
      */
-    public function testReadAndWriteCacheExpired()
+    public function testReadAndWriteCacheExpired(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -103,10 +94,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test reading and writing to the cache.
-     *
-     * @return void
      */
-    public function testReadAndWrite()
+    public function testReadAndWrite(): void
     {
         $result = Cache::read('test', 'file_test');
         $this->assertNull($result);
@@ -124,10 +113,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test read/write on the same cache key. Ensures file handles are re-wound.
-     *
-     * @return void
      */
-    public function testConsecutiveReadWrite()
+    public function testConsecutiveReadWrite(): void
     {
         Cache::write('rw', 'first write', 'file_test');
         $result = Cache::read('rw', 'file_test');
@@ -142,10 +129,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testExpiry method
-     *
-     * @return void
      */
-    public function testExpiry()
+    public function testExpiry(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -174,10 +159,8 @@ class FileEngineTest extends TestCase
 
     /**
      * test set ttl parameter
-     *
-     * @return void
      */
-    public function testSetWithTtl()
+    public function testSetWithTtl(): void
     {
         $this->_configCache(['duration' => 99]);
         $engine = Cache::pool('file_test');
@@ -198,10 +181,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test has() method
-     *
-     * @return void
      */
-    public function testHas()
+    public function testHas(): void
     {
         $engine = Cache::pool('file_test');
         $this->assertFalse($engine->has('test'));
@@ -212,10 +193,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testDeleteCache method
-     *
-     * @return void
      */
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('delete_test', $data, 'file_test');
@@ -231,10 +210,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testSerialize method
-     *
-     * @return void
      */
-    public function testSerialize()
+    public function testSerialize(): void
     {
         $this->_configCache(['serialize' => true]);
         $data = 'this is a test of the emergency broadcasting system';
@@ -251,10 +228,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testClear method
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         $this->_configCache(['duration' => 0]);
 
@@ -275,10 +250,8 @@ class FileEngineTest extends TestCase
 
     /**
      * test that clear() doesn't wipe files not in the current engine's prefix.
-     *
-     * @return void
      */
-    public function testClearWithPrefixes()
+    public function testClearWithPrefixes(): void
     {
         $FileOne = new FileEngine();
         $FileOne->init([
@@ -305,10 +278,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test that clear() also removes files with group tags.
-     *
-     * @return void
      */
-    public function testClearWithGroups()
+    public function testClearWithGroups(): void
     {
         $engine = new FileEngine();
         $engine->init([
@@ -324,10 +295,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test that clear() also removes files with group tags.
-     *
-     * @return void
      */
-    public function testClearWithNoKeys()
+    public function testClearWithNoKeys(): void
     {
         $engine = new FileEngine();
         $engine->init([
@@ -342,10 +311,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testKeyPath method
-     *
-     * @return void
      */
-    public function testKeyPath()
+    public function testKeyPath(): void
     {
         $result = Cache::write('views.countries.something', 'here', 'file_test');
         $this->assertTrue($result);
@@ -360,10 +327,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test invalid key() containing :
-     *
-     * @return void
      */
-    public function testInvalidKeyColon()
+    public function testInvalidKeyColon(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('contains invalid characters');
@@ -372,10 +337,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test invalid key() containing >
-     *
-     * @return void
      */
-    public function testInvalidKeyAngleBracket()
+    public function testInvalidKeyAngleBracket(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('contains invalid characters');
@@ -384,10 +347,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testRemoveWindowsSlashesFromCache method
-     *
-     * @return void
      */
-    public function testRemoveWindowsSlashesFromCache()
+    public function testRemoveWindowsSlashesFromCache(): void
     {
         Cache::setConfig('windows_test', [
             'engine' => 'File',
@@ -434,10 +395,8 @@ class FileEngineTest extends TestCase
 
     /**
      * testWriteQuotedString method
-     *
-     * @return void
      */
-    public function testWriteQuotedString()
+    public function testWriteQuotedString(): void
     {
         Cache::write('App.doubleQuoteTest', '"this is a quoted string"', 'file_test');
         $this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
@@ -460,10 +419,8 @@ class FileEngineTest extends TestCase
 
     /**
      * check that FileEngine does not generate an error when a configured Path does not exist in debug mode.
-     *
-     * @return void
      */
-    public function testPathDoesNotExist()
+    public function testPathDoesNotExist(): void
     {
         Configure::write('debug', true);
         $dir = TMP . 'tests/autocreate-' . microtime(true);
@@ -483,10 +440,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test that under debug 0 directories do get made.
-     *
-     * @return void
      */
-    public function testPathDoesNotExistDebugOff()
+    public function testPathDoesNotExistDebugOff(): void
     {
         Configure::write('debug', false);
         $dir = TMP . 'tests/autocreate-' . microtime(true);
@@ -506,10 +461,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Testing the mask setting in FileEngine
-     *
-     * @return void
      */
-    public function testMaskSetting()
+    public function testMaskSetting(): void
     {
         if (DS === '\\') {
             $this->markTestSkipped('File permission testing does not work on Windows.');
@@ -550,10 +503,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Tests that configuring groups for stored keys return the correct values when read/written
-     *
-     * @return void
      */
-    public function testGroupsReadWrite()
+    public function testGroupsReadWrite(): void
     {
         Cache::setConfig('file_groups', [
             'engine' => 'File',
@@ -569,10 +520,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test that clearing with repeat writes works properly
-     *
-     * @return void
      */
-    public function testClearingWithRepeatWrites()
+    public function testClearingWithRepeatWrites(): void
     {
         Cache::setConfig('repeat', [
             'engine' => 'File',
@@ -599,10 +548,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Tests that deleting from a groups-enabled config is possible
-     *
-     * @return void
      */
-    public function testGroupDelete()
+    public function testGroupDelete(): void
     {
         Cache::setConfig('file_groups', [
             'engine' => 'File',
@@ -618,10 +565,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test clearing a cache group
-     *
-     * @return void
      */
-    public function testGroupClear()
+    public function testGroupClear(): void
     {
         Cache::setConfig('file_groups', [
             'engine' => 'File',
@@ -661,10 +606,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test that clearGroup works with no prefix.
-     *
-     * @return void
      */
-    public function testGroupClearNoPrefix()
+    public function testGroupClearNoPrefix(): void
     {
         Cache::setConfig('file_groups', [
             'className' => 'File',
@@ -681,10 +624,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Test that failed add write return false.
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         Cache::delete('test_add_key', 'file_test');
 
@@ -701,10 +642,8 @@ class FileEngineTest extends TestCase
 
     /**
      * Tests that only files inside of the configured path are being deleted.
-     *
-     * @return void
      */
-    public function testClearIsRestrictedToConfiguredPath()
+    public function testClearIsRestrictedToConfiguredPath(): void
     {
         $this->_configCache([
             'prefix' => '',

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -35,8 +35,6 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -58,9 +56,8 @@ class MemcachedEngineTest extends TestCase
      * Helper method for testing.
      *
      * @param array $config
-     * @return void
      */
-    protected function _configCache($config = [])
+    protected function _configCache($config = []): void
     {
         $defaults = [
             'className' => 'Memcached',
@@ -74,8 +71,6 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -91,10 +86,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testConfig method
-     *
-     * @return void
      */
-    public function testConfig()
+    public function testConfig(): void
     {
         $config = Cache::pool('memcached')->getConfig();
         unset($config['path']);
@@ -117,10 +110,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testCompressionSetting method
-     *
-     * @return void
      */
-    public function testCompressionSetting()
+    public function testCompressionSetting(): void
     {
         $Memcached = new MemcachedEngine();
         $Memcached->init([
@@ -143,10 +134,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test setting options
-     *
-     * @return void
      */
-    public function testOptionsSetting()
+    public function testOptionsSetting(): void
     {
         $memcached = new MemcachedEngine();
         $memcached->init([
@@ -161,10 +150,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test accepts only valid serializer engine
-     *
-     * @return  void
      */
-    public function testInvalidSerializerSetting()
+    public function testInvalidSerializerSetting(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid_serializer is not a valid serializer engine for Memcached');
@@ -180,10 +167,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testPhpSerializerSetting method
-     *
-     * @return void
      */
-    public function testPhpSerializerSetting()
+    public function testPhpSerializerSetting(): void
     {
         $Memcached = new MemcachedEngine();
         $config = [
@@ -199,10 +184,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testJsonSerializerSetting method
-     *
-     * @return void
      */
-    public function testJsonSerializerSetting()
+    public function testJsonSerializerSetting(): void
     {
         $this->skipIf(
             !Memcached::HAVE_JSON,
@@ -223,10 +206,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testIgbinarySerializerSetting method
-     *
-     * @return void
      */
-    public function testIgbinarySerializerSetting()
+    public function testIgbinarySerializerSetting(): void
     {
         $this->skipIf(
             !Memcached::HAVE_IGBINARY,
@@ -247,10 +228,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testMsgpackSerializerSetting method
-     *
-     * @return void
      */
-    public function testMsgpackSerializerSetting()
+    public function testMsgpackSerializerSetting(): void
     {
         $this->skipIf(
             !defined('Memcached::HAVE_MSGPACK') || !Memcached::HAVE_MSGPACK,
@@ -271,10 +250,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testJsonSerializerThrowException method
-     *
-     * @return void
      */
-    public function testJsonSerializerThrowException()
+    public function testJsonSerializerThrowException(): void
     {
         $this->skipIf(
             (bool)Memcached::HAVE_JSON,
@@ -296,10 +273,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testMsgpackSerializerThrowException method
-     *
-     * @return void
      */
-    public function testMsgpackSerializerThrowException()
+    public function testMsgpackSerializerThrowException(): void
     {
         $this->skipIf(
             !defined('Memcached::HAVE_MSGPACK'),
@@ -325,10 +300,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testIgbinarySerializerThrowException method
-     *
-     * @return void
      */
-    public function testIgbinarySerializerThrowException()
+    public function testIgbinarySerializerThrowException(): void
     {
         $this->skipIf(
             (bool)Memcached::HAVE_IGBINARY,
@@ -351,10 +324,8 @@ class MemcachedEngineTest extends TestCase
     /**
      * test using authentication without memcached installed with SASL support
      * throw an exception
-     *
-     * @return void
      */
-    public function testSaslAuthException()
+    public function testSaslAuthException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Memcached extension is not build with SASL support');
@@ -377,10 +348,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testConfigDifferentPorts method
-     *
-     * @return void
      */
-    public function testConfigDifferentPorts()
+    public function testConfigDifferentPorts(): void
     {
         $Memcached1 = new MemcachedEngine();
         $config1 = [
@@ -403,10 +372,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testConfig method
-     *
-     * @return void
      */
-    public function testMultipleServers()
+    public function testMultipleServers(): void
     {
         $servers = ['127.0.0.1:' . $this->port, '127.0.0.1:11222'];
         $available = true;
@@ -433,10 +400,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test connecting to an ipv6 server.
-     *
-     * @return void
      */
-    public function testConnectIpv6()
+    public function testConnectIpv6(): void
     {
         $Memcached = new MemcachedEngine();
         $result = $Memcached->init([
@@ -452,10 +417,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test domain starts with u
-     *
-     * @return void
      */
-    public function testParseServerStringWithU()
+    public function testParseServerStringWithU(): void
     {
         $Memcached = new MemcachedEngine();
         $result = $Memcached->parseServerString('udomain.net:13211');
@@ -464,10 +427,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test non latin domains.
-     *
-     * @return void
      */
-    public function testParseServerStringNonLatin()
+    public function testParseServerStringNonLatin(): void
     {
         $Memcached = new MemcachedEngine();
         $result = $Memcached->parseServerString('schülervz.net:13211');
@@ -479,10 +440,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test unix sockets.
-     *
-     * @return void
      */
-    public function testParseServerStringUnix()
+    public function testParseServerStringUnix(): void
     {
         $Memcached = new MemcachedEngine();
         $result = $Memcached->parseServerString('unix:///path/to/memcachedd.sock');
@@ -491,10 +450,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testReadAndWriteCache method
-     *
-     * @return void
      */
-    public function testReadAndWriteCache()
+    public function testReadAndWriteCache(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -514,10 +471,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * Test get with default value
-     *
-     * @return void
      */
-    public function testGetDefaultValue()
+    public function testGetDefaultValue(): void
     {
         $memcache = Cache::pool('memcached');
         $this->assertFalse($memcache->get('nope', false));
@@ -531,10 +486,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testReadMany method
-     *
-     * @return void
      */
-    public function testReadMany()
+    public function testReadMany(): void
     {
         $this->_configCache(['duration' => 2]);
         $data = [
@@ -560,10 +513,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testWriteMany method
-     *
-     * @return void
      */
-    public function testWriteMany()
+    public function testWriteMany(): void
     {
         $this->_configCache(['duration' => 2]);
         $data = [
@@ -584,10 +535,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testExpiry method
-     *
-     * @return void
      */
-    public function testExpiry()
+    public function testExpiry(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -628,10 +577,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test set ttl parameter
-     *
-     * @return void
      */
-    public function testSetWithTtl()
+    public function testSetWithTtl(): void
     {
         $this->_configCache(['duration' => 99]);
         $engine = Cache::pool('memcached');
@@ -650,10 +597,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testDeleteCache method
-     *
-     * @return void
      */
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('delete_test', $data, 'memcached');
@@ -665,10 +610,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testDeleteMany method
-     *
-     * @return void
      */
-    public function testDeleteMany()
+    public function testDeleteMany(): void
     {
         $this->skipIf(defined('HHVM_VERSION'), 'HHVM does not implement deleteMulti');
         $this->_configCache();
@@ -696,10 +639,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testDecrement method
-     *
-     * @return void
      */
-    public function testDecrement()
+    public function testDecrement(): void
     {
         $result = Cache::write('test_decrement', 5, 'memcached');
         $this->assertTrue($result);
@@ -721,10 +662,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test decrementing compressed keys
-     *
-     * @return void
      */
-    public function testDecrementCompressedKeys()
+    public function testDecrementCompressedKeys(): void
     {
         Cache::setConfig('compressed_memcached', [
             'engine' => 'Memcached',
@@ -753,10 +692,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * testIncrement method
-     *
-     * @return void
      */
-    public function testIncrement()
+    public function testIncrement(): void
     {
         $result = Cache::write('test_increment', 5, 'memcached');
         $this->assertTrue($result);
@@ -778,10 +715,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * Test that increment and decrement set ttls.
-     *
-     * @return void
      */
-    public function testIncrementDecrementExpiring()
+    public function testIncrementDecrementExpiring(): void
     {
         $this->_configCache(['duration' => 1]);
         Cache::write('test_increment', 1, 'memcached');
@@ -798,10 +733,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test incrementing compressed keys
-     *
-     * @return void
      */
-    public function testIncrementCompressedKeys()
+    public function testIncrementCompressedKeys(): void
     {
         Cache::setConfig('compressed_memcached', [
             'engine' => 'Memcached',
@@ -830,10 +763,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test that configurations don't conflict, when a file engine is declared after a memcached one.
-     *
-     * @return void
      */
-    public function testConfigurationConflict()
+    public function testConfigurationConflict(): void
     {
         Cache::setConfig('long_memcached', [
             'engine' => 'Memcached',
@@ -865,10 +796,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test clearing memcached.
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         Cache::setConfig('memcached2', [
             'engine' => 'Memcached',
@@ -890,10 +819,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * test that a 0 duration can successfully write.
-     *
-     * @return void
      */
-    public function testZeroDuration()
+    public function testZeroDuration(): void
     {
         $this->_configCache(['duration' => 0]);
         $result = Cache::write('test_key', 'written!', 'memcached');
@@ -907,10 +834,8 @@ class MemcachedEngineTest extends TestCase
      * Tests that configuring groups for stored keys return the correct values when read/written
      * Shows that altering the group value is equivalent to deleting all keys under the same
      * group
-     *
-     * @return void
      */
-    public function testGroupReadWrite()
+    public function testGroupReadWrite(): void
     {
         Cache::setConfig('memcached_groups', [
             'engine' => 'Memcached',
@@ -941,10 +866,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * Tests that deleting from a groups-enabled config is possible
-     *
-     * @return void
      */
-    public function testGroupDelete()
+    public function testGroupDelete(): void
     {
         Cache::setConfig('memcached_groups', [
             'engine' => 'Memcached',
@@ -961,10 +884,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * Test clearing a cache group
-     *
-     * @return void
      */
-    public function testGroupClear()
+    public function testGroupClear(): void
     {
         Cache::setConfig('memcached_groups', [
             'engine' => 'Memcached',
@@ -984,10 +905,8 @@ class MemcachedEngineTest extends TestCase
 
     /**
      * Test add
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         Cache::delete('test_add_key', 'memcached');
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -33,8 +33,6 @@ class RedisEngineTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +53,6 @@ class RedisEngineTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -70,9 +66,8 @@ class RedisEngineTest extends TestCase
      * Helper method for testing.
      *
      * @param array $config
-     * @return void
      */
-    protected function _configCache($config = [])
+    protected function _configCache($config = []): void
     {
         $defaults = [
             'className' => 'Redis',
@@ -86,10 +81,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testConfig method
-     *
-     * @return void
      */
-    public function testConfig()
+    public function testConfig(): void
     {
         $config = Cache::pool('redis')->getConfig();
         $expecting = [
@@ -110,10 +103,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testConfigDsn method
-     *
-     * @return void
      */
-    public function testConfigDsn()
+    public function testConfigDsn(): void
     {
         Cache::setConfig('redis_dsn', [
             'url' => 'redis://localhost:' . $this->port . '?database=1&prefix=redis_',
@@ -141,10 +132,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testConnect method
-     *
-     * @return void
      */
-    public function testConnect()
+    public function testConnect(): void
     {
         $Redis = new RedisEngine();
         $this->assertTrue($Redis->init(Cache::pool('redis')->getConfig()));
@@ -152,10 +141,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testMultiDatabaseOperations method
-     *
-     * @return void
      */
-    public function testMultiDatabaseOperations()
+    public function testMultiDatabaseOperations(): void
     {
         Cache::setConfig('redisdb0', [
             'engine' => 'Redis',
@@ -200,10 +187,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * test write numbers method
-     *
-     * @return void
      */
-    public function testWriteNumbers()
+    public function testWriteNumbers(): void
     {
         $result = Cache::write('test-counter', 1, 'redis');
         $this->assertSame(1, Cache::read('test-counter', 'redis'));
@@ -217,10 +202,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testReadAndWriteCache method
-     *
-     * @return void
      */
-    public function testReadAndWriteCache()
+    public function testReadAndWriteCache(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -255,10 +238,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * Test get with default value
-     *
-     * @return void
      */
-    public function testGetDefaultValue()
+    public function testGetDefaultValue(): void
     {
         $redis = Cache::pool('redis');
         $this->assertFalse($redis->get('nope', false));
@@ -272,10 +253,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testExpiry method
-     *
-     * @return void
      */
-    public function testExpiry()
+    public function testExpiry(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -318,10 +297,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * test set ttl parameter
-     *
-     * @return void
      */
-    public function testSetWithTtl()
+    public function testSetWithTtl(): void
     {
         $this->_configCache(['duration' => 99]);
         $engine = Cache::pool('redis');
@@ -340,10 +317,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testDeleteCache method
-     *
-     * @return void
      */
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('delete_test', $data, 'redis');
@@ -355,10 +330,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testDecrement method
-     *
-     * @return void
      */
-    public function testDecrement()
+    public function testDecrement(): void
     {
         Cache::delete('test_decrement', 'redis');
         $result = Cache::write('test_decrement', 5, 'redis');
@@ -379,10 +352,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testIncrement method
-     *
-     * @return void
      */
-    public function testIncrement()
+    public function testIncrement(): void
     {
         Cache::delete('test_increment', 'redis');
         $result = Cache::increment('test_increment', 1, 'redis');
@@ -400,10 +371,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * testIncrementAfterWrite method
-     *
-     * @return void
      */
-    public function testIncrementAfterWrite()
+    public function testIncrementAfterWrite(): void
     {
         Cache::delete('test_increment', 'redis');
         $result = Cache::write('test_increment', 1, 'redis');
@@ -421,10 +390,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * Test that increment() and decrement() can live forever.
-     *
-     * @return void
      */
-    public function testIncrementDecrementForvever()
+    public function testIncrementDecrementForvever(): void
     {
         $this->_configCache(['duration' => 0]);
         Cache::delete('test_increment', 'redis');
@@ -442,10 +409,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * Test that increment and decrement set ttls.
-     *
-     * @return void
      */
-    public function testIncrementDecrementExpiring()
+    public function testIncrementDecrementExpiring(): void
     {
         $this->_configCache(['duration' => 1]);
         Cache::delete('test_increment', 'redis');
@@ -462,10 +427,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * test clearing redis.
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         Cache::setConfig('redis2', [
             'engine' => 'Redis',
@@ -490,10 +453,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * test that a 0 duration can successfully write.
-     *
-     * @return void
      */
-    public function testZeroDuration()
+    public function testZeroDuration(): void
     {
         $this->_configCache(['duration' => 0]);
         $result = Cache::write('test_key', 'written!', 'redis');
@@ -507,10 +468,8 @@ class RedisEngineTest extends TestCase
      * Tests that configuring groups for stored keys return the correct values when read/written
      * Shows that altering the group value is equivalent to deleting all keys under the same
      * group
-     *
-     * @return void
      */
-    public function testGroupReadWrite()
+    public function testGroupReadWrite(): void
     {
         Cache::setConfig('redis_groups', [
             'engine' => 'Redis',
@@ -541,10 +500,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * Tests that deleting from a groups-enabled config is possible
-     *
-     * @return void
      */
-    public function testGroupDelete()
+    public function testGroupDelete(): void
     {
         Cache::setConfig('redis_groups', [
             'engine' => 'Redis',
@@ -561,10 +518,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * Test clearing a cache group
-     *
-     * @return void
      */
-    public function testGroupClear()
+    public function testGroupClear(): void
     {
         Cache::setConfig('redis_groups', [
             'engine' => 'Redis',
@@ -584,10 +539,8 @@ class RedisEngineTest extends TestCase
 
     /**
      * Test add
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         Cache::delete('test_add_key', 'redis');
 

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -27,8 +27,6 @@ class WincacheEngineTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -41,8 +39,6 @@ class WincacheEngineTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -55,9 +51,8 @@ class WincacheEngineTest extends TestCase
      * Helper method for testing.
      *
      * @param array $config
-     * @return void
      */
-    protected function _configCache($config = [])
+    protected function _configCache($config = []): void
     {
         $defaults = [
             'className' => 'Wincache',
@@ -69,10 +64,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * testReadAndWriteCache method
-     *
-     * @return void
      */
-    public function testReadAndWriteCache()
+    public function testReadAndWriteCache(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -93,10 +86,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * Test get with default value
-     *
-     * @return void
      */
-    public function testGetDefaultValue()
+    public function testGetDefaultValue(): void
     {
         $wincache = Cache::pool('wincache');
         $this->assertFalse($wincache->get('nope', false));
@@ -110,10 +101,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * testExpiry method
-     *
-     * @return void
      */
-    public function testExpiry()
+    public function testExpiry(): void
     {
         $this->_configCache(['duration' => 1]);
 
@@ -139,10 +128,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * test set ttl parameter
-     *
-     * @return void
      */
-    public function testSetWithTtl()
+    public function testSetWithTtl(): void
     {
         $this->_configCache(['duration' => 99]);
         $engine = Cache::pool('wincache');
@@ -161,10 +148,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * testDeleteCache method
-     *
-     * @return void
      */
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
         $data = 'this is a test of the emergency broadcasting system';
         $result = Cache::write('delete_test', $data, 'wincache');
@@ -176,10 +161,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * testDecrement method
-     *
-     * @return void
      */
-    public function testDecrement()
+    public function testDecrement(): void
     {
         $this->skipIf(
             !function_exists('wincache_ucache_dec'),
@@ -204,10 +187,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * testIncrement method
-     *
-     * @return void
      */
-    public function testIncrement()
+    public function testIncrement(): void
     {
         $this->skipIf(
             !function_exists('wincache_ucache_inc'),
@@ -232,10 +213,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * test the clearing of cache keys
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         wincache_ucache_set('not_cake', 'safe');
         Cache::write('some_value', 'value', 'wincache');
@@ -250,10 +229,8 @@ class WincacheEngineTest extends TestCase
      * Tests that configuring groups for stored keys return the correct values when read/written
      * Shows that altering the group value is equivalent to deleting all keys under the same
      * group
-     *
-     * @return void
      */
-    public function testGroupsReadWrite()
+    public function testGroupsReadWrite(): void
     {
         Cache::setConfig('wincache_groups', [
             'engine' => 'Wincache',
@@ -277,10 +254,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * Tests that deleting from a groups-enabled config is possible
-     *
-     * @return void
      */
-    public function testGroupDelete()
+    public function testGroupDelete(): void
     {
         Cache::setConfig('wincache_groups', [
             'engine' => 'Wincache',
@@ -297,10 +272,8 @@ class WincacheEngineTest extends TestCase
 
     /**
      * Test clearing a cache group
-     *
-     * @return void
      */
-    public function testGroupClear()
+    public function testGroupClear(): void
     {
         Cache::setConfig('wincache_groups', [
             'engine' => 'Wincache',

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -21,6 +21,8 @@ use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use DatePeriod;
+use Generator;
 use InvalidArgumentException;
 use NoRewindIterator;
 use stdClass;
@@ -37,10 +39,8 @@ class CollectionTest extends TestCase
 {
     /**
      * Tests that it is possible to convert an array into a collection
-     *
-     * @return void
      */
-    public function testArrayIsWrapped()
+    public function testArrayIsWrapped(): void
     {
         $items = [1, 2, 3];
         $collection = new Collection($items);
@@ -66,9 +66,8 @@ class CollectionTest extends TestCase
      * Tests the avg method
      *
      * @dataProvider avgProvider
-     * @return void
      */
-    public function testAvg(iterable $items)
+    public function testAvg(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertSame(2, $collection->avg());
@@ -80,10 +79,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the avg method when on an empty collection
-     *
-     * @return void
      */
-    public function testAvgWithEmptyCollection()
+    public function testAvgWithEmptyCollection(): void
     {
         $collection = new Collection([]);
         $this->assertNull($collection->avg());
@@ -111,9 +108,8 @@ class CollectionTest extends TestCase
      * ests the avg method
      *
      * @dataProvider avgWithMatcherProvider
-     * @return void
      */
-    public function testAvgWithMatcher(iterable $items)
+    public function testAvgWithMatcher(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertSame(2, $collection->avg('foo'));
@@ -138,9 +134,8 @@ class CollectionTest extends TestCase
      * Tests the median method
      *
      * @dataProvider medianProvider
-     * @return void
      */
-    public function testMedian(iterable $items)
+    public function testMedian(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertSame(4, $collection->median());
@@ -148,10 +143,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the median method when on an empty collection
-     *
-     * @return void
      */
-    public function testMedianWithEmptyCollection()
+    public function testMedianWithEmptyCollection(): void
     {
         $collection = new Collection([]);
         $this->assertNull($collection->median());
@@ -164,9 +157,8 @@ class CollectionTest extends TestCase
      * Tests the median method
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testMedianEven(iterable $items)
+    public function testMedianEven(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertSame(2.5, $collection->median());
@@ -197,19 +189,16 @@ class CollectionTest extends TestCase
      * Tests the median method
      *
      * @dataProvider medianWithMatcherProvider
-     * @return void
      */
-    public function testMedianWithMatcher(iterable $items)
+    public function testMedianWithMatcher(iterable $items): void
     {
         $this->assertSame(333, (new Collection($items))->median('invoice.total'));
     }
 
     /**
      * Tests that it is possible to convert an iterator into a collection
-     *
-     * @return void
      */
-    public function testIteratorIsWrapped()
+    public function testIteratorIsWrapped(): void
     {
         $items = new \ArrayObject([1, 2, 3]);
         $collection = new Collection($items);
@@ -218,16 +207,14 @@ class CollectionTest extends TestCase
 
     /**
      * Test running a method over all elements in the collection
-     *
-     * @return void
      */
-    public function testEach()
+    public function testEach(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
 
         $results = [];
-        $collection->each(function ($value, $key) use (&$results) {
+        $collection->each(function ($value, $key) use (&$results): void {
             $results[] = [$key => $value];
         });
         $this->assertSame([['a' => 1], ['b' => 2], ['c' => 3]], $results);
@@ -247,9 +234,8 @@ class CollectionTest extends TestCase
      * Test filter() with no callback.
      *
      * @dataProvider filterProvider
-     * @return void
      */
-    public function testFilterNoCallback(iterable $items)
+    public function testFilterNoCallback(iterable $items): void
     {
         $collection = new Collection($items);
         $result = $collection->filter()->toArray();
@@ -259,10 +245,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that it is possible to chain filter() as it returns a collection object
-     *
-     * @return void
      */
-    public function testFilterChaining()
+    public function testFilterChaining(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
@@ -273,7 +257,7 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $filtered);
 
         $results = [];
-        $filtered->each(function ($value, $key) use (&$results) {
+        $filtered->each(function ($value, $key) use (&$results): void {
             $results[] = [$key => $value];
         });
         $this->assertSame([['c' => 3]], $results);
@@ -281,10 +265,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests reject
-     *
-     * @return void
      */
-    public function testReject()
+    public function testReject(): void
     {
         $collection = new Collection([]);
         $result = $collection->reject(function ($v) {
@@ -305,10 +287,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests every when the callback returns true for all elements
-     *
-     * @return void
      */
-    public function testEveryReturnTrue()
+    public function testEveryReturnTrue(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
@@ -324,10 +304,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests every when the callback returns false for one of the elements
-     *
-     * @return void
      */
-    public function testEveryReturnFalse()
+    public function testEveryReturnFalse(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
@@ -343,10 +321,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests some() when one of the calls return true
-     *
-     * @return void
      */
-    public function testSomeReturnTrue()
+    public function testSomeReturnTrue(): void
     {
         $collection = new Collection([]);
         $result = $collection->some(function ($v) {
@@ -368,10 +344,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests some() when none of the calls return true
-     *
-     * @return void
      */
-    public function testSomeReturnFalse()
+    public function testSomeReturnFalse(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
@@ -387,10 +361,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests contains
-     *
-     * @return void
      */
-    public function testContains()
+    public function testContains(): void
     {
         $collection = new Collection([]);
         $this->assertFalse($collection->contains('a'));
@@ -422,9 +394,8 @@ class CollectionTest extends TestCase
      * Tests map
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testMap(iterable $items)
+    public function testMap(iterable $items): void
     {
         $collection = new Collection($items);
         $map = $collection->map(function ($v, $k, $it) use ($collection) {
@@ -440,9 +411,8 @@ class CollectionTest extends TestCase
      * Tests reduce with initial value
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testReduceWithInitialValue(iterable $items)
+    public function testReduceWithInitialValue(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertSame(20, $collection->reduce(function ($reduction, $value, $key) {
@@ -454,9 +424,8 @@ class CollectionTest extends TestCase
      * Tests reduce without initial value
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testReduceWithoutInitialValue(iterable $items)
+    public function testReduceWithoutInitialValue(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertSame(10, $collection->reduce(function ($reduction, $value, $key) {
@@ -483,9 +452,8 @@ class CollectionTest extends TestCase
      * Tests extract
      *
      * @dataProvider extractProvider
-     * @return void
      */
-    public function testExtract(iterable $items)
+    public function testExtract(iterable $items): void
     {
         $collection = new Collection($items);
         $map = $collection->extract('a.b.c');
@@ -516,9 +484,8 @@ class CollectionTest extends TestCase
      * Tests sort
      *
      * @dataProvider sortProvider
-     * @return void
      */
-    public function testSortString(iterable $items)
+    public function testSortString(iterable $items): void
     {
         $collection = new Collection($items);
         $map = $collection->sortBy('a.b.c');
@@ -535,9 +502,8 @@ class CollectionTest extends TestCase
      * Tests max
      *
      * @dataProvider sortProvider
-     * @return void
      */
-    public function testMax(iterable $items)
+    public function testMax(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertEquals(['a' => ['b' => ['c' => 10]]], $collection->max('a.b.c'));
@@ -547,9 +513,8 @@ class CollectionTest extends TestCase
      * Tests max
      *
      * @dataProvider sortProvider
-     * @return void
      */
-    public function testMaxCallback(iterable $items)
+    public function testMaxCallback(iterable $items): void
     {
         $collection = new Collection($items);
         $callback = function ($e) {
@@ -562,9 +527,8 @@ class CollectionTest extends TestCase
      * Tests max
      *
      * @dataProvider sortProvider
-     * @return void
      */
-    public function testMaxCallable(iterable $items)
+    public function testMaxCallable(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->max(function ($e) {
@@ -574,10 +538,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test max with a collection of Entities
-     *
-     * @return void
      */
-    public function testMaxWithEntities()
+    public function testMaxWithEntities(): void
     {
         $collection = new Collection([
             new Entity(['id' => 1, 'count' => 18]),
@@ -596,9 +558,8 @@ class CollectionTest extends TestCase
      * Tests min
      *
      * @dataProvider sortProvider
-     * @return void
      */
-    public function testMin(iterable $items)
+    public function testMin(iterable $items): void
     {
         $collection = new Collection($items);
         $this->assertEquals(['a' => ['b' => ['c' => 4]]], $collection->min('a.b.c'));
@@ -606,10 +567,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test min with a collection of Entities
-     *
-     * @return void
      */
-    public function testMinWithEntities()
+    public function testMinWithEntities(): void
     {
         $collection = new Collection([
             new Entity(['id' => 1, 'count' => 18]),
@@ -647,9 +606,8 @@ class CollectionTest extends TestCase
      * Tests groupBy
      *
      * @dataProvider groupByProvider
-     * @return void
      */
-    public function testGroupBy(iterable $items)
+    public function testGroupBy(iterable $items): void
     {
         $collection = new Collection($items);
         $grouped = $collection->groupBy('parent_id');
@@ -670,9 +628,8 @@ class CollectionTest extends TestCase
      * Tests groupBy
      *
      * @dataProvider groupByProvider
-     * @return void
      */
-    public function testGroupByCallback(iterable $items)
+    public function testGroupByCallback(iterable $items): void
     {
         $collection = new Collection($items);
         $expected = [
@@ -692,10 +649,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests grouping by a deep key
-     *
-     * @return void
      */
-    public function testGroupByDeepKey()
+    public function testGroupByDeepKey(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => ['parent_id' => 10]],
@@ -718,10 +673,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests passing an invalid path to groupBy.
-     *
-     * @return void
      */
-    public function testGroupByInvalidPath()
+    public function testGroupByInvalidPath(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo'],
@@ -758,9 +711,8 @@ class CollectionTest extends TestCase
      * Tests indexBy
      *
      * @dataProvider indexByProvider
-     * @return void
      */
-    public function testIndexBy(iterable $items)
+    public function testIndexBy(iterable $items): void
     {
         $collection = new Collection($items);
         $grouped = $collection->indexBy('id');
@@ -777,9 +729,8 @@ class CollectionTest extends TestCase
      * Tests indexBy
      *
      * @dataProvider indexByProvider
-     * @return void
      */
-    public function testIndexByCallback(iterable $items)
+    public function testIndexByCallback(iterable $items): void
     {
         $collection = new Collection($items);
         $grouped = $collection->indexBy(function ($element) {
@@ -795,10 +746,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests indexBy with a deep property
-     *
-     * @return void
      */
-    public function testIndexByDeep()
+    public function testIndexByDeep(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => ['parent_id' => 10]],
@@ -816,10 +765,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests passing an invalid path to indexBy.
-     *
-     * @return void
      */
-    public function testIndexByInvalidPath()
+    public function testIndexByInvalidPath(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo'],
@@ -835,10 +782,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests passing an invalid path to indexBy.
-     *
-     * @return void
      */
-    public function testIndexByInvalidPathCallback()
+    public function testIndexByInvalidPathCallback(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo'],
@@ -858,9 +803,8 @@ class CollectionTest extends TestCase
      * Tests countBy
      *
      * @dataProvider groupByProvider
-     * @return void
      */
-    public function testCountBy(iterable $items)
+    public function testCountBy(iterable $items): void
     {
         $collection = new Collection($items);
         $grouped = $collection->countBy('parent_id');
@@ -877,9 +821,8 @@ class CollectionTest extends TestCase
      * Tests countBy
      *
      * @dataProvider groupByProvider
-     * @return void
      */
-    public function testCountByCallback(iterable $items)
+    public function testCountByCallback(iterable $items): void
     {
         $expected = [
             10 => 2,
@@ -896,9 +839,8 @@ class CollectionTest extends TestCase
      * Tests shuffle
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testShuffle(iterable $data)
+    public function testShuffle(iterable $data): void
     {
         $collection = (new Collection($data))->shuffle();
         $result = $collection->toArray();
@@ -911,10 +853,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests shuffle with duplicate keys.
-     *
-     * @return void
      */
-    public function testShuffleDuplicateKeys()
+    public function testShuffleDuplicateKeys(): void
     {
         $collection = (new Collection(['a' => 1]))->append(['a' => 2])->shuffle();
         $result = $collection->toArray();
@@ -928,9 +868,8 @@ class CollectionTest extends TestCase
      * Tests sample
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testSample(iterable $data)
+    public function testSample(iterable $data): void
     {
         $result = (new Collection($data))->sample(2)->toArray();
         $this->assertCount(2, $result);
@@ -941,10 +880,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the sample() method with a traversable non-iterator
-     *
-     * @return void
      */
-    public function testSampleWithTraversableNonIterator()
+    public function testSampleWithTraversableNonIterator(): void
     {
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $result = $collection->sample(3)->toList();
@@ -964,10 +901,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test toArray method
-     *
-     * @return void
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $data = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
         $collection = new Collection($data);
@@ -978,9 +913,8 @@ class CollectionTest extends TestCase
      * Test toList method
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testToList(iterable $data)
+    public function testToList(iterable $data): void
     {
         $collection = new Collection($data);
         $this->assertEquals([1, 2, 3, 4], $collection->toList());
@@ -988,10 +922,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test JSON encoding
-     *
-     * @return void
      */
-    public function testToJson()
+    public function testToJson(): void
     {
         $data = [1, 2, 3, 4];
         $collection = new Collection($data);
@@ -1002,9 +934,8 @@ class CollectionTest extends TestCase
      * Tests that Count returns the number of elements
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testCollectionCount(iterable $list)
+    public function testCollectionCount(iterable $list): void
     {
         $list = (new Collection($list))->buffered();
         $collection = new Collection($list);
@@ -1015,9 +946,8 @@ class CollectionTest extends TestCase
      * Tests that countKeys returns the number of unique keys
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testCollectionCountKeys(iterable $list)
+    public function testCollectionCountKeys(iterable $list): void
     {
         $list = (new Collection($list))->buffered();
         $collection = new Collection($list);
@@ -1026,10 +956,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests take method
-     *
-     * @return void
      */
-    public function testTake()
+    public function testTake(): void
     {
         $data = [1, 2, 3, 4];
         $collection = new Collection($data);
@@ -1055,10 +983,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the take() method with a traversable non-iterator
-     *
-     * @return void
      */
-    public function testTakeWithTraversableNonIterator()
+    public function testTakeWithTraversableNonIterator(): void
     {
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $result = $collection->take(3, 1)->toList();
@@ -1072,10 +998,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests match
-     *
-     * @return void
      */
-    public function testMatch()
+    public function testMatch(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => ['parent_id' => 10]],
@@ -1101,10 +1025,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests firstMatch
-     *
-     * @return void
      */
-    public function testFirstMatch()
+    public function testFirstMatch(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => ['parent_id' => 10]],
@@ -1127,10 +1049,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the append method
-     *
-     * @return void
      */
-    public function testAppend()
+    public function testAppend(): void
     {
         $collection = new Collection([1, 2, 3]);
         $combined = $collection->append([4, 5, 6]);
@@ -1144,7 +1064,7 @@ class CollectionTest extends TestCase
     /**
      * Tests the appendItem method
      */
-    public function testAppendItem()
+    public function testAppendItem(): void
     {
         $collection = new Collection([1, 2, 3]);
         $combined = $collection->appendItem(4);
@@ -1159,7 +1079,7 @@ class CollectionTest extends TestCase
     /**
      * Tests the prepend method
      */
-    public function testPrepend()
+    public function testPrepend(): void
     {
         $collection = new Collection([1, 2, 3]);
         $combined = $collection->prepend(['a']);
@@ -1173,7 +1093,7 @@ class CollectionTest extends TestCase
     /**
      * Tests prependItem method
      */
-    public function testPrependItem()
+    public function testPrependItem(): void
     {
         $collection = new Collection([1, 2, 3]);
         $combined = $collection->prependItem('a');
@@ -1188,7 +1108,7 @@ class CollectionTest extends TestCase
     /**
      * Tests prependItem method
      */
-    public function testPrependItemPreserveKeys()
+    public function testPrependItemPreserveKeys(): void
     {
         $collection = new Collection([1, 2, 3]);
         $combined = $collection->prependItem('a');
@@ -1203,7 +1123,7 @@ class CollectionTest extends TestCase
     /**
      * Tests the append method with iterator
      */
-    public function testAppendIterator()
+    public function testAppendIterator(): void
     {
         $collection = new Collection([1, 2, 3]);
         $iterator = new ArrayIterator([4, 5, 6]);
@@ -1211,7 +1131,7 @@ class CollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5, 6], $combined->toList());
     }
 
-    public function testAppendNotCollectionInstance()
+    public function testAppendNotCollectionInstance(): void
     {
         $collection = new TestCollection([1, 2, 3]);
         $combined = $collection->append([4, 5, 6]);
@@ -1221,10 +1141,8 @@ class CollectionTest extends TestCase
     /**
      * Tests that by calling compile internal iteration operations are not done
      * more than once
-     *
-     * @return void
      */
-    public function testCompile()
+    public function testCompile(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = new Collection($items);
@@ -1245,10 +1163,8 @@ class CollectionTest extends TestCase
     /**
      * Tests converting a non rewindable iterator into a rewindable one using
      * the buffered method.
-     *
-     * @return void
      */
-    public function testBuffered()
+    public function testBuffered(): void
     {
         $items = new NoRewindIterator(new ArrayIterator(['a' => 4, 'b' => 5, 'c' => 6]));
         $buffered = (new Collection($items))->buffered();
@@ -1256,7 +1172,7 @@ class CollectionTest extends TestCase
         $this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $buffered->toArray());
     }
 
-    public function testBufferedIterator()
+    public function testBufferedIterator(): void
     {
         $data = [
             ['myField' => '1'],
@@ -1277,10 +1193,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the combine method
-     *
-     * @return void
      */
-    public function testCombine()
+    public function testCombine(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo', 'parent' => 'a'],
@@ -1323,10 +1237,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the nest method with only one level
-     *
-     * @return void
      */
-    public function testNest()
+    public function testNest(): void
     {
         $items = [
             ['id' => 1, 'parent_id' => null],
@@ -1368,10 +1280,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the nest method with alternate nesting key
-     *
-     * @return void
      */
-    public function testNestAlternateNestingKey()
+    public function testNestAlternateNestingKey(): void
     {
         $items = [
             ['id' => 1, 'parent_id' => null],
@@ -1413,10 +1323,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the nest method with more than one level
-     *
-     * @return void
      */
-    public function testNestMultiLevel()
+    public function testNestMultiLevel(): void
     {
         $items = [
             ['id' => 1, 'parent_id' => null],
@@ -1473,10 +1381,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the nest method with more than one level
-     *
-     * @return void
      */
-    public function testNestMultiLevelAlternateNestingKey()
+    public function testNestMultiLevelAlternateNestingKey(): void
     {
         $items = [
             ['id' => 1, 'parent_id' => null],
@@ -1533,10 +1439,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the nest method with more than one level
-     *
-     * @return void
      */
-    public function testNestObjects()
+    public function testNestObjects(): void
     {
         $items = [
             new ArrayObject(['id' => 1, 'parent_id' => null]),
@@ -1593,10 +1497,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the nest method with more than one level
-     *
-     * @return void
      */
-    public function testNestObjectsAlternateNestingKey()
+    public function testNestObjectsAlternateNestingKey(): void
     {
         $items = [
             new ArrayObject(['id' => 1, 'parent_id' => null]),
@@ -1653,10 +1555,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests insert
-     *
-     * @return void
      */
-    public function testInsert()
+    public function testInsert(): void
     {
         $items = [['a' => 1], ['b' => 2]];
         $collection = new Collection($items);
@@ -1686,9 +1586,8 @@ class CollectionTest extends TestCase
      * Tests the listNested method with the default 'children' nesting key
      *
      * @dataProvider nestedListProvider
-     * @return void
      */
-    public function testListNested(string $dir, array $expected)
+    public function testListNested(string $dir, array $expected): void
     {
         $items = [
             ['id' => 1, 'parent_id' => null],
@@ -1708,10 +1607,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the listNested spacer output.
-     *
-     * @return void
      */
-    public function testListNestedSpacer()
+    public function testListNestedSpacer(): void
     {
         $items = [
             ['id' => 1, 'parent_id' => null, 'name' => 'Birds'],
@@ -1735,10 +1632,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests using listNested with a different nesting key
-     *
-     * @return void
      */
-    public function testListNestedCustomKey()
+    public function testListNestedCustomKey(): void
     {
         $items = [
             ['id' => 1, 'stuff' => [['id' => 2, 'stuff' => [['id' => 3]]]]],
@@ -1750,10 +1645,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests flattening the collection using a custom callable function
-     *
-     * @return void
      */
-    public function testListNestedWithCallable()
+    public function testListNestedWithCallable(): void
     {
         $items = [
             ['id' => 1, 'stuff' => [['id' => 2, 'stuff' => [['id' => 3]]]]],
@@ -1795,9 +1688,8 @@ class CollectionTest extends TestCase
      *
      * @dataProvider sumOfProvider
      * @param float|int $expected
-     * @return void
      */
-    public function testSumOf(iterable $items, $expected)
+    public function testSumOf(iterable $items, $expected): void
     {
         $this->assertEquals($expected, (new Collection($items))->sumOf('invoice.total'));
     }
@@ -1807,9 +1699,8 @@ class CollectionTest extends TestCase
      *
      * @dataProvider sumOfProvider
      * @param float|int $expected
-     * @return void
      */
-    public function testSumOfCallable(iterable $items, $expected)
+    public function testSumOfCallable(iterable $items, $expected): void
     {
         $sum = (new Collection($items))->sumOf(function ($v) {
             return $v['invoice']['total'];
@@ -1821,9 +1712,8 @@ class CollectionTest extends TestCase
      * Tests the stopWhen method with a callable
      *
      * @dataProvider simpleProvider
-     * @return void
      */
-    public function testStopWhenCallable(iterable $items)
+    public function testStopWhenCallable(iterable $items): void
     {
         $collection = (new Collection($items))->stopWhen(function ($v) {
             return $v > 3;
@@ -1833,10 +1723,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the stopWhen method with a matching array
-     *
-     * @return void
      */
-    public function testStopWhenWithArray()
+    public function testStopWhenWithArray(): void
     {
         $items = [
             ['foo' => 'bar'],
@@ -1849,10 +1737,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the unfold method
-     *
-     * @return void
      */
-    public function testUnfold()
+    public function testUnfold(): void
     {
         $items = [
             [1, 2, 3, 4],
@@ -1873,10 +1759,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the unfold method with empty levels
-     *
-     * @return void
      */
-    public function testUnfoldEmptyLevels()
+    public function testUnfoldEmptyLevels(): void
     {
         $items = [[], [1, 2], []];
         $collection = (new Collection($items))->unfold();
@@ -1889,10 +1773,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the unfold when passing a callable
-     *
-     * @return void
      */
-    public function testUnfoldWithCallable()
+    public function testUnfoldWithCallable(): void
     {
         $items = [1, 2, 3];
         $collection = (new Collection($items))->unfold(function ($item) {
@@ -1904,10 +1786,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the through() method
-     *
-     * @return void
      */
-    public function testThrough()
+    public function testThrough(): void
     {
         $items = [1, 2, 3];
         $collection = (new Collection($items))->through(function ($collection) {
@@ -1919,10 +1799,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the through method when it returns an array
-     *
-     * @return void
      */
-    public function testThroughReturnArray()
+    public function testThroughReturnArray(): void
     {
         $items = [1, 2, 3];
         $collection = (new Collection($items))->through(function ($collection) {
@@ -1937,10 +1815,8 @@ class CollectionTest extends TestCase
     /**
      * Tests that the sortBy method does not die when something that is not a
      * collection is passed
-     *
-     * @return void
      */
-    public function testComplexSortBy()
+    public function testComplexSortBy(): void
     {
         $results = collection([3, 7])
             ->unfold(function ($value) {
@@ -1957,10 +1833,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests __debugInfo() or debug() usage
-     *
-     * @return void
      */
-    public function testDebug()
+    public function testDebug(): void
     {
         $items = [1, 2, 3];
 
@@ -1999,10 +1873,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the isEmpty() method
-     *
-     * @return void
      */
-    public function testIsEmpty()
+    public function testIsEmpty(): void
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertFalse($collection->isEmpty());
@@ -2019,10 +1891,8 @@ class CollectionTest extends TestCase
     /**
      * Tests the isEmpty() method does not consume data
      * from buffered iterators.
-     *
-     * @return void
      */
-    public function testIsEmptyDoesNotConsume()
+    public function testIsEmptyDoesNotConsume(): void
     {
         $array = new \ArrayIterator([1, 2, 3]);
         $inner = new \Cake\Collection\Iterator\BufferedIterator($array);
@@ -2033,10 +1903,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the zip() method
-     *
-     * @return void
      */
-    public function testZip()
+    public function testZip(): void
     {
         $collection = new Collection([1, 2]);
         $zipped = $collection->zip([3, 4]);
@@ -2056,10 +1924,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the zipWith() method
-     *
-     * @return void
      */
-    public function testZipWith()
+    public function testZipWith(): void
     {
         $collection = new Collection([1, 2]);
         $zipped = $collection->zipWith([3, 4], function ($a, $b) {
@@ -2075,10 +1941,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the skip() method
-     *
-     * @return void
      */
-    public function testSkip()
+    public function testSkip(): void
     {
         $collection = new Collection([1, 2, 3, 4, 5]);
         $this->assertEquals([3, 4, 5], $collection->skip(2)->toList());
@@ -2090,10 +1954,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test skip() with an overflow
-     *
-     * @return void
      */
-    public function testSkipOverflow()
+    public function testSkipOverflow(): void
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertEquals([], $collection->skip(3)->toArray());
@@ -2102,10 +1964,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the skip() method with a traversable non-iterator
-     *
-     * @return void
      */
-    public function testSkipWithTraversableNonIterator()
+    public function testSkipWithTraversableNonIterator(): void
     {
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $result = $collection->skip(3)->toList();
@@ -2119,10 +1979,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the first() method with a traversable non-iterator
-     *
-     * @return void
      */
-    public function testFirstWithTraversableNonIterator()
+    public function testFirstWithTraversableNonIterator(): void
     {
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $date = $collection->first();
@@ -2132,10 +1990,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the last() method
-     *
-     * @return void
      */
-    public function testLast()
+    public function testLast(): void
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertSame(3, $collection->last());
@@ -2148,10 +2004,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the last() method when on an empty collection
-     *
-     * @return void
      */
-    public function testLastWithEmptyCollection()
+    public function testLastWithEmptyCollection(): void
     {
         $collection = new Collection([]);
         $this->assertNull($collection->last());
@@ -2159,10 +2013,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the last() method with a countable object
-     *
-     * @return void
      */
-    public function testLastWithCountable()
+    public function testLastWithCountable(): void
     {
         $collection = new Collection(new ArrayObject([1, 2, 3]));
         $this->assertSame(3, $collection->last());
@@ -2170,10 +2022,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the last() method with an empty countable object
-     *
-     * @return void
      */
-    public function testLastWithEmptyCountable()
+    public function testLastWithEmptyCountable(): void
     {
         $collection = new Collection(new ArrayObject([]));
         $this->assertNull($collection->last());
@@ -2181,10 +2031,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the last() method with a non-rewindable iterator
-     *
-     * @return void
      */
-    public function testLastWithNonRewindableIterator()
+    public function testLastWithNonRewindableIterator(): void
     {
         $iterator = new NoRewindIterator(new ArrayIterator([1, 2, 3]));
         $collection = new Collection($iterator);
@@ -2193,10 +2041,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the last() method with a traversable non-iterator
-     *
-     * @return void
      */
-    public function testLastWithTraversableNonIterator()
+    public function testLastWithTraversableNonIterator(): void
     {
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $date = $collection->last();
@@ -2209,10 +2055,9 @@ class CollectionTest extends TestCase
      *
      * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @return void
      * @covers ::takeLast
      */
-    public function testLastN($data)
+    public function testLastN($data): void
     {
         $collection = new Collection($data);
         $result = $collection->takeLast(3)->toArray();
@@ -2225,10 +2070,9 @@ class CollectionTest extends TestCase
      *
      * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @return void
      * @covers ::takeLast
      */
-    public function testLastNtWithOverflow($data)
+    public function testLastNtWithOverflow($data): void
     {
         $collection = new Collection($data);
         $result = $collection->takeLast(10)->toArray();
@@ -2241,10 +2085,9 @@ class CollectionTest extends TestCase
      *
      * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @return void
      * @covers ::takeLast
      */
-    public function testLastNtWithOddData($data)
+    public function testLastNtWithOddData($data): void
     {
         $collection = new Collection($data);
         $result = $collection->take(3)->takeLast(2)->toArray();
@@ -2255,10 +2098,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the takeLast() with countable collection
      *
-     * @return void
      * @covers ::takeLast
      */
-    public function testLastNtWithCountable()
+    public function testLastNtWithCountable(): void
     {
         $rangeZeroToFive = range(0, 5);
 
@@ -2276,10 +2118,9 @@ class CollectionTest extends TestCase
      *
      * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @return void
      * @covers ::takeLast
      */
-    public function testLastNtWithNegative($data)
+    public function testLastNtWithNegative($data): void
     {
         $collection = new Collection($data);
         $this->expectException(\InvalidArgumentException::class);
@@ -2289,10 +2130,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests sumOf with no parameters
-     *
-     * @return void
      */
-    public function testSumOfWithIdentity()
+    public function testSumOfWithIdentity(): void
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertSame(6, $collection->sumOf());
@@ -2303,10 +2142,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests using extract with the {*} notation
-     *
-     * @return void
      */
-    public function testUnfoldedExtract()
+    public function testUnfoldedExtract(): void
     {
         $items = [
             ['comments' => [['id' => 1], ['id' => 2]]],
@@ -2356,10 +2193,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests serializing a simple collection
-     *
-     * @return void
      */
-    public function testSerializeSimpleCollection()
+    public function testSerializeSimpleCollection(): void
     {
         $collection = new Collection([1, 2, 3]);
         $serialized = serialize($collection);
@@ -2370,10 +2205,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests serialization when using append
-     *
-     * @return void
      */
-    public function testSerializeWithAppendIterators()
+    public function testSerializeWithAppendIterators(): void
     {
         $collection = new Collection([1, 2, 3]);
         $collection = $collection->append(['a' => 4, 'b' => 5, 'c' => 6]);
@@ -2385,10 +2218,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests serialization when using nested iterators
-     *
-     * @return void
      */
-    public function testSerializeWithNestedIterators()
+    public function testSerializeWithNestedIterators(): void
     {
         $collection = new Collection([1, 2, 3]);
         $collection = $collection->map(function ($e) {
@@ -2407,10 +2238,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests serializing a zip() call
-     *
-     * @return void
      */
-    public function testSerializeWithZipIterator()
+    public function testSerializeWithZipIterator(): void
     {
         $collection = new Collection([4, 5]);
         $collection = $collection->zip([1, 2]);
@@ -2438,9 +2267,8 @@ class CollectionTest extends TestCase
      * Tests the chunk method with exact chunks
      *
      * @dataProvider chunkProvider
-     * @return void
      */
-    public function testChunk(iterable $items)
+    public function testChunk(iterable $items): void
     {
         $collection = new Collection($items);
         $chunked = $collection->chunk(2)->toList();
@@ -2450,10 +2278,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunk method with overflowing chunk size
-     *
-     * @return void
      */
-    public function testChunkOverflow()
+    public function testChunkOverflow(): void
     {
         $collection = new Collection(range(1, 11));
         $chunked = $collection->chunk(2)->toList();
@@ -2463,10 +2289,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunk method with non-scalar items
-     *
-     * @return void
      */
-    public function testChunkNested()
+    public function testChunkNested(): void
     {
         $collection = new Collection([1, 2, 3, [4, 5], 6, [7, [8, 9], 10], 11]);
         $chunked = $collection->chunk(2)->toList();
@@ -2476,10 +2300,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunkWithKeys method with exact chunks
-     *
-     * @return void
      */
-    public function testChunkWithKeys()
+    public function testChunkWithKeys(): void
     {
         $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6]);
         $chunked = $collection->chunkWithKeys(2)->toList();
@@ -2489,10 +2311,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunkWithKeys method with overflowing chunk size
-     *
-     * @return void
      */
-    public function testChunkWithKeysOverflow()
+    public function testChunkWithKeysOverflow(): void
     {
         $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'g' => 7]);
         $chunked = $collection->chunkWithKeys(2)->toList();
@@ -2502,10 +2322,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunkWithKeys method with non-scalar items
-     *
-     * @return void
      */
-    public function testChunkWithKeysNested()
+    public function testChunkWithKeysNested(): void
     {
         $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3, 'd' => [4, 5], 'e' => 6, 'f' => [7, [8, 9], 10], 'g' => 11]);
         $chunked = $collection->chunkWithKeys(2)->toList();
@@ -2515,10 +2333,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunkWithKeys method without preserving keys
-     *
-     * @return void
      */
-    public function testChunkWithKeysNoPreserveKeys()
+    public function testChunkWithKeysNoPreserveKeys(): void
     {
         $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'g' => 7]);
         $chunked = $collection->chunkWithKeys(2, false)->toList();
@@ -2528,10 +2344,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests cartesianProduct
-     *
-     * @return void
      */
-    public function testCartesianProduct()
+    public function testCartesianProduct(): void
     {
         $collection = new Collection([]);
 
@@ -2659,10 +2473,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that an exception is thrown if the cartesian product is called with multidimensional arrays
-     *
-     * @return void
      */
-    public function testCartesianProductMultidimensionalArray()
+    public function testCartesianProductMultidimensionalArray(): void
     {
         $this->expectException(\LogicException::class);
         $collection = new Collection([
@@ -2681,7 +2493,7 @@ class CollectionTest extends TestCase
         $result = $collection->cartesianProduct();
     }
 
-    public function testTranspose()
+    public function testTranspose(): void
     {
         $collection = new Collection([
             ['Products', '2012', '2013', '2014'],
@@ -2703,10 +2515,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that provided arrays do not have even length
-     *
-     * @return void
      */
-    public function testTransposeUnEvenLengthShouldThrowException()
+    public function testTransposeUnEvenLengthShouldThrowException(): void
     {
         $this->expectException(\LogicException::class);
         $collection = new Collection([
@@ -2725,7 +2535,7 @@ class CollectionTest extends TestCase
      * @param iterable $items the elements to be yielded
      * @return \Generator<array>
      */
-    protected function yieldItems(iterable $items)
+    protected function yieldItems(iterable $items): Generator
     {
         foreach ($items as $k => $v) {
             yield $k => $v;
@@ -2737,19 +2547,16 @@ class CollectionTest extends TestCase
      *
      * @param string $start Start date
      * @param string $end End date
-     * @return \DatePeriod
      */
-    protected function datePeriod($start, $end)
+    protected function datePeriod($start, $end): DatePeriod
     {
         return new \DatePeriod(new \DateTime($start), new \DateInterval('P1D'), new \DateTime($end));
     }
 
     /**
      * Tests to ensure that collection classes extending ArrayIterator work as expected.
-     *
-     * @return void
      */
-    public function testArrayIteratorExtend()
+    public function testArrayIteratorExtend(): void
     {
         $iterator = new TestIterator(range(0, 10));
 
@@ -2772,10 +2579,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that elements in a lazy collection are not fetched immediately.
-     *
-     * @return void
      */
-    public function testLazy()
+    public function testLazy(): void
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = (new Collection($items))->lazy();

--- a/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/BufferedIteratorTest.php
@@ -28,10 +28,8 @@ class BufferedIteratorTest extends TestCase
 {
     /**
      * Tests that items are cached once iterated over them
-     *
-     * @return void
      */
-    public function testBufferItems()
+    public function testBufferItems(): void
     {
         $items = new ArrayObject([
             'a' => 1,
@@ -49,10 +47,8 @@ class BufferedIteratorTest extends TestCase
 
     /**
      * Tests that items are cached once iterated over them
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $items = new ArrayObject([
             'a' => 1,
@@ -72,10 +68,8 @@ class BufferedIteratorTest extends TestCase
 
     /**
      * Tests that partial iteration can be reset.
-     *
-     * @return void
      */
-    public function testBufferPartial()
+    public function testBufferPartial(): void
     {
         $items = new ArrayObject([1, 2, 3]);
         $iterator = new BufferedIterator($items);
@@ -93,10 +87,8 @@ class BufferedIteratorTest extends TestCase
 
     /**
      * Testing serialize and unserialize features.
-     *
-     * @return void
      */
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $items = new ArrayObject([
             'a' => 1,

--- a/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ExtractIteratorTest.php
@@ -27,10 +27,8 @@ class ExtractIteratorTest extends TestCase
 {
     /**
      * Tests it is possible to extract a column in the first level of an array
-     *
-     * @return void
      */
-    public function testExtractFromArrayShallow()
+    public function testExtractFromArrayShallow(): void
     {
         $items = [
             ['a' => 1, 'b' => 2],
@@ -48,10 +46,8 @@ class ExtractIteratorTest extends TestCase
 
     /**
      * Tests it is possible to extract a column in the first level of an object
-     *
-     * @return void
      */
-    public function testExtractFromObjectShallow()
+    public function testExtractFromObjectShallow(): void
     {
         $items = [
             new ArrayObject(['a' => 1, 'b' => 2]),
@@ -69,10 +65,8 @@ class ExtractIteratorTest extends TestCase
 
     /**
      * Tests it is possible to extract a column deeply nested in the structure
-     *
-     * @return void
      */
-    public function testExtractFromArrayDeep()
+    public function testExtractFromArrayDeep(): void
     {
         $items = [
             ['a' => ['b' => ['c' => 10]], 'b' => 2],
@@ -86,10 +80,8 @@ class ExtractIteratorTest extends TestCase
 
     /**
      * Tests that it is possible to pass a callable as the extractor.
-     *
-     * @return void
      */
-    public function testExtractWithCallable()
+    public function testExtractWithCallable(): void
     {
         $items = [
             ['a' => 1, 'b' => 2],

--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -26,10 +26,8 @@ class FilterIteratorTest extends TestCase
 {
     /**
      * Tests that the iterator works correctly
-     *
-     * @return void
      */
-    public function testFilter()
+    public function testFilter(): void
     {
         $items = new \ArrayIterator([1, 2, 3]);
         $callable = function ($value, $key, $itemArg) use ($items) {

--- a/tests/TestCase/Collection/Iterator/InsertIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/InsertIteratorTest.php
@@ -26,10 +26,8 @@ class InsertIteratorTest extends TestCase
 {
     /**
      * Test insert simple path
-     *
-     * @return void
      */
-    public function testInsertSimplePath()
+    public function testInsertSimplePath(): void
     {
         $items = [
             'a' => ['name' => 'Derp'],
@@ -47,10 +45,8 @@ class InsertIteratorTest extends TestCase
 
     /**
      * Test insert deep path
-     *
-     * @return void
      */
-    public function testInsertDeepPath()
+    public function testInsertDeepPath(): void
     {
         $items = [
             'a' => ['name' => 'Derp', 'a' => ['deep' => ['thing' => 1]]],
@@ -68,10 +64,8 @@ class InsertIteratorTest extends TestCase
 
     /**
      * Test that missing properties in the path will skip inserting
-     *
-     * @return void
      */
-    public function testInsertDeepPathMissingStep()
+    public function testInsertDeepPathMissingStep(): void
     {
         $items = [
             'a' => ['name' => 'Derp', 'a' => ['deep' => ['thing' => 1]]],
@@ -90,10 +84,8 @@ class InsertIteratorTest extends TestCase
     /**
      * Tests that the iterator will insert values as long as there still exist
      * some in the values array
-     *
-     * @return void
      */
-    public function testInsertTargetCountBigger()
+    public function testInsertTargetCountBigger(): void
     {
         $items = [
             'a' => ['name' => 'Derp'],
@@ -112,10 +104,8 @@ class InsertIteratorTest extends TestCase
     /**
      * Tests that the iterator will insert values as long as there still exist
      * some in the values array
-     *
-     * @return void
      */
-    public function testInsertSourceBigger()
+    public function testInsertSourceBigger(): void
     {
         $items = [
             'a' => ['name' => 'Derp'],
@@ -133,10 +123,8 @@ class InsertIteratorTest extends TestCase
 
     /**
      * Tests the iterator can be rewound
-     *
-     * @return void
      */
-    public function testRewind()
+    public function testRewind(): void
     {
         $items = [
             'a' => ['name' => 'Derp'],

--- a/tests/TestCase/Collection/Iterator/MapReduceTest.php
+++ b/tests/TestCase/Collection/Iterator/MapReduceTest.php
@@ -27,23 +27,21 @@ class MapReduceTest extends TestCase
     /**
      * Tests the creation of an inversed index of words to documents using
      * MapReduce
-     *
-     * @return void
      */
-    public function testInvertedIndexCreation()
+    public function testInvertedIndexCreation(): void
     {
         $data = [
             'document_1' => 'Dogs are the most amazing animal in history',
             'document_2' => 'History is not only amazing but boring',
             'document_3' => 'One thing that is not boring is dogs',
         ];
-        $mapper = function ($row, $document, $mr) {
+        $mapper = function ($row, $document, $mr): void {
             $words = array_map('strtolower', explode(' ', $row));
             foreach ($words as $word) {
                 $mr->emitIntermediate($document, $word);
             }
         };
-        $reducer = function ($documents, $word, $mr) {
+        $reducer = function ($documents, $word, $mr): void {
             $mr->emit(array_unique($documents), $word);
         };
         $results = new MapReduce(new ArrayIterator($data), $mapper, $reducer);
@@ -70,13 +68,11 @@ class MapReduceTest extends TestCase
 
     /**
      * Tests that it is possible to use the emit function directly in the mapper
-     *
-     * @return void
      */
-    public function testEmitFinalInMapper()
+    public function testEmitFinalInMapper(): void
     {
         $data = ['a' => ['one', 'two'], 'b' => ['three', 'four']];
-        $mapper = function ($row, $key, $mr) {
+        $mapper = function ($row, $key, $mr): void {
             foreach ($row as $number) {
                 $mr->emit($number);
             }
@@ -88,14 +84,12 @@ class MapReduceTest extends TestCase
 
     /**
      * Tests that a reducer is required when there are intermediate results
-     *
-     * @return void
      */
-    public function testReducerRequired()
+    public function testReducerRequired(): void
     {
         $this->expectException(\LogicException::class);
         $data = ['a' => ['one', 'two'], 'b' => ['three', 'four']];
-        $mapper = function ($row, $key, $mr) {
+        $mapper = function ($row, $key, $mr): void {
             foreach ($row as $number) {
                 $mr->emitIntermediate('a', $number);
             }

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -26,10 +26,8 @@ class ReplaceIteratorTest extends TestCase
 {
     /**
      * Tests that the iterator works correctly
-     *
-     * @return void
      */
-    public function testReplace()
+    public function testReplace(): void
     {
         $items = new \ArrayIterator([1, 2, 3]);
         $callable = function ($value, $key, $itemsArg) use ($items) {

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -27,10 +27,8 @@ class SortIteratorTest extends TestCase
 {
     /**
      * Tests sorting numbers with an identity callbacks
-     *
-     * @return void
      */
-    public function testSortNumbersIdentity()
+    public function testSortNumbersIdentity(): void
     {
         $items = new ArrayObject([3, 5, 1, 2, 4]);
         $identity = function ($a) {
@@ -47,10 +45,8 @@ class SortIteratorTest extends TestCase
 
     /**
      * Tests sorting numbers with custom callback
-     *
-     * @return void
      */
-    public function testSortNumbersCustom()
+    public function testSortNumbersCustom(): void
     {
         $items = new ArrayObject([3, 5, 1, 2, 4]);
         $callback = function ($a) {
@@ -67,10 +63,8 @@ class SortIteratorTest extends TestCase
 
     /**
      * Tests sorting a complex structure with numeric sort
-     *
-     * @return void
      */
-    public function testSortComplexNumeric()
+    public function testSortComplexNumeric(): void
     {
         $items = new ArrayObject([
             ['foo' => 1, 'bar' => 'a'],
@@ -102,10 +96,8 @@ class SortIteratorTest extends TestCase
 
     /**
      * Tests sorting a complex structure with natural sort
-     *
-     * @return void
      */
-    public function testSortComplexNatural()
+    public function testSortComplexNatural(): void
     {
         $items = new ArrayObject([
             ['foo' => 'foo_1', 'bar' => 'a'],
@@ -138,10 +130,8 @@ class SortIteratorTest extends TestCase
 
     /**
      * Tests sorting a complex structure with natural sort with string callback
-     *
-     * @return void
      */
-    public function testSortComplexNaturalWithPath()
+    public function testSortComplexNaturalWithPath(): void
     {
         $items = new ArrayObject([
             ['foo' => 'foo_1', 'bar' => 'a'],
@@ -171,10 +161,8 @@ class SortIteratorTest extends TestCase
 
     /**
      * Tests sorting a complex structure with a deep path
-     *
-     * @return void
      */
-    public function testSortComplexDeepPath()
+    public function testSortComplexDeepPath(): void
     {
         $items = new ArrayObject([
             ['foo' => ['bar' => 1], 'bar' => 'a'],
@@ -194,10 +182,8 @@ class SortIteratorTest extends TestCase
 
     /**
      * Tests sorting datetime
-     *
-     * @return void
      */
-    public function testSortDateTime()
+    public function testSortDateTime(): void
     {
         $items = new ArrayObject([
             new \DateTime('2014-07-21'),

--- a/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/TreeIteratorTest.php
@@ -27,10 +27,8 @@ class TreeIteratorTest extends TestCase
 {
     /**
      * Tests the printer function with defaults
-     *
-     * @return void
      */
-    public function testPrinter()
+    public function testPrinter(): void
     {
         $items = [
             [
@@ -56,10 +54,8 @@ class TreeIteratorTest extends TestCase
 
     /**
      * Tests the printer function with a custom key extractor and spacer
-     *
-     * @return void
      */
-    public function testPrinterCustomKeyAndSpacer()
+    public function testPrinterCustomKeyAndSpacer(): void
     {
         $items = [
             [
@@ -85,10 +81,8 @@ class TreeIteratorTest extends TestCase
 
     /**
      * Tests the printer function with a closure extractor
-     *
-     * @return void
      */
-    public function testPrinterWithClosure()
+    public function testPrinterWithClosure(): void
     {
         $items = [
             [

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -30,8 +30,6 @@ class CacheCommandsTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,8 +41,6 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,10 +50,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test help output
-     *
-     * @return void
      */
-    public function testClearHelp()
+    public function testClearHelp(): void
     {
         $this->exec('cache clear -h');
 
@@ -67,10 +61,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test help output
-     *
-     * @return void
      */
-    public function testClearAllHelp()
+    public function testClearAllHelp(): void
     {
         $this->exec('cache clear_all -h');
 
@@ -80,10 +72,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test list output
-     *
-     * @return void
      */
-    public function testList()
+    public function testList(): void
     {
         $this->exec('cache list');
 
@@ -95,10 +85,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test help output
-     *
-     * @return void
      */
-    public function testListHelp()
+    public function testListHelp(): void
     {
         $this->exec('cache list -h');
 
@@ -108,10 +96,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test that clear() throws \Cake\Console\Exception\StopException if cache prefix is invalid
-     *
-     * @return void
      */
-    public function testClearInvalidPrefix()
+    public function testClearInvalidPrefix(): void
     {
         $this->exec('cache clear foo');
         $this->assertExitCode(Shell::CODE_ERROR);
@@ -120,10 +106,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test that clear() clears the specified cache when a valid prefix is used
-     *
-     * @return void
      */
-    public function testClearValidPrefix()
+    public function testClearValidPrefix(): void
     {
         Cache::add('key', 'value', 'test');
         $this->exec('cache clear test');
@@ -134,10 +118,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test that clear() only clears the specified cache
-     *
-     * @return void
      */
-    public function testClearIgnoresOtherCaches()
+    public function testClearIgnoresOtherCaches(): void
     {
         Cache::add('key', 'value', 'test');
         $this->exec('cache clear _cake_core_');
@@ -148,10 +130,8 @@ class CacheCommandsTest extends TestCase
 
     /**
      * Test that clearAll() clears values from all defined caches
-     *
-     * @return void
      */
-    public function testClearAll()
+    public function testClearAll(): void
     {
         Cache::add('key', 'value1', 'test');
         Cache::add('key', 'value3', '_cake_core_');

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -31,8 +31,6 @@ class CompletionCommandTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -45,8 +43,6 @@ class CompletionCommandTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -57,10 +53,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that the startup method suppresses the command header
-     *
-     * @return void
      */
-    public function testStartup()
+    public function testStartup(): void
     {
         $this->exec('completion');
         $this->assertExitCode(Command::CODE_ERROR);
@@ -70,10 +64,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test commands method that list all available commands
-     *
-     * @return void
      */
-    public function testCommands()
+    public function testCommands(): void
     {
         $this->exec('completion commands');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -109,10 +101,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that options without argument returns nothing
-     *
-     * @return void
      */
-    public function testOptionsNoArguments()
+    public function testOptionsNoArguments(): void
     {
         $this->exec('completion options');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -121,10 +111,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that options with a nonexistent command returns nothing
-     *
-     * @return void
      */
-    public function testOptionsNonExistentCommand()
+    public function testOptionsNonExistentCommand(): void
     {
         $this->exec('completion options foo');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -133,10 +121,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that options with an existing command returns the proper options
-     *
-     * @return void
      */
-    public function testOptionsCommand()
+    public function testOptionsCommand(): void
     {
         $this->exec('completion options schema_cache');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -154,10 +140,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that options with an existing command / subcommand pair returns the proper options
-     *
-     * @return void
      */
-    public function testOptionsShellTask()
+    public function testOptionsShellTask(): void
     {
         //details: https://github.com/cakephp/cakephp/pull/13533
         $this->markTestIncomplete(
@@ -179,10 +163,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that options with an existing command / subcommand pair returns the proper options
-     *
-     * @return void
      */
-    public function testOptionsSubCommand()
+    public function testOptionsSubCommand(): void
     {
         $this->exec('completion options cache list');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -199,10 +181,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that nested command returns subcommand's options not command.
-     *
-     * @return void
      */
-    public function testOptionsNestedCommand()
+    public function testOptionsNestedCommand(): void
     {
         $this->exec('completion options i18n extract');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -218,10 +198,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subCommands with a existing CORE command returns the proper sub commands
-     *
-     * @return void
      */
-    public function testSubCommandsCorePlugin()
+    public function testSubCommandsCorePlugin(): void
     {
         $this->exec('completion subcommands schema_cache');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -232,10 +210,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subCommands with a existing APP command returns the proper sub commands (in this case none)
-     *
-     * @return void
      */
-    public function testSubCommandsAppPlugin()
+    public function testSubCommandsAppPlugin(): void
     {
         $this->exec('completion subcommands sample');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -260,10 +236,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subCommands with a existing CORE command
-     *
-     * @return void
      */
-    public function testSubCommandsCoreMultiwordCommand()
+    public function testSubCommandsCoreMultiwordCommand(): void
     {
         $this->exec('completion subcommands cache');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -279,10 +253,8 @@ class CompletionCommandTest extends TestCase
     /**
      * test that subCommands with an existing plugin command returns the proper sub commands
      * when the Shell name is unique and the dot notation not mandatory
-     *
-     * @return void
      */
-    public function testSubCommandsPlugin()
+    public function testSubCommandsPlugin(): void
     {
         $this->exec('completion subcommands welcome');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -293,10 +265,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that using the dot notation when not mandatory works to provide backward compatibility
-     *
-     * @return void
      */
-    public function testSubCommandsPluginDotNotationBackwardCompatibility()
+    public function testSubCommandsPluginDotNotationBackwardCompatibility(): void
     {
         $this->exec('completion subcommands test_plugin_two.welcome');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -307,10 +277,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subCommands with an existing plugin command returns the proper sub commands
-     *
-     * @return void
      */
-    public function testSubCommandsPluginDotNotation()
+    public function testSubCommandsPluginDotNotation(): void
     {
         $this->exec('completion subcommands test_plugin_two.example');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -322,10 +290,8 @@ class CompletionCommandTest extends TestCase
     /**
      * test that subCommands with an app shell that is also defined in a plugin and without the prefix "app."
      * returns proper sub commands
-     *
-     * @return void
      */
-    public function testSubCommandsAppDuplicatePluginNoDot()
+    public function testSubCommandsAppDuplicatePluginNoDot(): void
     {
         $this->exec('completion subcommands sample');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -343,10 +309,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subCommands with a plugin shell that is also defined in the returns proper sub commands
-     *
-     * @return void
      */
-    public function testSubCommandsPluginDuplicateApp()
+    public function testSubCommandsPluginDuplicateApp(): void
     {
         $this->exec('completion subcommands test_plugin.sample');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -357,10 +321,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subcommands without arguments returns nothing
-     *
-     * @return void
      */
-    public function testSubCommandsNoArguments()
+    public function testSubCommandsNoArguments(): void
     {
         $this->exec('completion subcommands');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -370,10 +332,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subcommands with a nonexistent command returns nothing
-     *
-     * @return void
      */
-    public function testSubCommandsNonExistentCommand()
+    public function testSubCommandsNonExistentCommand(): void
     {
         $this->exec('completion subcommands foo');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -383,10 +343,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that subcommands returns the available subcommands for the given command
-     *
-     * @return void
      */
-    public function testSubCommands()
+    public function testSubCommands(): void
     {
         $this->exec('completion subcommands schema_cache');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -397,10 +355,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that fuzzy returns nothing
-     *
-     * @return void
      */
-    public function testFuzzy()
+    public function testFuzzy(): void
     {
         $this->exec('completion fuzzy');
         $this->assertOutputEmpty();
@@ -408,10 +364,8 @@ class CompletionCommandTest extends TestCase
 
     /**
      * test that help returns content
-     *
-     * @return void
      */
-    public function testHelp()
+    public function testHelp(): void
     {
         $this->exec('completion --help');
         $this->assertExitCode(Command::CODE_SUCCESS);

--- a/tests/TestCase/Command/I18nCommandTest.php
+++ b/tests/TestCase/Command/I18nCommandTest.php
@@ -33,8 +33,6 @@ class I18nCommandTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class I18nCommandTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,10 +64,8 @@ class I18nCommandTest extends TestCase
 
     /**
      * Tests that init() creates the PO files from POT files.
-     *
-     * @return void
      */
-    public function testInit()
+    public function testInit(): void
     {
         $deDir = $this->localeDir . 'de_DE' . DS;
         if (!is_dir($deDir)) {
@@ -99,10 +93,8 @@ class I18nCommandTest extends TestCase
 
     /**
      * Test that the option parser is shaped right.
-     *
-     * @return void
      */
-    public function testGetOptionParser()
+    public function testGetOptionParser(): void
     {
         $this->exec('i18n -h');
 
@@ -112,10 +104,8 @@ class I18nCommandTest extends TestCase
 
     /**
      * Tests main interactive mode
-     *
-     * @return void
      */
-    public function testInteractiveQuit()
+    public function testInteractiveQuit(): void
     {
         $this->exec('i18n', ['q']);
         $this->assertExitSuccess();
@@ -123,10 +113,8 @@ class I18nCommandTest extends TestCase
 
     /**
      * Tests main interactive mode
-     *
-     * @return void
      */
-    public function testInteractiveHelp()
+    public function testInteractiveHelp(): void
     {
         $this->exec('i18n', ['h', 'q']);
         $this->assertExitSuccess();
@@ -135,10 +123,8 @@ class I18nCommandTest extends TestCase
 
     /**
      * Tests main interactive mode
-     *
-     * @return void
      */
-    public function testInteractiveInit()
+    public function testInteractiveInit(): void
     {
         $this->exec('i18n', [
             'i',

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -35,8 +35,6 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,8 +50,6 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -66,10 +62,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * testExecute method
-     *
-     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -135,10 +129,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * testExecute with no paths
-     *
-     * @return void
      */
-    public function testExecuteNoPathOption()
+    public function testExecuteNoPathOption(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -156,10 +148,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * testExecute with merging on method
-     *
-     * @return void
      */
-    public function testExecuteMerge()
+    public function testExecuteMerge(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -176,10 +166,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * test exclusions
-     *
-     * @return void
      */
-    public function testExtractWithExclude()
+    public function testExtractWithExclude(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -201,10 +189,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * testExtractWithoutLocations method
-     *
-     * @return void
      */
-    public function testExtractWithoutLocations()
+    public function testExtractWithoutLocations(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -225,10 +211,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * test extract can read more than one path.
-     *
-     * @return void
      */
-    public function testExtractMultiplePaths()
+    public function testExtractMultiplePaths(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -247,10 +231,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * Tests that it is possible to exclude plugin paths by enabling the param option for the ExtractTask
-     *
-     * @return void
      */
-    public function testExtractExcludePlugins()
+    public function testExtractExcludePlugins(): void
     {
         static::setAppNamespace();
         $this->exec(
@@ -268,10 +250,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * Test that is possible to extract messages from a single plugin
-     *
-     * @return void
      */
-    public function testExtractPlugin()
+    public function testExtractPlugin(): void
     {
         Configure::write('Plugins.autoload', ['TestPlugin']);
 
@@ -291,10 +271,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * Test that is possible to extract messages from a vendored plugin.
-     *
-     * @return void
      */
-    public function testExtractVendoredPlugin()
+    public function testExtractVendoredPlugin(): void
     {
         $this->loadPlugins(['Company/TestPluginThree']);
 
@@ -314,10 +292,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * Test that the extract shell overwrites existing files with the overwrite parameter
-     *
-     * @return void
      */
-    public function testExtractOverwrite()
+    public function testExtractOverwrite(): void
     {
         file_put_contents($this->path . DS . 'default.pot', 'will be overwritten');
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -338,10 +314,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      *  Test that the extract shell scans the core libs
-     *
-     * @return void
      */
-    public function testExtractCore()
+    public function testExtractCore(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -366,7 +340,7 @@ class I18nExtractCommandTest extends TestCase
      * When marker-error is unset, it's already test
      * with other functions like testExecute that not detects error because err never called
      */
-    public function testMarkerErrorSets()
+    public function testMarkerErrorSets(): void
     {
         $this->exec(
             'i18n extract ' .
@@ -383,10 +357,8 @@ class I18nExtractCommandTest extends TestCase
 
     /**
      * test relative-paths option
-     *
-     * @return void
      */
-    public function testExtractWithRelativePaths()
+    public function testExtractWithRelativePaths(): void
     {
         $this->exec(
             'i18n extract ' .

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -44,8 +44,6 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -65,8 +63,6 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -76,10 +72,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testSymlink method
-     *
-     * @return void
      */
-    public function testSymlink()
+    public function testSymlink(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
@@ -95,10 +89,7 @@ class PluginAssetsCommandsTest extends TestCase
         $this->assertTrue(is_link($path));
     }
 
-    /**
-     * @return void
-     */
-    public function testSymlinkWhenVendorDirectoryExists()
+    public function testSymlinkWhenVendorDirectoryExists(): void
     {
         $this->loadPlugins(['Company/TestPluginThree']);
 
@@ -114,10 +105,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testSymlinkWhenTargetAlreadyExits
-     *
-     * @return void
      */
-    public function testSymlinkWhenTargetAlreadyExits()
+    public function testSymlinkWhenTargetAlreadyExits(): void
     {
         $this->loadPlugins(['TestTheme']);
 
@@ -144,10 +133,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * test that plugins without webroot are not processed
-     *
-     * @return void
      */
-    public function testForPluginWithoutWebroot()
+    public function testForPluginWithoutWebroot(): void
     {
         $this->loadPlugins(['TestPluginTwo']);
 
@@ -157,10 +144,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testSymlinkingSpecifiedPlugin
-     *
-     * @return void
      */
-    public function testSymlinkingSpecifiedPlugin()
+    public function testSymlinkingSpecifiedPlugin(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
@@ -177,10 +162,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testCopy
-     *
-     * @return void
      */
-    public function testCopy()
+    public function testCopy(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
@@ -197,10 +180,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testCopyOverwrite
-     *
-     * @return void
      */
-    public function testCopyOverwrite()
+    public function testCopyOverwrite(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false]]);
 
@@ -226,10 +207,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testRemoveSymlink method
-     *
-     * @return void
      */
-    public function testRemoveSymlink()
+    public function testRemoveSymlink(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
@@ -251,10 +230,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testRemoveFolder method
-     *
-     * @return void
      */
-    public function testRemoveFolder()
+    public function testRemoveFolder(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 
@@ -273,10 +250,8 @@ class PluginAssetsCommandsTest extends TestCase
 
     /**
      * testOverwrite
-     *
-     * @return void
      */
-    public function testOverwrite()
+    public function testOverwrite(): void
     {
         $this->loadPlugins(['TestPlugin' => ['routes' => false], 'Company/TestPluginThree']);
 

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -38,8 +38,6 @@ class PluginLoadCommandTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -54,8 +52,6 @@ class PluginLoadCommandTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -66,10 +62,8 @@ class PluginLoadCommandTest extends TestCase
 
     /**
      * Test generating help succeeds
-     *
-     * @return void
      */
-    public function testHelp()
+    public function testHelp(): void
     {
         $this->exec('plugin load --help');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -78,10 +72,8 @@ class PluginLoadCommandTest extends TestCase
 
     /**
      * Test loading a plugin modifies the app
-     *
-     * @return void
      */
-    public function testLoadModifiesApplication()
+    public function testLoadModifiesApplication(): void
     {
         $this->exec('plugin load TestPlugin');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -92,10 +84,8 @@ class PluginLoadCommandTest extends TestCase
 
     /**
      * Test loading an unknown plugin
-     *
-     * @return void
      */
-    public function testLoadUnknownPlugin()
+    public function testLoadUnknownPlugin(): void
     {
         $this->exec('plugin load NopeNotThere');
         $this->assertExitCode(Command::CODE_ERROR);

--- a/tests/TestCase/Command/PluginLoadedCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadedCommandTest.php
@@ -30,8 +30,6 @@ class PluginLoadedCommandTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class PluginLoadedCommandTest extends TestCase
 
     /**
      * Tests that list of loaded plugins is shown with loaded command.
-     *
-     * @return void
      */
-    public function testLoaded()
+    public function testLoaded(): void
     {
         $expected = Plugin::loaded();
 

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -38,8 +38,6 @@ class PluginUnloadCommandTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -54,8 +52,6 @@ class PluginUnloadCommandTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -67,10 +63,8 @@ class PluginUnloadCommandTest extends TestCase
 
     /**
      * testUnload
-     *
-     * @return void
      */
-    public function testUnload()
+    public function testUnload(): void
     {
         $plugin1 = "\$this->addPlugin('TestPlugin', ['bootstrap' => false, 'routes' => false]);";
         $plugin2 = "\$this->addPlugin('TestPluginTwo', ['bootstrap' => false, 'routes' => false]);";
@@ -87,10 +81,8 @@ class PluginUnloadCommandTest extends TestCase
 
     /**
      * test removing the first plugin leaves the second behind.
-     *
-     * @return void
      */
-    public function testUnloadFirstPlugin()
+    public function testUnloadFirstPlugin(): void
     {
         $plugin1 = "\$this->addPlugin('TestPlugin');";
         $plugin2 = "\$this->addPlugin('Vendor/TestPluginTwo');";
@@ -165,9 +157,8 @@ class PluginUnloadCommandTest extends TestCase
      * This method will tests multiple notations of plugin loading in the application class
      *
      * @dataProvider variantProvider
-     * @return void
      */
-    public function testRegularExpressionsApplication(string $content)
+    public function testRegularExpressionsApplication(string $content): void
     {
         $this->addPluginToApp($content);
 
@@ -187,9 +178,8 @@ class PluginUnloadCommandTest extends TestCase
      * This is useful for the tests
      *
      * @param string $insert The addPlugin line to add.
-     * @return void
      */
-    protected function addPluginToApp($insert)
+    protected function addPluginToApp($insert): void
     {
         $contents = file_get_contents($this->app);
         $contents = preg_replace('/(function bootstrap\(\)(?:\s*)\:(?:\s*)void(?:\s+)\{)/m', "\$1\n        " . $insert, $contents);

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -31,8 +31,6 @@ class RoutesCommandTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,8 +41,6 @@ class RoutesCommandTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,10 +50,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Ensure help for `routes` works
-     *
-     * @return void
      */
-    public function testRouteListHelp()
+    public function testRouteListHelp(): void
     {
         $this->exec('routes -h');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -67,10 +61,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test checking an nonexistent route.
-     *
-     * @return void
      */
-    public function testRouteList()
+    public function testRouteList(): void
     {
         $this->exec('routes');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -114,10 +106,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test routes with --verbose option
-     *
-     * @return void
      */
-    public function testRouteListVerbose()
+    public function testRouteListVerbose(): void
     {
         $this->exec('routes -v');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -145,10 +135,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test routes with --sort option
-     *
-     * @return void
      */
-    public function testRouteListSorted()
+    public function testRouteListSorted(): void
     {
         Router::connect(
             new Route('/a/route/sorted', [], ['_name' => '_aRoute'])
@@ -161,10 +149,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Ensure help for `routes` works
-     *
-     * @return void
      */
-    public function testCheckHelp()
+    public function testCheckHelp(): void
     {
         $this->exec('routes check -h');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -174,10 +160,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Ensure routes check with no input
-     *
-     * @return void
      */
-    public function testCheckNoInput()
+    public function testCheckNoInput(): void
     {
         $this->exec('routes check');
         $this->assertExitCode(Command::CODE_ERROR);
@@ -186,10 +170,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test checking an existing route.
-     *
-     * @return void
      */
-    public function testCheck()
+    public function testCheck(): void
     {
         $this->exec('routes check /app/articles/check');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -207,10 +189,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test checking an existing route with named route.
-     *
-     * @return void
      */
-    public function testCheckWithNamedRoute()
+    public function testCheckWithNamedRoute(): void
     {
         $this->exec('routes check /app/tests/index');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -228,10 +208,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test checking an existing route with redirect route.
-     *
-     * @return void
      */
-    public function testCheckWithRedirectRoute()
+    public function testCheckWithRedirectRoute(): void
     {
         $this->exec('routes check /app/redirect');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -247,10 +225,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test checking an nonexistent route.
-     *
-     * @return void
      */
-    public function testCheckNotFound()
+    public function testCheckNotFound(): void
     {
         $this->exec('routes check /nope');
         $this->assertExitCode(Command::CODE_ERROR);
@@ -259,10 +235,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Ensure help for `routes` works
-     *
-     * @return void
      */
-    public function testGenerareHelp()
+    public function testGenerareHelp(): void
     {
         $this->exec('routes generate -h');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -272,10 +246,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test generating URLs
-     *
-     * @return void
      */
-    public function testGenerateNoPassArgs()
+    public function testGenerateNoPassArgs(): void
     {
         $this->exec('routes generate controller:Articles action:index');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -285,10 +257,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test generating URLs with passed arguments
-     *
-     * @return void
      */
-    public function testGeneratePassedArguments()
+    public function testGeneratePassedArguments(): void
     {
         $this->exec('routes generate controller:Articles action:view 2 3');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -298,10 +268,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test generating URLs with bool params
-     *
-     * @return void
      */
-    public function testGenerateBoolParams()
+    public function testGenerateBoolParams(): void
     {
         $this->exec('routes generate controller:Articles action:index _ssl:true _host:example.com');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -310,10 +278,8 @@ class RoutesCommandTest extends TestCase
 
     /**
      * Test generating URLs
-     *
-     * @return void
      */
-    public function testGenerateMissing()
+    public function testGenerateMissing(): void
     {
         $this->exec('routes generate plugin:Derp controller:Derp');
         $this->assertExitCode(Command::CODE_ERROR);

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -48,8 +48,6 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -68,8 +66,6 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -82,10 +78,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test that clear enables the cache if it was disabled.
-     *
-     * @return void
      */
-    public function testClearEnablesMetadataCache()
+    public function testClearEnablesMetadataCache(): void
     {
         $this->connection->cacheMetadata(false);
 
@@ -96,10 +90,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test that build enables the cache if it was disabled.
-     *
-     * @return void
      */
-    public function testBuildEnablesMetadataCache()
+    public function testBuildEnablesMetadataCache(): void
     {
         $this->connection->cacheMetadata(false);
 
@@ -110,10 +102,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test build() with no args.
-     *
-     * @return void
      */
-    public function testBuildNoArgs()
+    public function testBuildNoArgs(): void
     {
         $this->cache->expects($this->atLeastOnce())
             ->method('set')
@@ -126,10 +116,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test build() with one arg.
-     *
-     * @return void
      */
-    public function testBuildNamedModel()
+    public function testBuildNamedModel(): void
     {
         $this->cache->expects($this->once())
             ->method('set')
@@ -145,10 +133,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test build() overwrites cached data.
-     *
-     * @return void
      */
-    public function testBuildOverwritesExistingData()
+    public function testBuildOverwritesExistingData(): void
     {
         $this->cache->expects($this->once())
             ->method('set')
@@ -166,10 +152,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test build() with a nonexistent connection name.
-     *
-     * @return void
      */
-    public function testBuildInvalidConnection()
+    public function testBuildInvalidConnection(): void
     {
         $this->exec('schema_cache build --connection derpy-derp articles');
         $this->assertExitError();
@@ -177,10 +161,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test clear() with an invalid connection name.
-     *
-     * @return void
      */
-    public function testClearInvalidConnection()
+    public function testClearInvalidConnection(): void
     {
         $this->exec('schema_cache clear --connection derpy-derp articles');
         $this->assertExitError();
@@ -188,10 +170,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test clear() with no args.
-     *
-     * @return void
      */
-    public function testClearNoArgs()
+    public function testClearNoArgs(): void
     {
         $this->cache->expects($this->atLeastOnce())
             ->method('delete')
@@ -204,10 +184,8 @@ class SchemaCacheCommandsTest extends TestCase
 
     /**
      * Test clear() with a model name.
-     *
-     * @return void
      */
-    public function testClearNamedModel()
+    public function testClearNamedModel(): void
     {
         $this->cache->expects($this->never())
             ->method('set')

--- a/tests/TestCase/Command/ServerCommandTest.php
+++ b/tests/TestCase/Command/ServerCommandTest.php
@@ -31,8 +31,6 @@ class ServerCommandTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,10 +40,8 @@ class ServerCommandTest extends TestCase
 
     /**
      * Test that the option parser is shaped right.
-     *
-     * @return void
      */
-    public function testGetOptionParser()
+    public function testGetOptionParser(): void
     {
         $parser = $this->command->getOptionParser();
         $options = $parser->options();

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -26,10 +26,8 @@ class ArgumentsTest extends TestCase
 {
     /**
      * Get all arguments
-     *
-     * @return void
      */
-    public function testGetArguments()
+    public function testGetArguments(): void
     {
         $values = ['big', 'brown', 'bear'];
         $args = new Arguments($values, [], []);
@@ -38,10 +36,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * Get arguments by index
-     *
-     * @return void
      */
-    public function testGetArgumentAt()
+    public function testGetArgumentAt(): void
     {
         $values = ['big', 'brown', 'bear'];
         $args = new Arguments($values, [], []);
@@ -52,10 +48,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * check arguments by index
-     *
-     * @return void
      */
-    public function testHasArgumentAt()
+    public function testHasArgumentAt(): void
     {
         $values = ['big', 'brown', 'bear'];
         $args = new Arguments($values, [], []);
@@ -67,10 +61,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * check arguments by name
-     *
-     * @return void
      */
-    public function testHasArgument()
+    public function testHasArgument(): void
     {
         $values = ['big', 'brown', 'bear'];
         $names = ['size', 'color', 'species', 'odd'];
@@ -84,10 +76,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * get arguments by name
-     *
-     * @return void
      */
-    public function testGetArgument()
+    public function testGetArgument(): void
     {
         $values = ['big', 'brown', 'bear'];
         $names = ['size', 'color', 'species', 'odd'];
@@ -100,10 +90,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * get arguments missing value
-     *
-     * @return void
      */
-    public function testGetArgumentMissing()
+    public function testGetArgumentMissing(): void
     {
         $values = [];
         $names = ['size', 'color'];
@@ -114,10 +102,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * test getOptions()
-     *
-     * @return void
      */
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $options = [
             'verbose' => true,
@@ -130,10 +116,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * test hasOption()
-     *
-     * @return void
      */
-    public function testHasOption()
+    public function testHasOption(): void
     {
         $options = [
             'verbose' => true,
@@ -151,10 +135,8 @@ class ArgumentsTest extends TestCase
 
     /**
      * test getOption()
-     *
-     * @return void
      */
-    public function testGetOption()
+    public function testGetOption(): void
     {
         $options = [
             'verbose' => true,

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -31,8 +31,6 @@ class HelpCommandTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -50,8 +48,6 @@ class HelpCommandTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -61,10 +57,8 @@ class HelpCommandTest extends TestCase
 
     /**
      * Test the command listing fallback when no commands are set
-     *
-     * @return void
      */
-    public function testMainNoCommandsFallback()
+    public function testMainNoCommandsFallback(): void
     {
         $this->exec('help');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -74,10 +68,8 @@ class HelpCommandTest extends TestCase
 
     /**
      * Test the command listing
-     *
-     * @return void
      */
-    public function testMain()
+    public function testMain(): void
     {
         $this->exec('help');
         $this->assertExitCode(Command::CODE_SUCCESS);
@@ -86,10 +78,8 @@ class HelpCommandTest extends TestCase
 
     /**
      * Assert the help output.
-     *
-     * @return void
      */
-    protected function assertCommandList()
+    protected function assertCommandList(): void
     {
         $this->assertOutputContains('<info>TestPlugin</info>', 'plugin header should appear');
         $this->assertOutputContains('- widget', 'plugin command should appear');
@@ -109,10 +99,8 @@ class HelpCommandTest extends TestCase
 
     /**
      * Test help --xml
-     *
-     * @return void
      */
-    public function testMainAsXml()
+    public function testMainAsXml(): void
     {
         $this->exec('help --xml');
         $this->assertExitCode(Command::CODE_SUCCESS);

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -39,10 +39,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Test constructor with valid classnames
-     *
-     * @return void
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $collection = new CommandCollection([
             'sample' => SampleShell::class,
@@ -55,10 +53,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Constructor with invalid class names should blow up
-     *
-     * @return void
      */
-    public function testConstructorInvalidClass()
+    public function testConstructorInvalidClass(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'nope\'. It is not a subclass of Cake\Console\Shell');
@@ -70,10 +66,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Test basic add/get
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $collection = new CommandCollection();
         $this->assertSame($collection, $collection->add('routes', RoutesCommand::class));
@@ -83,10 +77,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test adding a command instance.
-     *
-     * @return void
      */
-    public function testAddCommand()
+    public function testAddCommand(): void
     {
         $collection = new CommandCollection();
         $this->assertSame($collection, $collection->add('ex', DemoCommand::class));
@@ -96,10 +88,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Test that add() replaces.
-     *
-     * @return void
      */
-    public function testAddReplace()
+    public function testAddReplace(): void
     {
         $collection = new CommandCollection();
         $this->assertSame($collection, $collection->add('routes', RoutesCommand::class));
@@ -110,10 +100,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Test adding with instances
-     *
-     * @return void
      */
-    public function testAddInstance()
+    public function testAddInstance(): void
     {
         $collection = new CommandCollection();
         $command = new RoutesCommand();
@@ -126,7 +114,7 @@ class CommandCollectionTest extends TestCase
     /**
      * Instances that are not shells should fail.
      */
-    public function testAddInvalidInstance()
+    public function testAddInvalidInstance(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'routes\'. It is not a subclass of Cake\Console\Shell');
@@ -158,9 +146,8 @@ class CommandCollectionTest extends TestCase
      * test adding a command instance.
      *
      * @dataProvider invalidNameProvider
-     * @return void
      */
-    public function testAddCommandInvalidName(string $name)
+    public function testAddCommandInvalidName(string $name): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The command name `$name` is invalid.");
@@ -171,7 +158,7 @@ class CommandCollectionTest extends TestCase
     /**
      * Class names that are not shells should fail
      */
-    public function testInvalidShellClassName()
+    public function testInvalidShellClassName(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'routes\'. It is not a subclass of Cake\Console\Shell');
@@ -181,10 +168,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Test removing a command
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $collection = new CommandCollection();
         $collection->add('routes', RoutesCommand::class);
@@ -194,10 +179,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Removing an unknown command does not fail
-     *
-     * @return void
      */
-    public function testRemoveUnknown()
+    public function testRemoveUnknown(): void
     {
         $collection = new CommandCollection();
         $this->assertSame($collection, $collection->remove('nope'));
@@ -206,10 +189,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test getIterator
-     *
-     * @return void
      */
-    public function testGetIterator()
+    public function testGetIterator(): void
     {
         $in = [
             'sample' => SampleShell::class,
@@ -225,10 +206,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test autodiscovering app shells
-     *
-     * @return void
      */
-    public function testAutoDiscoverApp()
+    public function testAutoDiscoverApp(): void
     {
         $collection = new CommandCollection();
         $collection->addMany($collection->autoDiscover());
@@ -247,10 +226,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test autodiscovering core shells
-     *
-     * @return void
      */
-    public function testAutoDiscoverCore()
+    public function testAutoDiscoverCore(): void
     {
         $collection = new CommandCollection();
         $collection->addMany($collection->autoDiscover());
@@ -272,10 +249,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test missing plugin discovery
-     *
-     * @return void
      */
-    public function testDiscoverPluginUnknown()
+    public function testDiscoverPluginUnknown(): void
     {
         $collection = new CommandCollection();
         $this->assertSame([], $collection->discoverPlugin('Nope'));
@@ -283,10 +258,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test autodiscovering plugin shells
-     *
-     * @return void
      */
-    public function testDiscoverPlugin()
+    public function testDiscoverPlugin(): void
     {
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
 
@@ -333,10 +306,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * Test keys
-     *
-     * @return void
      */
-    public function testKeys()
+    public function testKeys(): void
     {
         $collection = new CommandCollection();
         $collection->add('demo', DemoCommand::class);

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -26,7 +26,7 @@ use TestApp\Shell\SampleShell;
 
 class CommandFactoryTest extends TestCase
 {
-    public function testCreateCommand()
+    public function testCreateCommand(): void
     {
         $factory = new CommandFactory();
 
@@ -35,7 +35,7 @@ class CommandFactoryTest extends TestCase
         $this->assertInstanceOf(CommandInterface::class, $command);
     }
 
-    public function testCreateCommandDependencies()
+    public function testCreateCommandDependencies(): void
     {
         $container = new Container();
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
@@ -48,7 +48,7 @@ class CommandFactoryTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $command->inject);
     }
 
-    public function testCreateShell()
+    public function testCreateShell(): void
     {
         $factory = new CommandFactory();
 
@@ -56,7 +56,7 @@ class CommandFactoryTest extends TestCase
         $this->assertInstanceOf(SampleShell::class, $shell);
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $factory = new CommandFactory();
 

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -53,8 +53,6 @@ class CommandRunnerTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -65,10 +63,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * test event manager proxies to the application.
-     *
-     * @return void
      */
-    public function testEventManagerProxies()
+    public function testEventManagerProxies(): void
     {
         $app = $this->getMockForAbstractClass(
             BaseApplication::class,
@@ -81,10 +77,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * test event manager cannot be set on applications without events.
-     *
-     * @return void
      */
-    public function testGetEventManagerNonEventedApplication()
+    public function testGetEventManagerNonEventedApplication(): void
     {
         $app = $this->createMock(ConsoleApplicationInterface::class);
 
@@ -94,10 +88,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * test event manager cannot be set on applications without events.
-     *
-     * @return void
      */
-    public function testSetEventManagerNonEventedApplication()
+    public function testSetEventManagerNonEventedApplication(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $app = $this->createMock(ConsoleApplicationInterface::class);
@@ -109,10 +101,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that running with empty argv fails
-     *
-     * @return void
      */
-    public function testRunMissingRootCommand()
+    public function testRunMissingRootCommand(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot run any commands. No arguments received.');
@@ -127,10 +117,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that running an unknown command raises an error.
-     *
-     * @return void
      */
-    public function testRunInvalidCommand()
+    public function testRunInvalidCommand(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -150,10 +138,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that running an unknown command gives suggestions.
-     *
-     * @return void
      */
-    public function testRunInvalidCommandSuggestion()
+    public function testRunInvalidCommandSuggestion(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -177,10 +163,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test using `cake --help` invokes the help command
-     *
-     * @return void
      */
-    public function testRunHelpLongOption()
+    public function testRunHelpLongOption(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -199,10 +183,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test using `cake -h` invokes the help command
-     *
-     * @return void
      */
-    public function testRunHelpShortOption()
+    public function testRunHelpShortOption(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -220,10 +202,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that no command outputs the command list
-     *
-     * @return void
      */
-    public function testRunNoCommand()
+    public function testRunNoCommand(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -243,10 +223,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test using `cake --version` invokes the version command
-     *
-     * @return void
      */
-    public function testRunVersionAlias()
+    public function testRunVersionAlias(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -261,10 +239,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test running a valid command
-     *
-     * @return void
      */
-    public function testRunValidCommand()
+    public function testRunValidCommand(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -284,10 +260,8 @@ class CommandRunnerTest extends TestCase
     /**
      * Test running a valid command and that backwards compatible
      * inflection is hooked up.
-     *
-     * @return void
      */
-    public function testRunValidCommandInflection()
+    public function testRunValidCommandInflection(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -306,10 +280,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test running a valid raising an error
-     *
-     * @return void
      */
-    public function testRunValidCommandWithAbort()
+    public function testRunValidCommandWithAbort(): void
     {
         $app = $this->makeAppWithCommands(['failure' => SampleShell::class]);
         $output = new ConsoleOutput();
@@ -321,10 +293,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test returning a non-zero value
-     *
-     * @return void
      */
-    public function testRunValidCommandReturnInteger()
+    public function testRunValidCommandReturnInteger(): void
     {
         $app = $this->makeAppWithCommands(['failure' => SampleShell::class]);
         $output = new ConsoleOutput();
@@ -336,10 +306,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Ensure that the root command name propagates to shell help
-     *
-     * @return void
      */
-    public function testRunRootNamePropagates()
+    public function testRunRootNamePropagates(): void
     {
         $app = $this->makeAppWithCommands(['sample' => SampleShell::class]);
         $output = new ConsoleOutput();
@@ -353,10 +321,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test running a valid command
-     *
-     * @return void
      */
-    public function testRunValidCommandClass()
+    public function testRunValidCommandClass(): void
     {
         $app = $this->makeAppWithCommands(['ex' => DemoCommand::class]);
         $output = new ConsoleOutput();
@@ -371,10 +337,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test running a valid command with spaces in the name
-     *
-     * @return void
      */
-    public function testRunValidCommandSubcommandName()
+    public function testRunValidCommandSubcommandName(): void
     {
         $app = $this->makeAppWithCommands([
             'tool build' => DemoCommand::class,
@@ -392,10 +356,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test running a valid command with spaces in the name
-     *
-     * @return void
      */
-    public function testRunValidCommandNestedName()
+    public function testRunValidCommandNestedName(): void
     {
         $app = $this->makeAppWithCommands([
             'tool build assets' => DemoCommand::class,
@@ -413,10 +375,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test using a custom factory
-     *
-     * @return void
      */
-    public function testRunWithCustomFactory()
+    public function testRunWithCustomFactory(): void
     {
         $output = new ConsoleOutput();
         $io = $this->getMockIo($output);
@@ -436,7 +396,7 @@ class CommandRunnerTest extends TestCase
         $this->assertStringContainsString('Demo Command!', $messages);
     }
 
-    public function testRunWithContainerDependencies()
+    public function testRunWithContainerDependencies(): void
     {
         $app = $this->makeAppWithCommands([
             'dependency' => DependencyCommand::class,
@@ -459,10 +419,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test running a command class' help
-     *
-     * @return void
      */
-    public function testRunValidCommandClassHelp()
+    public function testRunValidCommandClassHelp(): void
     {
         $app = $this->makeAppWithCommands(['ex' => DemoCommand::class]);
         $output = new ConsoleOutput();
@@ -478,10 +436,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that run() fires off the buildCommands event.
-     *
-     * @return void
      */
-    public function testRunTriggersBuildCommandsEvent()
+    public function testRunTriggersBuildCommandsEvent(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])
@@ -490,7 +446,7 @@ class CommandRunnerTest extends TestCase
 
         $output = new ConsoleOutput();
         $runner = new CommandRunner($app, 'cake');
-        $runner->getEventManager()->on('Console.buildCommands', function ($event, $commands) {
+        $runner->getEventManager()->on('Console.buildCommands', function ($event, $commands): void {
             $this->assertInstanceOf(CommandCollection::class, $commands);
             $this->eventTriggered = true;
         });
@@ -500,10 +456,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that run calls plugin hook methods
-     *
-     * @return void
      */
-    public function testRunCallsPluginHookMethods()
+    public function testRunCallsPluginHookMethods(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods([
@@ -534,10 +488,8 @@ class CommandRunnerTest extends TestCase
 
     /**
      * Test that run() loads routing.
-     *
-     * @return void
      */
-    public function testRunLoadsRoutes()
+    public function testRunLoadsRoutes(): void
     {
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap'])

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -37,10 +37,8 @@ class CommandTest extends TestCase
 {
     /**
      * test orm locator is setup
-     *
-     * @return void
      */
-    public function testConstructorSetsLocator()
+    public function testConstructorSetsLocator(): void
     {
         $command = new Command();
         $result = $command->getTableLocator();
@@ -49,10 +47,8 @@ class CommandTest extends TestCase
 
     /**
      * test loadModel is configured properly
-     *
-     * @return void
      */
-    public function testConstructorLoadModel()
+    public function testConstructorLoadModel(): void
     {
         $command = new Command();
         $command->loadModel('Comments');
@@ -61,10 +57,8 @@ class CommandTest extends TestCase
 
     /**
      * test loadModel is configured properly
-     *
-     * @return void
      */
-    public function testConstructorAutoLoadModel()
+    public function testConstructorAutoLoadModel(): void
     {
         $command = new AutoLoadModelCommand();
         $this->assertInstanceOf(Table::class, $command->Posts);
@@ -72,10 +66,8 @@ class CommandTest extends TestCase
 
     /**
      * Test name
-     *
-     * @return void
      */
-    public function testSetName()
+    public function testSetName(): void
     {
         $command = new Command();
         $this->assertSame($command, $command->setName('routes show'));
@@ -85,10 +77,8 @@ class CommandTest extends TestCase
 
     /**
      * Test invalid name
-     *
-     * @return void
      */
-    public function testSetNameInvalid()
+    public function testSetNameInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The name \'routes_show\' is missing a space. Names should look like `cake routes`');
@@ -99,10 +89,8 @@ class CommandTest extends TestCase
 
     /**
      * Test invalid name
-     *
-     * @return void
      */
-    public function testSetNameInvalidLeadingSpace()
+    public function testSetNameInvalidLeadingSpace(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -112,10 +100,8 @@ class CommandTest extends TestCase
 
     /**
      * Test option parser fetching
-     *
-     * @return void
      */
-    public function testGetOptionParser()
+    public function testGetOptionParser(): void
     {
         $command = new Command();
         $command->setName('cake routes show');
@@ -126,10 +112,8 @@ class CommandTest extends TestCase
 
     /**
      * Test that initialize is called.
-     *
-     * @return void
      */
-    public function testRunCallsInitialize()
+    public function testRunCallsInitialize(): void
     {
         /** @var \Cake\Console\Command|\PHPUnit\Framework\MockObject\MockObject $command */
         $command = $this->getMockBuilder(Command::class)
@@ -142,10 +126,8 @@ class CommandTest extends TestCase
 
     /**
      * Test run() outputs help
-     *
-     * @return void
      */
-    public function testRunOutputHelp()
+    public function testRunOutputHelp(): void
     {
         $command = new Command();
         $command->setName('cake demo');
@@ -162,10 +144,8 @@ class CommandTest extends TestCase
 
     /**
      * Test run() outputs help
-     *
-     * @return void
      */
-    public function testRunOutputHelpLongOption()
+    public function testRunOutputHelpLongOption(): void
     {
         $command = new Command();
         $command->setName('cake demo');
@@ -182,10 +162,8 @@ class CommandTest extends TestCase
 
     /**
      * Test run() sets output level
-     *
-     * @return void
      */
-    public function testRunVerboseOption()
+    public function testRunVerboseOption(): void
     {
         $command = new DemoCommand();
         $command->setName('cake demo');
@@ -201,10 +179,8 @@ class CommandTest extends TestCase
 
     /**
      * Test run() sets output level
-     *
-     * @return void
      */
-    public function testRunQuietOption()
+    public function testRunQuietOption(): void
     {
         $command = new DemoCommand();
         $command->setName('cake demo');
@@ -219,10 +195,8 @@ class CommandTest extends TestCase
 
     /**
      * Test run() sets option parser failure
-     *
-     * @return void
      */
-    public function testRunOptionParserFailure()
+    public function testRunOptionParserFailure(): void
     {
         /** @var \Cake\Console\Command|\PHPUnit\Framework\MockObject\MockObject $command */
         $command = $this->getMockBuilder(Command::class)
@@ -246,10 +220,8 @@ class CommandTest extends TestCase
 
     /**
      * Test abort()
-     *
-     * @return void
      */
-    public function testAbort()
+    public function testAbort(): void
     {
         $this->expectException(StopException::class);
         $this->expectExceptionCode(1);
@@ -260,10 +232,8 @@ class CommandTest extends TestCase
 
     /**
      * Test abort()
-     *
-     * @return void
      */
-    public function testAbortCustomCode()
+    public function testAbortCustomCode(): void
     {
         $this->expectException(StopException::class);
         $this->expectExceptionCode(99);
@@ -274,10 +244,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with a string class
-     *
-     * @return void
      */
-    public function testExecuteCommandString()
+    public function testExecuteCommandString(): void
     {
         $output = new ConsoleOutput();
         $command = new Command();
@@ -288,10 +256,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with an invalid string class
-     *
-     * @return void
      */
-    public function testExecuteCommandStringInvalid()
+    public function testExecuteCommandStringInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Command class 'Nope' does not exist");
@@ -302,10 +268,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with arguments
-     *
-     * @return void
      */
-    public function testExecuteCommandArguments()
+    public function testExecuteCommandArguments(): void
     {
         $output = new ConsoleOutput();
         $command = new Command();
@@ -315,10 +279,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with arguments
-     *
-     * @return void
      */
-    public function testExecuteCommandArgumentsOptions()
+    public function testExecuteCommandArgumentsOptions(): void
     {
         $output = new ConsoleOutput();
         $command = new Command();
@@ -328,10 +290,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with an instance
-     *
-     * @return void
      */
-    public function testExecuteCommandInstance()
+    public function testExecuteCommandInstance(): void
     {
         $output = new ConsoleOutput();
         $command = new Command();
@@ -342,10 +302,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with an abort
-     *
-     * @return void
      */
-    public function testExecuteCommandAbort()
+    public function testExecuteCommandAbort(): void
     {
         $output = new ConsoleOutput();
         $command = new Command();
@@ -356,10 +314,8 @@ class CommandTest extends TestCase
 
     /**
      * test executeCommand with an invalid instance
-     *
-     * @return void
      */
-    public function testExecuteCommandInstanceInvalid()
+    public function testExecuteCommandInstanceInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Command 'stdClass' is not a subclass");
@@ -370,10 +326,8 @@ class CommandTest extends TestCase
 
     /**
      * Test that noninteractive commands use defaults where applicable.
-     *
-     * @return void
      */
-    public function testExecuteCommandNonInteractive()
+    public function testExecuteCommandNonInteractive(): void
     {
         $output = new ConsoleOutput();
         $command = new Command();

--- a/tests/TestCase/Console/ConsoleInputTest.php
+++ b/tests/TestCase/Console/ConsoleInputTest.php
@@ -32,8 +32,6 @@ class ConsoleInputTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -44,10 +42,8 @@ class ConsoleInputTest extends TestCase
 
     /**
      * Test dataAvailable method
-     *
-     * @return void
      */
-    public function testDataAvailable()
+    public function testDataAvailable(): void
     {
         $this->skipIf(
             (bool)env('GITHUB_ACTIONS'),

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -49,8 +49,6 @@ class ConsoleIoTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -71,8 +69,6 @@ class ConsoleIoTest extends TestCase
 
     /**
      * teardown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -103,9 +99,8 @@ class ConsoleIoTest extends TestCase
      *
      * @dataProvider choiceProvider
      * @param array|string $choices
-     * @return void
      */
-    public function testAskChoices($choices)
+    public function testAskChoices($choices): void
     {
         $this->in->expects($this->once())
             ->method('read')
@@ -120,9 +115,8 @@ class ConsoleIoTest extends TestCase
      *
      * @dataProvider choiceProvider
      * @param array|string $choices
-     * @return void
      */
-    public function testAskChoicesInsensitive($choices)
+    public function testAskChoicesInsensitive($choices): void
     {
         $this->in->expects($this->once())
             ->method('read')
@@ -134,10 +128,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test ask method
-     *
-     * @return void
      */
-    public function testAsk()
+    public function testAsk(): void
     {
         $this->out->expects($this->once())
             ->method('write')
@@ -153,10 +145,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test ask method
-     *
-     * @return void
      */
-    public function testAskDefaultValue()
+    public function testAskDefaultValue(): void
     {
         $this->out->expects($this->once())
             ->method('write')
@@ -172,10 +162,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * testOut method
-     *
-     * @return void
      */
-    public function testOut()
+    public function testOut(): void
     {
         $this->out->expects($this->exactly(4))
             ->method('write')
@@ -194,10 +182,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * test that verbose and quiet output levels work
-     *
-     * @return void
      */
-    public function testVerboseOut()
+    public function testVerboseOut(): void
     {
         $this->out->expects($this->exactly(3))
             ->method('write')
@@ -216,10 +202,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * test that verbose and quiet output levels work
-     *
-     * @return void
      */
-    public function testVerboseOutput()
+    public function testVerboseOutput(): void
     {
         $this->out->expects($this->exactly(3))
             ->method('write')
@@ -238,10 +222,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * test that verbose and quiet output levels work
-     *
-     * @return void
      */
-    public function testQuietOutput()
+    public function testQuietOutput(): void
     {
         $this->out->expects($this->exactly(2))
             ->method('write')
@@ -261,10 +243,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * testErr method
-     *
-     * @return void
      */
-    public function testErr()
+    public function testErr(): void
     {
         $this->err->expects($this->exactly(4))
             ->method('write')
@@ -283,10 +263,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Tests abort() wrapper.
-     *
-     * @return void
      */
-    public function testAbort()
+    public function testAbort(): void
     {
         $this->expectException(StopException::class);
         $this->expectExceptionMessage('Some error');
@@ -305,10 +283,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Tests abort() wrapper.
-     *
-     * @return void
      */
-    public function testAbortCustomCode()
+    public function testAbortCustomCode(): void
     {
         $this->expectException(StopException::class);
         $this->expectExceptionMessage('Some error');
@@ -327,10 +303,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * testNl
-     *
-     * @return void
      */
-    public function testNl()
+    public function testNl(): void
     {
         $newLine = "\n";
         if (DS === '\\') {
@@ -343,10 +317,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * testHr
-     *
-     * @return void
      */
-    public function testHr()
+    public function testHr(): void
     {
         $bar = str_repeat('-', 79);
 
@@ -367,10 +339,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test overwriting.
-     *
-     * @return void
      */
-    public function testOverwrite()
+    public function testOverwrite(): void
     {
         $number = strlen('Some text I want to overwrite');
 
@@ -397,10 +367,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test overwriting content with shorter content
-     *
-     * @return void
      */
-    public function testOverwriteWithShorterContent()
+    public function testOverwriteWithShorterContent(): void
     {
         $length = strlen('12345');
 
@@ -435,10 +403,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test overwriting content with longer content
-     *
-     * @return void
      */
-    public function testOverwriteWithLongerContent()
+    public function testOverwriteWithLongerContent(): void
     {
         $this->out->expects($this->exactly(5))
             ->method('write')
@@ -466,10 +432,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Tests that setLoggers works properly
-     *
-     * @return void
      */
-    public function testSetLoggers()
+    public function testSetLoggers(): void
     {
         Log::drop('stdout');
         Log::drop('stderr');
@@ -484,10 +448,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Tests that setLoggers works properly with quiet
-     *
-     * @return void
      */
-    public function testSetLoggersQuiet()
+    public function testSetLoggersQuiet(): void
     {
         Log::drop('stdout');
         Log::drop('stderr');
@@ -498,10 +460,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Tests that setLoggers works properly with verbose
-     *
-     * @return void
      */
-    public function testSetLoggersVerbose()
+    public function testSetLoggersVerbose(): void
     {
         Log::drop('stdout');
         Log::drop('stderr');
@@ -514,10 +474,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Ensure that setStyle() just proxies to stdout.
-     *
-     * @return void
      */
-    public function testSetStyle()
+    public function testSetStyle(): void
     {
         $this->out->expects($this->once())
             ->method('setStyle')
@@ -527,10 +485,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Ensure that getStyle() just proxies to stdout.
-     *
-     * @return void
      */
-    public function testGetStyle()
+    public function testGetStyle(): void
     {
         $this->out->expects($this->once())
             ->method('getStyle')
@@ -540,10 +496,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Ensure that styles() just proxies to stdout.
-     *
-     * @return void
      */
-    public function testStyles()
+    public function testStyles(): void
     {
         $this->out->expects($this->once())
             ->method('styles');
@@ -552,10 +506,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test the helper method.
-     *
-     * @return void
      */
-    public function testHelper()
+    public function testHelper(): void
     {
         $this->out->expects($this->once())
             ->method('write')
@@ -589,9 +541,8 @@ class ConsoleIoTest extends TestCase
      * test out helper methods
      *
      * @dataProvider outHelperProvider
-     * @return void
      */
-    public function testOutHelpers(string $method)
+    public function testOutHelpers(string $method): void
     {
         $this->out->expects($this->exactly(2))
             ->method('write')
@@ -608,9 +559,8 @@ class ConsoleIoTest extends TestCase
      * test err helper methods
      *
      * @dataProvider errHelperProvider
-     * @return void
      */
-    public function testErrHelpers(string $method)
+    public function testErrHelpers(string $method): void
     {
         $this->err->expects($this->exactly(2))
             ->method('write')
@@ -625,10 +575,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test that createFile
-     *
-     * @return void
      */
-    public function testCreateFileSuccess()
+    public function testCreateFileSuccess(): void
     {
         $this->err->expects($this->never())
             ->method('write');
@@ -644,7 +592,7 @@ class ConsoleIoTest extends TestCase
         $this->assertStringEqualsFile($file, $contents);
     }
 
-    public function testCreateFileEmptySuccess()
+    public function testCreateFileEmptySuccess(): void
     {
         $this->err->expects($this->never())
             ->method('write');
@@ -660,7 +608,7 @@ class ConsoleIoTest extends TestCase
         $this->assertStringEqualsFile($file, $contents);
     }
 
-    public function testCreateFileDirectoryCreation()
+    public function testCreateFileDirectoryCreation(): void
     {
         $this->err->expects($this->never())
             ->method('write');
@@ -679,10 +627,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test that createFile with permissions error.
-     *
-     * @return void
      */
-    public function testCreateFilePermissionsError()
+    public function testCreateFilePermissionsError(): void
     {
         $this->skipIf(DS === '\\', 'Cant perform operations using permissions on windows.');
 
@@ -703,10 +649,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test that `q` raises an error.
-     *
-     * @return void
      */
-    public function testCreateFileOverwriteQuit()
+    public function testCreateFileOverwriteQuit(): void
     {
         $path = TMP . 'shell_test';
         mkdir($path);
@@ -725,10 +669,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test that `n` raises an error.
-     *
-     * @return void
      */
-    public function testCreateFileOverwriteNo()
+    public function testCreateFileOverwriteNo(): void
     {
         $path = TMP . 'shell_test';
         mkdir($path);
@@ -751,10 +693,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test the forceOverwrite parameter
-     *
-     * @return void
      */
-    public function testCreateFileOverwriteParam()
+    public function testCreateFileOverwriteParam(): void
     {
         $path = TMP . 'shell_test';
         mkdir($path);
@@ -773,10 +713,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * Test the `a` response
-     *
-     * @return void
      */
-    public function testCreateFileOverwriteAll()
+    public function testCreateFileOverwriteAll(): void
     {
         $path = TMP . 'shell_test';
         mkdir($path);

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -32,10 +32,8 @@ class ConsoleOptionParserTest extends TestCase
 {
     /**
      * test setting the console description
-     *
-     * @return void
      */
-    public function testDescription()
+    public function testDescription(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->setDescription('A test');
@@ -49,10 +47,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test setting and getting the console epilog
-     *
-     * @return void
      */
-    public function testEpilog()
+    public function testEpilog(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->setEpilog('A test');
@@ -66,10 +62,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option returns self.
-     *
-     * @return void
      */
-    public function testAddOptionReturnSelf()
+    public function testAddOptionReturnSelf(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addOption('test');
@@ -78,10 +72,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test removing an option
-     *
-     * @return void
      */
-    public function testRemoveOption()
+    public function testRemoveOption(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addOption('test')
@@ -93,10 +85,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option and using the long value for parsing.
-     *
-     * @return void
      */
-    public function testAddOptionLong()
+    public function testAddOptionLong(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('test', [
@@ -108,10 +98,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option with a zero value
-     *
-     * @return void
      */
-    public function testAddOptionZero()
+    public function testAddOptionZero(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('count', []);
@@ -121,10 +109,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test addOption with an object.
-     *
-     * @return void
      */
-    public function testAddOptionObject()
+    public function testAddOptionObject(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption(new ConsoleInputOption('test', 't'));
@@ -134,10 +120,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option and using the long value for parsing.
-     *
-     * @return void
      */
-    public function testAddOptionLongEquals()
+    public function testAddOptionLongEquals(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('test', [
@@ -149,10 +133,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option and using the default.
-     *
-     * @return void
      */
-    public function testAddOptionDefault()
+    public function testAddOptionDefault(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser
@@ -178,10 +160,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option and using the short value for parsing.
-     *
-     * @return void
      */
-    public function testAddOptionShort()
+    public function testAddOptionShort(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('test', [
@@ -193,10 +173,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option and using the short value for parsing.
-     *
-     * @return void
      */
-    public function testAddOptionWithMultipleShort()
+    public function testAddOptionWithMultipleShort(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('source', [
@@ -217,10 +195,8 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * Test that adding an option using a two letter short value causes an exception.
      * As they will not parse correctly.
-     *
-     * @return void
      */
-    public function testAddOptionShortOneLetter()
+    public function testAddOptionShortOneLetter(): void
     {
         $this->expectException(ConsoleException::class);
         $parser = new ConsoleOptionParser('test', false);
@@ -229,10 +205,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding and using boolean options.
-     *
-     * @return void
      */
-    public function testAddOptionBoolean()
+    public function testAddOptionBoolean(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('test', [
@@ -250,10 +224,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an multiple shorts.
-     *
-     * @return void
      */
-    public function testAddOptionMultipleShort()
+    public function testAddOptionMultipleShort(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('test', ['short' => 't', 'boolean' => true])
@@ -270,10 +242,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test multiple options at once.
-     *
-     * @return void
      */
-    public function testAddOptionMultipleOptions()
+    public function testAddOptionMultipleOptions(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('test')
@@ -287,10 +257,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding an option that accepts multiple values.
-     *
-     * @return void
      */
-    public function testAddOptionWithMultiple()
+    public function testAddOptionWithMultiple(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('source', ['short' => 's', 'multiple' => true]);
@@ -308,10 +276,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding multiple options, including one that accepts multiple values.
-     *
-     * @return void
      */
-    public function testAddOptionMultipleOptionsWithMultiple()
+    public function testAddOptionMultipleOptionsWithMultiple(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser
@@ -334,10 +300,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding a required option with a default.
-     *
-     * @return void
      */
-    public function testAddOptionRequiredDefaultValue()
+    public function testAddOptionRequiredDefaultValue(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser
@@ -363,10 +327,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding a required option that is missing.
-     *
-     * @return void
      */
-    public function testAddOptionRequiredMissing()
+    public function testAddOptionRequiredMissing(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser
@@ -384,10 +346,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * Test adding multiple options.
-     *
-     * @return void
      */
-    public function testAddOptions()
+    public function testAddOptions(): void
     {
         $parser = new ConsoleOptionParser('something', false);
         $result = $parser->addOptions([
@@ -402,10 +362,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that boolean options work
-     *
-     * @return void
      */
-    public function testOptionWithBooleanParam()
+    public function testOptionWithBooleanParam(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('no-commit', ['boolean' => true])
@@ -418,10 +376,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test parsing options that do not exist.
-     *
-     * @return void
      */
-    public function testOptionThatDoesNotExist()
+    public function testOptionThatDoesNotExist(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('no-commit', ['boolean' => true]);
@@ -443,10 +399,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test parsing short options that do not exist.
-     *
-     * @return void
      */
-    public function testShortOptionThatDoesNotExist()
+    public function testShortOptionThatDoesNotExist(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('no-commit', ['boolean' => true, 'short' => 'n']);
@@ -462,10 +416,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that options with choices enforce them.
-     *
-     * @return void
      */
-    public function testOptionWithChoices()
+    public function testOptionWithChoices(): void
     {
         $this->expectException(ConsoleException::class);
         $parser = new ConsoleOptionParser('test', false);
@@ -480,10 +432,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * Ensure that option values can start with -
-     *
-     * @return void
      */
-    public function testOptionWithValueStartingWithMinus()
+    public function testOptionWithValueStartingWithMinus(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('name')
@@ -496,10 +446,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test positional argument parsing.
-     *
-     * @return void
      */
-    public function testPositionalArgument()
+    public function testPositionalArgument(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addArgument('name', ['help' => 'An argument']);
@@ -508,10 +456,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test addOption with an object.
-     *
-     * @return void
      */
-    public function testAddArgumentObject()
+    public function testAddArgumentObject(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addArgument(new ConsoleInputArgument('test'));
@@ -522,10 +468,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * Test adding arguments out of order.
-     *
-     * @return void
      */
-    public function testAddArgumentOutOfOrder()
+    public function testAddArgumentOutOfOrder(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addArgument('name', ['index' => 1, 'help' => 'first argument'])
@@ -546,10 +490,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test overwriting positional arguments.
-     *
-     * @return void
      */
-    public function testPositionalArgOverwrite()
+    public function testPositionalArgOverwrite(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addArgument('name', ['help' => 'An argument'])
@@ -561,10 +503,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test parsing arguments.
-     *
-     * @return void
      */
-    public function testParseArgumentTooMany()
+    public function testParseArgumentTooMany(): void
     {
         $this->expectException(ConsoleException::class);
         $parser = new ConsoleOptionParser('test', false);
@@ -580,10 +520,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test parsing arguments with 0 value.
-     *
-     * @return void
      */
-    public function testParseArgumentZero()
+    public function testParseArgumentZero(): void
     {
         $parser = new ConsoleOptionParser('test', false);
 
@@ -594,10 +532,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that when there are not enough arguments an exception is raised
-     *
-     * @return void
      */
-    public function testPositionalArgNotEnough()
+    public function testPositionalArgNotEnough(): void
     {
         $this->expectException(ConsoleException::class);
         $parser = new ConsoleOptionParser('test', false);
@@ -609,10 +545,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that when there are required arguments after optional ones an exception is raised
-     *
-     * @return void
      */
-    public function testPositionalArgRequiredAfterOptional()
+    public function testPositionalArgRequiredAfterOptional(): void
     {
         $this->expectException(LogicException::class);
         $parser = new ConsoleOptionParser('test');
@@ -622,10 +556,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that arguments with choices enforce them.
-     *
-     * @return void
      */
-    public function testPositionalArgWithChoices()
+    public function testPositionalArgWithChoices(): void
     {
         $this->expectException(ConsoleException::class);
         $parser = new ConsoleOptionParser('test', false);
@@ -642,10 +574,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * Test adding multiple arguments.
-     *
-     * @return void
      */
-    public function testAddArguments()
+    public function testAddArguments(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addArguments([
@@ -660,10 +590,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test setting a subcommand up.
-     *
-     * @return void
      */
-    public function testSubcommand()
+    public function testSubcommand(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addSubcommand('initdb', [
@@ -674,10 +602,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * Tests setting a subcommand up for a Shell method `initMyDb`.
-     *
-     * @return void
      */
-    public function testSubcommandCamelBacked()
+    public function testSubcommandCamelBacked(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addSubcommand('initMyDb', [
@@ -691,10 +617,8 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * Test addSubcommand inherits options as no
      * parser is created.
-     *
-     * @return void
      */
-    public function testAddSubcommandInheritOptions()
+    public function testAddSubcommandInheritOptions(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addSubcommand('build', [
@@ -714,10 +638,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test addSubcommand with an object.
-     *
-     * @return void
      */
-    public function testAddSubcommandObject()
+    public function testAddSubcommandObject(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addSubcommand(new ConsoleInputSubcommand('test'));
@@ -729,7 +651,7 @@ class ConsoleOptionParserTest extends TestCase
     /**
      * test addSubcommand without sorting applied.
      */
-    public function testAddSubcommandSort()
+    public function testAddSubcommandSort(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $this->assertTrue($parser->isSubcommandSortEnabled());
@@ -745,10 +667,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test removeSubcommand with an object.
-     *
-     * @return void
      */
-    public function testRemoveSubcommand()
+    public function testRemoveSubcommand(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addSubcommand(new ConsoleInputSubcommand('test'));
@@ -761,10 +681,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test adding multiple subcommands
-     *
-     * @return void
      */
-    public function testAddSubcommands()
+    public function testAddSubcommands(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $result = $parser->addSubcommands([
@@ -778,10 +696,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that no exception is triggered when help is being generated
-     *
-     * @return void
      */
-    public function testHelpNoExceptionWhenGettingHelp()
+    public function testHelpNoExceptionWhenGettingHelp(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
@@ -793,10 +709,8 @@ class ConsoleOptionParserTest extends TestCase
 
     /**
      * test that help() with a command param shows the help for a subcommand
-     *
-     * @return void
      */
-    public function testHelpSubcommandHelp()
+    public function testHelpSubcommandHelp(): void
     {
         $subParser = new ConsoleOptionParser('method', false);
         $subParser->addOption('connection', ['help' => 'Db connection.']);
@@ -829,10 +743,8 @@ TEXT;
     /**
      * Test addSubcommand inherits options as no
      * parser is created.
-     *
-     * @return void
      */
-    public function testHelpSubcommandInheritOptions()
+    public function testHelpSubcommandInheritOptions(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addSubcommand('build', [
@@ -868,10 +780,8 @@ TEXT;
 
     /**
      * test that help() with a command param shows the help for a subcommand
-     *
-     * @return void
      */
-    public function testHelpSubcommandHelpArray()
+    public function testHelpSubcommandHelpArray(): void
     {
         $subParser = [
             'options' => [
@@ -911,10 +821,8 @@ TEXT;
 
     /**
      * test that help() with a command param shows the help for a subcommand
-     *
-     * @return void
      */
-    public function testHelpSubcommandInheritParser()
+    public function testHelpSubcommandInheritParser(): void
     {
         $subParser = new ConsoleOptionParser('method', false);
         $subParser->addOption('connection', ['help' => 'Db connection.']);
@@ -946,10 +854,8 @@ TEXT;
 
     /**
      * test that help() with a custom rootName
-     *
-     * @return void
      */
-    public function testHelpWithRootName()
+    public function testHelpWithRootName(): void
     {
         $parser = new ConsoleOptionParser('sample', false);
         $parser->setDescription('A command!')
@@ -976,10 +882,8 @@ TEXT;
 
     /**
      * test that getCommandError() with an unknown subcommand param shows a helpful message
-     *
-     * @return void
      */
-    public function testHelpUnknownSubcommand()
+    public function testHelpUnknownSubcommand(): void
     {
         $subParser = [
             'options' => [
@@ -1017,10 +921,8 @@ TEXT;
 
     /**
      * test building a parser from an array.
-     *
-     * @return void
      */
-    public function testBuildFromArray()
+    public function testBuildFromArray(): void
     {
         $spec = [
             'command' => 'test',
@@ -1056,10 +958,8 @@ TEXT;
 
     /**
      * test that create() returns instances
-     *
-     * @return void
      */
-    public function testCreateFactory()
+    public function testCreateFactory(): void
     {
         $parser = ConsoleOptionParser::create('factory', false);
         $this->assertInstanceOf('Cake\Console\ConsoleOptionParser', $parser);
@@ -1068,10 +968,8 @@ TEXT;
 
     /**
      * test that getCommand() inflects the command name.
-     *
-     * @return void
      */
-    public function testCommandInflection()
+    public function testCommandInflection(): void
     {
         $parser = new ConsoleOptionParser('CommandLine');
         $this->assertSame('command_line', $parser->getCommand());
@@ -1080,10 +978,8 @@ TEXT;
     /**
      * test that parse() takes a subcommand argument, and that the subcommand parser
      * is used.
-     *
-     * @return void
      */
-    public function testParsingWithSubParser()
+    public function testParsingWithSubParser(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->addOption('primary')
@@ -1113,10 +1009,8 @@ TEXT;
 
     /**
      * Tests toArray()
-     *
-     * @return void
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $spec = [
             'command' => 'test',
@@ -1150,10 +1044,8 @@ TEXT;
 
     /**
      * Tests merge()
-     *
-     * @return void
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $parser = new ConsoleOptionParser('test');
         $parser->addOption('test', ['short' => 't', 'boolean' => true])

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -33,8 +33,6 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -56,7 +52,7 @@ class ConsoleOutputTest extends TestCase
         unset($this->output);
     }
 
-    public function testNoColorEnvironmentVariable()
+    public function testNoColorEnvironmentVariable(): void
     {
         $_SERVER['NO_COLOR'] = '1';
         $output = new ConsoleOutput();
@@ -67,10 +63,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test writing with no new line
-     *
-     * @return void
      */
-    public function testWriteNoNewLine()
+    public function testWriteNoNewLine(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with('Some output');
@@ -80,10 +74,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test writing with no new line
-     *
-     * @return void
      */
-    public function testWriteNewLine()
+    public function testWriteNewLine(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with('Some output' . PHP_EOL);
@@ -93,10 +85,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test write() with multiple new lines
-     *
-     * @return void
      */
-    public function testWriteMultipleNewLines()
+    public function testWriteMultipleNewLines(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with('Some output' . PHP_EOL . PHP_EOL . PHP_EOL . PHP_EOL);
@@ -106,10 +96,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test writing an array of messages.
-     *
-     * @return void
      */
-    public function testWriteArray()
+    public function testWriteArray(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with('Line' . PHP_EOL . 'Line' . PHP_EOL . 'Line' . PHP_EOL);
@@ -119,10 +107,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test getting a style.
-     *
-     * @return void
      */
-    public function testStylesGet()
+    public function testStylesGet(): void
     {
         $result = $this->output->getStyle('error');
         $expected = ['text' => 'red'];
@@ -137,10 +123,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test adding a style.
-     *
-     * @return void
      */
-    public function testStylesAdding()
+    public function testStylesAdding(): void
     {
         $this->output->setStyle('test', ['text' => 'red', 'background' => 'black']);
         $result = $this->output->getStyle('test');
@@ -153,10 +137,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test formatting text with styles.
-     *
-     * @return void
      */
-    public function testFormattingSimple()
+    public function testFormattingSimple(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with("\033[31mError:\033[0m Something bad");
@@ -166,10 +148,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test that formatting doesn't eat tags it doesn't know about.
-     *
-     * @return void
      */
-    public function testFormattingNotEatingTags()
+    public function testFormattingNotEatingTags(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with('<red> Something bad');
@@ -179,10 +159,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test formatting with custom styles.
-     *
-     * @return void
      */
-    public function testFormattingCustom()
+    public function testFormattingCustom(): void
     {
         $this->output->setStyle('annoying', [
             'text' => 'magenta',
@@ -199,10 +177,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test formatting text with missing styles.
-     *
-     * @return void
      */
-    public function testFormattingMissingStyleName()
+    public function testFormattingMissingStyleName(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with('<not_there>Error:</not_there> Something bad');
@@ -212,10 +188,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test formatting text with multiple styles.
-     *
-     * @return void
      */
-    public function testFormattingMultipleStylesName()
+    public function testFormattingMultipleStylesName(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with("\033[31mBad\033[0m \033[33mWarning\033[0m Regular");
@@ -225,10 +199,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test that multiple tags of the same name work in one string.
-     *
-     * @return void
      */
-    public function testFormattingMultipleSameTags()
+    public function testFormattingMultipleSameTags(): void
     {
         $this->output->expects($this->once())->method('_write')
             ->with("\033[31mBad\033[0m \033[31mWarning\033[0m Regular");
@@ -238,10 +210,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test raw output not getting tags replaced.
-     *
-     * @return void
      */
-    public function testSetOutputAsRaw()
+    public function testSetOutputAsRaw(): void
     {
         $this->output->setOutputAs(ConsoleOutput::RAW);
         $this->output->expects($this->once())->method('_write')
@@ -252,10 +222,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test set/get plain output.
-     *
-     * @return void
      */
-    public function testSetOutputAsPlain()
+    public function testSetOutputAsPlain(): void
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->assertSame(ConsoleOutput::PLAIN, $this->output->getOutputAs());
@@ -267,10 +235,8 @@ class ConsoleOutputTest extends TestCase
 
     /**
      * test plain output only strips tags used for formatting.
-     *
-     * @return void
      */
-    public function testSetOutputAsPlainSelectiveTagRemoval()
+    public function testSetOutputAsPlainSelectiveTagRemoval(): void
     {
         $this->output->setOutputAs(ConsoleOutput::PLAIN);
         $this->output->expects($this->once())

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -29,10 +29,8 @@ class HelpFormatterTest extends TestCase
 {
     /**
      * test that the console max width is respected when generating help.
-     *
-     * @return void
      */
-    public function testWidthFormatting()
+    public function testWidthFormatting(): void
     {
         $parser = new ConsoleOptionParser('test', false);
         $parser->setDescription('This is fifteen This is fifteen This is fifteen')
@@ -74,10 +72,8 @@ txt;
 
     /**
      * test help() with options and arguments that have choices.
-     *
-     * @return void
      */
-    public function testHelpWithChoices()
+    public function testHelpWithChoices(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.', 'choices' => ['one', 'two']])
@@ -110,10 +106,8 @@ txt;
 
     /**
      * test description and epilog in the help
-     *
-     * @return void
      */
-    public function testHelpDescriptionAndEpilog()
+    public function testHelpDescriptionAndEpilog(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->setDescription('Description text')
@@ -146,10 +140,8 @@ txt;
 
     /**
      * test that help() outputs subcommands.
-     *
-     * @return void
      */
-    public function testHelpSubcommand()
+    public function testHelpSubcommand(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addSubcommand('method', ['help' => 'This is another command'])
@@ -184,10 +176,8 @@ txt;
 
     /**
      * test getting help with defined options.
-     *
-     * @return void
      */
-    public function testHelpWithOptions()
+    public function testHelpWithOptions(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
@@ -221,10 +211,8 @@ txt;
 
     /**
      * test getting help with defined options.
-     *
-     * @return void
      */
-    public function testHelpWithOptionsAndArguments()
+    public function testHelpWithOptionsAndArguments(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
@@ -253,10 +241,8 @@ xml;
 
     /**
      * Test that a long set of options doesn't make useless output.
-     *
-     * @return void
      */
-    public function testHelpWithLotsOfOptions()
+    public function testHelpWithLotsOfOptions(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser
@@ -278,10 +264,8 @@ xml;
 
     /**
      * Test that a long set of arguments doesn't make useless output.
-     *
-     * @return void
      */
-    public function testHelpWithLotsOfArguments()
+    public function testHelpWithLotsOfArguments(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser
@@ -303,10 +287,8 @@ xml;
 
     /**
      * Test setting a help alias
-     *
-     * @return void
      */
-    public function testWithHelpAlias()
+    public function testWithHelpAlias(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $formatter = new HelpFormatter($parser);
@@ -318,10 +300,8 @@ xml;
 
     /**
      * test help() with options and arguments that have choices.
-     *
-     * @return void
      */
-    public function testXmlHelpWithChoices()
+    public function testXmlHelpWithChoices(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.', 'choices' => ['one', 'two']])
@@ -372,10 +352,8 @@ xml;
 
     /**
      * test description and epilog in the help
-     *
-     * @return void
      */
-    public function testXmlHelpDescriptionAndEpilog()
+    public function testXmlHelpDescriptionAndEpilog(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->setDescription('Description text')
@@ -414,10 +392,8 @@ xml;
 
     /**
      * test that help() outputs subcommands.
-     *
-     * @return void
      */
-    public function testXmlHelpSubcommand()
+    public function testXmlHelpSubcommand(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addSubcommand('method', ['help' => 'This is another command'])
@@ -452,10 +428,8 @@ xml;
 
     /**
      * test getting help with defined options.
-     *
-     * @return void
      */
-    public function testXmlHelpWithOptions()
+    public function testXmlHelpWithOptions(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
@@ -494,10 +468,8 @@ xml;
 
     /**
      * test getting help with defined options.
-     *
-     * @return void
      */
-    public function testXmlHelpWithOptionsAndArguments()
+    public function testXmlHelpWithOptionsAndArguments(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
@@ -538,10 +510,8 @@ xml;
 
     /**
      * Test XML help as object
-     *
-     * @return void
      */
-    public function testXmlHelpAsObject()
+    public function testXmlHelpAsObject(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -33,8 +33,6 @@ class HelperRegistryTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class HelperRegistryTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -60,10 +56,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test loading helpers.
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $result = $this->helpers->load('Simple');
         $this->assertInstanceOf(SimpleHelper::class, $result);
@@ -75,10 +69,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test loading helpers.
-     *
-     * @return void
      */
-    public function testLoadCommandNamespace()
+    public function testLoadCommandNamespace(): void
     {
         $result = $this->helpers->load('Command');
         $this->assertInstanceOf(CommandHelper::class, $result);
@@ -90,10 +82,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test triggering callbacks on loaded helpers
-     *
-     * @return void
      */
-    public function testLoadWithConfig()
+    public function testLoadWithConfig(): void
     {
         $result = $this->helpers->load('Simple', ['key' => 'value']);
         $this->assertSame('value', $result->getConfig('key'));
@@ -101,10 +91,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test missing helper exception
-     *
-     * @return void
      */
-    public function testLoadMissingHelper()
+    public function testLoadMissingHelper(): void
     {
         $this->expectException(\Cake\Console\Exception\MissingHelperException::class);
         $this->helpers->load('ThisTaskShouldAlwaysBeMissing');
@@ -112,10 +100,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Tests loading as an alias
-     *
-     * @return void
      */
-    public function testLoadWithAlias()
+    public function testLoadWithAlias(): void
     {
         $this->loadPlugins(['TestPlugin']);
 

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -27,8 +27,6 @@ class ShellDispatcherTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,8 +40,6 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,10 +50,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Test error on missing shell
-     *
-     * @return void
      */
-    public function testFindShellMissing()
+    public function testFindShellMissing(): void
     {
         $this->expectException(\Cake\Console\Exception\MissingShellException::class);
         $this->dispatcher->findShell('nope');
@@ -65,10 +59,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Test error on missing plugin shell
-     *
-     * @return void
      */
-    public function testFindShellMissingPlugin()
+    public function testFindShellMissingPlugin(): void
     {
         $this->expectException(\Cake\Console\Exception\MissingShellException::class);
         $this->dispatcher->findShell('test_plugin.nope');
@@ -76,10 +68,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify loading of (plugin-) shells
-     *
-     * @return void
      */
-    public function testFindShell()
+    public function testFindShell(): void
     {
         $result = $this->dispatcher->findShell('sample');
         $this->assertInstanceOf('TestApp\Shell\SampleShell', $result);
@@ -98,10 +88,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * testAddShortPluginAlias
-     *
-     * @return void
      */
-    public function testAddShortPluginAlias()
+    public function testAddShortPluginAlias(): void
     {
         $expected = [
             'Company' => 'Company/TestPluginThree.company',
@@ -121,10 +109,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Test getting shells with aliases.
-     *
-     * @return void
      */
-    public function testFindShellAliased()
+    public function testFindShellAliased(): void
     {
         ShellDispatcher::alias('short', 'test_plugin.example');
 
@@ -138,10 +124,8 @@ class ShellDispatcherTest extends TestCase
      * Test finding a shell that has a matching alias.
      *
      * Aliases should not overload concrete shells.
-     *
-     * @return void
      */
-    public function testFindShellAliasedAppShadow()
+    public function testFindShellAliasedAppShadow(): void
     {
         ShellDispatcher::alias('sample', 'test_plugin.example');
 
@@ -153,10 +137,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify dispatch handling stop errors
-     *
-     * @return void
      */
-    public function testDispatchShellWithAbort()
+    public function testDispatchShellWithAbort(): void
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMockBuilder('Cake\Console\Shell')
@@ -165,7 +147,7 @@ class ShellDispatcherTest extends TestCase
             ->getMock();
         $shell->expects($this->once())
             ->method('main')
-            ->will($this->returnCallback(function () use ($shell) {
+            ->will($this->returnCallback(function () use ($shell): void {
                 $shell->abort('Bad things', 99);
             }));
 
@@ -184,10 +166,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify correct dispatch of Shell subclasses with a main method
-     *
-     * @return void
      */
-    public function testDispatchShellWithMain()
+    public function testDispatchShellWithMain(): void
     {
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->onlyMethods(['findShell'])
@@ -219,10 +199,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verifies correct dispatch of Shell subclasses with integer exit codes.
-     *
-     * @return void
      */
-    public function testDispatchShellWithIntegerSuccessCode()
+    public function testDispatchShellWithIntegerSuccessCode(): void
     {
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->onlyMethods(['findShell'])
@@ -248,10 +226,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verifies correct dispatch of Shell subclasses with custom integer exit codes.
-     *
-     * @return void
      */
-    public function testDispatchShellWithCustomIntegerCodes()
+    public function testDispatchShellWithCustomIntegerCodes(): void
     {
         $customErrorCode = 3;
 
@@ -279,10 +255,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify correct dispatch of Shell subclasses without a main method
-     *
-     * @return void
      */
-    public function testDispatchShellWithoutMain()
+    public function testDispatchShellWithoutMain(): void
     {
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->onlyMethods(['findShell'])
@@ -308,10 +282,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify you can dispatch a plugin's main shell with the shell name alone
-     *
-     * @return void
      */
-    public function testDispatchShortPluginAlias()
+    public function testDispatchShortPluginAlias(): void
     {
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->onlyMethods(['_shellExists', '_createShell'])
@@ -337,10 +309,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Ensure short plugin shell usage is case/camelized insensitive
-     *
-     * @return void
      */
-    public function testDispatchShortPluginAliasCamelized()
+    public function testDispatchShortPluginAliasCamelized(): void
     {
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->onlyMethods(['_shellExists', '_createShell'])
@@ -366,10 +336,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify that in case of conflict, app shells take precedence in alias list
-     *
-     * @return void
      */
-    public function testDispatchShortPluginAliasConflict()
+    public function testDispatchShortPluginAliasConflict(): void
     {
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
             ->onlyMethods(['_shellExists', '_createShell'])
@@ -395,10 +363,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Verify shifting of arguments
-     *
-     * @return void
      */
-    public function testShiftArgs()
+    public function testShiftArgs(): void
     {
         $this->dispatcher->args = ['a', 'b', 'c'];
         $this->assertSame('a', $this->dispatcher->shiftArgs());
@@ -423,10 +389,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Test how `bin/cake --help` works.
-     *
-     * @return void
      */
-    public function testHelpOption()
+    public function testHelpOption(): void
     {
         $this->expectWarning();
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')
@@ -438,10 +402,8 @@ class ShellDispatcherTest extends TestCase
 
     /**
      * Test how `bin/cake --version` works.
-     *
-     * @return void
      */
-    public function testVersionOption()
+    public function testVersionOption(): void
     {
         $this->expectWarning();
         $dispatcher = $this->getMockBuilder('Cake\Console\ShellDispatcher')

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -70,8 +70,6 @@ class ShellTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -91,10 +89,8 @@ class ShellTest extends TestCase
 
     /**
      * testConstruct method
-     *
-     * @return void
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertSame('ShellTestShell', $this->Shell->name);
         $this->assertInstanceOf(ConsoleIo::class, $this->Shell->getIo());
@@ -102,10 +98,8 @@ class ShellTest extends TestCase
 
     /**
      * testInitialize method
-     *
-     * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         static::setAppNamespace();
 
@@ -126,10 +120,8 @@ class ShellTest extends TestCase
 
     /**
      * test LoadModel method
-     *
-     * @return void
      */
-    public function testLoadModel()
+    public function testLoadModel(): void
     {
         static::setAppNamespace();
 
@@ -155,10 +147,8 @@ class ShellTest extends TestCase
 
     /**
      * testIn method
-     *
-     * @return void
      */
-    public function testIn()
+    public function testIn(): void
     {
         $this->io->expects($this->once())
             ->method('askChoice')
@@ -179,10 +169,8 @@ class ShellTest extends TestCase
 
     /**
      * Test in() when not interactive.
-     *
-     * @return void
      */
-    public function testInNonInteractive()
+    public function testInNonInteractive(): void
     {
         $this->io->expects($this->never())
             ->method('askChoice');
@@ -197,10 +185,8 @@ class ShellTest extends TestCase
 
     /**
      * testVerbose method
-     *
-     * @return void
      */
-    public function testVerbose()
+    public function testVerbose(): void
     {
         $this->io->expects($this->once())
             ->method('verbose')
@@ -211,10 +197,8 @@ class ShellTest extends TestCase
 
     /**
      * testQuiet method
-     *
-     * @return void
      */
-    public function testQuiet()
+    public function testQuiet(): void
     {
         $this->io->expects($this->once())
             ->method('quiet')
@@ -225,10 +209,8 @@ class ShellTest extends TestCase
 
     /**
      * testOut method
-     *
-     * @return void
      */
-    public function testOut()
+    public function testOut(): void
     {
         $this->io->expects($this->once())
             ->method('out')
@@ -239,10 +221,8 @@ class ShellTest extends TestCase
 
     /**
      * testErr method
-     *
-     * @return void
      */
-    public function testErr()
+    public function testErr(): void
     {
         $this->io->expects($this->once())
             ->method('error')
@@ -253,10 +233,8 @@ class ShellTest extends TestCase
 
     /**
      * testErr method with array
-     *
-     * @return void
      */
-    public function testErrArray()
+    public function testErrArray(): void
     {
         $this->io->expects($this->once())
             ->method('error')
@@ -267,10 +245,8 @@ class ShellTest extends TestCase
 
     /**
      * testInfo method
-     *
-     * @return void
      */
-    public function testInfo()
+    public function testInfo(): void
     {
         $this->io->expects($this->once())
             ->method('info')
@@ -281,10 +257,8 @@ class ShellTest extends TestCase
 
     /**
      * testInfo method with array
-     *
-     * @return void
      */
-    public function testInfoArray()
+    public function testInfoArray(): void
     {
         $this->io->expects($this->once())
             ->method('info')
@@ -295,10 +269,8 @@ class ShellTest extends TestCase
 
     /**
      * testWarn method
-     *
-     * @return void
      */
-    public function testWarn()
+    public function testWarn(): void
     {
         $this->io->expects($this->once())
             ->method('warning')
@@ -309,10 +281,8 @@ class ShellTest extends TestCase
 
     /**
      * testWarn method with array
-     *
-     * @return void
      */
-    public function testWarnArray()
+    public function testWarnArray(): void
     {
         $this->io->expects($this->once())
             ->method('warning')
@@ -323,10 +293,8 @@ class ShellTest extends TestCase
 
     /**
      * testSuccess method
-     *
-     * @return void
      */
-    public function testSuccess()
+    public function testSuccess(): void
     {
         $this->io->expects($this->once())
             ->method('success')
@@ -337,10 +305,8 @@ class ShellTest extends TestCase
 
     /**
      * testSuccess method with array
-     *
-     * @return void
      */
-    public function testSuccessArray()
+    public function testSuccessArray(): void
     {
         $this->io->expects($this->once())
             ->method('success')
@@ -351,10 +317,8 @@ class ShellTest extends TestCase
 
     /**
      * testNl
-     *
-     * @return void
      */
-    public function testNl()
+    public function testNl(): void
     {
         $this->io->expects($this->once())
             ->method('nl')
@@ -365,10 +329,8 @@ class ShellTest extends TestCase
 
     /**
      * testHr
-     *
-     * @return void
      */
-    public function testHr()
+    public function testHr(): void
     {
         $this->io->expects($this->once())
             ->method('hr')
@@ -379,10 +341,8 @@ class ShellTest extends TestCase
 
     /**
      * testAbort
-     *
-     * @return void
      */
-    public function testAbort()
+    public function testAbort(): void
     {
         $this->expectException(StopException::class);
         $this->expectExceptionMessage('Foo Not Found');
@@ -397,10 +357,8 @@ class ShellTest extends TestCase
 
     /**
      * testLoadTasks method
-     *
-     * @return void
      */
-    public function testLoadTasks()
+    public function testLoadTasks(): void
     {
         $this->assertTrue($this->Shell->loadTasks());
 
@@ -435,10 +393,8 @@ class ShellTest extends TestCase
 
     /**
      * test that __get() makes args and params references
-     *
-     * @return void
      */
-    public function testMagicGetArgAndParamReferences()
+    public function testMagicGetArgAndParamReferences(): void
     {
         $this->Shell->tasks = ['TestApple'];
         $this->Shell->args = ['one'];
@@ -454,10 +410,8 @@ class ShellTest extends TestCase
 
     /**
      * testShortPath method
-     *
-     * @return void
      */
-    public function testShortPath()
+    public function testShortPath(): void
     {
         $path = $expected = DS . 'tmp/ab/cd';
         $this->assertPathEquals($expected, $this->Shell->shortPath($path));
@@ -487,10 +441,8 @@ class ShellTest extends TestCase
 
     /**
      * testCreateFile method
-     *
-     * @return void
      */
-    public function testCreateFileNonInteractive()
+    public function testCreateFileNonInteractive(): void
     {
         $eol = PHP_EOL;
         $path = TMP . 'shell_test';
@@ -509,10 +461,8 @@ class ShellTest extends TestCase
 
     /**
      * Test that while in non interactive mode it will not overwrite files by default.
-     *
-     * @return void
      */
-    public function testCreateFileNonInteractiveFileExists()
+    public function testCreateFileNonInteractiveFileExists(): void
     {
         $eol = PHP_EOL;
         $path = TMP . 'shell_test';
@@ -533,10 +483,8 @@ class ShellTest extends TestCase
 
     /**
      * Test that files are not changed with a 'n' reply.
-     *
-     * @return void
      */
-    public function testCreateFileNoReply()
+    public function testCreateFileNoReply(): void
     {
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
@@ -559,10 +507,8 @@ class ShellTest extends TestCase
 
     /**
      * Test that files are changed with a 'y' reply.
-     *
-     * @return void
      */
-    public function testCreateFileOverwrite()
+    public function testCreateFileOverwrite(): void
     {
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
@@ -586,10 +532,8 @@ class ShellTest extends TestCase
     /**
      * Test that there is no user prompt in non-interactive mode while file already exists
      * and if force mode is explicitly enabled.
-     *
-     * @return void
      */
-    public function testCreateFileOverwriteNonInteractive()
+    public function testCreateFileOverwriteNonInteractive(): void
     {
         $path = TMP . 'shell_test';
         $file = $path . DS . 'file1.php';
@@ -610,10 +554,8 @@ class ShellTest extends TestCase
 
     /**
      * Test that all files are changed with a 'a' reply.
-     *
-     * @return void
      */
-    public function testCreateFileOverwriteAll()
+    public function testCreateFileOverwriteAll(): void
     {
         $path = TMP . 'shell_test';
         $files = [
@@ -641,10 +583,8 @@ class ShellTest extends TestCase
 
     /**
      * Test that you can't create files that aren't writable.
-     *
-     * @return void
      */
-    public function testCreateFileNoPermissions()
+    public function testCreateFileNoPermissions(): void
     {
         $this->skipIf(DS === '\\', 'Cant perform operations using permissions on windows.');
 
@@ -665,10 +605,8 @@ class ShellTest extends TestCase
 
     /**
      * test hasTask method
-     *
-     * @return void
      */
-    public function testHasTask()
+    public function testHasTask(): void
     {
         $this->setAppNamespace();
         $this->Shell->tasks = ['Sample', 'TestApple'];
@@ -684,10 +622,8 @@ class ShellTest extends TestCase
 
     /**
      * test task loading exception
-     *
-     * @return void
      */
-    public function testMissingTaskException()
+    public function testMissingTaskException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Task `DoesNotExist` not found. Maybe you made a typo or a plugin is missing or not loaded?');
@@ -698,10 +634,8 @@ class ShellTest extends TestCase
 
     /**
      * test the hasMethod
-     *
-     * @return void
      */
-    public function testHasMethod()
+    public function testHasMethod(): void
     {
         $this->assertTrue($this->Shell->hasMethod('doSomething'));
         $this->assertFalse($this->Shell->hasMethod('hr'), 'hr is callable');
@@ -711,10 +645,8 @@ class ShellTest extends TestCase
 
     /**
      * test run command calling main.
-     *
-     * @return void
      */
-    public function testRunCommandMain()
+    public function testRunCommandMain(): void
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         /** @var \Cake\Console\Shell|\PHPUnit\Framework\MockObject\MockObject $shell */
@@ -735,10 +667,8 @@ class ShellTest extends TestCase
 
     /**
      * test run command calling a real method with no subcommands defined.
-     *
-     * @return void
      */
-    public function testRunCommandWithMethod()
+    public function testRunCommandWithMethod(): void
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         /** @var \Cake\Console\Shell|\PHPUnit\Framework\MockObject\MockObject $shell */
@@ -762,10 +692,8 @@ class ShellTest extends TestCase
      * to the shell's one
      * Also tests that if an extra `requested` parameter prevents the welcome message from
      * being displayed
-     *
-     * @return void
      */
-    public function testRunCommandWithExtra()
+    public function testRunCommandWithExtra(): void
     {
         $Parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
             ->onlyMethods(['help'])
@@ -793,10 +721,8 @@ class ShellTest extends TestCase
 
     /**
      * Test the dispatchShell() arguments parser
-     *
-     * @return void
      */
-    public function testDispatchShellArgsParser()
+    public function testDispatchShellArgsParser(): void
     {
         $Shell = new Shell();
 
@@ -839,10 +765,8 @@ class ShellTest extends TestCase
 
     /**
      * test calling a shell that dispatch another one
-     *
-     * @return void
      */
-    public function testDispatchShell()
+    public function testDispatchShell(): void
     {
         $Shell = new TestingDispatchShell();
         ob_start();
@@ -911,10 +835,8 @@ TEXT;
 
     /**
      * Test that runCommand() doesn't call public methods when the second arg is false.
-     *
-     * @return void
      */
-    public function testRunCommandAutoMethodOff()
+    public function testRunCommandAutoMethodOff(): void
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         /** @var \Cake\Console\Shell|\PHPUnit\Framework\MockObject\MockObject $shell */
@@ -936,10 +858,8 @@ TEXT;
 
     /**
      * test run command calling a real method with mismatching subcommands defined.
-     *
-     * @return void
      */
-    public function testRunCommandWithMethodNotInSubcommands()
+    public function testRunCommandWithMethodNotInSubcommands(): void
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
             ->onlyMethods(['help'])
@@ -970,10 +890,8 @@ TEXT;
 
     /**
      * test run command calling a real method with subcommands defined.
-     *
-     * @return void
      */
-    public function testRunCommandWithMethodInSubcommands()
+    public function testRunCommandWithMethodInSubcommands(): void
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
             ->onlyMethods(['help'])
@@ -1002,10 +920,8 @@ TEXT;
 
     /**
      * test run command calling a missing method with subcommands defined.
-     *
-     * @return void
      */
-    public function testRunCommandWithMissingMethodInSubcommands()
+    public function testRunCommandWithMissingMethodInSubcommands(): void
     {
         /** @var \Cake\Console\ConsoleOptionParser|\PHPUnit\Framework\MockObject\MockObject $parser */
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
@@ -1035,10 +951,8 @@ TEXT;
 
     /**
      * test run command causing exception on Shell method.
-     *
-     * @return void
      */
-    public function testRunCommandBaseClassMethod()
+    public function testRunCommandBaseClassMethod(): void
     {
         /** @var \Cake\Console\Shell|\PHPUnit\Framework\MockObject\MockObject $shell */
         $shell = $this->getMockBuilder('Cake\Console\Shell')
@@ -1067,10 +981,8 @@ TEXT;
 
     /**
      * test run command causing exception on Shell method.
-     *
-     * @return void
      */
-    public function testRunCommandMissingMethod()
+    public function testRunCommandMissingMethod(): void
     {
         /** @var \Cake\Console\Shell|\PHPUnit\Framework\MockObject\MockObject $shell */
         $shell = $this->getMockBuilder('Cake\Console\Shell')
@@ -1099,10 +1011,8 @@ TEXT;
 
     /**
      * test that a --help causes help to show.
-     *
-     * @return void
      */
-    public function testRunCommandTriggeringHelp()
+    public function testRunCommandTriggeringHelp(): void
     {
         $parser = $this->getMockBuilder('Cake\Console\ConsoleOptionParser')
             ->disableOriginalConstructor()
@@ -1126,10 +1036,8 @@ TEXT;
 
     /**
      * test that runCommand will not call runCommand on tasks that are not subcommands.
-     *
-     * @return void
      */
-    public function testRunCommandNotCallUnexposedTask()
+    public function testRunCommandNotCallUnexposedTask(): void
     {
         /** @var \Cake\Console\Shell|\PHPUnit\Framework\MockObject\MockObject $shell */
         $shell = $this->getMockBuilder('Cake\Console\Shell')
@@ -1162,10 +1070,8 @@ TEXT;
 
     /**
      * test that runCommand will call runCommand on the task.
-     *
-     * @return void
      */
-    public function testRunCommandHittingTaskInSubcommand()
+    public function testRunCommandHittingTaskInSubcommand(): void
     {
         $parser = new ConsoleOptionParser('knife');
         $parser->addSubcommand('slice');
@@ -1200,10 +1106,8 @@ TEXT;
 
     /**
      * test that runCommand will invoke a task
-     *
-     * @return void
      */
-    public function testRunCommandInvokeTask()
+    public function testRunCommandInvokeTask(): void
     {
         $parser = new ConsoleOptionParser('knife');
         $parser->addSubcommand('slice');
@@ -1237,10 +1141,8 @@ TEXT;
 
     /**
      * test run command missing parameters
-     *
-     * @return void
      */
-    public function testRunCommandMainMissingArgument()
+    public function testRunCommandMainMissingArgument(): void
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')->getMock();
         $shell = $this->getMockBuilder('Cake\Console\Shell')
@@ -1268,10 +1170,8 @@ TEXT;
 
     /**
      * test wrapBlock wrapping text.
-     *
-     * @return void
      */
-    public function testWrapText()
+    public function testWrapText(): void
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
         $result = $this->Shell->wrapText($text, ['width' => 33]);
@@ -1293,10 +1193,8 @@ TEXT;
 
     /**
      * Testing camel cased naming of tasks
-     *
-     * @return void
      */
-    public function testShellNaming()
+    public function testShellNaming(): void
     {
         $this->Shell->tasks = ['TestApple'];
         $this->Shell->loadTasks();
@@ -1310,7 +1208,7 @@ TEXT;
      * @dataProvider paramReadingDataProvider
      * @param mixed $expected
      */
-    public function testParamReading(string $toRead, $expected)
+    public function testParamReading(string $toRead, $expected): void
     {
         $this->Shell->params = [
             'key' => 'value',
@@ -1354,10 +1252,8 @@ TEXT;
 
     /**
      * Test that option parsers are created with the correct name/command.
-     *
-     * @return void
      */
-    public function testGetOptionParser()
+    public function testGetOptionParser(): void
     {
         $this->Shell->name = 'test';
         $this->Shell->plugin = 'plugin';
@@ -1368,10 +1264,8 @@ TEXT;
 
     /**
      * Test file and console and logging quiet output
-     *
-     * @return void
      */
-    public function testQuietLog()
+    public function testQuietLog(): void
     {
         $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
             ->disableOriginalConstructor()
@@ -1393,10 +1287,8 @@ TEXT;
 
     /**
      * Test getIo() and setIo() methods
-     *
-     * @return void
      */
-    public function testGetSetIo()
+    public function testGetSetIo(): void
     {
         $this->Shell->setIo($this->io);
         $this->assertSame($this->Shell->getIo(), $this->io);
@@ -1404,10 +1296,8 @@ TEXT;
 
     /**
      * Test setRootName filters into the option parser help text.
-     *
-     * @return void
      */
-    public function testSetRootNamePropagatesToHelpText()
+    public function testSetRootNamePropagatesToHelpText(): void
     {
         $this->assertSame($this->Shell, $this->Shell->setRootName('tool'), 'is chainable');
         $this->assertStringContainsString('tool shell_test_shell [-h]', $this->Shell->getOptionParser()->help());
@@ -1415,10 +1305,8 @@ TEXT;
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $expected = [
             'name' => 'ShellTestShell',

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -31,8 +31,6 @@ class TaskRegistryTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -45,8 +43,6 @@ class TaskRegistryTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -56,10 +52,8 @@ class TaskRegistryTest extends TestCase
 
     /**
      * test triggering callbacks on loaded tasks
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $result = $this->Tasks->load('Command');
         $this->assertInstanceOf('Cake\Shell\Task\CommandTask', $result);
@@ -71,10 +65,8 @@ class TaskRegistryTest extends TestCase
 
     /**
      * test missingtask exception
-     *
-     * @return void
      */
-    public function testLoadMissingTask()
+    public function testLoadMissingTask(): void
     {
         $this->expectException(\Cake\Console\Exception\MissingTaskException::class);
         $this->Tasks->load('ThisTaskShouldAlwaysBeMissing');
@@ -82,10 +74,8 @@ class TaskRegistryTest extends TestCase
 
     /**
      * test loading a plugin helper.
-     *
-     * @return void
      */
-    public function testLoadPluginTask()
+    public function testLoadPluginTask(): void
     {
         $shell = $this->getMockBuilder('Cake\Console\Shell')
             ->disableOriginalConstructor()
@@ -101,10 +91,8 @@ class TaskRegistryTest extends TestCase
 
     /**
      * Tests loading as an alias
-     *
-     * @return void
      */
-    public function testLoadWithAlias()
+    public function testLoadWithAlias(): void
     {
         $this->loadPlugins(['TestPlugin']);
 

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -60,8 +60,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -99,8 +97,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -112,8 +108,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testNoAuth method
-     *
-     * @return void
      */
     public function testNoAuth(): void
     {
@@ -122,8 +116,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testIdentify method
-     *
-     * @return void
      */
     public function testIdentify(): void
     {
@@ -163,8 +155,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * Test identify with user record as ArrayObject instance.
-     *
-     * @return void
      */
     public function testIdentifyArrayAccess(): void
     {
@@ -205,7 +195,6 @@ class AuthComponentTest extends TestCase
     /**
      * testAuthorizeFalse method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAuthorizeFalse(): void
@@ -233,8 +222,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testIsAuthorizedMissingFile function
-     *
-     * @return void
      */
     public function testIsAuthorizedMissingFile(): void
     {
@@ -245,8 +232,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test that isAuthorized calls methods correctly
-     *
-     * @return void
      */
     public function testIsAuthorizedDelegation(): void
     {
@@ -287,8 +272,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test isAuthorized passing it an ArrayObject instance.
-     *
-     * @return void
      */
     public function testIsAuthorizedWithArrayObject(): void
     {
@@ -313,8 +296,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test that isAuthorized will use the session user if none is given.
-     *
-     * @return void
      */
     public function testIsAuthorizedUsingUserInSession(): void
     {
@@ -339,8 +320,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test that loadAuthorize resets the loaded objects each time.
-     *
-     * @return void
      */
     public function testLoadAuthorizeResets(): void
     {
@@ -354,8 +333,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testLoadAuthenticateNoFile function
-     *
-     * @return void
      */
     public function testLoadAuthenticateNoFile(): void
     {
@@ -369,8 +346,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test the * key with authenticate
-     *
-     * @return void
      */
     public function testAllConfigWithAuthorize(): void
     {
@@ -385,8 +360,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test that loadAuthorize resets the loaded objects each time.
-     *
-     * @return void
      */
     public function testLoadAuthenticateResets(): void
     {
@@ -400,8 +373,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test the * key with authenticate
-     *
-     * @return void
      */
     public function testAllConfigWithAuthenticate(): void
     {
@@ -416,8 +387,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test defining the same Authenticate object but with different password hashers
-     *
-     * @return void
      */
     public function testSameAuthenticateWithDifferentHashers(): void
     {
@@ -439,7 +408,6 @@ class AuthComponentTest extends TestCase
     /**
      * Tests that deny always takes precedence over allow
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAllowDenyAll(): void
@@ -499,7 +467,6 @@ class AuthComponentTest extends TestCase
     /**
      * test that deny() converts camel case inputs to lowercase.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testDenyWithCamelCaseMethods(): void
@@ -527,7 +494,6 @@ class AuthComponentTest extends TestCase
     /**
      * test that allow() and allowedActions work with camelCase method names.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAllowedActionsWithCamelCaseMethods(): void
@@ -570,8 +536,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testAllowedActionsSetWithAllowMethod method
-     *
-     * @return void
      */
     public function testAllowedActionsSetWithAllowMethod(): void
     {
@@ -585,7 +549,6 @@ class AuthComponentTest extends TestCase
     /**
      * testLoginRedirect method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testLoginRedirect(): void
@@ -660,8 +623,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testLoginRedirect method with non GET
-     *
-     * @return void
      */
     public function testLoginRedirectPost(): void
     {
@@ -687,8 +648,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testLoginRedirect method with non GET and no referrer
-     *
-     * @return void
      */
     public function testLoginRedirectPostNoReferer(): void
     {
@@ -804,7 +763,6 @@ class AuthComponentTest extends TestCase
     /**
      * testNoLoginRedirectForAuthenticatedUser method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testNoLoginRedirectForAuthenticatedUser(): void
@@ -839,7 +797,6 @@ class AuthComponentTest extends TestCase
     /**
      * testNoLoginRedirectForAuthenticatedUser method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testStartupLoginActionIgnoreQueryString(): void
@@ -869,7 +826,6 @@ class AuthComponentTest extends TestCase
     /**
      * Default to loginRedirect, if set, on authError.
      *
-     * @return void
      * @triggers Controller.startup $Controller
      */
     public function testDefaultToLoginRedirect(): void
@@ -917,7 +873,6 @@ class AuthComponentTest extends TestCase
     /**
      * testRedirectToUnauthorizedRedirect
      *
-     * @return void
      * @triggers Controller.startup $Controller
      */
     public function testRedirectToUnauthorizedRedirect(): void
@@ -959,8 +914,6 @@ class AuthComponentTest extends TestCase
     /**
      * test unauthorized redirect defaults to loginRedirect
      * which is a string URL.
-     *
-     * @return void
      */
     public function testRedirectToUnauthorizedRedirectLoginAction(): void
     {
@@ -999,7 +952,6 @@ class AuthComponentTest extends TestCase
     /**
      * testRedirectToUnauthorizedRedirectSuppressedAuthError
      *
-     * @return void
      * @triggers Controller.startup $Controller
      */
     public function testRedirectToUnauthorizedRedirectSuppressedAuthError(): void
@@ -1040,7 +992,6 @@ class AuthComponentTest extends TestCase
     /**
      * Throw ForbiddenException if config `unauthorizedRedirect` is set to false
      *
-     * @return void
      * @triggers Controller.startup $Controller
      */
     public function testForbiddenException(): void
@@ -1069,7 +1020,6 @@ class AuthComponentTest extends TestCase
     /**
      * Test that no redirects or authorization tests occur on the loginAction
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testNoRedirectOnLoginAction(): void
@@ -1100,7 +1050,6 @@ class AuthComponentTest extends TestCase
      * Ensure that no redirect is performed when a 404 is reached
      * And the user doesn't have a session.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testNoRedirectOn404(): void
@@ -1118,7 +1067,6 @@ class AuthComponentTest extends TestCase
     /**
      * testAdminRoute method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAdminRoute(): void
@@ -1167,7 +1115,6 @@ class AuthComponentTest extends TestCase
     /**
      * test AJAX unauthenticated
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAjaxUnauthenticated(): void
@@ -1189,7 +1136,6 @@ class AuthComponentTest extends TestCase
     /**
      * testLoginActionRedirect method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testLoginActionRedirect(): void
@@ -1231,7 +1177,6 @@ class AuthComponentTest extends TestCase
      * Stateless auth methods like Basic should populate data that can be
      * accessed by $this->user().
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testStatelessAuthWorksWithUser(): void
@@ -1269,8 +1214,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test $settings in Controller::$components
-     *
-     * @return void
      */
     public function testComponentSettings(): void
     {
@@ -1295,8 +1238,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test that logout deletes the session variables. and returns the correct URL
-     *
-     * @return void
      */
     public function testLogout(): void
     {
@@ -1310,8 +1251,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * Test that Auth.afterIdentify and Auth.logout events are triggered
-     *
-     * @return void
      */
     public function testEventTriggering(): void
     {
@@ -1342,7 +1281,6 @@ class AuthComponentTest extends TestCase
     /**
      * testAfterIdentifyForStatelessAuthentication
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAfterIdentifyForStatelessAuthentication(): void
@@ -1374,8 +1312,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test setting user info to session.
-     *
-     * @return void
      */
     public function testSetUser(): void
     {
@@ -1396,8 +1332,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testGettingUserAfterSetUser
-     *
-     * @return void
      */
     public function testGettingUserAfterSetUser(): void
     {
@@ -1417,7 +1351,6 @@ class AuthComponentTest extends TestCase
     /**
      * test flash settings.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller)
      */
     public function testFlashSettings(): void
@@ -1458,8 +1391,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test the various states of Auth::redirect()
-     *
-     * @return void
      */
     public function testRedirectSet(): void
     {
@@ -1470,8 +1401,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * Tests redirect using redirect key from the query string.
-     *
-     * @return void
      */
     public function testRedirectQueryStringRead(): void
     {
@@ -1484,8 +1413,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * Tests redirectUrl with duplicate base.
-     *
-     * @return void
      */
     public function testRedirectQueryStringReadDuplicateBase(): void
     {
@@ -1503,8 +1430,6 @@ class AuthComponentTest extends TestCase
     /**
      * test that redirect does not return loginAction if that is what's passed as redirect.
      * instead loginRedirect should be used.
-     *
-     * @return void
      */
     public function testRedirectQueryStringReadEqualToLoginAction(): void
     {
@@ -1521,8 +1446,6 @@ class AuthComponentTest extends TestCase
     /**
      * Tests that redirect does not return loginAction if that contains a host,
      * instead loginRedirect should be used.
-     *
-     * @return void
      */
     public function testRedirectQueryStringInvalid(): void
     {
@@ -1576,8 +1499,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * testUser method
-     *
-     * @return void
      */
     public function testUser(): void
     {
@@ -1617,7 +1538,6 @@ class AuthComponentTest extends TestCase
     /**
      * testStatelessAuthNoRedirect method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testStatelessAuthNoRedirect(): void
@@ -1636,7 +1556,6 @@ class AuthComponentTest extends TestCase
     /**
      * testStatelessAuthRedirect method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testStatelessAuthRedirectToLogin(): void
@@ -1656,8 +1575,6 @@ class AuthComponentTest extends TestCase
 
     /**
      * test null action no error
-     *
-     * @return void
      */
     public function testStartupNullAction(): void
     {
@@ -1687,8 +1604,6 @@ class AuthComponentTest extends TestCase
     /**
      * test for BC getting/setting AuthComponent::$sessionKey gets/sets `key`
      * config of session storage.
-     *
-     * @return void
      */
     public function testSessionKeyBC(): void
     {
@@ -1705,8 +1620,6 @@ class AuthComponentTest extends TestCase
     /**
      * Test that setting config 'earlyAuth' to true make AuthComponent do the initial
      * checks in beforeFilter() instead of startup().
-     *
-     * @return void
      */
     public function testCheckAuthInConfig(): void
     {

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -41,8 +41,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -56,8 +54,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,7 +64,6 @@ class FlashComponentTest extends TestCase
     /**
      * testSet method
      *
-     * @return void
      * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testSet(): void
@@ -163,7 +158,6 @@ class FlashComponentTest extends TestCase
     /**
      * test setting messages with using the clear option
      *
-     * @return void
      * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testSetWithClear(): void
@@ -198,7 +192,6 @@ class FlashComponentTest extends TestCase
     /**
      * testSetWithException method
      *
-     * @return void
      * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testSetWithException(): void
@@ -220,8 +213,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * testSetWithComponentConfiguration method
-     *
-     * @return void
      */
     public function testSetWithComponentConfiguration(): void
     {
@@ -245,7 +236,6 @@ class FlashComponentTest extends TestCase
      * Test magic call method.
      *
      * @covers \Cake\Controller\Component\FlashComponent::__call
-     * @return void
      */
     public function testCall(): void
     {
@@ -289,7 +279,6 @@ class FlashComponentTest extends TestCase
     /**
      * Test a magic call with the "clear" flag to true
      *
-     * @return void
      * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testCallWithClear(): void

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -47,8 +47,6 @@ class FormProtectionComponentTest extends TestCase
      * setUp method
      *
      * Initializes environment state.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -216,7 +214,7 @@ class FormProtectionComponentTest extends TestCase
         $this->FormProtection->startup($event);
     }
 
-    public function testValidationUnlockedFieldsMismatch()
+    public function testValidationUnlockedFieldsMismatch(): void
     {
         // Unlocked is empty when the token is created.
         $unlocked = '';
@@ -242,7 +240,7 @@ class FormProtectionComponentTest extends TestCase
         $this->FormProtection->startup($event);
     }
 
-    public function testValidationUnlockedFieldsSuccess()
+    public function testValidationUnlockedFieldsSuccess(): void
     {
         $unlocked = 'open';
         $fields = ['title'];
@@ -265,7 +263,7 @@ class FormProtectionComponentTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testCallbackReturnResponse()
+    public function testCallbackReturnResponse(): void
     {
         $this->FormProtection->setConfig('validationFailureCallback', function (BadRequestException $exception) {
             return new Response(['body' => 'from callback']);
@@ -299,7 +297,7 @@ class FormProtectionComponentTest extends TestCase
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('error description');
 
-        $this->FormProtection->setConfig('validationFailureCallback', function (BadRequestException $exception) {
+        $this->FormProtection->setConfig('validationFailureCallback', function (BadRequestException $exception): void {
             throw new NotFoundException('error description');
         });
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -73,8 +73,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -92,8 +90,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * testPaginatorSetting
-     *
-     * @return void
      */
     public function testPaginatorSetting(): void
     {
@@ -113,8 +109,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that an exception is thrown when paginator option is invalid.
-     *
-     * @return void
      */
     public function testInvalidPaginatorOption(): void
     {
@@ -127,8 +121,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that non-numeric values are rejected for page, and limit
-     *
-     * @return void
      */
     public function testPageParamCasting(): void
     {
@@ -151,8 +143,6 @@ class PaginatorComponentTest extends TestCase
     /**
      * test that unknown keys in the default settings are
      * passed to the find operations.
-     *
-     * @return void
      */
     public function testPaginateExtraParams(): void
     {
@@ -190,8 +180,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test to make sure options get sent to custom finder methods via paginate
-     *
-     * @return void
      */
     public function testPaginateCustomFinderOptions(): void
     {
@@ -218,7 +206,6 @@ class PaginatorComponentTest extends TestCase
     /**
      * testRequestParamsSetting
      *
-     * @return void
      * @see https://github.com/cakephp/cakephp/issues/11655
      */
     public function testRequestParamsSetting(): void
@@ -241,8 +228,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that special paginate types are called and that the type param doesn't leak out into defaults or options.
-     *
-     * @return void
      */
     public function testPaginateCustomFinder(): void
     {
@@ -268,8 +253,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that nested eager loaders don't trigger invalid SQL errors.
-     *
-     * @return void
      */
     public function testPaginateNestedEagerLoader(): void
     {
@@ -296,8 +279,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that flat default pagination parameters work.
-     *
-     * @return void
      */
     public function testDefaultPaginateParams(): void
     {
@@ -330,8 +311,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that default sort and default direction are injected into request
-     *
-     * @return void
      */
     public function testDefaultPaginateParamsIntoRequest(): void
     {
@@ -367,8 +346,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that option merging prefers specific models
-     *
-     * @return void
      */
     public function testMergeOptionsModelSpecific(): void
     {
@@ -401,8 +378,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test mergeOptions with custom scope
-     *
-     * @return void
      */
     public function testMergeOptionsCustomScope(): void
     {
@@ -473,8 +448,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test mergeOptions with customFind key
-     *
-     * @return void
      */
     public function testMergeOptionsCustomFindKey(): void
     {
@@ -502,8 +475,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test merging options from the querystring.
-     *
-     * @return void
      */
     public function testMergeOptionsQueryString(): void
     {
@@ -529,8 +500,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that the default allowed parameters doesn't let people screw with things they should not be allowed to.
-     *
-     * @return void
      */
     public function testMergeOptionsDefaultAllowedParameters(): void
     {
@@ -560,8 +529,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that modifying the whitelist works.
-     *
-     * @return void
      */
     public function testMergeOptionsExtraWhitelist(): void
     {
@@ -578,7 +545,7 @@ class PaginatorComponentTest extends TestCase
             'limit' => 20,
             'maxLimit' => 100,
         ];
-        $this->deprecated(function () use ($settings) {
+        $this->deprecated(function () use ($settings): void {
             $this->Paginator->setConfig('whitelist', ['fields']);
             $result = $this->Paginator->mergeOptions('Post', $settings);
             $expected = [
@@ -595,8 +562,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test mergeOptions with limit > maxLimit in code.
-     *
-     * @return void
      */
     public function testMergeOptionsMaxLimit(): void
     {
@@ -633,8 +598,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test getDefaults with limit > maxLimit in code.
-     *
-     * @return void
      */
     public function testGetDefaultMaxLimit(): void
     {
@@ -683,8 +646,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Integration test to ensure that validateSort is being used by paginate()
-     *
-     * @return void
      */
     public function testValidateSortInvalid(): void
     {
@@ -719,8 +680,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that invalid directions are ignored.
-     *
-     * @return void
      */
     public function testValidateSortInvalidDirection(): void
     {
@@ -740,8 +699,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test empty pagination result.
-     *
-     * @return void
      */
     public function testEmptyPaginationResult(): void
     {
@@ -772,8 +729,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that a really large page number gets clamped to the max page size.
-     *
-     * @return void
      */
     public function testOutOfRangePageNumberGetsClamped(): void
     {
@@ -801,8 +756,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that a out of bounds request still knows about the page size
-     *
-     * @return void
      */
     public function testOutOfRangePageNumberStillProvidesPageCount(): void
     {
@@ -833,8 +786,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that a really REALLY large page number gets clamped to the max page size.
-     *
-     * @return void
      */
     public function testOutOfVeryBigPageNumberGetsClamped(): void
     {
@@ -850,8 +801,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that fields not in sortableFields won't be part of order conditions.
-     *
-     * @return void
      */
     public function testValidateAllowedSortFailure(): void
     {
@@ -873,8 +822,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that fields in the sortableFields are not validated
-     *
-     * @return void
      */
     public function testValidateAllowedSortTrusted(): void
     {
@@ -903,8 +850,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that sortableFields as empty array does not allow any sorting
-     *
-     * @return void
      */
     public function testValidateAllowedSortEmpty(): void
     {
@@ -931,8 +876,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that fields in the sortableFields are not validated
-     *
-     * @return void
      */
     public function testValidateSortNotInSchema(): void
     {
@@ -960,8 +903,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that multiple fields in the sortableFields are not validated and properly aliased.
-     *
-     * @return void
      */
     public function testValidateSortAllowMultiple(): void
     {
@@ -991,8 +932,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test that multiple sort works.
-     *
-     * @return void
      */
     public function testValidateSortMultiple(): void
     {
@@ -1020,8 +959,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Tests that order strings can used by Paginator
-     *
-     * @return void
      */
     public function testValidateSortWithString(): void
     {
@@ -1042,8 +979,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test that no sort doesn't trigger an error.
-     *
-     * @return void
      */
     public function testValidateSortNoSort(): void
     {
@@ -1064,8 +999,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Test sorting with incorrect aliases on valid fields.
-     *
-     * @return void
      */
     public function testValidateSortInvalidAlias(): void
     {
@@ -1129,7 +1062,6 @@ class PaginatorComponentTest extends TestCase
      * test that maxLimit is respected
      *
      * @dataProvider checkLimitProvider
-     * @return void
      */
     public function testCheckLimit(array $input, int $expected): void
     {
@@ -1139,8 +1071,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * Integration test for checkLimit() being applied inside paginate()
-     *
-     * @return void
      */
     public function testPaginateMaxLimit(): void
     {
@@ -1169,8 +1099,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test paginate() and custom find, to make sure the correct count is returned.
-     *
-     * @return void
      */
     public function testPaginateCustomFind(): void
     {
@@ -1233,8 +1161,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test paginate() and custom find with fields array, to make sure the correct count is returned.
-     *
-     * @return void
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
@@ -1268,8 +1194,6 @@ class PaginatorComponentTest extends TestCase
     /**
      * test paginate() and custom finders to ensure the count + find
      * use the custom type.
-     *
-     * @return void
      */
     public function testPaginateCustomFindCount(): void
     {
@@ -1300,8 +1224,6 @@ class PaginatorComponentTest extends TestCase
     /**
      * Tests that it is possible to pass an already made query object to
      * paginate()
-     *
-     * @return void
      */
     public function testPaginateQuery(): void
     {
@@ -1337,8 +1259,6 @@ class PaginatorComponentTest extends TestCase
 
     /**
      * test paginate() with bind()
-     *
-     * @return void
      */
     public function testPaginateQueryWithBindValue(): void
     {
@@ -1362,8 +1282,6 @@ class PaginatorComponentTest extends TestCase
     /**
      * Tests that passing a query object with a limit clause set will
      * overwrite it with the passed defaults.
-     *
-     * @return void
      */
     public function testPaginateQueryWithLimit(): void
     {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -62,8 +62,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -75,8 +73,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * init method
-     *
-     * @return void
      */
     protected function _init(): void
     {
@@ -94,8 +90,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -107,8 +101,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that the constructor sets the config.
-     *
-     * @return void
      */
     public function testConstructorConfig(): void
     {
@@ -126,8 +118,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * testInitializeCallback method
-     *
-     * @return void
      */
     public function testInitializeCallback(): void
     {
@@ -139,8 +129,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test that a mapped Accept-type header will set $this->ext correctly.
-     *
-     * @return void
      */
     public function testInitializeContentTypeSettingExt(): void
     {
@@ -154,8 +142,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that RequestHandler sets $this->ext when jQuery sends its wonky-ish headers.
-     *
-     * @return void
      */
     public function testInitializeContentTypeWithjQueryAccept(): void
     {
@@ -172,8 +158,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that RequestHandler does not set extension to csv for text/plain mimetype
-     *
-     * @return void
      */
     public function testInitializeContentTypeWithjQueryTextPlainAccept(): void
     {
@@ -187,8 +171,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * Test that RequestHandler sets $this->ext when jQuery sends its wonky-ish headers
      * and the application is configured to handle multiple extensions
-     *
-     * @return void
      */
     public function testInitializeContentTypeWithjQueryAcceptAndMultiplesExtensions(): void
     {
@@ -203,8 +185,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that RequestHandler does not set $this->ext when multiple accepts are sent.
-     *
-     * @return void
      */
     public function testInitializeNoContentTypeWithSingleAccept(): void
     {
@@ -221,8 +201,6 @@ class RequestHandlerComponentTest extends TestCase
      * content types.
      * Having multiple types accepted with same weight, means the client lets the
      * server choose the returned content type.
-     *
-     * @return void
      */
     public function testInitializeNoContentTypeWithMultipleAcceptedTypes(): void
     {
@@ -245,8 +223,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that ext is set to type with highest weight
-     *
-     * @return void
      */
     public function testInitializeContentTypeWithMultipleAcceptedTypes(): void
     {
@@ -263,8 +239,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that ext is not set with confusing android accepts headers.
-     *
-     * @return void
      */
     public function testInitializeAmbiguousAndroidAccepts(): void
     {
@@ -281,8 +255,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that the headers sent by firefox are not treated as XML requests.
-     *
-     * @return void
      */
     public function testInititalizeFirefoxHeaderNotXml(): void
     {
@@ -295,8 +267,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that a type mismatch doesn't incorrectly set the ext
-     *
-     * @return void
      */
     public function testInitializeContentTypeAndExtensionMismatch(): void
     {
@@ -317,10 +287,8 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test that startup() throws deprecation warning if input data is available and request data is not populated.
-     *
-     * @return void
      */
-    public function testInitializeInputNoWarningEmptyJsonObject()
+    public function testInitializeInputNoWarningEmptyJsonObject(): void
     {
         $request = new ServerRequest([
             'input' => json_encode([]),
@@ -332,8 +300,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * testViewClassMap
-     *
-     * @return void
      */
     public function testViewClassMap(): void
     {
@@ -362,7 +328,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * Verify that isAjax is set on the request params for AJAX requests
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testIsAjaxParams(): void
@@ -377,7 +342,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * testAutoAjaxLayout method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAutoAjaxLayout(): void
@@ -412,9 +376,8 @@ class RequestHandlerComponentTest extends TestCase
      *
      * @param string $extension Extension to test.
      * @dataProvider defaultExtensionsProvider
-     * @return void
      */
-    public function testDefaultExtensions($extension)
+    public function testDefaultExtensions($extension): void
     {
         Router::extensions([$extension], false);
 
@@ -436,9 +399,8 @@ class RequestHandlerComponentTest extends TestCase
      *
      * @param string $extension Extension to test.
      * @dataProvider defaultExtensionsProvider
-     * @return void
      */
-    public function testDefaultExtensionsOverwrittenByAcceptHeader($extension)
+    public function testDefaultExtensionsOverwrittenByAcceptHeader($extension): void
     {
         Router::extensions([$extension], false);
 
@@ -462,7 +424,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * test custom JsonView class is loaded and correct.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testJsonViewLoaded(): void
@@ -482,7 +443,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * test custom XmlView class is loaded and correct.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testXmlViewLoaded(): void
@@ -502,7 +462,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * test custom AjaxView class is loaded and correct.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testAjaxViewLoaded(): void
@@ -521,7 +480,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * test configured extension but no view class set.
      *
-     * @return void
      * @triggers Controller.beforeRender $this->Controller
      */
     public function testNoViewClassExtension(): void
@@ -540,10 +498,8 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Tests that configured extensions that have no configured mimetype do not silently fallback to HTML.
-     *
-     * @return void
      */
-    public function testUnrecognizedExtensionFailure()
+    public function testUnrecognizedExtensionFailure(): void
     {
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('Invoked extension not recognized/configured: foo');
@@ -561,8 +517,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * testRenderAs method
-     *
-     * @return void
      */
     public function testRenderAs(): void
     {
@@ -575,8 +529,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test that attachment headers work with renderAs
-     *
-     * @return void
      */
     public function testRenderAsWithAttachment(): void
     {
@@ -591,8 +543,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test that respondAs works as expected.
-     *
-     * @return void
      */
     public function testRespondAs(): void
     {
@@ -607,8 +557,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test that attachment headers work with respondAs
-     *
-     * @return void
      */
     public function testRespondAsWithAttachment(): void
     {
@@ -623,7 +571,6 @@ class RequestHandlerComponentTest extends TestCase
      * test that calling renderAs() more than once continues to work.
      *
      * @link #6466
-     * @return void
      */
     public function testRenderAsCalledTwice(): void
     {
@@ -643,8 +590,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * testRequestContentTypes method
-     *
-     * @return void
      */
     public function testRequestContentTypes(): void
     {
@@ -705,8 +650,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test that map alias converts aliases to content types.
-     *
-     * @return void
      */
     public function testMapAlias(): void
     {
@@ -726,8 +669,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test accepts() on the component
-     *
-     * @return void
      */
     public function testAccepts(): void
     {
@@ -744,8 +685,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test accepts and prefers methods.
-     *
-     * @return void
      */
     public function testPrefers(): void
     {
@@ -783,7 +722,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * Test checkNotModified method
      *
-     * @return void
      * @triggers Controller.beforeRender $this->Controller
      */
     public function testCheckNotModifiedByEtagStar(): void
@@ -807,7 +745,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * Test checkNotModified method
      *
-     * @return void
      * @triggers Controller.beforeRender
      */
     public function testCheckNotModifiedByEtagExact(): void
@@ -832,7 +769,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * Test checkNotModified method
      *
-     * @return void
      * @triggers Controller.beforeRender $this->Controller
      */
     public function testCheckNotModifiedByEtagAndTime(): void
@@ -861,7 +797,6 @@ class RequestHandlerComponentTest extends TestCase
     /**
      * Test checkNotModified method
      *
-     * @return void
      * @triggers Controller.beforeRender $this->Controller
      */
     public function testCheckNotModifiedNoInfo(): void
@@ -877,8 +812,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test default options in construction
-     *
-     * @return void
      */
     public function testConstructDefaultOptions(): void
     {
@@ -894,8 +827,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * Test options in constructor replace defaults
-     *
-     * @return void
      */
     public function testConstructReplaceOptions(): void
     {
@@ -919,8 +850,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * test beforeRender() doesn't override response type set in controller action
-     *
-     * @return void
      */
     public function testBeforeRender(): void
     {
@@ -932,8 +861,6 @@ class RequestHandlerComponentTest extends TestCase
 
     /**
      * tests beforeRender automatically uses renderAs when a supported extension is found
-     *
-     * @return void
      */
     public function testBeforeRenderAutoRenderAs(): void
     {

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -61,8 +61,6 @@ class SecurityComponentTest extends TestCase
      * setUp method
      *
      * Initializes environment state.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -85,8 +83,6 @@ class SecurityComponentTest extends TestCase
 
     /**
      * Resets environment state.
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -117,7 +113,6 @@ class SecurityComponentTest extends TestCase
      * Test that requests are still blackholed when controller has incorrect
      * visibility keyword in the blackhole callback.
      *
-     * @return void
      * @triggers Controller.startup $Controller, $this->Controller
      */
     public function testBlackholeWithBrokenCallback(): void
@@ -145,7 +140,6 @@ class SecurityComponentTest extends TestCase
      * Ensure that directly requesting the blackholeCallback as the controller
      * action results in an exception.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testExceptionWhenActionIsBlackholeCallback(): void
@@ -162,10 +156,8 @@ class SecurityComponentTest extends TestCase
 
     /**
      * test blackholeCallback returning a response
-     *
-     * @return void
      */
-    public function testBlackholeReturnResponse()
+    public function testBlackholeReturnResponse(): void
     {
         $request = new ServerRequest([
             'url' => 'posts/index',
@@ -192,8 +184,6 @@ class SecurityComponentTest extends TestCase
      * testConstructorSettingProperties method
      *
      * Test that initialize can set properties.
-     *
-     * @return void
      */
     public function testConstructorSettingProperties(): void
     {
@@ -208,7 +198,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testRequireSecureFail method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testRequireSecureFail(): void
@@ -227,7 +216,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testRequireSecureSucceed method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testRequireSecureSucceed(): void
@@ -245,7 +233,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testRequireSecureEmptyFail method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testRequireSecureEmptyFail(): void
@@ -263,7 +250,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testRequireSecureEmptySucceed method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testRequireSecureEmptySucceed(): void
@@ -283,7 +269,6 @@ class SecurityComponentTest extends TestCase
      *
      * Simple hash validation test
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePost(): void
@@ -308,7 +293,6 @@ class SecurityComponentTest extends TestCase
      * Test that validatePost fires on GET with request data.
      * This could happen when method overriding is used.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostOnGetWithData(): void
@@ -338,7 +322,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails if you are missing the session information.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostNoSession(): void
@@ -366,7 +349,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails if you are missing unlocked in request data.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostNoUnlockedInRequestData(): void
@@ -388,7 +370,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails if any of its required fields are missing.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFormTampering(): void
@@ -410,7 +391,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails if empty form is submitted.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostEmptyForm(): void
@@ -430,7 +410,6 @@ class SecurityComponentTest extends TestCase
      * Test that objects can't be passed into the serialized string. This was a vector for RFI and LFI
      * attacks. Thanks to Felix Wilhelm
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostObjectDeserialize(): void
@@ -462,7 +441,6 @@ class SecurityComponentTest extends TestCase
      *
      * Tests validation post data ignores `_csrfToken`.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostIgnoresCsrfToken(): void
@@ -486,7 +464,6 @@ class SecurityComponentTest extends TestCase
      *
      * Tests validation of checkbox arrays.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostArray(): void
@@ -519,8 +496,6 @@ class SecurityComponentTest extends TestCase
      * testValidateIntFieldName method
      *
      * Tests validation of integer field names.
-     *
-     * @return void
      */
     public function testValidateIntFieldName(): void
     {
@@ -545,7 +520,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testValidatePostNoModel method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostNoModel(): void
@@ -569,7 +543,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testValidatePostSimple method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostSimple(): void
@@ -593,7 +566,6 @@ class SecurityComponentTest extends TestCase
     /**
      * test validatePost uses full URL
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostSubdirectory(): void
@@ -626,7 +598,6 @@ class SecurityComponentTest extends TestCase
      *
      * Tests hash validation for multiple records, including locked fields.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostComplex(): void
@@ -660,7 +631,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test ValidatePost with multiple select elements.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostMultipleSelect(): void
@@ -709,7 +679,6 @@ class SecurityComponentTest extends TestCase
      * First block tests un-checked checkbox
      * Second block tests checked checkbox
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostCheckbox(): void
@@ -753,7 +722,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testValidatePostHidden method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostHidden(): void
@@ -780,7 +748,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test validating post data with posted unlocked fields.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostDisabledFieldsInData(): void
@@ -812,7 +779,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that missing 'unlocked' input causes failure.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFailNoDisabled(): void
@@ -840,7 +806,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that missing 'debug' input causes failure.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFailNoDebug(): void
@@ -869,7 +834,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that missing 'debug' input is not the problem when debug mode disabled.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFailNoDebugMode(): void
@@ -898,7 +862,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails when unlocked fields are changed.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFailDisabledFieldTampering(): void
@@ -932,10 +895,8 @@ class SecurityComponentTest extends TestCase
 
     /**
      * Test that invalid types cause failures.
-     *
-     * @return void
      */
-    public function testValidatePostFailArrayData()
+    public function testValidatePostFailArrayData(): void
     {
         $event = new Event('Controller.startup', $this->Controller);
         $this->Security->startup($event);
@@ -957,7 +918,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testValidateHiddenMultipleModel method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidateHiddenMultipleModel(): void
@@ -981,7 +941,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testValidateHasManyModel method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidateHasManyModel(): void
@@ -1014,7 +973,6 @@ class SecurityComponentTest extends TestCase
     /**
      * testValidateHasManyRecordsPass method
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidateHasManyRecordsPass(): void
@@ -1061,7 +1019,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that values like Foo.0.1
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidateNestedNumericSets(): void
@@ -1091,7 +1048,6 @@ class SecurityComponentTest extends TestCase
      *
      * validatePost should fail, hidden fields have been changed.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidateHasManyRecordsFail(): void
@@ -1158,7 +1114,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test validatePost with radio buttons.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostRadio(): void
@@ -1206,7 +1161,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test validatePost uses here() as a hash input.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostUrlAsHashInput(): void
@@ -1246,8 +1200,6 @@ class SecurityComponentTest extends TestCase
      * testGenerateToken method
      *
      * Test generateToken().
-     *
-     * @return void
      */
     public function testGenerateToken(): void
     {
@@ -1264,7 +1216,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test unlocked actions.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testUnlockedActions(): void
@@ -1283,7 +1234,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that debug token format is right.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostDebugFormat(): void
@@ -1321,8 +1271,6 @@ class SecurityComponentTest extends TestCase
      * testBlackholeThrowsException method
      *
      * Test blackhole will now throw passed exception if debug enabled.
-     *
-     * @return void
      */
     public function testBlackholeThrowsException(): void
     {
@@ -1336,8 +1284,6 @@ class SecurityComponentTest extends TestCase
      * testBlackholeThrowsBadRequest method
      *
      * Test blackhole will throw BadRequest if debug disabled.
-     *
-     * @return void
      */
     public function testBlackholeThrowsBadRequest(): void
     {
@@ -1360,7 +1306,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails with tampered fields and explanation.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFailTampering(): void
@@ -1393,7 +1338,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that validatePost fails with tampered fields and explanation.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostFailTamperingMutatedIntoArray(): void
@@ -1426,7 +1370,6 @@ class SecurityComponentTest extends TestCase
      *
      * Test that debug token should not be sent if debug is disabled.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidatePostUnexpectedDebugToken(): void

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -37,8 +37,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -61,8 +57,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * test triggering callbacks on loaded helpers
-     *
-     * @return void
      */
     public function testLoad(): void
     {
@@ -79,8 +73,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Tests loading as an alias
-     *
-     * @return void
      */
     public function testLoadWithAlias(): void
     {
@@ -106,8 +98,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * test load and enable = false
-     *
-     * @return void
      */
     public function testLoadWithEnableFalse(): void
     {
@@ -124,8 +114,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * test MissingComponent exception
-     *
-     * @return void
      */
     public function testLoadMissingComponent(): void
     {
@@ -135,8 +123,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * test loading a plugin component.
-     *
-     * @return void
      */
     public function testLoadPluginComponent(): void
     {
@@ -148,8 +134,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test loading components with aliases and plugins.
-     *
-     * @return void
      */
     public function testLoadWithAliasAndPlugin(): void
     {
@@ -164,8 +148,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * test getting the controller out of the collection
-     *
-     * @return void
      */
     public function testGetController(): void
     {
@@ -175,8 +157,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test reset.
-     *
-     * @return void
      */
     public function testReset(): void
     {
@@ -197,8 +177,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test unloading.
-     *
-     * @return void
      */
     public function testUnload(): void
     {
@@ -214,8 +192,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test __unset.
-     *
-     * @return void
      */
     public function testUnset(): void
     {
@@ -230,8 +206,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test that unloading a none existing component triggers an error.
-     *
-     * @return void
      */
     public function testUnloadUnknown(): void
     {
@@ -242,8 +216,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test set.
-     *
-     * @return void
      */
     public function testSet(): void
     {
@@ -260,8 +232,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test __set.
-     *
-     * @return void
      */
     public function testMagicSet(): void
     {
@@ -277,8 +247,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test Countable.
-     *
-     * @return void
      */
     public function testCountable(): void
     {
@@ -290,8 +258,6 @@ class ComponentRegistryTest extends TestCase
 
     /**
      * Test Traversable.
-     *
-     * @return void
      */
     public function testTraversable(): void
     {

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -35,8 +35,6 @@ class ComponentTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,8 +44,6 @@ class ComponentTest extends TestCase
 
     /**
      * test accessing inner components.
-     *
-     * @return void
      */
     public function testInnerComponentConstruction(): void
     {
@@ -59,8 +55,6 @@ class ComponentTest extends TestCase
 
     /**
      * test component loading
-     *
-     * @return void
      */
     public function testNestedComponentLoading(): void
     {
@@ -75,8 +69,6 @@ class ComponentTest extends TestCase
 
     /**
      * test that component components are not enabled in the collection.
-     *
-     * @return void
      */
     public function testInnerComponentsAreNotEnabled(): void
     {
@@ -96,8 +88,6 @@ class ComponentTest extends TestCase
 
     /**
      * test a component being used more than once.
-     *
-     * @return void
      */
     public function testMultipleComponentInitialize(): void
     {
@@ -113,8 +103,6 @@ class ComponentTest extends TestCase
 
     /**
      * Test a duplicate component being loaded more than once with same and differing configurations.
-     *
-     * @return void
      */
     public function testDuplicateComponentInitialize(): void
     {
@@ -133,8 +121,6 @@ class ComponentTest extends TestCase
 
     /**
      * Test mutually referencing components.
-     *
-     * @return void
      */
     public function testSomethingReferencingFlashComponent(): void
     {
@@ -148,8 +134,6 @@ class ComponentTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
     public function testDebugInfo(): void
     {
@@ -171,8 +155,6 @@ class ComponentTest extends TestCase
 
     /**
      * Tests null return for unknown magic properties.
-     *
-     * @return void
      */
     public function testMagicReturnsNull(): void
     {
@@ -182,8 +164,6 @@ class ComponentTest extends TestCase
 
     /**
      * Tests config via constructor
-     *
-     * @return void
      */
     public function testConfigViaConstructor(): void
     {
@@ -194,8 +174,6 @@ class ComponentTest extends TestCase
 
     /**
      * Lazy load a component without events.
-     *
-     * @return void
      */
     public function testLazyLoading(): void
     {
@@ -211,8 +189,6 @@ class ComponentTest extends TestCase
 
     /**
      * Lazy load a component that does not exist.
-     *
-     * @return void
      */
     public function testLazyLoadingDoesNotExists(): void
     {
@@ -224,8 +200,6 @@ class ComponentTest extends TestCase
 
     /**
      * Lazy loaded components can have config options
-     *
-     * @return void
      */
     public function testConfiguringInnerComponent(): void
     {
@@ -237,8 +211,6 @@ class ComponentTest extends TestCase
 
     /**
      * Test enabling events for lazy loaded components
-     *
-     * @return void
      */
     public function testEventsInnerComponent(): void
     {
@@ -258,8 +230,6 @@ class ComponentTest extends TestCase
 
     /**
      * Disabled events do not register for event listeners.
-     *
-     * @return void
      */
     public function testNoEventsInnerComponent(): void
     {
@@ -277,10 +247,8 @@ class ComponentTest extends TestCase
 
     /**
      * Test that calling getController() without setting a controller throws exception
-     *
-     * @return void
      */
-    public function testGetControllerException()
+    public function testGetControllerException(): void
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Controller not set for ComponentRegistry');

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -39,8 +39,6 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,10 +50,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building an application controller
-     *
-     * @return void
      */
-    public function testApplicationController()
+    public function testApplicationController(): void
     {
         $request = new ServerRequest([
             'url' => 'cakes/index',
@@ -71,12 +67,10 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building a prefixed app controller.
-     *
-     * @return void
      */
-    public function testPrefixedAppControllerDeprecated()
+    public function testPrefixedAppControllerDeprecated(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $request = new ServerRequest([
                 'url' => 'admin/posts/index',
                 'params' => [
@@ -96,10 +90,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building a nested prefix app controller
-     *
-     * @return void
      */
-    public function testNestedPrefixedAppController()
+    public function testNestedPrefixedAppController(): void
     {
         $request = new ServerRequest([
             'url' => 'admin/sub/posts/index',
@@ -119,10 +111,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building a plugin controller
-     *
-     * @return void
      */
-    public function testPluginController()
+    public function testPluginController(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin/test_plugin/index',
@@ -142,10 +132,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building a vendored plugin controller.
-     *
-     * @return void
      */
-    public function testVendorPluginController()
+    public function testVendorPluginController(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/ovens/index',
@@ -165,10 +153,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building a prefixed plugin controller
-     *
-     * @return void
      */
-    public function testPrefixedPluginController()
+    public function testPrefixedPluginController(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin/admin/comments',
@@ -187,10 +173,7 @@ class ControllerFactoryTest extends TestCase
         $this->assertSame($request, $result->getRequest());
     }
 
-    /**
-     * @return void
-     */
-    public function testAbstractClassFailure()
+    public function testAbstractClassFailure(): void
     {
         $this->expectException(MissingControllerException::class);
         $this->expectExceptionMessage('Controller class Abstract could not be found.');
@@ -204,10 +187,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->create($request);
     }
 
-    /**
-     * @return void
-     */
-    public function testInterfaceFailure()
+    public function testInterfaceFailure(): void
     {
         $this->expectException(MissingControllerException::class);
         $this->expectExceptionMessage('Controller class Interface could not be found.');
@@ -221,10 +201,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->create($request);
     }
 
-    /**
-     * @return void
-     */
-    public function testMissingClassFailure()
+    public function testMissingClassFailure(): void
     {
         $this->expectException(MissingControllerException::class);
         $this->expectExceptionMessage('Controller class Invisible could not be found.');
@@ -238,10 +215,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->create($request);
     }
 
-    /**
-     * @return void
-     */
-    public function testSlashedControllerFailure()
+    public function testSlashedControllerFailure(): void
     {
         $this->expectException(MissingControllerException::class);
         $this->expectExceptionMessage('Controller class Admin/Posts could not be found.');
@@ -255,10 +229,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->create($request);
     }
 
-    /**
-     * @return void
-     */
-    public function testAbsoluteReferenceFailure()
+    public function testAbsoluteReferenceFailure(): void
     {
         $this->expectException(MissingControllerException::class);
         $this->expectExceptionMessage('Controller class TestApp\Controller\CakesController could not be found.');
@@ -274,10 +245,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test create() injecting dependcies on defined controllers.
-     *
-     * @return void
      */
-    public function testCreateWithContainerDependenciesNoController()
+    public function testCreateWithContainerDependenciesNoController(): void
     {
         $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
 
@@ -295,10 +264,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test create() injecting dependcies on defined controllers.
-     *
-     * @return void
      */
-    public function testCreateWithContainerDependenciesWithController()
+    public function testCreateWithContainerDependenciesWithController(): void
     {
         $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
         $this->container->add(DependenciesController::class)
@@ -324,10 +291,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test building controller name when passing no controller name
-     *
-     * @return void
      */
-    public function testGetControllerClassNoControllerName()
+    public function testGetControllerClassNoControllerName(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/ovens/index',
@@ -343,10 +308,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test invoke with autorender
-     *
-     * @return void
      */
-    public function testInvokeAutoRender()
+    public function testInvokeAutoRender(): void
     {
         $request = new ServerRequest([
             'url' => 'posts',
@@ -365,10 +328,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test dispatch with autorender=false
-     *
-     * @return void
      */
-    public function testInvokeAutoRenderFalse()
+    public function testInvokeAutoRenderFalse(): void
     {
         $request = new ServerRequest([
             'url' => 'posts',
@@ -387,10 +348,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controller's startup event can stop the request.
-     *
-     * @return void
      */
-    public function testStartupProcessAbort()
+    public function testStartupProcessAbort(): void
     {
         $request = new ServerRequest([
             'url' => 'cakes/index',
@@ -410,10 +369,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controllers startup process can emit a response
-     *
-     * @return void
      */
-    public function testShutdownProcessResponse()
+    public function testShutdownProcessResponse(): void
     {
         $request = new ServerRequest([
             'url' => 'cakes/index',
@@ -433,10 +390,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controllers startup process can emit a response
-     *
-     * @return void
      */
-    public function testInvokeInjectOptionalParameterDefined()
+    public function testInvokeInjectOptionalParameterDefined(): void
     {
         $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
         $request = new ServerRequest([
@@ -459,10 +414,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controllers startup process can emit a response
-     *
-     * @return void
      */
-    public function testInvokeInjectParametersOptionalNotDefined()
+    public function testInvokeInjectParametersOptionalNotDefined(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/index',
@@ -485,10 +438,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controllers startup process can emit a response
-     *
-     * @return void
      */
-    public function testInvokeInjectParametersOptionalWithPassedParameters()
+    public function testInvokeInjectParametersOptionalWithPassedParameters(): void
     {
         $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
         $request = new ServerRequest([
@@ -512,10 +463,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controllers startup process can emit a response
-     *
-     * @return void
      */
-    public function testInvokeInjectParametersRequiredDefined()
+    public function testInvokeInjectParametersRequiredDefined(): void
     {
         $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
         $request = new ServerRequest([
@@ -538,10 +487,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Ensure that a controllers startup process can emit a response
-     *
-     * @return void
      */
-    public function testInvokeInjectParametersRequiredNotDefined()
+    public function testInvokeInjectParametersRequiredNotDefined(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/index',
@@ -558,7 +505,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->invoke($controller);
     }
 
-    public function testInvokeInjectParametersRequiredMissingUntyped()
+    public function testInvokeInjectParametersRequiredMissingUntyped(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/requiredParam',
@@ -575,7 +522,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->invoke($controller);
     }
 
-    public function testInvokeInjectParametersRequiredUntyped()
+    public function testInvokeInjectParametersRequiredUntyped(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/requiredParam',
@@ -594,7 +541,7 @@ class ControllerFactoryTest extends TestCase
         $this->assertSame($data->one, 'one');
     }
 
-    public function testInvokeInjectParametersRequiredWithPassedParameters()
+    public function testInvokeInjectParametersRequiredWithPassedParameters(): void
     {
         $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
         $request = new ServerRequest([
@@ -618,10 +565,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test that routing parameters are passed into variadic controller functions
-     *
-     * @return void
      */
-    public function testInvokeInjectPassedParametersVariadic()
+    public function testInvokeInjectPassedParametersVariadic(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/variadic',
@@ -642,10 +587,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test that routing parameters are passed into controller action using spread operator
-     *
-     * @return void
      */
-    public function testInvokeInjectPassedParametersSpread()
+    public function testInvokeInjectPassedParametersSpread(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/spread',
@@ -666,10 +609,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test that routing parameters are passed into controller action using spread operator
-     *
-     * @return void
      */
-    public function testInvokeInjectPassedParametersSpreadNoParams()
+    public function testInvokeInjectPassedParametersSpreadNoParams(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/spread',
@@ -690,10 +631,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test that default parameters work for controller methods
-     *
-     * @return void
      */
-    public function testInvokeOptionalStringParam()
+    public function testInvokeOptionalStringParam(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/optionalString',
@@ -714,10 +653,8 @@ class ControllerFactoryTest extends TestCase
 
     /**
      * Test that required strings a default value.
-     *
-     * @return void
      */
-    public function testInvokeRequiredStringParam()
+    public function testInvokeRequiredStringParam(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/requiredString',
@@ -734,7 +671,7 @@ class ControllerFactoryTest extends TestCase
         $this->factory->invoke($controller);
     }
 
-    public function testMiddleware()
+    public function testMiddleware(): void
     {
         $request = new ServerRequest([
             'url' => 'posts',

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -49,8 +49,6 @@ class ControllerTest extends TestCase
 
     /**
      * reset environment.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,8 +60,6 @@ class ControllerTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -73,8 +69,6 @@ class ControllerTest extends TestCase
 
     /**
      * test autoload modelClass
-     *
-     * @return void
      */
     public function testTableAutoload(): void
     {
@@ -100,10 +94,8 @@ class ControllerTest extends TestCase
 
     /**
      * testUndefinedPropertyError
-     *
-     * @return void
      */
-    public function testUndefinedPropertyError()
+    public function testUndefinedPropertyError(): void
     {
         $controller = new Controller();
 
@@ -121,8 +113,6 @@ class ControllerTest extends TestCase
 
     /**
      * testLoadModel method
-     *
-     * @return void
      */
     public function testLoadModel(): void
     {
@@ -144,7 +134,6 @@ class ControllerTest extends TestCase
 
     /**
      * @link https://github.com/cakephp/cakephp/issues/14804
-     * @return void
      */
     public function testAutoLoadModelUsingFqcn(): void
     {
@@ -158,8 +147,6 @@ class ControllerTest extends TestCase
 
     /**
      * testLoadModel method from a plugin controller
-     *
-     * @return void
      */
     public function testLoadModelInPlugins(): void
     {
@@ -183,8 +170,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test that the constructor sets modelClass properly.
-     *
-     * @return void
      */
     public function testConstructSetModelClass(): void
     {
@@ -208,8 +193,6 @@ class ControllerTest extends TestCase
 
     /**
      * testConstructClassesWithComponents method
-     *
-     * @return void
      */
     public function testConstructClassesWithComponents(): void
     {
@@ -223,8 +206,6 @@ class ControllerTest extends TestCase
 
     /**
      * testRender method
-     *
-     * @return void
      */
     public function testRender(): void
     {
@@ -253,8 +234,6 @@ class ControllerTest extends TestCase
 
     /**
      * test view rendering changing response
-     *
-     * @return void
      */
     public function testRenderViewChangesResponse(): void
     {
@@ -276,8 +255,6 @@ class ControllerTest extends TestCase
 
     /**
      * test that a component beforeRender can change the controller view class.
-     *
-     * @return void
      */
     public function testBeforeRenderCallbackChangingViewClass(): void
     {
@@ -301,8 +278,6 @@ class ControllerTest extends TestCase
 
     /**
      * test that a component beforeRender can change the controller view class.
-     *
-     * @return void
      */
     public function testBeforeRenderEventCancelsRender(): void
     {
@@ -316,7 +291,7 @@ class ControllerTest extends TestCase
         $this->assertInstanceOf('Cake\Http\Response', $result);
     }
 
-    public function testControllerRedirect()
+    public function testControllerRedirect(): void
     {
         $Controller = new Controller();
         $uri = new Uri('/foo/bar');
@@ -352,7 +327,6 @@ class ControllerTest extends TestCase
      * testRedirect method
      *
      * @dataProvider statusCodeProvider
-     * @return void
      */
     public function testRedirectByCode(int $code, string $msg): void
     {
@@ -367,8 +341,6 @@ class ControllerTest extends TestCase
 
     /**
      * test that beforeRedirect callbacks can set the URL that is being redirected to.
-     *
-     * @return void
      */
     public function testRedirectBeforeRedirectModifyingUrl(): void
     {
@@ -386,8 +358,6 @@ class ControllerTest extends TestCase
 
     /**
      * test that beforeRedirect callback returning null doesn't affect things.
-     *
-     * @return void
      */
     public function testRedirectBeforeRedirectModifyingStatusCode(): void
     {
@@ -421,8 +391,6 @@ class ControllerTest extends TestCase
 
     /**
      * testReferer method
-     *
-     * @return void
      */
     public function testReferer(): void
     {
@@ -460,8 +428,6 @@ class ControllerTest extends TestCase
      * Test that the referer is not absolute if it is '/'.
      *
      * This avoids the base path being applied twice on string urls.
-     *
-     * @return void
      */
     public function testRefererSlash(): void
     {
@@ -481,12 +447,11 @@ class ControllerTest extends TestCase
     /**
      * testSetAction method
      *
-     * @return void
      * @group deprecated
      */
     public function testSetAction(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $request = new ServerRequest(['url' => 'controller/posts/index']);
 
             $TestController = new TestController($request);
@@ -499,8 +464,6 @@ class ControllerTest extends TestCase
 
     /**
      * Tests that the startup process calls the correct functions
-     *
-     * @return void
      */
     public function testStartupProcess(): void
     {
@@ -525,8 +488,6 @@ class ControllerTest extends TestCase
 
     /**
      * Tests that the shutdown process calls the correct functions
-     *
-     * @return void
      */
     public function testShutdownProcess(): void
     {
@@ -545,8 +506,6 @@ class ControllerTest extends TestCase
 
     /**
      * test using Controller::paginate()
-     *
-     * @return void
      */
     public function testPaginate(): void
     {
@@ -595,8 +554,6 @@ class ControllerTest extends TestCase
 
     /**
      * test that paginate uses modelClass property.
-     *
-     * @return void
      */
     public function testPaginateUsesModelClass(): void
     {
@@ -614,8 +571,6 @@ class ControllerTest extends TestCase
 
     /**
      * testMissingAction method
-     *
-     * @return void
      */
     public function testGetActionMissingAction(): void
     {
@@ -633,8 +588,6 @@ class ControllerTest extends TestCase
 
     /**
      * test invoking private methods.
-     *
-     * @return void
      */
     public function testGetActionPrivate(): void
     {
@@ -652,8 +605,6 @@ class ControllerTest extends TestCase
 
     /**
      * test invoking protected methods.
-     *
-     * @return void
      */
     public function testGetActionProtected(): void
     {
@@ -671,8 +622,6 @@ class ControllerTest extends TestCase
 
     /**
      * test invoking controller methods.
-     *
-     * @return void
      */
     public function testGetActionBaseMethods(): void
     {
@@ -690,8 +639,6 @@ class ControllerTest extends TestCase
 
     /**
      * test invoking action method with mismatched casing.
-     *
-     * @return void
      */
     public function testGetActionMethodCasing(): void
     {
@@ -728,8 +675,6 @@ class ControllerTest extends TestCase
 
     /**
      * test invoking controller methods.
-     *
-     * @return void
      */
     public function testInvokeActionReturnValue(): void
     {
@@ -751,8 +696,6 @@ class ControllerTest extends TestCase
 
     /**
      * test invoking controller methods with passed params
-     *
-     * @return void
      */
     public function testInvokeActionWithPassedParams(): void
     {
@@ -776,10 +719,8 @@ class ControllerTest extends TestCase
 
     /**
      * test invalid return value from action method.
-     *
-     * @return void
      */
-    public function testInvokeActionException()
+    public function testInvokeActionException(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage(
@@ -803,8 +744,6 @@ class ControllerTest extends TestCase
 
     /**
      * test that a classes namespace is used in the viewPath.
-     *
-     * @return void
      */
     public function testViewPathConventions(): void
     {
@@ -845,8 +784,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test the components() method.
-     *
-     * @return void
      */
     public function testComponents(): void
     {
@@ -862,8 +799,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test the components property errors
-     *
-     * @return void
      */
     public function testComponentsPropertyError(): void
     {
@@ -877,8 +812,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test the helpers property errors
-     *
-     * @return void
      */
     public function testHelpersPropertyError(): void
     {
@@ -892,8 +825,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test the components() method with the custom ObjectRegistry.
-     *
-     * @return void
      */
     public function testComponentsWithCustomRegistry(): void
     {
@@ -912,8 +843,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test adding a component
-     *
-     * @return void
      */
     public function testLoadComponent(): void
     {
@@ -931,8 +860,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test adding a component that is a duplicate.
-     *
-     * @return void
      */
     public function testLoadComponentDuplicate(): void
     {
@@ -952,8 +879,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test the isAction method.
-     *
-     * @return void
      */
     public function testIsAction(): void
     {
@@ -968,8 +893,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test that view variables are being set after the beforeRender event gets dispatched
-     *
-     * @return void
      */
     public function testBeforeRenderViewVariables(): void
     {
@@ -990,13 +913,11 @@ class ControllerTest extends TestCase
 
     /**
      * Test that render()'s arguments are available in beforeRender() through view builder.
-     *
-     * @return void
      */
-    public function testBeforeRenderTemplateAndLayout()
+    public function testBeforeRenderTemplateAndLayout(): void
     {
         $Controller = new Controller(new ServerRequest(), new Response());
-        $Controller->getEventManager()->on('Controller.beforeRender', function ($event) {
+        $Controller->getEventManager()->on('Controller.beforeRender', function ($event): void {
             $this->assertSame(
                 '/Element/test_element',
                 $event->getSubject()->viewBuilder()->getTemplate()
@@ -1017,8 +938,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test name getter and setter.
-     *
-     * @return void
      */
     public function testName(): void
     {
@@ -1031,8 +950,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test plugin getter and setter.
-     *
-     * @return void
      */
     public function testPlugin(): void
     {
@@ -1045,8 +962,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test request getter and setter.
-     *
-     * @return void
      */
     public function testRequest(): void
     {
@@ -1071,8 +986,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test response getter and setter.
-     *
-     * @return void
      */
     public function testResponse(): void
     {
@@ -1086,8 +999,6 @@ class ControllerTest extends TestCase
 
     /**
      * Test autoRender getter and setter.
-     *
-     * @return void
      */
     public function testAutoRender(): void
     {

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -26,8 +26,6 @@ class AuthSecurityExceptionTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -37,8 +35,6 @@ class AuthSecurityExceptionTest extends TestCase
 
     /**
      * Test the getType() function.
-     *
-     * @return void
      */
     public function testGetType(): void
     {

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -31,8 +31,6 @@ class SecurityExceptionTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,8 +40,6 @@ class SecurityExceptionTest extends TestCase
 
     /**
      * Test the getType() function.
-     *
-     * @return void
      */
     public function testGetType(): void
     {
@@ -56,8 +52,6 @@ class SecurityExceptionTest extends TestCase
 
     /**
      * Test the setMessage() function.
-     *
-     * @return void
      */
     public function testSetMessage(): void
     {
@@ -72,8 +66,6 @@ class SecurityExceptionTest extends TestCase
 
     /**
      * Test the setReason() and corresponding getReason() function.
-     *
-     * @return void
      */
     public function testSetGetReason(): void
     {

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -28,8 +28,6 @@ class AppTest extends TestCase
 {
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -47,10 +45,9 @@ class AppTest extends TestCase
      * @param string $suffix Class suffix
      * @param bool $existsInBase Whether class exists in base.
      * @param mixed $expected Expected value.
-     * @return void
      * @dataProvider classNameProvider
      */
-    public function testClassName($class, $type, $suffix = '', $existsInBase = false, $expected = false)
+    public function testClassName($class, $type, $suffix = '', $existsInBase = false, $expected = false): void
     {
         static::setAppNamespace();
         $i = 0;
@@ -69,7 +66,7 @@ class AppTest extends TestCase
         $this->assertSame($expected === false ? null : $expected, $return);
     }
 
-    public function testClassNameWithFqcn()
+    public function testClassNameWithFqcn(): void
     {
         $this->assertSame(TestCase::class, App::className(TestCase::class));
         $this->assertNull(App::className('\Foo'));
@@ -82,10 +79,9 @@ class AppTest extends TestCase
      * @param string $type Class type
      * @param string $suffix Class suffix
      * @param mixed $expected Expected value.
-     * @return void
      * @dataProvider shortNameProvider
      */
-    public function testShortName($class, $type, $suffix = '', $expected = false)
+    public function testShortName($class, $type, $suffix = '', $expected = false): void
     {
         static::setAppNamespace();
 
@@ -95,10 +91,8 @@ class AppTest extends TestCase
 
     /**
      * testShortNameWithNestedAppNamespace
-     *
-     * @return void
      */
-    public function testShortNameWithNestedAppNamespace()
+    public function testShortNameWithNestedAppNamespace(): void
     {
         static::setAppNamespace('TestApp/Nested');
 
@@ -114,9 +108,8 @@ class AppTest extends TestCase
 
     /**
      * @link https://github.com/cakephp/cakephp/issues/15415
-     * @return void
      */
-    public function testShortNameWithAppNamespaceUnset()
+    public function testShortNameWithAppNamespaceUnset(): void
     {
         Configure::delete('App.namespace');
 
@@ -232,10 +225,8 @@ class AppTest extends TestCase
 
     /**
      * test classPath() with a plugin.
-     *
-     * @return void
      */
-    public function testClassPathWithPlugins()
+    public function testClassPathWithPlugins(): void
     {
         $basepath = TEST_APP . 'Plugin' . DS;
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
@@ -251,10 +242,9 @@ class AppTest extends TestCase
     /**
      * test path() with a plugin.
      *
-     * @return void
      * @deprecated
      */
-    public function testPathWithPlugins()
+    public function testPathWithPlugins(): void
     {
         $basepath = TEST_APP . 'Plugin' . DS;
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
@@ -266,7 +256,7 @@ class AppTest extends TestCase
         $expected = $basepath . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS;
         $this->assertPathEquals($expected, $result[0]);
 
-        $this->deprecated(function () use ($basepath) {
+        $this->deprecated(function () use ($basepath): void {
             $result = App::path('Controller', 'TestPlugin');
             $this->assertPathEquals($basepath . 'TestPlugin' . DS . 'src' . DS . 'Controller' . DS, $result[0]);
 
@@ -278,10 +268,8 @@ class AppTest extends TestCase
 
     /**
      * testCore method
-     *
-     * @return void
      */
-    public function testCore()
+    public function testCore(): void
     {
         $model = App::core('Model');
         $this->assertEquals([CAKE . 'Model' . DS], $model);

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -35,8 +35,6 @@ class BasePluginTest extends TestCase
 {
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -46,10 +44,8 @@ class BasePluginTest extends TestCase
 
     /**
      * testConfigForRoutesAndBootstrap
-     *
-     * @return void
      */
-    public function testConfigForRoutesAndBootstrap()
+    public function testConfigForRoutesAndBootstrap(): void
     {
         $plugin = new BasePlugin([
             'bootstrap' => false,
@@ -63,7 +59,7 @@ class BasePluginTest extends TestCase
         $this->assertTrue($plugin->isEnabled('services'));
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         $plugin = new TestPlugin();
         $this->assertSame('TestPlugin', $plugin->getName());
@@ -72,34 +68,34 @@ class BasePluginTest extends TestCase
         $this->assertSame('Company/TestPluginThree', $plugin->getName());
     }
 
-    public function testGetNameOption()
+    public function testGetNameOption(): void
     {
         $plugin = new TestPlugin(['name' => 'Elephants']);
         $this->assertSame('Elephants', $plugin->getName());
     }
 
-    public function testMiddleware()
+    public function testMiddleware(): void
     {
         $plugin = new BasePlugin();
         $middleware = new MiddlewareQueue();
         $this->assertSame($middleware, $plugin->middleware($middleware));
     }
 
-    public function testConsole()
+    public function testConsole(): void
     {
         $plugin = new BasePlugin();
         $commands = new CommandCollection();
         $this->assertSame($commands, $plugin->console($commands));
     }
 
-    public function testServices()
+    public function testServices(): void
     {
         $plugin = new BasePlugin();
         $container = new Container();
         $this->assertNull($plugin->services($container));
     }
 
-    public function testConsoleFind()
+    public function testConsoleFind(): void
     {
         $plugin = new TestPlugin();
         Plugin::getCollection()->add($plugin);
@@ -113,7 +109,7 @@ class BasePluginTest extends TestCase
         $this->assertTrue($result->has('test_plugin.example'), 'Should have long plugin name');
     }
 
-    public function testBootstrap()
+    public function testBootstrap(): void
     {
         $app = $this->createMock(PluginApplicationInterface::class);
         $plugin = new TestPlugin();
@@ -126,7 +122,7 @@ class BasePluginTest extends TestCase
     /**
      * No errors should be emitted when a plugin doesn't have a bootstrap file.
      */
-    public function testBootstrapSkipMissingFile()
+    public function testBootstrapSkipMissingFile(): void
     {
         $app = $this->createMock(PluginApplicationInterface::class);
         $plugin = new BasePlugin();
@@ -137,7 +133,7 @@ class BasePluginTest extends TestCase
     /**
      * No errors should be emitted when a plugin doesn't have a routes file.
      */
-    public function testRoutesSkipMissingFile()
+    public function testRoutesSkipMissingFile(): void
     {
         $plugin = new BasePlugin();
         $routeBuilder = new RouteBuilder(new RouteCollection(), '/');
@@ -145,7 +141,7 @@ class BasePluginTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testConstructorArguments()
+    public function testConstructorArguments(): void
     {
         $plugin = new BasePlugin([
             'routes' => false,
@@ -162,7 +158,7 @@ class BasePluginTest extends TestCase
         $this->assertSame('/plates/', $plugin->getTemplatePath());
     }
 
-    public function testGetPathBaseClass()
+    public function testGetPathBaseClass(): void
     {
         $plugin = new BasePlugin();
 
@@ -173,7 +169,7 @@ class BasePluginTest extends TestCase
         $this->assertSame($expected . 'templates' . DS, $plugin->getTemplatePath());
     }
 
-    public function testGetPathOptionValue()
+    public function testGetPathOptionValue(): void
     {
         $plugin = new BasePlugin(['path' => '/some/path']);
         $expected = '/some/path';
@@ -183,7 +179,7 @@ class BasePluginTest extends TestCase
         $this->assertSame($expected . 'templates' . DS, $plugin->getTemplatePath());
     }
 
-    public function testGetPathSubclass()
+    public function testGetPathSubclass(): void
     {
         $plugin = new TestPlugin();
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -51,8 +51,6 @@ class IniConfigTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,10 +60,8 @@ class IniConfigTest extends TestCase
 
     /**
      * test construct
-     *
-     * @return void
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $engine = new IniConfig($this->path);
         $config = $engine->read('acl');
@@ -77,10 +73,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test reading files.
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $engine = new IniConfig($this->path);
         $config = $engine->read('nested');
@@ -92,10 +86,8 @@ class IniConfigTest extends TestCase
 
     /**
      * No other sections should exist.
-     *
-     * @return void
      */
-    public function testReadOnlyOneSection()
+    public function testReadOnlyOneSection(): void
     {
         $engine = new IniConfig($this->path, 'admin');
         $config = $engine->read('acl');
@@ -106,10 +98,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test without section.
-     *
-     * @return void
      */
-    public function testReadWithoutSection()
+    public function testReadWithoutSection(): void
     {
         $engine = new IniConfig($this->path);
         $config = $engine->read('no_section');
@@ -123,10 +113,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test that names with .'s get exploded into arrays.
-     *
-     * @return void
      */
-    public function testReadValuesWithDots()
+    public function testReadValuesWithDots(): void
     {
         $engine = new IniConfig($this->path);
         $config = $engine->read('nested');
@@ -140,10 +128,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test boolean reading.
-     *
-     * @return void
      */
-    public function testBooleanReading()
+    public function testBooleanReading(): void
     {
         $engine = new IniConfig($this->path);
         $config = $engine->read('nested');
@@ -162,10 +148,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that exist without .ini extension.
-     *
-     * @return void
      */
-    public function testReadWithExistentFileWithoutExtension()
+    public function testReadWithExistentFileWithoutExtension(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new IniConfig($this->path);
@@ -174,10 +158,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that don't exist.
-     *
-     * @return void
      */
-    public function testReadWithNonExistentFile()
+    public function testReadWithNonExistentFile(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new IniConfig($this->path);
@@ -186,10 +168,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test reading an empty file.
-     *
-     * @return void
      */
-    public function testReadEmptyFile()
+    public function testReadEmptyFile(): void
     {
         $engine = new IniConfig($this->path);
         $config = $engine->read('empty');
@@ -198,10 +178,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test reading keys with ../ doesn't work.
-     *
-     * @return void
      */
-    public function testReadWithDots()
+    public function testReadWithDots(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new IniConfig($this->path);
@@ -210,10 +188,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test reading from plugins.
-     *
-     * @return void
      */
-    public function testReadPluginValue()
+    public function testReadPluginValue(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $engine = new IniConfig($this->path);
@@ -231,10 +207,8 @@ class IniConfigTest extends TestCase
 
     /**
      * Test dump method.
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         $engine = new IniConfig(TMP);
         $result = $engine->dump('test', $this->testData);
@@ -267,10 +241,8 @@ INI;
 
     /**
      * Test that dump() makes files read() can read.
-     *
-     * @return void
      */
-    public function testDumpRead()
+    public function testDumpRead(): void
     {
         $engine = new IniConfig(TMP);
         $engine->dump('test', $this->testData);

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -51,8 +51,6 @@ class JsonConfigTest extends TestCase
 
     /**
      * Setup.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,10 +60,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test reading files.
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $engine = new JsonConfig($this->path);
         $values = $engine->read('json_test');
@@ -75,10 +71,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that exist without .php extension.
-     *
-     * @return void
      */
-    public function testReadWithExistentFileWithoutExtension()
+    public function testReadWithExistentFileWithoutExtension(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new JsonConfig($this->path);
@@ -87,10 +81,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that don't exist.
-     *
-     * @return void
      */
-    public function testReadWithNonExistentFile()
+    public function testReadWithNonExistentFile(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new JsonConfig($this->path);
@@ -99,10 +91,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test reading an empty file.
-     *
-     * @return void
      */
-    public function testReadEmptyFile()
+    public function testReadEmptyFile(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('config file "empty.json"');
@@ -112,10 +102,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that contain invalid JSON.
-     *
-     * @return void
      */
-    public function testReadWithInvalidJson()
+    public function testReadWithInvalidJson(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Error parsing JSON string fetched from config file "invalid.json"');
@@ -125,10 +113,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test reading keys with ../ doesn't work.
-     *
-     * @return void
      */
-    public function testReadWithDots()
+    public function testReadWithDots(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new JsonConfig($this->path);
@@ -137,10 +123,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test reading from plugins.
-     *
-     * @return void
      */
-    public function testReadPluginValue()
+    public function testReadPluginValue(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $engine = new JsonConfig($this->path);
@@ -152,10 +136,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test dumping data to JSON format.
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         $engine = new JsonConfig(TMP);
         $result = $engine->dump('test', $this->testData);
@@ -190,10 +172,8 @@ class JsonConfigTest extends TestCase
 
     /**
      * Test that dump() makes files read() can read.
-     *
-     * @return void
      */
-    public function testDumpRead()
+    public function testDumpRead(): void
     {
         $engine = new JsonConfig(TMP);
         $engine->dump('test', $this->testData);

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -51,8 +51,6 @@ class PhpConfigTest extends TestCase
 
     /**
      * Setup.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,10 +60,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test reading files.
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $engine = new PhpConfig($this->path);
         $values = $engine->read('var_test');
@@ -75,10 +71,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that exist without .php extension.
-     *
-     * @return void
      */
-    public function testReadWithExistentFileWithoutExtension()
+    public function testReadWithExistentFileWithoutExtension(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
@@ -87,10 +81,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test an exception is thrown by reading files that don't exist.
-     *
-     * @return void
      */
-    public function testReadWithNonExistentFile()
+    public function testReadWithNonExistentFile(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
@@ -99,10 +91,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test reading an empty file.
-     *
-     * @return void
      */
-    public function testReadEmptyFile()
+    public function testReadEmptyFile(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
@@ -111,10 +101,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test reading keys with ../ doesn't work.
-     *
-     * @return void
      */
-    public function testReadWithDots()
+    public function testReadWithDots(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $engine = new PhpConfig($this->path);
@@ -123,10 +111,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test reading from plugins.
-     *
-     * @return void
      */
-    public function testReadPluginValue()
+    public function testReadPluginValue(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $engine = new PhpConfig($this->path);
@@ -138,10 +124,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test dumping data to PHP format.
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         $engine = new PhpConfig(TMP);
         $result = $engine->dump('test', $this->testData);
@@ -164,10 +148,8 @@ class PhpConfigTest extends TestCase
 
     /**
      * Test that dump() makes files read() can read.
-     *
-     * @return void
      */
-    public function testDumpRead()
+    public function testDumpRead(): void
     {
         $engine = new PhpConfig(TMP);
         $engine->dump('test', $this->testData);

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -28,8 +28,6 @@ class ConfigureTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -39,8 +37,6 @@ class ConfigureTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -69,10 +65,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testReadOrFail method
-     *
-     * @return void
      */
-    public function testReadOrFail()
+    public function testReadOrFail(): void
     {
         $expected = 'ok';
         Configure::write('This.Key.Exists', $expected);
@@ -82,10 +76,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testReadOrFail method
-     *
-     * @return void
      */
-    public function testReadOrFailThrowingException()
+    public function testReadOrFailThrowingException(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
@@ -94,10 +86,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testRead method
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $expected = 'ok';
         Configure::write('level1.level2.level3_1', $expected);
@@ -130,10 +120,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testWrite method
-     *
-     * @return void
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         Configure::write('SomeName.someKey', 'myvalue');
         $result = Configure::read('SomeName.someKey');
@@ -165,10 +153,8 @@ class ConfigureTest extends TestCase
 
     /**
      * test setting display_errors with debug.
-     *
-     * @return void
      */
-    public function testDebugSettingDisplayErrors()
+    public function testDebugSettingDisplayErrors(): void
     {
         $this->skipIf(
             defined('HHVM_VERSION'),
@@ -185,10 +171,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testDelete method
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         Configure::write('SomeName.someKey', 'myvalue');
         $result = Configure::read('SomeName.someKey');
@@ -217,10 +201,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testCheck method
-     *
-     * @return void
      */
-    public function testCheck()
+    public function testCheck(): void
     {
         Configure::write('ConfigureTestCase', 'value');
         $this->assertTrue(Configure::check('ConfigureTestCase'));
@@ -230,10 +212,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testCheckingSavedEmpty method
-     *
-     * @return void
      */
-    public function testCheckingSavedEmpty()
+    public function testCheckingSavedEmpty(): void
     {
         Configure::write('ConfigureTestCase', 0);
         $this->assertTrue(Configure::check('ConfigureTestCase'));
@@ -250,10 +230,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testCheckKeyWithSpaces method
-     *
-     * @return void
      */
-    public function testCheckKeyWithSpaces()
+    public function testCheckKeyWithSpaces(): void
     {
         Configure::write('Configure Test', 'test');
         $this->assertTrue(Configure::check('Configure Test'));
@@ -265,20 +243,16 @@ class ConfigureTest extends TestCase
 
     /**
      * testCheckEmpty
-     *
-     * @return void
      */
-    public function testCheckEmpty()
+    public function testCheckEmpty(): void
     {
         $this->assertFalse(Configure::check(''));
     }
 
     /**
      * testLoad method
-     *
-     * @return void
      */
-    public function testLoadExceptionOnNonExistentFile()
+    public function testLoadExceptionOnNonExistentFile(): void
     {
         $this->expectException(\RuntimeException::class);
         Configure::config('test', new PhpConfig());
@@ -287,10 +261,8 @@ class ConfigureTest extends TestCase
 
     /**
      * test load method for default config creation
-     *
-     * @return void
      */
-    public function testLoadDefaultConfig()
+    public function testLoadDefaultConfig(): void
     {
         try {
             Configure::load('nonexistent_configuration_file');
@@ -302,10 +274,8 @@ class ConfigureTest extends TestCase
 
     /**
      * test load with merging
-     *
-     * @return void
      */
-    public function testLoadWithMerge()
+    public function testLoadWithMerge(): void
     {
         Configure::config('test', new PhpConfig(CONFIG));
 
@@ -326,10 +296,8 @@ class ConfigureTest extends TestCase
 
     /**
      * test loading with overwrite
-     *
-     * @return void
      */
-    public function testLoadNoMerge()
+    public function testLoadNoMerge(): void
     {
         Configure::config('test', new PhpConfig(CONFIG));
 
@@ -348,10 +316,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Test load() replacing existing data
-     *
-     * @return void
      */
-    public function testLoadWithExistingData()
+    public function testLoadWithExistingData(): void
     {
         Configure::config('test', new PhpConfig(CONFIG));
         Configure::write('my_key', 'value');
@@ -363,10 +329,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Test load() merging on top of existing data
-     *
-     * @return void
      */
-    public function testLoadMergeWithExistingData()
+    public function testLoadMergeWithExistingData(): void
     {
         Configure::config('test', new PhpConfig());
         Configure::write('my_key', 'value');
@@ -384,10 +348,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testLoad method
-     *
-     * @return void
      */
-    public function testLoadPlugin()
+    public function testLoadPlugin(): void
     {
         Configure::config('test', new PhpConfig());
         $this->loadPlugins(['TestPlugin']);
@@ -407,10 +369,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testStore method
-     *
-     * @return void
      */
-    public function testStoreAndRestore()
+    public function testStoreAndRestore(): void
     {
         Cache::enable();
         Cache::setConfig('configure', [
@@ -433,10 +393,8 @@ class ConfigureTest extends TestCase
 
     /**
      * test that store and restore only store/restore the provided data.
-     *
-     * @return void
      */
-    public function testStoreAndRestoreWithData()
+    public function testStoreAndRestoreWithData(): void
     {
         Cache::enable();
         Cache::setConfig('configure', [
@@ -459,10 +417,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testVersion method
-     *
-     * @return void
      */
-    public function testVersion()
+    public function testVersion(): void
     {
         $original = Configure::version();
         $this->assertTrue(version_compare($original, '4.0', '>='));
@@ -476,10 +432,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Tests adding new engines.
-     *
-     * @return void
      */
-    public function testEngineSetup()
+    public function testEngineSetup(): void
     {
         $engine = new PhpConfig();
         Configure::config('test', $engine);
@@ -496,10 +450,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Tests adding new engines as numeric strings.
-     *
-     * @return void
      */
-    public function testEngineSetupNumeric()
+    public function testEngineSetupNumeric(): void
     {
         $engine = new PhpConfig();
         Configure::config('123', $engine);
@@ -515,10 +467,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Test that clear wipes all values.
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         Configure::write('test', 'value');
         Configure::clear();
@@ -526,10 +476,7 @@ class ConfigureTest extends TestCase
         $this->assertNull(Configure::read('test'));
     }
 
-    /**
-     * @return void
-     */
-    public function testDumpNoAdapter()
+    public function testDumpNoAdapter(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         Configure::dump(TMP . 'test.php', 'does_not_exist');
@@ -537,10 +484,8 @@ class ConfigureTest extends TestCase
 
     /**
      * test dump integrated with the PhpConfig.
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         Configure::config('test_Engine', new PhpConfig(TMP));
 
@@ -556,10 +501,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Test dumping only some of the data.
-     *
-     * @return void
      */
-    public function testDumpPartial()
+    public function testDumpPartial(): void
     {
         Configure::config('test_Engine', new PhpConfig(TMP));
         Configure::write('Error', ['test' => 'value']);
@@ -579,10 +522,8 @@ class ConfigureTest extends TestCase
 
     /**
      * Test the consume method.
-     *
-     * @return void
      */
-    public function testConsume()
+    public function testConsume(): void
     {
         $this->assertNull(Configure::consume('DoesNotExist'), 'Should be null on empty value');
         Configure::write('Test', ['key' => 'value', 'key2' => 'value2']);
@@ -600,10 +541,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testConsumeEmpty
-     *
-     * @return void
      */
-    public function testConsumeEmpty()
+    public function testConsumeEmpty(): void
     {
         Configure::write('Test', ['key' => 'value', 'key2' => 'value2']);
 
@@ -613,10 +552,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testConsumeOrFail method
-     *
-     * @return void
      */
-    public function testConsumeOrFail()
+    public function testConsumeOrFail(): void
     {
         $expected = 'ok';
         Configure::write('This.Key.Exists', $expected);
@@ -626,10 +563,8 @@ class ConfigureTest extends TestCase
 
     /**
      * testConsumeOrFail method
-     *
-     * @return void
      */
-    public function testConsumeOrFailThrowingException()
+    public function testConsumeOrFailThrowingException(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -28,7 +28,7 @@ class FunctionsTest extends TestCase
     /**
      * Test cases for env()
      */
-    public function testEnv()
+    public function testEnv(): void
     {
         $_ENV['DOES_NOT_EXIST'] = null;
         $this->assertNull(env('DOES_NOT_EXIST'));
@@ -53,12 +53,11 @@ class FunctionsTest extends TestCase
     /**
      * Test cases for h()
      *
-     * @return void
      * @dataProvider hInputProvider
      * @param mixed $value
      * @param mixed $expected
      */
-    public function testH($value, $expected)
+    public function testH($value, $expected): void
     {
         $result = h($value);
         $this->assertSame($expected, $result);
@@ -81,12 +80,12 @@ class FunctionsTest extends TestCase
     /**
      * Test error messages coming out when deprecated level is on, manually setting the stack frame
      */
-    public function testDeprecationWarningEnabled()
+    public function testDeprecationWarningEnabled(): void
     {
         $this->expectDeprecation();
         $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
 
-        $this->withErrorReporting(E_ALL, function () {
+        $this->withErrorReporting(E_ALL, function (): void {
             deprecationWarning('This is going away', 2);
         });
     }
@@ -94,41 +93,37 @@ class FunctionsTest extends TestCase
     /**
      * Test error messages coming out when deprecated level is on, not setting the stack frame manually
      */
-    public function testDeprecationWarningEnabledDefaultFrame()
+    public function testDeprecationWarningEnabledDefaultFrame(): void
     {
         $this->expectDeprecation();
         $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
-        $this->withErrorReporting(E_ALL, function () {
+        $this->withErrorReporting(E_ALL, function (): void {
             deprecationWarning('This is going away');
         });
     }
 
     /**
      * Test no error when deprecation matches ignore paths.
-     *
-     * @return void
      */
-    public function testDeprecationWarningPathDisabled()
+    public function testDeprecationWarningPathDisabled(): void
     {
         $this->expectNotToPerformAssertions();
 
         Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/*']);
-        $this->withErrorReporting(E_ALL, function () {
+        $this->withErrorReporting(E_ALL, function (): void {
             deprecationWarning('This is going away');
         });
     }
 
     /**
      * Test no error when deprecated level is off.
-     *
-     * @return void
      */
-    public function testDeprecationWarningLevelDisabled()
+    public function testDeprecationWarningLevelDisabled(): void
     {
         $this->expectNotToPerformAssertions();
 
-        $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function () {
+        $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function (): void {
             deprecationWarning('This is going away');
         });
     }
@@ -136,12 +131,12 @@ class FunctionsTest extends TestCase
     /**
      * Test error messages coming out when warning level is on.
      */
-    public function testTriggerWarningEnabled()
+    public function testTriggerWarningEnabled(): void
     {
         $this->expectWarning();
         $this->expectWarningMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
-        $this->withErrorReporting(E_ALL, function () {
+        $this->withErrorReporting(E_ALL, function (): void {
             triggerWarning('This is going away');
             $this->assertTrue(true);
         });
@@ -149,12 +144,10 @@ class FunctionsTest extends TestCase
 
     /**
      * Test no error when warning level is off.
-     *
-     * @return void
      */
-    public function testTriggerWarningLevelDisabled()
+    public function testTriggerWarningLevelDisabled(): void
     {
-        $this->withErrorReporting(E_ALL ^ E_USER_WARNING, function () {
+        $this->withErrorReporting(E_ALL ^ E_USER_WARNING, function (): void {
             triggerWarning('This is going away');
             $this->assertTrue(true);
         });
@@ -162,10 +155,8 @@ class FunctionsTest extends TestCase
 
     /**
      * testing getTypeName()
-     *
-     * @return void
      */
-    public function testgetTypeName()
+    public function testgetTypeName(): void
     {
         $this->assertSame('stdClass', getTypeName(new \stdClass()));
         $this->assertSame('array', getTypeName([]));

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -31,8 +31,6 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,10 +40,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testDefaultsAreSet
-     *
-     * @return void
      */
-    public function testDefaultsAreSet()
+    public function testDefaultsAreSet(): void
     {
         $this->assertSame(
             [
@@ -62,10 +58,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testGetSimple
-     *
-     * @return void
      */
-    public function testGetSimple()
+    public function testGetSimple(): void
     {
         $this->assertSame(
             'string',
@@ -82,10 +76,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testGetDot
-     *
-     * @return void
      */
-    public function testGetDot()
+    public function testGetDot(): void
     {
         $this->assertSame(
             'value',
@@ -96,10 +88,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testGetDefault
-     *
-     * @return void
      */
-    public function testGetDefault()
+    public function testGetDefault(): void
     {
         $this->assertSame(
             'default',
@@ -114,10 +104,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testSetSimple
-     *
-     * @return void
      */
-    public function testSetSimple()
+    public function testSetSimple(): void
     {
         $this->object->setConfig('foo', 'bar');
         $this->assertSame(
@@ -151,10 +139,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testSetNested
-     *
-     * @return void
      */
-    public function testSetNested()
+    public function testSetNested(): void
     {
         $this->object->setConfig('new.foo', 'bar');
         $this->assertSame(
@@ -183,10 +169,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testSetNested
-     *
-     * @return void
      */
-    public function testSetArray()
+    public function testSetArray(): void
     {
         $this->object->setConfig(['foo' => 'bar']);
         $this->assertSame(
@@ -238,10 +222,7 @@ class InstanceConfigTraitTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConfigOrFail()
+    public function testGetConfigOrFail(): void
     {
         $this->object->setConfig(['foo' => 'bar']);
         $this->assertSame(
@@ -251,10 +232,7 @@ class InstanceConfigTraitTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConfigOrFailException()
+    public function testGetConfigOrFailException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected configuration `foo` not found.');
@@ -264,10 +242,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * test shallow merge
-     *
-     * @return void
      */
-    public function testConfigShallow()
+    public function testConfigShallow(): void
     {
         $this->object->configShallow(['a' => ['new_nested' => true], 'new' => 'bar']);
 
@@ -284,10 +260,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testSetClobber
-     *
-     * @return void
      */
-    public function testSetClobber()
+    public function testSetClobber(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot set a.nested.value');
@@ -297,10 +271,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testMerge
-     *
-     * @return void
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $this->object->setConfig(['a' => ['nother' => 'value']]);
 
@@ -320,10 +292,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testMergeDotKey
-     *
-     * @return void
      */
-    public function testMergeDotKey()
+    public function testMergeDotKey(): void
     {
         $this->object->setConfig('a.nother', 'value');
 
@@ -359,10 +329,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testSetDefaultsMerge
-     *
-     * @return void
      */
-    public function testSetDefaultsMerge()
+    public function testSetDefaultsMerge(): void
     {
         $this->object->setConfig(['a' => ['nother' => 'value']]);
 
@@ -382,10 +350,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testSetDefaultsNoMerge
-     *
-     * @return void
      */
-    public function testSetDefaultsNoMerge()
+    public function testSetDefaultsNoMerge(): void
     {
         $this->object->setConfig(['a' => ['nother' => 'value']], null, false);
 
@@ -406,10 +372,8 @@ class InstanceConfigTraitTest extends TestCase
      *
      * Merging offers no such protection of clobbering a value whilst implemented
      * using the Hash class
-     *
-     * @return void
      */
-    public function testSetMergeNoClobber()
+    public function testSetMergeNoClobber(): void
     {
         $this->object->setConfig(['a.nested.value' => 'it is possible']);
 
@@ -430,10 +394,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testReadOnlyConfig
-     *
-     * @return void
      */
-    public function testReadOnlyConfig()
+    public function testReadOnlyConfig(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('This Instance is readonly');
@@ -453,10 +415,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testDeleteSimple
-     *
-     * @return void
      */
-    public function testDeleteSimple()
+    public function testDeleteSimple(): void
     {
         $this->object->setConfig('foo', null);
         $this->assertNull(
@@ -481,10 +441,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testDeleteNested
-     *
-     * @return void
      */
-    public function testDeleteNested()
+    public function testDeleteNested(): void
     {
         $this->object->setConfig('new.foo', null);
         $this->assertNull(
@@ -525,10 +483,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testDeleteArray
-     *
-     * @return void
      */
-    public function testDeleteArray()
+    public function testDeleteArray(): void
     {
         $this->object->setConfig('a', null);
         $this->assertNull(
@@ -546,10 +502,8 @@ class InstanceConfigTraitTest extends TestCase
 
     /**
      * testDeleteClobber
-     *
-     * @return void
      */
-    public function testDeleteClobber()
+    public function testDeleteClobber(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Cannot unset a.nested.value.whoops');

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -30,7 +30,7 @@ use TestPlugin\Plugin as TestPlugin;
  */
 class PluginCollectionTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $plugins = new PluginCollection([new TestPlugin()]);
 
@@ -38,7 +38,7 @@ class PluginCollectionTest extends TestCase
         $this->assertTrue($plugins->has('TestPlugin'));
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $plugins = new PluginCollection();
         $this->assertCount(0, $plugins);
@@ -47,7 +47,7 @@ class PluginCollectionTest extends TestCase
         $this->assertCount(1, $plugins);
     }
 
-    public function testAddOperations()
+    public function testAddOperations(): void
     {
         $plugins = new PluginCollection();
         $plugins->add(new TestPlugin());
@@ -61,7 +61,7 @@ class PluginCollectionTest extends TestCase
         $this->assertFalse($plugins->has('TestPlugin'));
     }
 
-    public function testAddVendoredPlugin()
+    public function testAddVendoredPlugin(): void
     {
         $plugins = new PluginCollection();
         $plugins->add(new TestPluginThree());
@@ -72,7 +72,7 @@ class PluginCollectionTest extends TestCase
         $this->assertFalse($plugins->has('TestPlugin'));
     }
 
-    public function testHas()
+    public function testHas(): void
     {
         $plugins = new PluginCollection();
         $this->assertFalse($plugins->has('TestPlugin'));
@@ -82,7 +82,7 @@ class PluginCollectionTest extends TestCase
         $this->assertFalse($plugins->has('Plugin'));
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $plugins = new PluginCollection();
         $plugin = new TestPlugin();
@@ -91,14 +91,14 @@ class PluginCollectionTest extends TestCase
         $this->assertSame($plugin, $plugins->get('TestPlugin'));
     }
 
-    public function testGetAutoload()
+    public function testGetAutoload(): void
     {
         $plugins = new PluginCollection();
         $plugin = $plugins->get('ParentPlugin');
         $this->assertInstanceOf(\ParentPlugin\Plugin::class, $plugin);
     }
 
-    public function testGetInvalid()
+    public function testGetInvalid(): void
     {
         $this->expectException(MissingPluginException::class);
 
@@ -106,7 +106,7 @@ class PluginCollectionTest extends TestCase
         $plugins->get('Invalid');
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $plugins = new PluginCollection();
 
@@ -125,7 +125,7 @@ class PluginCollectionTest extends TestCase
         $this->assertSame('TestTheme', $plugin->getName());
     }
 
-    public function testIterator()
+    public function testIterator(): void
     {
         $data = [
             new TestPlugin(),
@@ -140,7 +140,7 @@ class PluginCollectionTest extends TestCase
         $this->assertSame($data, $out);
     }
 
-    public function testWith()
+    public function testWith(): void
     {
         $plugins = new PluginCollection();
         $plugin = new TestPlugin();
@@ -165,10 +165,8 @@ class PluginCollectionTest extends TestCase
      *
      * This situation can happen when a plugin like bake
      * needs to discover things inside other plugins.
-     *
-     * @return void
      */
-    public function testWithInnerIteration()
+    public function testWithInnerIteration(): void
     {
         $plugins = new PluginCollection();
         $plugin = new TestPlugin();
@@ -189,7 +187,7 @@ class PluginCollectionTest extends TestCase
         $this->assertSame($pluginThree, $out[1]);
     }
 
-    public function testWithInvalidHook()
+    public function testWithInvalidHook(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -198,7 +196,7 @@ class PluginCollectionTest extends TestCase
         }
     }
 
-    public function testFindPathNoConfigureData()
+    public function testFindPathNoConfigureData(): void
     {
         Configure::write('plugins', []);
         $plugins = new PluginCollection();
@@ -207,7 +205,7 @@ class PluginCollectionTest extends TestCase
         $this->assertSame(TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS, $path);
     }
 
-    public function testFindPathLoadsConfigureData()
+    public function testFindPathLoadsConfigureData(): void
     {
         $configPath = ROOT . DS . 'cakephp-plugins.php';
         $this->skipIf(file_exists($configPath), 'cakephp-plugins.php exists, skipping overwrite');
@@ -230,7 +228,7 @@ PHP;
         $this->assertSame('/config/path', $path);
     }
 
-    public function testFindPathConfigureData()
+    public function testFindPathConfigureData(): void
     {
         Configure::write('plugins', ['TestPlugin' => '/some/path']);
         $plugins = new PluginCollection();
@@ -239,7 +237,7 @@ PHP;
         $this->assertSame('/some/path', $path);
     }
 
-    public function testFindPathMissingPlugin()
+    public function testFindPathMissingPlugin(): void
     {
         Configure::write('plugins', []);
         $plugins = new PluginCollection();

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -28,8 +28,6 @@ class PluginTest extends TestCase
 {
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -39,8 +37,6 @@ class PluginTest extends TestCase
 
     /**
      * Reverts the changes done to the environment while testing
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -50,10 +46,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests loading a plugin with a class
-     *
-     * @return void
      */
-    public function testLoadConcreteClass()
+    public function testLoadConcreteClass(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $instance = Plugin::getCollection()->get('TestPlugin');
@@ -62,10 +56,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests loading a plugin without a class
-     *
-     * @return void
      */
-    public function testLoadDynamicClass()
+    public function testLoadDynamicClass(): void
     {
         $this->loadPlugins(['TestPluginTwo']);
         $instance = Plugin::getCollection()->get('TestPluginTwo');
@@ -74,10 +66,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests that Plugin::path() returns the correct path for the loaded plugins
-     *
-     * @return void
      */
-    public function testPath()
+    public function testPath(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'Company/TestPluginThree']);
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
@@ -92,10 +82,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests that Plugin::path() throws an exception on unknown plugin
-     *
-     * @return void
      */
-    public function testPathNotFound()
+    public function testPathNotFound(): void
     {
         $this->expectException(MissingPluginException::class);
         Plugin::path('NonExistentPlugin');
@@ -103,10 +91,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests that Plugin::classPath() returns the correct path for the loaded plugins
-     *
-     * @return void
      */
-    public function testClassPath()
+    public function testClassPath(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'Company/TestPluginThree']);
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'src' . DS;
@@ -121,10 +107,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests that Plugin::templatePath() returns the correct path for the loaded plugins
-     *
-     * @return void
      */
-    public function testTemplatePath()
+    public function testTemplatePath(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'Company/TestPluginThree']);
         $expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'templates' . DS;
@@ -139,10 +123,8 @@ class PluginTest extends TestCase
 
     /**
      * Tests that Plugin::classPath() throws an exception on unknown plugin
-     *
-     * @return void
      */
-    public function testClassPathNotFound()
+    public function testClassPathNotFound(): void
     {
         $this->expectException(MissingPluginException::class);
         Plugin::classPath('NonExistentPlugin');

--- a/tests/TestCase/Core/Retry/CommandRetryTest.php
+++ b/tests/TestCase/Core/Retry/CommandRetryTest.php
@@ -26,10 +26,8 @@ class CommandRetryTest extends TestCase
 {
     /**
      * Simple retry test
-     *
-     * @return void
      */
-    public function testRetry()
+    public function testRetry(): void
     {
         $count = 0;
         $action = function () use (&$count) {
@@ -48,10 +46,8 @@ class CommandRetryTest extends TestCase
 
     /**
      * Test attempts exceeded
-     *
-     * @return void
      */
-    public function testExceedAttempts()
+    public function testExceedAttempts(): void
     {
         $count = 0;
         $action = function () use (&$count) {
@@ -72,12 +68,10 @@ class CommandRetryTest extends TestCase
 
     /**
      * Test that the strategy is respected
-     *
-     * @return void
      */
-    public function testRespectStrategy()
+    public function testRespectStrategy(): void
     {
-        $action = function () {
+        $action = function (): void {
             throw new Exception('this is failing');
         };
 

--- a/tests/TestCase/Core/ServiceConfigTest.php
+++ b/tests/TestCase/Core/ServiceConfigTest.php
@@ -25,7 +25,7 @@ use Cake\TestSuite\TestCase;
  */
 class ServiceConfigTest extends TestCase
 {
-    public function testGet()
+    public function testGet(): void
     {
         Configure::write('first', 'first-val');
         Configure::write('nested.path', 'nested-val');
@@ -38,7 +38,7 @@ class ServiceConfigTest extends TestCase
         $this->assertSame('default', $config->get('nested.nope', 'default'));
     }
 
-    public function testHas()
+    public function testHas(): void
     {
         Configure::write('first', 'first-val');
         Configure::write('nested.path', 'nested-val');

--- a/tests/TestCase/Core/ServiceProviderTest.php
+++ b/tests/TestCase/Core/ServiceProviderTest.php
@@ -25,7 +25,7 @@ use TestApp\ServiceProvider\PersonServiceProvider;
  */
 class ServiceProviderTest extends TestCase
 {
-    public function testBootstrapHook()
+    public function testBootstrapHook(): void
     {
         $container = new Container();
         $container->addServiceProvider(new PersonServiceProvider());
@@ -37,7 +37,7 @@ class ServiceProviderTest extends TestCase
         $this->assertSame('boot', $container->get('boot')->name);
     }
 
-    public function testServicesHook()
+    public function testServicesHook(): void
     {
         $container = new Container();
         $container->addServiceProvider(new PersonServiceProvider());

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -34,8 +34,6 @@ class StaticConfigTraitTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -45,8 +43,6 @@ class StaticConfigTraitTest extends TestCase
 
     /**
      * teardown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -56,10 +52,8 @@ class StaticConfigTraitTest extends TestCase
 
     /**
      * Tests simple usage of parseDsn
-     *
-     * @return void
      */
-    public function testSimpleParseDsn()
+    public function testSimpleParseDsn(): void
     {
         $className = get_class($this->subject);
         $this->assertSame([], $className::parseDsn(''));
@@ -67,20 +61,15 @@ class StaticConfigTraitTest extends TestCase
 
     /**
      * Tests that failing to pass a string to parseDsn will throw an exception
-     *
-     * @return void
      */
-    public function testParseBadType()
+    public function testParseBadType(): void
     {
         $this->expectException(TypeError::class);
         $className = get_class($this->subject);
         $className::parseDsn(['url' => 'http://:80']);
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConfigOrFail()
+    public function testGetConfigOrFail(): void
     {
         $className = get_class($this->subject);
         $className::setConfig('foo', 'bar');
@@ -89,10 +78,7 @@ class StaticConfigTraitTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
-    /**
-     * @return void
-     */
-    public function testGetConfigOrFailException()
+    public function testGetConfigOrFailException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected configuration `foo` not found.');
@@ -104,10 +90,8 @@ class StaticConfigTraitTest extends TestCase
 
     /**
      * Tests parsing querystring values
-     *
-     * @return void
      */
-    public function testParseDsnQuerystring()
+    public function testParseDsnQuerystring(): void
     {
         $dsn = 'file:///?url=test';
         $expected = [
@@ -196,10 +180,8 @@ class StaticConfigTraitTest extends TestCase
 
     /**
      * Tests loading a single plugin
-     *
-     * @return void
      */
-    public function testParseDsnPathSetting()
+    public function testParseDsnPathSetting(): void
     {
         $dsn = 'file:///?path=/tmp/persistent/';
         $expected = [

--- a/tests/TestCase/Database/ColumnSchemaAwareTypeTest.php
+++ b/tests/TestCase/Database/ColumnSchemaAwareTypeTest.php
@@ -26,7 +26,7 @@ class ColumnSchemaAwareTypeTest extends TestCase
         TypeFactory::map('columnSchemaAwareType', ColumnSchemaAwareType::class);
     }
 
-    public function testColumnSql()
+    public function testColumnSql(): void
     {
         $dialect = $this->connection->getDriver()->schemaDialect();
 
@@ -46,7 +46,7 @@ class ColumnSchemaAwareTypeTest extends TestCase
         }
     }
 
-    public function testColumnSqlForUnmappedType()
+    public function testColumnSqlForUnmappedType(): void
     {
         $map = TypeFactory::getMap();
         TypeFactory::clear();

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -74,9 +74,6 @@ class ConnectionTest extends TestCase
      */
     protected $defaultLogger;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -89,9 +86,6 @@ class ConnectionTest extends TestCase
         static::setAppNamespace();
     }
 
-    /**
-     * @return void
-     */
     public function tearDown(): void
     {
         $this->connection->disableSavePoints();
@@ -121,10 +115,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests connecting to database
-     *
-     * @return void
      */
-    public function testConnect()
+    public function testConnect(): void
     {
         $this->assertTrue($this->connection->connect());
         $this->assertTrue($this->connection->isConnected());
@@ -132,10 +124,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests creating a connection using no driver throws an exception
-     *
-     * @return void
      */
-    public function testNoDriver()
+    public function testNoDriver(): void
     {
         $this->expectException(\Cake\Database\Exception\MissingDriverException::class);
         $this->expectExceptionMessage('Database driver  could not be found.');
@@ -144,10 +134,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests creating a connection using an invalid driver throws an exception
-     *
-     * @return void
      */
-    public function testEmptyDriver()
+    public function testEmptyDriver(): void
     {
         $this->expectException(\Cake\Database\Exception\MissingDriverException::class);
         $this->expectExceptionMessage('Database driver  could not be found.');
@@ -156,10 +144,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests creating a connection using an invalid driver throws an exception
-     *
-     * @return void
      */
-    public function testMissingDriver()
+    public function testMissingDriver(): void
     {
         $this->expectException(\Cake\Database\Exception\MissingDriverException::class);
         $this->expectExceptionMessage('Database driver \Foo\InvalidDriver could not be found.');
@@ -168,10 +154,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests trying to use a disabled driver throws an exception
-     *
-     * @return void
      */
-    public function testDisabledDriver()
+    public function testDisabledDriver(): void
     {
         $this->expectException(\Cake\Database\Exception\MissingExtensionException::class);
         $this->expectExceptionMessage('Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency');
@@ -184,10 +168,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that the `driver` option supports the short classname/plugin syntax.
-     *
-     * @return void
      */
-    public function testDriverOptionClassNameSupport()
+    public function testDriverOptionClassNameSupport(): void
     {
         $connection = new Connection(['driver' => 'TestDriver']);
         $this->assertInstanceOf('TestApp\Database\Driver\TestDriver', $connection->getDriver());
@@ -202,10 +184,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that connecting with invalid credentials or database name throws an exception
-     *
-     * @return void
      */
-    public function testWrongCredentials()
+    public function testWrongCredentials(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(isset($config['url']), 'Datasource has dsn, skipping.');
@@ -228,7 +208,7 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf('PDOException', $e->getPrevious());
     }
 
-    public function testConnectRetry()
+    public function testConnectRetry(): void
     {
         $this->skipIf(!ConnectionManager::get('test')->getDriver() instanceof \Cake\Database\Driver\Sqlserver);
 
@@ -245,10 +225,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests creation of prepared statements
-     *
-     * @return void
      */
-    public function testPrepare()
+    public function testPrepare(): void
     {
         $sql = 'SELECT 1 + 1';
         $result = $this->connection->prepare($sql);
@@ -264,10 +242,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests executing a simple query using bound values
-     *
-     * @return void
      */
-    public function testExecuteWithArguments()
+    public function testExecuteWithArguments(): void
     {
         $sql = 'SELECT 1 + ?';
         $statement = $this->connection->execute($sql, [1], ['integer']);
@@ -293,10 +269,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests executing a query with params and associated types
-     *
-     * @return void
      */
-    public function testExecuteWithArgumentsAndTypes()
+    public function testExecuteWithArgumentsAndTypes(): void
     {
         $sql = "SELECT '2012-01-01' = ?";
         $statement = $this->connection->execute($sql, [new \DateTime('2012-01-01')], ['date']);
@@ -307,10 +281,8 @@ class ConnectionTest extends TestCase
 
     /**
      * test executing a buffered query interacts with Collection well.
-     *
-     * @return void
      */
-    public function testBufferedStatementCollectionWrappingStatement()
+    public function testBufferedStatementCollectionWrappingStatement(): void
     {
         $this->skipIf(
             !($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite),
@@ -333,10 +305,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that passing a unknown value to a query throws an exception
-     *
-     * @return void
      */
-    public function testExecuteWithMissingType()
+    public function testExecuteWithMissingType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $sql = 'SELECT ?';
@@ -345,10 +315,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests executing a query with no params also works
-     *
-     * @return void
      */
-    public function testExecuteWithNoParams()
+    public function testExecuteWithNoParams(): void
     {
         $sql = 'SELECT 1';
         $statement = $this->connection->execute($sql);
@@ -360,10 +328,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests it is possible to insert data into a table using matching types by key name
-     *
-     * @return void
      */
-    public function testInsertWithMatchingTypes()
+    public function testInsertWithMatchingTypes(): void
     {
         $data = ['id' => '3', 'title' => 'a title', 'body' => 'a body'];
         $result = $this->connection->insert(
@@ -382,10 +348,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests it is possible to insert data into a table using matching types by array position
-     *
-     * @return void
      */
-    public function testInsertWithPositionalTypes()
+    public function testInsertWithPositionalTypes(): void
     {
         $data = ['id' => '3', 'title' => 'a title', 'body' => 'a body'];
         $result = $this->connection->insert(
@@ -404,10 +368,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests an statement class can be reused for multiple executions
-     *
-     * @return void
      */
-    public function testStatementReusing()
+    public function testStatementReusing(): void
     {
         $total = $this->connection->execute('SELECT COUNT(*) AS total FROM things');
         $result = $total->fetch('assoc');
@@ -438,10 +400,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that it is possible to pass PDO constants to the underlying statement
      * object for using alternate fetch types
-     *
-     * @return void
      */
-    public function testStatementFetchObject()
+    public function testStatementFetchObject(): void
     {
         $statement = $this->connection->execute('SELECT title, body  FROM things');
         $row = $statement->fetch(\PDO::FETCH_OBJ);
@@ -452,10 +412,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests rows can be updated without specifying any conditions nor types
-     *
-     * @return void
      */
-    public function testUpdateWithoutConditionsNorTypes()
+    public function testUpdateWithoutConditionsNorTypes(): void
     {
         $title = 'changed the title!';
         $body = 'changed the body!';
@@ -467,10 +425,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests it is possible to use key => value conditions for update
-     *
-     * @return void
      */
-    public function testUpdateWithConditionsNoTypes()
+    public function testUpdateWithConditionsNoTypes(): void
     {
         $title = 'changed the title!';
         $body = 'changed the body!';
@@ -482,10 +438,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests it is possible to use key => value and string conditions for update
-     *
-     * @return void
      */
-    public function testUpdateWithConditionsCombinedNoTypes()
+    public function testUpdateWithConditionsCombinedNoTypes(): void
     {
         $title = 'changed the title!';
         $body = 'changed the body!';
@@ -497,10 +451,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests you can bind types to update values
-     *
-     * @return void
      */
-    public function testUpdateWithTypes()
+    public function testUpdateWithTypes(): void
     {
         $title = 'changed the title!';
         $body = new \DateTime('2012-01-01');
@@ -517,10 +469,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests you can bind types to update values
-     *
-     * @return void
      */
-    public function testUpdateWithConditionsAndTypes()
+    public function testUpdateWithConditionsAndTypes(): void
     {
         $title = 'changed the title!';
         $body = new \DateTime('2012-01-01');
@@ -535,10 +485,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests delete from table with no conditions
-     *
-     * @return void
      */
-    public function testDeleteNoConditions()
+    public function testDeleteNoConditions(): void
     {
         $this->connection->delete('things');
         $result = $this->connection->execute('SELECT * FROM things');
@@ -548,10 +496,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests delete from table with conditions
-     *
-     * @return void
      */
-    public function testDeleteWithConditions()
+    public function testDeleteWithConditions(): void
     {
         $this->connection->delete('things', ['id' => '1'], ['id' => 'integer']);
         $result = $this->connection->execute('SELECT * FROM things');
@@ -571,10 +517,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that it is possible to use simple database transactions
-     *
-     * @return void
      */
-    public function testSimpleTransactions()
+    public function testSimpleTransactions(): void
     {
         $this->connection->begin();
         $this->connection->delete('things', ['id' => 1]);
@@ -593,10 +537,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that the destructor of Connection generates a warning log
      * when transaction is not closed
-     *
-     * @return void
      */
-    public function testDestructorWithUncommittedTransaction()
+    public function testDestructorWithUncommittedTransaction(): void
     {
         $driver = $this->getMockFormDriver();
         $connection = new Connection(['driver' => $driver]);
@@ -617,10 +559,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that it is possible to use virtualized nested transaction
      * with early rollback algorithm
-     *
-     * @return void
      */
-    public function testVirtualNestedTransaction()
+    public function testVirtualNestedTransaction(): void
     {
         //starting 3 virtual transaction
         $this->connection->begin();
@@ -641,10 +581,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that it is possible to use virtualized nested transaction
      * with early rollback algorithm
-     *
-     * @return void
      */
-    public function testVirtualNestedTransaction2()
+    public function testVirtualNestedTransaction2(): void
     {
         //starting 3 virtual transaction
         $this->connection->begin();
@@ -663,11 +601,9 @@ class ConnectionTest extends TestCase
     /**
      * Tests that it is possible to use virtualized nested transaction
      * with early rollback algorithm
-     *
-     * @return void
      */
 
-    public function testVirtualNestedTransaction3()
+    public function testVirtualNestedTransaction3(): void
     {
         //starting 3 virtual transaction
         $this->connection->begin();
@@ -687,10 +623,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that it is possible to real use  nested transactions
-     *
-     * @return void
      */
-    public function testSavePoints()
+    public function testSavePoints(): void
     {
         $this->skipIf(!$this->connection->enableSavePoints(true));
 
@@ -716,11 +650,9 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that it is possible to real use  nested transactions
-     *
-     * @return void
      */
 
-    public function testSavePoints2()
+    public function testSavePoints2(): void
     {
         $this->skipIf(!$this->connection->enableSavePoints(true));
         $this->connection->begin();
@@ -745,10 +677,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests inTransaction()
-     *
-     * @return void
      */
-    public function testInTransaction()
+    public function testInTransaction(): void
     {
         $this->connection->begin();
         $this->assertTrue($this->connection->inTransaction());
@@ -772,10 +702,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests inTransaction() with save points
-     *
-     * @return void
      */
-    public function testInTransactionWithSavePoints()
+    public function testInTransactionWithSavePoints(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver,
@@ -807,10 +735,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests connection can quote values to be safely used in query strings
-     *
-     * @return void
      */
-    public function testQuote()
+    public function testQuote(): void
     {
         $this->skipIf(!$this->connection->supportsQuoting());
         $expected = "'2012-01-01'";
@@ -828,10 +754,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests identifier quoting
-     *
-     * @return void
      */
-    public function testQuoteIdentifier()
+    public function testQuoteIdentifier(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')
             ->onlyMethods(['enabled'])
@@ -940,10 +864,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests default return vale for logger() function
-     *
-     * @return void
      */
-    public function testGetLoggerDefault()
+    public function testGetLoggerDefault(): void
     {
         $logger = $this->connection->getLogger();
         $this->assertInstanceOf('Cake\Database\Log\QueryLogger', $logger);
@@ -952,10 +874,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests setting and getting the logger object
-     *
-     * @return void
      */
-    public function testGetAndSetLogger()
+    public function testGetAndSetLogger(): void
     {
         $logger = new QueryLogger();
         $this->connection->setLogger($logger);
@@ -964,10 +884,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that statements are decorated with a logger when logQueries is set to true
-     *
-     * @return void
      */
-    public function testLoggerDecorator()
+    public function testLoggerDecorator(): void
     {
         $logger = new QueryLogger();
         $this->connection->enableQueryLogging(true);
@@ -983,10 +901,8 @@ class ConnectionTest extends TestCase
 
     /**
      * test enableQueryLogging method
-     *
-     * @return void
      */
-    public function testEnableQueryLogging()
+    public function testEnableQueryLogging(): void
     {
         $this->connection->enableQueryLogging(true);
         $this->assertTrue($this->connection->isQueryLoggingEnabled());
@@ -997,10 +913,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that log() function logs to the configured query logger
-     *
-     * @return void
      */
-    public function testLogFunction()
+    public function testLogFunction(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
         $this->connection->enableQueryLogging();
@@ -1013,9 +927,8 @@ class ConnectionTest extends TestCase
 
     /**
      * @see https://github.com/cakephp/cakephp/issues/14676
-     * @return void
      */
-    public function testLoggerDecoratorDoesNotPrematurelyFetchRecords()
+    public function testLoggerDecoratorDoesNotPrematurelyFetchRecords(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
         $logger = new QueryLogger();
@@ -1046,10 +959,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that begin and rollback are also logged
-     *
-     * @return void
      */
-    public function testLogBeginRollbackTransaction()
+    public function testLogBeginRollbackTransaction(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
 
@@ -1075,10 +986,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests that commits are logged
-     *
-     * @return void
      */
-    public function testLogCommitTransaction()
+    public function testLogCommitTransaction(): void
     {
         $driver = $this->getMockFormDriver();
         $connection = $this->getMockBuilder(Connection::class)
@@ -1099,10 +1008,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests setting and getting the cacher object
-     *
-     * @return void
      */
-    public function testGetAndSetCacher()
+    public function testGetAndSetCacher(): void
     {
         $cacher = new NullEngine();
         $this->connection->setCacher($cacher);
@@ -1112,10 +1019,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that the transactional method will start and commit a transaction
      * around some arbitrary function passed as argument
-     *
-     * @return void
      */
-    public function testTransactionalSuccess()
+    public function testTransactionalSuccess(): void
     {
         $driver = $this->getMockFormDriver();
         $connection = $this->getMockBuilder(Connection::class)
@@ -1135,10 +1040,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that the transactional method will rollback the transaction if false
      * is returned from the callback
-     *
-     * @return void
      */
-    public function testTransactionalFail()
+    public function testTransactionalFail(): void
     {
         $driver = $this->getMockFormDriver();
         $connection = $this->getMockBuilder(Connection::class)
@@ -1160,10 +1063,9 @@ class ConnectionTest extends TestCase
      * Tests that the transactional method will rollback the transaction
      * and throw the same exception if the callback raises one
      *
-     * @return void
      * @throws \InvalidArgumentException
      */
-    public function testTransactionalWithException()
+    public function testTransactionalWithException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $driver = $this->getMockFormDriver();
@@ -1174,7 +1076,7 @@ class ConnectionTest extends TestCase
         $connection->expects($this->once())->method('begin');
         $connection->expects($this->once())->method('rollback');
         $connection->expects($this->never())->method('commit');
-        $connection->transactional(function ($conn) use ($connection) {
+        $connection->transactional(function ($conn) use ($connection): void {
             $this->assertSame($connection, $conn);
             throw new \InvalidArgumentException();
         });
@@ -1182,10 +1084,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Tests it is possible to set a schema collection object
-     *
-     * @return void
      */
-    public function testSetSchemaCollection()
+    public function testSetSchemaCollection(): void
     {
         $driver = $this->getMockFormDriver();
         $connection = $this->getMockBuilder(Connection::class)
@@ -1205,10 +1105,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Test CachedCollection creation with default and custom cache key prefix.
-     *
-     * @return void
      */
-    public function testGetCachedCollection()
+    public function testGetCachedCollection(): void
     {
         $driver = $this->getMockFormDriver();
         $connection = $this->getMockBuilder(Connection::class)
@@ -1243,10 +1141,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that allowed nesting of commit/rollback operations doesn't
      * throw any exceptions.
-     *
-     * @return void
      */
-    public function testNestedTransactionRollbackExceptionNotThrown()
+    public function testNestedTransactionRollbackExceptionNotThrown(): void
     {
         $this->connection->transactional(function () {
             $this->connection->transactional(function () {
@@ -1279,10 +1175,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that not allowed nesting of commit/rollback operations throws
      * a NestedTransactionRollbackException.
-     *
-     * @return void
      */
-    public function testNestedTransactionRollbackExceptionThrown()
+    public function testNestedTransactionRollbackExceptionThrown(): void
     {
         $this->rollbackSourceLine = -1;
 
@@ -1309,10 +1203,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests more detail about that not allowed nesting of rollback/commit
      * operations throws a NestedTransactionRollbackException.
-     *
-     * @return void
      */
-    public function testNestedTransactionStates()
+    public function testNestedTransactionStates(): void
     {
         $this->rollbackSourceLine = -1;
         $this->nestedTransactionStates = [];
@@ -1364,10 +1256,8 @@ class ConnectionTest extends TestCase
 
     /**
      * Helper method to trace nested transaction states.
-     *
-     * @return void
      */
-    public function pushNestedTransactionState()
+    public function pushNestedTransactionState(): void
     {
         $method = new ReflectionMethod($this->connection, 'wasNestedTransactionRolledback');
         $method->setAccessible(true);
@@ -1377,10 +1267,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that the connection is restablished whenever it is interrupted
      * after having used the connection at least once.
-     *
-     * @return void
      */
-    public function testAutomaticReconnect()
+    public function testAutomaticReconnect(): void
     {
         $conn = clone $this->connection;
         $statement = $conn->query('SELECT 1');
@@ -1407,10 +1295,8 @@ class ConnectionTest extends TestCase
     /**
      * Tests that the connection is not restablished whenever it is interrupted
      * inside a transaction.
-     *
-     * @return void
      */
-    public function testNoAutomaticReconnect()
+    public function testNoAutomaticReconnect(): void
     {
         $conn = clone $this->connection;
         $statement = $conn->query('SELECT 1');

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -29,8 +29,6 @@ class MysqlTest extends TestCase
 {
     /**
      * setup
-     *
-     * @return void
      */
     public function setup(): void
     {
@@ -41,10 +39,8 @@ class MysqlTest extends TestCase
 
     /**
      * Test connecting to MySQL with default configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigDefault()
+    public function testConnectionConfigDefault(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Mysql')
             ->onlyMethods(['_connect', 'getConnection'])
@@ -83,10 +79,8 @@ class MysqlTest extends TestCase
 
     /**
      * Test connecting to MySQL with custom configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigCustom()
+    public function testConnectionConfigCustom(): void
     {
         $config = [
             'persistent' => false,
@@ -133,10 +127,8 @@ class MysqlTest extends TestCase
 
     /**
      * Test schema
-     *
-     * @return void
      */
-    public function testSchema()
+    public function testSchema(): void
     {
         $connection = ConnectionManager::get('test');
         $config = ConnectionManager::getConfig('test');
@@ -145,10 +137,8 @@ class MysqlTest extends TestCase
 
     /**
      * Test isConnected
-     *
-     * @return void
      */
-    public function testIsConnected()
+    public function testIsConnected(): void
     {
         $connection = ConnectionManager::get('test');
         $connection->disconnect();
@@ -158,7 +148,7 @@ class MysqlTest extends TestCase
         $this->assertTrue($connection->isConnected(), 'Should be connected.');
     }
 
-    public function testRollbackTransactionAutoConnect()
+    public function testRollbackTransactionAutoConnect(): void
     {
         $connection = ConnectionManager::get('test');
         $connection->disconnect();
@@ -168,7 +158,7 @@ class MysqlTest extends TestCase
         $this->assertTrue($driver->isConnected());
     }
 
-    public function testCommitTransactionAutoConnect()
+    public function testCommitTransactionAutoConnect(): void
     {
         $connection = ConnectionManager::get('test');
         $driver = $connection->getDriver();
@@ -181,9 +171,8 @@ class MysqlTest extends TestCase
      * @dataProvider versionStringProvider
      * @param string $dbVersion
      * @param string $expectedVersion
-     * @return void
      */
-    public function testVersion($dbVersion, $expectedVersion)
+    public function testVersion($dbVersion, $expectedVersion): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject&\Cake\Database\Connection $connection */
         $connection = $this->getMockBuilder(Connection::class)

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -27,10 +27,8 @@ class PostgresTest extends TestCase
 {
     /**
      * Test connecting to Postgres with default configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigDefault()
+    public function testConnectionConfigDefault(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
             ->onlyMethods(['_connect', 'getConnection'])
@@ -84,10 +82,8 @@ class PostgresTest extends TestCase
 
     /**
      * Test connecting to Postgres with custom configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigCustom()
+    public function testConnectionConfigCustom(): void
     {
         $config = [
             'persistent' => false,
@@ -148,10 +144,8 @@ class PostgresTest extends TestCase
 
     /**
      * Tests that insert queries get a "RETURNING *" string at the end
-     *
-     * @return void
      */
-    public function testInsertReturning()
+    public function testInsertReturning(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
             ->onlyMethods(['_connect', 'getConnection'])
@@ -182,10 +176,8 @@ class PostgresTest extends TestCase
 
     /**
      * Test that having queries replace the aggregated alias field.
-     *
-     * @return void
      */
-    public function testHavingReplacesAlias()
+    public function testHavingReplacesAlias(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
             ->onlyMethods(['connect', 'getConnection', 'version'])
@@ -216,10 +208,8 @@ class PostgresTest extends TestCase
 
     /**
      * Test that having queries replaces nothing if no alias is used.
-     *
-     * @return void
      */
-    public function testHavingWhenNoAliasIsUsed()
+    public function testHavingWhenNoAliasIsUsed(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
             ->onlyMethods(['connect', 'getConnection', 'version'])

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -27,10 +27,8 @@ class SqliteTest extends TestCase
 {
     /**
      * Test connecting to Sqlite with default configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigDefault()
+    public function testConnectionConfigDefault(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')
             ->onlyMethods(['_connect'])
@@ -59,10 +57,8 @@ class SqliteTest extends TestCase
 
     /**
      * Test connecting to Sqlite with custom configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigCustom()
+    public function testConnectionConfigCustom(): void
     {
         $config = [
             'persistent' => true,
@@ -127,9 +123,8 @@ class SqliteTest extends TestCase
      * @dataProvider schemaValueProvider
      * @param mixed $input
      * @param mixed $expected
-     * @return void
      */
-    public function testSchemaValue($input, $expected)
+    public function testSchemaValue($input, $expected): void
     {
         $driver = new Sqlite();
         $mock = $this->getMockBuilder(PDO::class)

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -37,8 +37,6 @@ class SqlserverTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -98,9 +96,8 @@ class SqlserverTest extends TestCase
      * @dataProvider dnsStringDataProvider
      * @param array $constructorArgs
      * @param string $dnsString
-     * @return void
      */
-    public function testDnsString($constructorArgs, $dnsString)
+    public function testDnsString($constructorArgs, $dnsString): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->onlyMethods(['_connect', 'getConnection'])
@@ -123,10 +120,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test connecting to Sqlserver with custom configuration
-     *
-     * @return void
      */
-    public function testConnectionConfigCustom()
+    public function testConnectionConfigCustom(): void
     {
         $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
         $config = [
@@ -190,10 +185,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test connecting to Sqlserver with persistent set to false
-     *
-     * @return void
      */
-    public function testConnectionPersistentFalse()
+    public function testConnectionPersistentFalse(): void
     {
         $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
         $config = [
@@ -235,10 +228,8 @@ class SqlserverTest extends TestCase
     /**
      * Test if attempting to connect with the driver throws an exception when
      * using an invalid config setting.
-     *
-     * @return void
      */
-    public function testConnectionPersistentTrueException()
+    public function testConnectionPersistentTrueException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Config setting "persistent" cannot be set to true, as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT');
@@ -259,10 +250,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test select with limit only and SQLServer2012+
-     *
-     * @return void
      */
-    public function testSelectLimitVersion12()
+    public function testSelectLimitVersion12(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->onlyMethods(['_connect', 'getConnection', 'version'])
@@ -308,10 +297,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test select with limit on lte SQLServer2008
-     *
-     * @return void
      */
-    public function testSelectLimitOldServer()
+    public function testSelectLimitOldServer(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->onlyMethods(['_connect', 'getConnection', 'version'])
@@ -437,10 +424,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test that insert queries have results available to them.
-     *
-     * @return void
      */
-    public function testInsertUsesOutput()
+    public function testInsertUsesOutput(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->onlyMethods(['_connect', 'getConnection'])
@@ -463,10 +448,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test that having queries replace the aggregated alias field.
-     *
-     * @return void
      */
-    public function testHavingReplacesAlias()
+    public function testHavingReplacesAlias(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->onlyMethods(['connect', 'getConnection', 'version'])
@@ -500,10 +483,8 @@ class SqlserverTest extends TestCase
 
     /**
      * Test that having queries replaces nothing is no alias is used.
-     *
-     * @return void
      */
-    public function testHavingWhenNoAliasIsUsed()
+    public function testHavingWhenNoAliasIsUsed(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
             ->onlyMethods(['connect', 'getConnection', 'version'])
@@ -535,7 +516,7 @@ class SqlserverTest extends TestCase
         $this->assertSame($expected, $query->sql());
     }
 
-    public function testExceedingMaxParameters()
+    public function testExceedingMaxParameters(): void
     {
         $connection = ConnectionManager::get('test');
         $this->skipIf(!$connection->getDriver() instanceof Sqlserver);

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -50,10 +50,8 @@ class DriverTest extends TestCase
     /**
      * Test if building the object throws an exception if we're not passing
      * required config data.
-     *
-     * @return void
      */
-    public function testConstructorException()
+    public function testConstructorException(): void
     {
         $arg = ['login' => 'Bear'];
         try {
@@ -68,10 +66,8 @@ class DriverTest extends TestCase
 
     /**
      * Test the constructor.
-     *
-     * @return void
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $arg = ['quoteIdentifiers' => true];
         $driver = $this->getMockForAbstractClass(Driver::class, [$arg]);
@@ -86,10 +82,8 @@ class DriverTest extends TestCase
 
     /**
      * Test supportsSavePoints().
-     *
-     * @return void
      */
-    public function testSupportsSavePoints()
+    public function testSupportsSavePoints(): void
     {
         $result = $this->driver->supportsSavePoints();
         $this->assertTrue($result);
@@ -97,10 +91,8 @@ class DriverTest extends TestCase
 
     /**
      * Test supportsQuoting().
-     *
-     * @return void
      */
-    public function testSupportsQuoting()
+    public function testSupportsQuoting(): void
     {
         $connection = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()
@@ -125,9 +117,8 @@ class DriverTest extends TestCase
      *
      * @dataProvider schemaValueProvider
      * @param mixed $input
-     * @return void
      */
-    public function testSchemaValue($input, string $expected)
+    public function testSchemaValue($input, string $expected): void
     {
         $result = $this->driver->schemaValue($input);
         $this->assertSame($expected, $result);
@@ -136,10 +127,8 @@ class DriverTest extends TestCase
     /**
      * Test schemaValue().
      * Asserting that quote() is being called because none of the conditions were met before.
-     *
-     * @return void
      */
-    public function testSchemaValueConnectionQuoting()
+    public function testSchemaValueConnectionQuoting(): void
     {
         $value = 'string';
 
@@ -160,10 +149,8 @@ class DriverTest extends TestCase
 
     /**
      * Test lastInsertId().
-     *
-     * @return void
      */
-    public function testLastInsertId()
+    public function testLastInsertId(): void
     {
         $connection = $this->getMockBuilder(Mysql::class)
             ->disableOriginalConstructor()
@@ -181,10 +168,8 @@ class DriverTest extends TestCase
 
     /**
      * Test isConnected().
-     *
-     * @return void
      */
-    public function testIsConnected()
+    public function testIsConnected(): void
     {
         $this->assertFalse($this->driver->isConnected());
 
@@ -204,10 +189,8 @@ class DriverTest extends TestCase
 
     /**
      * test autoQuoting().
-     *
-     * @return void
      */
-    public function testAutoQuoting()
+    public function testAutoQuoting(): void
     {
         $this->assertFalse($this->driver->isAutoQuotingEnabled());
 
@@ -220,10 +203,8 @@ class DriverTest extends TestCase
 
     /**
      * Test compileQuery().
-     *
-     * @return void
      */
-    public function testCompileQuery()
+    public function testCompileQuery(): void
     {
         $compiler = $this->getMockBuilder(QueryCompiler::class)
             ->onlyMethods(['compile'])
@@ -264,20 +245,16 @@ class DriverTest extends TestCase
 
     /**
      * Test newCompiler().
-     *
-     * @return void
      */
-    public function testNewCompiler()
+    public function testNewCompiler(): void
     {
         $this->assertInstanceOf(QueryCompiler::class, $this->driver->newCompiler());
     }
 
     /**
      * Test newTableSchema().
-     *
-     * @return void
      */
-    public function testNewTableSchema()
+    public function testNewTableSchema(): void
     {
         $tableName = 'articles';
         $actual = $this->driver->newTableSchema($tableName);
@@ -287,10 +264,8 @@ class DriverTest extends TestCase
 
     /**
      * Test __destruct().
-     *
-     * @return void
      */
-    public function testDestructor()
+    public function testDestructor(): void
     {
         $this->driver->setConnection(true);
         $this->driver->__destruct();

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -33,10 +33,8 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
     /**
      * Tests annotating an aggregate with an empty window expression
-     *
-     * @return void
      */
-    public function testEmptyWindow()
+    public function testEmptyWindow(): void
     {
         $f = (new AggregateExpression('MyFunction'))->over();
         $this->assertSame('MyFunction() OVER ()', $f->sql(new ValueBinder()));
@@ -50,10 +48,8 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
     /**
      * Tests filter() clauses.
-     *
-     * @return void
      */
-    public function testFilter()
+    public function testFilter(): void
     {
         $f = (new AggregateExpression('MyFunction'))->filter(['this' => new IdentifierExpression('that')]);
         $this->assertEqualsSql(
@@ -78,10 +74,8 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
     /**
      * Tests WindowInterface calls are passed to the WindowExpression
-     *
-     * @return void
      */
-    public function testWindowInterface()
+    public function testWindowInterface(): void
     {
         $f = (new AggregateExpression('MyFunction'))->partition('test');
         $this->assertEqualsSql(
@@ -170,17 +164,15 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
     /**
      * Tests traversing aggregate expressions.
-     *
-     * @return void
      */
-    public function testTraverse()
+    public function testTraverse(): void
     {
         $w = (new AggregateExpression('MyFunction'))
             ->filter(['this' => true])
             ->over();
 
         $expressions = [];
-        $w->traverse(function ($expression) use (&$expressions) {
+        $w->traverse(function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 
@@ -190,10 +182,8 @@ class AggregateExpressionTest extends FunctionExpressionTest
 
     /**
      * Tests cloning aggregate expressions
-     *
-     * @return void
      */
-    public function testCloning()
+    public function testCloning(): void
     {
         $a1 = (new AggregateExpression('MyFunction'))->partition('test');
         $a2 = (clone $a1)->partition('new');

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -27,10 +27,8 @@ class CaseExpressionTest extends TestCase
 {
     /**
      * Test that the sql output works correctly
-     *
-     * @return void
      */
-    public function testSqlOutput()
+    public function testSqlOutput(): void
     {
         $expr = new QueryExpression();
         $expr->eq('test', 'true');
@@ -56,10 +54,8 @@ class CaseExpressionTest extends TestCase
 
     /**
      * Test sql generation with 0 case.
-     *
-     * @return void
      */
-    public function testSqlOutputZero()
+    public function testSqlOutputZero(): void
     {
         $expression = new QueryExpression();
         $expression->add(['id' => 'test']);
@@ -76,13 +72,11 @@ class CaseExpressionTest extends TestCase
 
     /**
      * Tests that the expression is correctly traversed
-     *
-     * @return void
      */
-    public function testTraverse()
+    public function testTraverse(): void
     {
         $count = 0;
-        $visitor = function () use (&$count) {
+        $visitor = function () use (&$count): void {
             $count++;
         };
 
@@ -97,10 +91,8 @@ class CaseExpressionTest extends TestCase
 
     /**
      * Test cloning
-     *
-     * @return void
      */
-    public function testClone()
+    public function testClone(): void
     {
         $expr = new QueryExpression();
         $expr->eq('test', 'true');

--- a/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
@@ -43,10 +43,8 @@ class CommonTableExpressionTest extends TestCase
 
     /**
      * Tests constructing CommonTableExpressions.
-     *
-     * @return void
      */
-    public function testCteConstructor()
+    public function testCteConstructor(): void
     {
         $cte = new CommonTableExpression('test', $this->connection->newQuery());
         $this->assertEqualsSql('test AS ()', $cte->sql(new ValueBinder()));
@@ -59,8 +57,6 @@ class CommonTableExpressionTest extends TestCase
 
     /**
      * Tests setting fields.
-     *
-     * @return void
      */
     public function testFields(): void
     {
@@ -72,10 +68,8 @@ class CommonTableExpressionTest extends TestCase
 
     /**
      * Tests setting CTE materialized
-     *
-     * @return void
      */
-    public function testMaterialized()
+    public function testMaterialized(): void
     {
         $cte = (new CommonTableExpression('test', $this->connection->newQuery()))
             ->materialized();
@@ -87,10 +81,8 @@ class CommonTableExpressionTest extends TestCase
 
     /**
      * Tests setting CTE as recursive.
-     *
-     * @return void
      */
-    public function testRecursive()
+    public function testRecursive(): void
     {
         $cte = (new CommonTableExpression('test', $this->connection->newQuery()))
             ->recursive();
@@ -99,10 +91,8 @@ class CommonTableExpressionTest extends TestCase
 
     /**
      * Tests setting query using closures.
-     *
-     * @return void
      */
-    public function testQueryClosures()
+    public function testQueryClosures(): void
     {
         $cte = new CommonTableExpression('test', function () {
             return $this->connection->newQuery();
@@ -117,16 +107,14 @@ class CommonTableExpressionTest extends TestCase
 
     /**
      * Tests traversing CommonTableExpression.
-     *
-     * @return void
      */
-    public function testTraverse()
+    public function testTraverse(): void
     {
         $query = $this->connection->newQuery()->select('1');
         $cte = (new CommonTableExpression('test', $query))->field('field');
 
         $expressions = [];
-        $cte->traverse(function ($expression) use (&$expressions) {
+        $cte->traverse(function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 

--- a/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
+++ b/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
@@ -27,10 +27,8 @@ class ComparisonExpressionTest extends TestCase
 {
     /**
      * Tests that cloning Comparion instance clones it's value and field expressions.
-     *
-     * @return void
      */
-    public function testClone()
+    public function testClone(): void
     {
         $exp = new ComparisonExpression(new QueryExpression('field1'), 1, 'integer', '<');
         $exp2 = clone $exp;

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -33,10 +33,8 @@ class FunctionExpressionTest extends TestCase
 
     /**
      * Tests generating a function with no arguments
-     *
-     * @return void
      */
-    public function testArityZero()
+    public function testArityZero(): void
     {
         $f = new $this->expressionClass('MyFunction');
         $this->assertSame('MyFunction()', $f->sql(new ValueBinder()));
@@ -45,10 +43,8 @@ class FunctionExpressionTest extends TestCase
     /**
      * Tests generating a function one or multiple arguments and make sure
      * they are correctly replaced by placeholders
-     *
-     * @return void
      */
-    public function testArityMultiplePlainValues()
+    public function testArityMultiplePlainValues(): void
     {
         $f = new $this->expressionClass('MyFunction', ['foo', 'bar']);
         $binder = new ValueBinder();
@@ -65,10 +61,8 @@ class FunctionExpressionTest extends TestCase
 
     /**
      * Tests that it is possible to use literal strings as arguments
-     *
-     * @return void
      */
-    public function testLiteralParams()
+    public function testLiteralParams(): void
     {
         $binder = new ValueBinder();
         $f = new $this->expressionClass('MyFunction', ['foo' => 'literal', 'bar']);
@@ -78,10 +72,8 @@ class FunctionExpressionTest extends TestCase
     /**
      * Tests that it is possible to nest expression objects and pass them as arguments
      * In particular nesting multiple FunctionExpression
-     *
-     * @return void
      */
-    public function testFunctionNesting()
+    public function testFunctionNesting(): void
     {
         $binder = new ValueBinder();
         $f = new $this->expressionClass('MyFunction', ['foo', 'bar']);
@@ -92,10 +84,8 @@ class FunctionExpressionTest extends TestCase
     /**
      * Tests to avoid regression, prevents double parenthesis
      * In particular nesting with QueryExpression
-     *
-     * @return void
      */
-    public function testFunctionNestingQueryExpression()
+    public function testFunctionNestingQueryExpression(): void
     {
         $binder = new ValueBinder();
         $q = new QueryExpression('a');
@@ -105,10 +95,8 @@ class FunctionExpressionTest extends TestCase
 
     /**
      * Tests that passing a database query as an argument wraps the query SQL into parentheses.
-     *
-     * @return void
      */
-    public function testFunctionWithDatabaseQuery()
+    public function testFunctionWithDatabaseQuery(): void
     {
         $query = ConnectionManager::get('test')
             ->newQuery()
@@ -124,10 +112,8 @@ class FunctionExpressionTest extends TestCase
 
     /**
      * Tests that passing a ORM query as an argument wraps the query SQL into parentheses.
-     *
-     * @return void
      */
-    public function testFunctionWithOrmQuery()
+    public function testFunctionWithOrmQuery(): void
     {
         $query = $this->getTableLocator()->get('Articles')
             ->setSchema(['column' => 'integer'])
@@ -144,10 +130,8 @@ class FunctionExpressionTest extends TestCase
 
     /**
      * Tests that it is possible to use a number as a literal in a function.
-     *
-     * @return void
      */
-    public function testNumericLiteral()
+    public function testNumericLiteral(): void
     {
         $binder = new ValueBinder();
         $f = new $this->expressionClass('MyFunction', ['a_field' => 'literal', '32' => 'literal']);
@@ -159,10 +143,8 @@ class FunctionExpressionTest extends TestCase
 
     /**
      * Tests setReturnType() and getReturnType()
-     *
-     * @return void
      */
-    public function testGetSetReturnType()
+    public function testGetSetReturnType(): void
     {
         $f = new $this->expressionClass('MyFunction');
         $f = $f->setReturnType('foo');

--- a/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
+++ b/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
@@ -27,10 +27,8 @@ class IdentifierExpressionTest extends TestCase
 {
     /**
      * Tests getting and setting the field
-     *
-     * @return void
      */
-    public function testGetAndSet()
+    public function testGetAndSet(): void
     {
         $expression = new IdentifierExpression('foo');
         $this->assertSame('foo', $expression->getIdentifier());
@@ -40,10 +38,8 @@ class IdentifierExpressionTest extends TestCase
 
     /**
      * Tests converting to sql
-     *
-     * @return void
      */
-    public function testSQL()
+    public function testSQL(): void
     {
         $expression = new IdentifierExpression('foo');
         $this->assertSame('foo', $expression->sql(new ValueBinder()));
@@ -51,10 +47,8 @@ class IdentifierExpressionTest extends TestCase
 
     /**
      * Tests setting collation.
-     *
-     * @return void
      */
-    public function testCollation()
+    public function testCollation(): void
     {
         $expresssion = new IdentifierExpression('test', 'utf8_general_ci');
         $this->assertSame('test COLLATE utf8_general_ci', $expresssion->sql(new ValueBinder()));

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -27,10 +27,8 @@ class QueryExpressionTest extends TestCase
 {
     /**
      * Test setConjunction()/getConjunction() works.
-     *
-     * @return void
      */
-    public function testConjunction()
+    public function testConjunction(): void
     {
         $expr = new QueryExpression(['1', '2']);
         $binder = new ValueBinder();
@@ -44,10 +42,8 @@ class QueryExpressionTest extends TestCase
 
     /**
      * Test and() and or() calls work transparently
-     *
-     * @return void
      */
-    public function testAndOrCalls()
+    public function testAndOrCalls(): void
     {
         $expr = new QueryExpression();
         $expected = 'Cake\Database\Expression\QueryExpression';
@@ -57,10 +53,8 @@ class QueryExpressionTest extends TestCase
 
     /**
      * Test SQL generation with one element
-     *
-     * @return void
      */
-    public function testSqlGenerationOneClause()
+    public function testSqlGenerationOneClause(): void
     {
         $expr = new QueryExpression();
         $binder = new ValueBinder();
@@ -72,10 +66,8 @@ class QueryExpressionTest extends TestCase
 
     /**
      * Test SQL generation with many elements
-     *
-     * @return void
      */
-    public function testSqlGenerationMultipleClauses()
+    public function testSqlGenerationMultipleClauses(): void
     {
         $expr = new QueryExpression();
         $binder = new ValueBinder();
@@ -96,10 +88,8 @@ class QueryExpressionTest extends TestCase
 
     /**
      * Test that empty expressions don't emit invalid SQL.
-     *
-     * @return void
      */
-    public function testSqlWhenEmpty()
+    public function testSqlWhenEmpty(): void
     {
         $expr = new QueryExpression();
         $binder = new ValueBinder();
@@ -109,10 +99,8 @@ class QueryExpressionTest extends TestCase
 
     /**
      * Test deep cloning of expression trees.
-     *
-     * @return void
      */
-    public function testDeepCloning()
+    public function testDeepCloning(): void
     {
         $expr = new QueryExpression();
         $expr = $expr->add(new QueryExpression('1 + 1'))
@@ -123,20 +111,18 @@ class QueryExpressionTest extends TestCase
         $this->assertEquals($dupe, $expr);
         $this->assertNotSame($dupe, $expr);
         $originalParts = [];
-        $expr->iterateParts(function ($part) use (&$originalParts) {
+        $expr->iterateParts(function ($part) use (&$originalParts): void {
             $originalParts[] = $part;
         });
-        $dupe->iterateParts(function ($part, $i) use ($originalParts) {
+        $dupe->iterateParts(function ($part, $i) use ($originalParts): void {
             $this->assertNotSame($originalParts[$i], $part);
         });
     }
 
     /**
      * Tests the hasNestedExpression() function
-     *
-     * @return void
      */
-    public function testHasNestedExpression()
+    public function testHasNestedExpression(): void
     {
         $expr = new QueryExpression();
         $this->assertFalse($expr->hasNestedExpression());
@@ -170,9 +156,8 @@ class QueryExpressionTest extends TestCase
      * specific comparison functions are used.
      *
      * @dataProvider methodsProvider
-     * @return void
      */
-    public function testTypeMapUsage(string $method)
+    public function testTypeMapUsage(string $method): void
     {
         $expr = new QueryExpression([], ['created' => 'date']);
         $expr->{$method}('created', 'foo');
@@ -191,9 +176,8 @@ class QueryExpressionTest extends TestCase
      * zero-count expression object.
      *
      * @see https://github.com/cakephp/cakephp/issues/12081
-     * @return void
      */
-    public function testEmptyOr()
+    public function testEmptyOr(): void
     {
         $expr = new QueryExpression();
         $expr = $expr->or([]);
@@ -206,10 +190,8 @@ class QueryExpressionTest extends TestCase
 
     /**
      * Tests that both conditions are generated for notInOrNull().
-     *
-     * @return void
      */
-    public function testNotInOrNull()
+    public function testNotInOrNull(): void
     {
         $expr = new QueryExpression();
         $expr->notInOrNull('test', ['one', 'two']);

--- a/tests/TestCase/Database/Expression/StringExpressionTest.php
+++ b/tests/TestCase/Database/Expression/StringExpressionTest.php
@@ -24,7 +24,7 @@ use Cake\TestSuite\TestCase;
  */
 class StringExpressionTest extends TestCase
 {
-    public function testCollation()
+    public function testCollation(): void
     {
         $expr = new StringExpression('testString', 'utf8_general_ci');
 

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -28,10 +28,8 @@ class TupleComparisonTest extends TestCase
 {
     /**
      * Tests generating a function with no arguments
-     *
-     * @return void
      */
-    public function testsSimpleTuple()
+    public function testsSimpleTuple(): void
     {
         $f = new TupleComparison(['field1', 'field2'], [1, 2], ['integer', 'integer'], '=');
         $binder = new ValueBinder();
@@ -44,10 +42,8 @@ class TupleComparisonTest extends TestCase
 
     /**
      * Tests generating tuples in the fields side containing expressions
-     *
-     * @return void
      */
-    public function testTupleWithExpressionFields()
+    public function testTupleWithExpressionFields(): void
     {
         $field1 = new QueryExpression(['a' => 1]);
         $f = new TupleComparison([$field1, 'field2'], [4, 5], ['integer', 'integer'], '>');
@@ -60,10 +56,8 @@ class TupleComparisonTest extends TestCase
 
     /**
      * Tests generating tuples in the values side containing expressions
-     *
-     * @return void
      */
-    public function testTupleWithExpressionValues()
+    public function testTupleWithExpressionValues(): void
     {
         $value1 = new QueryExpression(['a' => 1]);
         $f = new TupleComparison(['field1', 'field2'], [$value1, 2], ['integer', 'integer'], '=');
@@ -75,10 +69,8 @@ class TupleComparisonTest extends TestCase
 
     /**
      * Tests generating tuples using the IN conjunction
-     *
-     * @return void
      */
-    public function testTupleWithInComparison()
+    public function testTupleWithInComparison(): void
     {
         $f = new TupleComparison(
             ['field1', 'field2'],
@@ -96,10 +88,8 @@ class TupleComparisonTest extends TestCase
 
     /**
      * Tests traversing
-     *
-     * @return void
      */
-    public function testTraverse()
+    public function testTraverse(): void
     {
         $value1 = new QueryExpression(['a' => 1]);
         $field2 = new QueryExpression(['b' => 2]);
@@ -107,7 +97,7 @@ class TupleComparisonTest extends TestCase
         $binder = new ValueBinder();
         $expressions = [];
 
-        $collector = function ($e) use (&$expressions) {
+        $collector = function ($e) use (&$expressions): void {
             $expressions[] = $e;
         };
 
@@ -132,10 +122,8 @@ class TupleComparisonTest extends TestCase
     /**
      * Tests that a single ExpressionInterface can be used as the value for
      * comparison
-     *
-     * @return void
      */
-    public function testValueAsSingleExpression()
+    public function testValueAsSingleExpression(): void
     {
         $value = new QueryExpression('SELECT 1, 1');
         $f = new TupleComparison(['field1', 'field2'], $value);
@@ -146,10 +134,8 @@ class TupleComparisonTest extends TestCase
     /**
      * Tests that a single ExpressionInterface can be used as the field for
      * comparison
-     *
-     * @return void
      */
-    public function testFieldAsSingleExpression()
+    public function testFieldAsSingleExpression(): void
     {
         $value = [1, 1];
         $f = new TupleComparison(new QueryExpression('a, b'), $value);

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -31,10 +31,8 @@ class WindowExpressionTest extends TestCase
 {
     /**
      * Tests an empty window expression
-     *
-     * @return void
      */
-    public function testEmptyWindow()
+    public function testEmptyWindow(): void
     {
         $w = new WindowExpression();
         $this->assertSame('', $w->sql(new ValueBinder()));
@@ -45,10 +43,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with partitions
-     *
-     * @return void
      */
-    public function testPartitions()
+    public function testPartitions(): void
     {
         $w = (new WindowExpression())->partition('test');
         $this->assertEqualsSql(
@@ -79,10 +75,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with order by
-     *
-     * @return void
      */
-    public function testOrder()
+    public function testOrder(): void
     {
         $w = (new WindowExpression())->order('test');
         $this->assertEqualsSql(
@@ -117,10 +111,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with range frames
-     *
-     * @return void
      */
-    public function testRange()
+    public function testRange(): void
     {
         $w = (new WindowExpression())->range(null);
         $this->assertEqualsSql(
@@ -191,10 +183,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with rows frames
-     *
-     * @return void
      */
-    public function testRows()
+    public function testRows(): void
     {
         $w = (new WindowExpression())->rows(null);
         $this->assertEqualsSql(
@@ -254,10 +244,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with groups frames
-     *
-     * @return void
      */
-    public function testGroups()
+    public function testGroups(): void
     {
         $w = (new WindowExpression())->groups(null);
         $this->assertEqualsSql(
@@ -317,10 +305,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with frame exclusion
-     *
-     * @return void
      */
-    public function testExclusion()
+    public function testExclusion(): void
     {
         $w = (new WindowExpression())->excludeCurrent();
         $this->assertEqualsSql(
@@ -349,10 +335,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests windows with partition, order and frames
-     *
-     * @return void
      */
-    public function testCombined()
+    public function testCombined(): void
     {
         $w = (new WindowExpression())->partition('test')->range(null);
         $this->assertEqualsSql(
@@ -381,10 +365,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests named windows
-     *
-     * @return void
      */
-    public function testNamedWindow()
+    public function testNamedWindow(): void
     {
         $w = new WindowExpression();
         $this->assertFalse($w->isNamedOnly());
@@ -412,10 +394,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests traversing window expressions.
-     *
-     * @return void
      */
-    public function testTraverse()
+    public function testTraverse(): void
     {
         $w = (new WindowExpression('test1'))
             ->partition('test2')
@@ -423,7 +403,7 @@ class WindowExpressionTest extends TestCase
             ->range(new QueryExpression("'1 day'"));
 
         $expressions = [];
-        $w->traverse(function ($expression) use (&$expressions) {
+        $w->traverse(function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 
@@ -435,7 +415,7 @@ class WindowExpressionTest extends TestCase
         $w->range(new QueryExpression("'1 day'"), new QueryExpression("'10 days'"));
 
         $expressions = [];
-        $w->traverse(function ($expression) use (&$expressions) {
+        $w->traverse(function ($expression) use (&$expressions): void {
             $expressions[] = $expression;
         });
 
@@ -445,10 +425,8 @@ class WindowExpressionTest extends TestCase
 
     /**
      * Tests cloning window expressions
-     *
-     * @return void
      */
-    public function testCloning()
+    public function testCloning(): void
     {
         $w1 = (new WindowExpression())->name('test');
         $w2 = (clone $w1)->name('test2');

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -45,7 +45,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
         TypeFactory::map('ordered_uuid', OrderedUuidType::class);
     }
 
-    protected function _insert()
+    protected function _insert(): void
     {
         $query = $this->connection->newQuery();
         $query
@@ -61,10 +61,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     /**
      * Tests inserting a value that is to be converted to an expression
      * automatically
-     *
-     * @return void
      */
-    public function testInsert()
+    public function testInsert(): void
     {
         $this->_insert();
         $query = $this->connection->newQuery()
@@ -83,10 +81,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
 
     /**
      * Test selecting with a custom expression type using conditions
-     *
-     * @return void
      */
-    public function testSelectWithConditions()
+    public function testSelectWithConditions(): void
     {
         $this->_insert();
         $result = $this->connection->newQuery()
@@ -102,10 +98,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
 
     /**
      * Tests Select using value object in conditions
-     *
-     * @return void
      */
-    public function testSelectWithConditionsValueObject()
+    public function testSelectWithConditionsValueObject(): void
     {
         $this->_insert();
         $result = $this->connection->newQuery()
@@ -124,7 +118,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
      *
      * @var string
      */
-    public function testSelectWithInCondition()
+    public function testSelectWithInCondition(): void
     {
         $this->_insert();
         $result = $this->connection->newQuery()
@@ -145,10 +139,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
 
     /**
      * Tests using an expression type in a between condition
-     *
-     * @return void
      */
-    public function testSelectWithBetween()
+    public function testSelectWithBetween(): void
     {
         $this->_insert();
         $result = $this->connection->newQuery()
@@ -170,10 +162,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
 
     /**
      * Tests using an expression type inside a function expression
-     *
-     * @return void
      */
-    public function testSelectWithFunction()
+    public function testSelectWithFunction(): void
     {
         $this->_insert();
         $result = $this->connection->newQuery()

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -34,8 +34,6 @@ class ExpressionTypeCastingTest extends TestCase
 {
     /**
      * Setups a mock for FunctionsBuilder
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,10 +44,8 @@ class ExpressionTypeCastingTest extends TestCase
     /**
      * Tests that the Comparison expression can handle values convertible to
      * expressions
-     *
-     * @return void
      */
-    public function testComparisonSimple()
+    public function testComparisonSimple(): void
     {
         $comparison = new ComparisonExpression('field', 'the thing', 'test', '=');
         $binder = new ValueBinder();
@@ -58,7 +54,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('the thing', $binder->bindings()[':param0']['value']);
 
         $found = false;
-        $comparison->traverse(function ($exp) use (&$found) {
+        $comparison->traverse(function ($exp) use (&$found): void {
             $found = $exp instanceof FunctionExpression;
         });
         $this->assertTrue($found, 'The expression is not included in the tree');
@@ -67,10 +63,8 @@ class ExpressionTypeCastingTest extends TestCase
     /**
      * Tests that the Comparison expression can handle values convertible to
      * expressions
-     *
-     * @return void
      */
-    public function testComparisonMultiple()
+    public function testComparisonMultiple(): void
     {
         $comparison = new ComparisonExpression('field', ['2', '3'], 'test[]', 'IN');
         $binder = new ValueBinder();
@@ -80,7 +74,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('3', $binder->bindings()[':param2']['value']);
 
         $found = false;
-        $comparison->traverse(function ($exp) use (&$found) {
+        $comparison->traverse(function ($exp) use (&$found): void {
             $found = $exp instanceof FunctionExpression;
         });
         $this->assertTrue($found, 'The expression is not included in the tree');
@@ -88,10 +82,8 @@ class ExpressionTypeCastingTest extends TestCase
 
     /**
      * Tests that the Between expression casts values to expressions correctly
-     *
-     * @return void
      */
-    public function testBetween()
+    public function testBetween(): void
     {
         $between = new BetweenExpression('field', 'from', 'to', 'test');
         $binder = new ValueBinder();
@@ -101,7 +93,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('to', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
-        $between->traverse(function ($exp) use (&$expressions) {
+        $between->traverse(function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 
@@ -111,10 +103,8 @@ class ExpressionTypeCastingTest extends TestCase
 
     /**
      * Tests that the Case expressions converts values to expressions correctly
-     *
-     * @return void
      */
-    public function testCaseExpression()
+    public function testCaseExpression(): void
     {
         $case = new CaseExpression(
             [new ComparisonExpression('foo', '1', 'string', '=')],
@@ -131,7 +121,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('value2', $binder->bindings()[':param3']['value']);
 
         $expressions = [];
-        $case->traverse(function ($exp) use (&$expressions) {
+        $case->traverse(function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 
@@ -141,10 +131,8 @@ class ExpressionTypeCastingTest extends TestCase
 
     /**
      * Tests that values in FunctionExpressions are converted to expressions correctly
-     *
-     * @return void
      */
-    public function testFunctionExpression()
+    public function testFunctionExpression(): void
     {
         $function = new FunctionExpression('DATE', ['2016-01'], ['test']);
         $binder = new ValueBinder();
@@ -153,7 +141,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('2016-01', $binder->bindings()[':param0']['value']);
 
         $expressions = [];
-        $function->traverse(function ($exp) use (&$expressions) {
+        $function->traverse(function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 
@@ -163,10 +151,8 @@ class ExpressionTypeCastingTest extends TestCase
 
     /**
      * Tests that values in ValuesExpression are converted to expressions correctly
-     *
-     * @return void
      */
-    public function testValuesExpression()
+    public function testValuesExpression(): void
     {
         $values = new ValuesExpression(['title'], new TypeMap(['title' => 'test']));
         $values->add(['title' => 'foo']);
@@ -182,7 +168,7 @@ class ExpressionTypeCastingTest extends TestCase
         $this->assertSame('bar', $binder->bindings()[':param2']['value']);
 
         $expressions = [];
-        $values->traverse(function ($exp) use (&$expressions) {
+        $values->traverse(function ($exp) use (&$expressions): void {
             $expressions[] = $exp instanceof FunctionExpression ? 1 : 0;
         });
 

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -35,8 +35,6 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Setups a mock for FunctionsBuilder
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,10 +44,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a generic function call
-     *
-     * @return void
      */
-    public function testArbitrary()
+    public function testArbitrary(): void
     {
         $function = $this->functions->MyFunc(['b' => 'literal']);
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -62,10 +58,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a generic aggregate call
-     *
-     * @return void
      */
-    public function testArbitraryAggregate()
+    public function testArbitraryAggregate(): void
     {
         $function = $this->functions->aggregate('MyFunc', ['b' => 'literal']);
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -78,10 +72,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a SUM() function
-     *
-     * @return void
      */
-    public function testSum()
+    public function testSum(): void
     {
         $function = $this->functions->sum('total');
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -96,10 +88,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a AVG() function
-     *
-     * @return void
      */
-    public function testAvg()
+    public function testAvg(): void
     {
         $function = $this->functions->avg('salary');
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -109,10 +99,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a MAX() function
-     *
-     * @return void
      */
-    public function testMax()
+    public function testMax(): void
     {
         $function = $this->functions->max('total');
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -127,10 +115,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a MIN() function
-     *
-     * @return void
      */
-    public function testMin()
+    public function testMin(): void
     {
         $function = $this->functions->min('created', ['date']);
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -140,10 +126,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a COUNT() function
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $function = $this->functions->count('*');
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -153,10 +137,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a CONCAT() function
-     *
-     * @return void
      */
-    public function testConcat()
+    public function testConcat(): void
     {
         $function = $this->functions->concat(['title' => 'literal', ' is a string']);
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -166,10 +148,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a COALESCE() function
-     *
-     * @return void
      */
-    public function testCoalesce()
+    public function testCoalesce(): void
     {
         $function = $this->functions->coalesce(['NULL' => 'literal', '1', 'a'], ['a' => 'date']);
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -179,10 +159,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a CAST() function
-     *
-     * @return void
      */
-    public function testCast()
+    public function testCast(): void
     {
         $function = $this->functions->cast('field', 'varchar');
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -197,10 +175,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests missing type in new CAST() wrapper throws exception.
-     *
-     * @return void
      */
-    public function testInvalidCast()
+    public function testInvalidCast(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->functions->cast('field');
@@ -208,10 +184,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a NOW(), CURRENT_TIME() and CURRENT_DATE() function
-     *
-     * @return void
      */
-    public function testNow()
+    public function testNow(): void
     {
         $function = $this->functions->now();
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -231,10 +205,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a EXTRACT() function
-     *
-     * @return void
      */
-    public function testExtract()
+    public function testExtract(): void
     {
         $function = $this->functions->extract('day', 'created');
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -249,10 +221,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a DATE_ADD() function
-     *
-     * @return void
      */
-    public function testDateAdd()
+    public function testDateAdd(): void
     {
         $function = $this->functions->dateAdd('created', -3, 'day');
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -266,10 +236,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a DAYOFWEEK() function
-     *
-     * @return void
      */
-    public function testDayOfWeek()
+    public function testDayOfWeek(): void
     {
         $function = $this->functions->dayOfWeek('created');
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -284,10 +252,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a RAND() function
-     *
-     * @return void
      */
-    public function testRand()
+    public function testRand(): void
     {
         $function = $this->functions->rand();
         $this->assertInstanceOf(FunctionExpression::class, $function);
@@ -298,7 +264,7 @@ class FunctionsBuilderTest extends TestCase
     /**
      * Tests generating a ROW_NUMBER() window function
      */
-    public function testRowNumber()
+    public function testRowNumber(): void
     {
         $function = $this->functions->rowNumber();
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -308,10 +274,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a LAG() window function
-     *
-     * @return void
      */
-    public function testLag()
+    public function testLag(): void
     {
         $function = $this->functions->lag('field', 1);
         $this->assertInstanceOf(AggregateExpression::class, $function);
@@ -326,10 +290,8 @@ class FunctionsBuilderTest extends TestCase
 
     /**
      * Tests generating a LAG() window function
-     *
-     * @return void
      */
-    public function testLead()
+    public function testLead(): void
     {
         $function = $this->functions->lead('field', 1);
         $this->assertInstanceOf(AggregateExpression::class, $function);

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -45,10 +45,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that LoggedQuery can be converted to string
-     *
-     * @return void
      */
-    public function testStringConversion()
+    public function testStringConversion(): void
     {
         $logged = new LoggedQuery();
         $logged->query = 'SELECT foo FROM bar';
@@ -57,10 +55,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that query placeholders are replaced when logged
-     *
-     * @return void
      */
-    public function testStringInterpolation()
+    public function testStringInterpolation(): void
     {
         $query = new LoggedQuery();
         $query->driver = $this->driver;
@@ -73,10 +69,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that positional placeholders are replaced when logging a query
-     *
-     * @return void
      */
-    public function testStringInterpolationNotNamed()
+    public function testStringInterpolationNotNamed(): void
     {
         $query = new LoggedQuery();
         $query->driver = $this->driver;
@@ -89,10 +83,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that repeated placeholders are correctly replaced
-     *
-     * @return void
      */
-    public function testStringInterpolationDuplicate()
+    public function testStringInterpolationDuplicate(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p1 AND c = :p2 AND d = :p2';
@@ -104,10 +96,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that named placeholders
-     *
-     * @return void
      */
-    public function testStringInterpolationNamed()
+    public function testStringInterpolationNamed(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p11 AND c = :p20 AND d = :p2';
@@ -119,10 +109,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that placeholders are replaced with correctly escaped strings
-     *
-     * @return void
      */
-    public function testStringInterpolationSpecialChars()
+    public function testStringInterpolationSpecialChars(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1 AND b = :p2 AND c = :p3 AND d = :p4';
@@ -134,10 +122,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that query placeholders are replaced when logged
-     *
-     * @return void
      */
-    public function testBinaryInterpolation()
+    public function testBinaryInterpolation(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1';
@@ -150,10 +136,8 @@ class LoggedQueryTest extends TestCase
 
     /**
      * Tests that unknown possible binary data is not replaced to hex.
-     *
-     * @return void
      */
-    public function testBinaryInterpolationIgnored()
+    public function testBinaryInterpolationIgnored(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1';
@@ -163,7 +147,7 @@ class LoggedQueryTest extends TestCase
         $this->assertSame($expected, (string)$query);
     }
 
-    public function testGetContext()
+    public function testGetContext(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1';
@@ -177,10 +161,7 @@ class LoggedQueryTest extends TestCase
         $this->assertSame($expected, $query->getContext());
     }
 
-    /**
-     * @return void
-     */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $query = new LoggedQuery();
         $query->query = 'SELECT a FROM b where a = :p1';

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -46,10 +46,8 @@ class LoggingStatementTest extends TestCase
 
     /**
      * Tests that queries are logged when executed without params
-     *
-     * @return void
      */
-    public function testExecuteNoParams()
+    public function testExecuteNoParams(): void
     {
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->method('rowCount')->will($this->returnValue(3));
@@ -69,10 +67,8 @@ class LoggingStatementTest extends TestCase
 
     /**
      * Tests that queries are logged when executed with params
-     *
-     * @return void
      */
-    public function testExecuteWithParams()
+    public function testExecuteWithParams(): void
     {
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->method('rowCount')->will($this->returnValue(4));
@@ -92,10 +88,8 @@ class LoggingStatementTest extends TestCase
 
     /**
      * Tests that queries are logged when executed with bound params
-     *
-     * @return void
      */
-    public function testExecuteWithBinding()
+    public function testExecuteWithBinding(): void
     {
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->method('rowCount')->will($this->returnValue(4));
@@ -127,10 +121,8 @@ class LoggingStatementTest extends TestCase
 
     /**
      * Tests that queries are logged despite database errors
-     *
-     * @return void
      */
-    public function testExecuteWithError()
+    public function testExecuteWithError(): void
     {
         $exception = new LogicException('This is bad');
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
@@ -156,10 +148,8 @@ class LoggingStatementTest extends TestCase
 
     /**
      * Tests setting and getting the logger
-     *
-     * @return void
      */
-    public function testSetAndGetLogger()
+    public function testSetAndGetLogger(): void
     {
         $logger = new QueryLogger(['connection' => 'test']);
         $st = new LoggingStatement(

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -29,8 +29,6 @@ class QueryLoggerTest extends TestCase
 {
     /**
      * Tear down
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -42,10 +40,8 @@ class QueryLoggerTest extends TestCase
     /**
      * Tests that the logged query object is passed to the built-in logger using
      * the correct scope
-     *
-     * @return void
      */
-    public function testLogFunction()
+    public function testLogFunction(): void
     {
         $logger = new QueryLogger(['connection' => '']);
         $query = new LoggedQuery();
@@ -68,10 +64,8 @@ class QueryLoggerTest extends TestCase
 
     /**
      * Tests that the connection name is logged with the query.
-     *
-     * @return void
      */
-    public function testLogConnection()
+    public function testLogConnection(): void
     {
         $logger = new QueryLogger(['connection' => 'test']);
         $query = new LoggedQuery();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -87,10 +87,8 @@ class QueryTest extends TestCase
     /**
      * Queries need a default type to prevent fatal errors
      * when an uninitialized query has its sql() method called.
-     *
-     * @return void
      */
-    public function testDefaultType()
+    public function testDefaultType(): void
     {
         $query = new Query($this->connection);
         $this->assertSame('', $query->sql());
@@ -99,10 +97,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to obtain expression results from a query
-     *
-     * @return void
      */
-    public function testSelectFieldsOnly()
+    public function testSelectFieldsOnly(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(false);
         $query = new Query($this->connection);
@@ -125,10 +121,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to pass a closure as fields in select()
-     *
-     * @return void
      */
-    public function testSelectClosure()
+    public function testSelectClosure(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(false);
         $query = new Query($this->connection);
@@ -143,10 +137,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests it is possible to select fields from tables with no conditions
-     *
-     * @return void
      */
-    public function testSelectFieldsFromTable()
+    public function testSelectFieldsFromTable(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -172,10 +164,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests it is possible to select aliased fields
-     *
-     * @return void
      */
-    public function testSelectAliasedFieldsFromTable()
+    public function testSelectAliasedFieldsFromTable(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -210,10 +200,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that tables can also be aliased and referenced in the select clause using such alias
-     *
-     * @return void
      */
-    public function testSelectAliasedTables()
+    public function testSelectAliasedTables(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -240,10 +228,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests it is possible to add joins to a select query
-     *
-     * @return void
      */
-    public function testSelectWithJoins()
+    public function testSelectWithJoins(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -274,10 +260,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests it is possible to add joins to a select query using array or expression as conditions
-     *
-     * @return void
      */
-    public function testSelectWithJoinsConditions()
+    public function testSelectWithJoinsConditions(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Comments');
         $query = new Query($this->connection);
@@ -317,10 +301,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that joins can be aliased using array keys
-     *
-     * @return void
      */
-    public function testSelectAliasedJoins()
+    public function testSelectAliasedJoins(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Comments');
         $query = new Query($this->connection);
@@ -360,10 +342,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests the leftJoin method
-     *
-     * @return void
      */
-    public function testSelectLeftJoin()
+    public function testSelectLeftJoin(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
@@ -393,10 +373,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests the innerJoin method
-     *
-     * @return void
      */
-    public function testSelectInnerJoin()
+    public function testSelectInnerJoin(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
@@ -413,10 +391,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests the rightJoin method
-     *
-     * @return void
      */
-    public function testSelectRightJoin()
+    public function testSelectRightJoin(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
@@ -441,10 +417,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to pass a callable as conditions for a join
-     *
-     * @return void
      */
-    public function testSelectJoinWithCallback()
+    public function testSelectJoinWithCallback(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
@@ -465,10 +439,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to pass a callable as conditions for a join
-     *
-     * @return void
      */
-    public function testSelectJoinWithCallback2()
+    public function testSelectJoinWithCallback2(): void
     {
         $this->loadFixtures('Authors', 'Comments');
         $query = new Query($this->connection);
@@ -492,10 +464,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests it is possible to filter a query by using simple AND joined conditions
-     *
-     * @return void
      */
-    public function testSelectSimpleWhere()
+    public function testSelectSimpleWhere(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -519,10 +489,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorMoreThan()
+    public function testSelectWhereOperatorMoreThan(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -538,10 +506,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorLessThan()
+    public function testSelectWhereOperatorLessThan(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -557,10 +523,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorLessThanEqual()
+    public function testSelectWhereOperatorLessThanEqual(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -575,10 +539,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorMoreThanEqual()
+    public function testSelectWhereOperatorMoreThanEqual(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -593,10 +555,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorNotEqual()
+    public function testSelectWhereOperatorNotEqual(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -612,10 +572,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorLike()
+    public function testSelectWhereOperatorLike(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -631,10 +589,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorLikeExpansion()
+    public function testSelectWhereOperatorLikeExpansion(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -649,10 +605,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operators and scalar values works
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorNotLike()
+    public function testSelectWhereOperatorNotLike(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -667,10 +621,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that unary expressions in selects are built correctly.
-     *
-     * @return void
      */
-    public function testSelectWhereUnary()
+    public function testSelectWhereUnary(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -691,10 +643,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests selecting with conditions and specifying types for those
-     *
-     * @return void
      */
-    public function testSelectWhereTypes()
+    public function testSelectWhereTypes(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -769,10 +719,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests Query::whereNull()
-     *
-     * @return void
      */
-    public function testSelectWhereNull()
+    public function testSelectWhereNull(): void
     {
         $this->loadFixtures('MenuLinkTrees');
 
@@ -806,10 +754,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests Query::whereNotNull()
-     *
-     * @return void
      */
-    public function testSelectWhereNotNull()
+    public function testSelectWhereNotNull(): void
     {
         $this->loadFixtures('MenuLinkTrees');
 
@@ -844,10 +790,8 @@ class QueryTest extends TestCase
     /**
      * Tests that passing an array type to any where condition will replace
      * the passed array accordingly as a proper IN condition
-     *
-     * @return void
      */
-    public function testSelectWhereArrayType()
+    public function testSelectWhereArrayType(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -865,10 +809,8 @@ class QueryTest extends TestCase
     /**
      * Tests that passing an empty array type to any where condition will not
      * result in a SQL error, but an internal exception
-     *
-     * @return void
      */
-    public function testSelectWhereArrayTypeEmpty()
+    public function testSelectWhereArrayTypeEmpty(): void
     {
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Impossible to generate condition with empty list of values for field');
@@ -883,10 +825,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests exception message for impossible condition when using an expression
-     *
-     * @return void
      */
-    public function testSelectWhereArrayTypeEmptyWithExpression()
+    public function testSelectWhereArrayTypeEmptyWithExpression(): void
     {
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('with empty list of values for field (SELECT 1)');
@@ -903,10 +843,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that Query::andWhere() can be used to concatenate conditions with AND
-     *
-     * @return void
      */
-    public function testSelectAndWhere()
+    public function testSelectAndWhere(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -933,10 +871,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that Query::andWhere() can be used without calling where() before
-     *
-     * @return void
      */
-    public function testSelectAndWhereNoPreviousCondition()
+    public function testSelectAndWhereNoPreviousCondition(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -954,10 +890,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to pass a closure to where() to build a set of
      * conditions and return the expression to be used
-     *
-     * @return void
      */
-    public function testSelectWhereUsingClosure()
+    public function testSelectWhereUsingClosure(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1002,10 +936,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests generating tuples in the values side containing closure expressions
-     *
-     * @return void
      */
-    public function testTupleWithClosureExpression()
+    public function testTupleWithClosureExpression(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1031,10 +963,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to pass a closure to andWhere() to build a set of
      * conditions and return the expression to be used
-     *
-     * @return void
      */
-    public function testSelectAndWhereUsingClosure()
+    public function testSelectAndWhereUsingClosure(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1066,10 +996,8 @@ class QueryTest extends TestCase
     /**
      * Tests that expression objects can be used as the field in a comparison
      * and the values will be bound correctly to the query
-     *
-     * @return void
      */
-    public function testSelectWhereUsingExpressionInField()
+    public function testSelectWhereUsingExpressionInField(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1090,10 +1018,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests using where conditions with operator methods
-     *
-     * @return void
      */
-    public function testSelectWhereOperatorMethods()
+    public function testSelectWhereOperatorMethods(): void
     {
         $this->loadFixtures('Articles', 'Comments', 'Authors');
         $query = new Query($this->connection);
@@ -1266,10 +1192,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that calling "in" and "notIn" will cast the passed values to an array
-     *
-     * @return void
      */
-    public function testInValueCast()
+    public function testInValueCast(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1333,10 +1257,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that calling "in" and "notIn" will cast the passed values to an array
-     *
-     * @return void
      */
-    public function testInValueCast2()
+    public function testInValueCast2(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1361,10 +1283,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that IN clauses generate correct placeholders
-     *
-     * @return void
      */
-    public function testInClausePlaceholderGeneration()
+    public function testInClausePlaceholderGeneration(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1381,10 +1301,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests where() with callable types.
-     *
-     * @return void
      */
-    public function testWhereCallables()
+    public function testWhereCallables(): void
     {
         $query = new Query($this->connection);
         $query->select(['id'])
@@ -1405,10 +1323,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that empty values don't set where clauses.
-     *
-     * @return void
      */
-    public function testWhereEmptyValues()
+    public function testWhereEmptyValues(): void
     {
         $query = new Query($this->connection);
         $query->from('comments')
@@ -1423,10 +1339,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to use a between expression
      * in a where condition
-     *
-     * @return void
      */
-    public function testWhereWithBetween()
+    public function testWhereWithBetween(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1450,10 +1364,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to use a between expression
      * in a where condition with a complex data type
-     *
-     * @return void
      */
-    public function testWhereWithBetweenComplex()
+    public function testWhereWithBetweenComplex(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1480,10 +1392,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to use an expression object
      * as the field for a between expression
-     *
-     * @return void
      */
-    public function testWhereWithBetweenWithExpressionField()
+    public function testWhereWithBetweenWithExpressionField(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1509,10 +1419,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to use an expression object
      * as any of the parts of the between expression
-     *
-     * @return void
      */
-    public function testWhereWithBetweenWithExpressionParts()
+    public function testWhereWithBetweenWithExpressionParts(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1538,10 +1446,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests nesting query expressions both using arrays and closures
-     *
-     * @return void
      */
-    public function testSelectExpressionComposition()
+    public function testSelectExpressionComposition(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1624,10 +1530,8 @@ class QueryTest extends TestCase
     /**
      * Tests that conditions can be nested with an unary operator using the array notation
      * and the not() method
-     *
-     * @return void
      */
-    public function testSelectWhereNot()
+    public function testSelectWhereNot(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
@@ -1662,10 +1566,8 @@ class QueryTest extends TestCase
     /**
      * Tests that conditions can be nested with an unary operator using the array notation
      * and the not() method
-     *
-     * @return void
      */
-    public function testSelectWhereNot2()
+    public function testSelectWhereNot2(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1684,10 +1586,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests whereInArray() and its input types.
-     *
-     * @return void
      */
-    public function testWhereInArray()
+    public function testWhereInArray(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1709,10 +1609,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests whereInArray() and empty array input.
-     *
-     * @return void
      */
-    public function testWhereInArrayEmpty()
+    public function testWhereInArrayEmpty(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1733,10 +1631,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests whereNotInList() and its input types.
-     *
-     * @return void
      */
-    public function testWhereNotInList()
+    public function testWhereNotInList(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1756,10 +1652,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests whereNotInList() and empty array input.
-     *
-     * @return void
      */
-    public function testWhereNotInListEmpty()
+    public function testWhereNotInListEmpty(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1780,10 +1674,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests whereNotInListOrNull() and its input types.
-     *
-     * @return void
      */
-    public function testWhereNotInListOrNull()
+    public function testWhereNotInListOrNull(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1803,10 +1695,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests whereNotInListOrNull() and empty array input.
-     *
-     * @return void
      */
-    public function testWhereNotInListOrNullEmpty()
+    public function testWhereNotInListOrNullEmpty(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1827,10 +1717,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests order() method both with simple fields and expressions
-     *
-     * @return void
      */
-    public function testSelectOrderBy()
+    public function testSelectOrderBy(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -1892,10 +1780,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that order() being a string works.
-     *
-     * @return void
      */
-    public function testSelectOrderByString()
+    public function testSelectOrderByString(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -1911,10 +1797,8 @@ class QueryTest extends TestCase
 
     /**
      * Test exception for order() with an associative array which contains extra values.
-     *
-     * @return void
      */
-    public function testSelectOrderByAssociativeArrayContainingExtraExpressions()
+    public function testSelectOrderByAssociativeArrayContainingExtraExpressions(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage(
@@ -1934,10 +1818,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that order() works with closures.
-     *
-     * @return void
      */
-    public function testSelectOrderByClosure()
+    public function testSelectOrderByClosure(): void
     {
         $query = new Query($this->connection);
         $query
@@ -2001,10 +1883,8 @@ class QueryTest extends TestCase
 
     /**
      * Test orderAsc() and its input types.
-     *
-     * @return void
      */
-    public function testSelectOrderAsc()
+    public function testSelectOrderAsc(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -2067,10 +1947,8 @@ class QueryTest extends TestCase
 
     /**
      * Test orderDesc() and its input types.
-     *
-     * @return void
      */
-    public function testSelectOrderDesc()
+    public function testSelectOrderDesc(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -2133,10 +2011,8 @@ class QueryTest extends TestCase
     /**
      * Tests that group by fields can be passed similar to select fields
      * and that it sends the correct query to the database
-     *
-     * @return void
      */
-    public function testSelectGroup()
+    public function testSelectGroup(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -2165,10 +2041,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to select distinct rows
-     *
-     * @return void
      */
-    public function testSelectDistinct()
+    public function testSelectDistinct(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -2187,10 +2061,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests distinct on a specific column reduces rows based on that column.
-     *
-     * @return void
      */
-    public function testSelectDistinctON()
+    public function testSelectDistinctON(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -2226,10 +2098,8 @@ class QueryTest extends TestCase
      * Test use of modifiers in the query
      *
      * Testing the generated SQL since the modifiers are usually different per driver
-     *
-     * @return void
      */
-    public function testSelectModifiers()
+    public function testSelectModifiers(): void
     {
         $query = new Query($this->connection);
         $result = $query
@@ -2279,10 +2149,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that having() behaves pretty much the same as the where() method
-     *
-     * @return void
      */
-    public function testSelectHaving()
+    public function testSelectHaving(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -2312,10 +2180,8 @@ class QueryTest extends TestCase
     /**
      * Tests that Query::andHaving() can be used to concatenate conditions with AND
      * in the having clause
-     *
-     * @return void
      */
-    public function testSelectAndHaving()
+    public function testSelectAndHaving(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
@@ -2357,10 +2223,8 @@ class QueryTest extends TestCase
 
     /**
      * Test having casing with string expressions
-     *
-     * @return void
      */
-    public function testHavingAliasCasingStringExpression()
+    public function testHavingAliasCasingStringExpression(): void
     {
         $this->skipIf($this->autoQuote, 'Does not work when autoquoting is enabled.');
         $query = new Query($this->connection);
@@ -2383,10 +2247,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests selecting rows using a limit clause
-     *
-     * @return void
      */
-    public function testSelectLimit()
+    public function testSelectLimit(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -2400,10 +2262,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests selecting rows combining a limit and offset clause
-     *
-     * @return void
      */
-    public function testSelectOffset()
+    public function testSelectOffset(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
@@ -2462,10 +2322,8 @@ class QueryTest extends TestCase
 
     /**
      * Test Pages number.
-     *
-     * @return void
      */
-    public function testPageShouldStartAtOne()
+    public function testPageShouldStartAtOne(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Pages must start at 1.');
@@ -2477,10 +2335,8 @@ class QueryTest extends TestCase
 
     /**
      * Test selecting rows using the page() method.
-     *
-     * @return void
      */
-    public function testSelectPage()
+    public function testSelectPage(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -2519,10 +2375,8 @@ class QueryTest extends TestCase
     /**
      * Test selecting rows using the page() method and ordering the results
      * by a calculated column.
-     *
-     * @return void
      */
-    public function testSelectPageWithOrder()
+    public function testSelectPageWithOrder(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -2549,10 +2403,8 @@ class QueryTest extends TestCase
     /**
      * Tests that Query objects can be included inside the select clause
      * and be used as a normal field, including binding any passed parameter
-     *
-     * @return void
      */
-    public function testSubqueryInSelect()
+    public function testSubqueryInSelect(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Comments');
         $query = new Query($this->connection);
@@ -2594,10 +2446,8 @@ class QueryTest extends TestCase
     /**
      * Tests that Query objects can be included inside the from clause
      * and be used as a normal table, including binding any passed parameter
-     *
-     * @return void
      */
-    public function testSuqueryInFrom()
+    public function testSuqueryInFrom(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -2623,10 +2473,8 @@ class QueryTest extends TestCase
     /**
      * Tests that Query objects can be included inside the where clause
      * and be used as a normal condition, including binding any passed parameter
-     *
-     * @return void
      */
-    public function testSubqueryInWhere()
+    public function testSubqueryInWhere(): void
     {
         $this->loadFixtures('Authors', 'Comments');
         $query = new Query($this->connection);
@@ -2669,10 +2517,8 @@ class QueryTest extends TestCase
     /**
      * Tests that Query objects can be included inside the where clause
      * and be used as a EXISTS and NOT EXISTS conditions
-     *
-     * @return void
      */
-    public function testSubqueryExistsWhere()
+    public function testSubqueryExistsWhere(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $query = new Query($this->connection);
@@ -2714,10 +2560,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to use a subquery in a join clause
-     *
-     * @return void
      */
-    public function testSubqueryInJoin()
+    public function testSubqueryInJoin(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $subquery = (new Query($this->connection))->select('*')->from('authors');
@@ -2744,10 +2588,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to one or multiple UNION statements in a query
-     *
-     * @return void
      */
-    public function testUnion()
+    public function testUnion(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Comments');
         $union = (new Query($this->connection))->select(['id', 'title'])->from(['a' => 'articles']);
@@ -2785,10 +2627,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to run unions with order statements
-     *
-     * @return void
      */
-    public function testUnionOrderBy()
+    public function testUnionOrderBy(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
@@ -2815,10 +2655,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that UNION ALL can be built by setting the second param of union() to true
-     *
-     * @return void
      */
-    public function testUnionAll()
+    public function testUnionAll(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Comments');
         $union = (new Query($this->connection))->select(['id', 'title'])->from(['a' => 'articles']);
@@ -2847,10 +2685,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests stacking decorators for results and resetting the list of decorators
-     *
-     * @return void
      */
-    public function testDecorateResults()
+    public function testDecorateResults(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -2903,10 +2739,8 @@ class QueryTest extends TestCase
 
     /**
      * Test a basic delete using from()
-     *
-     * @return void
      */
-    public function testDeleteWithFrom()
+    public function testDeleteWithFrom(): void
     {
         $this->loadFixtures('Authors');
         $query = new Query($this->connection);
@@ -2926,10 +2760,8 @@ class QueryTest extends TestCase
 
     /**
      * Test delete with from and alias.
-     *
-     * @return void
      */
-    public function testDeleteWithAliasedFrom()
+    public function testDeleteWithAliasedFrom(): void
     {
         $this->loadFixtures('Authors');
         $query = new Query($this->connection);
@@ -2949,10 +2781,8 @@ class QueryTest extends TestCase
 
     /**
      * Test a basic delete with no from() call.
-     *
-     * @return void
      */
-    public function testDeleteNoFrom()
+    public function testDeleteNoFrom(): void
     {
         $this->loadFixtures('Authors');
         $query = new Query($this->connection);
@@ -2973,10 +2803,8 @@ class QueryTest extends TestCase
      * Tests that delete queries that contain joins do trigger a notice,
      * warning about possible incompatibilities with aliases being removed
      * from the conditions.
-     *
-     * @return void
      */
-    public function testDeleteRemovingAliasesCanBreakJoins()
+    public function testDeleteRemovingAliasesCanBreakJoins(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.');
@@ -2994,10 +2822,8 @@ class QueryTest extends TestCase
     /**
      * Tests that aliases are stripped from delete query conditions
      * where possible.
-     *
-     * @return void
      */
-    public function testDeleteStripAliasesFromConditions()
+    public function testDeleteStripAliasesFromConditions(): void
     {
         $query = new Query($this->connection);
 
@@ -3035,10 +2861,8 @@ class QueryTest extends TestCase
 
     /**
      * Test setting select() & delete() modes.
-     *
-     * @return void
      */
-    public function testSelectAndDeleteOnSameQuery()
+    public function testSelectAndDeleteOnSameQuery(): void
     {
         $this->loadFixtures('Authors');
         $query = new Query($this->connection);
@@ -3053,10 +2877,8 @@ class QueryTest extends TestCase
 
     /**
      * Test a simple update.
-     *
-     * @return void
      */
-    public function testUpdateSimple()
+    public function testUpdateSimple(): void
     {
         $this->loadFixtures('Authors');
         $query = new Query($this->connection);
@@ -3074,10 +2896,8 @@ class QueryTest extends TestCase
     /**
      * Test update with type checking
      * by passing an array as table arg
-     *
-     * @return void
      */
-    public function testUpdateArgTypeChecking()
+    public function testUpdateArgTypeChecking(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $query = new Query($this->connection);
@@ -3086,10 +2906,8 @@ class QueryTest extends TestCase
 
     /**
      * Test update with multiple fields.
-     *
-     * @return void
      */
-    public function testUpdateMultipleFields()
+    public function testUpdateMultipleFields(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3113,10 +2931,8 @@ class QueryTest extends TestCase
 
     /**
      * Test updating multiple fields with an array.
-     *
-     * @return void
      */
-    public function testUpdateMultipleFieldsArray()
+    public function testUpdateMultipleFieldsArray(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3142,10 +2958,8 @@ class QueryTest extends TestCase
 
     /**
      * Test updates with an expression.
-     *
-     * @return void
      */
-    public function testUpdateWithExpression()
+    public function testUpdateWithExpression(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -3170,10 +2984,8 @@ class QueryTest extends TestCase
 
     /**
      * Test update with array fields and types.
-     *
-     * @return void
      */
-    public function testUpdateArrayFields()
+    public function testUpdateArrayFields(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -3201,10 +3013,8 @@ class QueryTest extends TestCase
 
     /**
      * Test update with callable in set
-     *
-     * @return void
      */
-    public function testUpdateSetCallable()
+    public function testUpdateSetCallable(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -3232,10 +3042,8 @@ class QueryTest extends TestCase
     /**
      * Tests that aliases are stripped from update query conditions
      * where possible.
-     *
-     * @return void
      */
-    public function testUpdateStripAliasesFromConditions()
+    public function testUpdateStripAliasesFromConditions(): void
     {
         $query = new Query($this->connection);
 
@@ -3275,10 +3083,8 @@ class QueryTest extends TestCase
      * Tests that update queries that contain joins do trigger a notice,
      * warning about possible incompatibilities with aliases being removed
      * from the conditions.
-     *
-     * @return void
      */
-    public function testUpdateRemovingAliasesCanBreakJoins()
+    public function testUpdateRemovingAliasesCanBreakJoins(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.');
@@ -3295,10 +3101,8 @@ class QueryTest extends TestCase
 
     /**
      * You cannot call values() before insert() it causes all sorts of pain.
-     *
-     * @return void
      */
-    public function testInsertValuesBeforeInsertFailure()
+    public function testInsertValuesBeforeInsertFailure(): void
     {
         $this->expectException(DatabaseException::class);
         $query = new Query($this->connection);
@@ -3311,10 +3115,8 @@ class QueryTest extends TestCase
 
     /**
      * Inserting nothing should not generate an error.
-     *
-     * @return void
      */
-    public function testInsertNothing()
+    public function testInsertNothing(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('At least 1 column is required to perform an insert.');
@@ -3324,10 +3126,8 @@ class QueryTest extends TestCase
 
     /**
      * Test insert() with no into()
-     *
-     * @return void
      */
-    public function testInsertNoInto()
+    public function testInsertNoInto(): void
     {
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Could not compile insert query. No table was specified');
@@ -3337,10 +3137,8 @@ class QueryTest extends TestCase
 
     /**
      * Test insert overwrites values
-     *
-     * @return void
      */
-    public function testInsertOverwritesValues()
+    public function testInsertOverwritesValues(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3362,10 +3160,8 @@ class QueryTest extends TestCase
 
     /**
      * Test inserting a single row.
-     *
-     * @return void
      */
-    public function testInsertSimple()
+    public function testInsertSimple(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3405,10 +3201,8 @@ class QueryTest extends TestCase
 
     /**
      * Test insert queries quote integer column names
-     *
-     * @return void
      */
-    public function testInsertQuoteColumns()
+    public function testInsertQuoteColumns(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3429,10 +3223,8 @@ class QueryTest extends TestCase
     /**
      * Test an insert when not all the listed fields are provided.
      * Columns should be matched up where possible.
-     *
-     * @return void
      */
-    public function testInsertSparseRow()
+    public function testInsertSparseRow(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3471,10 +3263,8 @@ class QueryTest extends TestCase
 
     /**
      * Test inserting multiple rows with sparse data.
-     *
-     * @return void
      */
-    public function testInsertMultipleRowsSparse()
+    public function testInsertMultipleRowsSparse(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3516,10 +3306,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that INSERT INTO ... SELECT works.
-     *
-     * @return void
      */
-    public function testInsertFromSelect()
+    public function testInsertFromSelect(): void
     {
         $this->loadFixtures('Authors', 'Articles');
         $select = (new Query($this->connection))->select(['name', "'some text'", 99])
@@ -3571,7 +3359,7 @@ class QueryTest extends TestCase
     /**
      * Test that an exception is raised when mixing query + array types.
      */
-    public function testInsertFailureMixingTypesArrayFirst()
+    public function testInsertFailureMixingTypesArrayFirst(): void
     {
         $this->expectException(DatabaseException::class);
         $this->loadFixtures('Articles');
@@ -3585,7 +3373,7 @@ class QueryTest extends TestCase
     /**
      * Test that an exception is raised when mixing query + array types.
      */
-    public function testInsertFailureMixingTypesQueryFirst()
+    public function testInsertFailureMixingTypesQueryFirst(): void
     {
         $this->expectException(DatabaseException::class);
         $this->loadFixtures('Articles');
@@ -3598,10 +3386,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that insert can use expression objects as values.
-     *
-     * @return void
      */
-    public function testInsertExpressionValues()
+    public function testInsertExpressionValues(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $query = new Query($this->connection);
@@ -3664,10 +3450,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that the identifier method creates an expression object.
-     *
-     * @return void
      */
-    public function testIdentifierExpression()
+    public function testIdentifierExpression(): void
     {
         $query = new Query($this->connection);
         /** @var \Cake\Database\Expression\IdentifierExpression $identifier */
@@ -3679,10 +3463,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests the interface contract of identifier
-     *
-     * @return void
      */
-    public function testIdentifierInterface()
+    public function testIdentifierInterface(): void
     {
         $query = new Query($this->connection);
         $identifier = $query->identifier('description');
@@ -3698,9 +3480,8 @@ class QueryTest extends TestCase
      * Tests that functions are correctly transformed and their parameters are bound
      *
      * @group FunctionExpression
-     * @return void
      */
-    public function testSQLFunctions()
+    public function testSQLFunctions(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -3804,12 +3585,11 @@ class QueryTest extends TestCase
      * Tests that the values in tuple comparison expression are being bound correctly,
      * specifically for dialects that translate tuple comparisons.
      *
-     * @return void
      * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
      * @see \Cake\Database\Driver\Sqlite::_expressionTranslators()
      * @see \Cake\Database\Driver\Sqlserver::_expressionTranslators()
      */
-    public function testTupleComparisonValuesAreBeingBoundCorrectly()
+    public function testTupleComparisonValuesAreBeingBoundCorrectly(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
@@ -3850,12 +3630,11 @@ class QueryTest extends TestCase
      * Tests that the values in tuple comparison expressions are being bound as expected
      * when types are omitted, specifically for dialects that translate tuple comparisons.
      *
-     * @return void
      * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
      * @see \Cake\Database\Driver\Sqlite::_expressionTranslators()
      * @see \Cake\Database\Driver\Sqlserver::_expressionTranslators()
      */
-    public function testTupleComparisonTypesCanBeOmitted()
+    public function testTupleComparisonTypesCanBeOmitted(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
@@ -3892,10 +3671,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that default types are passed to functions accepting a $types param
-     *
-     * @return void
      */
-    public function testDefaultTypes()
+    public function testDefaultTypes(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -3921,10 +3698,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests parameter binding
-     *
-     * @return void
      */
-    public function testBind()
+    public function testBind(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -3949,10 +3724,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that epilog() will actually append a string to a select query
-     *
-     * @return void
      */
-    public function testAppendSelect()
+    public function testAppendSelect(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -3970,10 +3743,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that epilog() will actually append a string to an insert query
-     *
-     * @return void
      */
-    public function testAppendInsert()
+    public function testAppendInsert(): void
     {
         $query = new Query($this->connection);
         $sql = $query
@@ -3990,10 +3761,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that epilog() will actually append a string to an update query
-     *
-     * @return void
      */
-    public function testAppendUpdate()
+    public function testAppendUpdate(): void
     {
         $query = new Query($this->connection);
         $sql = $query
@@ -4010,10 +3779,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that epilog() will actually append a string to a delete query
-     *
-     * @return void
      */
-    public function testAppendDelete()
+    public function testAppendDelete(): void
     {
         $query = new Query($this->connection);
         $sql = $query
@@ -4028,10 +3795,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests automatic identifier quoting in the select clause
-     *
-     * @return void
      */
-    public function testQuotingSelectFieldsAndAlias()
+    public function testQuotingSelectFieldsAndAlias(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4061,10 +3826,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests automatic identifier quoting in the from clause
-     *
-     * @return void
      */
-    public function testQuotingFromAndAlias()
+    public function testQuotingFromAndAlias(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4082,10 +3845,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests automatic identifier quoting for DISTINCT ON
-     *
-     * @return void
      */
-    public function testQuotingDistinctOn()
+    public function testQuotingDistinctOn(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4095,10 +3856,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests automatic identifier quoting in the join clause
-     *
-     * @return void
      */
-    public function testQuotingJoinsAndAlias()
+    public function testQuotingJoinsAndAlias(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4124,10 +3883,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests automatic identifier quoting in the group by clause
-     *
-     * @return void
      */
-    public function testQuotingGroupBy()
+    public function testQuotingGroupBy(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4145,10 +3902,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests automatic identifier quoting strings inside conditions expressions
-     *
-     * @return void
      */
-    public function testQuotingExpressions()
+    public function testQuotingExpressions(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4170,10 +3925,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that insert query parts get quoted automatically
-     *
-     * @return void
      */
-    public function testQuotingInsert()
+    public function testQuotingInsert(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4193,10 +3946,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests converting a query to a string
-     *
-     * @return void
      */
-    public function testToString()
+    public function testToString(): void
     {
         $query = new Query($this->connection);
         $query
@@ -4208,10 +3959,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $query = (new Query($this->connection))->select('*')
             ->from('articles')
@@ -4248,10 +3997,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests __debugInfo on incomplete query
-     *
-     * @return void
      */
-    public function testDebugInfoIncompleteQuery()
+    public function testDebugInfoIncompleteQuery(): void
     {
         $query = (new Query($this->connection))
             ->insert(['title']);
@@ -4262,10 +4009,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to pass ExpressionInterface to isNull and isNotNull
-     *
-     * @return void
      */
-    public function testIsNullWithExpressions()
+    public function testIsNullWithExpressions(): void
     {
         $this->loadFixtures('Authors');
         $query = new Query($this->connection);
@@ -4296,10 +4041,8 @@ class QueryTest extends TestCase
     /**
      * Tests that strings passed to isNull and isNotNull will be treated as identifiers
      * when using autoQuoting
-     *
-     * @return void
      */
-    public function testIsNullAutoQuoting()
+    public function testIsNullAutoQuoting(): void
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new Query($this->connection);
@@ -4318,10 +4061,8 @@ class QueryTest extends TestCase
     /**
      * Tests that using the IS operator will automatically translate to the best
      * possible operator depending on the passed value
-     *
-     * @return void
      */
-    public function testDirectIsNull()
+    public function testDirectIsNull(): void
     {
         $this->loadFixtures('Authors');
         $sql = (new Query($this->connection))
@@ -4343,10 +4084,8 @@ class QueryTest extends TestCase
     /**
      * Tests that using the wrong NULL operator will throw meaningful exception instead of
      * cloaking as always-empty result set.
-     *
-     * @return void
      */
-    public function testIsNullInvalid()
+    public function testIsNullInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Expression `name` is missing operator (IS, IS NOT) with `null` value.');
@@ -4362,10 +4101,8 @@ class QueryTest extends TestCase
     /**
      * Tests that using the wrong NULL operator will throw meaningful exception instead of
      * cloaking as always-empty result set.
-     *
-     * @return void
      */
-    public function testIsNotNullInvalid()
+    public function testIsNotNullInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -4380,10 +4117,8 @@ class QueryTest extends TestCase
     /**
      * Tests that using the IS NOT operator will automatically translate to the best
      * possible operator depending on the passed value
-     *
-     * @return void
      */
-    public function testDirectIsNotNull()
+    public function testDirectIsNotNull(): void
     {
         $this->loadFixtures('Authors');
         $sql = (new Query($this->connection))
@@ -4404,10 +4139,8 @@ class QueryTest extends TestCase
 
     /**
      * Performs the simple update query and verifies the row count.
-     *
-     * @return void
      */
-    public function testRowCountAndClose()
+    public function testRowCountAndClose(): void
     {
         $this->loadFixtures('Authors');
 
@@ -4442,10 +4175,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that case statements work correctly for various use-cases.
-     *
-     * @return void
      */
-    public function testSqlCaseStatement()
+    public function testSqlCaseStatement(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -4530,10 +4261,8 @@ class QueryTest extends TestCase
 
     /**
      * Shows that bufferResults(false) will prevent client-side results buffering
-     *
-     * @return void
      */
-    public function testUnbufferedQuery()
+    public function testUnbufferedQuery(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -4566,10 +4295,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that cloning goes deep.
-     *
-     * @return void
      */
-    public function testDeepClone()
+    public function testDeepClone(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -4604,10 +4331,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests the selectTypeMap method
-     *
-     * @return void
      */
-    public function testSelectTypeMap()
+    public function testSelectTypeMap(): void
     {
         $query = new Query($this->connection);
         $typeMap = $query->getSelectTypeMap();
@@ -4619,10 +4344,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests the automatic type conversion for the fields in the result
-     *
-     * @return void
      */
-    public function testSelectTypeConversion()
+    public function testSelectTypeConversion(): void
     {
         TypeFactory::set('custom_datetime', new BarType('custom_datetime'));
         $this->loadFixtures('Comments');
@@ -4647,10 +4370,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that the JSON type can save and get data symmetrically
-     *
-     * @return void
      */
-    public function testSymmetricJsonType()
+    public function testSymmetricJsonType(): void
     {
         $query = new Query($this->connection);
         $insert = $query
@@ -4681,10 +4402,8 @@ class QueryTest extends TestCase
 
     /**
      * Test removeJoin().
-     *
-     * @return void
      */
-    public function testRemoveJoin()
+    public function testRemoveJoin(): void
     {
         $this->loadFixtures('Articles');
         $query = new Query($this->connection);
@@ -4703,10 +4422,8 @@ class QueryTest extends TestCase
     /**
      * Tests that types in the type map are used in the
      * specific comparison functions when using a callable
-     *
-     * @return void
      */
-    public function testBetweenExpressionAndTypeMap()
+    public function testBetweenExpressionAndTypeMap(): void
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
@@ -4726,10 +4443,8 @@ class QueryTest extends TestCase
      * Test use of modifiers in a INSERT query
      *
      * Testing the generated SQL since the modifiers are usually different per driver
-     *
-     * @return void
      */
-    public function testInsertModifiers()
+    public function testInsertModifiers(): void
     {
         $query = new Query($this->connection);
         $result = $query
@@ -4760,10 +4475,8 @@ class QueryTest extends TestCase
      * Test use of modifiers in a UPDATE query
      *
      * Testing the generated SQL since the modifiers are usually different per driver
-     *
-     * @return void
      */
-    public function testUpdateModifiers()
+    public function testUpdateModifiers(): void
     {
         $query = new Query($this->connection);
         $result = $query
@@ -4803,10 +4516,8 @@ class QueryTest extends TestCase
      * Test use of modifiers in a DELETE query
      *
      * Testing the generated SQL since the modifiers are usually different per driver
-     *
-     * @return void
      */
-    public function testDeleteModifiers()
+    public function testDeleteModifiers(): void
     {
         $query = new Query($this->connection);
         $result = $query->delete()
@@ -4833,10 +4544,8 @@ class QueryTest extends TestCase
 
     /**
      * Test getValueBinder()
-     *
-     * @return void
      */
-    public function testGetValueBinder()
+    public function testGetValueBinder(): void
     {
         $query = new Query($this->connection);
 
@@ -4845,10 +4554,8 @@ class QueryTest extends TestCase
 
     /**
      * Test automatic results casting
-     *
-     * @return void
      */
-    public function testCastResults()
+    public function testCastResults(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -4870,10 +4577,8 @@ class QueryTest extends TestCase
 
     /**
      * Test disabling type casting
-     *
-     * @return void
      */
-    public function testCastResultsDisable()
+    public function testCastResultsDisable(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -4891,10 +4596,8 @@ class QueryTest extends TestCase
 
     /**
      * Test obtaining the current results casting mode.
-     *
-     * @return void
      */
-    public function testObtainingResultsCastingMode()
+    public function testObtainingResultsCastingMode(): void
     {
         $query = new Query($this->connection);
 
@@ -4906,10 +4609,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that type conversion is only applied once.
-     *
-     * @return void
      */
-    public function testAllNoDuplicateTypeCasting()
+    public function testAllNoDuplicateTypeCasting(): void
     {
         $this->skipIf($this->autoQuote, 'Produces bad SQL in postgres with autoQuoting');
         $query = new Query($this->connection);
@@ -4932,10 +4633,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that reading an undefined clause does not emit an error.
-     *
-     * @return void
      */
-    public function testClauseUndefined()
+    public function testClauseUndefined(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The \'nope\' clause is not defined. Valid clauses are: delete, update');
@@ -4951,9 +4650,8 @@ class QueryTest extends TestCase
      * @param int $count
      * @param array $rows
      * @param array $conditions
-     * @return void
      */
-    public function assertTable($table, $count, $rows, $conditions = [])
+    public function assertTable($table, $count, $rows, $conditions = []): void
     {
         $result = (new Query($this->connection))->select('*')
             ->from($table)
@@ -4973,9 +4671,8 @@ class QueryTest extends TestCase
      * @param string $pattern
      * @param string $query the result to compare against
      * @param bool $optional
-     * @return void
      */
-    public function assertQuotedQuery($pattern, $query, $optional = false)
+    public function assertQuotedQuery($pattern, $query, $optional = false): void
     {
         if ($optional) {
             $optional = '?';
@@ -4988,10 +4685,9 @@ class QueryTest extends TestCase
     /**
      * Test that calling fetchAssoc return an associated array.
      *
-     * @return void
      * @throws \Exception
      */
-    public function testFetchAssoc()
+    public function testFetchAssoc(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -5019,10 +4715,9 @@ class QueryTest extends TestCase
     /**
      * Test that calling fetchAssoc return an empty associated array.
      *
-     * @return void
      * @throws \Exception
      */
-    public function testFetchAssocWithEmptyResult()
+    public function testFetchAssocWithEmptyResult(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -5039,10 +4734,9 @@ class QueryTest extends TestCase
     /**
      * Test that calling fetch with with FETCH_TYPE_OBJ return stdClass object.
      *
-     * @return void
      * @throws \Exception
      */
-    public function testFetchObjects()
+    public function testFetchObjects(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -5065,9 +4759,8 @@ class QueryTest extends TestCase
      * Test that fetchColumn() will return the correct value at $position.
      *
      * @throws \Exception
-     * @return void
      */
-    public function testFetchColumn()
+    public function testFetchColumn(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -5107,9 +4800,8 @@ class QueryTest extends TestCase
      * Test that fetchColumn() will return false if $position is not set.
      *
      * @throws \Exception
-     * @return void
      */
-    public function testFetchColumnReturnsFalse()
+    public function testFetchColumnReturnsFalse(): void
     {
         $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
@@ -5137,10 +4829,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that query expressions can be used for ordering.
-     *
-     * @return void
      */
-    public function testOrderBySubquery()
+    public function testOrderBySubquery(): void
     {
         $this->autoQuote = true;
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);
@@ -5208,10 +4898,9 @@ class QueryTest extends TestCase
      * This replicates what the SQL Server driver would do for <= SQL Server 2008
      * when ordering on fields that are expressions.
      *
-     * @return void
      * @see \Cake\Database\Driver\Sqlserver::_pagingSubquery()
      */
-    public function testReusingExpressions()
+    public function testReusingExpressions(): void
     {
         $this->loadFixtures('Articles');
         $connection = $this->connection;
@@ -5311,10 +5000,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests creating StringExpression.
-     *
-     * @return void
      */
-    public function testStringExpression()
+    public function testStringExpression(): void
     {
         $driver = $this->connection->getDriver();
         if ($driver instanceof Mysql) {
@@ -5349,10 +5036,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests setting identifier collation.
-     *
-     * @return void
      */
-    public function testIdentifierCollation()
+    public function testIdentifierCollation(): void
     {
         $this->loadFixtures('Articles');
         $driver = $this->connection->getDriver();

--- a/tests/TestCase/Database/QueryTests/AggregatesQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/AggregatesQueryTests.php
@@ -53,10 +53,8 @@ class AggregatesQueryTests extends TestCase
 
     /**
      * Tests filtering aggregate function rows.
-     *
-     * @return void
      */
-    public function testFilters()
+    public function testFilters(): void
     {
         $skip = !($this->connection->getDriver() instanceof \Cake\Database\Driver\Postgres);
         if ($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite) {

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
@@ -70,10 +70,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Tests with() sql generation.
-     *
-     * @return void
      */
-    public function testWithCte()
+    public function testWithCte(): void
     {
         $query = $this->connection->newQuery()
             ->with(new CommonTableExpression('cte', function () {
@@ -101,10 +99,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Tests calling with() with overwrite clears other CTEs.
-     *
-     * @return void
      */
-    public function testWithCteOverwrite()
+    public function testWithCteOverwrite(): void
     {
         $query = $this->connection->newQuery()
             ->with(new CommonTableExpression('cte', function () {
@@ -129,10 +125,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Tests recursive CTE.
-     *
-     * @return void
      */
-    public function testWithRecursiveCte()
+    public function testWithRecursiveCte(): void
     {
         $query = $this->connection->newQuery()
             ->with(function (CommonTableExpression $cte, Query $query) {
@@ -197,10 +191,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Test inserting from CTE.
-     *
-     * @return void
      */
-    public function testWithInsertQuery()
+    public function testWithInsertQuery(): void
     {
         $this->skipIf(
             ($this->connection->getDriver() instanceof Mysql),
@@ -265,10 +257,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Tests inserting from CTE as values list.
-     *
-     * @return void
      */
-    public function testWithInInsertWithValuesQuery()
+    public function testWithInInsertWithValuesQuery(): void
     {
         $this->skipIf(
             ($this->connection->getDriver() instanceof Sqlserver),
@@ -322,10 +312,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Tests updating from CTE.
-     *
-     * @return void
      */
-    public function testWithInUpdateQuery()
+    public function testWithInUpdateQuery(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Mysql && $this->connection->getDriver()->isMariadb(),
@@ -388,10 +376,8 @@ class CommonTableExpressionQueryTests extends TestCase
 
     /**
      * Tests deleting from CTE.
-     *
-     * @return void
      */
-    public function testWithInDeleteQuery()
+    public function testWithInDeleteQuery(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Mysql && $this->connection->getDriver()->isMariadb(),

--- a/tests/TestCase/Database/QueryTests/WindowQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTests.php
@@ -72,10 +72,8 @@ class WindowQueryTests extends TestCase
 
     /**
      * Tests window sql generation.
-     *
-     * @return void
      */
-    public function testWindowSql()
+    public function testWindowSql(): void
     {
         $query = new Query($this->connection);
         $sql = $query
@@ -97,7 +95,7 @@ class WindowQueryTests extends TestCase
         $this->assertEqualsSql('SELECT * WINDOW name AS (name3)', $sql);
     }
 
-    public function testMissingWindow()
+    public function testMissingWindow(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('You must return a `WindowExpression`');
@@ -106,7 +104,7 @@ class WindowQueryTests extends TestCase
         });
     }
 
-    public function testPartitions()
+    public function testPartitions(): void
     {
         $this->skipIf($this->skipTests);
         $this->loadFixtures('Comments');
@@ -142,10 +140,8 @@ class WindowQueryTests extends TestCase
 
     /**
      * Tests adding named windows to the query.
-     *
-     * @return void
      */
-    public function testNamedWindow()
+    public function testNamedWindow(): void
     {
         $skip = $this->skipTests;
         if (!$skip) {
@@ -166,7 +162,7 @@ class WindowQueryTests extends TestCase
         $this->assertEquals(4, $result[0]['num_rows']);
     }
 
-    public function testWindowChaining()
+    public function testWindowChaining(): void
     {
         $skip = $this->skipTests;
         if (!$skip) {

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -40,8 +40,6 @@ class CollectionTest extends TestCase
 
     /**
      * Setup function
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -53,8 +51,6 @@ class CollectionTest extends TestCase
 
     /**
      * Teardown function
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,10 +64,8 @@ class CollectionTest extends TestCase
      *
      * Tests for positive describe() calls are in each platformSchema
      * test case.
-     *
-     * @return void
      */
-    public function testDescribeIncorrectTable()
+    public function testDescribeIncorrectTable(): void
     {
         $this->expectException(\Cake\Database\Exception::class);
         $schema = new Collection($this->connection);
@@ -80,10 +74,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that schema metadata is cached
-     *
-     * @return void
      */
-    public function testDescribeCache()
+    public function testDescribeCache(): void
     {
         $this->connection->cacheMetadata('_cake_model_');
         $schema = $this->connection->getSchemaCollection();

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
+use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\MysqlSchemaDialect;
@@ -31,10 +32,8 @@ class MysqlSchemaTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.
-     *
-     * @return void
      */
-    protected function _needsConnection()
+    protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Not using Mysql for test config');
@@ -223,9 +222,8 @@ class MysqlSchemaTest extends TestCase
      * Test parsing MySQL column types from field description.
      *
      * @dataProvider convertColumnProvider
-     * @return void
      */
-    public function testConvertColumn(string $type, array $expected)
+    public function testConvertColumn(string $type, array $expected): void
     {
         $field = [
             'Field' => 'field',
@@ -256,9 +254,8 @@ class MysqlSchemaTest extends TestCase
      * Helper method for testing methods.
      *
      * @param \Cake\Datasource\ConnectionInterface $connection
-     * @return void
      */
-    protected function _createTables($connection)
+    protected function _createTables($connection): void
     {
         $this->_needsConnection();
         $connection->execute('DROP TABLE IF EXISTS schema_articles');
@@ -305,10 +302,8 @@ SQL;
 
     /**
      * Integration test for SchemaCollection & MysqlSchemaDialect.
-     *
-     * @return void
      */
-    public function testListTables()
+    public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -323,10 +318,8 @@ SQL;
 
     /**
      * Test describing a table with MySQL
-     *
-     * @return void
      */
-    public function testDescribeTable()
+    public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -424,10 +417,8 @@ SQL;
 
     /**
      * Test describing a table with indexes in MySQL
-     *
-     * @return void
      */
-    public function testDescribeTableIndexes()
+    public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -479,10 +470,8 @@ SQL;
 
     /**
      * Test describing a table creates options
-     *
-     * @return void
      */
-    public function testDescribeTableOptions()
+    public function testDescribeTableOptions(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -493,7 +482,7 @@ SQL;
         $this->assertArrayHasKey('collation', $result->getOptions());
     }
 
-    public function testDescribeNonPrimaryAutoIncrement()
+    public function testDescribeNonPrimaryAutoIncrement(): void
     {
         $this->_needsConnection();
         $connection = ConnectionManager::get('test');
@@ -824,9 +813,8 @@ SQL;
      * Test generating column definitions
      *
      * @dataProvider columnSqlProvider
-     * @return void
      */
-    public function testColumnSql(string $name, array $data, string $expected)
+    public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
@@ -900,7 +888,7 @@ SQL;
      *
      * @dataProvider constraintSqlProvider
      */
-    public function testConstraintSql(string $name, array $data, string $expected)
+    public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
@@ -941,7 +929,7 @@ SQL;
      *
      * @dataProvider indexSqlProvider
      */
-    public function testIndexSql(string $name, array $data, string $expected)
+    public function testIndexSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
@@ -958,10 +946,8 @@ SQL;
 
     /**
      * Test the addConstraintSql method.
-     *
-     * @return void
      */
-    public function testAddConstraintSql()
+    public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1009,10 +995,8 @@ SQL;
 
     /**
      * Test the dropConstraintSql method.
-     *
-     * @return void
      */
-    public function testDropConstraintSql()
+    public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1060,10 +1044,8 @@ SQL;
 
     /**
      * Test generating a column that is a primary key.
-     *
-     * @return void
      */
-    public function testColumnSqlPrimaryKey()
+    public function testColumnSqlPrimaryKey(): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new MysqlSchemaDialect($driver);
@@ -1095,10 +1077,8 @@ SQL;
 
     /**
      * Integration test for converting a Schema\Table into MySQL table creates.
-     *
-     * @return void
      */
-    public function testCreateSql()
+    public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1164,10 +1144,8 @@ SQL;
 
     /**
      * Integration test for converting a Schema\Table with native JSON
-     *
-     * @return void
      */
-    public function testCreateSqlJson()
+    public function testCreateSqlJson(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1213,10 +1191,8 @@ SQL;
 
     /**
      * Tests creating temporary tables
-     *
-     * @return void
      */
-    public function testCreateTemporary()
+    public function testCreateTemporary(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1235,10 +1211,8 @@ SQL;
 
     /**
      * Test primary key generation & auto-increment.
-     *
-     * @return void
      */
-    public function testCreateSqlCompositeIntegerKey()
+    public function testCreateSqlCompositeIntegerKey(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1301,10 +1275,8 @@ SQL;
 
     /**
      * test dropSql
-     *
-     * @return void
      */
-    public function testDropSql()
+    public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1321,10 +1293,8 @@ SQL;
 
     /**
      * Test truncateSql()
-     *
-     * @return void
      */
-    public function testTruncateSql()
+    public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1341,10 +1311,8 @@ SQL;
 
     /**
      * Test that constructing a schema dialect connects the driver.
-     *
-     * @return void
      */
-    public function testConstructConnectsDriver()
+    public function testConstructConnectsDriver(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
         $driver->expects($this->once())
@@ -1354,10 +1322,8 @@ SQL;
 
     /**
      * Tests JSON column parsing on MySQL 5.7+
-     *
-     * @return void
      */
-    public function testDescribeJson()
+    public function testDescribeJson(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -1384,10 +1350,8 @@ SQL;
 
     /**
      * Get a schema instance with a mocked driver/pdo instances
-     *
-     * @return \Cake\Database\Schema\MysqlSchemaDialect
      */
-    protected function _getMockedDriver()
+    protected function _getMockedDriver(): Driver
     {
         $driver = new Mysql();
         $mock = $this->getMockBuilder(PDO::class)

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
+use Cake\Database\Driver;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\PostgresSchemaDialect;
@@ -31,10 +32,8 @@ class PostgresSchemaTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.
-     *
-     * @return void
      */
-    protected function _needsConnection()
+    protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Postgres') === false, 'Not using Postgres for test config');
@@ -44,9 +43,8 @@ class PostgresSchemaTest extends TestCase
      * Helper method for testing methods.
      *
      * @param \Cake\Datasource\ConnectionInterface $connection
-     * @return void
      */
-    protected function _createTables($connection)
+    protected function _createTables($connection): void
     {
         $this->_needsConnection();
 
@@ -248,9 +246,8 @@ SQL;
      * Test parsing Postgres column types from field description.
      *
      * @dataProvider convertColumnProvider
-     * @return void
      */
-    public function testConvertColumn(array $field, array $expected)
+    public function testConvertColumn(array $field, array $expected): void
     {
         $field += [
             'name' => 'field',
@@ -282,10 +279,8 @@ SQL;
 
     /**
      * Test listing tables with Postgres
-     *
-     * @return void
      */
-    public function testListTables()
+    public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -299,10 +294,8 @@ SQL;
 
     /**
      * Test that describe accepts tablenames containing `schema.table`.
-     *
-     * @return void
      */
-    public function testDescribeWithSchemaName()
+    public function testDescribeWithSchemaName(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -315,10 +308,8 @@ SQL;
 
     /**
      * Test describing a table with Postgres
-     *
-     * @return void
      */
-    public function testDescribeTable()
+    public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -456,10 +447,8 @@ SQL;
 
     /**
      * Test describing a table with postgres and composite keys
-     *
-     * @return void
      */
-    public function testDescribeTableCompositeKey()
+    public function testDescribeTableCompositeKey(): void
     {
         $this->_needsConnection();
         $connection = ConnectionManager::get('test');
@@ -483,10 +472,8 @@ SQL;
 
     /**
      * Test describing a table containing defaults with Postgres
-     *
-     * @return void
      */
-    public function testDescribeTableWithDefaults()
+    public function testDescribeTableWithDefaults(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -548,10 +535,8 @@ SQL;
 
     /**
      * Test describing a table with containing keywords
-     *
-     * @return void
      */
-    public function testDescribeTableConstraintsWithKeywords()
+    public function testDescribeTableConstraintsWithKeywords(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -578,10 +563,8 @@ SQL;
 
     /**
      * Test describing a table with indexes
-     *
-     * @return void
      */
-    public function testDescribeTableIndexes()
+    public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -637,10 +620,8 @@ SQL;
 
     /**
      * Test describing a table with indexes with nulls first
-     *
-     * @return void
      */
-    public function testDescribeTableIndexesNullsFirst()
+    public function testDescribeTableIndexesNullsFirst(): void
     {
         $this->_needsConnection();
         $connection = ConnectionManager::get('test');
@@ -681,10 +662,8 @@ SQL;
 
     /**
      * Test describing a table with postgres function defaults
-     *
-     * @return void
      */
-    public function testDescribeTableFunctionDefaultValue()
+    public function testDescribeTableFunctionDefaultValue(): void
     {
         $this->_needsConnection();
         $connection = ConnectionManager::get('test');
@@ -964,9 +943,8 @@ SQL;
      * Test generating column definitions
      *
      * @dataProvider columnSqlProvider
-     * @return void
      */
-    public function testColumnSql(string $name, array $data, string $expected)
+    public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
@@ -977,10 +955,8 @@ SQL;
 
     /**
      * Test generating a column that is a primary key.
-     *
-     * @return void
      */
-    public function testColumnSqlPrimaryKey()
+    public function testColumnSqlPrimaryKey(): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
@@ -1055,7 +1031,7 @@ SQL;
      *
      * @dataProvider constraintSqlProvider
      */
-    public function testConstraintSql(string $name, array $data, string $expected)
+    public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new PostgresSchemaDialect($driver);
@@ -1072,10 +1048,8 @@ SQL;
 
     /**
      * Test the addConstraintSql method.
-     *
-     * @return void
      */
-    public function testAddConstraintSql()
+    public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1123,10 +1097,8 @@ SQL;
 
     /**
      * Test the dropConstraintSql method.
-     *
-     * @return void
      */
-    public function testDropConstraintSql()
+    public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1174,10 +1146,8 @@ SQL;
 
     /**
      * Integration test for converting a Schema\Table into MySQL table creates.
-     *
-     * @return void
      */
-    public function testCreateSql()
+    public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1246,10 +1216,8 @@ SQL;
 
     /**
      * Tests creating temporary tables
-     *
-     * @return void
      */
-    public function testCreateTemporary()
+    public function testCreateTemporary(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1268,10 +1236,8 @@ SQL;
 
     /**
      * Test primary key generation & auto-increment.
-     *
-     * @return void
      */
-    public function testCreateSqlCompositeIntegerKey()
+    public function testCreateSqlCompositeIntegerKey(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1334,10 +1300,8 @@ SQL;
 
     /**
      * test dropSql
-     *
-     * @return void
      */
-    public function testDropSql()
+    public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1354,10 +1318,8 @@ SQL;
 
     /**
      * Test truncateSql()
-     *
-     * @return void
      */
-    public function testTruncateSql()
+    public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1379,10 +1341,8 @@ SQL;
 
     /**
      * Get a schema instance with a mocked driver/pdo instances
-     *
-     * @return \Cake\Database\Driver
      */
-    protected function _getMockedDriver()
+    protected function _getMockedDriver(): Driver
     {
         $driver = new Postgres();
         $mock = $this->getMockBuilder(PDO::class)

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
+use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqliteSchemaDialect;
@@ -31,10 +32,8 @@ class SqliteSchemaTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.
-     *
-     * @return void
      */
-    protected function _needsConnection()
+    protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite for test config');
@@ -155,9 +154,8 @@ class SqliteSchemaTest extends TestCase
      * Test parsing SQLite column types from field description.
      *
      * @dataProvider convertColumnProvider
-     * @return void
      */
-    public function testConvertColumn(string $type, array $expected)
+    public function testConvertColumn(string $type, array $expected): void
     {
         $field = [
             'pk' => false,
@@ -187,10 +185,8 @@ class SqliteSchemaTest extends TestCase
     /**
      * Tests converting multiple rows into a primary constraint with multiple
      * columns
-     *
-     * @return void
      */
-    public function testConvertCompositePrimaryKey()
+    public function testConvertCompositePrimaryKey(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')->getMock();
         $dialect = new SqliteSchemaDialect($driver);
@@ -220,9 +216,8 @@ class SqliteSchemaTest extends TestCase
      * Creates tables for testing listTables/describe()
      *
      * @param \Cake\Database\Connection $connection
-     * @return void
      */
-    protected function _createTables($connection)
+    protected function _createTables($connection): void
     {
         $this->_needsConnection();
 
@@ -283,10 +278,8 @@ SQL;
 
     /**
      * Test SchemaCollection listing tables with Sqlite
-     *
-     * @return void
      */
-    public function testListTables()
+    public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -301,10 +294,8 @@ SQL;
 
     /**
      * Test describing a table with Sqlite
-     *
-     * @return void
      */
-    public function testDescribeTable()
+    public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -394,10 +385,8 @@ SQL;
 
     /**
      * Tests SQLite views
-     *
-     * @return void
      */
-    public function testDescribeView()
+    public function testDescribeView(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -426,10 +415,8 @@ SQL;
      *
      * Composite keys in SQLite are never autoincrement, and shouldn't be marked
      * as such.
-     *
-     * @return void
      */
-    public function testDescribeTableCompositeKey()
+    public function testDescribeTableCompositeKey(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -443,10 +430,8 @@ SQL;
 
     /**
      * Test describing a table with indexes
-     *
-     * @return void
      */
-    public function testDescribeTableIndexes()
+    public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -676,10 +661,8 @@ SQL;
 
     /**
      * Test the addConstraintSql method.
-     *
-     * @return void
      */
-    public function testAddConstraintSql()
+    public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -696,10 +679,8 @@ SQL;
 
     /**
      * Test the dropConstraintSql method.
-     *
-     * @return void
      */
-    public function testDropConstraintSql()
+    public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -717,9 +698,8 @@ SQL;
      * Test generating column definitions
      *
      * @dataProvider columnSqlProvider
-     * @return void
      */
-    public function testColumnSql(string $name, array $data, string $expected)
+    public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
@@ -730,10 +710,8 @@ SQL;
 
     /**
      * Test generating a column that is a primary key.
-     *
-     * @return void
      */
-    public function testColumnSqlPrimaryKey()
+    public function testColumnSqlPrimaryKey(): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
@@ -758,10 +736,8 @@ SQL;
 
     /**
      * Test generating a bigint column that is a primary key.
-     *
-     * @return void
      */
-    public function testColumnSqlPrimaryKeyBigInt()
+    public function testColumnSqlPrimaryKeyBigInt(): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
@@ -838,7 +814,7 @@ SQL;
      *
      * @dataProvider constraintSqlProvider
      */
-    public function testConstraintSql(string $name, array $data, string $expected)
+    public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
@@ -874,7 +850,7 @@ SQL;
      *
      * @dataProvider indexSqlProvider
      */
-    public function testIndexSql(string $name, array $data, string $expected)
+    public function testIndexSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqliteSchemaDialect($driver);
@@ -891,10 +867,8 @@ SQL;
 
     /**
      * Integration test for converting a Schema\Table into MySQL table creates.
-     *
-     * @return void
      */
-    public function testCreateSql()
+    public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -943,10 +917,8 @@ SQL;
 
     /**
      * Tests creating temporary tables
-     *
-     * @return void
      */
-    public function testCreateTemporary()
+    public function testCreateTemporary(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -965,10 +937,8 @@ SQL;
 
     /**
      * Test primary key generation & auto-increment.
-     *
-     * @return void
      */
-    public function testCreateSqlCompositeIntegerKey()
+    public function testCreateSqlCompositeIntegerKey(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1033,10 +1003,8 @@ SQL;
 
     /**
      * test dropSql
-     *
-     * @return void
      */
-    public function testDropSql()
+    public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1053,10 +1021,8 @@ SQL;
 
     /**
      * Test truncateSql()
-     *
-     * @return void
      */
-    public function testTruncateSql()
+    public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1086,10 +1052,8 @@ SQL;
 
     /**
      * Test truncateSql() with no sequences
-     *
-     * @return void
      */
-    public function testTruncateSqlNoSequences()
+    public function testTruncateSqlNoSequences(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1119,10 +1083,8 @@ SQL;
 
     /**
      * Get a schema instance with a mocked driver/pdo instances
-     *
-     * @return \Cake\Database\Driver
      */
-    protected function _getMockedDriver()
+    protected function _getMockedDriver(): Driver
     {
         $driver = new Sqlite();
         $mock = $this->getMockBuilder(PDO::class)

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
+use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\SqlserverSchemaDialect;
@@ -32,10 +33,8 @@ class SqlserverSchemaTest extends TestCase
 {
     /**
      * Helper method for skipping tests that need a real connection.
-     *
-     * @return void
      */
-    protected function _needsConnection()
+    protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') === false, 'Not using Sqlserver for test config');
@@ -43,10 +42,8 @@ class SqlserverSchemaTest extends TestCase
 
     /**
      * Helper method for testing methods.
-     *
-     * @return void
      */
-    protected function _createTables(ConnectionInterface $connection)
+    protected function _createTables(ConnectionInterface $connection): void
     {
         $this->_needsConnection();
 
@@ -300,9 +297,8 @@ SQL;
      * Test parsing Sqlserver column types from field description.
      *
      * @dataProvider convertColumnProvider
-     * @return void
      */
-    public function testConvertColumn(string $type, ?int $length, ?int $precision, ?int $scale, array $expected)
+    public function testConvertColumn(string $type, ?int $length, ?int $precision, ?int $scale, array $expected): void
     {
         $field = [
             'name' => 'field',
@@ -333,10 +329,8 @@ SQL;
 
     /**
      * Test listing tables with Sqlserver
-     *
-     * @return void
      */
-    public function testListTables()
+    public function testListTables(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -350,10 +344,8 @@ SQL;
 
     /**
      * Test describing a table with Sqlserver
-     *
-     * @return void
      */
-    public function testDescribeTable()
+    public function testDescribeTable(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -495,10 +487,8 @@ SQL;
 
     /**
      * Test describing a table with postgres and composite keys
-     *
-     * @return void
      */
-    public function testDescribeTableCompositeKey()
+    public function testDescribeTableCompositeKey(): void
     {
         $this->_needsConnection();
         $connection = ConnectionManager::get('test');
@@ -522,10 +512,8 @@ SQL;
 
     /**
      * Test that describe accepts tablenames containing `schema.table`.
-     *
-     * @return void
      */
-    public function testDescribeWithSchemaName()
+    public function testDescribeWithSchemaName(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -538,10 +526,8 @@ SQL;
 
     /**
      * Test describing a table with indexes
-     *
-     * @return void
      */
-    public function testDescribeTableIndexes()
+    public function testDescribeTableIndexes(): void
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
@@ -823,9 +809,8 @@ SQL;
      * Test generating column definitions
      *
      * @dataProvider columnSqlProvider
-     * @return void
      */
-    public function testColumnSql(string $name, array $data, string $expected)
+    public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqlserverSchemaDialect($driver);
@@ -890,7 +875,7 @@ SQL;
      *
      * @dataProvider constraintSqlProvider
      */
-    public function testConstraintSql(string $name, array $data, string $expected)
+    public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
         $schema = new SqlserverSchemaDialect($driver);
@@ -907,10 +892,8 @@ SQL;
 
     /**
      * Test the addConstraintSql method.
-     *
-     * @return void
      */
-    public function testAddConstraintSql()
+    public function testAddConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -958,10 +941,8 @@ SQL;
 
     /**
      * Test the dropConstraintSql method.
-     *
-     * @return void
      */
-    public function testDropConstraintSql()
+    public function testDropConstraintSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1009,10 +990,8 @@ SQL;
 
     /**
      * Integration test for converting a Schema\Table into MySQL table creates.
-     *
-     * @return void
      */
-    public function testCreateSql()
+    public function testCreateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1085,10 +1064,8 @@ SQL;
 
     /**
      * test dropSql
-     *
-     * @return void
      */
-    public function testDropSql()
+    public function testDropSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1105,10 +1082,8 @@ SQL;
 
     /**
      * Test truncateSql()
-     *
-     * @return void
      */
-    public function testTruncateSql()
+    public function testTruncateSql(): void
     {
         $driver = $this->_getMockedDriver();
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -1131,10 +1106,8 @@ SQL;
 
     /**
      * Get a schema instance with a mocked driver/pdo instances
-     *
-     * @return \Cake\Database\Driver
      */
-    protected function _getMockedDriver()
+    protected function _getMockedDriver(): Driver
     {
         $driver = new Sqlserver();
         $mock = $this->getMockBuilder(PDO::class)

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -53,10 +53,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test construction with columns
-     *
-     * @return void
      */
-    public function testConstructWithColumns()
+    public function testConstructWithColumns(): void
     {
         $columns = [
             'id' => [
@@ -74,10 +72,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test adding columns.
-     *
-     * @return void
      */
-    public function testAddColumn()
+    public function testAddColumn(): void
     {
         $table = new TableSchema('articles');
         $result = $table->addColumn('title', [
@@ -95,10 +91,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test hasColumn() method.
-     *
-     * @return void
      */
-    public function testHasColumn()
+    public function testHasColumn(): void
     {
         $schema = new TableSchema('articles', [
             'title' => 'string',
@@ -110,10 +104,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test removing columns.
-     *
-     * @return void
      */
-    public function testRemoveColumn()
+    public function testRemoveColumn(): void
     {
         $table = new TableSchema('articles');
         $result = $table->addColumn('title', [
@@ -131,10 +123,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test isNullable method
-     *
-     * @return void
      */
-    public function testIsNullable()
+    public function testIsNullable(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('title', [
@@ -153,10 +143,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test columnType method
-     *
-     * @return void
      */
-    public function testColumnType()
+    public function testColumnType(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('title', [
@@ -170,10 +158,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test setColumnType setter method
-     *
-     * @return void
      */
-    public function testSetColumnType()
+    public function testSetColumnType(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('title', [
@@ -188,10 +174,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Tests getting the baseType as configured when creating the column
-     *
-     * @return void
      */
-    public function testBaseColumnType()
+    public function testBaseColumnType(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('title', [
@@ -206,10 +190,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Tests getting the base type as it is returned by the Type class
-     *
-     * @return void
      */
-    public function testBaseColumnTypeInherited()
+    public function testBaseColumnTypeInherited(): void
     {
         TypeFactory::map('int', IntType::class);
         $table = new TableSchema('articles');
@@ -223,10 +205,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Attribute keys should be filtered and have defaults set.
-     *
-     * @return void
      */
-    public function testAddColumnFiltersAttributes()
+    public function testAddColumnFiltersAttributes(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('title', [
@@ -278,10 +258,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test reading default values.
-     *
-     * @return void
      */
-    public function testDefaultValues()
+    public function testDefaultValues(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('id', [
@@ -316,10 +294,8 @@ class TableSchemaTest extends TestCase
     /**
      * Test adding an constraint.
      * >
-     *
-     * @return void
      */
-    public function testAddConstraint()
+    public function testAddConstraint(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('id', [
@@ -336,10 +312,8 @@ class TableSchemaTest extends TestCase
     /**
      * Test adding an constraint with an overlapping unique index
      * >
-     *
-     * @return void
      */
-    public function testAddConstraintOverwriteUniqueIndex()
+    public function testAddConstraintOverwriteUniqueIndex(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('project_id', [
@@ -392,9 +366,8 @@ class TableSchemaTest extends TestCase
      * are added for fields that do not exist.
      *
      * @dataProvider addConstraintErrorProvider
-     * @return void
      */
-    public function testAddConstraintError(array $props)
+    public function testAddConstraintError(array $props): void
     {
         $this->expectException(\Cake\Database\Exception::class);
         $table = new TableSchema('articles');
@@ -404,10 +377,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test adding an index.
-     *
-     * @return void
      */
-    public function testAddIndex()
+    public function testAddIndex(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('title', [
@@ -446,9 +417,8 @@ class TableSchemaTest extends TestCase
      * are added for fields that do not exist.
      *
      * @dataProvider addIndexErrorProvider
-     * @return void
      */
-    public function testAddIndexError(array $props)
+    public function testAddIndexError(array $props): void
     {
         $this->expectException(\Cake\Database\Exception::class);
         $table = new TableSchema('articles');
@@ -458,10 +428,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test adding different kinds of indexes.
-     *
-     * @return void
      */
-    public function testAddIndexTypes()
+    public function testAddIndexTypes(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('id', 'integer')
@@ -484,10 +452,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test getting the primary key.
-     *
-     * @return void
      */
-    public function testPrimaryKey()
+    public function testPrimaryKey(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('id', 'integer')
@@ -511,10 +477,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test the setOptions/getOptions methods.
-     *
-     * @return void
      */
-    public function testOptions()
+    public function testOptions(): void
     {
         $table = new TableSchema('articles');
         $options = [
@@ -527,10 +491,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Add a basic foreign key constraint.
-     *
-     * @return void
      */
-    public function testAddConstraintForeignKey()
+    public function testAddConstraintForeignKey(): void
     {
         $table = new TableSchema('articles');
         $table->addColumn('author_id', 'integer')
@@ -546,10 +508,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test single column foreign keys constraint support
-     *
-     * @return void
      */
-    public function testConstraintForeignKey()
+    public function testConstraintForeignKey(): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');
         $compositeConstraint = $table->getSchema()->getConstraint('tag_id_fk');
@@ -569,10 +529,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Test composite foreign keys support
-     *
-     * @return void
      */
-    public function testConstraintForeignKeyTwoColumns()
+    public function testConstraintForeignKeyTwoColumns(): void
     {
         $this->getTableLocator()->clear();
         $table = $this->getTableLocator()->get('Orders');
@@ -637,9 +595,8 @@ class TableSchemaTest extends TestCase
      * Add a foreign key constraint with bad data
      *
      * @dataProvider badForeignKeyProvider
-     * @return void
      */
-    public function testAddConstraintForeignKeyBadData(array $data)
+    public function testAddConstraintForeignKeyBadData(array $data): void
     {
         $this->expectException(\Cake\Database\Exception::class);
         $table = new TableSchema('articles');
@@ -649,10 +606,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Tests the setTemporary() & isTemporary() method
-     *
-     * @return void
      */
-    public function testSetTemporary()
+    public function testSetTemporary(): void
     {
         $table = new TableSchema('articles');
         $this->assertFalse($table->isTemporary());
@@ -672,9 +627,8 @@ class TableSchemaTest extends TestCase
      * @param string $pattern
      * @param string $query the result to compare against
      * @param bool $optional
-     * @return void
      */
-    public function assertQuotedQuery($pattern, $query, $optional = false)
+    public function assertQuotedQuery($pattern, $query, $optional = false): void
     {
         if ($optional) {
             $optional = '?';

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -48,8 +48,6 @@ class SchemaCacheTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -64,8 +62,6 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -78,10 +74,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test that clear enables the cache if it was disabled.
-     *
-     * @return void
      */
-    public function testClearEnablesMetadataCache()
+    public function testClearEnablesMetadataCache(): void
     {
         $this->connection->cacheMetadata(false);
 
@@ -93,10 +87,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test that build enables the cache if it was disabled.
-     *
-     * @return void
      */
-    public function testBuildEnablesMetadataCache()
+    public function testBuildEnablesMetadataCache(): void
     {
         $this->connection->cacheMetadata(false);
 
@@ -108,10 +100,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test build() with no args.
-     *
-     * @return void
      */
-    public function testBuildNoArgs()
+    public function testBuildNoArgs(): void
     {
         $ormCache = new SchemaCache($this->connection);
         $ormCache->build();
@@ -121,10 +111,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test build() with one arg.
-     *
-     * @return void
      */
-    public function testBuildNamedModel()
+    public function testBuildNamedModel(): void
     {
         $ormCache = new SchemaCache($this->connection);
         $ormCache->build('articles');
@@ -134,10 +122,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test build() overwrites cached data.
-     *
-     * @return void
      */
-    public function testBuildOverwritesExistingData()
+    public function testBuildOverwritesExistingData(): void
     {
         $this->cache->set('test_articles', 'dummy data');
 
@@ -149,10 +135,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test clear() with no args.
-     *
-     * @return void
      */
-    public function testClearNoArgs()
+    public function testClearNoArgs(): void
     {
         $this->cache->set('test_articles', 'dummy data');
 
@@ -163,10 +147,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Test clear() with a model name.
-     *
-     * @return void
      */
-    public function testClearNamedModel()
+    public function testClearNamedModel(): void
     {
         $this->cache->set('test_articles', 'dummy data');
 
@@ -177,10 +159,8 @@ class SchemaCacheTest extends TestCase
 
     /**
      * Tests getting a schema config from a connection instance
-     *
-     * @return void
      */
-    public function testGetSchemaWithConnectionInstance()
+    public function testGetSchemaWithConnectionInstance(): void
     {
         $ormCache = new SchemaCache($this->connection);
         $result = $ormCache->getSchema($this->connection);

--- a/tests/TestCase/Database/Statement/StatementDecoratorTest.php
+++ b/tests/TestCase/Database/Statement/StatementDecoratorTest.php
@@ -28,10 +28,8 @@ class StatementDecoratorTest extends TestCase
     /**
      * Tests that calling lastInsertId will proxy it to
      * the driver's lastInsertId method
-     *
-     * @return void
      */
-    public function testLastInsertId()
+    public function testLastInsertId(): void
     {
         $statement = $this->getMockBuilder(StatementInterface::class)->getMock();
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
@@ -46,10 +44,8 @@ class StatementDecoratorTest extends TestCase
     /**
      * Tests that calling lastInsertId will get the last insert id by
      * column name
-     *
-     * @return void
      */
-    public function testLastInsertIdWithReturning()
+    public function testLastInsertIdWithReturning(): void
     {
         $internal = $this->getMockBuilder(StatementInterface::class)->getMock();
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
@@ -67,10 +63,8 @@ class StatementDecoratorTest extends TestCase
     /**
      * Tests that the statement will not be executed twice if the iterator
      * is requested more than once
-     *
-     * @return void
      */
-    public function testNoDoubleExecution()
+    public function testNoDoubleExecution(): void
     {
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $driver = $this->getMockBuilder('Cake\Database\DriverInterface')->getMock();

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -37,8 +37,6 @@ class BinaryTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,10 +47,8 @@ class BinaryTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -68,7 +64,7 @@ class BinaryTypeTest extends TestCase
     /**
      * Test exceptions on invalid data.
      */
-    public function testToPHPFailure()
+    public function testToPHPFailure(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Unable to convert array into binary.');
@@ -77,10 +73,8 @@ class BinaryTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $value = 'some data';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -93,10 +87,8 @@ class BinaryTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_LOB, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -39,8 +39,6 @@ class BinaryUuidTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,10 +49,8 @@ class BinaryUuidTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -79,7 +75,7 @@ class BinaryUuidTypeTest extends TestCase
     /**
      * Test exceptions on invalid data.
      */
-    public function testToPHPFailure()
+    public function testToPHPFailure(): void
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to convert array into binary uuid.');
@@ -89,10 +85,8 @@ class BinaryUuidTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $fh = fopen(__FILE__, 'r');
         $result = $this->type->toDatabase($fh, $this->driver);
@@ -105,10 +99,8 @@ class BinaryUuidTypeTest extends TestCase
 
     /**
      * Test converting to database format fails
-     *
-     * @return void
      */
-    public function testToDatabaseInvalid()
+    public function testToDatabaseInvalid(): void
     {
         $value = 'mUMPWUxCpaCi685A9fEwJZ';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -117,10 +109,8 @@ class BinaryUuidTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_LOB, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -37,8 +37,6 @@ class BoolTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,10 +47,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $this->assertNull($this->type->toDatabase(null, $this->driver));
         $this->assertTrue($this->type->toDatabase(true, $this->driver));
@@ -65,10 +61,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Test converting an array to boolean results in an exception
-     *
-     * @return void
      */
-    public function testToDatabaseInvalid()
+    public function testToDatabaseInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->type->toDatabase([1, 2], $this->driver);
@@ -76,10 +70,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Tests that passing an invalid value will throw an exception
-     *
-     * @return void
      */
-    public function testToDatabaseInvalidArray()
+    public function testToDatabaseInvalidArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->type->toDatabase([1, 2, 3], $this->driver);
@@ -87,10 +79,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Test converting string booleans to PHP values.
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertTrue($this->type->toPHP(1, $this->driver));
@@ -108,10 +98,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Test converting string booleans to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -143,10 +131,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Test marshalling booleans
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $this->assertNull($this->type->marshal(null));
         $this->assertTrue($this->type->marshal(true));
@@ -167,10 +153,8 @@ class BoolTypeTest extends TestCase
 
     /**
      * Test converting booleans to PDO types.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_NULL, $this->type->toStatement(null, $this->driver));
         $this->assertSame(PDO::PARAM_BOOL, $this->type->toStatement(true, $this->driver));

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -39,8 +39,6 @@ class DateTimeFractionalTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,10 +49,8 @@ class DateTimeFractionalTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHPEmpty()
+    public function testToPHPEmpty(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertNull($this->type->toPHP('0000-00-00 00:00:00', $this->driver));
@@ -63,10 +59,8 @@ class DateTimeFractionalTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHPString()
+    public function testToPHPString(): void
     {
         $result = $this->type->toPHP('2001-01-04 12:13:14.123456', $this->driver);
         $this->assertInstanceOf(FrozenTime::class, $result);
@@ -97,10 +91,8 @@ class DateTimeFractionalTypeTest extends TestCase
 
     /**
      * Test converting string datetimes to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -143,10 +135,8 @@ class DateTimeFractionalTypeTest extends TestCase
 
     /**
      * Test converting to database format with microseconds
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $value = '2001-01-04 12:13:14.123456';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -184,10 +174,8 @@ class DateTimeFractionalTypeTest extends TestCase
 
     /**
      * Test converting to database format without microseconds
-     *
-     * @return void
      */
-    public function testToDatabaseNoMicroseconds()
+    public function testToDatabaseNoMicroseconds(): void
     {
         $date = new Time('2013-08-12 15:16:17');
         $result = $this->type->toDatabase($date, $this->driver);
@@ -294,9 +282,8 @@ class DateTimeFractionalTypeTest extends TestCase
      * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshal($value, $expected)
+    public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
         if (is_object($expected)) {
@@ -311,7 +298,7 @@ class DateTimeFractionalTypeTest extends TestCase
      *
      * @return array
      */
-    public function marshalProviderWithoutMicroseconds()
+    public function marshalProviderWithoutMicroseconds(): array
     {
         return [
             // invalid types.
@@ -405,9 +392,8 @@ class DateTimeFractionalTypeTest extends TestCase
      * @dataProvider marshalProviderWithoutMicroseconds
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshalWithoutMicroseconds($value, $expected)
+    public function testMarshalWithoutMicroseconds($value, $expected): void
     {
         $result = $this->type->marshal($value);
         if (is_object($expected)) {

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -39,8 +39,6 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,10 +49,8 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHPEmpty()
+    public function testToPHPEmpty(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertNull($this->type->toPHP('0000-00-00 00:00:00', $this->driver));
@@ -64,10 +60,8 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHPString()
+    public function testToPHPString(): void
     {
         $result = $this->type->toPHP('2001-01-04 12:13:14.123456+02:00', $this->driver);
         $this->assertInstanceOf(FrozenTime::class, $result);
@@ -100,10 +94,8 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Test toPHP keeping database time zone
-     *
-     * @return void
      */
-    public function testToPHPStringKeepDatabaseTimezone()
+    public function testToPHPStringKeepDatabaseTimezone(): void
     {
         $this->type->setKeepDatabaseTimezone(true);
         $result = $this->type->toPHP('2001-01-04 12:13:14.123456+02:00', $this->driver);
@@ -121,10 +113,8 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Test converting string datetimes to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -169,10 +159,8 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Test converting to database format with microseconds
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $value = '2001-01-04 12:13:14.123456';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -216,10 +204,8 @@ class DateTimeTimezoneTypeTest extends TestCase
 
     /**
      * Test converting to database format without microseconds
-     *
-     * @return void
      */
-    public function testToDatabaseNoMicroseconds()
+    public function testToDatabaseNoMicroseconds(): void
     {
         $date = new Time('2013-08-12 15:16:17');
         $result = $this->type->toDatabase($date, $this->driver);
@@ -334,9 +320,8 @@ class DateTimeTimezoneTypeTest extends TestCase
      * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshal($value, $expected)
+    public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
         if (is_object($expected)) {
@@ -351,7 +336,7 @@ class DateTimeTimezoneTypeTest extends TestCase
      *
      * @return array
      */
-    public function marshalProviderWithoutMicroseconds()
+    public function marshalProviderWithoutMicroseconds(): array
     {
         return [
             // invalid types.
@@ -445,9 +430,8 @@ class DateTimeTimezoneTypeTest extends TestCase
      * @dataProvider marshalProviderWithoutMicroseconds
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshalWithoutMicroseconds($value, $expected)
+    public function testMarshalWithoutMicroseconds($value, $expected): void
     {
         $result = $this->type->marshal($value);
         if (is_object($expected)) {

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -46,8 +46,6 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -58,10 +56,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test getDateTimeClassName
-     *
-     * @return void
      */
-    public function testGetDateTimeClassName()
+    public function testGetDateTimeClassName(): void
     {
         $this->assertSame(FrozenTime::class, $this->type->getDateTimeClassName());
 
@@ -71,10 +67,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHPEmpty()
+    public function testToPHPEmpty(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertNull($this->type->toPHP('0000-00-00 00:00:00', $this->driver));
@@ -82,10 +76,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHPString()
+    public function testToPHPString(): void
     {
         $result = $this->type->toPHP('2001-01-04 12:13:14', $this->driver);
         $this->assertInstanceOf(FrozenTime::class, $result);
@@ -109,10 +101,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test converting string datetimes to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -147,10 +137,8 @@ class DateTimeTypeTest extends TestCase
      *
      * Postgres includes milliseconds in timestamp columns,
      * data from those columns should work.
-     *
-     * @return void
      */
-    public function testToPHPIncludingMilliseconds()
+    public function testToPHPIncludingMilliseconds(): void
     {
         $in = '2014-03-24 20:44:36.315113';
         $result = $this->type->toPHP($in, $this->driver);
@@ -159,10 +147,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $value = '2001-01-04 12:13:14';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -298,9 +284,8 @@ class DateTimeTypeTest extends TestCase
      * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshal($value, $expected)
+    public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
         if (is_object($expected)) {
@@ -312,10 +297,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test that the marhsalled datetime instance always has the system's default timezone.
-     *
-     * @return void
      */
-    public function testMarshalDateTimeInstance()
+    public function testMarshalDateTimeInstance(): void
     {
         $expected = new Time('2020-05-01 23:28:00', 'Europe/Paris');
 
@@ -325,7 +308,7 @@ class DateTimeTypeTest extends TestCase
         $this->assertEquals('Europe/Paris', $expected->getTimezone()->getName());
     }
 
-    public function testMarshalWithUserTimezone()
+    public function testMarshalWithUserTimezone(): void
     {
         $this->type->setUserTimezone('+0200');
 
@@ -349,10 +332,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test that useLocaleParser() can disable locale parsing.
-     *
-     * @return void
      */
-    public function testLocaleParserDisable()
+    public function testLocaleParserDisable(): void
     {
         $expected = new Time('13-10-2013 23:28:00');
         $this->type->useLocaleParser();
@@ -366,10 +347,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Tests marshalling dates using the locale aware parser
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsing()
+    public function testMarshalWithLocaleParsing(): void
     {
         $this->type->useLocaleParser();
 
@@ -390,10 +369,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Tests marshalling dates using the locale aware parser and custom format
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsingWithFormat()
+    public function testMarshalWithLocaleParsingWithFormat(): void
     {
         $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y hh:mma');
 
@@ -406,10 +383,8 @@ class DateTimeTypeTest extends TestCase
 
     /**
      * Test that toImmutable changes all the methods to create frozen time instances.
-     *
-     * @return void
      */
-    public function testToImmutableAndToMutable()
+    public function testToImmutableAndToMutable(): void
     {
         $this->type->useImmutable();
         $this->assertInstanceOf('DateTimeImmutable', $this->type->marshal('2015-11-01 11:23:00'));

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -39,8 +39,6 @@ class DateTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,8 +49,6 @@ class DateTypeTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -63,10 +59,8 @@ class DateTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertNull($this->type->toPHP('0000-00-00', $this->driver));
@@ -80,10 +74,8 @@ class DateTypeTest extends TestCase
 
     /**
      * Test converting string dates to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -103,10 +95,8 @@ class DateTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $value = '2001-01-04';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -202,9 +192,8 @@ class DateTypeTest extends TestCase
      * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshal($value, $expected)
+    public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
         $this->assertEquals($expected, $result);
@@ -216,10 +205,8 @@ class DateTypeTest extends TestCase
 
     /**
      * Tests marshalling dates using the locale aware parser
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsing()
+    public function testMarshalWithLocaleParsing(): void
     {
         $this->type->useLocaleParser();
         $this->assertNull($this->type->marshal('11/derp/2013'));
@@ -235,10 +222,8 @@ class DateTypeTest extends TestCase
 
     /**
      * Tests marshalling dates using the locale aware parser and custom format
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsingWithFormat()
+    public function testMarshalWithLocaleParsingWithFormat(): void
     {
         $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y');
         $this->assertNull($this->type->marshal('11/derp/2013'));
@@ -254,10 +239,8 @@ class DateTypeTest extends TestCase
 
     /**
      * Test that toImmutable changes all the methods to create frozen time instances.
-     *
-     * @return void
      */
-    public function testToImmutableAndToMutable()
+    public function testToImmutableAndToMutable(): void
     {
         $this->type->useImmutable();
         $this->assertInstanceOf('DateTimeImmutable', $this->type->marshal('2015-11-01'));

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -49,8 +49,6 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -65,8 +63,6 @@ class DecimalTypeTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -77,10 +73,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -93,10 +87,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Test converting string decimals to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -118,10 +110,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $result = $this->type->toDatabase('', $this->driver);
         $this->assertNull($result);
@@ -150,10 +140,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Arrays are invalid.
-     *
-     * @return void
      */
-    public function testToDatabaseInvalid()
+    public function testToDatabaseInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->type->toDatabase(['3', '4'], $this->driver);
@@ -161,10 +149,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Non numeric strings are invalid.
-     *
-     * @return void
      */
-    public function testToDatabaseInvalid2()
+    public function testToDatabaseInvalid2(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->type->toDatabase('some data', $this->driver);
@@ -172,10 +158,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Test marshalling
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $result = $this->type->marshal('some data');
         $this->assertNull($result);
@@ -208,10 +192,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Tests marshalling numbers using the locale aware parser
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsing()
+    public function testMarshalWithLocaleParsing(): void
     {
         $this->type->useLocaleParser();
 
@@ -235,10 +217,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * test marshal() number in the danish locale which uses . for thousands separator.
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsingDanish()
+    public function testMarshalWithLocaleParsingDanish(): void
     {
         $this->type->useLocaleParser();
 
@@ -252,10 +232,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Test that exceptions are raised on invalid parsers.
-     *
-     * @return void
      */
-    public function testUseLocaleParsingInvalid()
+    public function testUseLocaleParsingInvalid(): void
     {
         $this->expectException(\RuntimeException::class);
         DecimalType::$numberClass = 'stdClass';
@@ -264,10 +242,8 @@ class DecimalTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -48,8 +48,6 @@ class FloatTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -64,8 +62,6 @@ class FloatTypeTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -76,10 +72,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -92,10 +86,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Test converting string float to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -117,10 +109,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $result = $this->type->toDatabase('', $this->driver);
         $this->assertNull($result);
@@ -143,10 +133,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Test marshalling
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $result = $this->type->marshal('some data');
         $this->assertNull($result);
@@ -170,10 +158,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Tests marshalling numbers using the locale aware parser
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsing()
+    public function testMarshalWithLocaleParsing(): void
     {
         $this->type->useLocaleParser();
 
@@ -197,10 +183,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Test that exceptions are raised on invalid parsers.
-     *
-     * @return void
      */
-    public function testUseLocaleParsingInvalid()
+    public function testUseLocaleParsingInvalid(): void
     {
         $this->expectException(\RuntimeException::class);
         FloatType::$numberClass = 'stdClass';
@@ -209,10 +193,8 @@ class FloatTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -37,8 +37,6 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,10 +47,8 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -71,10 +67,8 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Test converting string float to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -98,10 +92,8 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Test to make sure the method throws an exception for invalid integer values.
-     *
-     * @return void
      */
-    public function testInvalidManyToPHP()
+    public function testInvalidManyToPHP(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $values = [
@@ -128,10 +120,8 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $this->assertNull($this->type->toDatabase(null, $this->driver));
 
@@ -161,9 +151,8 @@ class IntegerTypeTest extends TestCase
      *
      * @dataProvider invalidIntegerProvider
      * @param  mixed $value Invalid value to test against the database type.
-     * @return void
      */
-    public function testToDatabaseInvalid($value)
+    public function testToDatabaseInvalid($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->type->toDatabase($value, $this->driver);
@@ -171,10 +160,8 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Test marshalling
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $result = $this->type->marshal('some data');
         $this->assertNull($result);
@@ -212,10 +199,8 @@ class IntegerTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_INT, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -37,8 +37,6 @@ class JsonTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,10 +47,8 @@ class JsonTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertSame('word', $this->type->toPHP(json_encode('word'), $this->driver));
@@ -61,10 +57,8 @@ class JsonTypeTest extends TestCase
 
     /**
      * Test converting JSON strings to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -86,10 +80,8 @@ class JsonTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $this->assertNull($this->type->toDatabase(null, $this->driver));
         $this->assertSame(json_encode('word'), $this->type->toDatabase('word', $this->driver));
@@ -99,10 +91,8 @@ class JsonTypeTest extends TestCase
 
     /**
      * Tests that passing an invalid value will throw an exception
-     *
-     * @return void
      */
-    public function testToDatabaseInvalid()
+    public function testToDatabaseInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $value = fopen(__FILE__, 'r');
@@ -111,10 +101,8 @@ class JsonTypeTest extends TestCase
 
     /**
      * Test marshalling
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $this->assertNull($this->type->marshal(null));
         $this->assertSame('', $this->type->marshal(''));
@@ -126,10 +114,8 @@ class JsonTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -38,8 +38,6 @@ class StringTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -50,10 +48,8 @@ class StringTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
         $this->assertSame('word', $this->type->toPHP('word', $this->driver));
@@ -62,10 +58,8 @@ class StringTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $obj = $this->getMockBuilder('StdClass')
             ->addMethods(['__toString'])
@@ -80,10 +74,8 @@ class StringTypeTest extends TestCase
 
     /**
      * Tests that passing an invalid value will throw an exception
-     *
-     * @return void
      */
-    public function testToDatabaseInvalidArray()
+    public function testToDatabaseInvalidArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->type->toDatabase([1, 2, 3], $this->driver);
@@ -91,10 +83,8 @@ class StringTypeTest extends TestCase
 
     /**
      * Test marshalling
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $this->assertNull($this->type->marshal(null));
         $this->assertNull($this->type->marshal([1, 2, 3]));
@@ -104,10 +94,8 @@ class StringTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
     }

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -44,8 +44,6 @@ class TimeTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,8 +55,6 @@ class TimeTypeTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,10 +64,8 @@ class TimeTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -90,10 +84,8 @@ class TimeTypeTest extends TestCase
 
     /**
      * Test converting string times to PHP values.
-     *
-     * @return void
      */
-    public function testManyToPHP()
+    public function testManyToPHP(): void
     {
         $values = [
             'a' => null,
@@ -111,10 +103,8 @@ class TimeTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $value = '16:30:15';
         $result = $this->type->toDatabase($value, $this->driver);
@@ -211,9 +201,8 @@ class TimeTypeTest extends TestCase
      * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
-     * @return void
      */
-    public function testMarshal($value, $expected)
+    public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
         if (is_object($expected)) {
@@ -226,10 +215,8 @@ class TimeTypeTest extends TestCase
 
     /**
      * Tests marshalling times using the locale aware parser
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsing()
+    public function testMarshalWithLocaleParsing(): void
     {
         $this->type->useLocaleParser();
 
@@ -243,10 +230,8 @@ class TimeTypeTest extends TestCase
 
     /**
      * Tests marshalling times in denmark.
-     *
-     * @return void
      */
-    public function testMarshalWithLocaleParsingDanishLocale()
+    public function testMarshalWithLocaleParsingDanishLocale(): void
     {
         $updated = setlocale(LC_COLLATE, 'da_DK.utf8');
         $this->skipIf($updated === false, 'Could not set locale to da_DK.utf8, skipping test.');
@@ -263,10 +248,8 @@ class TimeTypeTest extends TestCase
 
     /**
      * Test that toImmutable changes all the methods to create frozen time instances.
-     *
-     * @return void
      */
-    public function testToImmutableAndToMutable()
+    public function testToImmutableAndToMutable(): void
     {
         $this->type->useImmutable();
         $this->assertInstanceOf('DateTimeImmutable', $this->type->marshal('11:23:12'));

--- a/tests/TestCase/Database/Type/UuidTypeTest.php
+++ b/tests/TestCase/Database/Type/UuidTypeTest.php
@@ -37,8 +37,6 @@ class UuidTypeTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,10 +47,8 @@ class UuidTypeTest extends TestCase
 
     /**
      * Test toPHP
-     *
-     * @return void
      */
-    public function testToPHP()
+    public function testToPHP(): void
     {
         $this->assertNull($this->type->toPHP(null, $this->driver));
 
@@ -65,10 +61,8 @@ class UuidTypeTest extends TestCase
 
     /**
      * Test converting to database format
-     *
-     * @return void
      */
-    public function testToDatabase()
+    public function testToDatabase(): void
     {
         $result = $this->type->toDatabase('some data', $this->driver);
         $this->assertSame('some data', $result);
@@ -88,20 +82,16 @@ class UuidTypeTest extends TestCase
 
     /**
      * Test that the PDO binding type is correct.
-     *
-     * @return void
      */
-    public function testToStatement()
+    public function testToStatement(): void
     {
         $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
     }
 
     /**
      * Test generating new ids
-     *
-     * @return void
      */
-    public function testNewId()
+    public function testNewId(): void
     {
         $one = $this->type->newId();
         $two = $this->type->newId();
@@ -113,10 +103,8 @@ class UuidTypeTest extends TestCase
 
     /**
      * Tests that marshalling an empty string results in null
-     *
-     * @return void
      */
-    public function testMarshal()
+    public function testMarshal(): void
     {
         $this->assertNull($this->type->marshal(''));
         $this->assertSame('2', $this->type->marshal(2));

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -37,8 +37,6 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Backup original Type class state
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Restores Type class state
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -62,9 +58,8 @@ class TypeFactoryTest extends TestCase
      * Tests Type class is able to instantiate basic types
      *
      * @dataProvider basicTypesProvider
-     * @return void
      */
-    public function testBuildBasicTypes(string $name)
+    public function testBuildBasicTypes(string $name): void
     {
         $type = TypeFactory::build($name);
         $this->assertInstanceOf(TypeInterface::class, $type);
@@ -91,10 +86,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests trying to build an unknown type throws exception
-     *
-     * @return void
      */
-    public function testBuildUnknownType()
+    public function testBuildUnknownType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         TypeFactory::build('foo');
@@ -103,10 +96,8 @@ class TypeFactoryTest extends TestCase
     /**
      * Tests that once a type with a name is instantiated, the reference is kept
      * for future use
-     *
-     * @return void
      */
-    public function testInstanceRecycling()
+    public function testInstanceRecycling(): void
     {
         $type = TypeFactory::build('integer');
         $this->assertSame($type, TypeFactory::build('integer'));
@@ -114,10 +105,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests new types can be registered and built
-     *
-     * @return void
      */
-    public function testMapAndBuild()
+    public function testMapAndBuild(): void
     {
         $map = TypeFactory::getMap();
         $this->assertNotEmpty($map);
@@ -140,10 +129,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests new types set with set() are returned by buildAll()
-     *
-     * @return void
      */
-    public function testSetAndBuild()
+    public function testSetAndBuild(): void
     {
         $types = TypeFactory::buildAll();
         $this->assertFalse(isset($types['foo']));
@@ -155,10 +142,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests overwriting type map works for building
-     *
-     * @return void
      */
-    public function testReMapAndBuild()
+    public function testReMapAndBuild(): void
     {
         $fooType = FooType::class;
         TypeFactory::map('foo', $fooType);
@@ -173,10 +158,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests clear function in conjunction with map
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         $map = TypeFactory::getMap();
         $this->assertNotEmpty($map);
@@ -195,10 +178,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests bigintegers from database are converted correctly to PHP
-     *
-     * @return void
      */
-    public function testBigintegerToPHP()
+    public function testBigintegerToPHP(): void
     {
         $this->skipIf(
             PHP_INT_SIZE === 4,
@@ -214,10 +195,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests bigintegers from PHP are converted correctly to statement value
-     *
-     * @return void
      */
-    public function testBigintegerToStatement()
+    public function testBigintegerToStatement(): void
     {
         $type = TypeFactory::build('biginteger');
         $integer = time() * time();
@@ -227,10 +206,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests decimal from database are converted correctly to PHP
-     *
-     * @return void
      */
-    public function testDecimalToPHP()
+    public function testDecimalToPHP(): void
     {
         $type = TypeFactory::build('decimal');
         $driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
@@ -242,10 +219,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests integers from PHP are converted correctly to statement value
-     *
-     * @return void
      */
-    public function testDecimalToStatement()
+    public function testDecimalToStatement(): void
     {
         $type = TypeFactory::build('decimal');
         $string = '12.55';
@@ -255,10 +230,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Test setting instances into the factory/registry.
-     *
-     * @return void
      */
-    public function testSet()
+    public function testSet(): void
     {
         $instance = $this->getMockBuilder(TypeInterface::class)->getMock();
         TypeFactory::set('random', $instance);

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -27,7 +27,7 @@ class ValueBinderTest extends TestCase
     /**
      * test the bind method
      */
-    public function testBind()
+    public function testBind(): void
     {
         $valueBinder = new ValueBinder();
         $valueBinder->bind(':c0', 'value0');
@@ -61,7 +61,7 @@ class ValueBinderTest extends TestCase
     /**
      * test the placeholder method
      */
-    public function testPlaceholder()
+    public function testPlaceholder(): void
     {
         $valueBinder = new ValueBinder();
         $result = $valueBinder->placeholder('?');
@@ -80,7 +80,7 @@ class ValueBinderTest extends TestCase
         $this->assertSame(':c2', $result);
     }
 
-    public function testGenerateManyNamed()
+    public function testGenerateManyNamed(): void
     {
         $valueBinder = new ValueBinder();
         $values = [
@@ -99,7 +99,7 @@ class ValueBinderTest extends TestCase
     /**
      * test the reset method
      */
-    public function testReset()
+    public function testReset(): void
     {
         $valueBinder = new ValueBinder();
         $valueBinder->bind(':c0', 'value0');
@@ -116,7 +116,7 @@ class ValueBinderTest extends TestCase
     /**
      * test the resetCount method
      */
-    public function testResetCount()
+    public function testResetCount(): void
     {
         $valueBinder = new ValueBinder();
 
@@ -141,7 +141,7 @@ class ValueBinderTest extends TestCase
     /**
      * tests the attachTo method
      */
-    public function testAttachTo()
+    public function testAttachTo(): void
     {
         $valueBinder = new ValueBinder();
         $statementMock = $this->getMockBuilder('Cake\Database\Statement\StatementDecorator')

--- a/tests/TestCase/DatabaseSuite.php
+++ b/tests/TestCase/DatabaseSuite.php
@@ -42,7 +42,6 @@ class DatabaseSuite extends TestSuite
 
     /**
      * @param bool $preferCache
-     * @return int
      */
     public function count($preferCache = false): int
     {
@@ -51,16 +50,14 @@ class DatabaseSuite extends TestSuite
 
     /**
      * Runs the tests and collects their result in a TestResult.
-     *
-     * @return \PHPUnit\Framework\TestResult
      */
     public function run(?TestResult $result = null): TestResult
     {
         $permutations = [
-            'Identifier Quoting' => function () {
+            'Identifier Quoting' => function (): void {
                 ConnectionManager::get('test')->getDriver()->enableAutoQuoting(true);
             },
-            'No identifier quoting' => function () {
+            'No identifier quoting' => function (): void {
                 ConnectionManager::get('test')->getDriver()->enableAutoQuoting(false);
             },
         ];

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -24,8 +24,6 @@ class ConnectionManagerTest extends TestCase
 {
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -57,9 +55,8 @@ class ConnectionManagerTest extends TestCase
      *
      * @dataProvider configProvider
      * @param \Cake\Datasource\ConnectionInterface|array $settings
-     * @return void
      */
-    public function testConfigVariants($settings)
+    public function testConfigVariants($settings): void
     {
         $this->assertNotContains('test_variant', ConnectionManager::configured(), 'test_variant config should not exist.');
         ConnectionManager::setConfig('test_variant', $settings);
@@ -72,7 +69,7 @@ class ConnectionManagerTest extends TestCase
     /**
      * Test invalid classes cause exceptions
      */
-    public function testConfigInvalidOptions()
+    public function testConfigInvalidOptions(): void
     {
         $this->expectException(\Cake\Datasource\Exception\MissingDatasourceException::class);
         ConnectionManager::setConfig('test_variant', [
@@ -83,10 +80,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test for errors on duplicate config.
-     *
-     * @return void
      */
-    public function testConfigDuplicateConfig()
+    public function testConfigDuplicateConfig(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot reconfigure existing key "test_variant"');
@@ -100,10 +95,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test get() failing on missing config.
-     *
-     * @return void
      */
-    public function testGetFailOnMissingConfig()
+    public function testGetFailOnMissingConfig(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('The datasource configuration "test_variant" was not found.');
@@ -112,10 +105,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test loading configured connections.
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');
@@ -128,10 +119,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test loading connections without aliases
-     *
-     * @return void
      */
-    public function testGetNoAlias()
+    public function testGetNoAlias(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('The datasource configuration "other_name" was not found.');
@@ -144,10 +133,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test that configured() finds configured sources.
-     *
-     * @return void
      */
-    public function testConfigured()
+    public function testConfigured(): void
     {
         ConnectionManager::setConfig('test_variant', [
             'className' => FakeConnection::class,
@@ -159,10 +146,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * testGetPluginDataSource method
-     *
-     * @return void
      */
-    public function testGetPluginDataSource()
+    public function testGetPluginDataSource(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $name = 'test_variant';
@@ -177,10 +162,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Tests that a connection configuration can be deleted in runtime
-     *
-     * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         ConnectionManager::setConfig('test_variant', [
             'className' => FakeConnection::class,
@@ -198,10 +181,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test aliasing connections.
-     *
-     * @return void
      */
-    public function testAlias()
+    public function testAlias(): void
     {
         ConnectionManager::setConfig('test_variant', [
             'className' => FakeConnection::class,
@@ -214,10 +195,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test alias() raises an error when aliasing an undefined connection.
-     *
-     * @return void
      */
-    public function testAliasError()
+    public function testAliasError(): void
     {
         $this->expectException(\Cake\Datasource\Exception\MissingDatasourceConfigException::class);
         $this->assertNotContains('test_kaboom', ConnectionManager::configured());
@@ -399,9 +378,8 @@ class ConnectionManagerTest extends TestCase
      * Test parseDsn method.
      *
      * @dataProvider dsnProvider
-     * @return void
      */
-    public function testParseDsn(string $dsn, array $expected)
+    public function testParseDsn(string $dsn, array $expected): void
     {
         $result = ConnectionManager::parseDsn($dsn);
         $this->assertEquals($expected, $result);
@@ -409,10 +387,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test parseDsn invalid.
-     *
-     * @return void
      */
-    public function testParseDsnInvalid()
+    public function testParseDsnInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The DSN string \'bagof:nope\' could not be parsed.');
@@ -422,10 +398,8 @@ class ConnectionManagerTest extends TestCase
     /**
      * Tests that directly setting an instance in a config, will not return a different
      * instance later on
-     *
-     * @return void
      */
-    public function testConfigWithObject()
+    public function testConfigWithObject(): void
     {
         $connection = new FakeConnection();
         ConnectionManager::setConfig('test_variant', $connection);
@@ -434,10 +408,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Tests configuring an instance with a callable
-     *
-     * @return void
      */
-    public function testConfigWithCallable()
+    public function testConfigWithCallable(): void
     {
         $connection = new FakeConnection();
         $callable = function ($alias) use ($connection) {
@@ -452,10 +424,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Tests that setting a config will also correctly set the name for the connection
-     *
-     * @return void
      */
-    public function testSetConfigName()
+    public function testSetConfigName(): void
     {
         //Set with explicit name
         ConnectionManager::setConfig('test_variant', [

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -27,10 +27,8 @@ class FactoryLocatorTest extends TestCase
 {
     /**
      * Test get factory
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $factory = FactoryLocator::get('Table');
         $this->assertTrue(is_callable($factory) || $factory instanceof LocatorInterface);
@@ -38,10 +36,8 @@ class FactoryLocatorTest extends TestCase
 
     /**
      * Test get nonexistent factory
-     *
-     * @return void
      */
-    public function testGetNonExistent()
+    public function testGetNonExistent(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
@@ -50,10 +46,8 @@ class FactoryLocatorTest extends TestCase
 
     /**
      * test add()
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         FactoryLocator::add('Test', function ($name) {
             $mock = new \stdClass();
@@ -68,7 +62,7 @@ class FactoryLocatorTest extends TestCase
         $this->assertInstanceOf(LocatorInterface::class, FactoryLocator::get('MyType'));
     }
 
-    public function testFactoryAddException()
+    public function testFactoryAddException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -81,10 +75,8 @@ class FactoryLocatorTest extends TestCase
 
     /**
      * test drop()
-     *
-     * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -30,10 +30,8 @@ class ModelAwareTraitTest extends TestCase
 {
     /**
      * Test set modelClass
-     *
-     * @return void
      */
-    public function testSetModelClass()
+    public function testSetModelClass(): void
     {
         $stub = new Stub();
         $this->assertNull($stub->getModelClass());
@@ -44,10 +42,8 @@ class ModelAwareTraitTest extends TestCase
 
     /**
      * test loadModel()
-     *
-     * @return void
      */
-    public function testLoadModel()
+    public function testLoadModel(): void
     {
         $stub = new Stub();
         $stub->setProps('Articles');
@@ -70,10 +66,8 @@ class ModelAwareTraitTest extends TestCase
     /**
      * Test that calling loadModel() without $modelClass argument when default
      * $modelClass property is empty generates exception.
-     *
-     * @return void
      */
-    public function testLoadModelException()
+    public function testLoadModelException(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Default modelClass is empty');
@@ -90,10 +84,8 @@ class ModelAwareTraitTest extends TestCase
      *
      * Load model should not be called with Foo.Model Bar.Model Model
      * But if it is, the first call wins.
-     *
-     * @return void
      */
-    public function testLoadModelPlugin()
+    public function testLoadModelPlugin(): void
     {
         $stub = new Stub();
         $stub->setProps('Articles');
@@ -110,10 +102,8 @@ class ModelAwareTraitTest extends TestCase
 
     /**
      * test alternate model factories.
-     *
-     * @return void
      */
-    public function testModelFactory()
+    public function testModelFactory(): void
     {
         $stub = new Stub();
         $stub->setProps('Articles');
@@ -143,7 +133,7 @@ class ModelAwareTraitTest extends TestCase
         $this->assertSame('Foo', $stub->Foo->alias);
     }
 
-    public function testModelFactoryException()
+    public function testModelFactoryException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -157,10 +147,8 @@ class ModelAwareTraitTest extends TestCase
 
     /**
      * test getModelType() and setModelType()
-     *
-     * @return void
      */
-    public function testGetSetModelType()
+    public function testGetSetModelType(): void
     {
         $stub = new Stub();
         $stub->setProps('Articles');
@@ -177,10 +165,8 @@ class ModelAwareTraitTest extends TestCase
 
     /**
      * test MissingModelException being thrown
-     *
-     * @return void
      */
-    public function testMissingModelException()
+    public function testMissingModelException(): void
     {
         $this->expectException(\Cake\Datasource\Exception\MissingModelException::class);
         $this->expectExceptionMessage('Model class "Magic" of type "Test" could not be found.');

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -42,10 +42,8 @@ class PaginatorTest extends TestCase
 
     /**
      * test paginate() and custom find, to make sure the correct count is returned.
-     *
-     * @return void
      */
-    public function testPaginateCustomFind()
+    public function testPaginateCustomFind(): void
     {
         $this->loadFixtures('Posts');
         $titleExtractor = function ($result) {
@@ -106,10 +104,8 @@ class PaginatorTest extends TestCase
 
     /**
      * test paginate() and custom find with fields array, to make sure the correct count is returned.
-     *
-     * @return void
      */
-    public function testPaginateCustomFindFieldsArray()
+    public function testPaginateCustomFindFieldsArray(): void
     {
         $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
@@ -140,10 +136,8 @@ class PaginatorTest extends TestCase
 
     /**
      * Test that special paginate types are called and that the type param doesn't leak out into defaults or options.
-     *
-     * @return void
      */
-    public function testPaginateCustomFinder()
+    public function testPaginateCustomFinder(): void
     {
         $settings = [
             'PaginatorPosts' => [
@@ -168,10 +162,8 @@ class PaginatorTest extends TestCase
 
     /**
      * test direction setting.
-     *
-     * @return void
      */
-    public function testPaginateDefaultDirection()
+    public function testPaginateDefaultDirection(): void
     {
         $settings = [
             'PaginatorPosts' => [

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -37,8 +37,6 @@ trait PaginatorTestTrait
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -53,8 +51,6 @@ trait PaginatorTestTrait
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -64,10 +60,8 @@ trait PaginatorTestTrait
 
     /**
      * Test that non-numeric values are rejected for page, and limit
-     *
-     * @return void
      */
-    public function testPageParamCasting()
+    public function testPageParamCasting(): void
     {
         $this->Post->expects($this->any())
             ->method('getAlias')
@@ -88,10 +82,8 @@ trait PaginatorTestTrait
     /**
      * test that unknown keys in the default settings are
      * passed to the find operations.
-     *
-     * @return void
      */
-    public function testPaginateExtraParams()
+    public function testPaginateExtraParams(): void
     {
         $params = ['page' => '-1'];
         $settings = [
@@ -127,10 +119,8 @@ trait PaginatorTestTrait
 
     /**
      * Test to make sure options get sent to custom finder methods via paginate
-     *
-     * @return void
      */
-    public function testPaginateCustomFinderOptions()
+    public function testPaginateCustomFinderOptions(): void
     {
         $this->loadFixtures('Posts');
         $settings = [
@@ -154,17 +144,15 @@ trait PaginatorTestTrait
 
     /**
      * Test that nested eager loaders don't trigger invalid SQL errors.
-     *
-     * @return void
      */
-    public function testPaginateNestedEagerLoader()
+    public function testPaginateNestedEagerLoader(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'Authors', 'ArticlesTags', 'AuthorsTags');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Tags');
         $tags = $this->getTableLocator()->get('Tags');
         $tags->belongsToMany('Authors');
-        $articles->getEventManager()->on('Model.beforeFind', function ($event, $query) {
+        $articles->getEventManager()->on('Model.beforeFind', function ($event, $query): void {
             $query ->matching('Tags', function ($q) {
                 return $q->matching('Authors', function ($q) {
                     return $q->where(['Authors.name' => 'larry']);
@@ -180,10 +168,8 @@ trait PaginatorTestTrait
 
     /**
      * test that flat default pagination parameters work.
-     *
-     * @return void
      */
-    public function testDefaultPaginateParams()
+    public function testDefaultPaginateParams(): void
     {
         $settings = [
             'order' => ['PaginatorPosts.id' => 'DESC'],
@@ -214,10 +200,8 @@ trait PaginatorTestTrait
 
     /**
      * Tests that flat default pagination parameters work for multi order.
-     *
-     * @return void
      */
-    public function testDefaultPaginateParamsMultiOrder()
+    public function testDefaultPaginateParamsMultiOrder(): void
     {
         $settings = [
             'order' => ['PaginatorPosts.id' => 'DESC', 'PaginatorPosts.title' => 'ASC'],
@@ -252,10 +236,8 @@ trait PaginatorTestTrait
 
     /**
      * test that default sort and default direction are injected into request
-     *
-     * @return void
      */
-    public function testDefaultPaginateParamsIntoRequest()
+    public function testDefaultPaginateParamsIntoRequest(): void
     {
         $settings = [
             'order' => ['PaginatorPosts.id' => 'DESC'],
@@ -289,10 +271,8 @@ trait PaginatorTestTrait
 
     /**
      * test that option merging prefers specific models
-     *
-     * @return void
      */
-    public function testMergeOptionsModelSpecific()
+    public function testMergeOptionsModelSpecific(): void
     {
         $settings = [
             'page' => 1,
@@ -324,10 +304,8 @@ trait PaginatorTestTrait
 
     /**
      * test mergeOptions with custom scope
-     *
-     * @return void
      */
-    public function testMergeOptionsCustomScope()
+    public function testMergeOptionsCustomScope(): void
     {
         $params = [
             'page' => 10,
@@ -399,10 +377,8 @@ trait PaginatorTestTrait
 
     /**
      * test mergeOptions with customFind key
-     *
-     * @return void
      */
-    public function testMergeOptionsCustomFindKey()
+    public function testMergeOptionsCustomFindKey(): void
     {
         $params = [
             'page' => 10,
@@ -429,10 +405,8 @@ trait PaginatorTestTrait
 
     /**
      * test merging options from the querystring.
-     *
-     * @return void
      */
-    public function testMergeOptionsQueryString()
+    public function testMergeOptionsQueryString(): void
     {
         $params = [
             'page' => 99,
@@ -457,10 +431,8 @@ trait PaginatorTestTrait
 
     /**
      * test that the default allowedParameters doesn't let people screw with things they should not be allowed to.
-     *
-     * @return void
      */
-    public function testMergeOptionsDefaultAllowedParameters()
+    public function testMergeOptionsDefaultAllowedParameters(): void
     {
         $params = [
             'page' => 10,
@@ -489,10 +461,8 @@ trait PaginatorTestTrait
 
     /**
      * test that modifying the deprecated whitelist works.
-     *
-     * @return void
      */
-    public function testMergeOptionsExtraWhitelist()
+    public function testMergeOptionsExtraWhitelist(): void
     {
         $params = [
             'page' => 10,
@@ -507,7 +477,7 @@ trait PaginatorTestTrait
             'limit' => 20,
             'maxLimit' => 100,
         ];
-        $this->deprecated(function () use ($settings, $params) {
+        $this->deprecated(function () use ($settings, $params): void {
             $this->Paginator->setConfig('whitelist', ['fields']);
             $defaults = $this->Paginator->getDefaults('Post', $settings);
             $result = $this->Paginator->mergeOptions($params, $defaults);
@@ -525,10 +495,8 @@ trait PaginatorTestTrait
 
     /**
      * test mergeOptions with limit > maxLimit in code.
-     *
-     * @return void
      */
-    public function testMergeOptionsMaxLimit()
+    public function testMergeOptionsMaxLimit(): void
     {
         $settings = [
             'limit' => 200,
@@ -565,10 +533,8 @@ trait PaginatorTestTrait
 
     /**
      * test getDefaults with limit > maxLimit in code.
-     *
-     * @return void
      */
-    public function testGetDefaultMaxLimit()
+    public function testGetDefaultMaxLimit(): void
     {
         $settings = [
             'page' => 1,
@@ -617,10 +583,8 @@ trait PaginatorTestTrait
 
     /**
      * Integration test to ensure that validateSort is being used by paginate()
-     *
-     * @return void
      */
-    public function testValidateSortInvalid()
+    public function testValidateSortInvalid(): void
     {
         $table = $this->_getMockPosts(['query']);
         $query = $this->_getMockFindQuery();
@@ -653,10 +617,8 @@ trait PaginatorTestTrait
 
     /**
      * test that invalid directions are ignored.
-     *
-     * @return void
      */
-    public function testValidateSortInvalidDirection()
+    public function testValidateSortInvalidDirection(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -675,10 +637,8 @@ trait PaginatorTestTrait
     /**
      * Test that "sort" and "direction" in paging params is properly set based
      * on initial value of "order" in paging settings.
-     *
-     * @return void
      */
-    public function testValidaSortInitialSortAndDirection()
+    public function testValidaSortInitialSortAndDirection(): void
     {
         $table = $this->_getMockPosts(['query']);
         $query = $this->_getMockFindQuery();
@@ -716,10 +676,8 @@ trait PaginatorTestTrait
     /**
      * Test that "sort" and "direction" in paging params is properly set based
      * on initial value of "order" in paging settings.
-     *
-     * @return void
      */
-    public function testValidateSortAndDirectionAliased()
+    public function testValidateSortAndDirectionAliased(): void
     {
         $table = $this->_getMockPosts(['query']);
         $query = $this->_getMockFindQuery();
@@ -763,10 +721,9 @@ trait PaginatorTestTrait
     /**
      * testValidateSortRetainsOriginalSortValue
      *
-     * @return void
      * @see https://github.com/cakephp/cakephp/issues/11740
      */
-    public function testValidateSortRetainsOriginalSortValue()
+    public function testValidateSortRetainsOriginalSortValue(): void
     {
         $table = $this->_getMockPosts(['query']);
         $query = $this->_getMockFindQuery();
@@ -803,10 +760,8 @@ trait PaginatorTestTrait
 
     /**
      * Test that a really large page number gets clamped to the max page size.
-     *
-     * @return void
      */
-    public function testOutOfRangePageNumberGetsClamped()
+    public function testOutOfRangePageNumberGetsClamped(): void
     {
         $this->loadFixtures('Posts');
         $params['page'] = 3000;
@@ -833,10 +788,8 @@ trait PaginatorTestTrait
 
     /**
      * Test that a really REALLY large page number gets clamped to the max page size.
-     *
-     * @return void
      */
-    public function testOutOfVeryBigPageNumberGetsClamped()
+    public function testOutOfVeryBigPageNumberGetsClamped(): void
     {
         $this->expectException(\Cake\Datasource\Exception\PageOutOfBoundsException::class);
         $this->loadFixtures('Posts');
@@ -850,10 +803,8 @@ trait PaginatorTestTrait
 
     /**
      * test that fields not in sortableFields won't be part of order conditions.
-     *
-     * @return void
      */
-    public function testValidateAllowedSortFailure()
+    public function testValidateAllowedSortFailure(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -869,12 +820,10 @@ trait PaginatorTestTrait
 
     /**
      * test that fields not in whitelist won't be part of order conditions.
-     *
-     * @return void
      */
-    public function testValidateSortWhitelistFailure()
+    public function testValidateSortWhitelistFailure(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $model = $this->mockAliasHasFieldModel();
             $options = [
                 'sort' => 'body',
@@ -888,10 +837,8 @@ trait PaginatorTestTrait
 
     /**
      * test that fields in the sortableFields are not validated
-     *
-     * @return void
      */
-    public function testValidateAllowedSortTrusted()
+    public function testValidateAllowedSortTrusted(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -912,10 +859,8 @@ trait PaginatorTestTrait
 
     /**
      * test that sortableFields as empty array does not allow any sorting
-     *
-     * @return void
      */
-    public function testValidateAllowedSortEmpty()
+    public function testValidateAllowedSortEmpty(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -935,10 +880,8 @@ trait PaginatorTestTrait
 
     /**
      * test that fields in the sortableFields are not validated
-     *
-     * @return void
      */
-    public function testValidateAllowedSortNotInSchema()
+    public function testValidateAllowedSortNotInSchema(): void
     {
         $model = $this->getMockRepository();
         $model->expects($this->any())
@@ -964,10 +907,8 @@ trait PaginatorTestTrait
 
     /**
      * test that multiple fields in the sortableFields are not validated and properly aliased.
-     *
-     * @return void
      */
-    public function testValidateAllowedSortMultiple()
+    public function testValidateAllowedSortMultiple(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1017,10 +958,8 @@ trait PaginatorTestTrait
 
     /**
      * test that multiple sort works.
-     *
-     * @return void
      */
-    public function testValidateSortMultiple()
+    public function testValidateSortMultiple(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1041,10 +980,8 @@ trait PaginatorTestTrait
 
     /**
      * test that multiple sort adds in query data.
-     *
-     * @return void
      */
-    public function testValidateSortMultipleWithQuery()
+    public function testValidateSortMultipleWithQuery(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1084,10 +1021,8 @@ trait PaginatorTestTrait
 
     /**
      * Tests that sort query string and model prefixes default match on assoc merging.
-     *
-     * @return void
      */
-    public function testValidateSortMultipleWithQueryAndAliasedDefault()
+    public function testValidateSortMultipleWithQueryAndAliasedDefault(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1111,10 +1046,8 @@ trait PaginatorTestTrait
 
     /**
      * Tests that order strings can used by Paginator
-     *
-     * @return void
      */
-    public function testValidateSortWithString()
+    public function testValidateSortWithString(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1129,10 +1062,8 @@ trait PaginatorTestTrait
 
     /**
      * Test that no sort doesn't trigger an error.
-     *
-     * @return void
      */
-    public function testValidateSortNoSort()
+    public function testValidateSortNoSort(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1146,10 +1077,8 @@ trait PaginatorTestTrait
 
     /**
      * Test sorting with incorrect aliases on valid fields.
-     *
-     * @return void
      */
-    public function testValidateSortInvalidAlias()
+    public function testValidateSortInvalidAlias(): void
     {
         $model = $this->mockAliasHasFieldModel();
 
@@ -1207,9 +1136,8 @@ trait PaginatorTestTrait
      * test that maxLimit is respected
      *
      * @dataProvider checkLimitProvider
-     * @return void
      */
-    public function testCheckLimit(array $input, int $expected)
+    public function testCheckLimit(array $input, int $expected): void
     {
         $result = $this->Paginator->checkLimit($input);
         $this->assertSame($expected, $result['limit']);
@@ -1217,10 +1145,8 @@ trait PaginatorTestTrait
 
     /**
      * Integration test for checkLimit() being applied inside paginate()
-     *
-     * @return void
      */
-    public function testPaginateMaxLimit()
+    public function testPaginateMaxLimit(): void
     {
         $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
@@ -1248,10 +1174,8 @@ trait PaginatorTestTrait
     /**
      * test paginate() and custom finders to ensure the count + find
      * use the custom type.
-     *
-     * @return void
      */
-    public function testPaginateCustomFindCount()
+    public function testPaginateCustomFindCount(): void
     {
         $settings = [
             'finder' => 'published',
@@ -1280,10 +1204,8 @@ trait PaginatorTestTrait
     /**
      * Tests that it is possible to pass an already made query object to
      * paginate()
-     *
-     * @return void
      */
-    public function testPaginateQuery()
+    public function testPaginateQuery(): void
     {
         $params = ['page' => '-1'];
         $settings = [
@@ -1315,10 +1237,8 @@ trait PaginatorTestTrait
 
     /**
      * test paginate() with bind()
-     *
-     * @return void
      */
-    public function testPaginateQueryWithBindValue()
+    public function testPaginateQueryWithBindValue(): void
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') !== false, 'Test temporarily broken in SQLServer');
@@ -1340,10 +1260,8 @@ trait PaginatorTestTrait
     /**
      * Tests that passing a query object with a limit clause set will
      * overwrite it with the passed defaults.
-     *
-     * @return void
      */
-    public function testPaginateQueryWithLimit()
+    public function testPaginateQueryWithLimit(): void
     {
         $params = ['page' => '-1'];
         $settings = [

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -33,8 +33,6 @@ class QueryCacherTest extends TestCase
 
     /**
      * Setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,8 +44,6 @@ class QueryCacherTest extends TestCase
 
     /**
      * Teardown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -57,10 +53,8 @@ class QueryCacherTest extends TestCase
 
     /**
      * Test fetching with a function to generate the key.
-     *
-     * @return void
      */
-    public function testFetchFunctionKey()
+    public function testFetchFunctionKey(): void
     {
         $this->engine->set('my_key', 'A winner');
         $query = new stdClass();
@@ -77,10 +71,8 @@ class QueryCacherTest extends TestCase
 
     /**
      * Test fetching with a function to generate the key but the function is poop.
-     *
-     * @return void
      */
-    public function testFetchFunctionKeyNoString()
+    public function testFetchFunctionKeyNoString(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cache key functions must return a string. Got false.');
@@ -96,10 +88,8 @@ class QueryCacherTest extends TestCase
 
     /**
      * Test fetching with a cache instance.
-     *
-     * @return void
      */
-    public function testFetchCacheHitStringEngine()
+    public function testFetchCacheHitStringEngine(): void
     {
         $this->engine->set('my_key', 'A winner');
         $cacher = new QueryCacher('my_key', 'queryCache');
@@ -110,10 +100,8 @@ class QueryCacherTest extends TestCase
 
     /**
      * Test fetching with a cache hit.
-     *
-     * @return void
      */
-    public function testFetchCacheHit()
+    public function testFetchCacheHit(): void
     {
         $this->engine->set('my_key', 'A winner');
         $cacher = new QueryCacher('my_key', $this->engine);
@@ -124,10 +112,8 @@ class QueryCacherTest extends TestCase
 
     /**
      * Test fetching with a cache miss.
-     *
-     * @return void
      */
-    public function testFetchCacheMiss()
+    public function testFetchCacheMiss(): void
     {
         $this->engine->set('my_key', false);
         $cacher = new QueryCacher('my_key', $this->engine);

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -26,10 +26,8 @@ class ResultSetDecoratorTest extends TestCase
 {
     /**
      * Tests the decorator can wrap a simple iterator
-     *
-     * @return void
      */
-    public function testDecorateSimpleIterator()
+    public function testDecorateSimpleIterator(): void
     {
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
@@ -38,10 +36,8 @@ class ResultSetDecoratorTest extends TestCase
 
     /**
      * Tests it toArray() method
-     *
-     * @return void
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
@@ -50,10 +46,8 @@ class ResultSetDecoratorTest extends TestCase
 
     /**
      * Tests JSON encoding method
-     *
-     * @return void
      */
-    public function testToJson()
+    public function testToJson(): void
     {
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
@@ -62,10 +56,8 @@ class ResultSetDecoratorTest extends TestCase
 
     /**
      * Tests serializing and unserializing the decorator
-     *
-     * @return void
      */
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
@@ -75,10 +67,8 @@ class ResultSetDecoratorTest extends TestCase
 
     /**
      * Test the first() method which is part of the ResultSet duck type.
-     *
-     * @return void
      */
-    public function testFirst()
+    public function testFirst(): void
     {
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
@@ -89,10 +79,8 @@ class ResultSetDecoratorTest extends TestCase
 
     /**
      * Test the count() method which is part of the ResultSet duck type.
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $data = new \ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -27,10 +27,8 @@ class RulesCheckerTest extends TestCase
 {
     /**
      * Test adding rule for update mode
-     *
-     * @return void
      */
-    public function testAddingRuleDeleteMode()
+    public function testAddingRuleDeleteMode(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -56,10 +54,8 @@ class RulesCheckerTest extends TestCase
 
     /**
      * Test adding rule for update mode
-     *
-     * @return void
      */
-    public function testAddingRuleUpdateMode()
+    public function testAddingRuleUpdateMode(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -85,10 +81,8 @@ class RulesCheckerTest extends TestCase
 
     /**
      * Test adding rule for create mode
-     *
-     * @return void
      */
-    public function testAddingRuleCreateMode()
+    public function testAddingRuleCreateMode(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -114,10 +108,8 @@ class RulesCheckerTest extends TestCase
 
     /**
      * Test adding rule with name
-     *
-     * @return void
      */
-    public function testAddingRuleWithName()
+    public function testAddingRuleWithName(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -138,10 +130,8 @@ class RulesCheckerTest extends TestCase
 
     /**
      * Test that returned error messages work.
-     *
-     * @return void
      */
-    public function testAddWithErrorMessage()
+    public function testAddWithErrorMessage(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -161,10 +151,8 @@ class RulesCheckerTest extends TestCase
 
     /**
      * Test that returned error messages work.
-     *
-     * @return void
      */
-    public function testAddWithMessageOption()
+    public function testAddWithMessageOption(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -184,10 +172,8 @@ class RulesCheckerTest extends TestCase
 
     /**
      * Test that returned error messages work.
-     *
-     * @return void
      */
-    public function testAddWithoutFields()
+    public function testAddWithoutFields(): void
     {
         $entity = new Entity([
             'name' => 'larry',

--- a/tests/TestCase/Datasource/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/SimplePaginatorTest.php
@@ -22,9 +22,6 @@ use Cake\ORM\Entity;
 
 class SimplePaginatorTest extends PaginatorTest
 {
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -36,10 +33,8 @@ class SimplePaginatorTest extends PaginatorTest
 
     /**
      * test paginate() and custom find, to make sure the correct count is returned.
-     *
-     * @return void
      */
-    public function testPaginateCustomFind()
+    public function testPaginateCustomFind(): void
     {
         $this->loadFixtures('Posts');
         $titleExtractor = function ($result) {
@@ -100,10 +95,8 @@ class SimplePaginatorTest extends PaginatorTest
 
     /**
      * test paginate() and custom find with fields array, to make sure the correct count is returned.
-     *
-     * @return void
      */
-    public function testPaginateCustomFindFieldsArray()
+    public function testPaginateCustomFindFieldsArray(): void
     {
         $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
@@ -134,10 +127,8 @@ class SimplePaginatorTest extends PaginatorTest
 
     /**
      * Test that special paginate types are called and that the type param doesn't leak out into defaults or options.
-     *
-     * @return void
      */
-    public function testPaginateCustomFinder()
+    public function testPaginateCustomFinder(): void
     {
         $settings = [
             'PaginatorPosts' => [

--- a/tests/TestCase/Error/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Error/ConsoleErrorHandlerTest.php
@@ -39,8 +39,6 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * setup, create mocks
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -56,8 +54,6 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -67,10 +63,8 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * test that the console error handler can deal with Exceptions.
-     *
-     * @return void
      */
-    public function testHandleError()
+    public function testHandleError(): void
     {
         $content = "<error>Notice Error:</error> This is a notice error\nIn [/some/file, line 275]\n";
         $this->Error->expects($this->never())
@@ -82,10 +76,8 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * test that the console error handler can deal with fatal errors.
-     *
-     * @return void
      */
-    public function testHandleFatalError()
+    public function testHandleFatalError(): void
     {
         ob_start();
         $content = "<error>Fatal Error:</error> This is a fatal error\nIn [/some/file, line 275]\n";
@@ -98,10 +90,8 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * test that the console error handler can deal with CakeExceptions.
-     *
-     * @return void
      */
-    public function testCakeErrors()
+    public function testCakeErrors(): void
     {
         $exception = new MissingActionException('Missing action');
         $message = sprintf("<error>Exception:</error> Missing action\nIn [%s, line %s]\n", $exception->getFile(), $exception->getLine());
@@ -118,10 +108,8 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * test a non Cake Exception exception.
-     *
-     * @return void
      */
-    public function testNonCakeExceptions()
+    public function testNonCakeExceptions(): void
     {
         $exception = new \InvalidArgumentException('Too many parameters.');
 
@@ -135,10 +123,8 @@ class ConsoleErrorHandlerTest extends TestCase
 
     /**
      * Test error code is used as exit code for ConsoleException.
-     *
-     * @return void
      */
-    public function testConsoleExceptions()
+    public function testConsoleExceptions(): void
     {
         $exception = new ConsoleException('Test ConsoleException', 2);
 

--- a/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
+++ b/tests/TestCase/Error/Debug/ConsoleFormatterTest.php
@@ -33,10 +33,8 @@ class ConsoleFormatterTest extends TestCase
 {
     /**
      * Test dumping a graph that contains all possible nodes.
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         $node = new ClassNode('MyObject', 1);
         $node->addProperty(new PropertyNode('stringProp', 'public', new ScalarNode('string', 'value')));

--- a/tests/TestCase/Error/Debug/HtmlFormatterTest.php
+++ b/tests/TestCase/Error/Debug/HtmlFormatterTest.php
@@ -34,10 +34,8 @@ class HtmlFormatterTest extends TestCase
 {
     /**
      * Test dumping a graph that contains all possible nodes.
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         $node = new ClassNode('MyObject', 1);
         $node->addProperty(new PropertyNode('stringProp', 'public', new ScalarNode('string', 'value')));

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -51,8 +51,6 @@ class DebuggerTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -65,8 +63,6 @@ class DebuggerTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -78,10 +74,8 @@ class DebuggerTest extends TestCase
 
     /**
      * testDocRef method
-     *
-     * @return void
      */
-    public function testDocRef()
+    public function testDocRef(): void
     {
         ini_set('docref_root', '');
         $this->assertEquals(ini_get('docref_root'), '');
@@ -94,10 +88,8 @@ class DebuggerTest extends TestCase
 
     /**
      * test Excerpt writing
-     *
-     * @return void
      */
-    public function testExcerpt()
+    public function testExcerpt(): void
     {
         $result = Debugger::excerpt(__FILE__, __LINE__ - 1, 2);
         $this->assertIsArray($result);
@@ -137,10 +129,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Test that setOutputFormat works.
-     *
-     * @return void
      */
-    public function testSetOutputFormat()
+    public function testSetOutputFormat(): void
     {
         Debugger::setOutputFormat('html');
         $this->assertSame('html', Debugger::getOutputFormat());
@@ -148,10 +138,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Test that getOutputFormat/setOutputFormat works.
-     *
-     * @return void
      */
-    public function testGetSetOutputFormat()
+    public function testGetSetOutputFormat(): void
     {
         Debugger::setOutputFormat('html');
         $this->assertSame('html', Debugger::getOutputFormat());
@@ -159,10 +147,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Test that choosing a nonexistent format causes an exception
-     *
-     * @return void
      */
-    public function testSetOutputAsException()
+    public function testSetOutputAsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Debugger::setOutputFormat('Invalid junk');
@@ -170,10 +156,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Test outputError with description encoding
-     *
-     * @return void
      */
-    public function testOutputErrorDescriptionEncoding()
+    public function testOutputErrorDescriptionEncoding(): void
     {
         Debugger::setOutputFormat('html');
 
@@ -194,10 +178,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Tests that the correct line is being highlighted.
-     *
-     * @return void
      */
-    public function testOutputErrorLineHighlight()
+    public function testOutputErrorLineHighlight(): void
     {
         Debugger::setOutputFormat('js');
 
@@ -219,10 +201,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Tests that changes in output formats using Debugger::output() change the templates used.
-     *
-     * @return void
      */
-    public function testAddFormat()
+    public function testAddFormat(): void
     {
         Debugger::addFormat('js', [
             'traceLine' => '{:reference} - <a href="txmt://open?url=file://{:file}' .
@@ -263,10 +243,8 @@ class DebuggerTest extends TestCase
 
     /**
      * Test adding a format that is handled by a callback.
-     *
-     * @return void
      */
-    public function testAddFormatCallback()
+    public function testAddFormatCallback(): void
     {
         Debugger::addFormat('callback', ['callback' => [$this, 'customFormat']]);
         Debugger::setOutputFormat('callback');
@@ -290,20 +268,16 @@ class DebuggerTest extends TestCase
 
     /**
      * Test method for testing addFormat with callbacks.
-     *
-     * @return void
      */
-    public function customFormat(array $error, array $strings)
+    public function customFormat(array $error, array $strings): void
     {
         echo $error['error'] . ': I eated an error ' . $error['file'];
     }
 
     /**
      * testTrimPath method
-     *
-     * @return void
      */
-    public function testTrimPath()
+    public function testTrimPath(): void
     {
         $this->assertSame('APP/', Debugger::trimPath(APP));
         $this->assertSame('CORE' . DS . 'src' . DS, Debugger::trimPath(CAKE));
@@ -312,10 +286,8 @@ class DebuggerTest extends TestCase
 
     /**
      * testExportVar method
-     *
-     * @return void
      */
-    public function testExportVar()
+    public function testExportVar(): void
     {
         $Controller = new Controller();
         $Controller->viewBuilder()->setHelpers(['Html', 'Form']);
@@ -421,7 +393,7 @@ TEXT;
         $this->assertStringContainsString('(resource (closed)) Resource id #', $result);
     }
 
-    public function testExportVarTypedProperty()
+    public function testExportVarTypedProperty(): void
     {
         $this->skipIf(version_compare(PHP_VERSION, '7.4.0', '<'), 'typed properties require PHP7.4');
         // This is gross but was simpler than adding a fixture file.
@@ -434,10 +406,8 @@ TEXT;
 
     /**
      * Test exporting various kinds of false.
-     *
-     * @return void
      */
-    public function testExportVarZero()
+    public function testExportVarZero(): void
     {
         $data = [
             'nothing' => '',
@@ -461,10 +431,8 @@ TEXT;
 
     /**
      * test exportVar with cyclic objects.
-     *
-     * @return void
      */
-    public function testExportVarCyclicRef()
+    public function testExportVarCyclicRef(): void
     {
         $parent = new stdClass();
         $parent->name = 'cake';
@@ -489,10 +457,8 @@ TEXT;
 
     /**
      * test exportVar with array objects
-     *
-     * @return void
      */
-    public function testExportVarSplFixedArray()
+    public function testExportVarSplFixedArray(): void
     {
         $subject = new SplFixedArray(2);
         $subject[0] = 'red';
@@ -510,10 +476,8 @@ TEXT;
 
     /**
      * Tests plain text variable export.
-     *
-     * @return void
      */
-    public function testExportVarAsPlainText()
+    public function testExportVarAsPlainText(): void
     {
         Debugger::configInstance('exportFormatter', null);
         $result = Debugger::exportVarAsPlainText(123);
@@ -526,10 +490,8 @@ TEXT;
 
     /**
      * test exportVar with cyclic objects.
-     *
-     * @return void
      */
-    public function testExportVarDebugInfo()
+    public function testExportVarDebugInfo(): void
     {
         $form = new Form();
 
@@ -540,10 +502,8 @@ TEXT;
 
     /**
      * Test exportVar with an exception during __debugInfo()
-     *
-     * @return void
      */
-    public function testExportVarInvalidDebugInfo()
+    public function testExportVarInvalidDebugInfo(): void
     {
         $result = Debugger::exportVar(new ThrowsDebugInfo());
         $expected = '(unable to export object: from __debugInfo)';
@@ -552,10 +512,8 @@ TEXT;
 
     /**
      * Text exportVarAsNodes()
-     *
-     * @return void
      */
-    public function testExportVarAsNodes()
+    public function testExportVarAsNodes(): void
     {
         $data = [
             1 => 'Index one',
@@ -587,10 +545,8 @@ TEXT;
 
     /**
      * testLog method
-     *
-     * @return void
      */
-    public function testLog()
+    public function testLog(): void
     {
         Log::setConfig('test', [
             'className' => 'Array',
@@ -613,10 +569,8 @@ TEXT;
 
     /**
      * Tests that logging does not apply formatting.
-     *
-     * @return void
      */
-    public function testLogShouldNotApplyFormatting()
+    public function testLogShouldNotApplyFormatting(): void
     {
         Log::setConfig('test', [
             'className' => 'Array',
@@ -648,10 +602,8 @@ TEXT;
 
     /**
      * test log() depth
-     *
-     * @return void
      */
-    public function testLogDepth()
+    public function testLogDepth(): void
     {
         Log::setConfig('test', [
             'className' => 'Array',
@@ -669,10 +621,8 @@ TEXT;
 
     /**
      * testDump method
-     *
-     * @return void
      */
-    public function testDump()
+    public function testDump(): void
     {
         $var = ['People' => [
             [
@@ -726,10 +676,8 @@ TEXT;
 
     /**
      * test getInstance.
-     *
-     * @return void
      */
-    public function testGetInstance()
+    public function testGetInstance(): void
     {
         $result = Debugger::getInstance();
         $exporter = $result->getConfig('exportFormatter');
@@ -749,10 +697,8 @@ TEXT;
 
     /**
      * Test that exportVar() will stop traversing recursive arrays.
-     *
-     * @return void
      */
-    public function testExportVarRecursion()
+    public function testExportVarRecursion(): void
     {
         $array = [];
         $array['foo'] = &$array;
@@ -763,10 +709,8 @@ TEXT;
 
     /**
      * test trace exclude
-     *
-     * @return void
      */
-    public function testTraceExclude()
+    public function testTraceExclude(): void
     {
         $result = Debugger::trace();
         $this->assertMatchesRegularExpression('/^Cake\\\Test\\\TestCase\\\Error\\\DebuggerTest::testTraceExclude/', $result);
@@ -779,10 +723,8 @@ TEXT;
 
     /**
      * Tests that __debugInfo is used when available
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $object = new DebuggableThing();
         $result = Debugger::exportVar($object, 2);
@@ -797,10 +739,8 @@ eos;
 
     /**
      * Tests reading the output mask settings.
-     *
-     * @return void
      */
-    public function testSetOutputMask()
+    public function testSetOutputMask(): void
     {
         Debugger::setOutputMask(['password' => '[**********]']);
         $this->assertEquals(['password' => '[**********]'], Debugger::outputMask());
@@ -812,10 +752,8 @@ eos;
 
     /**
      * Test configure based output mask configuration
-     *
-     * @return void
      */
-    public function testConfigureOutputMask()
+    public function testConfigureOutputMask(): void
     {
         Configure::write('Debugger.outputMask', ['wow' => 'xxx']);
         Debugger::getInstance(TestDebugger::class);
@@ -828,10 +766,8 @@ eos;
 
     /**
      * Tests the masking of an array key.
-     *
-     * @return void
      */
-    public function testMaskArray()
+    public function testMaskArray(): void
     {
         Debugger::setOutputMask(['password' => '[**********]']);
         $result = Debugger::exportVar(['password' => 'pass1234']);
@@ -841,10 +777,8 @@ eos;
 
     /**
      * Tests the masking of an array key.
-     *
-     * @return void
      */
-    public function testMaskObject()
+    public function testMaskObject(): void
     {
         Debugger::setOutputMask(['password' => '[**********]']);
         $object = new SecurityThing();
@@ -855,10 +789,8 @@ eos;
 
     /**
      * test testPrintVar()
-     *
-     * @return void
      */
-    public function testPrintVar()
+    public function testPrintVar(): void
     {
         ob_start();
         Debugger::printVar('this-is-a-test', ['file' => __FILE__, 'line' => __LINE__], false);
@@ -933,10 +865,8 @@ EXPECTED;
 
     /**
      * test formatHtmlMessage
-     *
-     * @return void
      */
-    public function testFormatHtmlMessage()
+    public function testFormatHtmlMessage(): void
     {
         $output = Debugger::formatHtmlMessage('Some `code` to `replace`');
         $this->assertSame('Some <code>code</code> to <code>replace</code>', $output);
@@ -953,10 +883,8 @@ EXPECTED;
 
     /**
      * test adding invalid editor
-     *
-     * @return void
      */
-    public function testAddEditorInvalid()
+    public function testAddEditorInvalid(): void
     {
         $this->expectException(RuntimeException::class);
         Debugger::addEditor('nope', ['invalid']);
@@ -964,10 +892,8 @@ EXPECTED;
 
     /**
      * test choosing an unknown editor
-     *
-     * @return void
      */
-    public function testSetEditorInvalid()
+    public function testSetEditorInvalid(): void
     {
         $this->expectException(RuntimeException::class);
         Debugger::setEditor('nope');
@@ -975,10 +901,8 @@ EXPECTED;
 
     /**
      * test choosing a default editor
-     *
-     * @return void
      */
-    public function testSetEditorPredefined()
+    public function testSetEditorPredefined(): void
     {
         Debugger::setEditor('phpstorm');
         Debugger::setEditor('macvim');
@@ -990,10 +914,8 @@ EXPECTED;
 
     /**
      * Test configure based editor setup
-     *
-     * @return void
      */
-    public function testConfigureEditor()
+    public function testConfigureEditor(): void
     {
         Configure::write('Debugger.editor', 'emacs');
         Debugger::getInstance(TestDebugger::class);
@@ -1005,10 +927,8 @@ EXPECTED;
 
     /**
      * test using a valid editor.
-     *
-     * @return void
      */
-    public function testEditorUrlValid()
+    public function testEditorUrlValid(): void
     {
         Debugger::addEditor('open', 'open://{file}:{line}');
         Debugger::setEditor('open');
@@ -1017,10 +937,8 @@ EXPECTED;
 
     /**
      * test using a valid editor.
-     *
-     * @return void
      */
-    public function testEditorUrlClosure()
+    public function testEditorUrlClosure(): void
     {
         Debugger::addEditor('open', function (string $file, int $line) {
             return "${file}/${line}";

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -49,8 +49,6 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * setup create a request object to get out of router later.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -74,8 +72,6 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -91,8 +87,6 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * setUpBeforeClass
-     *
-     * @return void
      */
     public static function setUpBeforeClass(): void
     {
@@ -102,10 +96,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * Test an invalid rendering class.
-     *
-     * @return void
      */
-    public function testInvalidRenderer()
+    public function testInvalidRenderer(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The \'TotallyInvalid\' renderer class could not be found');
@@ -116,10 +108,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test error handling when debug is on, an error should be printed from Debugger.
-     *
-     * @return void
      */
-    public function testHandleErrorDebugOn()
+    public function testHandleErrorDebugOn(): void
     {
         $errorHandler = new ErrorHandler();
         $errorHandler->register();
@@ -146,12 +136,10 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test error handling with the _trace_offset context variable
-     *
-     * @return void
      */
-    public function testHandleErrorTraceOffset()
+    public function testHandleErrorTraceOffset(): void
     {
-        set_error_handler(function ($code, $message, $file, $line, $context = null) {
+        set_error_handler(function ($code, $message, $file, $line, $context = null): void {
             $errorHandler = new ErrorHandler();
             $context['_trace_frame_offset'] = 3;
             $errorHandler->handleError($code, $message, $file, $line, $context);
@@ -188,9 +176,8 @@ class ErrorHandlerTest extends TestCase
      * test error mappings
      *
      * @dataProvider errorProvider
-     * @return void
      */
-    public function testErrorMapping(int $error, string $expected)
+    public function testErrorMapping(int $error, string $expected): void
     {
         $errorHandler = new ErrorHandler();
         $errorHandler->register();
@@ -205,10 +192,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test error prepended by @
-     *
-     * @return void
      */
-    public function testErrorSuppressed()
+    public function testErrorSuppressed(): void
     {
         $this->skipIf(version_compare(PHP_VERSION, '8.0.0-dev', '>='));
 
@@ -226,10 +211,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * Test that errors go into Cake Log when debug = 0.
-     *
-     * @return void
      */
-    public function testHandleErrorDebugOff()
+    public function testHandleErrorDebugOff(): void
     {
         Configure::write('debug', false);
         $errorHandler = new ErrorHandler();
@@ -256,10 +239,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * Test that errors going into Cake Log include traces.
-     *
-     * @return void
      */
-    public function testHandleErrorLoggingTrace()
+    public function testHandleErrorLoggingTrace(): void
     {
         Configure::write('debug', false);
         $errorHandler = new ErrorHandler(['trace' => true]);
@@ -289,10 +270,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test handleException generating a page.
-     *
-     * @return void
      */
-    public function testHandleException()
+    public function testHandleException(): void
     {
         $error = new NotFoundException('Kaboom!');
         $errorHandler = new TestErrorHandler();
@@ -303,10 +282,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test handleException generating log.
-     *
-     * @return void
      */
-    public function testHandleExceptionLog()
+    public function testHandleExceptionLog(): void
     {
         $errorHandler = new TestErrorHandler([
             'log' => true,
@@ -342,10 +319,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test logging attributes with/without debug
-     *
-     * @return void
      */
-    public function testHandleExceptionLogAttributes()
+    public function testHandleExceptionLogAttributes(): void
     {
         $errorHandler = new TestErrorHandler([
             'log' => true,
@@ -377,10 +352,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test logging attributes with previous exception
-     *
-     * @return void
      */
-    public function testHandleExceptionLogPrevious()
+    public function testHandleExceptionLogPrevious(): void
     {
         $errorHandler = new TestErrorHandler([
             'log' => true,
@@ -405,10 +378,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test handleException generating log.
-     *
-     * @return void
      */
-    public function testHandleExceptionLogSkipping()
+    public function testHandleExceptionLogSkipping(): void
     {
         $notFound = new NotFoundException('Kaboom!');
         $forbidden = new ForbiddenException('Fooled you!');
@@ -434,10 +405,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * tests it is possible to load a plugin exception renderer
-     *
-     * @return void
      */
-    public function testLoadPluginHandler()
+    public function testLoadPluginHandler(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $errorHandler = new TestErrorHandler([
@@ -455,10 +424,8 @@ class ErrorHandlerTest extends TestCase
      * test handleFatalError generating a page.
      *
      * These tests start two buffers as handleFatalError blows the outer one up.
-     *
-     * @return void
      */
-    public function testHandleFatalErrorPage()
+    public function testHandleFatalErrorPage(): void
     {
         $line = __LINE__;
         $errorHandler = new TestErrorHandler();
@@ -480,10 +447,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * test handleFatalError generating log.
-     *
-     * @return void
      */
-    public function testHandleFatalErrorLog()
+    public function testHandleFatalErrorLog(): void
     {
         $errorHandler = new TestErrorHandler(['log' => true]);
         $errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, __LINE__);
@@ -515,9 +480,8 @@ class ErrorHandlerTest extends TestCase
      * Test increasing the memory limit.
      *
      * @dataProvider memoryLimitProvider
-     * @return void
      */
-    public function testIncreaseMemoryLimit(string $start, int $adjust, string $expected)
+    public function testIncreaseMemoryLimit(string $start, int $adjust, string $expected): void
     {
         $initial = ini_get('memory_limit');
         $this->skipIf(strlen($initial) === 0, 'Cannot read memory limit, and cannot test increasing it.');
@@ -535,10 +499,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * Test getting a logger
-     *
-     * @return void
      */
-    public function testGetLogger()
+    public function testGetLogger(): void
     {
         $errorHandler = new TestErrorHandler(['key' => 'value', 'log' => true]);
         $logger = $errorHandler->getLogger();
@@ -550,10 +512,8 @@ class ErrorHandlerTest extends TestCase
 
     /**
      * Test getting a logger
-     *
-     * @return void
      */
-    public function testGetLoggerInvalid()
+    public function testGetLoggerInvalid(): void
     {
         $errorHandler = new TestErrorHandler(['errorLogger' => \stdClass::class]);
         $this->expectException(RuntimeException::class);

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -56,8 +56,6 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * setup create a request object to get out of router later.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -72,8 +70,6 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -84,7 +80,7 @@ class ExceptionRendererTest extends TestCase
         }
     }
 
-    public function testControllerInstanceForPrefixedRequest()
+    public function testControllerInstanceForPrefixedRequest(): void
     {
         $namespace = Configure::read('App.namespace');
         Configure::write('App.namespace', 'TestApp');
@@ -107,10 +103,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * testTemplatePath
-     *
-     * @return void
      */
-    public function testTemplatePath()
+    public function testTemplatePath(): void
     {
         $request = (new ServerRequest())
             ->withParam('controller', 'Foo')
@@ -148,10 +142,8 @@ class ExceptionRendererTest extends TestCase
     /**
      * test that methods declared in an ExceptionRenderer subclass are not converted
      * into error400 when debug > 0
-     *
-     * @return void
      */
-    public function testSubclassMethodsNotBeingConvertedToError()
+    public function testSubclassMethodsNotBeingConvertedToError(): void
     {
         $exception = new MissingWidgetThingException('Widget not found');
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
@@ -163,10 +155,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that subclass methods are not converted when debug = 0
-     *
-     * @return void
      */
-    public function testSubclassMethodsNotBeingConvertedDebug0()
+    public function testSubclassMethodsNotBeingConvertedDebug0(): void
     {
         Configure::write('debug', false);
         $exception = new MissingWidgetThingException('Widget not found');
@@ -187,10 +177,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that ExceptionRenderer subclasses properly convert framework errors.
-     *
-     * @return void
      */
-    public function testSubclassConvertingFrameworkErrors()
+    public function testSubclassConvertingFrameworkErrors(): void
     {
         Configure::write('debug', false);
 
@@ -208,10 +196,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test things in the constructor.
-     *
-     * @return void
      */
-    public function testConstruction()
+    public function testConstruction(): void
     {
         $exception = new NotFoundException('Page not found');
         $ExceptionRenderer = new ExceptionRenderer($exception);
@@ -225,10 +211,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that exception message gets coerced when debug = 0
-     *
-     * @return void
      */
-    public function testExceptionMessageCoercion()
+    public function testExceptionMessageCoercion(): void
     {
         Configure::write('debug', false);
         $exception = new MissingActionException('Secret info not to be leaked');
@@ -249,10 +233,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that helpers in custom CakeErrorController are not lost
-     *
-     * @return void
      */
-    public function testCakeErrorHelpersNotLost()
+    public function testCakeErrorHelpersNotLost(): void
     {
         static::setAppNamespace();
         $exception = new NotFoundException();
@@ -264,10 +246,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that unknown exception types with valid status codes are treated correctly.
-     *
-     * @return void
      */
-    public function testUnknownExceptionTypeWithExceptionThatHasA400Code()
+    public function testUnknownExceptionTypeWithExceptionThatHasA400Code(): void
     {
         $exception = new MissingWidgetThingException('coding fail.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
@@ -280,10 +260,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that unknown exception types with valid status codes are treated correctly.
-     *
-     * @return void
      */
-    public function testUnknownExceptionTypeWithNoCodeIsA500()
+    public function testUnknownExceptionTypeWithNoCodeIsA500(): void
     {
         $exception = new \OutOfBoundsException('foul ball.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
@@ -295,10 +273,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that unknown exceptions have messages ignored.
-     *
-     * @return void
      */
-    public function testUnknownExceptionInProduction()
+    public function testUnknownExceptionInProduction(): void
     {
         Configure::write('debug', false);
 
@@ -315,10 +291,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that unknown exception types with valid status codes are treated correctly.
-     *
-     * @return void
      */
-    public function testUnknownExceptionTypeWithCodeHigherThan500()
+    public function testUnknownExceptionTypeWithCodeHigherThan500(): void
     {
         $exception = new HttpException('foul ball.', 501);
         $ExceptionRenderer = new ExceptionRenderer($exception);
@@ -331,10 +305,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * testerror400 method
-     *
-     * @return void
      */
-    public function testError400()
+    public function testError400(): void
     {
         Router::reload();
 
@@ -354,10 +326,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * testerror400 method when returning as JSON
-     *
-     * @return void
      */
-    public function testError400AsJson()
+    public function testError400AsJson(): void
     {
         Router::reload();
 
@@ -385,10 +355,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that error400 only modifies the messages on Cake Exceptions.
-     *
-     * @return void
      */
-    public function testerror400OnlyChangingCakeException()
+    public function testerror400OnlyChangingCakeException(): void
     {
         Configure::write('debug', false);
 
@@ -407,10 +375,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that error400 doesn't expose XSS
-     *
-     * @return void
      */
-    public function testError400NoInjection()
+    public function testError400NoInjection(): void
     {
         Router::reload();
 
@@ -428,10 +394,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * testError500 method
-     *
-     * @return void
      */
-    public function testError500Message()
+    public function testError500Message(): void
     {
         $exception = new InternalErrorException('An Internal Error Has Occurred.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
@@ -445,10 +409,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * testExceptionResponseHeader method
-     *
-     * @return void
      */
-    public function testExceptionResponseHeader()
+    public function testExceptionResponseHeader(): void
     {
         $exception = new MethodNotAllowedException('Only allowing POST and DELETE');
         $exception->setHeader('Allow', ['POST', 'DELETE']);
@@ -466,12 +428,10 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Tests setting exception response headers through core Exception
-     *
-     * @return void
      */
-    public function testExceptionDeprecatedResponseHeader()
+    public function testExceptionDeprecatedResponseHeader(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $exception = new CakeException('Should Not Set Headers');
             $exception->responseHeader(['Allow' => 'POST, DELETE']);
 
@@ -485,10 +445,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * testMissingController method
-     *
-     * @return void
      */
-    public function testMissingController()
+    public function testMissingController(): void
     {
         $exception = new MissingControllerException([
             'class' => 'Posts',
@@ -509,10 +467,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test missingController method
-     *
-     * @return void
      */
-    public function testMissingControllerLowerCase()
+    public function testMissingControllerLowerCase(): void
     {
         $exception = new MissingControllerException([
             'class' => 'posts',
@@ -668,9 +624,8 @@ class ExceptionRendererTest extends TestCase
      * Test the various Cake Exception sub classes
      *
      * @dataProvider exceptionProvider
-     * @return void
      */
-    public function testCakeExceptionHandling(Exception $exception, array $patterns, int $code)
+    public function testCakeExceptionHandling(Exception $exception, array $patterns, int $code): void
     {
         $exceptionRenderer = new ExceptionRenderer($exception);
         $response = $exceptionRenderer->render();
@@ -684,10 +639,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that class names not ending in Exception are not mangled.
-     *
-     * @return void
      */
-    public function testExceptionNameMangling()
+    public function testExceptionNameMangling(): void
     {
         $exceptionRenderer = new MyCustomExceptionRenderer(new MissingWidgetThing());
 
@@ -704,10 +657,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test exceptions being raised when helpers are missing.
-     *
-     * @return void
      */
-    public function testMissingRenderSafe()
+    public function testMissingRenderSafe(): void
     {
         $exception = new MissingHelperException(['class' => 'Fail']);
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
@@ -734,10 +685,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that exceptions in beforeRender() are handled by outputMessageSafe
-     *
-     * @return void
      */
-    public function testRenderExceptionInBeforeRender()
+    public function testRenderExceptionInBeforeRender(): void
     {
         $exception = new NotFoundException('Not there, sorry');
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
@@ -759,10 +708,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that missing layoutPath don't cause other fatal errors.
-     *
-     * @return void
      */
-    public function testMissingLayoutPathRenderSafe()
+    public function testMissingLayoutPathRenderSafe(): void
     {
         $this->called = false;
         $exception = new NotFoundException();
@@ -772,7 +719,7 @@ class ExceptionRendererTest extends TestCase
         $controller->viewBuilder()->setHelpers(['Fail', 'Boom']);
         $controller->getEventManager()->on(
             'Controller.beforeRender',
-            function (EventInterface $event) {
+            function (EventInterface $event): void {
                 $this->called = true;
                 $event->getSubject()->viewBuilder()->setLayoutPath('boom');
             }
@@ -790,10 +737,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that missing layout don't cause other fatal errors.
-     *
-     * @return void
      */
-    public function testMissingLayoutRenderSafe()
+    public function testMissingLayoutRenderSafe(): void
     {
         $this->called = false;
         $exception = new NotFoundException();
@@ -802,7 +747,7 @@ class ExceptionRendererTest extends TestCase
         $controller = new Controller();
         $controller->getEventManager()->on(
             'Controller.beforeRender',
-            function (EventInterface $event) {
+            function (EventInterface $event): void {
                 $this->called = true;
                 $event->getSubject()->viewBuilder()->setTemplatePath('Error');
                 $event->getSubject()->viewBuilder()->setLayout('does-not-exist');
@@ -821,10 +766,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that missing plugin disables Controller::$plugin if the two are the same plugin.
-     *
-     * @return void
      */
-    public function testMissingPluginRenderSafe()
+    public function testMissingPluginRenderSafe(): void
     {
         $exception = new NotFoundException();
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
@@ -852,10 +795,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that missing plugin doesn't disable Controller::$plugin if the two aren't the same plugin.
-     *
-     * @return void
      */
-    public function testMissingPluginRenderSafeWithPlugin()
+    public function testMissingPluginRenderSafeWithPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $exception = new NotFoundException();
@@ -885,10 +826,8 @@ class ExceptionRendererTest extends TestCase
     /**
      * Test that exceptions can be rendered when a request hasn't been registered
      * with Router
-     *
-     * @return void
      */
-    public function testRenderWithNoRequest()
+    public function testRenderWithNoRequest(): void
     {
         Router::reload();
         $this->assertNull(Router::getRequest());
@@ -904,10 +843,8 @@ class ExceptionRendererTest extends TestCase
     /**
      * Test that router request parameters are applied when the passed
      * request has no params.
-     *
-     * @return void
      */
-    public function testRenderInheritRoutingParams()
+    public function testRenderInheritRoutingParams(): void
     {
         $routerRequest = new ServerRequest([
             'params' => [
@@ -934,13 +871,11 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Test that rendering exceptions triggers shutdown events.
-     *
-     * @return void
      */
-    public function testRenderShutdownEvents()
+    public function testRenderShutdownEvents(): void
     {
         $fired = [];
-        $listener = function (EventInterface $event) use (&$fired) {
+        $listener = function (EventInterface $event) use (&$fired): void {
             $fired[] = $event->getName();
         };
         $events = EventManager::instance();
@@ -956,13 +891,11 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * test that subclass methods fire shutdown events.
-     *
-     * @return void
      */
-    public function testSubclassTriggerShutdownEvents()
+    public function testSubclassTriggerShutdownEvents(): void
     {
         $fired = [];
-        $listener = function (EventInterface $event) use (&$fired) {
+        $listener = function (EventInterface $event) use (&$fired): void {
             $fired[] = $event->getName();
         };
         $events = EventManager::instance();
@@ -978,10 +911,8 @@ class ExceptionRendererTest extends TestCase
 
     /**
      * Tests the output of rendering a PDOException
-     *
-     * @return void
      */
-    public function testPDOException()
+    public function testPDOException(): void
     {
         $exception = new \PDOException('There was an error in the SQL query');
         $exception->queryString = 'SELECT * from poo_query < 5 and :seven';

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -44,8 +44,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,8 +60,6 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -73,10 +69,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test constructor error
-     *
-     * @return void
      */
-    public function testConstructorInvalid()
+    public function testConstructorInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('$errorHandler argument must be a config array or ErrorHandler');
@@ -85,10 +79,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test returning a response works ok.
-     *
-     * @return void
      */
-    public function testNoErrorResponse()
+    public function testNoErrorResponse(): void
     {
         $request = ServerRequestFactory::fromGlobals();
 
@@ -100,10 +92,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test using a factory method to make a renderer.
-     *
-     * @return void
      */
-    public function testRendererFactory()
+    public function testRendererFactory(): void
     {
         $request = ServerRequestFactory::fromGlobals();
 
@@ -122,7 +112,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ErrorHandler([
             'exceptionRenderer' => $factory,
         ]));
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new LogicException('Something bad');
         });
         $middleware->process($request, $handler);
@@ -130,14 +120,12 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test rendering an error page
-     *
-     * @return void
      */
-    public function testHandleException()
+    public function testHandleException(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new \Cake\Http\Exception\NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -148,14 +136,12 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test creating a redirect response
-     *
-     * @return void
      */
-    public function testHandleRedirectException()
+    public function testHandleRedirectException(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new RedirectException('http://example.org/login');
         });
         $result = $middleware->process($request, $handler);
@@ -170,16 +156,14 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test creating a redirect response
-     *
-     * @return void
      */
-    public function testHandleRedirectExceptionHeaders()
+    public function testHandleRedirectExceptionHeaders(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             $err = new RedirectException('http://example.org/login', 301, ['Constructor' => 'yes']);
-            $this->deprecated(function () use ($err) {
+            $this->deprecated(function () use ($err): void {
                 $err->addHeaders(['Constructor' => 'no', 'Method' => 'yes']);
             });
             throw $err;
@@ -199,16 +183,14 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test rendering an error page holds onto the original request.
-     *
-     * @return void
      */
-    public function testHandleExceptionPreserveRequest()
+    public function testHandleExceptionPreserveRequest(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $request = $request->withHeader('Accept', 'application/json');
 
         $middleware = new ErrorHandlerMiddleware();
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new \Cake\Http\Exception\NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
@@ -220,10 +202,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test handling PHP 7's Error instance.
-     *
-     * @return void
      */
-    public function testHandlePHP7Error()
+    public function testHandlePHP7Error(): void
     {
         $middleware = new ErrorHandlerMiddleware();
         $request = ServerRequestFactory::fromGlobals();
@@ -235,17 +215,15 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test rendering an error page logs errors
-     *
-     * @return void
      */
-    public function testHandleExceptionLogAndTrace()
+    public function testHandleExceptionLogAndTrace(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/target/url',
             'HTTP_REFERER' => '/other/path',
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
@@ -267,17 +245,15 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test rendering an error page logs errors with previous
-     *
-     * @return void
      */
-    public function testHandleExceptionLogAndTraceWithPrevious()
+    public function testHandleExceptionLogAndTraceWithPrevious(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/target/url',
             'HTTP_REFERER' => '/other/path',
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function ($req): void {
             $previous = new \Cake\Datasource\Exception\RecordNotFoundException('Previous logged');
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!', null, $previous);
         });
@@ -303,17 +279,15 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test rendering an error page skips logging for specific classes
-     *
-     * @return void
      */
-    public function testHandleExceptionSkipLog()
+    public function testHandleExceptionSkipLog(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware([
             'log' => true,
             'skipLog' => ['Cake\Http\Exception\NotFoundException'],
         ]);
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
@@ -325,14 +299,12 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test rendering an error page logs exception attributes
-     *
-     * @return void
      */
-    public function testHandleExceptionLogAttributes()
+    public function testHandleExceptionLogAttributes(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware(['log' => true]);
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new MissingControllerException(['class' => 'Articles']);
         });
         $result = $middleware->process($request, $handler);
@@ -350,10 +322,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test handling an error and having rendering fail.
-     *
-     * @return void
      */
-    public function testHandleExceptionRenderingFails()
+    public function testHandleExceptionRenderingFails(): void
     {
         $request = ServerRequestFactory::fromGlobals();
 
@@ -370,7 +340,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $middleware = new ErrorHandlerMiddleware(new ErrorHandler([
             'exceptionRenderer' => $factory,
         ]));
-        $handler = new TestRequestHandler(function () {
+        $handler = new TestRequestHandler(function (): void {
             throw new \Cake\Http\Exception\ServiceUnavailableException('whoops');
         });
         $response = $middleware->process($request, $handler);
@@ -380,10 +350,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
     /**
      * Test exception args are not ignored in php7.4 with debug enabled.
-     *
-     * @return void
      */
-    public function testExceptionArgs()
+    public function testExceptionArgs(): void
     {
         $this->skipIf(PHP_VERSION_ID < 70400);
 

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -29,10 +29,8 @@ class ConditionDecoratorTest extends TestCase
 {
     /**
      * testCanTriggerIf
-     *
-     * @return void
      */
-    public function testCanTriggerIf()
+    public function testCanTriggerIf(): void
     {
         $callable = function (EventInterface $event) {
             return 'success';
@@ -59,10 +57,8 @@ class ConditionDecoratorTest extends TestCase
 
     /**
      * testCascadingEvents
-     *
-     * @return void
      */
-    public function testCascadingEvents()
+    public function testCascadingEvents(): void
     {
         $callable = function (EventInterface $event) {
             $event->setData('counter', $event->getData('counter') + 1);
@@ -96,7 +92,7 @@ class ConditionDecoratorTest extends TestCase
     /**
      * testCallableRuntimeException
      */
-    public function testCallableRuntimeException()
+    public function testCallableRuntimeException(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cake\Event\Decorator\ConditionDecorator the `if` condition is not a callable!');

--- a/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/SubjectFilterDecoratorTest.php
@@ -28,10 +28,8 @@ class SubjectFilterDecoratorTest extends TestCase
 {
     /**
      * testCanTrigger
-     *
-     * @return void
      */
-    public function testCanTrigger()
+    public function testCanTrigger(): void
     {
         $event = new Event('decorator.test', $this);
         $callable = function (EventInterface $event) {

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -32,8 +32,6 @@ class EventDispatcherTraitTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -44,20 +42,16 @@ class EventDispatcherTraitTest extends TestCase
 
     /**
      * testGetEventManager
-     *
-     * @return void
      */
-    public function testGetEventManager()
+    public function testGetEventManager(): void
     {
         $this->assertInstanceOf(EventManager::class, $this->subject->getEventManager());
     }
 
     /**
      * testDispatchEvent
-     *
-     * @return void
      */
-    public function testDispatchEvent()
+    public function testDispatchEvent(): void
     {
         $event = $this->subject->dispatchEvent('some.event', ['foo' => 'bar']);
 

--- a/tests/TestCase/Event/EventListTest.php
+++ b/tests/TestCase/Event/EventListTest.php
@@ -27,10 +27,8 @@ class EventListTest extends TestCase
 {
     /**
      * testAddEventAndFlush
-     *
-     * @return void
      */
-    public function testAddEventAndFlush()
+    public function testAddEventAndFlush(): void
     {
         $eventList = new EventList();
         $event = new Event('my_event', $this);
@@ -50,10 +48,8 @@ class EventListTest extends TestCase
 
     /**
      * Testing implemented \ArrayAccess and \Count methods
-     *
-     * @return void
      */
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $eventList = new EventList();
         $event = new Event('my_event', $this);

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -32,10 +32,8 @@ class EventManagerTest extends TestCase
 {
     /**
      * Test attach() with a listener interface.
-     *
-     * @return void
      */
-    public function testAttachListener()
+    public function testAttachListener(): void
     {
         $manager = new EventManager();
         $listener = new CustomTestEventListenerInterface();
@@ -48,10 +46,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Tests attached event listeners for matching key pattern
-     *
-     * @return void
      */
-    public function testMatchingListeners()
+    public function testMatchingListeners(): void
     {
         $manager = new EventManager();
         $manager->on('fake.event', 'fakeFunction1');
@@ -117,10 +113,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Test the on() method for basic callable types.
-     *
-     * @return void
      */
-    public function testOn()
+    public function testOn(): void
     {
         $count = 1;
         $manager = new EventManager();
@@ -147,10 +141,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Tests off'ing an event from a event key queue
-     *
-     * @return void
      */
-    public function testOff()
+    public function testOff(): void
     {
         $manager = new EventManager();
         $manager->on('fake.event', ['AClass', 'aMethod']);
@@ -172,13 +164,11 @@ class EventManagerTest extends TestCase
 
     /**
      * Tests off'ing an event from all event queues
-     *
-     * @return void
      */
-    public function testOffFromAll()
+    public function testOffFromAll(): void
     {
         $manager = new EventManager();
-        $callable = function () {
+        $callable = function (): void {
         };
         $manager->on('fake.event', $callable);
         $manager->on('another.event', $callable);
@@ -195,7 +185,7 @@ class EventManagerTest extends TestCase
     /**
      * Tests off'ing all listeners for an event
      */
-    public function testRemoveAllListeners()
+    public function testRemoveAllListeners(): void
     {
         $manager = new EventManager();
         $manager->on('fake.event', ['AClass', 'aMethod']);
@@ -214,10 +204,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests event dispatching
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatch()
+    public function testDispatch(): void
     {
         $manager = new EventManager();
         $listener = $this->getMockBuilder(EventTestListener::class)
@@ -235,10 +224,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Tests event dispatching using event key name
-     *
-     * @return void
      */
-    public function testDispatchWithKeyName()
+    public function testDispatchWithKeyName(): void
     {
         $manager = new EventManager();
         $listener = new EventTestListener();
@@ -253,10 +240,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests event dispatching with a return value
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatchReturnValue()
+    public function testDispatchReturnValue(): void
     {
         $manager = new EventManager();
         $listener = $this->getMockBuilder(EventTestListener::class)
@@ -281,10 +267,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests that returning false in a callback stops the event
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatchFalseStopsEvent()
+    public function testDispatchFalseStopsEvent(): void
     {
         $manager = new EventManager();
         $listener = $this->getMockBuilder(EventTestListener::class)
@@ -307,10 +292,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests event dispatching using priorities
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatchPrioritized()
+    public function testDispatchPrioritized(): void
     {
         $manager = new EventManager();
         $listener = new EventTestListener();
@@ -326,11 +310,10 @@ class EventManagerTest extends TestCase
     /**
      * Tests subscribing a listener object and firing the events it subscribed to
      *
-     * @return void
      * @triggers fake.event
      * @triggers another.event $this, array(some => data)
      */
-    public function testOnSubscriber()
+    public function testOnSubscriber(): void
     {
         $manager = new EventManager();
         /** @var \TestApp\TestCase\Event\CustomTestEventListenerInterface|\PHPUnit\Framework\MockObject\MockObject $listener */
@@ -355,10 +338,9 @@ class EventManagerTest extends TestCase
     /**
      * Test implementedEvents binding multiple callbacks to the same event name.
      *
-     * @return void
      * @triggers multiple.handlers
      */
-    public function testOnSubscriberMultiple()
+    public function testOnSubscriberMultiple(): void
     {
         $manager = new EventManager();
         $listener = $this->getMockBuilder(CustomTestEventListenerInterface::class)
@@ -377,10 +359,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Tests subscribing a listener object and firing the events it subscribed to
-     *
-     * @return void
      */
-    public function testDetachSubscriber()
+    public function testDetachSubscriber(): void
     {
         $manager = new EventManager();
         $listener = $this->getMockBuilder(CustomTestEventListenerInterface::class)
@@ -402,10 +382,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Tests that it is possible to get/set the manager singleton
-     *
-     * @return void
      */
-    public function testGlobalDispatcherGetter()
+    public function testGlobalDispatcherGetter(): void
     {
         $this->assertInstanceOf('Cake\Event\EventManager', EventManager::instance());
         $manager = new EventManager();
@@ -417,10 +395,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests that the global event manager gets the event too from any other manager
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatchWithGlobal()
+    public function testDispatchWithGlobal(): void
     {
         $generalManager = $this->getMockBuilder('Cake\Event\EventManager')
             ->onlyMethods(['prioritisedListeners'])
@@ -437,10 +414,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests that stopping an event will not notify the rest of the listeners
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testStopPropagation()
+    public function testStopPropagation(): void
     {
         $generalManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $manager = new EventManager();
@@ -466,10 +442,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests event dispatching using priorities
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatchPrioritizedWithGlobal()
+    public function testDispatchPrioritizedWithGlobal(): void
     {
         $generalManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $manager = new EventManager();
@@ -499,10 +474,9 @@ class EventManagerTest extends TestCase
     /**
      * Tests event dispatching using priorities
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testDispatchGlobalBeforeLocal()
+    public function testDispatchGlobalBeforeLocal(): void
     {
         $generalManager = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $manager = new EventManager();
@@ -531,7 +505,7 @@ class EventManagerTest extends TestCase
     /**
      * test callback
      */
-    public function onMyEvent(EventInterface $event)
+    public function onMyEvent(EventInterface $event): void
     {
         $event->setData('callback', 'ok');
     }
@@ -542,7 +516,7 @@ class EventManagerTest extends TestCase
      *
      * @triggers my_event $manager
      */
-    public function testDispatchLocalHandledByGlobal()
+    public function testDispatchLocalHandledByGlobal(): void
     {
         $callback = [$this, 'onMyEvent'];
         EventManager::instance()->on('my_event', $callback);
@@ -556,10 +530,9 @@ class EventManagerTest extends TestCase
      * Test that events are dispatched properly when there are global and local
      * listeners at the same priority.
      *
-     * @return void
      * @triggers fake.event $this
      */
-    public function testDispatchWithGlobalAndLocalEvents()
+    public function testDispatchWithGlobalAndLocalEvents(): void
     {
         $listener = new CustomTestEventListenerInterface();
         EventManager::instance()->on($listener);
@@ -575,11 +548,10 @@ class EventManagerTest extends TestCase
     /**
      * Test getting a list of dispatched events from the manager.
      *
-     * @return void
      * @triggers my_event $this
      * @triggers my_second_event $this
      */
-    public function testGetDispatchedEvents()
+    public function testGetDispatchedEvents(): void
     {
         $eventList = new EventList();
         $event = new Event('my_event', $this);
@@ -611,10 +583,9 @@ class EventManagerTest extends TestCase
     /**
      * Test that locally dispatched events are also added to the global manager's event list
      *
-     * @return void
      * @triggers Event $this
      */
-    public function testGetLocallyDispatchedEventsFromGlobal()
+    public function testGetLocallyDispatchedEventsFromGlobal(): void
     {
         $localList = new EventList();
         $globalList = new EventList();
@@ -639,10 +610,8 @@ class EventManagerTest extends TestCase
 
     /**
      * Test isTrackingEvents
-     *
-     * @return void
      */
-    public function testIsTrackingEvents()
+    public function testIsTrackingEvents(): void
     {
         $this->assertFalse(EventManager::instance()->isTrackingEvents());
 
@@ -656,7 +625,7 @@ class EventManagerTest extends TestCase
         $this->assertFalse($manager->isTrackingEvents());
     }
 
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $eventManager = new EventManager();
 
@@ -688,7 +657,7 @@ class EventManagerTest extends TestCase
 
         $eventManager->unsetEventList();
 
-        $func = function () {
+        $func = function (): void {
         };
         $eventManager->on('foo', $func);
 
@@ -720,13 +689,13 @@ class EventManagerTest extends TestCase
             $eventManager->__debugInfo()
         );
 
-        $eventManager->on('bar', function () {
+        $eventManager->on('bar', function (): void {
         });
-        $eventManager->on('bar', function () {
+        $eventManager->on('bar', function (): void {
         });
-        $eventManager->on('bar', function () {
+        $eventManager->on('bar', function (): void {
         });
-        $eventManager->on('baz', function () {
+        $eventManager->on('baz', function (): void {
         });
 
         $this->assertSame(
@@ -747,15 +716,13 @@ class EventManagerTest extends TestCase
 
     /**
      * test debugInfo with an event list.
-     *
-     * @return void
      */
-    public function testDebugInfoEventList()
+    public function testDebugInfoEventList(): void
     {
         $eventList = new EventList();
         $eventManager = new EventManager();
         $eventManager->setEventList($eventList);
-        $eventManager->on('example', function () {
+        $eventManager->on('example', function (): void {
         });
         $eventManager->dispatch('example');
 
@@ -777,15 +744,13 @@ class EventManagerTest extends TestCase
 
     /**
      * Test that chainable methods return correct values.
-     *
-     * @return void
      */
-    public function testChainableMethods()
+    public function testChainableMethods(): void
     {
         $eventManager = new EventManager();
 
         $listener = $this->createMock(EventListenerInterface::class);
-        $callable = function () {
+        $callable = function (): void {
         };
 
         $returnValue = $eventManager->on($listener);

--- a/tests/TestCase/Event/EventTest.php
+++ b/tests/TestCase/Event/EventTest.php
@@ -33,10 +33,9 @@ class EventTest extends TestCase
     /**
      * Tests the name() method
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testName()
+    public function testName(): void
     {
         $event = new Event('fake.event');
         $this->assertSame('fake.event', $event->getName());
@@ -45,11 +44,10 @@ class EventTest extends TestCase
     /**
      * Tests the subject() method
      *
-     * @return void
      * @triggers fake.event $this
      * @triggers fake.event
      */
-    public function testSubject()
+    public function testSubject(): void
     {
         $event = new Event('fake.event', $this);
         $this->assertSame($this, $event->getSubject());
@@ -64,10 +62,9 @@ class EventTest extends TestCase
     /**
      * Tests the event propagation stopping property
      *
-     * @return void
      * @triggers fake.event
      */
-    public function testPropagation()
+    public function testPropagation(): void
     {
         $event = new Event('fake.event');
         $this->assertFalse($event->isStopped());
@@ -78,10 +75,9 @@ class EventTest extends TestCase
     /**
      * Tests that it is possible to get/set custom data in a event
      *
-     * @return void
      * @triggers fake.event $this, array('some' => 'data')
      */
-    public function testEventData()
+    public function testEventData(): void
     {
         $event = new Event('fake.event', $this, ['some' => 'data']);
         $this->assertEquals(['some' => 'data'], $event->getData());
@@ -93,10 +89,9 @@ class EventTest extends TestCase
     /**
      * Tests that it is possible to get/set custom data in a event
      *
-     * @return void
      * @triggers fake.event $this, array('some' => 'data')
      */
-    public function testEventDataObject()
+    public function testEventDataObject(): void
     {
         $data = new ArrayObject(['some' => 'data']);
         $event = new Event('fake.event', $this, $data);
@@ -109,10 +104,9 @@ class EventTest extends TestCase
     /**
      * Tests that it is possible to get the name and subject directly
      *
-     * @return void
      * @triggers fake.event $this
      */
-    public function testEventDirectPropertyAccess()
+    public function testEventDirectPropertyAccess(): void
     {
         $event = new Event('fake.event', $this);
         $this->assertEquals($this, $event->getSubject());

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -36,9 +36,8 @@ class ExceptionsTest extends TestCase
      * @dataProvider exceptionProvider
      * @param string $class The exception class name
      * @param int $defaultCode The default exception code
-     * @return void
      */
-    public function testSimpleException($class, $defaultCode)
+    public function testSimpleException($class, $defaultCode): void
     {
         $previous = new Exception();
 
@@ -56,10 +55,8 @@ class ExceptionsTest extends TestCase
 
     /**
      * Tests FatalErrorException works.
-     *
-     * @return void
      */
-    public function testFatalErrorException()
+    public function testFatalErrorException(): void
     {
         $previous = new Exception();
 
@@ -73,10 +70,8 @@ class ExceptionsTest extends TestCase
 
     /**
      * Tests PersistenceFailedException works.
-     *
-     * @return void
      */
-    public function testPersistenceFailedException()
+    public function testPersistenceFailedException(): void
     {
         $previous = new Exception();
         $entity = new Entity();
@@ -90,10 +85,8 @@ class ExceptionsTest extends TestCase
 
     /**
      * Test the template exceptions
-     *
-     * @return void
      */
-    public function testMissingTemplateExceptions()
+    public function testMissingTemplateExceptions(): void
     {
         $previous = new Exception();
 

--- a/tests/TestCase/Filesystem/FileTest.php
+++ b/tests/TestCase/Filesystem/FileTest.php
@@ -35,8 +35,6 @@ class FileTest extends TestCase
 
     /**
      * setup the test case
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class FileTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -62,10 +58,8 @@ class FileTest extends TestCase
 
     /**
      * testBasic method
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $file = CORE_PATH . DS . 'LICENSE';
 
@@ -128,9 +122,8 @@ class FileTest extends TestCase
      * testUtf8Filenames
      *
      * @link https://github.com/cakephp/cakephp/issues/11749
-     * @return void
      */
-    public function testUtf8Filenames()
+    public function testUtf8Filenames(): void
     {
         $File = new File(TMP . 'tests/permissions/نام فارسی.php', true);
         $this->assertSame('نام فارسی', $File->name());
@@ -142,9 +135,8 @@ class FileTest extends TestCase
      * Test _basename method
      *
      * @dataProvider baseNameValueProvider
-     * @return void
      */
-    public function testBasename(string $path, ?string $suffix, bool $isRoot)
+    public function testBasename(string $path, ?string $suffix, bool $isRoot): void
     {
         if (!$isRoot) {
             $path = TMP . 'tests/permissions' . $path;
@@ -207,10 +199,8 @@ class FileTest extends TestCase
 
     /**
      * testPermission method
-     *
-     * @return void
      */
-    public function testPermission()
+    public function testPermission(): void
     {
         $this->skipIf(DS === '\\', 'File permissions tests not supported on Windows.');
 
@@ -254,10 +244,8 @@ class FileTest extends TestCase
 
     /**
      * testRead method
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $file = __FILE__;
         $this->File = new File($file);
@@ -286,10 +274,8 @@ class FileTest extends TestCase
 
     /**
      * testOffset method
-     *
-     * @return void
      */
-    public function testOffset()
+    public function testOffset(): void
     {
         $this->File->close();
 
@@ -319,10 +305,8 @@ class FileTest extends TestCase
 
     /**
      * testOpen method
-     *
-     * @return void
      */
-    public function testOpen()
+    public function testOpen(): void
     {
         $this->File->handle = null;
 
@@ -344,10 +328,8 @@ class FileTest extends TestCase
 
     /**
      * testClose method
-     *
-     * @return void
      */
-    public function testClose()
+    public function testClose(): void
     {
         $this->File->handle = null;
         $this->assertNull($this->File->handle);
@@ -362,10 +344,8 @@ class FileTest extends TestCase
 
     /**
      * testCreate method
-     *
-     * @return void
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $tmpFile = TMP . 'tests/cakephp.file.test.tmp';
         $File = new File($tmpFile, true, 0777);
@@ -374,10 +354,8 @@ class FileTest extends TestCase
 
     /**
      * Tests the exists() method.
-     *
-     * @return void
      */
-    public function testExists()
+    public function testExists(): void
     {
         $tmpFile = TMP . 'tests/cakephp.file.test.tmp';
         $file = new File($tmpFile, true, 0777);
@@ -392,10 +370,8 @@ class FileTest extends TestCase
 
     /**
      * testOpeningNonExistentFileCreatesIt method
-     *
-     * @return void
      */
-    public function testOpeningNonExistentFileCreatesIt()
+    public function testOpeningNonExistentFileCreatesIt(): void
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertTrue($someFile->open());
@@ -406,10 +382,8 @@ class FileTest extends TestCase
 
     /**
      * testPrepare method
-     *
-     * @return void
      */
-    public function testPrepare()
+    public function testPrepare(): void
     {
         $string = "some\nvery\ncool\r\nteststring here\n\n\nfor\r\r\n\n\r\n\nhere";
         if (DS === '\\') {
@@ -427,10 +401,8 @@ class FileTest extends TestCase
 
     /**
      * testReadable method
-     *
-     * @return void
      */
-    public function testReadable()
+    public function testReadable(): void
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertTrue($someFile->open());
@@ -441,10 +413,8 @@ class FileTest extends TestCase
 
     /**
      * testWritable method
-     *
-     * @return void
      */
-    public function testWritable()
+    public function testWritable(): void
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertTrue($someFile->open());
@@ -455,10 +425,8 @@ class FileTest extends TestCase
 
     /**
      * testExecutable method
-     *
-     * @return void
      */
-    public function testExecutable()
+    public function testExecutable(): void
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertTrue($someFile->open());
@@ -469,10 +437,8 @@ class FileTest extends TestCase
 
     /**
      * testLastAccess method
-     *
-     * @return void
      */
-    public function testLastAccess()
+    public function testLastAccess(): void
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertFalse($someFile->lastAccess());
@@ -484,10 +450,8 @@ class FileTest extends TestCase
 
     /**
      * testLastChange method
-     *
-     * @return void
      */
-    public function testLastChange()
+    public function testLastChange(): void
     {
         $someFile = new File(TMP . 'some_file.txt', false);
         $this->assertFalse($someFile->lastChange());
@@ -503,10 +467,8 @@ class FileTest extends TestCase
 
     /**
      * testWrite method
-     *
-     * @return void
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $tmpFile = $this->_getTmpFile();
         if (file_exists($tmpFile)) {
@@ -531,10 +493,8 @@ class FileTest extends TestCase
 
     /**
      * testAppend method
-     *
-     * @return void
      */
-    public function testAppend()
+    public function testAppend(): void
     {
         $tmpFile = $this->_getTmpFile();
         if (file_exists($tmpFile)) {
@@ -566,10 +526,8 @@ class FileTest extends TestCase
 
     /**
      * testDelete method
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $tmpFile = $this->_getTmpFile();
         if (!file_exists($tmpFile)) {
@@ -591,10 +549,8 @@ class FileTest extends TestCase
     /**
      * Windows has issues unlinking files if there are
      * active filehandles open.
-     *
-     * @return void
      */
-    public function testDeleteAfterRead()
+    public function testDeleteAfterRead(): void
     {
         $tmpFile = $this->_getTmpFile();
         if (!file_exists($tmpFile)) {
@@ -607,10 +563,8 @@ class FileTest extends TestCase
 
     /**
      * testCopy method
-     *
-     * @return void
      */
-    public function testCopy()
+    public function testCopy(): void
     {
         $dest = TMP . 'tests/cakephp.file.test.tmp';
         $file = __FILE__;
@@ -636,10 +590,8 @@ class FileTest extends TestCase
 
     /**
      * Test mime()
-     *
-     * @return void
      */
-    public function testMime()
+    public function testMime(): void
     {
         $this->skipIf(!function_exists('finfo_open') && !function_exists('mime_content_type'), 'Not able to read mime type');
         $path = TEST_APP . 'webroot/img/cake.power.gif';
@@ -653,10 +605,8 @@ class FileTest extends TestCase
 
     /**
      * getTmpFile method
-     *
-     * @return string
      */
-    protected function _getTmpFile()
+    protected function _getTmpFile(): string
     {
         $tmpFile = TMP . 'tests/cakephp.file.test.tmp';
         if (is_writable(dirname($tmpFile)) && (!file_exists($tmpFile) || is_writable($tmpFile))) {
@@ -673,10 +623,8 @@ class FileTest extends TestCase
 
     /**
      * testReplaceText method
-     *
-     * @return void
      */
-    public function testReplaceText()
+    public function testReplaceText(): void
     {
         $TestFile = new File(TEST_APP . 'vendor/welcome.php');
         $TmpFile = new File(TMP . 'tests' . DS . 'cakephp.file.test.tmp');
@@ -711,10 +659,8 @@ class FileTest extends TestCase
     /**
      * Tests that no path is being set for passed file paths that
      * do not exist.
-     *
-     * @return void
      */
-    public function testNoPartialPathBeingSetForNonExistentPath()
+    public function testNoPartialPathBeingSetForNonExistentPath(): void
     {
         $TmpFile = new File('/non/existent/file');
         $this->assertNull($TmpFile->pwd());

--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -33,9 +33,6 @@ class FilesystemTest extends TestCase
 
     protected $vfsPath;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -49,10 +46,9 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @return void
      * @covers ::mkdir
      */
-    public function testMkdir()
+    public function testMkdir(): void
     {
         $path = $this->vfsPath . DS . 'tests' . DS . 'first' . DS . 'second' . DS . 'third';
         $this->fs->mkdir($path);
@@ -60,10 +56,9 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @return void
      * @covers ::dumpFile
      */
-    public function testDumpFile()
+    public function testDumpFile(): void
     {
         $path = $this->vfsPath . DS . 'foo.txt';
 
@@ -76,10 +71,9 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @return void
      * @covers ::copyDir
      */
-    public function testCopyDir()
+    public function testCopyDir(): void
     {
         $return = $this->fs->copyDir(WWW_ROOT, $this->vfsPath . DS . 'dest');
 
@@ -87,10 +81,9 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @return void
      * @covers ::deleteDir
      */
-    public function testDeleteDir()
+    public function testDeleteDir(): void
     {
         $structure = [
             'Core' => [
@@ -112,10 +105,8 @@ class FilesystemTest extends TestCase
 
     /**
      * Tests deleteDir() on directory that contains symlinks
-     *
-     * @return void
      */
-    public function testDeleteDirWithLinks()
+    public function testDeleteDirWithLinks(): void
     {
         $path = TMP . 'fs_links_test';
         // phpcs:ignore

--- a/tests/TestCase/Filesystem/FolderTest.php
+++ b/tests/TestCase/Filesystem/FolderTest.php
@@ -29,8 +29,6 @@ class FolderTest extends TestCase
 {
     /**
      * setUp clearstatcache() to flush file descriptors.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -40,13 +38,11 @@ class FolderTest extends TestCase
 
     /**
      * Remove TMP/tests directory to its original state.
-     *
-     * @return void
      */
     public function tearDown(): void
     {
         parent::tearDown();
-        $cleaner = function ($dir) use (&$cleaner) {
+        $cleaner = function ($dir) use (&$cleaner): void {
             $files = array_diff(scandir($dir), ['.', '..']);
             foreach ($files as $file) {
                 $path = $dir . DS . $file;
@@ -66,10 +62,8 @@ class FolderTest extends TestCase
 
     /**
      * testBasic method
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $path = __DIR__;
         $Folder = new Folder($path);
@@ -91,10 +85,8 @@ class FolderTest extends TestCase
 
     /**
      * testInPath method
-     *
-     * @return void
      */
-    public function testInPath()
+    public function testInPath(): void
     {
         // "/tests/test_app/"
         $basePath = TEST_APP;
@@ -172,7 +164,7 @@ class FolderTest extends TestCase
      * @dataProvider inPathInvalidPathArgumentDataProvider
      * @param string $path
      */
-    public function testInPathInvalidPathArgument($path)
+    public function testInPathInvalidPathArgument($path): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The $path argument is expected to be an absolute path.');
@@ -182,10 +174,8 @@ class FolderTest extends TestCase
 
     /**
      * test creation of single and multiple paths.
-     *
-     * @return void
      */
-    public function testCreation()
+    public function testCreation(): void
     {
         $Folder = new Folder(TMP . 'tests');
         $result = $Folder->create(TMP . 'tests' . DS . 'first' . DS . 'second' . DS . 'third');
@@ -202,10 +192,8 @@ class FolderTest extends TestCase
 
     /**
      * test that creation of folders with trailing ds works
-     *
-     * @return void
      */
-    public function testCreateWithTrailingDs()
+    public function testCreateWithTrailingDs(): void
     {
         $Folder = new Folder(TMP . 'tests');
         $path = TMP . 'tests' . DS . 'trailing' . DS . 'dir' . DS;
@@ -220,10 +208,8 @@ class FolderTest extends TestCase
 
     /**
      * Test that relative paths to create() are added to cwd.
-     *
-     * @return void
      */
-    public function testCreateRelative()
+    public function testCreateRelative(): void
     {
         $folder = new Folder(TMP);
         $path = TMP . 'tests' . DS . 'relative-test';
@@ -237,10 +223,8 @@ class FolderTest extends TestCase
 
     /**
      * test recursive directory create failure.
-     *
-     * @return void
      */
-    public function testRecursiveCreateFailure()
+    public function testRecursiveCreateFailure(): void
     {
         $this->skipIf(DS === '\\', 'Cant perform operations using permissions on windows.');
 
@@ -262,10 +246,8 @@ class FolderTest extends TestCase
 
     /**
      * testOperations method
-     *
-     * @return void
      */
-    public function testOperations()
+    public function testOperations(): void
     {
         $path = ROOT . DS . 'templates';
         $Folder = new Folder($path);
@@ -334,10 +316,8 @@ class FolderTest extends TestCase
 
     /**
      * testChmod method
-     *
-     * @return void
      */
-    public function testChmod()
+    public function testChmod(): void
     {
         $this->skipIf(DS === '\\', 'Folder permissions tests not supported on Windows.');
 
@@ -374,10 +354,8 @@ class FolderTest extends TestCase
 
     /**
      * testRealPathForWebroot method
-     *
-     * @return void
      */
-    public function testRealPathForWebroot()
+    public function testRealPathForWebroot(): void
     {
         $Folder = new Folder('files' . DS);
         $this->assertEquals(realpath('files' . DS), $Folder->path);
@@ -385,10 +363,8 @@ class FolderTest extends TestCase
 
     /**
      * testZeroAsDirectory method
-     *
-     * @return void
      */
-    public function testZeroAsDirectory()
+    public function testZeroAsDirectory(): void
     {
         $path = TMP . 'tests';
         $Folder = new Folder($path, true);
@@ -407,10 +383,8 @@ class FolderTest extends TestCase
 
     /**
      * test Adding path elements to a path
-     *
-     * @return void
      */
-    public function testAddPathElement()
+    public function testAddPathElement(): void
     {
         $expected = DS . 'some' . DS . 'dir' . DS . 'another_path';
 
@@ -434,10 +408,8 @@ class FolderTest extends TestCase
 
     /**
      * testFolderRead method
-     *
-     * @return void
      */
-    public function testFolderRead()
+    public function testFolderRead(): void
     {
         $Folder = new Folder(CAKE);
 
@@ -453,10 +425,8 @@ class FolderTest extends TestCase
 
     /**
      * testFolderReadWithHiddenFiles method
-     *
-     * @return void
      */
-    public function testFolderReadWithHiddenFiles()
+    public function testFolderReadWithHiddenFiles(): void
     {
         $this->skipIf(!is_writable(TMP), 'Cant test Folder::read with hidden files unless the tmp folder is writable.');
         $path = TMP . 'tests' . DS;
@@ -490,10 +460,8 @@ class FolderTest extends TestCase
 
     /**
      * testFolderSubdirectories method
-     *
-     * @return void
      */
-    public function testFolderSubdirectories()
+    public function testFolderSubdirectories(): void
     {
         $path = CAKE . 'Http';
         $folder = new Folder($path);
@@ -531,10 +499,8 @@ class FolderTest extends TestCase
 
     /**
      * testFolderTree method
-     *
-     * @return void
      */
-    public function testFolderTree()
+    public function testFolderTree(): void
     {
         $Folder = new Folder();
         $expected = [
@@ -561,10 +527,8 @@ class FolderTest extends TestCase
 
     /**
      * testFolderTreeWithHiddenFiles method
-     *
-     * @return void
      */
-    public function testFolderTreeWithHiddenFiles()
+    public function testFolderTreeWithHiddenFiles(): void
     {
         $this->skipIf(!is_writable(TMP), 'Can\'t test Folder::tree with hidden files unless the tmp folder is writable.');
         $path = TMP . 'tests' . DS;
@@ -622,10 +586,8 @@ class FolderTest extends TestCase
 
     /**
      * testWindowsPath method
-     *
-     * @return void
      */
-    public function testWindowsPath()
+    public function testWindowsPath(): void
     {
         $this->assertFalse(Folder::isWindowsPath('0:\\cake\\is\\awesome'));
         $this->assertTrue(Folder::isWindowsPath('C:\\cake\\is\\awesome'));
@@ -635,10 +597,8 @@ class FolderTest extends TestCase
 
     /**
      * testIsAbsolute method
-     *
-     * @return void
      */
-    public function testIsAbsolute()
+    public function testIsAbsolute(): void
     {
         $this->assertFalse(Folder::isAbsolute('path/to/file'));
         $this->assertFalse(Folder::isAbsolute('cake/'));
@@ -660,10 +620,8 @@ class FolderTest extends TestCase
 
     /**
      * testIsSlashTerm method
-     *
-     * @return void
      */
-    public function testIsSlashTerm()
+    public function testIsSlashTerm(): void
     {
         $this->assertFalse(Folder::isSlashTerm('cake'));
 
@@ -673,10 +631,8 @@ class FolderTest extends TestCase
 
     /**
      * testStatic method
-     *
-     * @return void
      */
-    public function testSlashTerm()
+    public function testSlashTerm(): void
     {
         $result = Folder::slashTerm('/path/to/file');
         $this->assertSame('/path/to/file/', $result);
@@ -684,10 +640,8 @@ class FolderTest extends TestCase
 
     /**
      * testNormalizeFullPath method
-     *
-     * @return void
      */
-    public function testNormalizeFullPath()
+    public function testNormalizeFullPath(): void
     {
         $path = '/path/to\file';
         $expected = '/path/to/file';
@@ -707,10 +661,8 @@ class FolderTest extends TestCase
 
     /**
      * correctSlashFor method
-     *
-     * @return void
      */
-    public function testCorrectSlashFor()
+    public function testCorrectSlashFor(): void
     {
         $path = '/path/to/file';
         $result = Folder::correctSlashFor($path);
@@ -727,10 +679,8 @@ class FolderTest extends TestCase
 
     /**
      * testFind method
-     *
-     * @return void
      */
-    public function testFind()
+    public function testFind(): void
     {
         $Folder = new Folder();
         $Folder->cd(CORE_PATH . 'config');
@@ -776,10 +726,8 @@ class FolderTest extends TestCase
 
     /**
      * testFindRecursive method
-     *
-     * @return void
      */
-    public function testFindRecursive()
+    public function testFindRecursive(): void
     {
         $Folder = new Folder(CORE_PATH . 'config');
         $result = $Folder->findRecursive('(config|paths)\.php');
@@ -832,10 +780,8 @@ class FolderTest extends TestCase
 
     /**
      * testConstructWithNonExistentPath method
-     *
-     * @return void
      */
-    public function testConstructWithNonExistentPath()
+    public function testConstructWithNonExistentPath(): void
     {
         $path = TMP . 'tests' . DS;
         $Folder = new Folder($path . 'config_nonexistent', true);
@@ -845,10 +791,8 @@ class FolderTest extends TestCase
 
     /**
      * testDirSize method
-     *
-     * @return void
      */
-    public function testDirSize()
+    public function testDirSize(): void
     {
         $path = TMP . 'tests' . DS;
         $Folder = new Folder($path . 'config_nonexistent', true);
@@ -863,10 +807,8 @@ class FolderTest extends TestCase
 
     /**
      * test that errors and messages can be restarted
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         $path = TMP . 'tests' . DS . 'folder_delete_test';
         mkdir($path, 0777, true);
@@ -913,10 +855,8 @@ class FolderTest extends TestCase
 
     /**
      * testDelete method
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $path = TMP . 'tests' . DS . 'folder_delete_test';
         mkdir($path, 0777, true);
@@ -956,10 +896,8 @@ class FolderTest extends TestCase
      *
      * Verify that subdirectories existing in both destination and source directory
      * are merged recursively.
-     *
-     * @return void
      */
-    public function testCopy()
+    public function testCopy(): void
     {
         // phpcs:disable
         /**
@@ -1000,10 +938,8 @@ class FolderTest extends TestCase
      *
      * Verify that subdirectories existing in both destination and source directory
      * are merged recursively.
-     *
-     * @return void
      */
-    public function testCopyWithMerge()
+    public function testCopyWithMerge(): void
     {
         // phpcs:disable
         /**
@@ -1043,10 +979,8 @@ class FolderTest extends TestCase
      * even if the destination directory already exists.
      * Subdirectories existing in both destination and source directory
      * are skipped and not merged or overwritten.
-     *
-     * @return void
      */
-    public function testCopyWithSkip()
+    public function testCopyWithSkip(): void
     {
         // phpcs:disable
         /**
@@ -1097,10 +1031,8 @@ class FolderTest extends TestCase
 
     /**
      * Test that SKIP mode skips files too.
-     *
-     * @return void
      */
-    public function testCopyWithSkipFileSkipped()
+    public function testCopyWithSkipFileSkipped(): void
     {
         $path = TMP . 'folder_test';
         $folderOne = $path . DS . 'folder1';
@@ -1123,10 +1055,8 @@ class FolderTest extends TestCase
      *
      * Verify that subdirectories existing in both destination and source directory
      * are overwritten/replaced recursively.
-     *
-     * @return void
      */
-    public function testCopyWithOverwrite()
+    public function testCopyWithOverwrite(): void
     {
         // phpcs:disable
         /**
@@ -1171,10 +1101,8 @@ class FolderTest extends TestCase
      * testCopyWithoutRecursive
      *
      * Verify that only the files exist in the target directory.
-     *
-     * @return void
      */
-    public function testCopyWithoutRecursive()
+    public function testCopyWithoutRecursive(): void
     {
         // phpcs:disable
         /**
@@ -1212,7 +1140,7 @@ class FolderTest extends TestCase
      *
      * @return array Filenames to extract in the test methods
      */
-    protected function _setupFilesystem()
+    protected function _setupFilesystem(): array
     {
         $path = TMP . 'tests';
 
@@ -1259,10 +1187,8 @@ class FolderTest extends TestCase
      * even if the destination directory already exists.
      * Subdirectories existing in both destination and source directory
      * are merged recursively.
-     *
-     * @return void
      */
-    public function testMove()
+    public function testMove(): void
     {
         // phpcs:disable
         /**
@@ -1342,10 +1268,8 @@ class FolderTest extends TestCase
      * even if the destination directory already exists.
      * Subdirectories existing in both destination and source directory
      * are skipped and not merged or overwritten.
-     *
-     * @return void
      */
-    public function testMoveWithSkip()
+    public function testMoveWithSkip(): void
     {
         // phpcs:disable
         /**
@@ -1416,7 +1340,7 @@ class FolderTest extends TestCase
         $Folder->delete();
     }
 
-    public function testMoveWithoutRecursive()
+    public function testMoveWithoutRecursive(): void
     {
         // phpcs:disable
         /**
@@ -1446,10 +1370,8 @@ class FolderTest extends TestCase
      * testSortByTime method
      *
      * Verify that the order using modified time is correct.
-     *
-     * @return void
      */
-    public function testSortByTime()
+    public function testSortByTime(): void
     {
         $Folder = new Folder(TMP . 'tests', true);
 
@@ -1469,7 +1391,7 @@ class FolderTest extends TestCase
     /**
      * Verify that the order using name is correct.
      */
-    public function testSortByName()
+    public function testSortByName(): void
     {
         $Folder = new Folder(TMP . 'tests', true);
 
@@ -1491,10 +1413,8 @@ class FolderTest extends TestCase
 
     /**
      * testIsRegisteredStreamWrapper
-     *
-     * @return void
      */
-    public function testIsRegisteredStreamWrapper()
+    public function testIsRegisteredStreamWrapper(): void
     {
         foreach (stream_get_wrappers() as $wrapper) {
             $this->assertTrue(Folder::isRegisteredStreamWrapper($wrapper . '://path/to/file'));

--- a/tests/TestCase/Form/FormProtectorTest.php
+++ b/tests/TestCase/Form/FormProtectorTest.php
@@ -50,9 +50,8 @@ class FormProtectorTest extends TestCase
      *
      * @param array $data
      * @param string|null $errorMessage
-     * @return void
      */
-    public function validate($data, $errorMessage = null)
+    public function validate($data, $errorMessage = null): void
     {
         $protector = new FormProtector();
         $result = $protector->validate($data, $this->url, $this->sessionId);
@@ -69,8 +68,6 @@ class FormProtectorTest extends TestCase
      * testValidate method
      *
      * Simple hash validation test
-     *
-     * @return void
      */
     public function testValidate(): void
     {
@@ -89,8 +86,6 @@ class FormProtectorTest extends TestCase
      * testValidateNoUnlockedInRequestData method
      *
      * Test that validate fails if you are missing unlocked in request data.
-     *
-     * @return void
      */
     public function testValidateNoUnlockedInRequestData(): void
     {
@@ -108,8 +103,6 @@ class FormProtectorTest extends TestCase
      * testValidateFormHacking method
      *
      * Test that validate fails if any of its required fields are missing.
-     *
-     * @return void
      */
     public function testValidateFormHacking(): void
     {
@@ -127,8 +120,6 @@ class FormProtectorTest extends TestCase
      * testValidateEmptyForm method
      *
      * Test that validate fails if empty form is submitted.
-     *
-     * @return void
      */
     public function testValidateEmptyForm(): void
     {
@@ -139,8 +130,6 @@ class FormProtectorTest extends TestCase
      * testValidate array fields method
      *
      * Test that validate fails if empty form is submitted.
-     *
-     * @return void
      */
     public function testValidateInvalidFields(): void
     {
@@ -159,8 +148,6 @@ class FormProtectorTest extends TestCase
      *
      * Test that objects can't be passed into the serialized string. This was a vector for RFI and LFI
      * attacks. Thanks to Felix Wilhelm
-     *
-     * @return void
      */
     public function testValidateObjectDeserialize(): void
     {
@@ -190,8 +177,6 @@ class FormProtectorTest extends TestCase
      * testValidateArray method
      *
      * Tests validation of checkbox arrays.
-     *
-     * @return void
      */
     public function testValidateArray(): void
     {
@@ -220,8 +205,6 @@ class FormProtectorTest extends TestCase
      * testValidateIntFieldName method
      *
      * Tests validation of integer field names.
-     *
-     * @return void
      */
     public function testValidateIntFieldName(): void
     {
@@ -242,8 +225,6 @@ class FormProtectorTest extends TestCase
 
     /**
      * testValidateNoModel method
-     *
-     * @return void
      */
     public function testValidateNoModel(): void
     {
@@ -261,8 +242,6 @@ class FormProtectorTest extends TestCase
 
     /**
      * test validate uses full URL
-     *
-     * @return void
      */
     public function testValidateSubdirectory(): void
     {
@@ -284,8 +263,6 @@ class FormProtectorTest extends TestCase
      * testValidateComplex method
      *
      * Tests hash validation for multiple records, including locked fields.
-     *
-     * @return void
      */
     public function testValidateComplex(): void
     {
@@ -313,8 +290,6 @@ class FormProtectorTest extends TestCase
      * testValidateMultipleSelect method
      *
      * Test ValidatePost with multiple select elements.
-     *
-     * @return void
      */
     public function testValidateMultipleSelect(): void
     {
@@ -354,8 +329,6 @@ class FormProtectorTest extends TestCase
      *
      * First block tests un-checked checkbox
      * Second block tests checked checkbox
-     *
-     * @return void
      */
     public function testValidateCheckbox(): void
     {
@@ -386,8 +359,6 @@ class FormProtectorTest extends TestCase
 
     /**
      * testValidateHidden method
-     *
-     * @return void
      */
     public function testValidateHidden(): void
     {
@@ -409,8 +380,6 @@ class FormProtectorTest extends TestCase
      * testValidateDisabledFieldsInData method
      *
      * Test validating post data with posted unlocked fields.
-     *
-     * @return void
      */
     public function testValidateDisabledFieldsInData(): void
     {
@@ -437,8 +406,6 @@ class FormProtectorTest extends TestCase
      * testValidateFailNoDisabled method
      *
      * Test that missing 'unlocked' input causes failure.
-     *
-     * @return void
      */
     public function testValidateFailNoDisabled(): void
     {
@@ -461,8 +428,6 @@ class FormProtectorTest extends TestCase
      * testValidateFailNoDebug method
      *
      * Test that missing 'debug' input causes failure.
-     *
-     * @return void
      */
     public function testValidateFailNoDebug(): void
     {
@@ -486,8 +451,6 @@ class FormProtectorTest extends TestCase
      * testValidateFailNoDebugMode method
      *
      * Test that missing 'debug' input is not the problem when debug mode disabled.
-     *
-     * @return void
      */
     public function testValidateFailNoDebugMode(): void
     {
@@ -513,8 +476,6 @@ class FormProtectorTest extends TestCase
      * testValidateFailDisabledFieldTampering method
      *
      * Test that validate fails when unlocked fields are changed.
-     *
-     * @return void
      */
     public function testValidateFailDisabledFieldTampering(): void
     {
@@ -544,8 +505,6 @@ class FormProtectorTest extends TestCase
 
     /**
      * testValidateHiddenMultipleModel method
-     *
-     * @return void
      */
     public function testValidateHiddenMultipleModel(): void
     {
@@ -564,8 +523,6 @@ class FormProtectorTest extends TestCase
 
     /**
      * testValidateHasManyModel method
-     *
-     * @return void
      */
     public function testValidateHasManyModel(): void
     {
@@ -593,8 +550,6 @@ class FormProtectorTest extends TestCase
 
     /**
      * testValidateHasManyRecordsPass method
-     *
-     * @return void
      */
     public function testValidateHasManyRecordsPass(): void
     {
@@ -636,8 +591,6 @@ class FormProtectorTest extends TestCase
      * testValidateHasManyRecords method
      *
      * validate should fail, hidden fields have been changed.
-     *
-     * @return void
      */
     public function testValidateHasManyRecordsFail(): void
     {
@@ -703,7 +656,6 @@ class FormProtectorTest extends TestCase
      *
      * Test validate with radio buttons.
      *
-     * @return void
      * @triggers Controller.startup $this->Controller
      */
     public function testValidateRadio(): void
@@ -746,8 +698,6 @@ class FormProtectorTest extends TestCase
      * testValidateUrlAsHashInput method
      *
      * Test validate uses here() as a hash input.
-     *
-     * @return void
      */
     public function testValidateUrlAsHashInput(): void
     {
@@ -782,8 +732,6 @@ class FormProtectorTest extends TestCase
      * testValidateDebugFormat method
      *
      * Test that debug token format is right.
-     *
-     * @return void
      */
     public function testValidateDebugFormat(): void
     {
@@ -816,8 +764,6 @@ class FormProtectorTest extends TestCase
      * testValidateFailTampering method
      *
      * Test that validate fails with tampered fields and explanation.
-     *
-     * @return void
      */
     public function testValidateFailTampering(): void
     {
@@ -845,8 +791,6 @@ class FormProtectorTest extends TestCase
      * testValidateFailTamperingMutatedIntoArray method
      *
      * Test that validate fails with tampered fields and explanation.
-     *
-     * @return void
      */
     public function testValidateFailTamperingMutatedIntoArray(): void
     {
@@ -877,8 +821,6 @@ class FormProtectorTest extends TestCase
      * testValidateUnexpectedDebugToken method
      *
      * Test that debug token should not be sent if debug is disabled.
-     *
-     * @return void
      */
     public function testValidateUnexpectedDebugToken(): void
     {

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -32,11 +32,10 @@ class FormTest extends TestCase
      * Test schema()
      *
      * @group deprecated
-     * @return void
      */
-    public function testSchema()
+    public function testSchema(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $form = new Form();
             $schema = $form->schema();
 
@@ -54,10 +53,8 @@ class FormTest extends TestCase
 
     /**
      * Test setSchema() and getSchema()
-     *
-     * @return void
      */
-    public function testSetGetSchema()
+    public function testSetGetSchema(): void
     {
         $form = new Form();
         $schema = $form->getSchema();
@@ -75,10 +72,8 @@ class FormTest extends TestCase
 
     /**
      * Test getValidator()
-     *
-     * @return void
      */
-    public function testGetValidator()
+    public function testGetValidator(): void
     {
         $form = $this->getMockBuilder(Form::class)
             ->addMethods(['buildValidator'])
@@ -92,10 +87,8 @@ class FormTest extends TestCase
 
     /**
      * Test setValidator()
-     *
-     * @return void
      */
-    public function testSetValidator()
+    public function testSetValidator(): void
     {
         $form = new Form();
         $validator = new Validator();
@@ -106,10 +99,8 @@ class FormTest extends TestCase
 
     /**
      * Test validate method.
-     *
-     * @return void
      */
-    public function testValidate()
+    public function testValidate(): void
     {
         $form = new Form();
         $form->getValidator()
@@ -133,10 +124,8 @@ class FormTest extends TestCase
 
     /**
      * Test the get errors methods.
-     *
-     * @return void
      */
-    public function testGetErrors()
+    public function testGetErrors(): void
     {
         $form = new Form();
         $form->getValidator()
@@ -162,10 +151,8 @@ class FormTest extends TestCase
 
     /**
      * Test setErrors()
-     *
-     * @return void
      */
-    public function testSetErrors()
+    public function testSetErrors(): void
     {
         $form = new Form();
         $expected = [
@@ -178,10 +165,8 @@ class FormTest extends TestCase
 
     /**
      * Test _execute is skipped on validation failure.
-     *
-     * @return void
      */
-    public function testExecuteInvalid()
+    public function testExecuteInvalid(): void
     {
         $form = $this->getMockBuilder('Cake\Form\Form')
             ->onlyMethods(['_execute'])
@@ -199,10 +184,8 @@ class FormTest extends TestCase
 
     /**
      * test execute() when data is valid.
-     *
-     * @return void
      */
-    public function testExecuteValid()
+    public function testExecuteValid(): void
     {
         $form = new Form();
         $form->getValidator()
@@ -216,10 +199,8 @@ class FormTest extends TestCase
 
     /**
      * Test set() with one param.
-     *
-     * @return void
      */
-    public function testSetOneParam()
+    public function testSetOneParam(): void
     {
         $form = new Form();
         $data = ['test' => 'val', 'foo' => 'bar'];
@@ -233,10 +214,8 @@ class FormTest extends TestCase
 
     /**
      * test set() with 2 params
-     *
-     * @return void
      */
-    public function testSetTwoParam()
+    public function testSetTwoParam(): void
     {
         $form = new Form();
         $form->set('testing', 'value');
@@ -245,10 +224,8 @@ class FormTest extends TestCase
 
     /**
      * test chainable set()
-     *
-     * @return void
      */
-    public function testSetChained()
+    public function testSetChained(): void
     {
         $form = new Form();
         $result = $form->set('testing', 'value')
@@ -259,10 +236,8 @@ class FormTest extends TestCase
 
     /**
      * Test setting and getting form data.
-     *
-     * @return void
      */
-    public function testDataSetGet()
+    public function testDataSetGet(): void
     {
         $form = new Form();
         $expected = ['title' => 'title', 'is_published' => true];
@@ -275,10 +250,8 @@ class FormTest extends TestCase
 
     /**
      * test __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $form = new Form();
         $result = $form->__debugInfo();

--- a/tests/TestCase/Form/SchemaTest.php
+++ b/tests/TestCase/Form/SchemaTest.php
@@ -26,10 +26,8 @@ class SchemaTest extends TestCase
 {
     /**
      * Test adding multiple fields.
-     *
-     * @return void
      */
-    public function testAddingMultipleFields()
+    public function testAddingMultipleFields(): void
     {
         $schema = new Schema();
         $schema->addFields([
@@ -43,10 +41,8 @@ class SchemaTest extends TestCase
 
     /**
      * test adding fields.
-     *
-     * @return void
      */
-    public function testAddingFields()
+    public function testAddingFields(): void
     {
         $schema = new Schema();
 
@@ -69,10 +65,8 @@ class SchemaTest extends TestCase
 
     /**
      * test adding field whitelist attrs
-     *
-     * @return void
      */
-    public function testAddingFieldsWhitelist()
+    public function testAddingFieldsWhitelist(): void
     {
         $schema = new Schema();
 
@@ -83,10 +77,8 @@ class SchemaTest extends TestCase
 
     /**
      * Test removing fields.
-     *
-     * @return void
      */
-    public function testRemovingFields()
+    public function testRemovingFields(): void
     {
         $schema = new Schema();
 
@@ -101,10 +93,8 @@ class SchemaTest extends TestCase
 
     /**
      * test fieldType
-     *
-     * @return void
      */
-    public function testFieldType()
+    public function testFieldType(): void
     {
         $schema = new Schema();
 
@@ -120,10 +110,8 @@ class SchemaTest extends TestCase
 
     /**
      * test __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $schema = new Schema();
 

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -43,8 +43,6 @@ class BaseApplicationTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -61,10 +59,8 @@ class BaseApplicationTest extends TestCase
 
     /**
      * Integration test for a simple controller.
-     *
-     * @return void
      */
-    public function testHandle()
+    public function testHandle(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/cakes']);
         $request = $request->withAttribute('params', [
@@ -84,7 +80,7 @@ class BaseApplicationTest extends TestCase
      * Ensure that plugins with no plugin class can be loaded.
      * This makes adopting the new API easier
      */
-    public function testAddPluginUnknownClass()
+    public function testAddPluginUnknownClass(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $app->addPlugin('PluginJs');
@@ -105,7 +101,7 @@ class BaseApplicationTest extends TestCase
         );
     }
 
-    public function testAddPluginValidShortName()
+    public function testAddPluginValidShortName(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $app->addPlugin('TestPlugin');
@@ -118,7 +114,7 @@ class BaseApplicationTest extends TestCase
         $this->assertTrue($app->getPlugins()->has('Company/TestPluginThree'));
     }
 
-    public function testAddPluginValid()
+    public function testAddPluginValid(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $app->addPlugin(TestPlugin::class);
@@ -127,7 +123,7 @@ class BaseApplicationTest extends TestCase
         $this->assertTrue($app->getPlugins()->has('TestPlugin'));
     }
 
-    public function testPluginMiddleware()
+    public function testPluginMiddleware(): void
     {
         $start = new MiddlewareQueue();
         $app = $this->getMockForAbstractClass(
@@ -141,7 +137,7 @@ class BaseApplicationTest extends TestCase
         $this->assertCount(1, $after);
     }
 
-    public function testPluginRoutes()
+    public function testPluginRoutes(): void
     {
         $collection = new RouteCollection();
         $routes = new RouteBuilder($collection, '/');
@@ -162,7 +158,7 @@ class BaseApplicationTest extends TestCase
         $this->assertNotEmpty($collection->match($url, []));
     }
 
-    public function testPluginBootstrap()
+    public function testPluginBootstrap(): void
     {
         $app = $this->getMockForAbstractClass(
             BaseApplication::class,
@@ -178,10 +174,8 @@ class BaseApplicationTest extends TestCase
     /**
      * Test that plugins loaded with addPlugin() can load additional
      * plugins.
-     *
-     * @return void
      */
-    public function testPluginBootstrapRecursivePlugins()
+    public function testPluginBootstrapRecursivePlugins(): void
     {
         $app = $this->getMockForAbstractClass(
             BaseApplication::class,
@@ -206,10 +200,9 @@ class BaseApplicationTest extends TestCase
     /**
      * Tests that loading a nonexistent plugin through addOptionalPlugin() does not throw an exception
      *
-     * @return void
      * @covers ::addOptionalPlugin
      */
-    public function testAddOptionalPluginLoadingNonExistentPlugin()
+    public function testAddOptionalPluginLoadingNonExistentPlugin(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $pluginCountBefore = count($app->getPlugins());
@@ -222,10 +215,9 @@ class BaseApplicationTest extends TestCase
     /**
      * Tests that loading an existing plugin through addOptionalPlugin() works
      *
-     * @return void
      * @covers ::addOptionalPlugin
      */
-    public function testAddOptionalPluginLoadingNonExistentPluginValid()
+    public function testAddOptionalPluginLoadingNonExistentPluginValid(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $app->addOptionalPlugin(TestPlugin::class);
@@ -234,7 +226,7 @@ class BaseApplicationTest extends TestCase
         $this->assertTrue($app->getPlugins()->has('TestPlugin'));
     }
 
-    public function testGetContainer()
+    public function testGetContainer(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $container = $app->getContainer();
@@ -243,11 +235,11 @@ class BaseApplicationTest extends TestCase
         $this->assertSame($container, $app->getContainer(), 'Should return a reference');
     }
 
-    public function testBuildContainerEvent()
+    public function testBuildContainerEvent(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $called = false;
-        $app->getEventManager()->on('Application.buildContainer', function ($event, $container) use (&$called) {
+        $app->getEventManager()->on('Application.buildContainer', function ($event, $container) use (&$called): void {
             $this->assertInstanceOf(BaseApplication::class, $event->getSubject());
             $this->assertInstanceOf(ContainerInterface::class, $container);
             $called = true;
@@ -258,7 +250,7 @@ class BaseApplicationTest extends TestCase
         $this->assertTrue($called, 'Listener should be called');
     }
 
-    public function testBuildContainerEventReplaceContainer()
+    public function testBuildContainerEventReplaceContainer(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
         $app->getEventManager()->on('Application.buildContainer', function () {

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -37,9 +37,6 @@ class CurlTest extends TestCase
      */
     protected $caFile;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -51,10 +48,8 @@ class CurlTest extends TestCase
 
     /**
      * Test the send method
-     *
-     * @return void
      */
-    public function testSendLive()
+    public function testSendLive(): void
     {
         $request = new Request('http://localhost', 'GET', [
             'User-Agent' => 'CakePHP TestSuite',
@@ -75,10 +70,8 @@ class CurlTest extends TestCase
 
     /**
      * Test the send method
-     *
-     * @return void
      */
-    public function testSendLiveResponseCheck()
+    public function testSendLiveResponseCheck(): void
     {
         $request = new Request('https://api.cakephp.org/3.0/', 'GET', [
             'User-Agent' => 'CakePHP TestSuite',
@@ -100,10 +93,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsGet()
+    public function testBuildOptionsGet(): void
     {
         $options = [
             'timeout' => 5,
@@ -133,10 +124,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsGetWithBody()
+    public function testBuildOptionsGetWithBody(): void
     {
         $options = [
             'timeout' => 5,
@@ -169,10 +158,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsPost()
+    public function testBuildOptionsPost(): void
     {
         $options = [];
         $request = new Request(
@@ -202,10 +189,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsPut()
+    public function testBuildOptionsPut(): void
     {
         $options = [];
         $request = new Request(
@@ -233,10 +218,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsJsonPost()
+    public function testBuildOptionsJsonPost(): void
     {
         $options = [];
         $content = json_encode(['a' => 1, 'b' => 2]);
@@ -266,10 +249,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsSsl()
+    public function testBuildOptionsSsl(): void
     {
         $options = [
             'ssl_verify_host' => true,
@@ -300,10 +281,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsProxy()
+    public function testBuildOptionsProxy(): void
     {
         $options = [
             'proxy' => [
@@ -333,10 +312,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsHead()
+    public function testBuildOptionsHead(): void
     {
         $options = [];
         $request = new Request(
@@ -363,10 +340,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsCurlOptions()
+    public function testBuildOptionsCurlOptions(): void
     {
         $options = [
             'curl' => [
@@ -395,10 +370,8 @@ class CurlTest extends TestCase
 
     /**
      * Test that an exception is raised when timed out.
-     *
-     * @return void
      */
-    public function testNetworkException()
+    public function testNetworkException(): void
     {
         $this->expectException(NetworkException::class);
         $this->expectExceptionMessageMatches('/(Could not resolve|Resolving timed out)/');
@@ -413,10 +386,8 @@ class CurlTest extends TestCase
 
     /**
      * Test converting client options into curl ones.
-     *
-     * @return void
      */
-    public function testBuildOptionsProtocolVersion()
+    public function testBuildOptionsProtocolVersion(): void
     {
         $this->skipIf(!defined('CURL_HTTP_VERSION_2TLS'), 'Requires libcurl 7.42');
         $options = [];

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -31,9 +31,6 @@ class StreamTest extends TestCase
      */
     protected $stream;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -44,9 +41,6 @@ class StreamTest extends TestCase
         stream_wrapper_register('http', CakeStreamWrapper::class);
     }
 
-    /**
-     * @return void
-     */
     public function tearDown(): void
     {
         parent::tearDown();
@@ -55,10 +49,8 @@ class StreamTest extends TestCase
 
     /**
      * Test the send method
-     *
-     * @return void
      */
-    public function testSend()
+    public function testSend(): void
     {
         $stream = new Stream();
         $request = new Request('http://localhost', 'GET', [
@@ -76,10 +68,8 @@ class StreamTest extends TestCase
 
     /**
      * Test the send method by using cakephp:// protocol.
-     *
-     * @return void
      */
-    public function testSendByUsingCakephpProtocol()
+    public function testSendByUsingCakephpProtocol(): void
     {
         $stream = new Stream();
         $request = new Request('http://dummy/');
@@ -93,15 +83,13 @@ class StreamTest extends TestCase
 
     /**
      * Test stream error_handler cleanup when wrapper throws exception
-     *
-     * @return void
      */
-    public function testSendWrapperException()
+    public function testSendWrapperException(): void
     {
         $stream = new Stream();
         $request = new Request('http://throw_exception/');
 
-        $currentHandler = set_error_handler(function () {
+        $currentHandler = set_error_handler(function (): void {
         });
         restore_error_handler();
 
@@ -110,7 +98,7 @@ class StreamTest extends TestCase
         } catch (\Exception $e) {
         }
 
-        $newHandler = set_error_handler(function () {
+        $newHandler = set_error_handler(function (): void {
         });
         restore_error_handler();
 
@@ -119,10 +107,8 @@ class StreamTest extends TestCase
 
     /**
      * Test building the context headers
-     *
-     * @return void
      */
-    public function testBuildingContextHeader()
+    public function testBuildingContextHeader(): void
     {
         $request = new Request(
             'http://localhost',
@@ -152,10 +138,8 @@ class StreamTest extends TestCase
 
     /**
      * Test send() + context options with string content.
-     *
-     * @return void
      */
-    public function testSendContextContentString()
+    public function testSendContextContentString(): void
     {
         $content = json_encode(['a' => 'b']);
         $request = new Request(
@@ -181,10 +165,8 @@ class StreamTest extends TestCase
 
     /**
      * Test send() + context options with array content.
-     *
-     * @return void
      */
-    public function testSendContextContentArray()
+    public function testSendContextContentArray(): void
     {
         $request = new Request(
             'http://localhost',
@@ -209,10 +191,8 @@ class StreamTest extends TestCase
 
     /**
      * Test send() + context options with array content.
-     *
-     * @return void
      */
-    public function testSendContextContentArrayFiles()
+    public function testSendContextContentArrayFiles(): void
     {
         $request = new Request(
             'http://localhost',
@@ -232,10 +212,8 @@ class StreamTest extends TestCase
 
     /**
      * Test send() + context options for SSL.
-     *
-     * @return void
      */
-    public function testSendContextSsl()
+    public function testSendContextSsl(): void
     {
         $request = new Request('https://localhost.com/test.html');
         $options = [
@@ -267,10 +245,8 @@ class StreamTest extends TestCase
 
     /**
      * Test send() + context options for SSL.
-     *
-     * @return void
      */
-    public function testSendContextSslNoVerifyPeerName()
+    public function testSendContextSslNoVerifyPeerName(): void
     {
         $request = new Request('https://localhost.com/test.html');
         $options = [
@@ -303,10 +279,8 @@ class StreamTest extends TestCase
     /**
      * The PHP stream API returns ALL the headers for ALL the requests when
      * there are redirects.
-     *
-     * @return void
      */
-    public function testCreateResponseWithRedirects()
+    public function testCreateResponseWithRedirects(): void
     {
         $headers = [
             'HTTP/1.1 302 Found',
@@ -365,10 +339,8 @@ class StreamTest extends TestCase
 
     /**
      * Test that no exception is radied when not timed out.
-     *
-     * @return void
      */
-    public function testKeepDeadline()
+    public function testKeepDeadline(): void
     {
         $request = new Request('http://dummy/?sleep');
         $options = [
@@ -383,10 +355,8 @@ class StreamTest extends TestCase
 
     /**
      * Test that an exception is raised when timed out.
-     *
-     * @return void
      */
-    public function testMissDeadline()
+    public function testMissDeadline(): void
     {
         $request = new Request('http://dummy/?sleep');
         $options = [

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -38,8 +38,6 @@ class DigestTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -61,10 +59,8 @@ class DigestTest extends TestCase
 
     /**
      * test getting data from additional request method
-     *
-     * @return void
      */
-    public function testRealmAndNonceFromExtraRequest()
+    public function testRealmAndNonceFromExtraRequest(): void
     {
         $headers = [
             'WWW-Authenticate: Digest realm="The batcave",nonce="4cded326c6c51"',
@@ -91,10 +87,8 @@ class DigestTest extends TestCase
 
     /**
      * testQop method
-     *
-     * @return void
      */
-    public function testQop()
+    public function testQop(): void
     {
         $headers = [
             'WWW-Authenticate: Digest realm="The batcave",nonce="4cded326c6c51",qop="auth"',
@@ -117,10 +111,8 @@ class DigestTest extends TestCase
 
     /**
      * testOpaque method
-     *
-     * @return void
      */
-    public function testOpaque()
+    public function testOpaque(): void
     {
         $headers = [
             'WWW-Authenticate: Digest realm="The batcave",nonce="4cded326c6c51",opaque="d8ea7aa61a1693024c4cc3a516f49b3c"',

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -60,10 +60,7 @@ UBABkD2ETB+EotdHTly5FQt0jwbHfF2najBmezxtEjIygCnDb02Rtuei4HTansBu
 shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
 -----END RSA PRIVATE KEY-----';
 
-    /**
-     * @return void
-     */
-    public function testExceptionUnknownSigningMethod()
+    public function testExceptionUnknownSigningMethod(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $auth = new Oauth();
@@ -80,10 +77,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
 
     /**
      * Test plain-text signing.
-     *
-     * @return void
      */
-    public function testPlainTextSigning()
+    public function testPlainTextSigning(): void
     {
         $auth = new Oauth();
         $creds = [
@@ -109,10 +104,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
 
     /**
      * Test that baseString() normalizes the URL.
-     *
-     * @return void
      */
-    public function testBaseStringNormalizeUrl()
+    public function testBaseStringNormalizeUrl(): void
     {
         $request = new Request('HTTP://exAmple.com:80/parts/foo');
 
@@ -125,10 +118,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
 
     /**
      * Test that the query string is stripped from the normalized host.
-     *
-     * @return void
      */
-    public function testBaseStringWithQueryString()
+    public function testBaseStringWithQueryString(): void
     {
         $request = new Request('http://example.com/search?q=pogo&cat=2');
 
@@ -167,10 +158,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      * is not part of the Oauth spec.
      *
      * See Normalize Request Parameters (section 9.1.1)
-     *
-     * @return void
      */
-    public function testBaseStringWithPostDataNestedArrays()
+    public function testBaseStringWithPostDataNestedArrays(): void
     {
         $request = new Request(
             'http://example.com/search?q=pogo',
@@ -225,10 +214,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * See Normalize Request Parameters (section 9.1.1)
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testBaseStringWithPostData()
+    public function testBaseStringWithPostData(): void
     {
         $request = new Request(
             'http://example.com/search?q=pogo',
@@ -281,10 +268,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      * is not part of the Oauth spec.
      *
      * See Normalize Request Parameters (section 9.1.1)
-     *
-     * @return void
      */
-    public function testBaseStringWithXmlPostData()
+    public function testBaseStringWithXmlPostData(): void
     {
         $request = new Request(
             'http://example.com/search?q=pogo',
@@ -328,10 +313,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testHmacSigning()
+    public function testHmacSigning(): void
     {
         $request = new Request(
             'http://photos.example.net/photos',
@@ -361,10 +344,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
 
     /**
      * Test HMAC-SHA1 signing with a base64 consumer key
-     *
-     * @return void
      */
-    public function testHmacBase64Signing()
+    public function testHmacBase64Signing(): void
     {
         $request = new Request(
             'http://photos.example.net/photos',
@@ -395,10 +376,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testRsaSigningString()
+    public function testRsaSigningString(): void
     {
         $request = new Request(
             'http://photos.example.net/photos',
@@ -431,10 +410,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testRsaSigningFile()
+    public function testRsaSigningFile(): void
     {
         $request = new Request(
             'http://photos.example.net/photos',
@@ -467,10 +444,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testRsaSigningWithPassphraseString()
+    public function testRsaSigningWithPassphraseString(): void
     {
         $request = new Request(
             'http://photos.example.net/photos',
@@ -505,10 +480,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testRsaSigningStringWithPassphraseString()
+    public function testRsaSigningStringWithPassphraseString(): void
     {
         $request = new Request(
             'http://photos.example.net/photos',
@@ -543,10 +516,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testRsaSigningWithPassphraseFile()
+    public function testRsaSigningWithPassphraseFile(): void
     {
         $this->skipIf(PHP_EOL !== "\n", 'Just the line ending "\n" is supported. You can run the test again e.g. on a linux system.');
 
@@ -585,10 +556,8 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
      *
      * Hash result + parameters taken from
      * http://wiki.oauth.net/w/page/12238556/TestCases
-     *
-     * @return void
      */
-    public function testRsaSigningStringWithPassphraseFile()
+    public function testRsaSigningStringWithPassphraseFile(): void
     {
         $this->skipIf(PHP_EOL !== "\n", 'Just the line ending "\n" is supported. You can run the test again e.g. on a linux system.');
 

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -25,10 +25,8 @@ class FormDataTest extends TestCase
 {
     /**
      * Test getting the boundary.
-     *
-     * @return void
      */
-    public function testBoundary()
+    public function testBoundary(): void
     {
         $data = new FormData();
         $result = $data->boundary();
@@ -40,10 +38,8 @@ class FormDataTest extends TestCase
 
     /**
      * test adding parts returns this.
-     *
-     * @return void
      */
-    public function testAddReturnThis()
+    public function testAddReturnThis(): void
     {
         $data = new FormData();
         $return = $data->add('test', 'value');
@@ -52,10 +48,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test adding parts that are simple.
-     *
-     * @return void
      */
-    public function testAddSimple()
+    public function testAddSimple(): void
     {
         $data = new FormData();
         $data->add('test', 'value')
@@ -73,10 +67,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test addMany method.
-     *
-     * @return void
      */
-    public function testAddMany()
+    public function testAddMany(): void
     {
         $data = new FormData();
         $array = [
@@ -94,10 +86,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test adding a part object.
-     *
-     * @return void
      */
-    public function testAddPartObject()
+    public function testAddPartObject(): void
     {
         $data = new FormData();
         $boundary = $data->boundary();
@@ -123,10 +113,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test adding parts that are arrays.
-     *
-     * @return void
      */
-    public function testAddArray()
+    public function testAddArray(): void
     {
         $data = new FormData();
         $data->add('Article', [
@@ -142,10 +130,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test adding a part with a file in it.
-     *
-     * @return void
      */
-    public function testAddFile()
+    public function testAddFile(): void
     {
         $file = CORE_PATH . 'VERSION.txt';
         $contents = file_get_contents($file);
@@ -169,10 +155,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test adding a part with a filehandle.
-     *
-     * @return void
      */
-    public function testAddFileHandle()
+    public function testAddFileHandle(): void
     {
         $file = CORE_PATH . 'VERSION.txt';
         $fh = fopen($file, 'r');
@@ -199,10 +183,8 @@ class FormDataTest extends TestCase
 
     /**
      * Test contentType method.
-     *
-     * @return void
      */
-    public function testContentType()
+    public function testContentType(): void
     {
         $data = new FormData();
         $data->add('key', 'value');

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -25,10 +25,8 @@ class RequestTest extends TestCase
 {
     /**
      * test string ata, header and constructor
-     *
-     * @return void
      */
-    public function testConstructorStringData()
+    public function testConstructorStringData(): void
     {
         $headers = [
             'Content-Type' => 'application/json',
@@ -49,7 +47,7 @@ class RequestTest extends TestCase
      * @param string $method The HTTP method to use.
      * @dataProvider additionProvider
      */
-    public function testMethods(array $headers, $data, $method)
+    public function testMethods(array $headers, $data, $method): void
     {
         $request = new Request('http://example.com', $method, $headers, json_encode($data));
 
@@ -80,10 +78,8 @@ class RequestTest extends TestCase
 
     /**
      * test array data, header and constructor
-     *
-     * @return void
      */
-    public function testConstructorArrayData()
+    public function testConstructorArrayData(): void
     {
         $headers = [
             'Content-Type' => 'application/json',
@@ -100,10 +96,8 @@ class RequestTest extends TestCase
 
     /**
      * test nested array data for encoding of brackets, header and constructor
-     *
-     * @return void
      */
-    public function testConstructorArrayNestedData()
+    public function testConstructorArrayNestedData(): void
     {
         $headers = [
             'Content-Type' => 'application/json',
@@ -120,10 +114,8 @@ class RequestTest extends TestCase
 
     /**
      * test body method.
-     *
-     * @return void
      */
-    public function testBody()
+    public function testBody(): void
     {
         $data = '{"json":"data"}';
         $request = new Request('', Request::METHOD_GET, [], $data);
@@ -133,10 +125,8 @@ class RequestTest extends TestCase
 
     /**
      * test body method with array payload
-     *
-     * @return void
      */
-    public function testBodyArray()
+    public function testBodyArray(): void
     {
         $data = [
             'a' => 'b',
@@ -154,10 +144,8 @@ class RequestTest extends TestCase
 
     /**
      * Test that body() modifies the PSR7 stream
-     *
-     * @return void
      */
-    public function testBodyInteroperability()
+    public function testBodyInteroperability(): void
     {
         $request = new Request();
         $this->assertSame('', $request->getBody()->__toString());
@@ -169,10 +157,8 @@ class RequestTest extends TestCase
 
     /**
      * Test the default headers
-     *
-     * @return void
      */
-    public function testDefaultHeaders()
+    public function testDefaultHeaders(): void
     {
         $request = new Request();
         $this->assertSame('CakePHP', $request->getHeaderLine('User-Agent'));

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -26,10 +26,8 @@ class ResponseTest extends TestCase
 {
     /**
      * Test parsing headers and reading with PSR7 methods.
-     *
-     * @return void
      */
-    public function testHeaderParsingPsr7()
+    public function testHeaderParsingPsr7(): void
     {
         $headers = [
             'HTTP/1.0 200 OK',
@@ -54,10 +52,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test parsing headers and capturing content
-     *
-     * @return void
      */
-    public function testHeaderParsing()
+    public function testHeaderParsing(): void
     {
         $headers = [
             'HTTP/1.0 200 OK',
@@ -93,10 +89,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test getStringBody()
-     *
-     * @return void
      */
-    public function getStringBody()
+    public function getStringBody(): void
     {
         $response = new Response([], 'string');
 
@@ -105,10 +99,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test accessor for JSON
-     *
-     * @return void
      */
-    public function testBodyJson()
+    public function testBodyJson(): void
     {
         $data = [
             'property' => 'value',
@@ -140,10 +132,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test accessor for JSON when set with PSR7 methods.
-     *
-     * @return void
      */
-    public function testBodyJsonPsr7()
+    public function testBodyJsonPsr7(): void
     {
         $data = [
             'property' => 'value',
@@ -156,10 +146,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test accessor for XML
-     *
-     * @return void
      */
-    public function testBodyXml()
+    public function testBodyXml(): void
     {
         $data = <<<XML
 <?xml version="1.0" encoding="utf-8"?>
@@ -177,10 +165,8 @@ XML;
 
     /**
      * Test isOk()
-     *
-     * @return void
      */
-    public function testIsOk()
+    public function testIsOk(): void
     {
         $headers = [
             'HTTP/1.1 200 OK',
@@ -296,19 +282,16 @@ XML;
      * Test isSuccess()
      *
      * @dataProvider isSuccessProvider
-     * @return void
      */
-    public function testIsSuccess(bool $expected, Response $response)
+    public function testIsSuccess(bool $expected, Response $response): void
     {
         $this->assertEquals($expected, $response->isSuccess());
     }
 
     /**
      * Test isRedirect()
-     *
-     * @return void
      */
-    public function testIsRedirect()
+    public function testIsRedirect(): void
     {
         $headers = [
             'HTTP/1.1 200 OK',
@@ -335,10 +318,8 @@ XML;
 
     /**
      * Test accessing cookies through the PSR7-like methods
-     *
-     * @return void
      */
-    public function testGetCookies()
+    public function testGetCookies(): void
     {
         $headers = [
             'HTTP/1.0 200 Ok',
@@ -371,10 +352,8 @@ XML;
 
     /**
      * Test accessing cookie collection
-     *
-     * @return void
      */
-    public function testGetCookieCollection()
+    public function testGetCookieCollection(): void
     {
         $headers = [
             'HTTP/1.0 200 Ok',
@@ -394,10 +373,8 @@ XML;
 
     /**
      * Test statusCode()
-     *
-     * @return void
      */
-    public function testGetStatusCode()
+    public function testGetStatusCode(): void
     {
         $headers = [
             'HTTP/1.0 404 Not Found',
@@ -409,10 +386,8 @@ XML;
 
     /**
      * Test reading the encoding out.
-     *
-     * @return void
      */
-    public function testGetEncoding()
+    public function testGetEncoding(): void
     {
         $headers = [
             'HTTP/1.0 200 Ok',
@@ -444,10 +419,8 @@ XML;
 
     /**
      * Test that gzip responses are automatically decompressed.
-     *
-     * @return void
      */
-    public function testAutoDecodeGzipBody()
+    public function testAutoDecodeGzipBody(): void
     {
         $headers = [
             'HTTP/1.0 200 OK',

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -31,10 +31,8 @@ class ClientTest extends TestCase
 {
     /**
      * Test storing config options and modifying them.
-     *
-     * @return void
      */
-    public function testConstructConfig()
+    public function testConstructConfig(): void
     {
         $config = [
             'scheme' => 'http',
@@ -66,10 +64,8 @@ class ClientTest extends TestCase
 
     /**
      * testAdapterInstanceCheck
-     *
-     * @return void
      */
-    public function testAdapterInstanceCheck()
+    public function testAdapterInstanceCheck(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
@@ -210,7 +206,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider urlProvider
      */
-    public function testBuildUrl(string $expected, string $url, array $query, ?array $opts)
+    public function testBuildUrl(string $expected, string $url, array $query, ?array $opts): void
     {
         $http = new Client();
 
@@ -220,10 +216,8 @@ class ClientTest extends TestCase
 
     /**
      * test simple get request with headers & cookies.
-     *
-     * @return void
      */
-    public function testGetSimpleWithHeadersAndCookies()
+    public function testGetSimpleWithHeadersAndCookies(): void
     {
         $response = new Response();
 
@@ -264,10 +258,8 @@ class ClientTest extends TestCase
 
     /**
      * test get request with no data
-     *
-     * @return void
      */
-    public function testGetNoData()
+    public function testGetNoData(): void
     {
         $response = new Response();
 
@@ -298,10 +290,8 @@ class ClientTest extends TestCase
 
     /**
      * test get request with querystring data
-     *
-     * @return void
      */
-    public function testGetQuerystring()
+    public function testGetQuerystring(): void
     {
         $response = new Response();
 
@@ -334,10 +324,8 @@ class ClientTest extends TestCase
 
     /**
      * test get request with string of query data.
-     *
-     * @return void
      */
-    public function testGetQuerystringString()
+    public function testGetQuerystringString(): void
     {
         $response = new Response();
 
@@ -371,10 +359,8 @@ class ClientTest extends TestCase
     /**
      * Test a GET with a request body. Services like
      * elasticsearch use this feature.
-     *
-     * @return void
      */
-    public function testGetWithContent()
+    public function testGetWithContent(): void
     {
         $response = new Response();
 
@@ -404,10 +390,8 @@ class ClientTest extends TestCase
 
     /**
      * Test invalid authentication types throw exceptions.
-     *
-     * @return void
      */
-    public function testInvalidAuthenticationType()
+    public function testInvalidAuthenticationType(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $mock = $this->getMockBuilder(Stream::class)
@@ -427,10 +411,8 @@ class ClientTest extends TestCase
 
     /**
      * Test setting basic authentication with get
-     *
-     * @return void
      */
-    public function testGetWithAuthenticationAndProxy()
+    public function testGetWithAuthenticationAndProxy(): void
     {
         $response = new Response();
 
@@ -486,9 +468,8 @@ class ClientTest extends TestCase
      * test simple POST request.
      *
      * @dataProvider methodProvider
-     * @return void
      */
-    public function testMethodsSimple(string $method)
+    public function testMethodsSimple(string $method): void
     {
         $response = new Response();
 
@@ -533,9 +514,8 @@ class ClientTest extends TestCase
      * Test that using the 'type' option sets the correct headers
      *
      * @dataProvider typeProvider
-     * @return void
      */
-    public function testPostWithTypeKey(string $type, string $mime)
+    public function testPostWithTypeKey(string $type, string $mime): void
     {
         $response = new Response();
         $data = 'some data';
@@ -567,10 +547,8 @@ class ClientTest extends TestCase
 
     /**
      * Test that string payloads with no content type have a default content-type set.
-     *
-     * @return void
      */
-    public function testPostWithStringDataDefaultsToFormEncoding()
+    public function testPostWithStringDataDefaultsToFormEncoding(): void
     {
         $response = new Response();
         $data = 'some=value&more=data';
@@ -599,10 +577,8 @@ class ClientTest extends TestCase
 
     /**
      * Test that exceptions are raised on invalid types.
-     *
-     * @return void
      */
-    public function testExceptionOnUnknownType()
+    public function testExceptionOnUnknownType(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $mock = $this->getMockBuilder(Stream::class)
@@ -620,10 +596,8 @@ class ClientTest extends TestCase
 
     /**
      * Test that Client stores cookies
-     *
-     * @return void
      */
-    public function testCookieStorage()
+    public function testCookieStorage(): void
     {
         $adapter = $this->getMockBuilder(Stream::class)
             ->onlyMethods(['send'])
@@ -653,10 +627,8 @@ class ClientTest extends TestCase
 
     /**
      * Test cookieJar config option.
-     *
-     * @return void
      */
-    public function testCookieJar()
+    public function testCookieJar(): void
     {
         $jar = new CookieCollection();
         $http = new Client([
@@ -668,10 +640,8 @@ class ClientTest extends TestCase
 
     /**
      * Test addCookie() method.
-     *
-     * @return void
      */
-    public function testAddCookie()
+    public function testAddCookie(): void
     {
         $client = new Client();
         $cookie = new Cookie('foo', '', null, '/', 'example.com');
@@ -684,10 +654,8 @@ class ClientTest extends TestCase
 
     /**
      * Test addCookie() method without a domain.
-     *
-     * @return void
      */
-    public function testAddCookieWithoutDomain()
+    public function testAddCookieWithoutDomain(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cookie must have a domain and a path set.');
@@ -702,10 +670,8 @@ class ClientTest extends TestCase
 
     /**
      * Test addCookie() method without a path.
-     *
-     * @return void
      */
-    public function testAddCookieWithoutPath()
+    public function testAddCookieWithoutPath(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cookie must have a domain and a path set.');
@@ -720,10 +686,8 @@ class ClientTest extends TestCase
 
     /**
      * test head request with querystring data
-     *
-     * @return void
      */
-    public function testHeadQuerystring()
+    public function testHeadQuerystring(): void
     {
         $response = new Response();
 
@@ -753,10 +717,8 @@ class ClientTest extends TestCase
 
     /**
      * test redirects
-     *
-     * @return void
      */
-    public function testRedirects()
+    public function testRedirects(): void
     {
         $url = 'http://cakephp.org';
 
@@ -838,10 +800,8 @@ class ClientTest extends TestCase
 
     /**
      * testSendRequest
-     *
-     * @return void
      */
-    public function testSendRequest()
+    public function testSendRequest(): void
     {
         $response = new Response();
 
@@ -881,10 +841,8 @@ class ClientTest extends TestCase
 
     /**
      * test redirect across sub domains
-     *
-     * @return void
      */
-    public function testRedirectDifferentSubDomains()
+    public function testRedirectDifferentSubDomains(): void
     {
         $adapter = $this->getMockBuilder(Client\Adapter\Stream::class)
             ->onlyMethods(['send'])
@@ -931,7 +889,7 @@ class ClientTest extends TestCase
     /**
      * Scheme is set when passed to client in string
      */
-    public function testCreateFromUrlSetsScheme()
+    public function testCreateFromUrlSetsScheme(): void
     {
         $client = Client::createFromUrl('https://example.co/');
         $this->assertSame('https', $client->getConfig('scheme'));
@@ -940,7 +898,7 @@ class ClientTest extends TestCase
     /**
      * Host is set when passed to client in string
      */
-    public function testCreateFromUrlSetsHost()
+    public function testCreateFromUrlSetsHost(): void
     {
         $client = Client::createFromUrl('https://example.co/');
         $this->assertSame('example.co', $client->getConfig('host'));
@@ -949,7 +907,7 @@ class ClientTest extends TestCase
     /**
      * basePath is set when passed to client in string
      */
-    public function testCreateFromUrlSetsBasePath()
+    public function testCreateFromUrlSetsBasePath(): void
     {
         $client = Client::createFromUrl('https://example.co/api/v1');
         $this->assertSame('/api/v1', $client->getConfig('basePath'));
@@ -958,7 +916,7 @@ class ClientTest extends TestCase
     /**
      * Test exception is thrown when URL cannot be parsed
      */
-    public function testCreateFromUrlThrowsInvalidExceptionWhenUrlCannotBeParsed()
+    public function testCreateFromUrlThrowsInvalidExceptionWhenUrlCannotBeParsed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Client::createFromUrl('htps://');
@@ -969,7 +927,7 @@ class ClientTest extends TestCase
     /**
      * Port is set when passed to client in string
      */
-    public function testCreateFromUrlSetsPort()
+    public function testCreateFromUrlSetsPort(): void
     {
         $client = Client::createFromUrl('https://example.co:8765/');
         $this->assertSame(8765, $client->getConfig('port'));
@@ -978,7 +936,7 @@ class ClientTest extends TestCase
     /**
      * Test exception is throw when no scheme is provided.
      */
-    public function testCreateFromUrlThrowsInvalidArgumentExceptionWhenNoSchemeProvided()
+    public function testCreateFromUrlThrowsInvalidArgumentExceptionWhenNoSchemeProvided(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Client::createFromUrl('example.co');
@@ -989,7 +947,7 @@ class ClientTest extends TestCase
     /**
      * Test exception is thrown if passed URL has no domain
      */
-    public function testCreateFromUrlThrowsInvalidArgumentExceptionWhenNoDomainProvided()
+    public function testCreateFromUrlThrowsInvalidArgumentExceptionWhenNoDomainProvided(): void
     {
         $this->expectException(InvalidArgumentException::class);
         Client::createFromUrl('/api/v1');
@@ -1001,7 +959,7 @@ class ClientTest extends TestCase
      * Test that the passed parsed URL parts won't override other constructor defaults
      * or add undefined configuration
      */
-    public function testCreateFromUrlOnlySetSchemePortHostBasePath()
+    public function testCreateFromUrlOnlySetSchemePortHostBasePath(): void
     {
         $client = Client::createFromUrl('http://example.co:80/some/uri/?foo=bar');
         $config = $client->getConfig();

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -31,10 +31,8 @@ class CookieCollectionTest extends TestCase
 {
     /**
      * Test constructor
-     *
-     * @return void
      */
-    public function testConstructorWithEmptyArray()
+    public function testConstructorWithEmptyArray(): void
     {
         $collection = new CookieCollection([]);
         $this->assertCount(0, $collection);
@@ -42,10 +40,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test valid cookies
-     *
-     * @return void
      */
-    public function testConstructorWithCookieArray()
+    public function testConstructorWithCookieArray(): void
     {
         $cookies = [
             new Cookie('one', 'one'),
@@ -58,10 +54,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test iteration
-     *
-     * @return void
      */
-    public function testIteration()
+    public function testIteration(): void
     {
         $cookies = [
             new Cookie('remember_me', 'a'),
@@ -79,10 +73,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $cookies = [];
 
@@ -102,10 +94,8 @@ class CookieCollectionTest extends TestCase
     /**
      * Cookie collections need to support duplicate cookie names because
      * of use cases in Http\Client
-     *
-     * @return void
      */
-    public function testAddDuplicates()
+    public function testAddDuplicates(): void
     {
         $remember = new Cookie('remember_me', 'yes');
         $rememberNo = new Cookie('remember_me', 'no', null, '/path2');
@@ -121,10 +111,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test has()
-     *
-     * @return void
      */
-    public function testHas()
+    public function testHas(): void
     {
         $cookies = [
             new Cookie('remember_me', 'a'),
@@ -139,10 +127,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test removing cookies
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $cookies = [
             new Cookie('remember_me', 'a'),
@@ -163,10 +149,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test getting cookies by name
-     *
-     * @return void
      */
-    public function testGetByName()
+    public function testGetByName(): void
     {
         $cookies = [
             new Cookie('remember_me', 'a'),
@@ -183,10 +167,8 @@ class CookieCollectionTest extends TestCase
     /**
      * Test that the constructor takes only an array of objects implementing
      * the CookieInterface
-     *
-     * @return void
      */
-    public function testConstructorWithInvalidCookieObjects()
+    public function testConstructorWithInvalidCookieObjects(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected `Cake\Http\Cookie\CookieCollection[]` as $cookies but instead got `array` at index 1');
@@ -200,10 +182,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from a response.
-     *
-     * @return void
      */
-    public function testAddFromResponse()
+    public function testAddFromResponse(): void
     {
         $collection = new CookieCollection();
         $request = new ServerRequest([
@@ -248,10 +228,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies that contain URL encoded data
-     *
-     * @return void
      */
-    public function testAddFromResponseValueUrldecodeData()
+    public function testAddFromResponseValueUrldecodeData(): void
     {
         $collection = new CookieCollection();
         $request = new ServerRequest([
@@ -269,10 +247,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from a response ignores empty headers
-     *
-     * @return void
      */
-    public function testAddFromResponseIgnoreEmpty()
+    public function testAddFromResponseIgnoreEmpty(): void
     {
         $collection = new CookieCollection();
         $request = new ServerRequest([
@@ -286,10 +262,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from a response ignores expired cookies
-     *
-     * @return void
      */
-    public function testAddFromResponseIgnoreExpired()
+    public function testAddFromResponseIgnoreExpired(): void
     {
         $collection = new CookieCollection();
         $request = new ServerRequest([
@@ -305,10 +279,8 @@ class CookieCollectionTest extends TestCase
     /**
      * Test adding cookies from a response removes existing cookies if
      * the new response marks them as expired.
-     *
-     * @return void
      */
-    public function testAddFromResponseRemoveExpired()
+    public function testAddFromResponseRemoveExpired(): void
     {
         $collection = new CookieCollection([
             new Cookie('expired', 'not yet', null, '/', 'example.com'),
@@ -328,10 +300,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from a response with bad expires values
-     *
-     * @return void
      */
-    public function testAddFromResponseInvalidExpires()
+    public function testAddFromResponseInvalidExpires(): void
     {
         $collection = new CookieCollection();
         $request = new ServerRequest([
@@ -349,10 +319,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from responses updates cookie values.
-     *
-     * @return void
      */
-    public function testAddFromResponseUpdateExisting()
+    public function testAddFromResponseUpdateExisting(): void
     {
         $collection = new CookieCollection([
             new Cookie('key', 'old value', null, '/', 'example.com'),
@@ -371,10 +339,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from the collection to request.
-     *
-     * @return void
      */
-    public function testAddToRequest()
+    public function testAddToRequest(): void
     {
         $collection = new CookieCollection();
         $collection = $collection
@@ -405,10 +371,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding no cookies
-     *
-     * @return void
      */
-    public function testAddToRequestNoCookies()
+    public function testAddToRequestNoCookies(): void
     {
         $collection = new CookieCollection();
         $request = new ClientRequest('http://example.com/api');
@@ -418,10 +382,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Testing the cookie size limit warning
-     *
-     * @return void
      */
-    public function testCookieSizeWarning()
+    public function testCookieSizeWarning(): void
     {
         $this->expectWarning();
         $this->expectWarningMessage('The cookie `default` exceeds the recommended maximum cookie length of 4096 bytes.');
@@ -436,10 +398,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies from the collection to request.
-     *
-     * @return void
      */
-    public function testAddToRequestExtraCookies()
+    public function testAddToRequestExtraCookies(): void
     {
         $collection = new CookieCollection();
         $collection = $collection
@@ -457,10 +417,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies ignores leading dot
-     *
-     * @return void
      */
-    public function testAddToRequestLeadingDot()
+    public function testAddToRequestLeadingDot(): void
     {
         $collection = new CookieCollection();
         $collection = $collection
@@ -472,10 +430,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * Test adding cookies checks the secure crumb
-     *
-     * @return void
      */
-    public function testAddToRequestSecureCrumb()
+    public function testAddToRequestSecureCrumb(): void
     {
         $collection = new CookieCollection();
         $collection = $collection
@@ -493,10 +449,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * test createFromHeader() building cookies from a header string.
-     *
-     * @return void
      */
-    public function testCreateFromHeader()
+    public function testCreateFromHeader(): void
     {
         $header = [
             'http=name; HttpOnly; Secure;',
@@ -513,10 +467,8 @@ class CookieCollectionTest extends TestCase
 
     /**
      * test createFromServerRequest() building cookies from a header string.
-     *
-     * @return void
      */
-    public function testCreateFromServerRequest()
+    public function testCreateFromServerRequest(): void
     {
         $request = new ServerRequest(['cookies' => ['name' => 'val', 'cakephp' => 'rocks']]);
         $cookies = CookieCollection::createFromServerRequest($request);

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -47,7 +47,7 @@ class CookieTest extends TestCase
      *
      * @dataProvider invalidNameProvider
      */
-    public function testValidateNameInvalidChars(string $name)
+    public function testValidateNameInvalidChars(string $name): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('contains invalid characters.');
@@ -56,10 +56,8 @@ class CookieTest extends TestCase
 
     /**
      * Test empty cookie name
-     *
-     * @return void
      */
-    public function testValidateNameEmptyName()
+    public function testValidateNameEmptyName(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The cookie name cannot be empty.');
@@ -68,10 +66,8 @@ class CookieTest extends TestCase
 
     /**
      * Tests the header value
-     *
-     * @return void
      */
-    public function testToHeaderValue()
+    public function testToHeaderValue(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $result = $cookie->toHeaderValue();
@@ -93,10 +89,8 @@ class CookieTest extends TestCase
 
     /**
      * Test getting the value from the cookie
-     *
-     * @return void
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $result = $cookie->getValue();
@@ -109,10 +103,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting values in cookies
-     *
-     * @return void
      */
-    public function testWithValue()
+    public function testWithValue(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withValue('new');
@@ -123,12 +115,10 @@ class CookieTest extends TestCase
 
     /**
      * Test getting the value from the cookie
-     *
-     * @return void
      */
-    public function testGetStringValue()
+    public function testGetStringValue(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $cookie = new Cookie('cakephp', 'thing');
             $this->assertSame('thing', $cookie->getStringValue());
 
@@ -142,10 +132,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting domain in cookies
-     *
-     * @return void
      */
-    public function testWithDomain()
+    public function testWithDomain(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withDomain('example.com');
@@ -156,10 +144,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting path in cookies
-     *
-     * @return void
      */
-    public function testWithPath()
+    public function testWithPath(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withPath('/api');
@@ -170,10 +156,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting SameSite in cookies
-     *
-     * @return void
      */
-    public function testWithSameSite()
+    public function testWithSameSite(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withSameSite(CookieInterface::SAMESITE_LAX);
@@ -184,10 +168,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting SameSite in cookies
-     *
-     * @return void
      */
-    public function testWithSameSiteException()
+    public function testWithSameSiteException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
@@ -198,10 +180,8 @@ class CookieTest extends TestCase
 
     /**
      * Test default path in cookies
-     *
-     * @return void
      */
-    public function testDefaultPath()
+    public function testDefaultPath(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertStringContainsString('path=/', $cookie->toHeaderValue());
@@ -209,10 +189,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting httponly in cookies
-     *
-     * @return void
      */
-    public function testWithHttpOnly()
+    public function testWithHttpOnly(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withHttpOnly(true);
@@ -223,10 +201,8 @@ class CookieTest extends TestCase
 
     /**
      * Test setting secure in cookies
-     *
-     * @return void
      */
-    public function testWithSecure()
+    public function testWithSecure(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withSecure(true);
@@ -237,10 +213,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the never expiry method
-     *
-     * @return void
      */
-    public function testWithNeverExpire()
+    public function testWithNeverExpire(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withNeverExpire();
@@ -250,10 +224,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the expired method
-     *
-     * @return void
      */
-    public function testWithExpired()
+    public function testWithExpired(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withExpired();
@@ -265,10 +237,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the withExpiry method
-     *
-     * @return void
      */
-    public function testWithExpiry()
+    public function testWithExpiry(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withExpiry(Chronos::createFromDate(2022, 6, 15));
@@ -280,10 +250,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the withExpiry method changes timezone
-     *
-     * @return void
      */
-    public function testWithExpiryChangesTimezone()
+    public function testWithExpiryChangesTimezone(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $date = Chronos::createFromDate(2022, 6, 15);
@@ -300,10 +268,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the isExpired method
-     *
-     * @return void
      */
-    public function testIsExpired()
+    public function testIsExpired(): void
     {
         $date = Chronos::now();
         $cookie = new Cookie('cakephp', 'yay');
@@ -321,10 +287,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the withName method
-     *
-     * @return void
      */
-    public function testWithName()
+    public function testWithName(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withName('user');
@@ -335,10 +299,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the withAddedValue method
-     *
-     * @return void
      */
-    public function testWithAddedValue()
+    public function testWithAddedValue(): void
     {
         $cookie = new Cookie('cakephp', '{"type":"mvc", "icing": true}');
         $new = $cookie->withAddedValue('type', 'mvc')
@@ -351,10 +313,8 @@ class CookieTest extends TestCase
 
     /**
      * Test the withoutAddedValue method
-     *
-     * @return void
      */
-    public function testWithoutAddedValue()
+    public function testWithoutAddedValue(): void
     {
         $cookie = new Cookie('cakephp', '{"type":"mvc", "user": {"name":"mark"}}');
         $new = $cookie->withoutAddedValue('type')
@@ -368,10 +328,8 @@ class CookieTest extends TestCase
 
     /**
      * Test check() with serialized source data.
-     *
-     * @return void
      */
-    public function testCheckStringSourceData()
+    public function testCheckStringSourceData(): void
     {
         $cookie = new Cookie('cakephp', '{"type":"mvc", "user": {"name":"mark"}}');
         $this->assertTrue($cookie->check('type'));
@@ -382,10 +340,8 @@ class CookieTest extends TestCase
 
     /**
      * Test check() with array source data.
-     *
-     * @return void
      */
-    public function testCheckArraySourceData()
+    public function testCheckArraySourceData(): void
     {
         $data = [
             'type' => 'mvc',
@@ -400,10 +356,8 @@ class CookieTest extends TestCase
 
     /**
      * test read() and set on different types
-     *
-     * @return void
      */
-    public function testReadExpandsOnDemand()
+    public function testReadExpandsOnDemand(): void
     {
         $data = [
             'username' => 'florian',
@@ -428,10 +382,8 @@ class CookieTest extends TestCase
 
     /**
      * test read() on structured data.
-     *
-     * @return void
      */
-    public function testReadComplexData()
+    public function testReadComplexData(): void
     {
         $data = [
             'username' => 'florian',
@@ -456,10 +408,8 @@ class CookieTest extends TestCase
 
     /**
      * Test reading complex data serialized in 1.x and early 2.x
-     *
-     * @return void
      */
-    public function testReadLegacyComplexData()
+    public function testReadLegacyComplexData(): void
     {
         $data = 'key|value,key2|value2';
         $cookie = new Cookie('cakephp', $data);
@@ -469,10 +419,8 @@ class CookieTest extends TestCase
 
     /**
      * Test that toHeaderValue() collapses data.
-     *
-     * @return void
      */
-    public function testToHeaderValueCollapsesComplexData()
+    public function testToHeaderValueCollapsesComplexData(): void
     {
         $data = [
             'username' => 'florian',
@@ -489,10 +437,8 @@ class CookieTest extends TestCase
 
     /**
      * Tests getting the id
-     *
-     * @return void
      */
-    public function testGetId()
+    public function testGetId(): void
     {
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $this->assertSame('cakephp;;/', $cookie->getId());
@@ -504,7 +450,7 @@ class CookieTest extends TestCase
         $this->assertSame('test;example.com;/path', $cookie->getId());
     }
 
-    public function testCreateFromHeaderString()
+    public function testCreateFromHeaderString(): void
     {
         $header = 'cakephp=cakephp-rocks; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org; samesite=invalid; secure; httponly';
         $result = Cookie::createFromHeaderString($header);
@@ -514,7 +460,7 @@ class CookieTest extends TestCase
         $this->assertNull($result->getSameSite());
     }
 
-    public function testDefaults()
+    public function testDefaults(): void
     {
         Cookie::setDefaults(['path' => '/cakephp', 'expires' => time()]);
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
@@ -527,7 +473,7 @@ class CookieTest extends TestCase
         $this->assertNull($cookie->getExpiry());
     }
 
-    public function testInvalidExpiresForDefaults()
+    public function testInvalidExpiresForDefaults(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid type `array` for expire');
@@ -536,7 +482,7 @@ class CookieTest extends TestCase
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
     }
 
-    public function testInvalidSameSiteForDefaults()
+    public function testInvalidSameSiteForDefaults(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));

--- a/tests/TestCase/Http/CorsBuilderTest.php
+++ b/tests/TestCase/Http/CorsBuilderTest.php
@@ -11,10 +11,8 @@ class CorsBuilderTest extends TestCase
 {
     /**
      * test allowOrigin() setting allow-origin
-     *
-     * @return void
      */
-    public function testAllowOriginNoOrigin()
+    public function testAllowOriginNoOrigin(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, '');
@@ -24,10 +22,8 @@ class CorsBuilderTest extends TestCase
 
     /**
      * test allowOrigin() setting allow-origin
-     *
-     * @return void
      */
-    public function testAllowOrigin()
+    public function testAllowOrigin(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://www.example.com');
@@ -48,10 +44,8 @@ class CorsBuilderTest extends TestCase
 
     /**
      * test allowOrigin() with SSL
-     *
-     * @return void
      */
-    public function testAllowOriginSsl()
+    public function testAllowOriginSsl(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'https://www.example.com', true);
@@ -69,7 +63,7 @@ class CorsBuilderTest extends TestCase
         $this->assertNoHeader($builder->build(), 'Access-Control-Allow-Origin');
     }
 
-    public function testAllowMethods()
+    public function testAllowMethods(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -78,7 +72,7 @@ class CorsBuilderTest extends TestCase
         $this->assertHeader('GET, POST', $builder->build(), 'Access-Control-Allow-Methods');
     }
 
-    public function testAllowCredentials()
+    public function testAllowCredentials(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -87,7 +81,7 @@ class CorsBuilderTest extends TestCase
         $this->assertHeader('true', $builder->build(), 'Access-Control-Allow-Credentials');
     }
 
-    public function testAllowHeaders()
+    public function testAllowHeaders(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -96,7 +90,7 @@ class CorsBuilderTest extends TestCase
         $this->assertHeader('Content-Type, Accept', $builder->build(), 'Access-Control-Allow-Headers');
     }
 
-    public function testExposeHeaders()
+    public function testExposeHeaders(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -105,7 +99,7 @@ class CorsBuilderTest extends TestCase
         $this->assertHeader('Content-Type, Accept', $builder->build(), 'Access-Control-Expose-Headers');
     }
 
-    public function testMaxAge()
+    public function testMaxAge(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -116,10 +110,8 @@ class CorsBuilderTest extends TestCase
 
     /**
      * When no origin is allowed, none of the other headers should be applied.
-     *
-     * @return void
      */
-    public function testNoAllowedOriginNoHeadersSet()
+    public function testNoAllowedOriginNoHeadersSet(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -139,10 +131,8 @@ class CorsBuilderTest extends TestCase
 
     /**
      * When an invalid origin is used, none of the other headers should be applied.
-     *
-     * @return void
      */
-    public function testInvalidAllowedOriginNoHeadersSet()
+    public function testInvalidAllowedOriginNoHeadersSet(): void
     {
         $response = new Response();
         $builder = new CorsBuilder($response, 'http://example.com');
@@ -168,7 +158,7 @@ class CorsBuilderTest extends TestCase
      * @param \Cake\Http\Response $response The Response object.
      * @param string $header The header key to check
      */
-    protected function assertHeader($expected, Response $response, $header)
+    protected function assertHeader($expected, Response $response, $header): void
     {
         $this->assertTrue($response->hasHeader($header), 'Header key not found.');
         $this->assertSame($expected, $response->getHeaderLine($header), 'Header value not found.');
@@ -180,7 +170,7 @@ class CorsBuilderTest extends TestCase
      * @param \Cake\Http\Response $response The Response object.
      * @param string $header The header key to check
      */
-    protected function assertNoHeader(Response $response, $header)
+    protected function assertNoHeader(Response $response, $header): void
     {
         $this->assertFalse($response->hasHeader($header), 'Header key was found.');
     }

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -104,7 +104,7 @@ class FlashMessageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testDefaultParamsOverriding()
+    public function testDefaultParamsOverriding(): void
     {
         $this->Flash = new FlashMessage(
             $this->Session,

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -60,7 +60,7 @@ class BodyParserMiddlewareTest extends TestCase
      *
      * @return array
      */
-    public static function jsonScalarValues()
+    public static function jsonScalarValues(): array
     {
         return [
             ['', []], // Requests without body
@@ -75,10 +75,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test constructor options
-     *
-     * @return void
      */
-    public function testConstructorMethodsOption()
+    public function testConstructorMethodsOption(): void
     {
         $parser = new BodyParserMiddleware(['methods' => ['PUT']]);
         $this->assertEquals(['PUT'], $parser->getMethods());
@@ -86,10 +84,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test constructor options
-     *
-     * @return void
      */
-    public function testConstructorXmlOption()
+    public function testConstructorXmlOption(): void
     {
         $parser = new BodyParserMiddleware(['json' => false]);
         $this->assertEquals([], $parser->getParsers(), 'Xml off by default');
@@ -107,10 +103,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test constructor options
-     *
-     * @return void
      */
-    public function testConstructorJsonOption()
+    public function testConstructorJsonOption(): void
     {
         $parser = new BodyParserMiddleware(['json' => false]);
         $this->assertEquals([], $parser->getParsers(), 'No JSON types set.');
@@ -125,10 +119,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test setMethods()
-     *
-     * @return void
      */
-    public function testSetMethodsReturn()
+    public function testSetMethodsReturn(): void
     {
         $parser = new BodyParserMiddleware();
         $this->assertSame($parser, $parser->setMethods(['PUT']));
@@ -137,10 +129,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test addParser()
-     *
-     * @return void
      */
-    public function testAddParserReturn()
+    public function testAddParserReturn(): void
     {
         $parser = new BodyParserMiddleware(['json' => false]);
         $f1 = function (string $body) {
@@ -151,10 +141,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test last parser defined wins
-     *
-     * @return void
      */
-    public function testAddParserOverwrite()
+    public function testAddParserOverwrite(): void
     {
         $parser = new BodyParserMiddleware(['json' => false]);
 
@@ -174,9 +162,8 @@ class BodyParserMiddlewareTest extends TestCase
      * test skipping parsing on unknown type
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvokeMismatchedType(string $method)
+    public function testInvokeMismatchedType(string $method): void
     {
         $parser = new BodyParserMiddleware();
 
@@ -199,9 +186,8 @@ class BodyParserMiddlewareTest extends TestCase
      * test parsing on valid http method
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvokeCaseInsensitiveContentType(string $method)
+    public function testInvokeCaseInsensitiveContentType(string $method): void
     {
         $parser = new BodyParserMiddleware();
 
@@ -224,9 +210,8 @@ class BodyParserMiddlewareTest extends TestCase
      * test parsing on valid http method
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvokeParse(string $method)
+    public function testInvokeParse(string $method): void
     {
         $parser = new BodyParserMiddleware();
 
@@ -247,10 +232,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test parsing on valid http method with charset
-     *
-     * @return void
      */
-    public function testInvokeParseStripCharset()
+    public function testInvokeParseStripCharset(): void
     {
         $parser = new BodyParserMiddleware();
 
@@ -273,9 +256,8 @@ class BodyParserMiddlewareTest extends TestCase
      * test parsing on ignored http method
      *
      * @dataProvider safeHttpMethodProvider
-     * @return void
      */
-    public function testInvokeNoParseOnSafe(string $method)
+    public function testInvokeNoParseOnSafe(string $method): void
     {
         $parser = new BodyParserMiddleware();
 
@@ -296,10 +278,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test parsing XML bodies.
-     *
-     * @return void
      */
-    public function testInvokeXml()
+    public function testInvokeXml(): void
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8"?>
@@ -329,10 +309,8 @@ XML;
 
     /**
      * Test that CDATA is removed in XML data.
-     *
-     * @return void
      */
-    public function testInvokeXmlCdata()
+    public function testInvokeXmlCdata(): void
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8"?>
@@ -365,10 +343,8 @@ XML;
 
     /**
      * Test that internal entity recursion is ignored.
-     *
-     * @return void
      */
-    public function testInvokeXmlInternalEntities()
+    public function testInvokeXmlInternalEntities(): void
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -409,9 +385,8 @@ XML;
      *
      * @dataProvider jsonScalarValues
      * @param mixed $expected
-     * @return void
      */
-    public function testInvokeParseNoArray(string $body, $expected)
+    public function testInvokeParseNoArray(string $body, $expected): void
     {
         $parser = new BodyParserMiddleware();
 
@@ -432,10 +407,8 @@ XML;
 
     /**
      * test parsing fails will raise a bad request.
-     *
-     * @return void
      */
-    public function testInvokeParseInvalidJson()
+    public function testInvokeParseInvalidJson(): void
     {
         $request = new ServerRequest([
             'environment' => [

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -22,6 +22,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use ParagonIE\CSPBuilder\CSPBuilder;
+use Psr\Http\Server\RequestHandlerInterface;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -31,10 +32,8 @@ class CspMiddlewareTest extends TestCase
 {
     /**
      * Provides the request handler
-     *
-     * @return \Psr\Http\Server\RequestHandlerInterface
      */
-    protected function _getRequestHandler()
+    protected function _getRequestHandler(): RequestHandlerInterface
     {
         return new TestRequestHandler(function ($request) {
             return new Response();
@@ -43,10 +42,8 @@ class CspMiddlewareTest extends TestCase
 
     /**
      * test process adding headers
-     *
-     * @return void
      */
-    public function testProcessAddHeaders()
+    public function testProcessAddHeaders(): void
     {
         $request = new ServerRequest();
 
@@ -75,10 +72,8 @@ class CspMiddlewareTest extends TestCase
 
     /**
      * test process adding request attributes for nonces
-     *
-     * @return void
      */
-    public function testProcessAddNonceAttributes()
+    public function testProcessAddNonceAttributes(): void
     {
         $request = new ServerRequest();
 
@@ -117,10 +112,8 @@ class CspMiddlewareTest extends TestCase
 
     /**
      * testPassingACSPBuilderInstance
-     *
-     * @return void
      */
-    public function testPassingACSPBuilderInstance()
+    public function testPassingACSPBuilderInstance(): void
     {
         $request = new ServerRequest();
 

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -27,6 +27,7 @@ use Cake\Utility\Security;
 use Laminas\Diactoros\Response as DiactorosResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use TestApp\Http\TestRequestHandler;
 
@@ -72,10 +73,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Provides the request handler
-     *
-     * @return \Psr\Http\Server\RequestHandlerInterface
      */
-    protected function _getRequestHandler()
+    protected function _getRequestHandler(): RequestHandlerInterface
     {
         return new TestRequestHandler(function () {
             return new Response();
@@ -84,10 +83,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test setting the cookie value
-     *
-     * @return void
      */
-    public function testSettingCookie()
+    public function testSettingCookie(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -119,10 +116,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test setting request attribute based on old cookie value.
-     *
-     * @return void
      */
-    public function testRequestAttributeCompatWithOldToken()
+    public function testRequestAttributeCompatWithOldToken(): void
     {
         $middleware = new CsrfProtectionMiddleware();
         $oldToken = $this->createOldToken();
@@ -152,9 +147,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that the CSRF tokens are not required for idempotent operations
      *
      * @dataProvider safeHttpMethodProvider
-     * @return void
      */
-    public function testSafeMethodNoCsrfRequired(string $method)
+    public function testSafeMethodNoCsrfRequired(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -172,10 +166,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the CSRF tokens are set for redirect responses
-     *
-     * @return void
      */
-    public function testRedirectResponseCookies()
+    public function testRedirectResponseCookies(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -191,10 +183,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that double applying CSRF causes a failure.
-     *
-     * @return void
      */
-    public function testDoubleApplicationFailure()
+    public function testDoubleApplicationFailure(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -211,10 +201,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the CSRF tokens are set for diactoros responses
-     *
-     * @return void
      */
-    public function testDiactorosResponseCookies()
+    public function testDiactorosResponseCookies(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -232,9 +220,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that the X-CSRF-Token works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenInHeaderCompat(string $method)
+    public function testValidTokenInHeaderCompat(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -257,9 +244,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that the X-CSRF-Token works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenInHeader(string $method)
+    public function testValidTokenInHeader(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -283,9 +269,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that the X-CSRF-Token works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvalidTokenInHeader(string $method)
+    public function testInvalidTokenInHeader(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -317,9 +302,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that request data works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenRequestDataCompat(string $method)
+    public function testValidTokenRequestDataCompat(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
         $token = $this->createOldToken();
@@ -346,9 +330,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that request data works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenRequestDataSalted(string $method)
+    public function testValidTokenRequestDataSalted(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -374,10 +357,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that request non string cookies are ignored.
-     *
-     * @return void
      */
-    public function testInvalidTokenNonStringCookies()
+    public function testInvalidTokenNonStringCookies(): void
     {
         $this->expectException(\Cake\Http\Exception\InvalidCsrfTokenException::class);
         $request = new ServerRequest([
@@ -395,9 +376,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that request data works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvalidTokenRequestData(string $method)
+    public function testInvalidTokenRequestData(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -425,10 +405,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that tokens cannot be simple matches and must pass our hmac.
-     *
-     * @return void
      */
-    public function testInvalidTokenIncorrectOrigin()
+    public function testInvalidTokenIncorrectOrigin(): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -446,10 +424,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that missing post field fails
-     *
-     * @return void
      */
-    public function testInvalidTokenRequestDataMissing()
+    public function testInvalidTokenRequestDataMissing(): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -468,9 +444,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that missing header and cookie fails
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvalidTokenMissingCookie(string $method)
+    public function testInvalidTokenMissingCookie(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -494,10 +469,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the configuration options work.
-     *
-     * @return void
      */
-    public function testConfigurationCookieCreate()
+    public function testConfigurationCookieCreate(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -524,9 +497,9 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertSame(CookieInterface::SAMESITE_STRICT, $cookie['samesite'], 'samesite attribute missing');
     }
 
-    public function testUsingDeprecatedConfigKey()
+    public function testUsingDeprecatedConfigKey(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $request = new ServerRequest([
                 'environment' => ['REQUEST_METHOD' => 'GET'],
                 'webroot' => '/dir/',
@@ -550,10 +523,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
      * Test that the configuration options work.
      *
      * There should be no exception thrown.
-     *
-     * @return void
      */
-    public function testConfigurationValidate()
+    public function testConfigurationValidate(): void
     {
         $middleware = new CsrfProtectionMiddleware([
             'cookieName' => 'token',
@@ -572,12 +543,9 @@ class CsrfProtectionMiddlewareTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
     }
 
-    /**
-     * @return void
-     */
-    public function testSkippingTokenCheckUsingWhitelistCallback()
+    public function testSkippingTokenCheckUsingWhitelistCallback(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $request = new ServerRequest([
                 'post' => [
                     '_csrfToken' => 'foo',
@@ -606,10 +574,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         });
     }
 
-    /**
-     * @return void
-     */
-    public function testSkippingTokenCheckUsingSkipCheckCallback()
+    public function testSkippingTokenCheckUsingSkipCheckCallback(): void
     {
         $request = new ServerRequest([
             'post' => [
@@ -640,10 +605,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Ensure salting is not consistent
-     *
-     * @return void
      */
-    public function testSaltToken()
+    public function testSaltToken(): void
     {
         $middleware = new CsrfProtectionMiddleware();
         $token = $middleware->createToken();

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -53,10 +53,8 @@ class EncryptedCookieMiddlewareTest extends TestCase
 
     /**
      * Test decoding request cookies
-     *
-     * @return void
      */
-    public function testDecodeRequestCookies()
+    public function testDecodeRequestCookies(): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
         $request = $request->withCookieParams([
@@ -80,9 +78,8 @@ class EncryptedCookieMiddlewareTest extends TestCase
      *
      * @dataProvider malformedCookies
      * @param string $cookie
-     * @return void
      */
-    public function testDecodeMalformedCookies($cookie)
+    public function testDecodeMalformedCookies($cookie): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
         $request = $request->withCookieParams(['secret' => $cookie]);
@@ -105,7 +102,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
      *
      * @return array
      */
-    public function malformedCookies()
+    public function malformedCookies(): array
     {
         $encrypted = $this->_encrypt('secret data', 'aes');
 
@@ -119,10 +116,8 @@ class EncryptedCookieMiddlewareTest extends TestCase
 
     /**
      * Test encoding cookies in the set-cookie header.
-     *
-     * @return void
      */
-    public function testEncodeResponseSetCookieHeader()
+    public function testEncodeResponseSetCookieHeader(): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
         $handler = new TestRequestHandler(function ($req) {
@@ -144,10 +139,8 @@ class EncryptedCookieMiddlewareTest extends TestCase
 
     /**
      * Test encoding cookies in the cookie collection.
-     *
-     * @return void
      */
-    public function testEncodeResponseCookieData()
+    public function testEncodeResponseCookieData(): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);
         $handler = new TestRequestHandler(function ($req) {

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -45,7 +45,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         Configure::write('debug', true);
     }
 
-    public function testForRequestWithHttps()
+    public function testForRequestWithHttps(): void
     {
         $uri = new Uri('https://localhost/foo');
         $request = new ServerRequest();
@@ -62,7 +62,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $this->assertSame('success', (string)$result->getBody());
     }
 
-    public function testRedirect()
+    public function testRedirect(): void
     {
         $uri = new Uri('http://localhost/foo');
         $request = new ServerRequest();
@@ -97,10 +97,8 @@ class HttpsEnforcerMiddlewareTest extends TestCase
 
     /**
      * Test that exception is thrown when redirect is disabled.
-     *
-     * @return void
      */
-    public function testNoRedirectException()
+    public function testNoRedirectException(): void
     {
         $this->expectException(BadRequestException::class);
 
@@ -118,10 +116,8 @@ class HttpsEnforcerMiddlewareTest extends TestCase
 
     /**
      * Test that exception is thrown for non GET request even if redirect is enabled.
-     *
-     * @return void
      */
-    public function testExceptionForNonGetRequest()
+    public function testExceptionForNonGetRequest(): void
     {
         $this->expectException(BadRequestException::class);
 
@@ -139,10 +135,8 @@ class HttpsEnforcerMiddlewareTest extends TestCase
 
     /**
      * Test that HTTPS check is skipped when debug is on.
-     *
-     * @return void
      */
-    public function testNoCheckWithDebugOn()
+    public function testNoCheckWithDebugOn(): void
     {
         Configure::write('debug', true);
 

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -29,10 +29,8 @@ class SecurityHeadersMiddlewareTest extends TestCase
 {
     /**
      * Test adding the security headers
-     *
-     * @return void
      */
-    public function testAddingSecurityHeaders()
+    public function testAddingSecurityHeaders(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/',
@@ -65,10 +63,8 @@ class SecurityHeadersMiddlewareTest extends TestCase
 
     /**
      * Testing that the URL is required when option is `allow-from`
-     *
-     * @return void
      */
-    public function testInvalidArgumentExceptionForsetXFrameOptionsUrl()
+    public function testInvalidArgumentExceptionForsetXFrameOptionsUrl(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The 2nd arg $url can not be empty when `allow-from` is used');
@@ -79,10 +75,8 @@ class SecurityHeadersMiddlewareTest extends TestCase
     /**
      * Testing the protected checkValues() method that is used by most of the
      * methods in the test to avoid passing an invalid argument.
-     *
-     * @return void
      */
-    public function testCheckValues()
+    public function testCheckValues(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid arg `INVALID-VALUE!`, use one of these: all, none, master-only, by-content-type, by-ftp-filename');

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -22,6 +22,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -58,10 +59,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Provides the request handler
-     *
-     * @return \Psr\Http\Server\RequestHandlerInterface
      */
-    protected function _getRequestHandler()
+    protected function _getRequestHandler(): RequestHandlerInterface
     {
         return new TestRequestHandler(function () {
             return new Response();
@@ -70,10 +69,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test setting the cookie value
-     *
-     * @return void
      */
-    public function testSettingTokenInSession()
+    public function testSettingTokenInSession(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -105,9 +102,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that the CSRF tokens are not required for idempotent operations
      *
      * @dataProvider safeHttpMethodProvider
-     * @return void
      */
-    public function testSafeMethodNoCsrfRequired(string $method)
+    public function testSafeMethodNoCsrfRequired(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -129,9 +125,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Ensure unsalted tokens work.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenInHeaderBackwardsCompat(string $method)
+    public function testValidTokenInHeaderBackwardsCompat(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -154,9 +149,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that the X-CSRF-Token works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenInHeader(string $method)
+    public function testValidTokenInHeader(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -180,9 +174,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that the X-CSRF-Token works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvalidTokenInHeader(string $method)
+    public function testInvalidTokenInHeader(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -211,9 +204,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Ensure unsalted tokens are still accepted.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenInRequestDataBackwardsCompat(string $method)
+    public function testValidTokenInRequestDataBackwardsCompat(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -242,9 +234,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Ensure salted tokens are accepted.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testValidTokenInRequestData(string $method)
+    public function testValidTokenInRequestData(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -272,9 +263,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that request data works with the various http methods.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvalidTokenRequestData(string $method)
+    public function testInvalidTokenRequestData(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();
@@ -294,10 +284,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that missing post field fails
-     *
-     * @return void
      */
-    public function testInvalidTokenRequestDataMissing()
+    public function testInvalidTokenRequestDataMissing(): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -316,9 +304,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that missing session key fails
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testInvalidTokenMissingSession(string $method)
+    public function testInvalidTokenMissingSession(string $method): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -342,10 +329,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the configuration options work.
-     *
-     * @return void
      */
-    public function testConfigurationCookieCreate()
+    public function testConfigurationCookieCreate(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'GET'],
@@ -368,10 +353,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that the configuration options work.
      *
      * There should be no exception thrown.
-     *
-     * @return void
      */
-    public function testConfigurationValidate()
+    public function testConfigurationValidate(): void
     {
         $middleware = new SessionCsrfProtectionMiddleware([
             'key' => 'csrf',
@@ -388,10 +371,7 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
     }
 
-    /**
-     * @return void
-     */
-    public function testSkippingTokenCheckUsingSkipCheckCallback()
+    public function testSkippingTokenCheckUsingSkipCheckCallback(): void
     {
         $request = new ServerRequest([
             'post' => [
@@ -422,10 +402,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Ensure salting is not consistent
-     *
-     * @return void
      */
-    public function testSaltToken()
+    public function testSaltToken(): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
         $token = $middleware->createToken();

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -28,8 +28,6 @@ class MiddlewareApplicationTest extends TestCase
 {
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -39,10 +37,8 @@ class MiddlewareApplicationTest extends TestCase
 
     /**
      * Integration test for a simple controller.
-     *
-     * @return void
      */
-    public function testHandle()
+    public function testHandle(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/cakes']);
         $request = $request->withAttribute('params', [

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -28,8 +28,6 @@ class MiddlewareQueueTest extends TestCase
 {
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -40,8 +38,6 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -49,9 +45,9 @@ class MiddlewareQueueTest extends TestCase
         static::setAppNamespace($this->previousNamespace);
     }
 
-    public function testConstructorAddingMiddleware()
+    public function testConstructorAddingMiddleware(): void
     {
-        $cb = function () {
+        $cb = function (): void {
         };
         $queue = new MiddlewareQueue([$cb]);
         $this->assertCount(1, $queue);
@@ -60,13 +56,11 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test get()
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $queue = new MiddlewareQueue();
-        $cb = function () {
+        $cb = function (): void {
         };
         $queue->add($cb);
         $this->assertSame($cb, $queue->current()->getCallable());
@@ -74,10 +68,8 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test that current() throws exception for invalid current position.
-     *
-     * @return void
      */
-    public function testGetException()
+    public function testGetException(): void
     {
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('Invalid current position (0)');
@@ -88,27 +80,23 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test the return value of add()
-     *
-     * @return void
      */
-    public function testAddReturn()
+    public function testAddReturn(): void
     {
         $queue = new MiddlewareQueue();
-        $cb = function () {
+        $cb = function (): void {
         };
         $this->assertSame($queue, $queue->add($cb));
     }
 
     /**
      * Test the add orders correctly
-     *
-     * @return void
      */
-    public function testAddOrdering()
+    public function testAddOrdering(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
-        $two = function () {
+        $two = function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -127,12 +115,10 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test the prepend can be chained
-     *
-     * @return void
      */
-    public function testPrependReturn()
+    public function testPrependReturn(): void
     {
-        $cb = function () {
+        $cb = function (): void {
         };
         $queue = new MiddlewareQueue();
         $this->assertSame($queue, $queue->prepend($cb));
@@ -140,14 +126,12 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test the prepend orders correctly.
-     *
-     * @return void
      */
-    public function testPrependOrdering()
+    public function testPrependOrdering(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
-        $two = function () {
+        $two = function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -166,10 +150,8 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test updating queue using class name
-     *
-     * @return void
      */
-    public function testAddingPrependingUsingString()
+    public function testAddingPrependingUsingString(): void
     {
         $queue = new MiddlewareQueue();
         $queue->add('Sample');
@@ -181,12 +163,10 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test updating queue using array
-     *
-     * @return void
      */
-    public function testAddingPrependingUsingArray()
+    public function testAddingPrependingUsingArray(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -200,16 +180,14 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertAt ordering
-     *
-     * @return void
      */
-    public function testInsertAt()
+    public function testInsertAt(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
-        $two = function () {
+        $two = function (): void {
         };
-        $three = function () {
+        $three = function (): void {
         };
         $four = new SampleMiddleware();
 
@@ -234,14 +212,12 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertAt out of the existing range
-     *
-     * @return void
      */
-    public function testInsertAtOutOfBounds()
+    public function testInsertAtOutOfBounds(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
-        $two = function () {
+        $two = function (): void {
         };
 
         $queue = new MiddlewareQueue();
@@ -255,14 +231,12 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertAt with a negative index
-     *
-     * @return void
      */
-    public function testInsertAtNegative()
+    public function testInsertAtNegative(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
-        $two = function () {
+        $two = function (): void {
         };
         $three = new SampleMiddleware();
 
@@ -279,15 +253,13 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertBefore
-     *
-     * @return void
      */
-    public function testInsertBefore()
+    public function testInsertBefore(): void
     {
-        $one = function () {
+        $one = function (): void {
         };
         $two = new SampleMiddleware();
-        $three = function () {
+        $three = function (): void {
         };
         $four = new DumbMiddleware();
 
@@ -320,17 +292,15 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertBefore an invalid classname
-     *
-     * @return void
      */
-    public function testInsertBeforeInvalid()
+    public function testInsertBeforeInvalid(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('No middleware matching \'InvalidClassName\' could be found.');
-        $one = function () {
+        $one = function (): void {
         };
         $two = new SampleMiddleware();
-        $three = function () {
+        $three = function (): void {
         };
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertBefore('InvalidClassName', $three);
@@ -338,15 +308,13 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertAfter
-     *
-     * @return void
      */
-    public function testInsertAfter()
+    public function testInsertAfter(): void
     {
         $one = new SampleMiddleware();
-        $two = function () {
+        $two = function (): void {
         };
-        $three = function () {
+        $three = function (): void {
         };
         $four = new DumbMiddleware();
         $queue = new MiddlewareQueue();
@@ -382,15 +350,13 @@ class MiddlewareQueueTest extends TestCase
 
     /**
      * Test insertAfter an invalid classname
-     *
-     * @return void
      */
-    public function testInsertAfterInvalid()
+    public function testInsertAfterInvalid(): void
     {
         $one = new SampleMiddleware();
-        $two = function () {
+        $two = function (): void {
         };
-        $three = function () {
+        $three = function (): void {
         };
         $queue = new MiddlewareQueue();
         $queue->add($one)->add($two)->insertAfter('InvalidClass', $three);
@@ -406,14 +372,14 @@ class MiddlewareQueueTest extends TestCase
     /**
      * @deprecated
      */
-    public function testAddingDeprecatedDoublePassMiddleware()
+    public function testAddingDeprecatedDoublePassMiddleware(): void
     {
         $queue = new MiddlewareQueue();
         $cb = function ($request, $response, $next) {
             return $next($request, $response);
         };
         $queue->add($cb);
-        $this->deprecated(function () use ($queue, $cb) {
+        $this->deprecated(function () use ($queue, $cb): void {
             $this->assertSame($cb, $queue->current()->getCallable());
         });
     }

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -36,8 +36,6 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -66,8 +64,6 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -77,10 +73,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test emitting simple responses.
-     *
-     * @return void
      */
-    public function testEmitResponseSimple()
+    public function testEmitResponseSimple(): void
     {
         $response = (new Response())
             ->withStatus(201)
@@ -103,10 +97,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test emitting a no-content response
-     *
-     * @return void
      */
-    public function testEmitNoContentResponse()
+    public function testEmitNoContentResponse(): void
     {
         $response = (new Response())
             ->withHeader('X-testing', 'value')
@@ -127,10 +119,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test emitting responses with array cookes
-     *
-     * @return void
      */
-    public function testEmitResponseArrayCookies()
+    public function testEmitResponseArrayCookies(): void
     {
         $response = (new Response())
             ->withCookie(new Cookie('simple', 'val', null, '/', '', true))
@@ -173,10 +163,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test emitting responses with cookies
-     *
-     * @return void
      */
-    public function testEmitResponseCookies()
+    public function testEmitResponseCookies(): void
     {
         $response = (new Response())
             ->withAddedHeader('Set-Cookie', "simple=val;\tSecure")
@@ -252,12 +240,10 @@ class ResponseEmitterTest extends TestCase
      * Test emitting responses using callback streams.
      *
      * We use callback streams for closure based responses.
-     *
-     * @return void
      */
-    public function testEmitResponseCallbackStream()
+    public function testEmitResponseCallbackStream(): void
     {
-        $stream = new CallbackStream(function () {
+        $stream = new CallbackStream(function (): void {
             echo 'It worked';
         });
         $response = (new Response())
@@ -279,10 +265,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test valid body ranges.
-     *
-     * @return void
      */
-    public function testEmitResponseBodyRange()
+    public function testEmitResponseBodyRange(): void
     {
         $response = (new Response())
             ->withHeader('Content-Type', 'text/plain')
@@ -304,10 +288,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test valid body ranges.
-     *
-     * @return void
      */
-    public function testEmitResponseBodyRangeComplete()
+    public function testEmitResponseBodyRangeComplete(): void
     {
         $response = (new Response())
             ->withHeader('Content-Type', 'text/plain')
@@ -323,10 +305,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test out of bounds body ranges.
-     *
-     * @return void
      */
-    public function testEmitResponseBodyRangeOverflow()
+    public function testEmitResponseBodyRangeOverflow(): void
     {
         $response = (new Response())
             ->withHeader('Content-Type', 'text/plain')
@@ -342,10 +322,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test malformed content-range header
-     *
-     * @return void
      */
-    public function testEmitResponseBodyRangeMalformed()
+    public function testEmitResponseBodyRangeMalformed(): void
     {
         $response = (new Response())
             ->withHeader('Content-Type', 'text/plain')
@@ -361,10 +339,8 @@ class ResponseEmitterTest extends TestCase
 
     /**
      * Test callback streams returning content and ranges
-     *
-     * @return void
      */
-    public function testEmitResponseBodyRangeCallbackStream()
+    public function testEmitResponseBodyRangeCallbackStream(): void
     {
         $stream = new CallbackStream(function () {
             return 'It worked';

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -43,8 +43,6 @@ class ResponseTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -54,8 +52,6 @@ class ResponseTest extends TestCase
 
     /**
      * teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -66,10 +62,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the request object constructor
-     *
-     * @return void
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $response = new Response();
         $this->assertSame('', (string)$response->getBody());
@@ -94,10 +88,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the getCharset/withCharset methods
-     *
-     * @return void
      */
-    public function testWithCharset()
+    public function testWithCharset(): void
     {
         $response = new Response();
         $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
@@ -111,10 +103,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the getType method
-     *
-     * @return void
      */
-    public function testGetType()
+    public function testGetType(): void
     {
         $response = new Response();
         $this->assertSame('text/html', $response->getType());
@@ -133,10 +123,7 @@ class ResponseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testSetTypeMap()
+    public function testSetTypeMap(): void
     {
         $response = new Response();
         $response->setTypeMap('ical', 'text/calendar');
@@ -145,10 +132,7 @@ class ResponseTest extends TestCase
         $this->assertSame('text/calendar', $response);
     }
 
-    /**
-     * @return void
-     */
-    public function testSetTypeMapAsArray()
+    public function testSetTypeMapAsArray(): void
     {
         $response = new Response();
         $response->setTypeMap('ical', ['text/calendar']);
@@ -159,10 +143,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the withType method
-     *
-     * @return void
      */
-    public function testWithTypeAlias()
+    public function testWithTypeAlias(): void
     {
         $response = new Response();
         $this->assertSame(
@@ -188,10 +170,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withType() and full mime-types
-     *
-     * @return void
      */
-    public function withTypeFull()
+    public function withTypeFull(): void
     {
         $response = new Response();
         $this->assertSame(
@@ -213,10 +193,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test that an invalid type raises an exception
-     *
-     * @return void
      */
-    public function testWithTypeInvalidType()
+    public function testWithTypeInvalidType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('"beans" is an invalid content type');
@@ -241,10 +219,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test that setting certain status codes clears the status code.
-     *
-     * @return void
      */
-    public function testWithStatusClearsContentType()
+    public function testWithStatusClearsContentType(): void
     {
         $response = new Response();
         $new = $response->withType('pdf')
@@ -272,10 +248,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test that setting status codes doesn't overwrite content-type
-     *
-     * @return void
      */
-    public function testWithStatusDoesNotChangeContentType()
+    public function testWithStatusDoesNotChangeContentType(): void
     {
         $response = new Response();
         $new = $response->withHeader('Content-Type', 'application/json')
@@ -293,10 +267,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the withDisabledCache method
-     *
-     * @return void
      */
-    public function testWithDisabledCache()
+    public function testWithDisabledCache(): void
     {
         $response = new Response();
         $expected = [
@@ -313,10 +285,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the withCache method
-     *
-     * @return void
      */
-    public function testWithCache()
+    public function testWithCache(): void
     {
         $response = new Response();
         $since = $time = time();
@@ -333,10 +303,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the compress method
-     *
-     * @return void
      */
-    public function testCompress()
+    public function testCompress(): void
     {
         $this->skipIf(defined('HHVM_VERSION'), 'HHVM does not implement ob_gzhandler');
 
@@ -360,10 +328,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the withDownload method
-     *
-     * @return void
      */
-    public function testWithDownload()
+    public function testWithDownload(): void
     {
         $response = new Response();
         $new = $response->withDownload('myfile.mp3');
@@ -375,10 +341,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the mapType method
-     *
-     * @return void
      */
-    public function testMapType()
+    public function testMapType(): void
     {
         $response = new Response();
         $this->assertSame('wav', $response->mapType('audio/x-wav'));
@@ -393,10 +357,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the outputCompressed method
-     *
-     * @return void
      */
-    public function testOutputCompressed()
+    public function testOutputCompressed(): void
     {
         $response = new Response();
 
@@ -431,10 +393,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests settings the content length
-     *
-     * @return void
      */
-    public function testWithLength()
+    public function testWithLength(): void
     {
         $response = new Response();
         $this->assertFalse($response->hasHeader('Content-Length'));
@@ -447,10 +407,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests settings the link
-     *
-     * @return void
      */
-    public function testWithAddedLink()
+    public function testWithAddedLink(): void
     {
         $response = new Response();
         $this->assertFalse($response->hasHeader('Link'));
@@ -469,10 +427,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the withExpires method
-     *
-     * @return void
      */
-    public function testWithExpires()
+    public function testWithExpires(): void
     {
         $response = new Response();
         $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
@@ -494,10 +450,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests the withModified method
-     *
-     * @return void
      */
-    public function testWithModified()
+    public function testWithModified(): void
     {
         $response = new Response();
         $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
@@ -522,10 +476,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests withSharable()
-     *
-     * @return void
      */
-    public function testWithSharable()
+    public function testWithSharable(): void
     {
         $response = new Response();
         $new = $response->withSharable(true);
@@ -544,10 +496,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests withMaxAge()
-     *
-     * @return void
      */
-    public function testWithMaxAge()
+    public function testWithMaxAge(): void
     {
         $response = new Response();
         $this->assertFalse($response->hasHeader('Cache-Control'));
@@ -562,10 +512,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests setting of s-maxage Cache-Control directive
-     *
-     * @return void
      */
-    public function testWithSharedMaxAge()
+    public function testWithSharedMaxAge(): void
     {
         $response = new Response();
         $new = $response->withSharedMaxAge(3600);
@@ -579,10 +527,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests setting of must-revalidate Cache-Control directive
-     *
-     * @return void
      */
-    public function testWithMustRevalidate()
+    public function testWithMustRevalidate(): void
     {
         $response = new Response();
         $this->assertFalse($response->hasHeader('Cache-Control'));
@@ -597,10 +543,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests withVary()
-     *
-     * @return void
      */
-    public function testWithVary()
+    public function testWithVary(): void
     {
         $response = new Response();
         $new = $response->withVary('Accept-encoding');
@@ -615,10 +559,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests withEtag()
-     *
-     * @return void
      */
-    public function testWithEtag()
+    public function testWithEtag(): void
     {
         $response = new Response();
         $new = $response->withEtag('something');
@@ -632,10 +574,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests that the response is able to be marked as not modified
-     *
-     * @return void
      */
-    public function testNotModified()
+    public function testNotModified(): void
     {
         $response = new Response();
         $response = $response->withStringBody('something')
@@ -653,10 +593,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests withNotModified()
-     *
-     * @return void
      */
-    public function testWithNotModified()
+    public function testWithNotModified(): void
     {
         $response = new Response(['body' => 'something']);
         $response = $response->withLength(100)
@@ -682,10 +620,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedByEtagStar()
+    public function testCheckNotModifiedByEtagStar(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-None-Match', '*');
@@ -699,10 +635,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedByEtagExact()
+    public function testCheckNotModifiedByEtagExact(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-None-Match', 'W/"something", "other"');
@@ -716,10 +650,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedByEtagAndTime()
+    public function testCheckNotModifiedByEtagAndTime(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-Modified-Since', '2012-01-01 00:00:00')
@@ -735,10 +667,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedByEtagAndTimeMismatch()
+    public function testCheckNotModifiedByEtagAndTimeMismatch(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-Modified-Since', '2012-01-01 00:00:00')
@@ -754,10 +684,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedByEtagMismatch()
+    public function testCheckNotModifiedByEtagMismatch(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-Modified-Since', '2012-01-01 00:00:00')
@@ -773,10 +701,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedByTime()
+    public function testCheckNotModifiedByTime(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-Modified-Since', '2012-01-01 00:00:00');
@@ -790,10 +716,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test checkNotModified method
-     *
-     * @return void
      */
-    public function testCheckNotModifiedNoHints()
+    public function testCheckNotModifiedNoHints(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('If-None-Match', 'W/"something", "other"')
@@ -805,10 +729,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test setting cookies with no value
-     *
-     * @return void
      */
-    public function testWithCookieEmpty()
+    public function testWithCookieEmpty(): void
     {
         $response = new Response();
         $new = $response->withCookie(new Cookie('testing'));
@@ -829,10 +751,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test setting cookies with scalar values
-     *
-     * @return void
      */
-    public function testWithCookieScalar()
+    public function testWithCookieScalar(): void
     {
         $response = new Response();
         $new = $response->withCookie(new Cookie('testing', 'abc123'));
@@ -852,10 +772,9 @@ class ResponseTest extends TestCase
     /**
      * Test withCookie() and duplicate data
      *
-     * @return void
      * @throws \Exception
      */
-    public function testWithDuplicateCookie()
+    public function testWithDuplicateCookie(): void
     {
         $expiry = new \DateTimeImmutable('+24 hours');
 
@@ -890,10 +809,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test withCookie() and a cookie instance
-     *
-     * @return void
      */
-    public function testWithCookieObject()
+    public function testWithCookieObject(): void
     {
         $response = new Response();
         $cookie = new Cookie('yay', 'a value');
@@ -904,7 +821,7 @@ class ResponseTest extends TestCase
         $this->assertSame($cookie, $new->getCookieCollection()->get('yay'));
     }
 
-    public function testWithExpiredCookieScalar()
+    public function testWithExpiredCookieScalar(): void
     {
         $response = new Response();
         $response = $response->withCookie(new Cookie('testing', 'abc123'));
@@ -919,7 +836,7 @@ class ResponseTest extends TestCase
     /**
      * @throws \Exception If DateImmutable emits an error.
      */
-    public function testWithExpiredCookieOptions()
+    public function testWithExpiredCookieOptions(): void
     {
         $options = [
             'name' => 'testing',
@@ -952,10 +869,7 @@ class ResponseTest extends TestCase
         $this->assertLessThan(FrozenTime::createFromTimestamp(1), (string)$expiredCookie->getCookie('testing')['expires']);
     }
 
-    /**
-     * @return void
-     */
-    public function testWithExpiredCookieObject()
+    public function testWithExpiredCookieObject(): void
     {
         $response = new Response();
         $cookie = new Cookie('yay', 'a value');
@@ -970,10 +884,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test getCookies() and array data.
-     *
-     * @return void
      */
-    public function testGetCookies()
+    public function testGetCookies(): void
     {
         $response = new Response();
         $new = $response->withCookie(new Cookie('testing', 'a'))
@@ -1003,10 +915,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test getCookies() and array data.
-     *
-     * @return void
      */
-    public function testGetCookiesArrayValue()
+    public function testGetCookiesArrayValue(): void
     {
         $response = new Response();
         $cookie = (new Cookie('urmc'))
@@ -1030,10 +940,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test getCookieCollection() as array data
-     *
-     * @return void
      */
-    public function testGetCookieCollection()
+    public function testGetCookieCollection(): void
     {
         $response = new Response();
         $new = $response->withCookie(new Cookie('testing', 'a'))
@@ -1052,10 +960,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test withCookieCollection()
-     *
-     * @return void
      */
-    public function testWithCookieCollection()
+    public function testWithCookieCollection(): void
     {
         $response = new Response();
         $collection = new CookieCollection([new Cookie('foo', 'bar')]);
@@ -1068,10 +974,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test that cors() returns a builder.
-     *
-     * @return void
      */
-    public function testCors()
+    public function testCors(): void
     {
         $request = new ServerRequest([
             'environment' => ['HTTP_ORIGIN' => 'http://example.com'],
@@ -1084,10 +988,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() not found
-     *
-     * @return void
      */
-    public function testWithFileNotFound()
+    public function testWithFileNotFound(): void
     {
         $this->expectException(\Cake\Http\Exception\NotFoundException::class);
         $this->expectExceptionMessage('The requested file /some/missing/folder/file.jpg was not found');
@@ -1098,10 +1000,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() not found
-     *
-     * @return void
      */
-    public function testWithFileNotFoundNoDebug()
+    public function testWithFileNotFoundNoDebug(): void
     {
         Configure::write('debug', 0);
 
@@ -1130,9 +1030,8 @@ class ResponseTest extends TestCase
      * test withFile and invalid paths
      *
      * @dataProvider invalidFileProvider
-     * @return void
      */
-    public function testWithFileInvalidPath(string $path, string $expectedMessage)
+    public function testWithFileInvalidPath(string $path, string $expectedMessage): void
     {
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage($expectedMessage);
@@ -1143,10 +1042,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() + download & name
-     *
-     * @return void
      */
-    public function testWithFileDownloadAndName()
+    public function testWithFileDownloadAndName(): void
     {
         $response = new Response();
         $new = $response->withFile(
@@ -1182,10 +1079,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() + a generic agent
-     *
-     * @return void
      */
-    public function testWithFileUnknownFileTypeGeneric()
+    public function testWithFileUnknownFileTypeGeneric(): void
     {
         $response = new Response();
         $new = $response->withFile(CONFIG . 'no_section.ini');
@@ -1202,10 +1097,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() + opera
-     *
-     * @return void
      */
-    public function testWithFileUnknownFileTypeOpera()
+    public function testWithFileUnknownFileTypeOpera(): void
     {
         $_SERVER['HTTP_USER_AGENT'] = 'Opera/9.80 (Windows NT 6.0; U; en) Presto/2.8.99 Version/11.10';
         $response = new Response();
@@ -1220,10 +1113,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() + old IE
-     *
-     * @return void
      */
-    public function testWithFileUnknownFileTypeOldIe()
+    public function testWithFileUnknownFileTypeOldIe(): void
     {
         $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; Media Center PC 4.0; SLCC1; .NET CLR 3.0.04320)';
         $response = new Response();
@@ -1234,10 +1125,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile() + no download
-     *
-     * @return void
      */
-    public function testWithFileNoDownload()
+    public function testWithFileNoDownload(): void
     {
         $response = new Response();
         $new = $response->withFile(CONFIG . 'no_section.ini', [
@@ -1253,10 +1142,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test that uppercase extensions result in correct content-types
-     *
-     * @return void
      */
-    public function testWithFileUpperExtension()
+    public function testWithFileUpperExtension(): void
     {
         $response = new Response();
         $new = $response->withFile(TEST_APP . 'vendor/img/test_2.JPG');
@@ -1299,9 +1186,8 @@ class ResponseTest extends TestCase
      * Test withFile() & the various range offset types.
      *
      * @dataProvider rangeProvider
-     * @return void
      */
-    public function testWithFileRangeOffsets(string $range, int $length, string $offsetResponse)
+    public function testWithFileRangeOffsets(string $range, int $length, string $offsetResponse): void
     {
         $_SERVER['HTTP_RANGE'] = $range;
         $response = new Response();
@@ -1321,10 +1207,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test withFile() fetching ranges from a file.
-     *
-     * @return void
      */
-    public function testWithFileRange()
+    public function testWithFileRange(): void
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=8-25';
         $response = new Response();
@@ -1368,9 +1252,8 @@ class ResponseTest extends TestCase
      * Test withFile() and invalid ranges
      *
      * @dataProvider invalidFileRangeProvider
-     * @return void
      */
-    public function testWithFileInvalidRange(string $range)
+    public function testWithFileInvalidRange(string $range): void
     {
         $_SERVER['HTTP_RANGE'] = $range;
         $response = new Response();
@@ -1392,10 +1275,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test withFile() and a reversed range
-     *
-     * @return void
      */
-    public function testWithFileReversedRange()
+    public function testWithFileReversedRange(): void
     {
         $_SERVER['HTTP_RANGE'] = 'bytes=30-2';
         $response = new Response();
@@ -1416,10 +1297,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test the withLocation method.
-     *
-     * @return void
      */
-    public function testWithLocation()
+    public function testWithLocation(): void
     {
         $response = new Response();
         $this->assertSame('', $response->getHeaderLine('Location'), 'No header should be set.');
@@ -1433,10 +1312,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test get protocol version.
-     *
-     * @return void
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): void
     {
         $response = new Response();
         $version = $response->getProtocolVersion();
@@ -1445,10 +1322,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test with protocol.
-     *
-     * @return void
      */
-    public function testWithProtocol()
+    public function testWithProtocol(): void
     {
         $response = new Response();
         $version = $response->getProtocolVersion();
@@ -1463,10 +1338,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test with status code.
-     *
-     * @return void
      */
-    public function testWithStatusCode()
+    public function testWithStatusCode(): void
     {
         $response = new Response();
         $statusCode = $response->getStatusCode();
@@ -1487,10 +1360,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test invalid status codes
-     *
-     * @return void
      */
-    public function testWithStatusInvalid()
+    public function testWithStatusInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid status code: 1001. Use a valid HTTP status code in range 1xx - 5xx.');
@@ -1500,10 +1371,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test get reason phrase.
-     *
-     * @return void
      */
-    public function testGetReasonPhrase()
+    public function testGetReasonPhrase(): void
     {
         $response = new Response();
         $this->assertSame('OK', $response->getReasonPhrase());
@@ -1515,10 +1384,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test with body.
-     *
-     * @return void
      */
-    public function testWithBody()
+    public function testWithBody(): void
     {
         $response = new Response();
         $body = $response->getBody();
@@ -1543,10 +1410,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test with string body.
-     *
-     * @return void
      */
-    public function testWithStringBody()
+    public function testWithStringBody(): void
     {
         $response = new Response();
         $newResponse = $response->withStringBody('Foo');
@@ -1575,10 +1440,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test get Body.
-     *
-     * @return void
      */
-    public function testGetBody()
+    public function testGetBody(): void
     {
         $response = new Response();
         $stream = $response->getBody();
@@ -1587,10 +1450,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test with header.
-     *
-     * @return void
      */
-    public function testWithHeader()
+    public function testWithHeader(): void
     {
         $response = new Response();
         $response2 = $response->withHeader('Accept', 'application/json');
@@ -1606,10 +1467,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test get headers.
-     *
-     * @return void
      */
-    public function testGetHeaders()
+    public function testGetHeaders(): void
     {
         $response = new Response();
         $headers = $response->getHeaders();
@@ -1629,10 +1488,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test without header.
-     *
-     * @return void
      */
-    public function testWithoutHeader()
+    public function testWithoutHeader(): void
     {
         $response = new Response();
         $response = $response->withAddedHeader('Location', 'localhost');
@@ -1651,10 +1508,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test get header.
-     *
-     * @return void
      */
-    public function testGetHeader()
+    public function testGetHeader(): void
     {
         $response = new Response();
         $response = $response->withAddedHeader('Location', 'localhost');
@@ -1671,10 +1526,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test get header line.
-     *
-     * @return void
      */
-    public function testGetHeaderLine()
+    public function testGetHeaderLine(): void
     {
         $response = new Response();
         $headers = $response->getHeaderLine('Accept');
@@ -1692,10 +1545,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test has header.
-     *
-     * @return void
      */
-    public function testHasHeader()
+    public function testHasHeader(): void
     {
         $response = new Response();
         $response = $response->withAddedHeader('Location', 'localhost');
@@ -1710,10 +1561,8 @@ class ResponseTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $response = new Response();
         $response = $response->withStringBody('Foo');

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -30,8 +30,6 @@ class RunnerTest extends TestCase
 {
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -45,17 +43,15 @@ class RunnerTest extends TestCase
         $this->pass = function ($request, $handler) {
             return $handler->handle($request);
         };
-        $this->fail = function ($request, $handler) {
+        $this->fail = function ($request, $handler): void {
             throw new RuntimeException('A bad thing');
         };
     }
 
     /**
      * Test running a single middleware object.
-     *
-     * @return void
      */
-    public function testRunSingle()
+    public function testRunSingle(): void
     {
         $this->queue->add($this->ok);
         $req = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
@@ -67,10 +63,8 @@ class RunnerTest extends TestCase
 
     /**
      * Test that middleware is run in sequence
-     *
-     * @return void
      */
-    public function testRunSequencing()
+    public function testRunSequencing(): void
     {
         $log = [];
         $one = function ($request, $handler) use (&$log) {
@@ -102,7 +96,7 @@ class RunnerTest extends TestCase
     /**
      * Test that exceptions bubble up.
      */
-    public function testRunExceptionInMiddleware()
+    public function testRunExceptionInMiddleware(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('A bad thing');

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -31,10 +31,8 @@ class ServerRequestFactoryTest extends TestCase
 {
     /**
      * Test fromGlobals reads super globals
-     *
-     * @return void
      */
-    public function testFromGlobalsSuperGlobals()
+    public function testFromGlobalsSuperGlobals(): void
     {
         $post = [
             'title' => 'custom',
@@ -71,9 +69,8 @@ class ServerRequestFactoryTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testFromGlobalsUrlSession()
+    public function testFromGlobalsUrlSession(): void
     {
         Configure::write('App.base', '/basedir');
         $server = [
@@ -89,10 +86,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test fromGlobals with App.base defined.
-     *
-     * @return void
      */
-    public function testFromGlobalsUrlBaseDefined()
+    public function testFromGlobalsUrlBaseDefined(): void
     {
         Configure::write('App.base', 'basedir');
         $server = [
@@ -108,10 +103,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test fromGlobals with mod-rewrite server configuration.
-     *
-     * @return void
      */
-    public function testFromGlobalsUrlModRewrite()
+    public function testFromGlobalsUrlModRewrite(): void
     {
         Configure::write('App.baseUrl', false);
 
@@ -174,10 +167,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test baseUrl with ModRewrite alias
-     *
-     * @return void
      */
-    public function testBaseUrlwithModRewriteAlias()
+    public function testBaseUrlwithModRewriteAlias(): void
     {
         Configure::write('App.base', '/control');
 
@@ -212,10 +203,8 @@ class ServerRequestFactoryTest extends TestCase
      * - index.php/
      * - index.php/apples/
      * - index.php/bananas/eat/tasty_banana
-     *
-     * @return void
      */
-    public function testBaseUrlWithModRewriteAndIndexPhp()
+    public function testBaseUrlWithModRewriteAndIndexPhp(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'DOCUMENT_ROOT' => '/cakephp/webroot/index.php',
@@ -270,10 +259,8 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Test that even if mod_rewrite is on, and the url contains index.php
      * and there are numerous //s that the base/webroot is calculated correctly.
-     *
-     * @return void
      */
-    public function testBaseUrlWithModRewriteAndExtraSlashes()
+    public function testBaseUrlWithModRewriteAndExtraSlashes(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'REQUEST_URI' => '/cakephp/webroot///index.php/bananas/eat',
@@ -288,10 +275,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test fromGlobals with mod-rewrite in the root dir.
-     *
-     * @return void
      */
-    public function testFromGlobalsUrlModRewriteRootDir()
+    public function testFromGlobalsUrlModRewriteRootDir(): void
     {
         $server = [
             'DOCUMENT_ROOT' => '/cake/repo/branches/1.2.x.x/webroot',
@@ -308,10 +293,8 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Test fromGlobals with App.baseUrl defined implying no
      * mod-rewrite and no virtual path.
-     *
-     * @return void
      */
-    public function testFromGlobalsUrlNoModRewriteWebrootDir()
+    public function testFromGlobalsUrlNoModRewriteWebrootDir(): void
     {
         Configure::write('App', [
             'dir' => 'app',
@@ -335,10 +318,8 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Test fromGlobals with App.baseUrl defined implying no
      * mod-rewrite
-     *
-     * @return void
      */
-    public function testFromGlobalsUrlNoModRewrite()
+    public function testFromGlobalsUrlNoModRewrite(): void
     {
         Configure::write('App', [
             'dir' => 'app',
@@ -362,10 +343,8 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Test fromGlobals with App.baseUrl defined implying no
      * mod-rewrite in the root dir.
-     *
-     * @return void
      */
-    public function testFromGlobalsUrlNoModRewriteRootDir()
+    public function testFromGlobalsUrlNoModRewriteRootDir(): void
     {
         Configure::write('App', [
             'dir' => 'cake',
@@ -388,10 +367,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Check that a sub-directory containing app|webroot doesn't get mishandled when re-writing is off.
-     *
-     * @return void
      */
-    public function testBaseUrlWithAppAndWebrootInDirname()
+    public function testBaseUrlWithAppAndWebrootInDirname(): void
     {
         Configure::write('App.baseUrl', '/approval/index.php');
 
@@ -414,10 +391,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test baseUrl and webroot with baseUrl
-     *
-     * @return void
      */
-    public function testBaseUrlAndWebrootWithBaseUrl()
+    public function testBaseUrlAndWebrootWithBaseUrl(): void
     {
         Configure::write('App.dir', 'App');
         Configure::write('App.baseUrl', '/App/webroot/index.php');
@@ -466,10 +441,8 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Test that a request with a . in the main GET parameter is filtered out.
      * PHP changes GET parameter keys containing dots to _.
-     *
-     * @return void
      */
-    public function testGetParamsWithDot()
+    public function testGetParamsWithDot(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'PHP_SELF' => '/webroot/index.php',
@@ -488,10 +461,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test that a request with urlencoded bits in the main GET parameter are filtered out.
-     *
-     * @return void
      */
-    public function testGetParamWithUrlencodedElement()
+    public function testGetParamWithUrlencodedElement(): void
     {
         $request = ServerRequestFactory::fromGlobals([
             'PHP_SELF' => '/webroot/index.php',
@@ -513,7 +484,7 @@ class ServerRequestFactoryTest extends TestCase
      *
      * @return array Environment array
      */
-    public static function environmentGenerator()
+    public static function environmentGenerator(): array
     {
         return [
             [
@@ -913,9 +884,8 @@ class ServerRequestFactoryTest extends TestCase
      * @param string $name
      * @param array $data
      * @param array $expected
-     * @return void
      */
-    public function testEnvironmentDetection($name, $data, $expected)
+    public function testEnvironmentDetection($name, $data, $expected): void
     {
         if (isset($data['App'])) {
             Configure::write('App', $data['App']);
@@ -936,10 +906,7 @@ class ServerRequestFactoryTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testFormUrlEncodedBodyParsing()
+    public function testFormUrlEncodedBodyParsing(): void
     {
         $data = [
             'Article' => ['title'],
@@ -984,10 +951,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test method overrides coming in from POST data.
-     *
-     * @return void
      */
-    public function testMethodOverrides()
+    public function testMethodOverrides(): void
     {
         $post = ['_method' => 'POST'];
         $request = ServerRequestFactory::fromGlobals([], [], $post);
@@ -1011,10 +976,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test getServerParams
-     *
-     * @return void
      */
-    public function testGetServerParams()
+    public function testGetServerParams(): void
     {
         $vars = [
             'REQUEST_METHOD' => 'PUT',
@@ -1033,10 +996,8 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Tests that overriding the method to GET will clean all request
      * data, to better simulate a GET request.
-     *
-     * @return void
      */
-    public function testMethodOverrideEmptyParsedBody()
+    public function testMethodOverrideEmptyParsedBody(): void
     {
         $body = ['_method' => 'GET', 'foo' => 'bar'];
         $request = ServerRequestFactory::fromGlobals(
@@ -1059,10 +1020,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Tests the default file upload merging behavior.
-     *
-     * @return void
      */
-    public function testFromGlobalsWithFilesAsObjectsDefault()
+    public function testFromGlobalsWithFilesAsObjectsDefault(): void
     {
         $this->assertNull(Configure::read('App.uploadedFilesAsObjects'));
 
@@ -1087,10 +1046,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Tests the "as arrays" file upload merging behavior.
-     *
-     * @return void
      */
-    public function testFromGlobalsWithFilesAsObjectsDisabled()
+    public function testFromGlobalsWithFilesAsObjectsDisabled(): void
     {
         Configure::write('App.uploadedFilesAsObjects', false);
 
@@ -1119,10 +1076,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Tests the "as objects" file upload merging behavior.
-     *
-     * @return void
      */
-    public function testFromGlobalsWithFilesAsObjectsEnabled()
+    public function testFromGlobalsWithFilesAsObjectsEnabled(): void
     {
         Configure::write('App.uploadedFilesAsObjects', true);
 
@@ -1151,10 +1106,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test processing files with `file` field names.
-     *
-     * @return void
      */
-    public function testFilesNested()
+    public function testFilesNested(): void
     {
         $files = [
             'image_main' => [
@@ -1266,10 +1219,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test processing a file input with no .'s in it.
-     *
-     * @return void
      */
-    public function testFilesFlat()
+    public function testFilesFlat(): void
     {
         $files = [
             'birth_cert' => [
@@ -1297,10 +1248,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test that files in the 0th index work.
-     *
-     * @return void
      */
-    public function testFilesZeroithIndex()
+    public function testFilesZeroithIndex(): void
     {
         $files = [
             0 => [
@@ -1324,10 +1273,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Tests that file uploads are merged into the post data as objects instead of as arrays.
-     *
-     * @return void
      */
-    public function testFilesAsObjectsInRequestData()
+    public function testFilesAsObjectsInRequestData(): void
     {
         $files = [
             'flat' => [
@@ -1468,10 +1415,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test passing invalid files list structure.
-     *
-     * @return void
      */
-    public function testFilesWithInvalidStructure()
+    public function testFilesWithInvalidStructure(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value in files specification');

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -34,10 +34,8 @@ class ServerRequestTest extends TestCase
 {
     /**
      * Test custom detector with extra arguments.
-     *
-     * @return void
      */
-    public function testCustomArgsDetector()
+    public function testCustomArgsDetector(): void
     {
         $request = new ServerRequest();
         $request->addDetector('controller', function ($request, $name) {
@@ -53,10 +51,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the header detector.
-     *
-     * @return void
      */
-    public function testHeaderDetector()
+    public function testHeaderDetector(): void
     {
         $request = new ServerRequest();
         $request->addDetector('host', ['header' => ['host' => 'cakephp.org']]);
@@ -70,10 +66,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the accept header detector.
-     *
-     * @return void
      */
-    public function testExtensionDetector()
+    public function testExtensionDetector(): void
     {
         $request = new ServerRequest();
         $request = $request->withParam('_ext', 'json');
@@ -86,10 +80,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the accept header detector.
-     *
-     * @return void
      */
-    public function testAcceptHeaderDetector()
+    public function testAcceptHeaderDetector(): void
     {
         $request = new ServerRequest();
         $request = $request->withEnv('HTTP_ACCEPT', 'application/json, text/plain, */*');
@@ -100,7 +92,7 @@ class ServerRequestTest extends TestCase
         $this->assertFalse($request->is('json'));
     }
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $request = new ServerRequest();
         $this->assertInstanceOf(FlashMessage::class, $request->getAttribute('flash'));
@@ -108,10 +100,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test construction with query data
-     *
-     * @return void
      */
-    public function testConstructionQueryData()
+    public function testConstructionQueryData(): void
     {
         $data = [
             'query' => [
@@ -128,10 +118,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test constructing with a string url.
-     *
-     * @return void
      */
-    public function testConstructStringUrlIgnoreServer()
+    public function testConstructStringUrlIgnoreServer(): void
     {
         $request = new ServerRequest([
             'url' => '/articles/view/1',
@@ -145,10 +133,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test that querystring args provided in the URL string are parsed.
-     *
-     * @return void
      */
-    public function testQueryStringParsingFromInputUrl()
+    public function testQueryStringParsingFromInputUrl(): void
     {
         $request = new ServerRequest(['url' => 'some/path?one=something&two=else']);
         $expected = ['one' => 'something', 'two' => 'else'];
@@ -159,10 +145,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test that querystrings are handled correctly.
-     *
-     * @return void
      */
-    public function testQueryStringAndNamedParams()
+    public function testQueryStringAndNamedParams(): void
     {
         $config = ['environment' => ['REQUEST_URI' => '/tasks/index?ts=123456']];
         $request = new ServerRequest($config);
@@ -182,7 +166,7 @@ class ServerRequestTest extends TestCase
     /**
      * Test that URL in path is handled correctly.
      */
-    public function testUrlInPath()
+    public function testUrlInPath(): void
     {
         $config = ['environment' => ['REQUEST_URI' => '/jump/http://cakephp.org']];
         $request = new ServerRequest($config);
@@ -197,10 +181,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getPath().
-     *
-     * @return void
      */
-    public function testGetPath()
+    public function testGetPath(): void
     {
         $request = new ServerRequest(['url' => '']);
         $this->assertSame('/', $request->getPath());
@@ -214,10 +196,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test parsing POST data into the object.
-     *
-     * @return void
      */
-    public function testPostParsing()
+    public function testPostParsing(): void
     {
         $post = [
             'Article' => ['title'],
@@ -240,10 +220,9 @@ class ServerRequestTest extends TestCase
     /**
      * Test parsing JSON PUT data into the object.
      *
-     * @return void
      * @group deprecated
      */
-    public function testPutParsingJSON()
+    public function testPutParsingJSON(): void
     {
         $data = '{"Article":["title"]}';
         $request = new ServerRequest([
@@ -255,7 +234,7 @@ class ServerRequestTest extends TestCase
         ]);
         $this->assertEquals([], $request->getData());
 
-        $this->deprecated(function () use ($request) {
+        $this->deprecated(function () use ($request): void {
             $result = $request->input('json_decode', true);
             $this->assertEquals(['title'], $result['Article']);
         });
@@ -264,10 +243,8 @@ class ServerRequestTest extends TestCase
     /**
      * Test that the constructor uses uploaded file objects
      * if they are present. This could happen in test scenarios.
-     *
-     * @return void
      */
-    public function testFilesObject()
+    public function testFilesObject(): void
     {
         $file = new UploadedFile(
             __FILE__,
@@ -282,10 +259,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test passing an empty files list.
-     *
-     * @return void
      */
-    public function testFilesWithEmptyList()
+    public function testFilesWithEmptyList(): void
     {
         $request = new ServerRequest([
             'files' => [],
@@ -297,10 +272,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test replacing files.
-     *
-     * @return void
      */
-    public function testWithUploadedFiles()
+    public function testWithUploadedFiles(): void
     {
         $file = new UploadedFile(
             __FILE__,
@@ -319,10 +292,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getting a single file
-     *
-     * @return void
      */
-    public function testGetUploadedFile()
+    public function testGetUploadedFile(): void
     {
         $file = new UploadedFile(
             __FILE__,
@@ -351,10 +322,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test replacing files with an invalid file
-     *
-     * @return void
      */
-    public function testWithUploadedFilesInvalidFile()
+    public function testWithUploadedFilesInvalidFile(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid file at \'avatar\'');
@@ -364,10 +333,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test replacing files with an invalid file
-     *
-     * @return void
      */
-    public function testWithUploadedFilesInvalidFileNested()
+    public function testWithUploadedFilesInvalidFileNested(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid file at \'user.avatar\'');
@@ -377,10 +344,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the clientIp method.
-     *
-     * @return void
      */
-    public function testClientIp()
+    public function testClientIp(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_X_FORWARDED_FOR' => '192.168.1.5, 10.0.1.1, proxy.com, real.ip',
@@ -410,10 +375,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * test clientIp method with trusted proxies
-     *
-     * @return void
      */
-    public function testClientIpWithTrustedProxies()
+    public function testClientIpWithTrustedProxies(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_X_FORWARDED_FOR' => 'real.ip, 192.168.1.0, 192.168.1.2, 192.168.1.3',
@@ -446,10 +409,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the referrer function.
-     *
-     * @return void
      */
-    public function testReferer()
+    public function testReferer(): void
     {
         $request = new ServerRequest(['webroot' => '/']);
 
@@ -488,10 +449,8 @@ class ServerRequestTest extends TestCase
     /**
      * Test referer() with a base path that duplicates the
      * first segment.
-     *
-     * @return void
      */
-    public function testRefererBasePath()
+    public function testRefererBasePath(): void
     {
         $request = new ServerRequest([
             'url' => '/waves/users/login',
@@ -506,10 +465,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * test the simple uses of is()
-     *
-     * @return void
      */
-    public function testIsHttpMethods()
+    public function testIsHttpMethods(): void
     {
         $request = new ServerRequest();
 
@@ -535,10 +492,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test is() with JSON and XML.
-     *
-     * @return void
      */
-    public function testIsJsonAndXml()
+    public function testIsJsonAndXml(): void
     {
         $request = new ServerRequest();
         $request = $request->withEnv('HTTP_ACCEPT', 'application/json, text/plain, */*');
@@ -555,10 +510,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test is() with multiple types.
-     *
-     * @return void
      */
-    public function testIsMultiple()
+    public function testIsMultiple(): void
     {
         $request = new ServerRequest();
 
@@ -574,10 +527,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test isAll()
-     *
-     * @return void
      */
-    public function testIsAll()
+    public function testIsAll(): void
     {
         $request = new ServerRequest();
 
@@ -591,10 +542,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getMethod()
-     *
-     * @return void
      */
-    public function testGetMethod()
+    public function testGetMethod(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'delete'],
@@ -604,10 +553,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test withMethod()
-     *
-     * @return void
      */
-    public function testWithMethod()
+    public function testWithMethod(): void
     {
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'delete'],
@@ -620,10 +567,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test withMethod() and invalid data
-     *
-     * @return void
      */
-    public function testWithMethodInvalid()
+    public function testWithMethodInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported HTTP method "no good" provided');
@@ -635,10 +580,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getProtocolVersion()
-     *
-     * @return void
      */
-    public function testGetProtocolVersion()
+    public function testGetProtocolVersion(): void
     {
         $request = new ServerRequest();
         $this->assertSame('1.1', $request->getProtocolVersion());
@@ -652,10 +595,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test withProtocolVersion()
-     *
-     * @return void
      */
-    public function testWithProtocolVersion()
+    public function testWithProtocolVersion(): void
     {
         $request = new ServerRequest();
         $new = $request->withProtocolVersion('1.0');
@@ -666,10 +607,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test withProtocolVersion() and invalid data
-     *
-     * @return void
      */
-    public function testWithProtocolVersionInvalid()
+    public function testWithProtocolVersionInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported protocol version \'no good\' provided');
@@ -679,10 +618,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test host retrieval.
-     *
-     * @return void
      */
-    public function testHost()
+    public function testHost(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -696,10 +633,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * test port retrieval.
-     *
-     * @return void
      */
-    public function testPort()
+    public function testPort(): void
     {
         $request = new ServerRequest(['environment' => ['SERVER_PORT' => '80']]);
 
@@ -715,10 +650,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * test domain retrieval.
-     *
-     * @return void
      */
-    public function testDomain()
+    public function testDomain(): void
     {
         $request = new ServerRequest(['environment' => ['HTTP_HOST' => 'something.example.com']]);
 
@@ -730,10 +663,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test scheme() method.
-     *
-     * @return void
      */
-    public function testScheme()
+    public function testScheme(): void
     {
         $request = new ServerRequest(['environment' => ['HTTPS' => 'on']]);
 
@@ -749,10 +680,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * test getting subdomains for a host.
-     *
-     * @return void
      */
-    public function testSubdomain()
+    public function testSubdomain(): void
     {
         $request = new ServerRequest(['environment' => ['HTTP_HOST' => 'something.example.com']]);
 
@@ -770,10 +699,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test AJAX, flash and friends
-     *
-     * @return void
      */
-    public function testisAjax()
+    public function testisAjax(): void
     {
         $request = new ServerRequest();
 
@@ -787,10 +714,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test __call exceptions
-     *
-     * @return void
      */
-    public function testMagicCallExceptionOnUnknownMethod()
+    public function testMagicCallExceptionOnUnknownMethod(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $request = new ServerRequest();
@@ -799,10 +724,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test is(ssl)
-     *
-     * @return void
      */
-    public function testIsSsl()
+    public function testIsSsl(): void
     {
         $request = new ServerRequest();
 
@@ -824,10 +747,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test adding detectors and having them work.
-     *
-     * @return void
      */
-    public function testAddDetector()
+    public function testAddDetector(): void
     {
         $request = new ServerRequest();
 
@@ -920,10 +841,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getting headers
-     *
-     * @return void
      */
-    public function testHeader()
+    public function testHeader(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -942,10 +861,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getting headers with psr7 methods
-     *
-     * @return void
      */
-    public function testGetHeaders()
+    public function testGetHeaders(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -967,10 +884,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test hasHeader
-     *
-     * @return void
      */
-    public function testHasHeader()
+    public function testHasHeader(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -988,10 +903,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getting headers with psr7 methods
-     *
-     * @return void
      */
-    public function testGetHeader()
+    public function testGetHeader(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -1011,10 +924,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getting headers with psr7 methods
-     *
-     * @return void
      */
-    public function testGetHeaderLine()
+    public function testGetHeaderLine(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -1034,10 +945,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test setting a header.
-     *
-     * @return void
      */
-    public function testWithHeader()
+    public function testWithHeader(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -1058,10 +967,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test adding a header.
-     *
-     * @return void
      */
-    public function testWithAddedHeader()
+    public function testWithAddedHeader(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -1085,10 +992,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test removing a header.
-     *
-     * @return void
      */
-    public function testWithoutHeader()
+    public function testWithoutHeader(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_HOST' => 'localhost',
@@ -1106,10 +1011,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test accepts() with and without parameters
-     *
-     * @return void
      */
-    public function testAccepts()
+    public function testAccepts(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_ACCEPT' => 'text/xml,application/xml;q=0.9,application/xhtml+xml,text/html,text/plain,image/png',
@@ -1130,10 +1033,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test that accept header types are trimmed for comparisons.
-     *
-     * @return void
      */
-    public function testAcceptWithWhitespace()
+    public function testAcceptWithWhitespace(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_ACCEPT' => 'text/xml  ,  text/html ,  text/plain,image/png',
@@ -1149,10 +1050,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Content types from accepts() should respect the client's q preference values.
-     *
-     * @return void
      */
-    public function testAcceptWithQvalueSorting()
+    public function testAcceptWithQvalueSorting(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_ACCEPT' => 'text/html;q=0.8,application/json;q=0.7,application/xml;q=1.0',
@@ -1164,10 +1063,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the raw parsing of accept headers into the q value formatting.
-     *
-     * @return void
      */
-    public function testParseAcceptWithQValue()
+    public function testParseAcceptWithQValue(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_ACCEPT' => 'text/html;q=0.8,application/json;q=0.7,application/xml;q=1.0,image/png',
@@ -1183,10 +1080,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test parsing accept with a confusing accept value.
-     *
-     * @return void
      */
-    public function testParseAcceptNoQValues()
+    public function testParseAcceptNoQValues(): void
     {
         $request = new ServerRequest(['environment' => [
             'HTTP_ACCEPT' => 'application/json, text/plain, */*',
@@ -1200,10 +1095,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test parsing accept ignores index param
-     *
-     * @return void
      */
-    public function testParseAcceptIgnoreAcceptExtensions()
+    public function testParseAcceptIgnoreAcceptExtensions(): void
     {
         $request = new ServerRequest(['environment' => [
             'url' => '/',
@@ -1221,10 +1114,8 @@ class ServerRequestTest extends TestCase
      * Test that parsing accept headers with invalid syntax works.
      *
      * The header used is missing a q value for application/xml.
-     *
-     * @return void
      */
-    public function testParseAcceptInvalidSyntax()
+    public function testParseAcceptInvalidSyntax(): void
     {
         $request = new ServerRequest(['environment' => [
             'url' => '/',
@@ -1241,10 +1132,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the getQuery() method
-     *
-     * @return void
      */
-    public function testGetQuery()
+    public function testGetQuery(): void
     {
         $array = [
             'query' => [
@@ -1279,10 +1168,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getQueryParams
-     *
-     * @return void
      */
-    public function testGetQueryParams()
+    public function testGetQueryParams(): void
     {
         $get = [
             'test' => ['foo', 'bar'],
@@ -1297,10 +1184,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test withQueryParams and immutability
-     *
-     * @return void
      */
-    public function testWithQueryParams()
+    public function testWithQueryParams(): void
     {
         $get = [
             'test' => ['foo', 'bar'],
@@ -1317,10 +1202,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test using param()
-     *
-     * @return void
      */
-    public function testReadingParams()
+    public function testReadingParams(): void
     {
         $request = new ServerRequest([
             'params' => [
@@ -1339,10 +1222,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the data() method reading
-     *
-     * @return void
      */
-    public function testGetData()
+    public function testGetData(): void
     {
         $post = [
             'Model' => [
@@ -1361,10 +1242,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test that getData() doesn't fail on scalar data.
-     *
-     * @return void
      */
-    public function testGetDataOnStringData()
+    public function testGetDataOnStringData(): void
     {
         $post = 'strange, but could happen';
         $request = new ServerRequest(compact('post'));
@@ -1374,10 +1253,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test writing falsey values.
-     *
-     * @return void
      */
-    public function testDataWritingFalsey()
+    public function testDataWritingFalsey(): void
     {
         $request = new ServerRequest();
 
@@ -1400,7 +1277,7 @@ class ServerRequestTest extends TestCase
      * @dataProvider paramReadingDataProvider
      * @param mixed $expected
      */
-    public function testGetParam(string $toRead, $expected)
+    public function testGetParam(string $toRead, $expected): void
     {
         $request = new ServerRequest([
             'url' => '/',
@@ -1422,10 +1299,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test getParam returning a default value.
-     *
-     * @return void
      */
-    public function testGetParamDefault()
+    public function testGetParamDefault(): void
     {
         $request = new ServerRequest([
             'params' => [
@@ -1484,10 +1359,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * test writing request params with param()
-     *
-     * @return void
      */
-    public function testParamWriting()
+    public function testParamWriting(): void
     {
         $request = new ServerRequest(['url' => '/']);
         $request = $request->withParam('action', 'index');
@@ -1517,10 +1390,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test accept language
-     *
-     * @return void
      */
-    public function testAcceptLanguage()
+    public function testAcceptLanguage(): void
     {
         $request = new ServerRequest();
 
@@ -1562,16 +1433,14 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test the input() method.
-     *
-     * @return void
      */
-    public function testInput()
+    public function testInput(): void
     {
         $request = new ServerRequest([
             'input' => 'I came from stdin',
         ]);
 
-        $this->deprecated(function () use ($request) {
+        $this->deprecated(function () use ($request): void {
             $result = $request->input();
             $this->assertSame('I came from stdin', $result);
         });
@@ -1580,16 +1449,15 @@ class ServerRequestTest extends TestCase
     /**
      * Test input() decoding.
      *
-     * @return void
      * @group deprecated
      */
-    public function testInputDecode()
+    public function testInputDecode(): void
     {
         $request = new ServerRequest([
             'input' => '{"name":"value"}',
         ]);
 
-        $this->deprecated(function () use ($request) {
+        $this->deprecated(function () use ($request): void {
             $result = $request->input('json_decode');
             $this->assertEquals(['name' => 'value'], (array)$result);
         });
@@ -1598,10 +1466,9 @@ class ServerRequestTest extends TestCase
     /**
      * Test input() decoding with additional arguments.
      *
-     * @return void
      * @group deprecated
      */
-    public function testInputDecodeExtraParams()
+    public function testInputDecodeExtraParams(): void
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="utf-8"?>
@@ -1614,7 +1481,7 @@ XML;
             'input' => $xml,
         ]);
 
-        $this->deprecated(function () use ($request) {
+        $this->deprecated(function () use ($request): void {
             $result = $request->input('Cake\Utility\Xml::build', ['return' => 'domdocument']);
             $this->assertInstanceOf('DOMDocument', $result);
             $this->assertSame(
@@ -1626,10 +1493,8 @@ XML;
 
     /**
      * Test getBody
-     *
-     * @return void
      */
-    public function testGetBody()
+    public function testGetBody(): void
     {
         $request = new ServerRequest([
             'input' => 'key=val&some=data',
@@ -1641,10 +1506,8 @@ XML;
 
     /**
      * Test withBody
-     *
-     * @return void
      */
-    public function testWithBody()
+    public function testWithBody(): void
     {
         $request = new ServerRequest([
             'input' => 'key=val&some=data',
@@ -1658,10 +1521,8 @@ XML;
 
     /**
      * Test getUri
-     *
-     * @return void
      */
-    public function testGetUri()
+    public function testGetUri(): void
     {
         $request = new ServerRequest(['url' => 'articles/view/3']);
         $result = $request->getUri();
@@ -1671,10 +1532,8 @@ XML;
 
     /**
      * Test withUri
-     *
-     * @return void
      */
-    public function testWithUri()
+    public function testWithUri(): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -1691,10 +1550,8 @@ XML;
 
     /**
      * Test withUri() and preserveHost
-     *
-     * @return void
      */
-    public function testWithUriPreserveHost()
+    public function testWithUriPreserveHost(): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -1714,10 +1571,8 @@ XML;
 
     /**
      * Test withUri() and preserveHost missing the host header
-     *
-     * @return void
      */
-    public function testWithUriPreserveHostNoHostHeader()
+    public function testWithUriPreserveHostNoHostHeader(): void
     {
         $request = new ServerRequest([
             'url' => 'articles/view/3',
@@ -1733,10 +1588,8 @@ XML;
 
     /**
      * Test the cookie() method.
-     *
-     * @return void
      */
-    public function testGetCookie()
+    public function testGetCookie(): void
     {
         $request = new ServerRequest([
             'cookies' => [
@@ -1757,10 +1610,8 @@ XML;
 
     /**
      * Test getCookieParams()
-     *
-     * @return void
      */
-    public function testGetCookieParams()
+    public function testGetCookieParams(): void
     {
         $cookies = [
             'testing' => 'A value in the cookie',
@@ -1771,10 +1622,8 @@ XML;
 
     /**
      * Test withCookieParams()
-     *
-     * @return void
      */
-    public function testWithCookieParams()
+    public function testWithCookieParams(): void
     {
         $cookies = [
             'testing' => 'A value in the cookie',
@@ -1788,10 +1637,8 @@ XML;
 
     /**
      * Test getting a cookie collection from a request.
-     *
-     * @return void
      */
-    public function testGetCookieCollection()
+    public function testGetCookieCollection(): void
     {
         $cookies = [
             'remember_me' => '1',
@@ -1808,10 +1655,8 @@ XML;
 
     /**
      * Test replacing cookies from a collection
-     *
-     * @return void
      */
-    public function testWithCookieCollection()
+    public function testWithCookieCollection(): void
     {
         $cookies = new CookieCollection([new Cookie('remember_me', 1), new Cookie('color', 'red')]);
         $request = new ServerRequest(['cookies' => ['bad' => 'goaway']]);
@@ -1827,10 +1672,8 @@ XML;
 
     /**
      * TestAllowMethod
-     *
-     * @return void
      */
-    public function testAllowMethod()
+    public function testAllowMethod(): void
     {
         $request = new ServerRequest(['environment' => [
             'url' => '/posts/edit/1',
@@ -1845,10 +1688,8 @@ XML;
 
     /**
      * Test allowMethod throwing exception
-     *
-     * @return void
      */
-    public function testAllowMethodException()
+    public function testAllowMethodException(): void
     {
         $request = new ServerRequest([
             'url' => '/posts/edit/1',
@@ -1869,10 +1710,8 @@ XML;
 
     /**
      * Tests getting the session from the request
-     *
-     * @return void
      */
-    public function testGetSession()
+    public function testGetSession(): void
     {
         $session = new Session();
         $request = new ServerRequest(['session' => $session]);
@@ -1882,7 +1721,7 @@ XML;
         $this->assertEquals($session, $request->getSession());
     }
 
-    public function testGetFlash()
+    public function testGetFlash(): void
     {
         $request = new ServerRequest();
         $this->assertInstanceOf(FlashMessage::class, $request->getFlash());
@@ -1890,10 +1729,8 @@ XML;
 
     /**
      * Test the content type method.
-     *
-     * @return void
      */
-    public function testContentType()
+    public function testContentType(): void
     {
         $request = new ServerRequest([
             'environment' => ['HTTP_CONTENT_TYPE' => 'application/json'],
@@ -1908,10 +1745,8 @@ XML;
 
     /**
      * Test updating params in a psr7 fashion.
-     *
-     * @return void
      */
-    public function testWithParam()
+    public function testWithParam(): void
     {
         $request = new ServerRequest([
             'params' => ['controller' => 'Articles'],
@@ -1933,10 +1768,8 @@ XML;
 
     /**
      * Test getting the parsed body parameters.
-     *
-     * @return void
      */
-    public function testGetParsedBody()
+    public function testGetParsedBody(): void
     {
         $data = ['title' => 'First', 'body' => 'Best Article!'];
         $request = new ServerRequest(['post' => $data]);
@@ -1948,10 +1781,8 @@ XML;
 
     /**
      * Test replacing the parsed body parameters.
-     *
-     * @return void
      */
-    public function testWithParsedBody()
+    public function testWithParsedBody(): void
     {
         $data = ['title' => 'First', 'body' => 'Best Article!'];
         $request = new ServerRequest([]);
@@ -1964,10 +1795,8 @@ XML;
 
     /**
      * Test updating POST data in a psr7 fashion.
-     *
-     * @return void
      */
-    public function testWithData()
+    public function testWithData(): void
     {
         $request = new ServerRequest([
             'post' => [
@@ -1986,10 +1815,8 @@ XML;
 
     /**
      * Test removing data from a request
-     *
-     * @return void
      */
-    public function testWithoutData()
+    public function testWithoutData(): void
     {
         $request = new ServerRequest([
             'post' => [
@@ -2008,10 +1835,8 @@ XML;
 
     /**
      * Test updating POST data when keys don't exist
-     *
-     * @return void
      */
-    public function testWithDataMissingIntermediaryKeys()
+    public function testWithDataMissingIntermediaryKeys(): void
     {
         $request = new ServerRequest([
             'post' => [
@@ -2033,10 +1858,8 @@ XML;
 
     /**
      * Test updating POST data with falsey values
-     *
-     * @return void
      */
-    public function testWithDataFalseyValues()
+    public function testWithDataFalseyValues(): void
     {
         $request = new ServerRequest([
             'post' => [],
@@ -2058,10 +1881,8 @@ XML;
 
     /**
      * Test setting attributes.
-     *
-     * @return void
      */
-    public function testWithAttribute()
+    public function testWithAttribute(): void
     {
         $request = new ServerRequest([]);
         $this->assertNull($request->getAttribute('key'));
@@ -2079,10 +1900,8 @@ XML;
 
     /**
      * Test that replacing the session can be done via withAttribute()
-     *
-     * @return void
      */
-    public function testWithAttributeSession()
+    public function testWithAttributeSession(): void
     {
         $request = new ServerRequest([]);
         $request->getSession()->write('attrKey', 'session-value');
@@ -2095,10 +1914,8 @@ XML;
 
     /**
      * Test getting all attributes.
-     *
-     * @return void
      */
-    public function testGetAttributes()
+    public function testGetAttributes(): void
     {
         $request = new ServerRequest([]);
         $new = $request->withAttribute('key', 'value')
@@ -2127,10 +1944,8 @@ XML;
 
     /**
      * Test unsetting attributes.
-     *
-     * @return void
      */
-    public function testWithoutAttribute()
+    public function testWithoutAttribute(): void
     {
         $request = new ServerRequest([]);
         $new = $request->withAttribute('key', 'value');
@@ -2144,9 +1959,8 @@ XML;
      * Test that withoutAttribute() cannot remove emulatedAttributes properties.
      *
      * @dataProvider emulatedPropertyProvider
-     * @return void
      */
-    public function testWithoutAttributesDenyEmulatedProperties(string $prop)
+    public function testWithoutAttributesDenyEmulatedProperties(string $prop): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $request = new ServerRequest([]);
@@ -2155,10 +1969,8 @@ XML;
 
     /**
      * Test the requestTarget methods.
-     *
-     * @return void
      */
-    public function testWithRequestTarget()
+    public function testWithRequestTarget(): void
     {
         $request = new ServerRequest([
             'environment' => [
@@ -2185,10 +1997,8 @@ XML;
 
     /**
      * Test withEnv()
-     *
-     * @return void
      */
-    public function testWithEnv()
+    public function testWithEnv(): void
     {
         $request = new ServerRequest();
 
@@ -2199,10 +2009,8 @@ XML;
 
     /**
      * Test getEnv()
-     *
-     * @return void
      */
-    public function testGetEnv()
+    public function testGetEnv(): void
     {
         $request = new ServerRequest([
             'environment' => ['TEST' => 'ing'],

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -54,8 +54,6 @@ class ServerTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -68,8 +66,6 @@ class ServerTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -80,10 +76,8 @@ class ServerTest extends TestCase
 
     /**
      * test get/set on the app
-     *
-     * @return void
      */
-    public function testAppGetSet()
+    public function testAppGetSet(): void
     {
         /** @var \Cake\Http\BaseApplication|\PHPUnit\Framework\MockObject\MockObject $app */
         $app = $this->getMockBuilder(BaseApplication::class)
@@ -101,10 +95,8 @@ class ServerTest extends TestCase
 
     /**
      * test run building a response
-     *
-     * @return void
      */
-    public function testRunWithRequest()
+    public function testRunWithRequest(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('X-pass', 'request header');
@@ -126,10 +118,8 @@ class ServerTest extends TestCase
 
     /**
      * test run calling plugin hooks
-     *
-     * @return void
      */
-    public function testRunCallingPluginHooks()
+    public function testRunCallingPluginHooks(): void
     {
         $request = new ServerRequest();
         $request = $request->withHeader('X-pass', 'request header');
@@ -165,10 +155,8 @@ class ServerTest extends TestCase
 
     /**
      * test run building a request from globals.
-     *
-     * @return void
      */
-    public function testRunWithGlobals()
+    public function testRunWithGlobals(): void
     {
         $_SERVER['HTTP_X_PASS'] = 'globalvalue';
 
@@ -185,10 +173,8 @@ class ServerTest extends TestCase
 
     /**
      * Test middleware being invoked.
-     *
-     * @return void
      */
-    public function testRunMultipleMiddlewareSuccess()
+    public function testRunMultipleMiddlewareSuccess(): void
     {
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
@@ -200,7 +186,7 @@ class ServerTest extends TestCase
     /**
      * Test that run closes session after invoking the application (if CakePHP ServerRequest is used).
      */
-    public function testRunClosesSessionIfServerRequestUsed()
+    public function testRunClosesSessionIfServerRequestUsed(): void
     {
         $sessionMock = $this->createMock(Session::class);
 
@@ -228,7 +214,7 @@ class ServerTest extends TestCase
     /**
      * Test that run does not close the session if CakePHP ServerRequest is not used.
      */
-    public function testRunDoesNotCloseSessionIfServerRequestNotUsed()
+    public function testRunDoesNotCloseSessionIfServerRequestNotUsed(): void
     {
         $request = new \Laminas\Diactoros\ServerRequest();
 
@@ -251,10 +237,8 @@ class ServerTest extends TestCase
 
     /**
      * Test that emit invokes the appropriate methods on the emitter.
-     *
-     * @return void
      */
-    public function testEmit()
+    public function testEmit(): void
     {
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
@@ -273,14 +257,12 @@ class ServerTest extends TestCase
 
     /**
      * Test that emit invokes the appropriate methods on the emitter.
-     *
-     * @return void
      */
-    public function testEmitCallbackStream()
+    public function testEmitCallbackStream(): void
     {
         $GLOBALS['mockedHeadersSent'] = false;
         $response = new Response('php://memory', 200, ['x-testing' => 'source header']);
-        $response = $response->withBody(new CallbackStream(function () {
+        $response = $response->withBody(new CallbackStream(function (): void {
             echo 'body content';
         }));
 
@@ -294,16 +276,14 @@ class ServerTest extends TestCase
 
     /**
      * Ensure that the Server.buildMiddleware event is fired.
-     *
-     * @return void
      */
-    public function testBuildMiddlewareEvent()
+    public function testBuildMiddlewareEvent(): void
     {
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
         $called = false;
 
-        $server->getEventManager()->on('Server.buildMiddleware', function (EventInterface $event, MiddlewareQueue $middlewareQueue) use (&$called) {
+        $server->getEventManager()->on('Server.buildMiddleware', function (EventInterface $event, MiddlewareQueue $middlewareQueue) use (&$called): void {
             $middlewareQueue->add(function ($request, $handler) use (&$called) {
                 $called = true;
 
@@ -319,10 +299,8 @@ class ServerTest extends TestCase
 
     /**
      * test event manager proxies to the application.
-     *
-     * @return void
      */
-    public function testEventManagerProxies()
+    public function testEventManagerProxies(): void
     {
         /** @var \Cake\Http\BaseApplication|\PHPUnit\Framework\MockObject\MockObject $app */
         $app = $this->getMockForAbstractClass(
@@ -336,10 +314,8 @@ class ServerTest extends TestCase
 
     /**
      * test event manager cannot be set on applications without events.
-     *
-     * @return void
      */
-    public function testGetEventManagerNonEventedApplication()
+    public function testGetEventManagerNonEventedApplication(): void
     {
         /** @var \Cake\Core\HttpApplicationInterface|\PHPUnit\Framework\MockObject\MockObject $app */
         $app = $this->createMock(HttpApplicationInterface::class);
@@ -350,10 +326,8 @@ class ServerTest extends TestCase
 
     /**
      * test event manager cannot be set on applications without events.
-     *
-     * @return void
      */
-    public function testSetEventManagerNonEventedApplication()
+    public function testSetEventManagerNonEventedApplication(): void
     {
         /** @var \Cake\Core\HttpApplicationInterface|\PHPUnit\Framework\MockObject\MockObject $app */
         $app = $this->createMock(HttpApplicationInterface::class);

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -36,8 +36,6 @@ class CacheSessionTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,8 +46,6 @@ class CacheSessionTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -61,20 +57,16 @@ class CacheSessionTest extends TestCase
 
     /**
      * test open
-     *
-     * @return void
      */
-    public function testOpen()
+    public function testOpen(): void
     {
         $this->assertTrue($this->storage->open(null, null));
     }
 
     /**
      * test write()
-     *
-     * @return void
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $this->storage->write('abc', 'Some value');
         $this->assertSame('Some value', Cache::read('abc', 'session_test'), 'Value was not written.');
@@ -82,10 +74,8 @@ class CacheSessionTest extends TestCase
 
     /**
      * test reading.
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $this->storage->write('test_one', 'Some other value');
         $this->assertSame('Some other value', $this->storage->read('test_one'), 'Incorrect value.');
@@ -93,10 +83,8 @@ class CacheSessionTest extends TestCase
 
     /**
      * test destroy
-     *
-     * @return void
      */
-    public function testDestroy()
+    public function testDestroy(): void
     {
         $this->storage->write('test_one', 'Some other value');
         $this->assertTrue($this->storage->destroy('test_one'), 'Value was not deleted.');
@@ -106,10 +94,8 @@ class CacheSessionTest extends TestCase
 
     /**
      * Tests that a cache config is required
-     *
-     * @return void
      */
-    public function testMissingConfig()
+    public function testMissingConfig(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The cache configuration name to use is required');

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -42,8 +42,6 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,8 +55,6 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,10 +64,8 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * test that constructor sets the right things up.
-     *
-     * @return void
      */
-    public function testConstructionSettings()
+    public function testConstructionSettings(): void
     {
         $this->getTableLocator()->clear();
         new DatabaseSession();
@@ -85,20 +79,16 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * test opening the session
-     *
-     * @return void
      */
-    public function testOpen()
+    public function testOpen(): void
     {
         $this->assertTrue($this->storage->open(null, null));
     }
 
     /**
      * test write()
-     *
-     * @return void
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $result = $this->storage->write('foo', 'Some value');
         $this->assertTrue($result);
@@ -110,10 +100,8 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * testReadAndWriteWithDatabaseStorage method
-     *
-     * @return void
      */
-    public function testWriteEmptySessionId()
+    public function testWriteEmptySessionId(): void
     {
         $result = $this->storage->write('', 'This is a Test');
         $this->assertFalse($result);
@@ -121,10 +109,8 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * test read()
-     *
-     * @return void
      */
-    public function testRead()
+    public function testRead(): void
     {
         $this->storage->write('foo', 'Some value');
 
@@ -138,10 +124,8 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * test blowing up the session.
-     *
-     * @return void
      */
-    public function testDestroy()
+    public function testDestroy(): void
     {
         $this->assertTrue($this->storage->write('foo', 'Some value'));
 
@@ -152,10 +136,8 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * test the garbage collector
-     *
-     * @return void
      */
-    public function testGc()
+    public function testGc(): void
     {
         $this->getTableLocator()->clear();
 
@@ -170,10 +152,8 @@ class DatabaseSessionTest extends TestCase
 
     /**
      * Tests serializing an entity
-     *
-     * @return void
      */
-    public function testSerializeEntity()
+    public function testSerializeEntity(): void
     {
         $entity = new Entity();
         $entity->value = 'something';

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -37,8 +37,6 @@ class SessionTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -52,9 +50,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testSessionConfigIniSetting()
+    public function testSessionConfigIniSetting(): void
     {
         $_SESSION = null;
 
@@ -79,9 +76,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testCookiePath()
+    public function testCookiePath(): void
     {
         ini_set('session.cookie_path', '/foo');
 
@@ -94,10 +90,8 @@ class SessionTest extends TestCase
 
     /**
      * testCheck method
-     *
-     * @return void
      */
-    public function testCheck()
+    public function testCheck(): void
     {
         $session = new Session();
         $session->write('SessionTestCase', 'value');
@@ -112,10 +106,8 @@ class SessionTest extends TestCase
 
     /**
      * test read with simple values
-     *
-     * @return void
      */
-    public function testReadSimple()
+    public function testReadSimple(): void
     {
         $session = new Session();
         $session->write('testing', '1,2,3');
@@ -139,10 +131,8 @@ class SessionTest extends TestCase
 
     /**
      * testReadEmpty
-     *
-     * @return void
      */
-    public function testReadEmpty()
+    public function testReadEmpty(): void
     {
         $session = new Session();
         $this->assertNull($session->read(''));
@@ -150,10 +140,8 @@ class SessionTest extends TestCase
 
     /**
      * test read fallback
-     *
-     * @return void
      */
-    public function testReadFallback()
+    public function testReadFallback(): void
     {
         $_SESSION = null;
         $session = new Session();
@@ -162,10 +150,8 @@ class SessionTest extends TestCase
 
     /**
      * Tests read() with defaulting.
-     *
-     * @return void
      */
-    public function testReadDefault()
+    public function testReadDefault(): void
     {
         $session = new Session();
         $this->assertSame('bar', $session->read('foo', 'bar'));
@@ -173,10 +159,8 @@ class SessionTest extends TestCase
 
     /**
      * Tests readOrFail()
-     *
-     * @return void
      */
-    public function testReadOrFail()
+    public function testReadOrFail(): void
     {
         $session = new Session();
         $session->write('testing', '1,2,3');
@@ -190,10 +174,8 @@ class SessionTest extends TestCase
 
     /**
      * Tests readOrFail() with nonexistent value
-     *
-     * @return void
      */
-    public function testReadOrFailException()
+    public function testReadOrFailException(): void
     {
         $session = new Session();
 
@@ -204,10 +186,8 @@ class SessionTest extends TestCase
 
     /**
      * Test writing simple keys
-     *
-     * @return void
      */
-    public function testWriteSimple()
+    public function testWriteSimple(): void
     {
         $session = new Session();
         $session->write('', 'empty');
@@ -219,10 +199,8 @@ class SessionTest extends TestCase
 
     /**
      * test writing a hash of values
-     *
-     * @return void
      */
-    public function testWriteArray()
+    public function testWriteArray(): void
     {
         $session = new Session();
         $session->write([
@@ -238,10 +216,8 @@ class SessionTest extends TestCase
 
     /**
      * Test overwriting a string value as if it were an array.
-     *
-     * @return void
      */
-    public function testWriteOverwriteStringValue()
+    public function testWriteOverwriteStringValue(): void
     {
         $session = new Session();
         $session->write('Some.string', 'value');
@@ -253,10 +229,8 @@ class SessionTest extends TestCase
 
     /**
      * Test consuming session data.
-     *
-     * @return void
      */
-    public function testConsume()
+    public function testConsume(): void
     {
         $session = new Session();
         $session->write('Some.string', 'value');
@@ -282,9 +256,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testId()
+    public function testId(): void
     {
         $session = new Session();
         $session->start();
@@ -302,10 +275,8 @@ class SessionTest extends TestCase
 
     /**
      * testStarted method
-     *
-     * @return void
      */
-    public function testStarted()
+    public function testStarted(): void
     {
         $session = new Session();
         $this->assertFalse($session->started());
@@ -315,10 +286,8 @@ class SessionTest extends TestCase
 
     /**
      * test close method
-     *
-     * @return void
      */
-    public function testCloseNotStarted()
+    public function testCloseNotStarted(): void
     {
         $session = new Session();
         $this->assertTrue($session->start());
@@ -329,10 +298,8 @@ class SessionTest extends TestCase
 
     /**
      * testClear method
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         $session = new Session();
         $session->write('Delete.me', 'Clearing out');
@@ -344,10 +311,8 @@ class SessionTest extends TestCase
 
     /**
      * testDelete method
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $session = new Session();
         $session->write('Delete.me', 'Clearing out');
@@ -366,10 +331,8 @@ class SessionTest extends TestCase
 
     /**
      * test delete
-     *
-     * @return void
      */
-    public function testDeleteEmptyString()
+    public function testDeleteEmptyString(): void
     {
         $session = new Session();
         $session->write('', 'empty string');
@@ -379,10 +342,8 @@ class SessionTest extends TestCase
 
     /**
      * testDestroy method
-     *
-     * @return void
      */
-    public function testDestroy()
+    public function testDestroy(): void
     {
         $session = new Session();
         $session->start();
@@ -395,10 +356,8 @@ class SessionTest extends TestCase
 
     /**
      * testCheckingSavedEmpty method
-     *
-     * @return void
      */
-    public function testCheckingSavedEmpty()
+    public function testCheckingSavedEmpty(): void
     {
         $session = new Session();
         $session->write('SessionTestCase', 0);
@@ -416,10 +375,8 @@ class SessionTest extends TestCase
 
     /**
      * testCheckKeyWithSpaces method
-     *
-     * @return void
      */
-    public function testCheckKeyWithSpaces()
+    public function testCheckKeyWithSpaces(): void
     {
         $session = new Session();
         $session->write('Session Test', 'test');
@@ -432,10 +389,8 @@ class SessionTest extends TestCase
 
     /**
      * testCheckEmpty
-     *
-     * @return void
      */
-    public function testCheckEmpty()
+    public function testCheckEmpty(): void
     {
         $session = new Session();
         $this->assertFalse($session->check());
@@ -443,10 +398,8 @@ class SessionTest extends TestCase
 
     /**
      * test key exploitation
-     *
-     * @return void
      */
-    public function testKeyExploit()
+    public function testKeyExploit(): void
     {
         $session = new Session();
         $key = "a'] = 1; phpinfo(); \$_SESSION['a";
@@ -458,10 +411,8 @@ class SessionTest extends TestCase
 
     /**
      * testReadingSavedEmpty method
-     *
-     * @return void
      */
-    public function testReadingSavedEmpty()
+    public function testReadingSavedEmpty(): void
     {
         $session = new Session();
         $session->write('', 'empty string');
@@ -487,9 +438,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testUsingAppLibsHandler()
+    public function testUsingAppLibsHandler(): void
     {
         static::setAppNamespace();
         $config = [
@@ -512,9 +462,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testUsingPluginHandler()
+    public function testUsingPluginHandler(): void
     {
         static::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
@@ -536,9 +485,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testEngineWithPreMadeInstance()
+    public function testEngineWithPreMadeInstance(): void
     {
         static::setAppNamespace();
         $engine = new TestAppLibSession();
@@ -552,10 +500,8 @@ class SessionTest extends TestCase
 
     /**
      * Tests instantiating a missing engine
-     *
-     * @return void
      */
-    public function testBadEngine()
+    public function testBadEngine(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The class "Derp" does not exist and cannot be used as a session engine');
@@ -568,9 +514,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testCookieTimeoutFallback()
+    public function testCookieTimeoutFallback(): void
     {
         $config = [
             'defaults' => 'cake',
@@ -587,9 +532,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testSessionName()
+    public function testSessionName(): void
     {
         new Session(['cookie' => 'made_up_name']);
         $this->assertSame('made_up_name', session_name());
@@ -601,7 +545,7 @@ class SessionTest extends TestCase
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function testCheckStartsSessionWithCookiesDisabled()
+    public function testCheckStartsSessionWithCookiesDisabled(): void
     {
         $_COOKIE = [];
         $_GET = [];
@@ -621,7 +565,7 @@ class SessionTest extends TestCase
     /**
      * Test that a call of check() starts the session when a cookie is already set
      */
-    public function testCheckStartsSessionWithCookie()
+    public function testCheckStartsSessionWithCookie(): void
     {
         $_COOKIE[session_name()] = '123abc';
         $_GET = [];
@@ -643,9 +587,8 @@ class SessionTest extends TestCase
      *
      * @preserveGlobalState disabled
      * @runInSeparateProcess
-     * @return void
      */
-    public function testCheckStartsSessionWithSIDinURL()
+    public function testCheckStartsSessionWithSIDinURL(): void
     {
         $_COOKIE = [];
         $_GET[session_name()] = '123abc';
@@ -665,7 +608,7 @@ class SessionTest extends TestCase
     /**
      * Test that a call of check() does not start the session when the session ID is passed via URL and session.use_trans_sid is disabled
      */
-    public function testCheckDoesntStartSessionWithoutTransSID()
+    public function testCheckDoesntStartSessionWithoutTransSID(): void
     {
         $_COOKIE = [];
         $_GET[session_name()] = '123abc';

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -35,8 +35,6 @@ class DateTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,8 +44,6 @@ class DateTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -71,9 +67,8 @@ class DateTest extends TestCase
      * Ensure that instances can be built from other objects.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testConstructFromAnotherInstance(string $class)
+    public function testConstructFromAnotherInstance(string $class): void
     {
         $time = '2015-01-22';
         $frozen = new FrozenDate($time);
@@ -89,9 +84,8 @@ class DateTest extends TestCase
      * test formatting dates taking in account preferred i18n locale file
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testI18nFormat(string $class)
+    public function testI18nFormat(string $class): void
     {
         $time = new $class('Thu Jan 14 13:59:28 2010');
         $result = $time->i18nFormat();
@@ -126,9 +120,8 @@ class DateTest extends TestCase
      * test __toString
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testToString(string $class)
+    public function testToString(string $class): void
     {
         $date = new $class('2015-11-06 11:32:45');
         $this->assertSame('11/6/15', (string)$date);
@@ -138,9 +131,8 @@ class DateTest extends TestCase
      * test nice()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testNice(string $class)
+    public function testNice(string $class): void
     {
         $date = new $class('2015-11-06 11:32:45');
 
@@ -153,9 +145,8 @@ class DateTest extends TestCase
      * test jsonSerialize()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testJsonSerialize(string $class)
+    public function testJsonSerialize(string $class): void
     {
         if (version_compare(INTL_ICU_VERSION, '50.0', '<')) {
             $this->markTestSkipped('ICU 5x is needed');
@@ -169,9 +160,8 @@ class DateTest extends TestCase
      * Tests change JSON encoding format
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testSetJsonEncodeFormat(string $class)
+    public function testSetJsonEncodeFormat(string $class): void
     {
         $date = new $class('2015-11-06 11:32:45');
 
@@ -188,9 +178,8 @@ class DateTest extends TestCase
      * test parseDate()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDate(string $class)
+    public function testParseDate(string $class): void
     {
         $date = $class::parseDate('11/6/15');
         $this->assertSame('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
@@ -204,9 +193,8 @@ class DateTest extends TestCase
      * test parseDateTime()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDateTime(string $class)
+    public function testParseDateTime(string $class): void
     {
         $date = $class::parseDate('11/6/15 12:33:12');
         $this->assertSame('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
@@ -220,9 +208,8 @@ class DateTest extends TestCase
      * Tests disabling leniency when parsing locale format.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testLenientParseDate(string $class)
+    public function testLenientParseDate(string $class): void
     {
         $class::setDefaultLocale('pt_BR');
 
@@ -261,9 +248,8 @@ class DateTest extends TestCase
      * testTimeAgoInWords method
      *
      * @dataProvider timeAgoProvider
-     * @return void
      */
-    public function testTimeAgoInWords(string $input, string $expected)
+    public function testTimeAgoInWords(string $input, string $expected): void
     {
         $date = new Date($input);
         $result = $date->timeAgoInWords();
@@ -274,9 +260,8 @@ class DateTest extends TestCase
      * testTimeAgoInWords with Frozen Date
      *
      * @dataProvider timeAgoProvider
-     * @return void
      */
-    public function testTimeAgoInWordsFrozenDate(string $input, string $expected)
+    public function testTimeAgoInWordsFrozenDate(string $input, string $expected): void
     {
         $date = new FrozenDate($input);
         $result = $date->timeAgoInWords();
@@ -287,9 +272,8 @@ class DateTest extends TestCase
      * test the timezone option for timeAgoInWords
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsTimezone(string $class)
+    public function testTimeAgoInWordsTimezone(string $class): void
     {
         $date = new $class('1990-07-31 20:33:00 UTC');
         $result = $date->timeAgoInWords(
@@ -352,9 +336,8 @@ class DateTest extends TestCase
      * test the end option for timeAgoInWords
      *
      * @dataProvider timeAgoEndProvider
-     * @return void
      */
-    public function testTimeAgoInWordsEnd(string $input, string $expected, string $end)
+    public function testTimeAgoInWordsEnd(string $input, string $expected, string $end): void
     {
         $time = new Date($input);
         $result = $time->timeAgoInWords(['end' => $end]);
@@ -365,9 +348,8 @@ class DateTest extends TestCase
      * test the end option for timeAgoInWords
      *
      * @dataProvider timeAgoEndProvider
-     * @return void
      */
-    public function testTimeAgoInWordsEndFrozenDate(string $input, string $expected, string $end)
+    public function testTimeAgoInWordsEndFrozenDate(string $input, string $expected, string $end): void
     {
         $time = new FrozenDate($input);
         $result = $time->timeAgoInWords(['end' => $end]);
@@ -378,9 +360,8 @@ class DateTest extends TestCase
      * test the custom string options for timeAgoInWords
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsCustomStrings(string $class)
+    public function testTimeAgoInWordsCustomStrings(string $class): void
     {
         $date = new $class('-8 years -4 months -2 weeks -3 days');
         $result = $date->timeAgoInWords([
@@ -405,9 +386,8 @@ class DateTest extends TestCase
      * Test the accuracy option for timeAgoInWords()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDateAgoInWordsAccuracy(string $class)
+    public function testDateAgoInWordsAccuracy(string $class): void
     {
         $date = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $date->timeAgoInWords([
@@ -461,9 +441,8 @@ class DateTest extends TestCase
      * Test the format option of timeAgoInWords()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDateAgoInWordsWithFormat(string $class)
+    public function testDateAgoInWordsWithFormat(string $class): void
     {
         $date = new $class('2007-9-25');
         $result = $date->timeAgoInWords(['format' => 'yyyy-MM-dd']);
@@ -486,9 +465,8 @@ class DateTest extends TestCase
      * test timeAgoInWords() with negative values.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDateAgoInWordsNegativeValues(string $class)
+    public function testDateAgoInWordsNegativeValues(string $class): void
     {
         $date = new $class('-2 months -2 days');
         $result = $date->timeAgoInWords(['end' => '3 month']);
@@ -538,9 +516,8 @@ class DateTest extends TestCase
      * will not alter the date
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDateDifferentTimezone(string $class)
+    public function testParseDateDifferentTimezone(string $class): void
     {
         date_default_timezone_set('Europe/Paris');
         $result = $class::parseDate('25-02-2016', 'd-M-y');
@@ -552,9 +529,8 @@ class DateTest extends TestCase
      * than UTC respects the timezone when grabbing the date.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDateTimeDifferentTimezone(string $class)
+    public function testParseDateTimeDifferentTimezone(string $class): void
     {
         date_default_timezone_set('America/Toronto');
         $result = $class::parseDateTime('25-02-2016 23:00:00', 'd-M-y H:m:s');
@@ -565,9 +541,8 @@ class DateTest extends TestCase
      * Tests the default locale setter.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testGetSetDefaultLocale(string $class)
+    public function testGetSetDefaultLocale(string $class): void
     {
         $class::setDefaultLocale('fr-FR');
         $this->assertSame('fr-FR', $class::getDefaultLocale());
@@ -577,9 +552,8 @@ class DateTest extends TestCase
      * Tests the default locale setter.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDefaultLocaleEffectsFormatting(string $class)
+    public function testDefaultLocaleEffectsFormatting(string $class): void
     {
         $result = $class::parseDate('12/03/2015');
         $this->assertSame('Dec 3, 2015', $result->nice());

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -26,10 +26,8 @@ class IcuFormatterTest extends TestCase
 {
     /**
      * Tests that empty values can be used as formatting strings
-     *
-     * @return void
      */
-    public function testFormatEmptyValues()
+    public function testFormatEmptyValues(): void
     {
         $formatter = new IcuFormatter();
         $this->assertSame('', $formatter->format('en_US', '', []));
@@ -37,10 +35,8 @@ class IcuFormatterTest extends TestCase
 
     /**
      * Tests that variables are interpolated correctly
-     *
-     * @return void
      */
-    public function testFormatSimple()
+    public function testFormatSimple(): void
     {
         $formatter = new IcuFormatter();
         $this->assertSame('Hello José', $formatter->format('en_US', 'Hello {0}', ['José']));
@@ -54,10 +50,8 @@ class IcuFormatterTest extends TestCase
 
     /**
      * Tests that plurals can instead be selected using ICU's native selector
-     *
-     * @return void
      */
-    public function testNativePluralSelection()
+    public function testNativePluralSelection(): void
     {
         $formatter = new IcuFormatter();
         $locale = 'en_US';
@@ -85,10 +79,8 @@ class IcuFormatterTest extends TestCase
 
     /**
      * Tests that passing a message in the wrong format will throw an exception
-     *
-     * @return void
      */
-    public function testBadMessageFormat()
+    public function testBadMessageFormat(): void
     {
         $this->expectException(\Exception::class);
 

--- a/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/SprintfFormatterTest.php
@@ -26,10 +26,8 @@ class SprintfFormatterTest extends TestCase
 {
     /**
      * Tests that variables are interpolated correctly
-     *
-     * @return void
      */
-    public function testFormatSimple()
+    public function testFormatSimple(): void
     {
         $formatter = new SprintfFormatter();
         $this->assertSame('Hello José', $formatter->format('en_US', 'Hello %s', ['José']));

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -38,8 +38,6 @@ class I18nTest extends TestCase
 
     /**
      * Set Up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class I18nTest extends TestCase
 
     /**
      * Tear down method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -64,10 +60,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that the default locale is set correctly
-     *
-     * @return void
      */
-    public function testDefaultLocale()
+    public function testDefaultLocale(): void
     {
         $newLocale = 'de_DE';
         I18n::setLocale($newLocale);
@@ -78,10 +72,8 @@ class I18nTest extends TestCase
     /**
      * Tests that a default translator is created and messages are parsed
      * correctly
-     *
-     * @return void
      */
-    public function testGetDefaultTranslator()
+    public function testGetDefaultTranslator(): void
     {
         $translator = I18n::getTranslator();
         $this->assertInstanceOf(Translator::class, $translator);
@@ -91,10 +83,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that the translator can automatically load messages from a .mo file
-     *
-     * @return void
      */
-    public function testGetTranslatorLoadMoFile()
+    public function testGetTranslatorLoadMoFile(): void
     {
         $translator = I18n::getTranslator('default', 'es_ES');
         $this->assertSame('Plural Rule 6 (translated)', $translator->translate('Plural Rule 1'));
@@ -103,10 +93,8 @@ class I18nTest extends TestCase
     /**
      * Tests that plural rules are correctly used for the English language
      * using the sprintf formatter
-     *
-     * @return void
      */
-    public function testPluralSelectionSprintfFormatter()
+    public function testPluralSelectionSprintfFormatter(): void
     {
         I18n::setDefaultFormatter('sprintf');
         $translator = I18n::getTranslator(); // en_US
@@ -120,10 +108,8 @@ class I18nTest extends TestCase
     /**
      * Tests that plural rules are correctly used for the English language
      * using the basic formatter
-     *
-     * @return void
      */
-    public function testPluralSelectionBasicFormatter()
+    public function testPluralSelectionBasicFormatter(): void
     {
         $translator = I18n::getTranslator('special');
         $result = $translator->translate('There are {0} things', ['_count' => 2, 'plenty']);
@@ -135,10 +121,8 @@ class I18nTest extends TestCase
 
     /**
      * Test plural rules are used for non-english languages
-     *
-     * @return void
      */
-    public function testPluralSelectionRussian()
+    public function testPluralSelectionRussian(): void
     {
         $translator = I18n::getTranslator('default', 'ru');
         $result = $translator->translate('{0} months', ['_count' => 1, 1]);
@@ -153,10 +137,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that custom translation packages can be created on the fly and used later on
-     *
-     * @return void
      */
-    public function testCreateCustomTranslationPackage()
+    public function testCreateCustomTranslationPackage(): void
     {
         I18n::setTranslator('custom', function () {
             $package = new Package('default');
@@ -174,10 +156,8 @@ class I18nTest extends TestCase
     /**
      * Tests that messages can also be loaded from plugins by using the
      * domain = plugin_name convention
-     *
-     * @return void
      */
-    public function testPluginMesagesLoad()
+    public function testPluginMesagesLoad(): void
     {
         $this->loadPlugins([
             'TestPlugin',
@@ -200,10 +180,8 @@ class I18nTest extends TestCase
     /**
      * Tests that messages messages from a plugin can be automatically
      * overridden by messages in app
-     *
-     * @return void
      */
-    public function testPluginOverride()
+    public function testPluginOverride(): void
     {
         $this->loadPlugins(['TestTheme']);
         $translator = I18n::getTranslator('test_theme');
@@ -215,10 +193,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the locale method
-     *
-     * @return void
      */
-    public function testGetDefaultLocale()
+    public function testGetDefaultLocale(): void
     {
         $this->assertSame('en_US', I18n::getLocale());
         $this->assertSame('en_US', ini_get('intl.default_locale'));
@@ -230,10 +206,8 @@ class I18nTest extends TestCase
     /**
      * Tests that changing the default locale also changes the way translators
      * are fetched
-     *
-     * @return void
      */
-    public function testGetTranslatorByDefaultLocale()
+    public function testGetTranslatorByDefaultLocale(): void
     {
         I18n::setTranslator('custom', function () {
             $package = new Package('default');
@@ -251,10 +225,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __() function
-     *
-     * @return void
      */
-    public function testBasicTranslateFunction()
+    public function testBasicTranslateFunction(): void
     {
         I18n::setDefaultFormatter('sprintf');
         $this->assertSame('%d is 1 (po translated)', __('%d = 1'));
@@ -266,10 +238,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __() functions with explicit null params
-     *
-     * @return void
      */
-    public function testBasicTranslateFunctionsWithNullParam()
+    public function testBasicTranslateFunctionsWithNullParam(): void
     {
         $this->assertSame('text {0}', __('text {0}'));
         $this->assertSame('text ', __('text {0}', null));
@@ -298,10 +268,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __() function on a plural key works
-     *
-     * @return void
      */
-    public function testBasicTranslateFunctionPluralData()
+    public function testBasicTranslateFunctionPluralData(): void
     {
         I18n::setDefaultFormatter('sprintf');
         $this->assertSame('%d is 1 (po translated)', __('%d = 0 or > 1'));
@@ -309,10 +277,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __n() function
-     *
-     * @return void
      */
-    public function testBasicTranslatePluralFunction()
+    public function testBasicTranslatePluralFunction(): void
     {
         I18n::setDefaultFormatter('sprintf');
         $result = __n('singular msg', '%d = 0 or > 1', 1, 1);
@@ -330,10 +296,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __n() function on singular keys
-     *
-     * @return void
      */
-    public function testBasicTranslatePluralFunctionSingularMessage()
+    public function testBasicTranslatePluralFunctionSingularMessage(): void
     {
         I18n::setDefaultFormatter('sprintf');
         $result = __n('No translation needed', 'not used', 1);
@@ -342,10 +306,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __d() function
-     *
-     * @return void
      */
-    public function testBasicDomainFunction()
+    public function testBasicDomainFunction(): void
     {
         I18n::setTranslator('custom', function () {
             $package = new Package('default');
@@ -373,10 +335,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __dn() function
-     *
-     * @return void
      */
-    public function testBasicDomainPluralFunction()
+    public function testBasicDomainPluralFunction(): void
     {
         I18n::setTranslator('custom', function () {
             $package = new Package('default');
@@ -402,10 +362,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __x() function
-     *
-     * @return void
      */
-    public function testBasicContextFunction()
+    public function testBasicContextFunction(): void
     {
         I18n::setTranslator('default', function () {
             $package = new Package('default');
@@ -460,10 +418,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __x() function with no msgstr
-     *
-     * @return void
      */
-    public function testBasicContextFunctionNoString()
+    public function testBasicContextFunctionNoString(): void
     {
         I18n::setTranslator('default', function () {
             $package = new Package('default');
@@ -484,10 +440,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __x() function with an invalid context
-     *
-     * @return void
      */
-    public function testBasicContextFunctionInvalidContext()
+    public function testBasicContextFunctionInvalidContext(): void
     {
         I18n::setTranslator('default', function () {
             $package = new Package('default');
@@ -508,10 +462,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __xn() function
-     *
-     * @return void
      */
-    public function testPluralContextFunction()
+    public function testPluralContextFunction(): void
     {
         I18n::setTranslator('default', function () {
             $package = new Package('default');
@@ -562,10 +514,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __dx() function
-     *
-     * @return void
      */
-    public function testDomainContextFunction()
+    public function testDomainContextFunction(): void
     {
         I18n::setTranslator('custom', function () {
             $package = new Package('default');
@@ -617,10 +567,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __dxn() function
-     *
-     * @return void
      */
-    public function testDomainPluralContextFunction()
+    public function testDomainPluralContextFunction(): void
     {
         I18n::setTranslator('custom', function () {
             $package = new Package('default');
@@ -677,10 +625,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that translators are cached for performance
-     *
-     * @return void
      */
-    public function testTranslatorCache()
+    public function testTranslatorCache(): void
     {
         $english = I18n::getTranslator();
         $spanish = I18n::getTranslator('default', 'es_ES');
@@ -699,10 +645,8 @@ class I18nTest extends TestCase
     /**
      * Tests that it is possible to register a generic translators factory for a domain
      * instead of having to create them manually
-     *
-     * @return void
      */
-    public function testLoaderFactory()
+    public function testLoaderFactory(): void
     {
         I18n::config('custom', function (string $name, string $locale) {
             $this->assertSame('custom', $name);
@@ -745,10 +689,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that it is possible to register a fallback translators factory
-     *
-     * @return void
      */
-    public function testFallbackLoaderFactory()
+    public function testFallbackLoaderFactory(): void
     {
         I18n::config(TranslatorRegistry::FALLBACK_LOADER, function (string $name, string $locale) {
             $package = new Package('default');
@@ -775,10 +717,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that missing translations will get fallbacked to the default translator
-     *
-     * @return void
      */
-    public function testFallbackTranslator()
+    public function testFallbackTranslator(): void
     {
         I18n::setTranslator('default', function () {
             $package = new Package('default');
@@ -805,10 +745,8 @@ class I18nTest extends TestCase
 
     /**
      * Test that the translation fallback can be disabled
-     *
-     * @return void
      */
-    public function testFallbackTranslatorDisabled()
+    public function testFallbackTranslatorDisabled(): void
     {
         I18n::useFallback(false);
 
@@ -834,10 +772,8 @@ class I18nTest extends TestCase
     /**
      * Tests that it is possible to register a generic translators factory for a domain
      * instead of having to create them manually
-     *
-     * @return void
      */
-    public function testFallbackTranslatorWithFactory()
+    public function testFallbackTranslatorWithFactory(): void
     {
         I18n::setTranslator('default', function () {
             $package = new Package('default');
@@ -864,10 +800,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests the __() function on empty translations
-     *
-     * @return void
      */
-    public function testEmptyTranslationString()
+    public function testEmptyTranslationString(): void
     {
         I18n::setDefaultFormatter('sprintf');
         $result = __('No translation needed');
@@ -876,10 +810,8 @@ class I18nTest extends TestCase
 
     /**
      * Tests that a plurals from a domain get translated correctly
-     *
-     * @return void
      */
-    public function testPluralTranslationsFromDomain()
+    public function testPluralTranslationsFromDomain(): void
     {
         I18n::setLocale('de');
         $this->assertSame('Standorte', __dn('wa', 'Location', 'Locations', 0));

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -32,8 +32,6 @@ class MessagesFileLoaderTest extends TestCase
 
     /**
      * Set Up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,8 +41,6 @@ class MessagesFileLoaderTest extends TestCase
 
     /**
      * Tear down method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,10 +50,8 @@ class MessagesFileLoaderTest extends TestCase
 
     /**
      * test reading file from custom locale folder
-     *
-     * @return void
      */
-    public function testCustomLocalePath()
+    public function testCustomLocalePath(): void
     {
         $loader = new MessagesFileLoader('default', 'en');
         $package = $loader();
@@ -73,10 +67,8 @@ class MessagesFileLoaderTest extends TestCase
 
     /**
      * Test reading MO files
-     *
-     * @return void
      */
-    public function testLoadingMoFiles()
+    public function testLoadingMoFiles(): void
     {
         $loader = new MessagesFileLoader('empty', 'es', 'mo');
         $package = $loader();

--- a/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
+++ b/tests/TestCase/I18n/Middleware/LocaleSelectorMiddlewareTest.php
@@ -35,8 +35,6 @@ class LocaleSelectorMiddlewareTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,8 +44,6 @@ class LocaleSelectorMiddlewareTest extends TestCase
 
     /**
      * Resets the default locale
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -58,10 +54,8 @@ class LocaleSelectorMiddlewareTest extends TestCase
     /**
      * The default locale should not change when there are no accepted
      * locales.
-     *
-     * @return void
      */
-    public function testInvokeNoAcceptedLocales()
+    public function testInvokeNoAcceptedLocales(): void
     {
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new LocaleSelectorMiddleware([]);
@@ -76,10 +70,8 @@ class LocaleSelectorMiddlewareTest extends TestCase
 
     /**
      * The default locale should not change when the request locale is not accepted
-     *
-     * @return void
      */
-    public function testInvokeLocaleNotAccepted()
+    public function testInvokeLocaleNotAccepted(): void
     {
         $request = ServerRequestFactory::fromGlobals(['HTTP_ACCEPT_LANGUAGE' => 'en-GB,en;q=0.8,es;q=0.6,da;q=0.4']);
         $middleware = new LocaleSelectorMiddleware(['en_CA', 'en_US', 'es']);
@@ -89,10 +81,8 @@ class LocaleSelectorMiddlewareTest extends TestCase
 
     /**
      * The default locale should change when the request locale is accepted
-     *
-     * @return void
      */
-    public function testInvokeLocaleAccepted()
+    public function testInvokeLocaleAccepted(): void
     {
         $request = ServerRequestFactory::fromGlobals(['HTTP_ACCEPT_LANGUAGE' => 'es,es-ES;q=0.8,da;q=0.4']);
         $middleware = new LocaleSelectorMiddleware(['en_CA', 'es']);
@@ -102,10 +92,8 @@ class LocaleSelectorMiddlewareTest extends TestCase
 
     /**
      * The default locale should change when the request locale has an accepted fallback option
-     *
-     * @return void
      */
-    public function testInvokeLocaleAcceptedFallback()
+    public function testInvokeLocaleAcceptedFallback(): void
     {
         $request = ServerRequestFactory::fromGlobals(['HTTP_ACCEPT_LANGUAGE' => 'es-ES;q=0.8,da;q=0.4']);
         $middleware = new LocaleSelectorMiddleware(['en_CA', 'es']);
@@ -115,10 +103,8 @@ class LocaleSelectorMiddlewareTest extends TestCase
 
     /**
      * The default locale should change when the '*' is accepted
-     *
-     * @return void
      */
-    public function testInvokeLocaleAcceptAll()
+    public function testInvokeLocaleAcceptAll(): void
     {
         $middleware = new LocaleSelectorMiddleware(['*']);
 

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -41,8 +41,6 @@ class NumberTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -53,8 +51,6 @@ class NumberTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -67,10 +63,8 @@ class NumberTest extends TestCase
 
     /**
      * testFormatAndCurrency method
-     *
-     * @return void
      */
-    public function testFormat()
+    public function testFormat(): void
     {
         $value = '100100100';
 
@@ -109,10 +103,8 @@ class NumberTest extends TestCase
 
     /**
      * testParseFloat method
-     *
-     * @return void
      */
-    public function testParseFloat()
+    public function testParseFloat(): void
     {
         I18n::setLocale('de_DE');
         $value = '1.234.567,891';
@@ -134,10 +126,8 @@ class NumberTest extends TestCase
 
     /**
      * testFormatDelta method
-     *
-     * @return void
      */
-    public function testFormatDelta()
+    public function testFormatDelta(): void
     {
         $value = '100100100';
 
@@ -179,10 +169,8 @@ class NumberTest extends TestCase
 
     /**
      * Test currency method.
-     *
-     * @return void
      */
-    public function testCurrency()
+    public function testCurrency(): void
     {
         $value = '100100100';
 
@@ -295,10 +283,8 @@ class NumberTest extends TestCase
     /**
      * Test currency format with places and fraction exponents.
      * Places should only matter for non fraction values and vice versa.
-     *
-     * @return void
      */
-    public function testCurrencyWithFractionAndPlaces()
+    public function testCurrencyWithFractionAndPlaces(): void
     {
         $result = $this->Number->currency('1.23', 'EUR', ['locale' => 'de_DE', 'places' => 3]);
         $expected = '1,230 €';
@@ -321,11 +307,10 @@ class NumberTest extends TestCase
      * Test default currency
      *
      * @group deprecated
-     * @return void
      */
-    public function testDefaultCurrency()
+    public function testDefaultCurrency(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->assertSame('USD', $this->Number->defaultCurrency());
 
             $this->Number->defaultCurrency(false);
@@ -339,20 +324,16 @@ class NumberTest extends TestCase
 
     /**
      * Test get default currency
-     *
-     * @return void
      */
-    public function testGetDefaultCurrency()
+    public function testGetDefaultCurrency(): void
     {
         $this->assertSame('USD', $this->Number->getDefaultCurrency());
     }
 
     /**
      * Test set default currency
-     *
-     * @return void
      */
-    public function testSetDefaultCurrency()
+    public function testSetDefaultCurrency(): void
     {
         $this->Number->setDefaultCurrency();
         I18n::setLocale('es_ES');
@@ -364,20 +345,16 @@ class NumberTest extends TestCase
 
     /**
      * Test get default currency format
-     *
-     * @return void
      */
-    public function testGetDefaultCurrencyFormat()
+    public function testGetDefaultCurrencyFormat(): void
     {
         $this->assertSame('currency', $this->Number->getDefaultCurrencyFormat());
     }
 
     /**
      * Test set default currency format
-     *
-     * @return void
      */
-    public function testSetDefaultCurrencyFormat()
+    public function testSetDefaultCurrencyFormat(): void
     {
         $this->Number->setDefaultCurrencyFormat(Number::FORMAT_CURRENCY_ACCOUNTING);
         $this->assertSame('currency_accounting', $this->Number->getDefaultCurrencyFormat());
@@ -387,10 +364,8 @@ class NumberTest extends TestCase
 
     /**
      * testCurrencyCentsNegative method
-     *
-     * @return void
      */
-    public function testCurrencyCentsNegative()
+    public function testCurrencyCentsNegative(): void
     {
         $value = '-0.99';
 
@@ -405,10 +380,8 @@ class NumberTest extends TestCase
 
     /**
      * testCurrencyZero method
-     *
-     * @return void
      */
-    public function testCurrencyZero()
+    public function testCurrencyZero(): void
     {
         $value = '0';
 
@@ -423,10 +396,8 @@ class NumberTest extends TestCase
 
     /**
      * testCurrencyOptions method
-     *
-     * @return void
      */
-    public function testCurrencyOptions()
+    public function testCurrencyOptions(): void
     {
         $value = '1234567.89';
 
@@ -442,10 +413,8 @@ class NumberTest extends TestCase
     /**
      * Tests that it is possible to use the international currency code instead of the whole
      * when using the currency method
-     *
-     * @return void
      */
-    public function testCurrencyIntlCode()
+    public function testCurrencyIntlCode(): void
     {
         $value = '123';
         $result = $this->Number->currency($value, 'USD', ['useIntlCode' => true]);
@@ -463,10 +432,8 @@ class NumberTest extends TestCase
 
     /**
      * test precision() with locales
-     *
-     * @return void
      */
-    public function testPrecisionLocalized()
+    public function testPrecisionLocalized(): void
     {
         I18n::setLocale('fr_FR');
         $result = $this->Number->precision(1.234);
@@ -475,10 +442,8 @@ class NumberTest extends TestCase
 
     /**
      * testToPercentage method
-     *
-     * @return void
      */
-    public function testToPercentage()
+    public function testToPercentage(): void
     {
         $result = $this->Number->toPercentage(45, 0);
         $expected = '45%';
@@ -535,10 +500,8 @@ class NumberTest extends TestCase
 
     /**
      * testToReadableSize method
-     *
-     * @return void
      */
-    public function testToReadableSize()
+    public function testToReadableSize(): void
     {
         $result = $this->Number->toReadableSize(0);
         $expected = '0 Bytes';
@@ -603,10 +566,8 @@ class NumberTest extends TestCase
 
     /**
      * test toReadableSize() with locales
-     *
-     * @return void
      */
-    public function testReadableSizeLocalized()
+    public function testReadableSizeLocalized(): void
     {
         I18n::setLocale('fr_FR');
         $result = $this->Number->toReadableSize(1321205);
@@ -618,10 +579,8 @@ class NumberTest extends TestCase
 
     /**
      * test config()
-     *
-     * @return void
      */
-    public function testConfig()
+    public function testConfig(): void
     {
         $result = $this->Number->currency(150000, 'USD', ['locale' => 'en_US']);
         $this->assertSame('$150,000.00', $result);
@@ -636,10 +595,8 @@ class NumberTest extends TestCase
 
     /**
      * test ordinal() with locales
-     *
-     * @return void
      */
-    public function testOrdinal()
+    public function testOrdinal(): void
     {
         I18n::setLocale('en_US');
         $result = $this->Number->ordinal(1);

--- a/tests/TestCase/I18n/PackageTest.php
+++ b/tests/TestCase/I18n/PackageTest.php
@@ -26,10 +26,8 @@ class PackageTest extends TestCase
 {
     /**
      * Test adding messages.
-     *
-     * @return void
      */
-    public function testAddMessage()
+    public function testAddMessage(): void
     {
         $package = new Package();
 

--- a/tests/TestCase/I18n/Parser/MoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/MoFileParserTest.php
@@ -34,8 +34,6 @@ class MoFileParserTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,10 +44,8 @@ class MoFileParserTest extends TestCase
 
     /**
      * Tests parsing a file with plurals and message context
-     *
-     * @return void
      */
-    public function testParse()
+    public function testParse(): void
     {
         $parser = new MoFileParser();
         $file = $this->path . 'rule_1_mo' . DS . 'core.mo';
@@ -80,10 +76,8 @@ class MoFileParserTest extends TestCase
 
     /**
      * Tests parsing a file with single form plurals
-     *
-     * @return void
      */
-    public function testParse0()
+    public function testParse0(): void
     {
         $parser = new MoFileParser();
         $file = $this->path . 'rule_0_mo' . DS . 'core.mo';
@@ -118,10 +112,8 @@ class MoFileParserTest extends TestCase
 
     /**
      * Tests parsing a file with larger plural forms
-     *
-     * @return void
      */
-    public function testParse2()
+    public function testParse2(): void
     {
         $parser = new MoFileParser();
         $file = $this->path . 'rule_9_mo' . DS . 'core.mo';
@@ -153,10 +145,8 @@ class MoFileParserTest extends TestCase
 
     /**
      * Tests parsing a file with plurals and message context
-     *
-     * @return void
      */
-    public function testParseFull()
+    public function testParseFull(): void
     {
         $parser = new MoFileParser();
         $file = $this->path . 'rule_0_mo' . DS . 'default.mo';

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -39,8 +39,6 @@ class PoFileParserTest extends TestCase
 
     /**
      * Set Up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,8 +49,6 @@ class PoFileParserTest extends TestCase
 
     /**
      * Tear down method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -64,10 +60,8 @@ class PoFileParserTest extends TestCase
 
     /**
      * Tests parsing a file with plurals and message context
-     *
-     * @return void
      */
-    public function testParse()
+    public function testParse(): void
     {
         $parser = new PoFileParser();
         $file = $this->path . 'rule_1_po' . DS . 'default.po';
@@ -136,10 +130,8 @@ class PoFileParserTest extends TestCase
 
     /**
      * Tests parsing a file with multiline keys and values
-     *
-     * @return void
      */
-    public function testParseMultiLine()
+    public function testParseMultiLine(): void
     {
         $parser = new PoFileParser();
         $file = $this->path . 'en' . DS . 'default.po';
@@ -152,10 +144,8 @@ class PoFileParserTest extends TestCase
 
     /**
      * Test parsing a file with quoted strings
-     *
-     * @return void
      */
-    public function testQuotedString()
+    public function testQuotedString(): void
     {
         $parser = new PoFileParser();
         $file = $this->path . 'en' . DS . 'default.po';
@@ -170,10 +160,8 @@ class PoFileParserTest extends TestCase
      * This behavior is not ideal, but more thorough solutions
      * would break compatibility. Perhaps this is something we can
      * reconsider in 4.x
-     *
-     * @return void
      */
-    public function testParseContextOnSomeMessages()
+    public function testParseContextOnSomeMessages(): void
     {
         $parser = new PoFileParser();
         $file = $this->path . 'en' . DS . 'context.po';
@@ -206,10 +194,8 @@ class PoFileParserTest extends TestCase
 
     /**
      * Test parsing context based messages
-     *
-     * @return void
      */
-    public function testParseContextMessages()
+    public function testParseContextMessages(): void
     {
         $parser = new PoFileParser();
         $file = $this->path . 'en' . DS . 'context.po';
@@ -231,10 +217,8 @@ class PoFileParserTest extends TestCase
 
     /**
      * Test parsing plurals
-     *
-     * @return void
      */
-    public function testPlurals()
+    public function testPlurals(): void
     {
         I18n::getTranslator('default', 'de_DE');
 

--- a/tests/TestCase/I18n/PluralRulesTest.php
+++ b/tests/TestCase/I18n/PluralRulesTest.php
@@ -128,9 +128,8 @@ class PluralRulesTest extends TestCase
      * Tests that the correct plural form is selected for the locale, number combination
      *
      * @dataProvider localesProvider
-     * @return void
      */
-    public function testCalculate(string $locale, int $number, int $expected)
+    public function testCalculate(string $locale, int $number, int $expected): void
     {
         $this->assertEquals($expected, PluralRules::calculate($locale, $number));
     }

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -30,8 +30,6 @@ class TimeTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -44,8 +42,6 @@ class TimeTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -77,9 +73,8 @@ class TimeTest extends TestCase
      * Ensure that instances can be built from other objects.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testConstructFromAnotherInstance(string $class)
+    public function testConstructFromAnotherInstance(string $class): void
     {
         $time = '2015-01-22 10:33:44.123456';
         $frozen = new FrozenTime($time, 'America/Chicago');
@@ -127,9 +122,8 @@ class TimeTest extends TestCase
      * testTimeAgoInWords method
      *
      * @dataProvider timeAgoProvider
-     * @return void
      */
-    public function testTimeAgoInWords(string $input, string $expected)
+    public function testTimeAgoInWords(string $input, string $expected): void
     {
         $time = new Time($input);
         $result = $time->timeAgoInWords();
@@ -140,9 +134,8 @@ class TimeTest extends TestCase
      * testTimeAgoInWords method
      *
      * @dataProvider timeAgoProvider
-     * @return void
      */
-    public function testTimeAgoInWordsFrozenTime(string $input, string $expected)
+    public function testTimeAgoInWordsFrozenTime(string $input, string $expected): void
     {
         $time = new FrozenTime($input);
         $result = $time->timeAgoInWords();
@@ -199,9 +192,8 @@ class TimeTest extends TestCase
      * test the timezone option for timeAgoInWords
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsTimezone(string $class)
+    public function testTimeAgoInWordsTimezone(string $class): void
     {
         $time = new FrozenTime('1990-07-31 20:33:00 UTC');
         $result = $time->timeAgoInWords(
@@ -218,9 +210,8 @@ class TimeTest extends TestCase
      * test the end option for timeAgoInWords
      *
      * @dataProvider timeAgoEndProvider
-     * @return void
      */
-    public function testTimeAgoInWordsEnd(string $input, string $expected, string $end)
+    public function testTimeAgoInWordsEnd(string $input, string $expected, string $end): void
     {
         $time = new Time($input);
         $result = $time->timeAgoInWords(['end' => $end]);
@@ -231,9 +222,8 @@ class TimeTest extends TestCase
      * test the custom string options for timeAgoInWords
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsCustomStrings(string $class)
+    public function testTimeAgoInWordsCustomStrings(string $class): void
     {
         $time = new $class('-8 years -4 months -2 weeks -3 days');
         $result = $time->timeAgoInWords([
@@ -258,9 +248,8 @@ class TimeTest extends TestCase
      * Test the accuracy option for timeAgoInWords()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsAccuracy(string $class)
+    public function testTimeAgoInWordsAccuracy(string $class): void
     {
         $time = new $class('+8 years +4 months +2 weeks +3 days');
         $result = $time->timeAgoInWords([
@@ -325,9 +314,8 @@ class TimeTest extends TestCase
      * Test the format option of timeAgoInWords()
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsWithFormat(string $class)
+    public function testTimeAgoInWordsWithFormat(string $class): void
     {
         $time = new $class('2007-9-25');
         $result = $time->timeAgoInWords(['format' => 'yyyy-MM-dd']);
@@ -346,9 +334,8 @@ class TimeTest extends TestCase
      * test timeAgoInWords() with negative values.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimeAgoInWordsNegativeValues(string $class)
+    public function testTimeAgoInWordsNegativeValues(string $class): void
     {
         $time = new $class('-2 months -2 days');
         $result = $time->timeAgoInWords(['end' => '3 month']);
@@ -409,9 +396,8 @@ class TimeTest extends TestCase
      * testNice method
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testNice(string $class)
+    public function testNice(string $class): void
     {
         $time = new $class('2014-04-20 20:00', 'UTC');
         $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $time->nice());
@@ -432,9 +418,8 @@ class TimeTest extends TestCase
      * test formatting dates taking in account preferred i18n locale file
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testI18nFormat(string $class)
+    public function testI18nFormat(string $class): void
     {
         $time = new $class('Thu Jan 14 13:59:28 2010');
 
@@ -473,10 +458,8 @@ class TimeTest extends TestCase
 
     /**
      * testI18nFormatUsingSystemLocale
-     *
-     * @return void
      */
-    public function testI18nFormatUsingSystemLocale()
+    public function testI18nFormatUsingSystemLocale(): void
     {
         // Unset default locale for the Time class to ensure system's locale is used.
         Time::setDefaultLocale();
@@ -497,9 +480,8 @@ class TimeTest extends TestCase
      *
      * @dataProvider classNameProvider
      * @see https://github.com/facebook/hhvm/issues/3637
-     * @return void
      */
-    public function testI18nFormatWithOffsetTimezone(string $class)
+    public function testI18nFormatWithOffsetTimezone(string $class): void
     {
         $time = new $class('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(\IntlDateFormatter::FULL);
@@ -526,9 +508,8 @@ class TimeTest extends TestCase
      * testListTimezones
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testListTimezones(string $class)
+    public function testListTimezones(string $class): void
     {
         $return = $class::listTimezones();
         $this->assertTrue(isset($return['Asia']['Asia/Bangkok']));
@@ -573,9 +554,8 @@ class TimeTest extends TestCase
      * Tests that __toString uses the i18n formatter
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testToString(string $class)
+    public function testToString(string $class): void
     {
         $time = new $class('2014-04-20 22:10');
         $class::setDefaultLocale('fr-FR');
@@ -601,9 +581,8 @@ class TimeTest extends TestCase
      *
      * @dataProvider invalidDataProvider
      * @param mixed $value
-     * @return void
      */
-    public function testToStringInvalid($value)
+    public function testToStringInvalid($value): void
     {
         $time = new Time($value);
         $this->assertIsString((string)$time);
@@ -615,9 +594,8 @@ class TimeTest extends TestCase
      *
      * @dataProvider invalidDataProvider
      * @param mixed $value
-     * @return void
      */
-    public function testToStringInvalidFrozen($value)
+    public function testToStringInvalidFrozen($value): void
     {
         $time = new FrozenTime($value);
         $this->assertIsString((string)$time);
@@ -628,9 +606,8 @@ class TimeTest extends TestCase
      * These invalid values are not invalid on windows :(
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testToStringInvalidZeros(string $class)
+    public function testToStringInvalidZeros(string $class): void
     {
         $this->skipIf(DS === '\\', 'All zeros are valid on windows.');
         $this->skipIf(PHP_INT_SIZE === 4, 'IntlDateFormatter throws exceptions on 32-bit systems');
@@ -647,9 +624,8 @@ class TimeTest extends TestCase
      * Tests diffForHumans
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDiffForHumans(string $class)
+    public function testDiffForHumans(string $class): void
     {
         $time = new $class('2014-04-20 10:10:10');
 
@@ -688,9 +664,8 @@ class TimeTest extends TestCase
      * Tests diffForHumans absolute
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDiffForHumansAbsolute(string $class)
+    public function testDiffForHumansAbsolute(string $class): void
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
         $time = new $class('2014-04-20 10:10:10');
@@ -707,9 +682,8 @@ class TimeTest extends TestCase
      * Tests diffForHumans with now
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDiffForHumansNow(string $class)
+    public function testDiffForHumansNow(string $class): void
     {
         Time::setTestNow(new $class('2015-12-12 10:10:10'));
         $time = new $class('2014-04-20 10:10:10');
@@ -723,9 +697,8 @@ class TimeTest extends TestCase
      * Tests encoding a Time object as JSON
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testJsonEncode(string $class)
+    public function testJsonEncode(string $class): void
     {
         if (version_compare(INTL_ICU_VERSION, '50.0', '<')) {
             $this->markTestSkipped('ICU 5x is needed');
@@ -745,9 +718,8 @@ class TimeTest extends TestCase
      * Test jsonSerialize no side-effects
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testJsonEncodeSideEffectFree(string $class)
+    public function testJsonEncodeSideEffectFree(string $class): void
     {
         if (version_compare(INTL_ICU_VERSION, '50.0', '<')) {
             $this->markTestSkipped('ICU 5x is needed');
@@ -764,9 +736,8 @@ class TimeTest extends TestCase
      * Tests change JSON encoding format
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testSetJsonEncodeFormat(string $class)
+    public function testSetJsonEncodeFormat(string $class): void
     {
         $time = new $class('2014-04-20 10:10:10');
 
@@ -783,9 +754,8 @@ class TimeTest extends TestCase
      * Tests debugInfo
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testDebugInfo(string $class)
+    public function testDebugInfo(string $class): void
     {
         $time = new $class('2014-04-20 10:10:10');
         $expected = [
@@ -800,9 +770,8 @@ class TimeTest extends TestCase
      * Tests parsing a string into a Time object based on the locale format.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDateTime(string $class)
+    public function testParseDateTime(string $class): void
     {
         $time = $class::parseDateTime('01/01/1970 00:00am');
         $this->assertNotNull($time);
@@ -846,9 +815,8 @@ class TimeTest extends TestCase
      * Tests parsing a string into a Time object based on the locale format.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDate(string $class)
+    public function testParseDate(string $class): void
     {
         $time = $class::parseDate('10/13/2013 12:54am');
         $this->assertNotNull($time);
@@ -875,9 +843,8 @@ class TimeTest extends TestCase
      * Tests parsing times using the parseTime function
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseTime(string $class)
+    public function testParseTime(string $class): void
     {
         $time = $class::parseTime('12:54am');
         $this->assertNotNull($time);
@@ -896,9 +863,8 @@ class TimeTest extends TestCase
      * Tests disabling leniency when parsing locale format.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testLenientParseDate(string $class)
+    public function testLenientParseDate(string $class): void
     {
         $class::setDefaultLocale('pt_BR');
 
@@ -915,9 +881,8 @@ class TimeTest extends TestCase
      * Tests that timeAgoInWords when using a russian locale does not break things
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testRussianTimeAgoInWords(string $class)
+    public function testRussianTimeAgoInWords(string $class): void
     {
         I18n::setLocale('ru_RU');
         $time = new $class('5 days ago');
@@ -929,9 +894,8 @@ class TimeTest extends TestCase
      * Tests that parsing a date respects de default timezone in PHP.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseDateDifferentTimezone(string $class)
+    public function testParseDateDifferentTimezone(string $class): void
     {
         date_default_timezone_set('Europe/Paris');
         $class::setDefaultLocale('fr-FR');
@@ -944,9 +908,8 @@ class TimeTest extends TestCase
      * Tests the default locale setter.
      *
      * @dataProvider classNameProvider
-     * @return void
      */
-    public function testGetSetDefaultLocale(string $class)
+    public function testGetSetDefaultLocale(string $class): void
     {
         $class::setDefaultLocale('fr-FR');
         $this->assertSame('fr-FR', $class::getDefaultLocale());
@@ -955,10 +918,8 @@ class TimeTest extends TestCase
     /**
      * Custom assert to allow for variation in the version of the intl library, where
      * some translations contain a few extra commas.
-     *
-     * @return void
      */
-    public function assertTimeFormat(string $expected, string $result, string $message = '')
+    public function assertTimeFormat(string $expected, string $result, string $message = ''): void
     {
         $expected = str_replace([',', '(', ')', ' at', ' م.', ' ه‍.ش.', ' AP', ' AH', ' SAKA', 'à '], '', $expected);
         $expected = str_replace(['  '], ' ', $expected);

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -30,7 +30,7 @@ class TranslatorRegistryTest extends TestCase
     /**
      * Test Package null initialization from cache
      */
-    public function testGetNullPackageInitializationFromCache()
+    public function testGetNullPackageInitializationFromCache(): void
     {
         $packageLocator = $this->getMockBuilder(PackageLocator::class)->getMock();
         $package = $this->getMockBuilder(Package::class)->getMock();

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -47,7 +47,7 @@ class BaseLogTest extends TestCase
         $this->logger = new TestBaseLog();
     }
 
-    private function assertUnescapedUnicode(array $needles, string $haystack)
+    private function assertUnescapedUnicode(array $needles, string $haystack): void
     {
         foreach ($needles as $needle) {
             $this->assertStringContainsString(
@@ -61,14 +61,14 @@ class BaseLogTest extends TestCase
     /**
      * Tests the logging output of a single string containing unicode characters.
      */
-    public function testLogUnicodeString()
+    public function testLogUnicodeString(): void
     {
         $this->logger->log(LogLevel::INFO, implode($this->testData));
 
         $this->assertUnescapedUnicode($this->testData, $this->logger->getMessage());
     }
 
-    public function testPlaceHoldersInMessage()
+    public function testPlaceHoldersInMessage(): void
     {
         $context = [
             'no-placholder' => 'no-placholder',
@@ -78,7 +78,7 @@ class BaseLogTest extends TestCase
             'array' => ['arr'],
             'array-obj' => new ArrayObject(['x' => 'y']),
             'debug-info' => ConnectionManager::get('test'),
-            'obj' => function () {
+            'obj' => function (): void {
             },
             'to-string' => new Response(['body' => 'response body']),
             'to-array' => new TypeMap(['my-type']),
@@ -150,10 +150,8 @@ class BaseLogTest extends TestCase
 
     /**
      * Test setting custom formatter option.
-     *
-     * @return void
      */
-    public function testCustomFormatter()
+    public function testCustomFormatter(): void
     {
         $log = new TestBaseLog(['formatter' => ValidFormatter::class]);
         $this->assertNotNull($log);
@@ -164,10 +162,8 @@ class BaseLogTest extends TestCase
 
     /**
      * Test creating log engine with invalid formatter.
-     *
-     * @return void
      */
-    public function testInvalidFormatter()
+    public function testInvalidFormatter(): void
     {
         $this->expectException(InvalidArgumentException::class);
         new TestBaseLog(['formatter' => InvalidFormatter::class]);

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -28,7 +28,7 @@ class ConsoleLogTest extends TestCase
     /**
      * Test writing to ConsoleOutput
      */
-    public function testConsoleOutputlogs()
+    public function testConsoleOutputlogs(): void
     {
         $output = $this->getMockBuilder('Cake\Console\ConsoleOutput')->getMock();
 
@@ -45,10 +45,8 @@ class ConsoleLogTest extends TestCase
 
     /**
      * Test writing to a file stream
-     *
-     * @return void
      */
-    public function testlogToFileStream()
+    public function testlogToFileStream(): void
     {
         $filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
         $log = new ConsoleLog([
@@ -64,7 +62,7 @@ class ConsoleLogTest extends TestCase
     /**
      * test value of stream 'outputAs'
      */
-    public function testDefaultOutputAs()
+    public function testDefaultOutputAs(): void
     {
         $output = $this->getMockBuilder(ConsoleOutput::class)->getMock();
 
@@ -81,10 +79,8 @@ class ConsoleLogTest extends TestCase
 
     /**
      * test dateFormat option
-     *
-     * @return void
      */
-    public function testDateFormat()
+    public function testDateFormat(): void
     {
         $filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
         $log = new ConsoleLog([
@@ -99,10 +95,8 @@ class ConsoleLogTest extends TestCase
 
     /**
      * Test json formatter
-     *
-     * @return void
      */
-    public function testJsonFormatter()
+    public function testJsonFormatter(): void
     {
         $filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
         $log = new ConsoleLog([
@@ -125,12 +119,10 @@ class ConsoleLogTest extends TestCase
 
     /**
      * Test deprecated dateFormat option
-     *
-     * @return void
      */
-    public function testDeprecatedDateFormat()
+    public function testDeprecatedDateFormat(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
             $log = new ConsoleLog([
                 'stream' => $filename,

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -28,10 +28,8 @@ class FileLogTest extends TestCase
 {
     /**
      * testLogFileWriting method
-     *
-     * @return void
      */
-    public function testLogFileWriting()
+    public function testLogFileWriting(): void
     {
         $this->_deleteLogs(LOGS);
 
@@ -57,10 +55,8 @@ class FileLogTest extends TestCase
 
     /**
      * test using the path setting to log logs in other places.
-     *
-     * @return void
      */
-    public function testPathSetting()
+    public function testPathSetting(): void
     {
         $path = TMP . 'tests' . DS;
         $this->_deleteLogs($path);
@@ -72,10 +68,8 @@ class FileLogTest extends TestCase
 
     /**
      * test log rotation
-     *
-     * @return void
      */
-    public function testRotation()
+    public function testRotation(): void
     {
         $path = TMP . 'tests' . DS;
         $this->_deleteLogs($path);
@@ -154,7 +148,7 @@ class FileLogTest extends TestCase
         $this->assertCount(0, glob($path . 'debug.log.*'));
     }
 
-    public function testMaskSetting()
+    public function testMaskSetting(): void
     {
         if (DS === '\\') {
             $this->markTestSkipped('File permission testing does not work on Windows.');
@@ -189,9 +183,8 @@ class FileLogTest extends TestCase
      * helper function to clears all log files in specified directory
      *
      * @param string $dir
-     * @return void
      */
-    protected function _deleteLogs($dir)
+    protected function _deleteLogs($dir): void
     {
         $files = array_merge(glob($dir . '*.log'), glob($dir . '*.log.*'));
         foreach ($files as $file) {
@@ -201,10 +194,8 @@ class FileLogTest extends TestCase
 
     /**
      * test dateFormat option
-     *
-     * @return void
      */
-    public function testDateFormat()
+    public function testDateFormat(): void
     {
         $this->_deleteLogs(LOGS);
 
@@ -218,12 +209,10 @@ class FileLogTest extends TestCase
 
     /**
      * Test deprecated dateFormat option
-     *
-     * @return void
      */
-    public function testDeprecatedDateFormat()
+    public function testDeprecatedDateFormat(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->_deleteLogs(LOGS);
 
             $log = new FileLog(['path' => LOGS, 'dateFormat' => 'c']);

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -26,10 +26,8 @@ class SyslogLogTest extends TestCase
 {
     /**
      * Tests that the connection to the logger is open with the right arguments
-     *
-     * @return void
      */
-    public function testOpenLog()
+    public function testOpenLog(): void
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
         $log = $this->getMockBuilder(SyslogLog::class)
@@ -56,9 +54,8 @@ class SyslogLogTest extends TestCase
      * Tests that single lines are written to syslog
      *
      * @dataProvider typesProvider
-     * @return void
      */
-    public function testWriteOneLine(string $type, int $expected)
+    public function testWriteOneLine(string $type, int $expected): void
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
         $log = $this->getMockBuilder(SyslogLog::class)
@@ -70,10 +67,8 @@ class SyslogLogTest extends TestCase
 
     /**
      * Tests that multiple lines are split and logged separately
-     *
-     * @return void
      */
-    public function testWriteMultiLine()
+    public function testWriteMultiLine(): void
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */
         $log = $this->getMockBuilder(SyslogLog::class)
@@ -90,12 +85,10 @@ class SyslogLogTest extends TestCase
 
     /**
      * Test deprecated format option
-     *
-     * @return void
      */
-    public function testDeprecatedFormat()
+    public function testDeprecatedFormat(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $log = $this->getMockBuilder(SyslogLog::class)
                 ->setConstructorArgs(['config' => ['format' => 'custom %s: %s']])
                 ->onlyMethods(['_open', '_write'])
@@ -112,10 +105,8 @@ class SyslogLogTest extends TestCase
 
     /**
      * Test deprecated format option
-     *
-     * @return void
      */
-    public function testDeprecatedFormatMessage()
+    public function testDeprecatedFormatMessage(): void
     {
         $this->expectDeprecation();
         $this->expectDeprecationMessage('`format` option is now deprecated in favor of custom formatters');

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -38,10 +38,8 @@ class LogTest extends TestCase
 
     /**
      * test importing loggers from app/libs and plugins.
-     *
-     * @return void
      */
-    public function testImportingLoggers()
+    public function testImportingLoggers(): void
     {
         static::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
@@ -69,10 +67,8 @@ class LogTest extends TestCase
 
     /**
      * test all the errors from failed logger imports
-     *
-     * @return void
      */
-    public function testImportingLoggerFailure()
+    public function testImportingLoggerFailure(): void
     {
         $this->expectException(\RuntimeException::class);
         Log::setConfig('fail', []);
@@ -81,10 +77,8 @@ class LogTest extends TestCase
 
     /**
      * test config() with valid key name
-     *
-     * @return void
      */
-    public function testValidKeyName()
+    public function testValidKeyName(): void
     {
         Log::setConfig('valid', ['engine' => 'File']);
         $stream = Log::engine('valid');
@@ -93,10 +87,8 @@ class LogTest extends TestCase
 
     /**
      * test config() with valid numeric key name
-     *
-     * @return void
      */
-    public function testValidKeyNameNumeric()
+    public function testValidKeyNameNumeric(): void
     {
         Log::setConfig('404', ['engine' => 'File']);
         $stream = Log::engine('404');
@@ -108,10 +100,8 @@ class LogTest extends TestCase
 
     /**
      * test that loggers have to implement the correct interface.
-     *
-     * @return void
      */
-    public function testNotImplementingInterface()
+    public function testNotImplementingInterface(): void
     {
         Log::setConfig('fail', ['engine' => '\stdClass']);
 
@@ -122,10 +112,8 @@ class LogTest extends TestCase
 
     /**
      * explicit tests for drop()
-     *
-     * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         Log::setConfig('file', [
             'engine' => 'File',
@@ -143,10 +131,8 @@ class LogTest extends TestCase
 
     /**
      * test invalid level
-     *
-     * @return void
      */
-    public function testInvalidLevel()
+    public function testInvalidLevel(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Log::setConfig('myengine', ['engine' => 'File']);
@@ -178,9 +164,8 @@ class LogTest extends TestCase
      *
      * @dataProvider configProvider
      * @param mixed $settings
-     * @return void
      */
-    public function testConfigVariants($settings)
+    public function testConfigVariants($settings): void
     {
         Log::setConfig('test', $settings);
         $this->assertContains('test', Log::configured());
@@ -193,9 +178,8 @@ class LogTest extends TestCase
      *
      * @dataProvider configProvider
      * @param mixed $settings
-     * @return void
      */
-    public function testSetConfigVariants($settings)
+    public function testSetConfigVariants($settings): void
     {
         Log::setConfig('test', $settings);
         $this->assertContains('test', Log::configured());
@@ -206,10 +190,8 @@ class LogTest extends TestCase
     /**
      * Test that config() throws an exception when adding an
      * adapter with the wrong type.
-     *
-     * @return void
      */
-    public function testConfigInjectErrorOnWrongType()
+    public function testConfigInjectErrorOnWrongType(): void
     {
         $this->expectException(\RuntimeException::class);
         Log::setConfig('test', new \stdClass());
@@ -219,10 +201,8 @@ class LogTest extends TestCase
     /**
      * Test that setConfig() throws an exception when adding an
      * adapter with the wrong type.
-     *
-     * @return void
      */
-    public function testSetConfigInjectErrorOnWrongType()
+    public function testSetConfigInjectErrorOnWrongType(): void
     {
         $this->expectException(\RuntimeException::class);
         Log::setConfig('test', new \stdClass());
@@ -231,10 +211,8 @@ class LogTest extends TestCase
 
     /**
      * Test that config() can read data back
-     *
-     * @return void
      */
-    public function testConfigRead()
+    public function testConfigRead(): void
     {
         $config = [
             'engine' => 'File',
@@ -250,10 +228,8 @@ class LogTest extends TestCase
 
     /**
      * Ensure you cannot reconfigure a log adapter.
-     *
-     * @return void
      */
-    public function testConfigErrorOnReconfigure()
+    public function testConfigErrorOnReconfigure(): void
     {
         $this->expectException(\BadMethodCallException::class);
         Log::setConfig('tests', ['engine' => 'File', 'path' => TMP]);
@@ -262,10 +238,8 @@ class LogTest extends TestCase
 
     /**
      * testLogFileWriting method
-     *
-     * @return void
      */
-    public function testLogFileWriting()
+    public function testLogFileWriting(): void
     {
         $this->_resetLogConfig();
         if (file_exists(LOGS . 'error.log')) {
@@ -286,10 +260,8 @@ class LogTest extends TestCase
 
     /**
      * test selective logging by level/type
-     *
-     * @return void
      */
-    public function testSelectiveLoggingByLevel()
+    public function testSelectiveLoggingByLevel(): void
     {
         if (file_exists(LOGS . 'spam.log')) {
             unlink(LOGS . 'spam.log');
@@ -334,10 +306,8 @@ class LogTest extends TestCase
 
     /**
      * test selective logging by level using the `types` attribute
-     *
-     * @return void
      */
-    public function testSelectiveLoggingByLevelUsingTypes()
+    public function testSelectiveLoggingByLevelUsingTypes(): void
     {
         if (file_exists(LOGS . 'spam.log')) {
             unlink(LOGS . 'spam.log');
@@ -380,7 +350,7 @@ class LogTest extends TestCase
         }
     }
 
-    protected function _resetLogConfig()
+    protected function _resetLogConfig(): void
     {
         Log::setConfig('debug', [
             'engine' => 'File',
@@ -396,7 +366,7 @@ class LogTest extends TestCase
         ]);
     }
 
-    protected function _deleteLogs()
+    protected function _deleteLogs(): void
     {
         if (file_exists(LOGS . 'shops.log')) {
             unlink(LOGS . 'shops.log');
@@ -420,10 +390,8 @@ class LogTest extends TestCase
 
     /**
      * test scoped logging
-     *
-     * @return void
      */
-    public function testScopedLogging()
+    public function testScopedLogging(): void
     {
         $this->_deleteLogs();
         $this->_resetLogConfig();
@@ -461,10 +429,8 @@ class LogTest extends TestCase
 
     /**
      * Test scoped logging without the default loggers catching everything
-     *
-     * @return void
      */
-    public function testScopedLoggingStrict()
+    public function testScopedLoggingStrict(): void
     {
         $this->_deleteLogs();
 
@@ -501,7 +467,7 @@ class LogTest extends TestCase
     /**
      * test scoped logging with convenience methods
      */
-    public function testConvenienceScopedLogging()
+    public function testConvenienceScopedLogging(): void
     {
         if (file_exists(LOGS . 'shops.log')) {
             unlink(LOGS . 'shops.log');
@@ -548,10 +514,8 @@ class LogTest extends TestCase
 
     /**
      * Test that scopes are exclusive and don't bleed.
-     *
-     * @return void
      */
-    public function testScopedLoggingExclusive()
+    public function testScopedLoggingExclusive(): void
     {
         $this->_deleteLogs();
 
@@ -584,7 +548,7 @@ class LogTest extends TestCase
     /**
      * testPassingScopeToEngine method
      */
-    public function testPassingScopeToEngine()
+    public function testPassingScopeToEngine(): void
     {
         static::setAppNamespace();
 
@@ -613,7 +577,7 @@ class LogTest extends TestCase
     /**
      * test convenience methods
      */
-    public function testConvenienceMethods()
+    public function testConvenienceMethods(): void
     {
         $this->_deleteLogs();
 
@@ -689,10 +653,8 @@ class LogTest extends TestCase
 
     /**
      * Test that write() returns false on an unhandled message.
-     *
-     * @return void
      */
-    public function testWriteUnhandled()
+    public function testWriteUnhandled(): void
     {
         Log::drop('error');
         Log::drop('debug');
@@ -703,10 +665,8 @@ class LogTest extends TestCase
 
     /**
      * Tests using a callable for creating a Log engine
-     *
-     * @return void
      */
-    public function testCreateLoggerWithCallable()
+    public function testCreateLoggerWithCallable(): void
     {
         $instance = new FileLog();
         Log::setConfig('default', function ($alias) use ($instance) {

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -31,10 +31,8 @@ class LogTraitTest extends TestCase
 
     /**
      * Test log method.
-     *
-     * @return void
      */
-    public function testLog()
+    public function testLog(): void
     {
         $mock = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $mock->expects($this->exactly(2))

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -47,8 +47,6 @@ class EmailTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -69,8 +67,6 @@ class EmailTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -85,10 +81,8 @@ class EmailTest extends TestCase
 
     /**
      * testFrom method
-     *
-     * @return void
      */
-    public function testFrom()
+    public function testFrom(): void
     {
         $this->assertSame([], $this->Email->getFrom());
 
@@ -113,10 +107,8 @@ class EmailTest extends TestCase
 
     /**
      * Test that from addresses using colons work.
-     *
-     * @return void
      */
-    public function testFromWithColonsAndQuotes()
+    public function testFromWithColonsAndQuotes(): void
     {
         $address = [
             'info@example.com' => '70:20:00 " Forum',
@@ -133,10 +125,8 @@ class EmailTest extends TestCase
 
     /**
      * testSender method
-     *
-     * @return void
      */
-    public function testSender()
+    public function testSender(): void
     {
         $this->Email->reset();
         $this->assertSame([], $this->Email->getSender());
@@ -157,10 +147,8 @@ class EmailTest extends TestCase
 
     /**
      * testTo method
-     *
-     * @return void
      */
-    public function testTo()
+    public function testTo(): void
     {
         $this->assertSame([], $this->Email->getTo());
 
@@ -212,10 +200,8 @@ class EmailTest extends TestCase
 
     /**
      * test to address with _ in domain name
-     *
-     * @return void
      */
-    public function testToUnderscoreDomain()
+    public function testToUnderscoreDomain(): void
     {
         $result = $this->Email->setTo('cake@cake_php.org');
         $expected = ['cake@cake_php.org' => 'cake@cake_php.org'];
@@ -228,7 +214,7 @@ class EmailTest extends TestCase
      *
      * @return array
      */
-    public static function invalidEmails()
+    public static function invalidEmails(): array
     {
         return [
             [''],
@@ -243,9 +229,8 @@ class EmailTest extends TestCase
      *
      * @dataProvider invalidEmails
      * @param array|string $value
-     * @return void
      */
-    public function testInvalidEmail($value)
+    public function testInvalidEmail($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->Email->setTo($value);
@@ -256,9 +241,8 @@ class EmailTest extends TestCase
      *
      * @dataProvider invalidEmails
      * @param array|string $value
-     * @return void
      */
-    public function testInvalidEmailAdd($value)
+    public function testInvalidEmailAdd($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->Email->addTo($value);
@@ -266,10 +250,8 @@ class EmailTest extends TestCase
 
     /**
      * test emailPattern method
-     *
-     * @return void
      */
-    public function testEmailPattern()
+    public function testEmailPattern(): void
     {
         $regex = '/.+@.+\..+/i';
         $this->assertSame($regex, $this->Email->setEmailPattern($regex)->getEmailPattern());
@@ -277,10 +259,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that it is possible to set email regex configuration to a CakeEmail object
-     *
-     * @return void
      */
-    public function testConfigEmailPattern()
+    public function testConfigEmailPattern(): void
     {
         $regex = '/.+@.+\..+/i';
         $email = new Email(['emailPattern' => $regex]);
@@ -289,10 +269,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that it is possible set custom email validation
-     *
-     * @return void
      */
-    public function testCustomEmailValidation()
+    public function testCustomEmailValidation(): void
     {
         $regex = '/^[\.a-z0-9!#$%&\'*+\/=?^_`{|}~-]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]{2,6}$/i';
 
@@ -333,10 +311,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests not found transport class name exception
-     *
-     * @return void
      */
-    public function testClassNameException()
+    public function testClassNameException(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Mailer transport TestFalse is not available.');
@@ -346,10 +322,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that it is possible to unset the email pattern and make use of filter_var() instead.
-     *
-     * @return void
      */
-    public function testUnsetEmailPattern()
+    public function testUnsetEmailPattern(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
@@ -365,10 +339,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that passing an empty string throws an InvalidArgumentException.
-     *
-     * @return void
      */
-    public function testEmptyTo()
+    public function testEmptyTo(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The email set for "to" is empty.');
@@ -378,10 +350,8 @@ class EmailTest extends TestCase
 
     /**
      * testFormatAddress method
-     *
-     * @return void
      */
-    public function testFormatAddress()
+    public function testFormatAddress(): void
     {
         $result = $this->Email->getMessage()->fmtAddress(['cake@cakephp.org' => 'cake@cakephp.org']);
         $expected = ['cake@cakephp.org'];
@@ -424,10 +394,8 @@ class EmailTest extends TestCase
 
     /**
      * testFormatAddressJapanese
-     *
-     * @return void
      */
-    public function testFormatAddressJapanese()
+    public function testFormatAddressJapanese(): void
     {
         $this->Email->setHeaderCharset('ISO-2022-JP');
         $result = $this->Email->getMessage()->fmtAddress(['cake@cakephp.org' => '日本語Test']);
@@ -446,10 +414,8 @@ class EmailTest extends TestCase
 
     /**
      * testAddresses method
-     *
-     * @return void
      */
-    public function testAddresses()
+    public function testAddresses(): void
     {
         $this->Email->reset();
         $this->Email->setFrom('cake@cakephp.org', 'CakePHP');
@@ -489,10 +455,8 @@ class EmailTest extends TestCase
 
     /**
      * test reset addresses method
-     *
-     * @return void
      */
-    public function testResetAddresses()
+    public function testResetAddresses(): void
     {
         $this->Email->reset();
         $this->Email
@@ -532,10 +496,8 @@ class EmailTest extends TestCase
 
     /**
      * testMessageId method
-     *
-     * @return void
      */
-    public function testMessageId()
+    public function testMessageId(): void
     {
         $this->Email->setMessageId(true);
         $result = $this->Email->getHeaders();
@@ -554,7 +516,7 @@ class EmailTest extends TestCase
         $this->assertSame('<my-email@localhost>', $result);
     }
 
-    public function testAutoMessageIdIsIdempotent()
+    public function testAutoMessageIdIsIdempotent(): void
     {
         $headers = $this->Email->getHeaders();
         $this->assertArrayHasKey('Message-ID', $headers);
@@ -563,10 +525,7 @@ class EmailTest extends TestCase
         $this->assertSame($headers['Message-ID'], $regeneratedHeaders['Message-ID']);
     }
 
-    /**
-     * @return void
-     */
-    public function testPriority()
+    public function testPriority(): void
     {
         $this->Email->setPriority(4);
 
@@ -578,10 +537,8 @@ class EmailTest extends TestCase
 
     /**
      * testMessageIdInvalid method
-     *
-     * @return void
      */
-    public function testMessageIdInvalid()
+    public function testMessageIdInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->Email->setMessageId('my-email@localhost');
@@ -589,10 +546,8 @@ class EmailTest extends TestCase
 
     /**
      * testDomain method
-     *
-     * @return void
      */
-    public function testDomain()
+    public function testDomain(): void
     {
         $result = $this->Email->getDomain();
         $expected = env('HTTP_HOST') ? env('HTTP_HOST') : php_uname('n');
@@ -606,10 +561,8 @@ class EmailTest extends TestCase
 
     /**
      * testMessageIdWithDomain method
-     *
-     * @return void
      */
-    public function testMessageIdWithDomain()
+    public function testMessageIdWithDomain(): void
     {
         $this->Email->setDomain('example.org');
         $result = $this->Email->getHeaders();
@@ -627,10 +580,8 @@ class EmailTest extends TestCase
 
     /**
      * testSubject method
-     *
-     * @return void
      */
-    public function testSubject()
+    public function testSubject(): void
     {
         $this->Email->setSubject('You have a new message.');
         $this->assertSame('You have a new message.', $this->Email->getSubject());
@@ -649,10 +600,8 @@ class EmailTest extends TestCase
 
     /**
      * testSubjectJapanese
-     *
-     * @return void
      */
-    public function testSubjectJapanese()
+    public function testSubjectJapanese(): void
     {
         mb_internal_encoding('UTF-8');
 
@@ -670,10 +619,8 @@ class EmailTest extends TestCase
 
     /**
      * testHeaders method
-     *
-     * @return void
      */
-    public function testHeaders()
+    public function testHeaders(): void
     {
         $this->Email->setMessageId(false);
         $this->Email->setHeaders(['X-Something' => 'nice']);
@@ -752,10 +699,8 @@ class EmailTest extends TestCase
 
     /**
      * testTemplate method
-     *
-     * @return void
      */
-    public function testTemplate()
+    public function testTemplate(): void
     {
         $this->Email->viewBuilder()->setTemplate('template');
         $this->assertSame('template', $this->Email->viewBuilder()->getTemplate());
@@ -763,10 +708,8 @@ class EmailTest extends TestCase
 
     /**
      * testLayout method
-     *
-     * @return void
      */
-    public function testLayout()
+    public function testLayout(): void
     {
         $this->Email->viewBuilder()->setLayout('layout');
         $this->assertSame('layout', $this->Email->viewBuilder()->getLayout());
@@ -774,10 +717,8 @@ class EmailTest extends TestCase
 
     /**
      * testTheme method
-     *
-     * @return void
      */
-    public function testTheme()
+    public function testTheme(): void
     {
         $this->assertNull($this->Email->viewBuilder()->getTheme());
 
@@ -788,10 +729,8 @@ class EmailTest extends TestCase
 
     /**
      * testViewVars method
-     *
-     * @return void
      */
-    public function testViewVars()
+    public function testViewVars(): void
     {
         $this->assertSame([], $this->Email->getViewVars());
 
@@ -807,10 +746,8 @@ class EmailTest extends TestCase
 
     /**
      * testAttachments method
-     *
-     * @return void
      */
-    public function testSetAttachments()
+    public function testSetAttachments(): void
     {
         $this->Email->setAttachments([CAKE . 'basics.php']);
         $expected = [
@@ -846,10 +783,8 @@ class EmailTest extends TestCase
 
     /**
      * Test send() with no template and data string attachment and no mimetype
-     *
-     * @return void
      */
-    public function testSetAttachmentDataNoMimetype()
+    public function testSetAttachmentDataNoMimetype(): void
     {
         $this->Email->setAttachments(['cake.icon.gif' => [
             'data' => 'test',
@@ -866,10 +801,8 @@ class EmailTest extends TestCase
 
     /**
      * testTransport method
-     *
-     * @return void
      */
-    public function testTransport()
+    public function testTransport(): void
     {
         $result = $this->Email->setTransport('debug');
         $this->assertSame($this->Email, $result);
@@ -885,7 +818,7 @@ class EmailTest extends TestCase
     /**
      * Test that using unknown transports fails.
      */
-    public function testTransportInvalid()
+    public function testTransportInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "Invalid" transport configuration does not exist');
@@ -895,7 +828,7 @@ class EmailTest extends TestCase
     /**
      * Test that using classes with no send method fails.
      */
-    public function testTransportInstanceInvalid()
+    public function testTransportInstanceInvalid(): void
     {
         $this->expectException(\LogicException::class);
         $this->Email->setTransport(new \stdClass());
@@ -904,7 +837,7 @@ class EmailTest extends TestCase
     /**
      * Test that using unknown transports fails.
      */
-    public function testTransportTypeInvalid()
+    public function testTransportTypeInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The value passed for the "$name" argument must be either a string, or an object, integer given.');
@@ -913,10 +846,8 @@ class EmailTest extends TestCase
 
     /**
      * Test reading/writing configuration profiles.
-     *
-     * @return void
      */
-    public function testConfig()
+    public function testConfig(): void
     {
         $settings = [
             'to' => 'mark@example.com',
@@ -931,10 +862,8 @@ class EmailTest extends TestCase
 
     /**
      * Test that exceptions are raised on duplicate config set.
-     *
-     * @return void
      */
-    public function testConfigErrorOnDuplicate()
+    public function testConfigErrorOnDuplicate(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $settings = [
@@ -947,10 +876,8 @@ class EmailTest extends TestCase
 
     /**
      * test profile method
-     *
-     * @return void
      */
-    public function testProfile()
+    public function testProfile(): void
     {
         $config = ['test' => 'ok', 'test2' => true];
         $this->Email->setProfile($config);
@@ -964,10 +891,8 @@ class EmailTest extends TestCase
 
     /**
      * test that default profile is used by constructor if available.
-     *
-     * @return void
      */
-    public function testDefaultProfile()
+    public function testDefaultProfile(): void
     {
         $config = ['test' => 'ok', 'test2' => true];
         Configure::write('Email.default', $config);
@@ -981,7 +906,7 @@ class EmailTest extends TestCase
     /**
      * Test that using an invalid profile fails.
      */
-    public function testProfileInvalid()
+    public function testProfileInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown email configuration "derp".');
@@ -991,10 +916,8 @@ class EmailTest extends TestCase
 
     /**
      * testConfigString method
-     *
-     * @return void
      */
-    public function testUseConfigString()
+    public function testUseConfigString(): void
     {
         $config = [
             'from' => ['some@example.com' => 'My website'],
@@ -1028,10 +951,8 @@ class EmailTest extends TestCase
 
     /**
      * Calling send() with no parameters should not overwrite the view variables.
-     *
-     * @return void
      */
-    public function testSendWithNoContentDoesNotOverwriteViewVar()
+    public function testSendWithNoContentDoesNotOverwriteViewVar(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1050,10 +971,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendWithContent method
-     *
-     * @return void
      */
-    public function testSendWithContent()
+    public function testSendWithContent(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1091,10 +1010,8 @@ class EmailTest extends TestCase
 
     /**
      * test send without a transport method
-     *
-     * @return void
      */
-    public function testSendWithoutTransport()
+    public function testSendWithoutTransport(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot send email, transport was not defined.');
@@ -1106,10 +1023,8 @@ class EmailTest extends TestCase
 
     /**
      * Test send() with no template.
-     *
-     * @return void
      */
-    public function testSendNoTemplateWithAttachments()
+    public function testSendNoTemplateWithAttachments(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1139,10 +1054,8 @@ class EmailTest extends TestCase
 
     /**
      * Test send() with no template and data string attachment
-     *
-     * @return void
      */
-    public function testSendNoTemplateWithDataStringAttachment()
+    public function testSendNoTemplateWithDataStringAttachment(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1176,10 +1089,8 @@ class EmailTest extends TestCase
 
     /**
      * Test send() with no template as both
-     *
-     * @return void
      */
-    public function testSendNoTemplateWithAttachmentsAsBoth()
+    public function testSendNoTemplateWithAttachmentsAsBoth(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1222,10 +1133,8 @@ class EmailTest extends TestCase
 
     /**
      * Test setting inline attachments and messages.
-     *
-     * @return void
      */
-    public function testSendWithInlineAttachments()
+    public function testSendWithInlineAttachments(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1279,10 +1188,8 @@ class EmailTest extends TestCase
 
     /**
      * Test setting inline attachments and HTML only messages.
-     *
-     * @return void
      */
-    public function testSendWithInlineAttachmentsHtmlOnly()
+    public function testSendWithInlineAttachmentsHtmlOnly(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1323,10 +1230,8 @@ class EmailTest extends TestCase
 
     /**
      * Test disabling content-disposition.
-     *
-     * @return void
      */
-    public function testSendWithNoContentDispositionAttachments()
+    public function testSendWithNoContentDispositionAttachments(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1362,10 +1267,8 @@ class EmailTest extends TestCase
 
     /**
      * Test an attachment filename with non-ASCII characters.
-     *
-     * @return void
      */
-    public function testSendWithNonAsciiFilenameAttachments()
+    public function testSendWithNonAsciiFilenameAttachments(): void
     {
         $this->Email->setTransport('debug');
         $this->Email->setFrom('cake@cakephp.org');
@@ -1422,10 +1325,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendWithLog method
-     *
-     * @return void
      */
-    public function testSendWithLog()
+    public function testSendWithLog(): void
     {
         Log::setConfig('email', [
             'className' => 'Array',
@@ -1450,10 +1351,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendWithLogAndScope method
-     *
-     * @return void
      */
-    public function testSendWithLogAndScope()
+    public function testSendWithLogAndScope(): void
     {
         Log::setConfig('email', [
             'className' => 'Array',
@@ -1478,10 +1377,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRender method
-     *
-     * @return void
      */
-    public function testSendRender()
+    public function testSendRender(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1500,10 +1397,8 @@ class EmailTest extends TestCase
 
     /**
      * test sending and rendering with no layout
-     *
-     * @return void
      */
-    public function testSendRenderNoLayout()
+    public function testSendRenderNoLayout(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1523,10 +1418,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRender both method
-     *
-     * @return void
      */
-    public function testSendRenderBoth()
+    public function testSendRenderBoth(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1572,10 +1465,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRender method for ISO-2022-JP
-     *
-     * @return void
      */
-    public function testSendRenderJapanese()
+    public function testSendRenderJapanese(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1597,10 +1488,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderThemed method
-     *
-     * @return void
      */
-    public function testSendRenderThemed()
+    public function testSendRenderThemed(): void
     {
         $this->loadPlugins(['TestTheme']);
         $this->Email->reset();
@@ -1624,10 +1513,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderWithHTML method and assert line length is kept below the required limit
-     *
-     * @return void
      */
-    public function testSendRenderWithHTML()
+    public function testSendRenderWithHTML(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1646,10 +1533,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderWithVars method
-     *
-     * @return void
      */
-    public function testSendRenderWithVars()
+    public function testSendRenderWithVars(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1667,10 +1552,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderWithVars method for ISO-2022-JP
-     *
-     * @return void
      */
-    public function testSendRenderWithVarsJapanese()
+    public function testSendRenderWithVarsJapanese(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1690,10 +1573,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderWithHelpers method
-     *
-     * @return void
      */
-    public function testSendRenderWithHelpers()
+    public function testSendRenderWithHelpers(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1720,10 +1601,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderWithImage method
-     *
-     * @return void
      */
-    public function testSendRenderWithImage()
+    public function testSendRenderWithImage(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1747,10 +1626,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendRenderPlugin method
-     *
-     * @return void
      */
-    public function testSendRenderPlugin()
+    public function testSendRenderPlugin(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'TestTheme']);
 
@@ -1807,10 +1684,8 @@ class EmailTest extends TestCase
 
     /**
      * Test that a MissingTemplateException is thrown
-     *
-     * @return void
      */
-    public function testMissingTemplateException()
+    public function testMissingTemplateException(): void
     {
         $this->expectException(MissingTemplateException::class);
 
@@ -1825,10 +1700,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendMultipleMIME method
-     *
-     * @return void
      */
-    public function testSendMultipleMIME()
+    public function testSendMultipleMIME(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1862,10 +1735,8 @@ class EmailTest extends TestCase
 
     /**
      * testSendAttachment method
-     *
-     * @return void
      */
-    public function testSendAttachment()
+    public function testSendAttachment(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1905,10 +1776,8 @@ class EmailTest extends TestCase
 
     /**
      * testDeliver method
-     *
-     * @return void
      */
-    public function testDeliver()
+    public function testDeliver(): void
     {
         TransportFactory::drop('default');
         TransportFactory::setConfig('default', ['className' => 'Debug']);
@@ -1946,10 +1815,8 @@ class EmailTest extends TestCase
 
     /**
      * testMessage method
-     *
-     * @return void
      */
-    public function testMessage()
+    public function testMessage(): void
     {
         $this->Email->reset();
         $this->Email->setTransport('debug');
@@ -1986,10 +1853,8 @@ class EmailTest extends TestCase
 
     /**
      * testReset method
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         $this->Email->setTo('cake@cakephp.org');
         $this->Email->viewBuilder()->setTheme('TestTheme');
@@ -2004,10 +1869,8 @@ class EmailTest extends TestCase
 
     /**
      * testReset with charset
-     *
-     * @return void
      */
-    public function testResetWithCharset()
+    public function testResetWithCharset(): void
     {
         $this->Email->setCharset('ISO-2022-JP');
         $this->Email->reset();
@@ -2018,10 +1881,8 @@ class EmailTest extends TestCase
 
     /**
      * testRender method
-     *
-     * @return void
      */
-    public function testRenderWithLayoutAndAttachment()
+    public function testRenderWithLayoutAndAttachment(): void
     {
         $this->Email->setEmailFormat('html');
         $this->Email->viewBuilder()->setTemplate('html', 'default');
@@ -2036,10 +1897,8 @@ class EmailTest extends TestCase
 
     /**
      * testConstructWithConfigArray method
-     *
-     * @return void
      */
-    public function testConstructWithConfigArray()
+    public function testConstructWithConfigArray(): void
     {
         $configs = [
             'from' => ['some@example.com' => 'My website'],
@@ -2069,10 +1928,8 @@ class EmailTest extends TestCase
 
     /**
      * testConfigArrayWithLayoutWithoutTemplate method
-     *
-     * @return void
      */
-    public function testConfigArrayWithLayoutWithoutTemplate()
+    public function testConfigArrayWithLayoutWithoutTemplate(): void
     {
         $configs = [
             'from' => ['some@example.com' => 'My website'],
@@ -2091,10 +1948,8 @@ class EmailTest extends TestCase
 
     /**
      * testConstructWithConfigString method
-     *
-     * @return void
      */
-    public function testConstructWithConfigString()
+    public function testConstructWithConfigString(): void
     {
         $configs = [
             'from' => ['some@example.com' => 'My website'],
@@ -2126,10 +1981,8 @@ class EmailTest extends TestCase
 
     /**
      * testViewRender method
-     *
-     * @return void
      */
-    public function testViewRender()
+    public function testViewRender(): void
     {
         $result = $this->Email->getViewRenderer();
         $this->assertSame('Cake\View\View', $result);
@@ -2143,10 +1996,8 @@ class EmailTest extends TestCase
 
     /**
      * testEmailFormat method
-     *
-     * @return void
      */
-    public function testEmailFormat()
+    public function testEmailFormat(): void
     {
         $result = $this->Email->getEmailFormat();
         $this->assertSame('text', $result);
@@ -2163,10 +2014,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that it is possible to add charset configuration to a CakeEmail object
-     *
-     * @return void
      */
-    public function testConfigCharset()
+    public function testConfigCharset(): void
     {
         $email = new Email();
         $this->assertEquals(Configure::read('App.encoding'), $email->getCharset());
@@ -2187,10 +2036,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that the header is encoded using the configured headerCharset
-     *
-     * @return void
      */
-    public function testHeaderEncoding()
+    public function testHeaderEncoding(): void
     {
         $email = new Email(['headerCharset' => 'iso-2022-jp-ms', 'transport' => 'debug']);
         $email->setSubject('あれ？もしかしての前と');
@@ -2205,10 +2052,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that the body is encoded using the configured charset
-     *
-     * @return void
      */
-    public function testBodyEncoding()
+    public function testBodyEncoding(): void
     {
         $email = new Email([
             'charset' => 'iso-2022-jp',
@@ -2228,10 +2073,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that the body is encoded using the configured charset (Japanese standard encoding)
-     *
-     * @return void
      */
-    public function testBodyEncodingIso2022Jp()
+    public function testBodyEncodingIso2022Jp(): void
     {
         $email = new Email([
             'charset' => 'iso-2022-jp',
@@ -2252,10 +2095,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests that the body is encoded using the configured charset (Japanese irregular encoding, but sometime use this)
-     *
-     * @return void
      */
-    public function testBodyEncodingIso2022JpMs()
+    public function testBodyEncodingIso2022JpMs(): void
     {
         $email = new Email([
             'charset' => 'iso-2022-jp-ms',
@@ -2308,10 +2149,8 @@ class EmailTest extends TestCase
 
     /**
      * Test CakeEmail::_encode function
-     *
-     * @return void
      */
-    public function testEncode()
+    public function testEncode(): void
     {
         $this->Email->setHeaderCharset('ISO-2022-JP');
         $result = $this->Email->getMessage()->encode('日本語');
@@ -2328,10 +2167,8 @@ class EmailTest extends TestCase
 
     /**
      * Test CakeEmail::_decode function
-     *
-     * @return void
      */
-    public function testDecode()
+    public function testDecode(): void
     {
         $this->Email->setHeaderCharset('ISO-2022-JP');
         $result = $this->Email->getMessage()->decode('=?ISO-2022-JP?B?GyRCRnxLXDhsGyhC?=');
@@ -2348,10 +2185,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests charset setter/getter
-     *
-     * @return void
      */
-    public function testCharset()
+    public function testCharset(): void
     {
         $this->Email->setCharset('UTF-8');
         $this->assertSame($this->Email->getCharset(), 'UTF-8');
@@ -2365,10 +2200,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests headerCharset setter/getter
-     *
-     * @return void
      */
-    public function testHeaderCharset()
+    public function testHeaderCharset(): void
     {
         $this->Email->setHeaderCharset('UTF-8');
         $this->assertSame($this->Email->getHeaderCharset(), 'UTF-8');
@@ -2382,10 +2215,8 @@ class EmailTest extends TestCase
 
     /**
      * Tests headerCharset on reset
-     *
-     * @return void
      */
-    public function testHeaderCharsetReset()
+    public function testHeaderCharsetReset(): void
     {
         $email = new Email(['headerCharset' => 'ISO-2022-JP']);
         $email->reset();
@@ -2396,10 +2227,8 @@ class EmailTest extends TestCase
 
     /**
      * Test transferEncoding
-     *
-     * @return void
      */
-    public function testTransferEncoding()
+    public function testTransferEncoding(): void
     {
         // Test new transfer encoding
         $expected = 'quoted-printable';
@@ -2422,10 +2251,8 @@ class EmailTest extends TestCase
      * Tests for compatible check.
      *          charset property and       charset() method.
      *    headerCharset property and headerCharset() method.
-     *
-     * @return void
      */
-    public function testCharsetsCompatible()
+    public function testCharsetsCompatible(): void
     {
         $checkHeaders = [
             'from' => true,
@@ -2477,9 +2304,8 @@ class EmailTest extends TestCase
     /**
      * @param mixed $charset
      * @param mixed $headerCharset
-     * @return \Cake\Mailer\Email
      */
-    protected function _getEmailByOldStyleCharset($charset, $headerCharset)
+    protected function _getEmailByOldStyleCharset($charset, $headerCharset): Email
     {
         $email = new Email(['transport' => 'debug']);
 
@@ -2502,9 +2328,8 @@ class EmailTest extends TestCase
     /**
      * @param mixed $charset
      * @param mixed $headerCharset
-     * @return \Cake\Mailer\Email
      */
-    protected function _getEmailByNewStyleCharset($charset, $headerCharset)
+    protected function _getEmailByNewStyleCharset($charset, $headerCharset): Email
     {
         $email = new Email(['transport' => 'debug']);
 
@@ -2526,10 +2351,8 @@ class EmailTest extends TestCase
 
     /**
      * testWrapLongLine()
-     *
-     * @return void
      */
-    public function testWrapLongLine()
+    public function testWrapLongLine(): void
     {
         $message = '<a href="http://cakephp.org">' . str_repeat('x', Message::LINE_LENGTH_MUST) . '</a>';
 
@@ -2572,10 +2395,8 @@ class EmailTest extends TestCase
 
     /**
      * testWrapWithTagsAcrossLines()
-     *
-     * @return void
      */
-    public function testWrapWithTagsAcrossLines()
+    public function testWrapWithTagsAcrossLines(): void
     {
         $str = <<<HTML
 <table>
@@ -2601,10 +2422,8 @@ HTML;
 
     /**
      * CakeEmailTest::testWrapIncludeLessThanSign()
-     *
-     * @return void
      */
-    public function testWrapIncludeLessThanSign()
+    public function testWrapIncludeLessThanSign(): void
     {
         $str = 'foo<bar';
         $length = strlen($str);
@@ -2625,10 +2444,8 @@ HTML;
 
     /**
      * CakeEmailTest::testWrapForJapaneseEncoding()
-     *
-     * @return void
      */
-    public function testWrapForJapaneseEncoding()
+    public function testWrapForJapaneseEncoding(): void
     {
         $this->skipIf(!function_exists('mb_convert_encoding'));
 
@@ -2650,7 +2467,7 @@ HTML;
     /**
      * CakeEmailTest::testMockTransport()
      */
-    public function testMockTransport()
+    public function testMockTransport(): void
     {
         TransportFactory::drop('default');
 
@@ -2667,10 +2484,8 @@ HTML;
 
     /**
      * testZeroOnlyLinesNotBeingEmptied()
-     *
-     * @return void
      */
-    public function testZeroOnlyLinesNotBeingEmptied()
+    public function testZeroOnlyLinesNotBeingEmptied(): void
     {
         $message = "Lorem\r\n0\r\n0\r\nipsum";
 
@@ -2686,10 +2501,8 @@ HTML;
 
     /**
      * testJsonSerialize()
-     *
-     * @return void
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $xmlstr = <<<XML
 <?xml version='1.0' standalone='yes'?>
@@ -2784,10 +2597,8 @@ XML;
 
     /**
      * testStaticMethodProxy
-     *
-     * @return void
      */
-    public function testStaticMethodProxy()
+    public function testStaticMethodProxy(): void
     {
         Email::setConfig('proxy_test', ['yay']);
         $this->assertEquals(['yay'], Mailer::getConfig('proxy_test'));
@@ -2800,9 +2611,8 @@ XML;
      * CakeEmailTest::assertLineLengths()
      *
      * @param string $message
-     * @return void
      */
-    public function assertLineLengths($message)
+    public function assertLineLengths($message): void
     {
         $lines = explode("\r\n", $message);
         foreach ($lines as $line) {

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -28,10 +28,8 @@ class MailerAwareTraitTest extends TestCase
 {
     /**
      * Test getMailer
-     *
-     * @return void
      */
-    public function testGetMailer()
+    public function testGetMailer(): void
     {
         $originalAppNamespace = Configure::read('App.namespace');
         static::setAppNamespace();
@@ -49,7 +47,7 @@ class MailerAwareTraitTest extends TestCase
     /**
      * Test exception thrown by getMailer.
      */
-    public function testGetMailerThrowsException()
+    public function testGetMailerThrowsException(): void
     {
         $this->expectException(MissingMailerException::class);
         $this->expectExceptionMessage('Mailer class "Test" could not be found.');

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -42,8 +42,6 @@ class MailerTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -65,8 +63,6 @@ class MailerTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -81,10 +77,8 @@ class MailerTest extends TestCase
 
     /**
      * testTransport method
-     *
-     * @return void
      */
-    public function testTransport()
+    public function testTransport(): void
     {
         $result = $this->mailer->setTransport('debug');
         $this->assertSame($this->mailer, $result);
@@ -100,7 +94,7 @@ class MailerTest extends TestCase
     /**
      * Test that using unknown transports fails.
      */
-    public function testTransportInvalid()
+    public function testTransportInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "Invalid" transport configuration does not exist');
@@ -110,7 +104,7 @@ class MailerTest extends TestCase
     /**
      * Test that using classes with no send method fails.
      */
-    public function testTransportInstanceInvalid()
+    public function testTransportInstanceInvalid(): void
     {
         $this->expectException(CakeException::class);
         $this->mailer->setTransport(new \stdClass());
@@ -119,7 +113,7 @@ class MailerTest extends TestCase
     /**
      * Test that using unknown transports fails.
      */
-    public function testTransportTypeInvalid()
+    public function testTransportTypeInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The value passed for the "$name" argument must be either a string, or an object, integer given.');
@@ -128,10 +122,8 @@ class MailerTest extends TestCase
 
     /**
      * testMessage function
-     *
-     * @return void
      */
-    public function testMessage()
+    public function testMessage(): void
     {
         $message = $this->mailer->getMessage();
         $this->assertInstanceOf(Message::class, $message);
@@ -144,10 +136,8 @@ class MailerTest extends TestCase
 
     /**
      * Test reading/writing configuration profiles.
-     *
-     * @return void
      */
-    public function testConfig()
+    public function testConfig(): void
     {
         $settings = [
             'to' => 'mark@example.com',
@@ -162,10 +152,8 @@ class MailerTest extends TestCase
 
     /**
      * Test that exceptions are raised on duplicate config set.
-     *
-     * @return void
      */
-    public function testConfigErrorOnDuplicate()
+    public function testConfigErrorOnDuplicate(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $settings = [
@@ -178,10 +166,8 @@ class MailerTest extends TestCase
 
     /**
      * testConstructWithConfigArray method
-     *
-     * @return void
      */
-    public function testConstructWithConfigArray()
+    public function testConstructWithConfigArray(): void
     {
         $configs = [
             'from' => ['some@example.com' => 'My website'],
@@ -211,10 +197,8 @@ class MailerTest extends TestCase
 
     /**
      * testConfigArrayWithLayoutWithoutTemplate method
-     *
-     * @return void
      */
-    public function testConfigArrayWithLayoutWithoutTemplate()
+    public function testConfigArrayWithLayoutWithoutTemplate(): void
     {
         $configs = [
             'from' => ['some@example.com' => 'My website'],
@@ -233,10 +217,8 @@ class MailerTest extends TestCase
 
     /**
      * testConstructWithConfigString method
-     *
-     * @return void
      */
-    public function testConstructWithConfigString()
+    public function testConstructWithConfigString(): void
     {
         $configs = [
             'from' => ['some@example.com' => 'My website'],
@@ -268,10 +250,8 @@ class MailerTest extends TestCase
 
     /**
      * test profile method
-     *
-     * @return void
      */
-    public function testSetProfile()
+    public function testSetProfile(): void
     {
         $config = ['to' => 'foo@bar.com'];
         $this->mailer->setProfile($config);
@@ -280,10 +260,8 @@ class MailerTest extends TestCase
 
     /**
      * test that default profile is used by constructor if available.
-     *
-     * @return void
      */
-    public function testDefaultProfile()
+    public function testDefaultProfile(): void
     {
         $config = ['to' => 'foo@bar.com', 'from' => 'from@bar.com'];
 
@@ -301,7 +279,7 @@ class MailerTest extends TestCase
     /**
      * Test that using an invalid profile fails.
      */
-    public function testProfileInvalid()
+    public function testProfileInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown email configuration "derp".');
@@ -311,10 +289,8 @@ class MailerTest extends TestCase
 
     /**
      * testConfigString method
-     *
-     * @return void
      */
-    public function testUseConfigString()
+    public function testUseConfigString(): void
     {
         $config = [
             'from' => ['some@example.com' => 'My website'],
@@ -351,7 +327,7 @@ class MailerTest extends TestCase
     /**
      * CakeEmailTest::testMockTransport()
      */
-    public function testMockTransport()
+    public function testMockTransport(): void
     {
         TransportFactory::drop('default');
 
@@ -368,10 +344,7 @@ class MailerTest extends TestCase
         TransportFactory::drop('default');
     }
 
-    /**
-     * @return void
-     */
-    public function testProxies()
+    public function testProxies(): void
     {
         $result = (new Mailer())->setHeaders(['X-Something' => 'nice']);
         $this->assertInstanceOf(Mailer::class, $result);
@@ -390,10 +363,8 @@ class MailerTest extends TestCase
 
     /**
      * Test that get/set methods can be proxied.
-     *
-     * @return void
      */
-    public function testGetSetProxies()
+    public function testGetSetProxies(): void
     {
         $mailer = new Mailer();
         $result = $mailer
@@ -405,7 +376,7 @@ class MailerTest extends TestCase
         $this->assertSame(['cc@example.com' => 'cc@example.com'], $result->getCc());
     }
 
-    public function testSet()
+    public function testSet(): void
     {
         $result = (new Mailer())->setViewVars('key', 'value');
         $this->assertInstanceOf(Mailer::class, $result);
@@ -414,10 +385,8 @@ class MailerTest extends TestCase
 
     /**
      * testRenderWithLayoutAndAttachment method
-     *
-     * @return void
      */
-    public function testRenderWithLayoutAndAttachment()
+    public function testRenderWithLayoutAndAttachment(): void
     {
         $this->mailer->setEmailFormat('html');
         $this->mailer->viewBuilder()->setTemplate('html', 'default');
@@ -430,7 +399,7 @@ class MailerTest extends TestCase
         $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $result);
     }
 
-    public function testSend()
+    public function testSend(): void
     {
         $mailer = $this->getMockBuilder(Mailer::class)
             ->onlyMethods(['deliver'])
@@ -450,10 +419,8 @@ class MailerTest extends TestCase
 
     /**
      * Calling send() with no parameters should not overwrite the view variables.
-     *
-     * @return void
      */
-    public function testSendWithNoContentDoesNotOverwriteViewVar()
+    public function testSendWithNoContentDoesNotOverwriteViewVar(): void
     {
         $this->mailer->reset();
         $this->mailer->setTransport('debug');
@@ -473,10 +440,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendWithContent method
-     *
-     * @return void
      */
-    public function testSendWithContent()
+    public function testSendWithContent(): void
     {
         $this->mailer->reset();
         $this->mailer->setTransport('debug');
@@ -504,10 +469,8 @@ class MailerTest extends TestCase
 
     /**
      * test send without a transport method
-     *
-     * @return void
      */
-    public function testSendWithoutTransport()
+    public function testSendWithoutTransport(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage(
@@ -521,10 +484,8 @@ class MailerTest extends TestCase
 
     /**
      * Test send() with no template.
-     *
-     * @return void
      */
-    public function testSendNoTemplateWithAttachments()
+    public function testSendNoTemplateWithAttachments(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -554,10 +515,8 @@ class MailerTest extends TestCase
 
     /**
      * Test send() with no template and data string attachment
-     *
-     * @return void
      */
-    public function testSendNoTemplateWithDataStringAttachment()
+    public function testSendNoTemplateWithDataStringAttachment(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -591,10 +550,8 @@ class MailerTest extends TestCase
 
     /**
      * Test send() with no template as both
-     *
-     * @return void
      */
-    public function testSendNoTemplateWithAttachmentsAsBoth()
+    public function testSendNoTemplateWithAttachmentsAsBoth(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -637,10 +594,8 @@ class MailerTest extends TestCase
 
     /**
      * Test setting inline attachments and messages.
-     *
-     * @return void
      */
-    public function testSendWithInlineAttachments()
+    public function testSendWithInlineAttachments(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -694,10 +649,8 @@ class MailerTest extends TestCase
 
     /**
      * Test setting inline attachments and HTML only messages.
-     *
-     * @return void
      */
-    public function testSendWithInlineAttachmentsHtmlOnly()
+    public function testSendWithInlineAttachmentsHtmlOnly(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -738,10 +691,8 @@ class MailerTest extends TestCase
 
     /**
      * Test disabling content-disposition.
-     *
-     * @return void
      */
-    public function testSendWithNoContentDispositionAttachments()
+    public function testSendWithNoContentDispositionAttachments(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -777,10 +728,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRender method
-     *
-     * @return void
      */
-    public function testSendRender()
+    public function testSendRender(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -798,10 +747,8 @@ class MailerTest extends TestCase
 
     /**
      * test sending and rendering with no layout
-     *
-     * @return void
      */
-    public function testSendRenderNoLayout()
+    public function testSendRenderNoLayout(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -821,10 +768,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRender both method
-     *
-     * @return void
      */
-    public function testSendRenderBoth()
+    public function testSendRenderBoth(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -869,10 +814,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRender method for ISO-2022-JP
-     *
-     * @return void
      */
-    public function testSendRenderJapanese()
+    public function testSendRenderJapanese(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -893,10 +836,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderThemed method
-     *
-     * @return void
      */
-    public function testSendRenderThemed()
+    public function testSendRenderThemed(): void
     {
         $this->loadPlugins(['TestTheme']);
         $this->mailer->setTransport('debug');
@@ -919,10 +860,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderWithHTML method and assert line length is kept below the required limit
-     *
-     * @return void
      */
-    public function testSendRenderWithHTML()
+    public function testSendRenderWithHTML(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -940,10 +879,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderWithVars method
-     *
-     * @return void
      */
-    public function testSendRenderWithVars()
+    public function testSendRenderWithVars(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -960,10 +897,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderWithVars method for ISO-2022-JP
-     *
-     * @return void
      */
-    public function testSendRenderWithVarsJapanese()
+    public function testSendRenderWithVarsJapanese(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -982,10 +917,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderWithHelpers method
-     *
-     * @return void
      */
-    public function testSendRenderWithHelpers()
+    public function testSendRenderWithHelpers(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -1011,10 +944,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderWithImage method
-     *
-     * @return void
      */
-    public function testSendRenderWithImage()
+    public function testSendRenderWithImage(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -1037,10 +968,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendRenderPlugin method
-     *
-     * @return void
      */
-    public function testSendRenderPlugin()
+    public function testSendRenderPlugin(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo', 'TestTheme']);
 
@@ -1096,10 +1025,8 @@ class MailerTest extends TestCase
 
     /**
      * Test that a MissingTemplateException is thrown
-     *
-     * @return void
      */
-    public function testMissingTemplateException()
+    public function testMissingTemplateException(): void
     {
         $this->expectException(MissingTemplateException::class);
 
@@ -1113,10 +1040,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendMultipleMIME method
-     *
-     * @return void
      */
-    public function testSendMultipleMIME()
+    public function testSendMultipleMIME(): void
     {
         $this->mailer->setTransport('debug');
 
@@ -1149,10 +1074,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendAttachment method
-     *
-     * @return void
      */
-    public function testSendAttachment()
+    public function testSendAttachment(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -1193,7 +1116,7 @@ class MailerTest extends TestCase
         $this->assertStringContainsString($expected, $result['message']);
     }
 
-    public function testSendWithUnsetTemplateDefaultsToActionName()
+    public function testSendWithUnsetTemplateDefaultsToActionName(): void
     {
         $mailer = $this->getMockBuilder(Mailer::class)
             ->onlyMethods(['deliver', 'restore'])
@@ -1212,10 +1135,8 @@ class MailerTest extends TestCase
 
     /**
      * testGetBody method
-     *
-     * @return void
      */
-    public function testGetBody()
+    public function testGetBody(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -1251,10 +1172,8 @@ class MailerTest extends TestCase
 
     /**
      * testZeroOnlyLinesNotBeingEmptied()
-     *
-     * @return void
      */
-    public function testZeroOnlyLinesNotBeingEmptied()
+    public function testZeroOnlyLinesNotBeingEmptied(): void
     {
         $message = "Lorem\r\n0\r\n0\r\nipsum";
 
@@ -1271,10 +1190,8 @@ class MailerTest extends TestCase
 
     /**
      * testReset method
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         $this->mailer->setTo('cake@cakephp.org');
         $this->mailer->viewBuilder()->setTheme('TestTheme');
@@ -1289,10 +1206,8 @@ class MailerTest extends TestCase
 
     /**
      * Test that mailers call reset() when send fails
-     *
-     * @return void
      */
-    public function testSendFailsEmailIsReset()
+    public function testSendFailsEmailIsReset(): void
     {
         $mailer = $this->getMockBuilder(Mailer::class)
             ->onlyMethods(['restore', 'deliver'])
@@ -1316,10 +1231,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendWithLog method
-     *
-     * @return void
      */
-    public function testSendWithLog()
+    public function testSendWithLog(): void
     {
         Log::setConfig('email', [
             'className' => 'Array',
@@ -1344,10 +1257,8 @@ class MailerTest extends TestCase
 
     /**
      * testSendWithLogAndScope method
-     *
-     * @return void
      */
-    public function testSendWithLogAndScope()
+    public function testSendWithLogAndScope(): void
     {
         Log::setConfig('email', [
             'className' => 'Array',
@@ -1371,10 +1282,8 @@ class MailerTest extends TestCase
 
     /**
      * test that initial email instance config is restored after email is sent.
-     *
-     * @return void
      */
-    public function testDefaultProfileRestoration()
+    public function testDefaultProfileRestoration(): void
     {
         $mailer = $this->getMockBuilder(Mailer::class)
             ->onlyMethods(['deliver'])
@@ -1392,17 +1301,14 @@ class MailerTest extends TestCase
         $this->assertSame('cakephp', $mailer->viewBuilder()->getTemplate());
     }
 
-    /**
-     * @return void
-     */
-    public function testMissingActionThrowsException()
+    public function testMissingActionThrowsException(): void
     {
         $this->expectException(MissingActionException::class);
         $this->expectExceptionMessage('Mail Cake\Mailer\Mailer::test() could not be found, or is not accessible.');
         (new Mailer())->send('test');
     }
 
-    public function testDeliver()
+    public function testDeliver(): void
     {
         $this->mailer->setTransport('debug');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -1426,10 +1332,7 @@ class MailerTest extends TestCase
         $this->assertStringContainsString('To: ', $result['headers']);
     }
 
-    /**
-     * @return void
-     */
-    protected function assertLineLengths(string $message)
+    protected function assertLineLengths(string $message): void
     {
         $lines = explode("\r\n", $message);
         foreach ($lines as $line) {

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -42,10 +42,8 @@ class MessageTest extends TestCase
 
     /**
      * testWrap method
-     *
-     * @return void
      */
-    public function testWrap()
+    public function testWrap(): void
     {
         $renderer = new TestMessage();
 
@@ -122,10 +120,8 @@ class MessageTest extends TestCase
 
     /**
      * testWrapLongLine()
-     *
-     * @return void
      */
-    public function testWrapLongLine()
+    public function testWrapLongLine(): void
     {
         $transort = new DebugTransport();
 
@@ -176,10 +172,8 @@ class MessageTest extends TestCase
 
     /**
      * testWrapWithTagsAcrossLines()
-     *
-     * @return void
      */
-    public function testWrapWithTagsAcrossLines()
+    public function testWrapWithTagsAcrossLines(): void
     {
         $str = <<<HTML
 <table>
@@ -205,10 +199,8 @@ HTML;
 
     /**
      * CakeEmailTest::testWrapIncludeLessThanSign()
-     *
-     * @return void
      */
-    public function testWrapIncludeLessThanSign()
+    public function testWrapIncludeLessThanSign(): void
     {
         $str = 'foo<bar';
         $length = strlen($str);
@@ -228,10 +220,8 @@ HTML;
 
     /**
      * CakeEmailTest::testWrapForJapaneseEncoding()
-     *
-     * @return void
      */
-    public function testWrapForJapaneseEncoding()
+    public function testWrapForJapaneseEncoding(): void
     {
         $this->skipIf(!function_exists('mb_convert_encoding'));
 
@@ -251,10 +241,8 @@ HTML;
 
     /**
      * testHeaders method
-     *
-     * @return void
      */
-    public function testHeaders()
+    public function testHeaders(): void
     {
         $this->message->setMessageId(false);
         $this->message->setHeaders(['X-Something' => 'nice']);
@@ -333,10 +321,8 @@ HTML;
 
     /**
      * testHeadersString method
-     *
-     * @return void
      */
-    public function testHeadersString()
+    public function testHeadersString(): void
     {
         $this->message->setMessageId(false);
         $this->message->setHeaders(['X-Something' => 'nice']);
@@ -352,10 +338,8 @@ HTML;
 
     /**
      * testFrom method
-     *
-     * @return void
      */
-    public function testFrom()
+    public function testFrom(): void
     {
         $this->assertSame([], $this->message->getFrom());
 
@@ -380,10 +364,8 @@ HTML;
 
     /**
      * Test that from addresses using colons work.
-     *
-     * @return void
      */
-    public function testFromWithColonsAndQuotes()
+    public function testFromWithColonsAndQuotes(): void
     {
         $address = [
             'info@example.com' => '70:20:00 " Forum',
@@ -397,10 +379,8 @@ HTML;
 
     /**
      * testSender method
-     *
-     * @return void
      */
-    public function testSender()
+    public function testSender(): void
     {
         $this->message->reset();
         $this->assertSame([], $this->message->getSender());
@@ -421,10 +401,8 @@ HTML;
 
     /**
      * testTo method
-     *
-     * @return void
      */
-    public function testTo()
+    public function testTo(): void
     {
         $this->assertSame([], $this->message->getTo());
 
@@ -476,10 +454,8 @@ HTML;
 
     /**
      * test to address with _ in domain name
-     *
-     * @return void
      */
-    public function testToUnderscoreDomain()
+    public function testToUnderscoreDomain(): void
     {
         $result = $this->message->setTo('cake@cake_php.org');
         $expected = ['cake@cake_php.org' => 'cake@cake_php.org'];
@@ -492,7 +468,7 @@ HTML;
      *
      * @return array
      */
-    public static function invalidEmails()
+    public static function invalidEmails(): array
     {
         return [
             [''],
@@ -507,9 +483,8 @@ HTML;
      *
      * @dataProvider invalidEmails
      * @param array|string $value
-     * @return void
      */
-    public function testInvalidEmail($value)
+    public function testInvalidEmail($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->message->setTo($value);
@@ -520,9 +495,8 @@ HTML;
      *
      * @dataProvider invalidEmails
      * @param array|string $value
-     * @return void
      */
-    public function testInvalidEmailAdd($value)
+    public function testInvalidEmailAdd($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->message->addTo($value);
@@ -530,10 +504,8 @@ HTML;
 
     /**
      * test emailPattern method
-     *
-     * @return void
      */
-    public function testEmailPattern()
+    public function testEmailPattern(): void
     {
         $regex = '/.+@.+\..+/i';
         $this->assertSame($regex, $this->message->setEmailPattern($regex)->getEmailPattern());
@@ -541,10 +513,8 @@ HTML;
 
     /**
      * Tests that it is possible to set email regex configuration to a CakeEmail object
-     *
-     * @return void
      */
-    public function testConfigEmailPattern()
+    public function testConfigEmailPattern(): void
     {
         $regex = '/.+@.+\..+/i';
         $email = new Message(['emailPattern' => $regex]);
@@ -553,10 +523,8 @@ HTML;
 
     /**
      * Tests that it is possible set custom email validation
-     *
-     * @return void
      */
-    public function testCustomEmailValidation()
+    public function testCustomEmailValidation(): void
     {
         $regex = '/^[\.a-z0-9!#$%&\'*+\/=?^_`{|}~-]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]{2,6}$/i';
 
@@ -597,10 +565,8 @@ HTML;
 
     /**
      * Tests that it is possible to unset the email pattern and make use of filter_var() instead.
-     *
-     * @return void
      */
-    public function testUnsetEmailPattern()
+    public function testUnsetEmailPattern(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
@@ -616,10 +582,8 @@ HTML;
 
     /**
      * Tests that passing an empty string throws an InvalidArgumentException.
-     *
-     * @return void
      */
-    public function testEmptyTo()
+    public function testEmptyTo(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The email set for "to" is empty.');
@@ -629,10 +593,8 @@ HTML;
 
     /**
      * testFormatAddress method
-     *
-     * @return void
      */
-    public function testFormatAddress()
+    public function testFormatAddress(): void
     {
         $result = $this->message->fmtAddress(['cake@cakephp.org' => 'cake@cakephp.org']);
         $expected = ['cake@cakephp.org'];
@@ -675,10 +637,8 @@ HTML;
 
     /**
      * testFormatAddressJapanese
-     *
-     * @return void
      */
-    public function testFormatAddressJapanese()
+    public function testFormatAddressJapanese(): void
     {
         $this->message->setHeaderCharset('ISO-2022-JP');
         $result = $this->message->fmtAddress(['cake@cakephp.org' => '日本語Test']);
@@ -697,10 +657,8 @@ HTML;
 
     /**
      * testAddresses method
-     *
-     * @return void
      */
-    public function testAddresses()
+    public function testAddresses(): void
     {
         $this->message->reset();
         $this->message->setFrom('cake@cakephp.org', 'CakePHP');
@@ -740,10 +698,8 @@ HTML;
 
     /**
      * test reset addresses method
-     *
-     * @return void
      */
-    public function testResetAddresses()
+    public function testResetAddresses(): void
     {
         $this->message->reset();
         $this->message
@@ -783,10 +739,8 @@ HTML;
 
     /**
      * testMessageId method
-     *
-     * @return void
      */
-    public function testMessageId()
+    public function testMessageId(): void
     {
         $this->message->setMessageId(true);
         $result = $this->message->getHeaders();
@@ -805,7 +759,7 @@ HTML;
         $this->assertSame('<my-email@localhost>', $result);
     }
 
-    public function testAutoMessageIdIsIdempotent()
+    public function testAutoMessageIdIsIdempotent(): void
     {
         $headers = $this->message->getHeaders();
         $this->assertArrayHasKey('Message-ID', $headers);
@@ -814,10 +768,7 @@ HTML;
         $this->assertSame($headers['Message-ID'], $regeneratedHeaders['Message-ID']);
     }
 
-    /**
-     * @return void
-     */
-    public function testPriority()
+    public function testPriority(): void
     {
         $this->message->setPriority(4);
 
@@ -829,10 +780,8 @@ HTML;
 
     /**
      * testMessageIdInvalid method
-     *
-     * @return void
      */
-    public function testMessageIdInvalid()
+    public function testMessageIdInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->message->setMessageId('my-email@localhost');
@@ -840,10 +789,8 @@ HTML;
 
     /**
      * testDomain method
-     *
-     * @return void
      */
-    public function testDomain()
+    public function testDomain(): void
     {
         $result = $this->message->getDomain();
         $expected = env('HTTP_HOST') ? env('HTTP_HOST') : php_uname('n');
@@ -857,10 +804,8 @@ HTML;
 
     /**
      * testMessageIdWithDomain method
-     *
-     * @return void
      */
-    public function testMessageIdWithDomain()
+    public function testMessageIdWithDomain(): void
     {
         $this->message->setDomain('example.org');
         $result = $this->message->getHeaders();
@@ -878,10 +823,8 @@ HTML;
 
     /**
      * testSubject method
-     *
-     * @return void
      */
-    public function testSubject()
+    public function testSubject(): void
     {
         $this->message->setSubject('You have a new message.');
         $this->assertSame('You have a new message.', $this->message->getSubject());
@@ -900,10 +843,8 @@ HTML;
 
     /**
      * testSubjectJapanese
-     *
-     * @return void
      */
-    public function testSubjectJapanese()
+    public function testSubjectJapanese(): void
     {
         mb_internal_encoding('UTF-8');
 
@@ -921,10 +862,8 @@ HTML;
 
     /**
      * testAttachments method
-     *
-     * @return void
      */
-    public function testSetAttachments()
+    public function testSetAttachments(): void
     {
         $uploadedFile = new UploadedFile(
             __FILE__,
@@ -975,10 +914,8 @@ HTML;
 
     /**
      * Test send() with no template and data string attachment and no mimetype
-     *
-     * @return void
      */
-    public function testSetAttachmentDataNoMimetype()
+    public function testSetAttachmentDataNoMimetype(): void
     {
         $this->message->setAttachments(['cake.icon.gif' => [
             'data' => 'test',
@@ -993,7 +930,7 @@ HTML;
         $this->assertSame($expected, $this->message->getAttachments());
     }
 
-    public function testSetAttachmentInvalidFile()
+    public function testSetAttachmentInvalidFile(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -1007,10 +944,8 @@ HTML;
 
     /**
      * testReset method
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         $this->message->setTo('cake@cakephp.org');
         $this->message->setEmailPattern('/.+@.+\..+/i');
@@ -1023,10 +958,8 @@ HTML;
 
     /**
      * testReset with charset
-     *
-     * @return void
      */
-    public function testResetWithCharset()
+    public function testResetWithCharset(): void
     {
         $this->message->setCharset('ISO-2022-JP');
         $this->message->reset();
@@ -1037,10 +970,8 @@ HTML;
 
     /**
      * testEmailFormat method
-     *
-     * @return void
      */
-    public function testEmailFormat()
+    public function testEmailFormat(): void
     {
         $result = $this->message->getEmailFormat();
         $this->assertSame('text', $result);
@@ -1057,10 +988,8 @@ HTML;
 
     /**
      * Tests that it is possible to add charset configuration to a CakeEmail object
-     *
-     * @return void
      */
-    public function testConfigCharset()
+    public function testConfigCharset(): void
     {
         $email = new Message();
         $this->assertEquals(Configure::read('App.encoding'), $email->getCharset());
@@ -1079,7 +1008,7 @@ HTML;
         $this->assertSame('iso-2022-jp-ms', $email->getHeaderCharset());
     }
 
-    public function testGetBody()
+    public function testGetBody(): void
     {
         $message = new Message();
 
@@ -1101,10 +1030,8 @@ HTML;
 
     /**
      * Tests that the body is encoded using the configured charset (Japanese standard encoding)
-     *
-     * @return void
      */
-    public function testBodyEncodingIso2022Jp()
+    public function testBodyEncodingIso2022Jp(): void
     {
         $message = new Message([
             'charset' => 'iso-2022-jp',
@@ -1129,10 +1056,8 @@ HTML;
 
     /**
      * Tests that the body is encoded using the configured charset (Japanese irregular encoding, but sometime use this)
-     *
-     * @return void
      */
-    public function testBodyEncodingIso2022JpMs()
+    public function testBodyEncodingIso2022JpMs(): void
     {
         $message = new Message([
             'charset' => 'iso-2022-jp-ms',
@@ -1156,10 +1081,8 @@ HTML;
 
     /**
      * Tests that the body is encoded using the configured charset
-     *
-     * @return void
      */
-    public function testEncodingMixed()
+    public function testEncodingMixed(): void
     {
         $message = new Message([
             'headerCharset' => 'iso-2022-jp-ms',
@@ -1177,10 +1100,8 @@ HTML;
 
     /**
      * Test CakeMessage::_encode function
-     *
-     * @return void
      */
-    public function testEncode()
+    public function testEncode(): void
     {
         $this->message->setHeaderCharset('ISO-2022-JP');
         $result = $this->message->encode('日本語');
@@ -1197,10 +1118,8 @@ HTML;
 
     /**
      * Test CakeMessage::_decode function
-     *
-     * @return void
      */
-    public function testDecode()
+    public function testDecode(): void
     {
         $this->message->setHeaderCharset('ISO-2022-JP');
         $result = $this->message->decode('=?ISO-2022-JP?B?GyRCRnxLXDhsGyhC?=');
@@ -1217,10 +1136,8 @@ HTML;
 
     /**
      * Tests charset setter/getter
-     *
-     * @return void
      */
-    public function testCharset()
+    public function testCharset(): void
     {
         $this->message->setCharset('UTF-8');
         $this->assertSame($this->message->getCharset(), 'UTF-8');
@@ -1234,10 +1151,8 @@ HTML;
 
     /**
      * Tests headerCharset setter/getter
-     *
-     * @return void
      */
-    public function testHeaderCharset()
+    public function testHeaderCharset(): void
     {
         $this->message->setHeaderCharset('UTF-8');
         $this->assertSame($this->message->getHeaderCharset(), 'UTF-8');
@@ -1251,10 +1166,8 @@ HTML;
 
     /**
      * Test transferEncoding
-     *
-     * @return void
      */
-    public function testTransferEncoding()
+    public function testTransferEncoding(): void
     {
         // Test new transfer encoding
         $expected = 'quoted-printable';
@@ -1277,10 +1190,8 @@ HTML;
      * Tests for compatible check.
      *          charset property and       charset() method.
      *    headerCharset property and headerCharset() method.
-     *
-     * @return void
      */
-    public function testCharsetsCompatible()
+    public function testCharsetsCompatible(): void
     {
         $checkHeaders = [
             'from' => true,
@@ -1332,9 +1243,8 @@ HTML;
     /**
      * @param mixed $charset
      * @param mixed $headerCharset
-     * @return \Cake\Mailer\Message
      */
-    protected function _getEmailByOldStyleCharset($charset, $headerCharset)
+    protected function _getEmailByOldStyleCharset($charset, $headerCharset): Message
     {
         $message = new Message(['transport' => 'debug']);
 
@@ -1357,9 +1267,8 @@ HTML;
     /**
      * @param mixed $charset
      * @param mixed $headerCharset
-     * @return \Cake\Mailer\Message
      */
-    protected function _getEmailByNewStyleCharset($charset, $headerCharset)
+    protected function _getEmailByNewStyleCharset($charset, $headerCharset): Message
     {
         $message = new Message();
 
@@ -1381,9 +1290,8 @@ HTML;
 
     /**
      * @param string $message
-     * @return void
      */
-    protected function assertLineLengths($message)
+    protected function assertLineLengths($message): void
     {
         $lines = explode("\r\n", $message);
         foreach ($lines as $line) {
@@ -1394,7 +1302,7 @@ HTML;
         }
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $message = new Message();
 

--- a/tests/TestCase/Mailer/Transport/DebugTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/DebugTransportTest.php
@@ -29,8 +29,6 @@ class DebugTransportTest extends TestCase
 {
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -40,10 +38,8 @@ class DebugTransportTest extends TestCase
 
     /**
      * testSend method
-     *
-     * @return void
      */
-    public function testSend()
+    public function testSend(): void
     {
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -34,8 +34,6 @@ class MailTransportTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,10 +46,8 @@ class MailTransportTest extends TestCase
 
     /**
      * testSendWithoutRecipient method
-     *
-     * @return void
      */
-    public function testSendWithoutRecipient()
+    public function testSendWithoutRecipient(): void
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('You must specify at least one recipient. Use one of `setTo`, `setCc` or `setBcc` to define a recipient.');
@@ -62,10 +58,8 @@ class MailTransportTest extends TestCase
 
     /**
      * testSend method
-     *
-     * @return void
      */
-    public function testSendData()
+    public function testSendData(): void
     {
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -52,8 +52,6 @@ class SmtpTransportTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -71,10 +69,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnectEhlo method
-     *
-     * @return void
      */
-    public function testConnectEhlo()
+    public function testConnectEhlo(): void
     {
         $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
         $this->socket->expects($this->any())
@@ -86,10 +82,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnectEhloTls method
-     *
-     * @return void
      */
-    public function testConnectEhloTls()
+    public function testConnectEhloTls(): void
     {
         $this->SmtpTransport->setConfig(['tls' => true]);
         $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
@@ -118,10 +112,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnectEhloTlsOnNonTlsServer method
-     *
-     * @return void
      */
-    public function testConnectEhloTlsOnNonTlsServer()
+    public function testConnectEhloTlsOnNonTlsServer(): void
     {
         $this->SmtpTransport->setConfig(['tls' => true]);
         $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
@@ -154,10 +146,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnectEhloNoTlsOnRequiredTlsServer method
-     *
-     * @return void
      */
-    public function testConnectEhloNoTlsOnRequiredTlsServer()
+    public function testConnectEhloNoTlsOnRequiredTlsServer(): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         $this->expectExceptionMessage('SMTP authentication method not allowed, check if SMTP server requires TLS.');
@@ -186,10 +176,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnectHelo method
-     *
-     * @return void
      */
-    public function testConnectHelo()
+    public function testConnectHelo(): void
     {
         $this->socket->expects($this->exactly(3))
             ->method('read')
@@ -211,10 +199,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnectFail method
-     *
-     * @return void
      */
-    public function testConnectFail()
+    public function testConnectFail(): void
     {
         $this->socket->expects($this->exactly(3))
             ->method('read')
@@ -243,7 +229,7 @@ class SmtpTransportTest extends TestCase
         $this->assertStringContainsString('200 Not Accepted', $e->getPrevious()->getMessage());
     }
 
-    public function testAuthPlain()
+    public function testAuthPlain(): void
     {
         $this->socket->expects($this->once())->method('write')->with("AUTH PLAIN {$this->credentialsEncoded}\r\n");
         $this->socket->expects($this->once())->method('read')->will($this->returnValue("235 OK\r\n"));
@@ -253,10 +239,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAuth method
-     *
-     * @return void
      */
-    public function testAuthLogin()
+    public function testAuthLogin(): void
     {
         $this->socket->expects($this->exactly(4))
             ->method('read')
@@ -281,10 +265,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAuthNotRecognized method
-     *
-     * @return void
      */
-    public function testAuthNotRecognized()
+    public function testAuthNotRecognized(): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         $this->expectExceptionMessage('AUTH command not recognized or not implemented, SMTP server may not require authentication.');
@@ -308,10 +290,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAuthNotImplemented method
-     *
-     * @return void
      */
-    public function testAuthNotImplemented()
+    public function testAuthNotImplemented(): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         $this->expectExceptionMessage('AUTH command not recognized or not implemented, SMTP server may not require authentication.');
@@ -334,10 +314,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAuthBadSequence method
-     *
-     * @return void
      */
-    public function testAuthBadSequence()
+    public function testAuthBadSequence(): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         $this->expectExceptionMessage('SMTP Error: 503 5.5.1 Already authenticated');
@@ -360,10 +338,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAuthBadUsername method
-     *
-     * @return void
      */
-    public function testAuthBadUsername()
+    public function testAuthBadUsername(): void
     {
         $this->socket->expects($this->exactly(3))
             ->method('read')
@@ -396,10 +372,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAuthBadPassword method
-     *
-     * @return void
      */
-    public function testAuthBadPassword()
+    public function testAuthBadPassword(): void
     {
         $this->socket->expects($this->exactly(4))
             ->method('read')
@@ -434,10 +408,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testRcpt method
-     *
-     * @return void
      */
-    public function testRcpt()
+    public function testRcpt(): void
     {
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
@@ -462,10 +434,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testRcptWithReturnPath method
-     *
-     * @return void
      */
-    public function testRcptWithReturnPath()
+    public function testRcptWithReturnPath(): void
     {
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
@@ -485,10 +455,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testSendData method
-     *
-     * @return void
      */
-    public function testSendData()
+    public function testSendData(): void
     {
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
@@ -540,10 +508,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testQuit method
-     *
-     * @return void
      */
-    public function testQuit()
+    public function testQuit(): void
     {
         $this->socket->expects($this->once())->method('write')->with("QUIT\r\n");
         $this->socket->connected = true;
@@ -552,10 +518,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * Tests using empty client name
-     *
-     * @return void
      */
-    public function testEmptyClientName()
+    public function testEmptyClientName(): void
     {
         $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
         $this->socket->expects($this->any())
@@ -571,10 +535,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testGetLastResponse method
-     *
-     * @return void
      */
-    public function testGetLastResponse()
+    public function testGetLastResponse(): void
     {
         $this->assertEmpty($this->SmtpTransport->getLastResponse());
 
@@ -615,10 +577,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * Test getLastResponse() with multiple operations
-     *
-     * @return void
      */
-    public function testGetLastResponseMultipleOperations()
+    public function testGetLastResponseMultipleOperations(): void
     {
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
@@ -645,10 +605,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testBufferResponseLines method
-     *
-     * @return void
      */
-    public function testBufferResponseLines()
+    public function testBufferResponseLines(): void
     {
         $responseLines = [
             '123',
@@ -674,10 +632,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testExplicitConnectAlreadyConnected method
-     *
-     * @return void
      */
-    public function testExplicitConnectAlreadyConnected()
+    public function testExplicitConnectAlreadyConnected(): void
     {
         $this->socket->expects($this->never())->method('connect');
         $this->socket->connected = true;
@@ -686,10 +642,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testConnected method
-     *
-     * @return void
      */
-    public function testConnected()
+    public function testConnected(): void
     {
         $this->socket->connected = true;
         $this->assertTrue($this->SmtpTransport->connected());
@@ -700,10 +654,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testAutoDisconnect method
-     *
-     * @return void
      */
-    public function testAutoDisconnect()
+    public function testAutoDisconnect(): void
     {
         $this->socket->expects($this->once())->method('write')->with("QUIT\r\n");
         $this->socket->expects($this->once())->method('disconnect');
@@ -713,10 +665,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testExplicitDisconnect method
-     *
-     * @return void
      */
-    public function testExplicitDisconnect()
+    public function testExplicitDisconnect(): void
     {
         $this->socket->expects($this->once())->method('write')->with("QUIT\r\n");
         $this->socket->expects($this->once())->method('disconnect');
@@ -726,12 +676,10 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testExplicitDisconnectNotConnected method
-     *
-     * @return void
      */
-    public function testExplicitDisconnectNotConnected()
+    public function testExplicitDisconnectNotConnected(): void
     {
-        $callback = function ($arg) {
+        $callback = function ($arg): void {
             $this->assertNotEquals("QUIT\r\n", $arg);
         };
         $this->socket->expects($this->any())->method('write')->will($this->returnCallback($callback));
@@ -741,10 +689,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testKeepAlive method
-     *
-     * @return void
      */
-    public function testKeepAlive()
+    public function testKeepAlive(): void
     {
         $this->SmtpTransport->setConfig(['keepAlive' => true]);
 
@@ -805,10 +751,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testSendDefaults method
-     *
-     * @return void
      */
-    public function testSendDefaults()
+    public function testSendDefaults(): void
     {
         /** @var \Cake\Mailer\Message $message */
         $message = $this->getMockBuilder(Message::class)
@@ -849,10 +793,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * testSendDefaults method
-     *
-     * @return void
      */
-    public function testSendMessageTooBigOnWindows()
+    public function testSendMessageTooBigOnWindows(): void
     {
         /** @var \Cake\Mailer\Message $message */
         $message = $this->getMockBuilder(Message::class)
@@ -893,10 +835,8 @@ class SmtpTransportTest extends TestCase
 
     /**
      * Ensure that unserialized transports have no connection.
-     *
-     * @return void
      */
-    public function testSerializeCleanupSocket()
+    public function testSerializeCleanupSocket(): void
     {
         $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
         $this->socket->expects($this->exactly(2))

--- a/tests/TestCase/Mailer/TransportFactoryTest.php
+++ b/tests/TestCase/Mailer/TransportFactoryTest.php
@@ -30,9 +30,6 @@ class TransportFactoryTest extends TestCase
      */
     protected $transports;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -49,8 +46,6 @@ class TransportFactoryTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -62,10 +57,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test that using misconfigured transports fails.
-     *
-     * @return void
      */
-    public function testGetMissingClassName()
+    public function testGetMissingClassName(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Transport config "debug" is invalid, the required `className` option is missing');
@@ -78,10 +71,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test configuring a transport.
-     *
-     * @return void
      */
-    public function testSetConfig()
+    public function testSetConfig(): void
     {
         $settings = [
             'className' => 'Debug',
@@ -96,10 +87,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test configuring multiple transports.
-     *
-     * @return void
      */
-    public function testSetConfigMultiple()
+    public function testSetConfigMultiple(): void
     {
         $settings = [
             'debug' => [
@@ -121,10 +110,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test that exceptions are raised when duplicate transports are configured.
-     *
-     * @return void
      */
-    public function testSetConfigErrorOnDuplicate()
+    public function testSetConfigErrorOnDuplicate(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $settings = [
@@ -138,10 +125,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test configTransport with an instance.
-     *
-     * @return void
      */
-    public function testSetConfigInstance()
+    public function testSetConfigInstance(): void
     {
         TransportFactory::drop('debug');
         $instance = new DebugTransport();
@@ -151,10 +136,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test enumerating all transport configurations
-     *
-     * @return void
      */
-    public function testConfigured()
+    public function testConfigured(): void
     {
         $result = TransportFactory::configured();
         $this->assertIsArray($result, 'Should have config keys');
@@ -165,10 +148,8 @@ class TransportFactoryTest extends TestCase
 
     /**
      * Test dropping a transport configuration
-     *
-     * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         $result = TransportFactory::getConfig('debug');
         $this->assertIsArray($result, 'Should have config data');

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -32,8 +32,6 @@ class SocketTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,8 +41,6 @@ class SocketTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -54,10 +50,8 @@ class SocketTest extends TestCase
 
     /**
      * testConstruct method
-     *
-     * @return void
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->Socket = new Socket();
         $config = $this->Socket->getConfig();
@@ -86,10 +80,8 @@ class SocketTest extends TestCase
 
     /**
      * test host() method
-     *
-     * @return void
      */
-    public function testHost()
+    public function testHost(): void
     {
         $this->Socket = new Socket(['host' => '8.8.8.8']);
         $this->assertSame('dns.google', $this->Socket->host());
@@ -97,10 +89,8 @@ class SocketTest extends TestCase
 
     /**
      * test addresses() method
-     *
-     * @return void
      */
-    public function testAddresses()
+    public function testAddresses(): void
     {
         $this->Socket = new Socket();
         $this->assertContainsEquals('127.0.0.1', $this->Socket->addresses());
@@ -111,10 +101,8 @@ class SocketTest extends TestCase
 
     /**
      * testSocketConnection method
-     *
-     * @return void
      */
-    public function testSocketConnection()
+    public function testSocketConnection(): void
     {
         $this->assertFalse($this->Socket->connected);
         $this->Socket->disconnect();
@@ -140,7 +128,7 @@ class SocketTest extends TestCase
      *
      * @return array
      */
-    public static function invalidConnections()
+    public static function invalidConnections(): array
     {
         return [
             [['host' => 'invalid.host', 'port' => 9999, 'timeout' => 1]],
@@ -152,9 +140,8 @@ class SocketTest extends TestCase
      * testInvalidConnection method
      *
      * @dataProvider invalidConnections
-     * @return void
      */
-    public function testInvalidConnection(array $data)
+    public function testInvalidConnection(array $data): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         $this->Socket->setConfig($data);
@@ -163,10 +150,8 @@ class SocketTest extends TestCase
 
     /**
      * testSocketHost method
-     *
-     * @return void
      */
-    public function testSocketHost()
+    public function testSocketHost(): void
     {
         try {
             $this->Socket = new Socket();
@@ -189,10 +174,8 @@ class SocketTest extends TestCase
 
     /**
      * testSocketWriting method
-     *
-     * @return void
      */
-    public function testSocketWriting()
+    public function testSocketWriting(): void
     {
         try {
             $request = "GET / HTTP/1.1\r\nConnection: close\r\n\r\n";
@@ -204,10 +187,8 @@ class SocketTest extends TestCase
 
     /**
      * testSocketReading method
-     *
-     * @return void
      */
-    public function testSocketReading()
+    public function testSocketReading(): void
     {
         $this->Socket = new Socket(['timeout' => 5]);
         try {
@@ -226,10 +207,8 @@ class SocketTest extends TestCase
 
     /**
      * testTimeOutConnection method
-     *
-     * @return void
      */
-    public function testTimeOutConnection()
+    public function testTimeOutConnection(): void
     {
         $config = ['host' => '127.0.0.1', 'timeout' => 1];
         $this->Socket = new Socket($config);
@@ -247,10 +226,8 @@ class SocketTest extends TestCase
 
     /**
      * testLastError method
-     *
-     * @return void
      */
-    public function testLastError()
+    public function testLastError(): void
     {
         $this->Socket = new Socket();
         $this->Socket->setLastError(4, 'some error here');
@@ -259,10 +236,8 @@ class SocketTest extends TestCase
 
     /**
      * testReset method
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         $config = [
             'persistent' => true,
@@ -290,10 +265,8 @@ class SocketTest extends TestCase
 
     /**
      * testEncrypt
-     *
-     * @return void
      */
-    public function testEnableCryptoSocketExceptionNoSsl()
+    public function testEnableCryptoSocketExceptionNoSsl(): void
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
         $configNoSslOrTls = ['host' => 'localhost', 'port' => 80, 'timeout' => 1];
@@ -319,10 +292,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCryptoSocketExceptionNoTls
-     *
-     * @return void
      */
-    public function testEnableCryptoSocketExceptionNoTls()
+    public function testEnableCryptoSocketExceptionNoTls(): void
     {
         $configNoSslOrTls = ['host' => 'localhost', 'port' => 80, 'timeout' => 1];
 
@@ -347,10 +318,8 @@ class SocketTest extends TestCase
 
     /**
      * Test that protocol in the host doesn't cause cert errors.
-     *
-     * @return void
      */
-    public function testConnectProtocolInHost()
+    public function testConnectProtocolInHost(): void
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
         $configSslTls = ['host' => 'ssl://smtp.gmail.com', 'port' => 465, 'timeout' => 5];
@@ -366,10 +335,8 @@ class SocketTest extends TestCase
 
     /**
      * _connectSocketToSslTls
-     *
-     * @return void
      */
-    protected function _connectSocketToSslTls()
+    protected function _connectSocketToSslTls(): void
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
         $configSslTls = ['host' => 'smtp.gmail.com', 'port' => 465, 'timeout' => 5];
@@ -383,10 +350,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCryptoBadMode
-     *
-     * @return void
      */
-    public function testEnableCryptoBadMode()
+    public function testEnableCryptoBadMode(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         // testing wrong encryption mode
@@ -397,10 +362,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCrypto
-     *
-     * @return void
      */
-    public function testEnableCrypto()
+    public function testEnableCrypto(): void
     {
         $this->_connectSocketToSslTls();
         $this->Socket->enableCrypto('tls', 'client');
@@ -410,10 +373,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCryptoExceptionEnableTwice
-     *
-     * @return void
      */
-    public function testEnableCryptoExceptionEnableTwice()
+    public function testEnableCryptoExceptionEnableTwice(): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         // testing on tls server
@@ -424,10 +385,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCryptoExceptionDisableTwice
-     *
-     * @return void
      */
-    public function testEnableCryptoExceptionDisableTwice()
+    public function testEnableCryptoExceptionDisableTwice(): void
     {
         $this->expectException(\Cake\Network\Exception\SocketException::class);
         $this->_connectSocketToSslTls();
@@ -436,10 +395,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCryptoEnableStatus
-     *
-     * @return void
      */
-    public function testEnableCryptoEnableTls12()
+    public function testEnableCryptoEnableTls12(): void
     {
         $this->_connectSocketToSslTls();
         $this->assertFalse($this->Socket->encrypted);
@@ -449,10 +406,8 @@ class SocketTest extends TestCase
 
     /**
      * testEnableCryptoEnableStatus
-     *
-     * @return void
      */
-    public function testEnableCryptoEnableStatus()
+    public function testEnableCryptoEnableStatus(): void
     {
         $this->_connectSocketToSslTls();
         $this->assertFalse($this->Socket->encrypted);
@@ -462,10 +417,8 @@ class SocketTest extends TestCase
 
     /**
      * test getting the context for a socket.
-     *
-     * @return void
      */
-    public function testGetContext()
+    public function testGetContext(): void
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
         $config = [
@@ -488,10 +441,8 @@ class SocketTest extends TestCase
 
     /**
      * test configuring the context from the flat keys.
-     *
-     * @return void
      */
-    public function testConfigContext()
+    public function testConfigContext(): void
     {
         $this->skipIf(!extension_loaded('openssl'), 'OpenSSL is not enabled cannot test SSL.');
         $this->skipIf(!empty(getenv('http_proxy')) || !empty(getenv('https_proxy')), 'Proxy detected and cannot test SSL.');
@@ -521,10 +472,8 @@ class SocketTest extends TestCase
 
     /**
      * test connect to a unix file socket
-     *
-     * @return void
      */
-    public function testConnectToUnixFileSocket()
+    public function testConnectToUnixFileSocket(): void
     {
         $socketName = 'unix:///tmp/test.socket';
         $socket = $this->getMockBuilder(Socket::class)

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -55,8 +55,6 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -87,10 +85,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests setForeignKey()
-     *
-     * @return void
      */
-    public function testSetForeignKey()
+    public function testSetForeignKey(): void
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
@@ -103,10 +99,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that the association reports it can be joined
-     *
-     * @return void
      */
-    public function testCanBeJoined()
+    public function testCanBeJoined(): void
     {
         $assoc = new BelongsToMany('Test');
         $this->assertFalse($assoc->canBeJoined());
@@ -114,10 +108,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests setSort() method
-     *
-     * @return void
      */
-    public function testSetSort()
+    public function testSetSort(): void
     {
         $assoc = new BelongsToMany('Test');
         $this->assertNull($assoc->getSort());
@@ -127,10 +119,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests requiresKeys() method
-     *
-     * @return void
      */
-    public function testRequiresKeys()
+    public function testRequiresKeys(): void
     {
         $assoc = new BelongsToMany('Test');
         $this->assertTrue($assoc->requiresKeys());
@@ -144,10 +134,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that BelongsToMany can't use the join strategy
-     *
-     * @return void
      */
-    public function testStrategyFailure()
+    public function testStrategyFailure(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid strategy "join" was provided');
@@ -157,10 +145,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests the junction method
-     *
-     * @return void
      */
-    public function testJunction()
+    public function testJunction(): void
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
@@ -201,10 +187,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests the junction passes the source connection name on.
-     *
-     * @return void
      */
-    public function testJunctionConnection()
+    public function testJunctionConnection(): void
     {
         $mock = $this->getMockBuilder(Connection::class)
             ->onlyMethods(['setDriver'])
@@ -224,10 +208,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests the junction method custom keys
-     *
-     * @return void
      */
-    public function testJunctionCustomKeys()
+    public function testJunctionCustomKeys(): void
     {
         $this->article->belongsToMany('Tags', [
             'targetTable' => $this->tag,
@@ -252,10 +234,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests it is possible to set the table name for the join table
-     *
-     * @return void
      */
-    public function testJunctionWithDefaultTableName()
+    public function testJunctionWithDefaultTableName(): void
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
@@ -269,10 +249,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test multiple associations with differerent keys fails
-     *
-     * @return void
      */
-    public function testMultipleAssociationsSameJunction()
+    public function testMultipleAssociationsSameJunction(): void
     {
         $assoc = new BelongsToMany('This', [
             'sourceTable' => $this->article,
@@ -293,10 +271,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests same source and target table failure.
-     *
-     * @return void
      */
-    public function testSameSourceTargetJunction()
+    public function testSameSourceTargetJunction(): void
     {
         $assoc = new BelongsToMany('This', [
             'sourceTable' => $this->article,
@@ -310,10 +286,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests saveStrategy
-     *
-     * @return void
      */
-    public function testSetSaveStrategy()
+    public function testSetSaveStrategy(): void
     {
         $assoc = new BelongsToMany('Test');
         $this->assertSame(BelongsToMany::SAVE_REPLACE, $assoc->getSaveStrategy());
@@ -327,10 +301,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that it is possible to pass the saveAssociated strategy in the constructor
-     *
-     * @return void
      */
-    public function testSaveStrategyInOptions()
+    public function testSaveStrategyInOptions(): void
     {
         $assoc = new BelongsToMany('Test', ['saveStrategy' => BelongsToMany::SAVE_APPEND]);
         $this->assertSame(BelongsToMany::SAVE_APPEND, $assoc->getSaveStrategy());
@@ -338,10 +310,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that passing an invalid strategy will throw an exception
-     *
-     * @return void
      */
-    public function testSaveStrategyInvalid()
+    public function testSaveStrategyInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid save strategy "depsert"');
@@ -351,10 +321,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Ensure that the `finder` option is applied to the target
      * table.
-     *
-     * @return void
      */
-    public function testFinderOption()
+    public function testFinderOption(): void
     {
         $this->setAppNamespace('TestApp');
 
@@ -374,10 +342,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test cascading deletes.
-     *
-     * @return void
      */
-    public function testCascadeDelete()
+    public function testCascadeDelete(): void
     {
         $articleTag = $this->getMockBuilder(Table::class)
             ->onlyMethods(['deleteAll'])
@@ -406,10 +372,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test cascading deletes with dependent=false
-     *
-     * @return void
      */
-    public function testCascadeDeleteDependent()
+    public function testCascadeDeleteDependent(): void
     {
         $articleTag = $this->getMockBuilder(Table::class)
             ->onlyMethods(['delete', 'deleteAll'])
@@ -437,10 +401,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test cascading deletes with callbacks.
-     *
-     * @return void
      */
-    public function testCascadeDeleteWithCallbacks()
+    public function testCascadeDeleteWithCallbacks(): void
     {
         $articleTag = $this->getTableLocator()->get('ArticlesTags');
         $config = [
@@ -453,7 +415,7 @@ class BelongsToManyTest extends TestCase
         $this->article->getAssociation($articleTag->getAlias());
 
         $counter = 0;
-        $articleTag->getEventManager()->on('Model.beforeDelete', function () use (&$counter) {
+        $articleTag->getEventManager()->on('Model.beforeDelete', function () use (&$counter): void {
             $counter++;
         });
 
@@ -467,10 +429,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test cascading delete with a rule preventing deletion
-     *
-     * @return void
      */
-    public function testCascadeDeleteCallbacksRuleFailure()
+    public function testCascadeDeleteCallbacksRuleFailure(): void
     {
         $articleTag = $this->getTableLocator()->get('ArticlesTags');
         $config = [
@@ -482,7 +442,7 @@ class BelongsToManyTest extends TestCase
         $association->junction($articleTag);
         $this->article->getAssociation($articleTag->getAlias());
 
-        $articleTag->getEventManager()->on('Model.buildRules', function ($event, $rules) {
+        $articleTag->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
             $rules->addDelete(function () {
                 return false;
             });
@@ -498,10 +458,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test linking entities having a non persisted source entity
-     *
-     * @return void
      */
-    public function testLinkWithNotPersistedSource()
+    public function testLinkWithNotPersistedSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Source entity needs to be persisted before links can be created or removed');
@@ -518,10 +476,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test liking entities having a non persisted target entity
-     *
-     * @return void
      */
-    public function testLinkWithNotPersistedTarget()
+    public function testLinkWithNotPersistedTarget(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot link entities that have not been persisted yet');
@@ -538,10 +494,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that linking entities will persist correctly with append strategy
-     *
-     * @return void
      */
-    public function testLinkSuccessSaveAppend()
+    public function testLinkSuccessSaveAppend(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
@@ -573,10 +527,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that linking the same tag to multiple articles works
-     *
-     * @return void
      */
-    public function testLinkSaveAppendSharedTarget()
+    public function testLinkSaveAppendSharedTarget(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
@@ -611,10 +563,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that liking entities will validate data and pass on to _saveLinks
-     *
-     * @return void
      */
-    public function testLinkSuccessWithMocks()
+    public function testLinkSuccessWithMocks(): void
     {
         $connection = ConnectionManager::get('test');
         $joint = $this->getMockBuilder(Table::class)
@@ -667,10 +617,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that linking entities will set the junction table registry alias
-     *
-     * @return void
      */
-    public function testLinkSetSourceToJunctionEntities()
+    public function testLinkSetSourceToJunctionEntities(): void
     {
         $connection = ConnectionManager::get('test');
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $joint */
@@ -709,10 +657,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test liking entities having a non persisted source entity
-     *
-     * @return void
      */
-    public function testUnlinkWithNotPersistedSource()
+    public function testUnlinkWithNotPersistedSource(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Source entity needs to be persisted before links can be created or removed');
@@ -729,10 +675,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test liking entities having a non persisted target entity
-     *
-     * @return void
      */
-    public function testUnlinkWithNotPersistedTarget()
+    public function testUnlinkWithNotPersistedTarget(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot link entities that have not been persisted');
@@ -749,10 +693,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that unlinking calls the right methods
-     *
-     * @return void
      */
-    public function testUnlinkSuccess()
+    public function testUnlinkSuccess(): void
     {
         $joint = $this->getTableLocator()->get('SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -779,10 +721,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Tests that unlinking with last parameter set to false
      * will not remove entities from the association property
-     *
-     * @return void
      */
-    public function testUnlinkWithoutPropertyClean()
+    public function testUnlinkWithoutPropertyClean(): void
     {
         $joint = $this->getTableLocator()->get('SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -810,10 +750,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Tests that replaceLink requires the sourceEntity to have primaryKey values
      * for the source entity
-     *
-     * @return void
      */
-    public function testReplaceWithMissingPrimaryKey()
+    public function testReplaceWithMissingPrimaryKey(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not find primary key value for source entity');
@@ -830,10 +768,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that replaceLinks() can saveAssociated an empty set, removing all rows.
-     *
-     * @return void
      */
-    public function testReplaceLinksUpdateToEmptySet()
+    public function testReplaceLinksUpdateToEmptySet(): void
     {
         $joint = $this->getTableLocator()->get('ArticlesTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -861,10 +797,8 @@ class BelongsToManyTest extends TestCase
      * Tests that replaceLinks will delete entities not present in the passed,
      * array, maintain those are already persisted and were passed and also
      * insert the rest.
-     *
-     * @return void
      */
-    public function testReplaceLinkSuccess()
+    public function testReplaceLinkSuccess(): void
     {
         $joint = $this->getTableLocator()->get('ArticlesTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -902,10 +836,8 @@ class BelongsToManyTest extends TestCase
      *
      * In this case the replacement will fail because the association conditions
      * hide the fixture data.
-     *
-     * @return void
      */
-    public function testReplaceLinkWithConditions()
+    public function testReplaceLinkWithConditions(): void
     {
         $joint = $this->getTableLocator()->get('SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -935,10 +867,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Test that replaceLinks() will apply finder conditions
      * defined in the junction table associations if they exist.
-     *
-     * @return void
      */
-    public function testReplaceLinkWithFinderInJunctionAssociations()
+    public function testReplaceLinkWithFinderInJunctionAssociations(): void
     {
         $this->setAppNamespace('TestApp');
 
@@ -972,14 +902,12 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests replaceLinks with failing domain rules and new link targets.
-     *
-     * @return void
      */
-    public function testReplaceLinkFailingDomainRules()
+    public function testReplaceLinkFailingDomainRules(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
-        $tags->getEventManager()->on('Model.buildRules', function (EventInterface $event, RulesChecker $rules) {
+        $tags->getEventManager()->on('Model.buildRules', function (EventInterface $event, RulesChecker $rules): void {
             $rules->add(function () {
                 return false;
             }, 'rule', ['errorField' => 'name', 'message' => 'Bad data']);
@@ -1010,10 +938,8 @@ class BelongsToManyTest extends TestCase
      * Tests that replaceLinks will delete entities not present in the passed,
      * array, maintain those are already persisted and were passed and also
      * insert the rest.
-     *
-     * @return void
      */
-    public function testReplaceLinkBinaryUuid()
+    public function testReplaceLinkBinaryUuid(): void
     {
         $items = $this->getTableLocator()->get('BinaryUuidItems');
         $tags = $this->getTableLocator()->get('BinaryUuidTags');
@@ -1064,9 +990,8 @@ class BelongsToManyTest extends TestCase
      *
      * @dataProvider emptyProvider
      * @param mixed $value
-     * @return void
      */
-    public function testSaveAssociatedEmptySetSuccess($value)
+    public function testSaveAssociatedEmptySetSuccess($value): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
         $table = $this->getMockBuilder(Table::class)
@@ -1096,9 +1021,8 @@ class BelongsToManyTest extends TestCase
      *
      * @dataProvider emptyProvider
      * @param mixed $value
-     * @return void
      */
-    public function testSaveAssociatedEmptySetUpdateSuccess($value)
+    public function testSaveAssociatedEmptySetUpdateSuccess($value): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
         $table = $this->getMockBuilder(Table::class)
@@ -1129,10 +1053,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests saving with replace strategy returning true
-     *
-     * @return void
      */
-    public function testSaveAssociatedWithReplace()
+    public function testSaveAssociatedWithReplace(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -1160,10 +1082,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests saving with replace strategy returning true
-     *
-     * @return void
      */
-    public function testSaveAssociatedWithReplaceReturnFalse()
+    public function testSaveAssociatedWithReplaceReturnFalse(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -1191,10 +1111,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that saveAssociated() ignores non entity values.
-     *
-     * @return void
      */
-    public function testSaveAssociatedOnlyEntitiesAppend()
+    public function testSaveAssociatedOnlyEntitiesAppend(): void
     {
         $connection = ConnectionManager::get('test');
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
@@ -1228,10 +1146,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that setTargetForeignKey() returns the correct configured value
-     *
-     * @return void
      */
-    public function testSetTargetForeignKey()
+    public function testSetTargetForeignKey(): void
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
@@ -1252,10 +1168,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Tests that custom foreignKeys are properly transmitted to involved associations
      * when they are customized
-     *
-     * @return void
      */
-    public function testJunctionWithCustomForeignKeys()
+    public function testJunctionWithCustomForeignKeys(): void
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
@@ -1275,10 +1189,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Test that fallback class is used for join table even when fallback
      * class usage is turned off for table locator.
-     *
-     * @return void
      */
-    public function testFallbackClassForJunction()
+    public function testFallbackClassForJunction(): void
     {
         $assoc = new BelongsToMany('Test', [
             'sourceTable' => $this->article,
@@ -1292,10 +1204,8 @@ class BelongsToManyTest extends TestCase
     /**
      * Test that fallback class is used for join table even when fallback
      * class usage is turned off for table locator.
-     *
-     * @return void
      */
-    public function testNoFallbackClassForThrough()
+    public function testNoFallbackClassForThrough(): void
     {
         $this->expectException(MissingTableClassException::class);
         $this->expectExceptionMessage('Table class for alias `ArticlesTags` could not be found.');
@@ -1313,10 +1223,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that property is being set using the constructor options.
-     *
-     * @return void
      */
-    public function testPropertyOption()
+    public function testPropertyOption(): void
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new BelongsToMany('Thing', $config);
@@ -1325,10 +1233,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that plugin names are omitted from property()
-     *
-     * @return void
      */
-    public function testPropertyNoPlugin()
+    public function testPropertyNoPlugin(): void
     {
         $mock = $this->getMockBuilder(Table::class)
             ->disableOriginalConstructor()
@@ -1343,10 +1249,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that the generated associations are correct.
-     *
-     * @return void
      */
-    public function testGeneratedAssociations()
+    public function testGeneratedAssociations(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
@@ -1388,10 +1292,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Tests that eager loading requires association keys
-     *
-     * @return void
      */
-    public function testEagerLoadingRequiresPrimaryKey()
+    public function testEagerLoadingRequiresPrimaryKey(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The "tags" table does not define a primary key');
@@ -1408,9 +1310,8 @@ class BelongsToManyTest extends TestCase
      * all fields being returned, but instead will honor the select() clause
      *
      * @see https://github.com/cakephp/cakephp/issues/7916
-     * @return void
      */
-    public function testEagerLoadingBelongsToManyLimitedFields()
+    public function testEagerLoadingBelongsToManyLimitedFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -1442,9 +1343,8 @@ class BelongsToManyTest extends TestCase
      * Tests that fetching belongsToMany association will retain autoFields(true) if it was used.
      *
      * @see https://github.com/cakephp/cakephp/issues/8052
-     * @return void
      */
-    public function testEagerLoadingBelongsToManyLimitedFieldsWithAutoFields()
+    public function testEagerLoadingBelongsToManyLimitedFieldsWithAutoFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -1461,10 +1361,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that association proxy find() works with no join records
-     *
-     * @return void
      */
-    public function testAssociationProxyFindNoJoinRecords()
+    public function testAssociationProxyFindNoJoinRecords(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -1481,10 +1379,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that association proxy find() applies joins when conditions are involved.
-     *
-     * @return void
      */
-    public function testAssociationProxyFindWithConditions()
+    public function testAssociationProxyFindWithConditions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -1501,10 +1397,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that association proxy find() applies complex conditions
-     *
-     * @return void
      */
-    public function testAssociationProxyFindWithComplexConditions()
+    public function testAssociationProxyFindWithComplexConditions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -1525,10 +1419,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that matching() works on belongsToMany associations.
-     *
-     * @return void
      */
-    public function testBelongsToManyAssociationWithArrayConditions()
+    public function testBelongsToManyAssociationWithArrayConditions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -1547,10 +1439,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that matching() works on belongsToMany associations.
-     *
-     * @return void
      */
-    public function testBelongsToManyAssociationWithExpressionConditions()
+    public function testBelongsToManyAssociationWithExpressionConditions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -1569,10 +1459,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test that association proxy find() with matching resolves joins correctly
-     *
-     * @return void
      */
-    public function testAssociationProxyFindWithConditionsMatching()
+    public function testAssociationProxyFindWithConditionsMatching(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -1590,10 +1478,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test custom binding key for target table association
-     *
-     * @return void
      */
-    public function testCustomTargetBindingKeyContain()
+    public function testCustomTargetBindingKeyContain(): void
     {
         $this->getTableLocator()->get('ArticlesTags')
             ->belongsTo('SpecialTags', [
@@ -1626,10 +1512,8 @@ class BelongsToManyTest extends TestCase
 
     /**
      * Test custom binding key for target table association
-     *
-     * @return void
      */
-    public function testCustomTargetBindingKeyLink()
+    public function testCustomTargetBindingKeyLink(): void
     {
         $this->getTableLocator()->get('ArticlesTags')
             ->belongsTo('SpecialTags', [

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -41,8 +41,6 @@ class BelongsToTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -78,10 +76,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Test that foreignKey generation
-     *
-     * @return void
      */
-    public function testSetForeignKey()
+    public function testSetForeignKey(): void
     {
         $assoc = new BelongsTo('Companies', [
             'sourceTable' => $this->client,
@@ -94,10 +90,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Test that foreignKey generation ignores database names in target table.
-     *
-     * @return void
      */
-    public function testForeignKeyIgnoreDatabaseName()
+    public function testForeignKeyIgnoreDatabaseName(): void
     {
         $this->company->setTable('schema.companies');
         $this->client->setTable('schema.clients');
@@ -110,10 +104,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Tests that the association reports it can be joined
-     *
-     * @return void
      */
-    public function testCanBeJoined()
+    public function testCanBeJoined(): void
     {
         $assoc = new BelongsTo('Test');
         $this->assertTrue($assoc->canBeJoined());
@@ -121,10 +113,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Tests that the alias set on associations is actually on the Entity
-     *
-     * @return void
      */
-    public function testCustomAlias()
+    public function testCustomAlias(): void
     {
         $table = $this->getTableLocator()->get('Articles', [
             'className' => 'TestPlugin.Articles',
@@ -144,10 +134,8 @@ class BelongsToTest extends TestCase
     /**
      * Tests that the correct join and fields are attached to a query depending on
      * the association config
-     *
-     * @return void
      */
-    public function testAttachTo()
+    public function testAttachTo(): void
     {
         $config = [
             'foreignKey' => 'company_id',
@@ -186,10 +174,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Tests that it is possible to avoid fields inclusion for the associated table
-     *
-     * @return void
      */
-    public function testAttachToNoFields()
+    public function testAttachToNoFields(): void
     {
         $config = [
             'sourceTable' => $this->client,
@@ -206,10 +192,8 @@ class BelongsToTest extends TestCase
     /**
      * Tests that using belongsto with a table having a multi column primary
      * key will work if the foreign key is passed
-     *
-     * @return void
      */
-    public function testAttachToMultiPrimaryKey()
+    public function testAttachToMultiPrimaryKey(): void
     {
         $this->company->setPrimaryKey(['id', 'tenant_id']);
         $config = [
@@ -247,10 +231,8 @@ class BelongsToTest extends TestCase
     /**
      * Tests that using belongsto with a table having a multi column primary
      * key will work if the foreign key is passed
-     *
-     * @return void
      */
-    public function testAttachToMultiPrimaryKeyMismatch()
+    public function testAttachToMultiPrimaryKeyMismatch(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"');
@@ -268,10 +250,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Test the cascading delete of BelongsTo.
-     *
-     * @return void
      */
-    public function testCascadeDelete()
+    public function testCascadeDelete(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\Table')
             ->disableOriginalConstructor()
@@ -292,10 +272,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Test that saveAssociated() ignores non entity values.
-     *
-     * @return void
      */
-    public function testSaveAssociatedOnlyEntities()
+    public function testSaveAssociatedOnlyEntities(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['saveAssociated'])
@@ -322,10 +300,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Tests that property is being set using the constructor options.
-     *
-     * @return void
      */
-    public function testPropertyOption()
+    public function testPropertyOption(): void
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new BelongsTo('Thing', $config);
@@ -334,10 +310,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Test that plugin names are omitted from property()
-     *
-     * @return void
      */
-    public function testPropertyNoPlugin()
+    public function testPropertyNoPlugin(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\Table')
             ->disableOriginalConstructor()
@@ -353,10 +327,8 @@ class BelongsToTest extends TestCase
     /**
      * Tests that attaching an association to a query will trigger beforeFind
      * for the target table
-     *
-     * @return void
      */
-    public function testAttachToBeforeFind()
+    public function testAttachToBeforeFind(): void
     {
         $config = [
             'foreignKey' => 'company_id',
@@ -364,7 +336,7 @@ class BelongsToTest extends TestCase
             'targetTable' => $this->company,
         ];
         $called = false;
-        $this->company->getEventManager()->on('Model.beforeFind', function ($event, $query, $options) use (&$called) {
+        $this->company->getEventManager()->on('Model.beforeFind', function ($event, $query, $options) use (&$called): void {
             $this->assertInstanceOf(Event::class, $event);
             $this->assertInstanceOf(Query::class, $query);
             $this->assertInstanceOf(ArrayObject::class, $options);
@@ -378,10 +350,8 @@ class BelongsToTest extends TestCase
     /**
      * Tests that attaching an association to a query will trigger beforeFind
      * for the target table
-     *
-     * @return void
      */
-    public function testAttachToBeforeFindExtraOptions()
+    public function testAttachToBeforeFindExtraOptions(): void
     {
         $config = [
             'foreignKey' => 'company_id',
@@ -389,7 +359,7 @@ class BelongsToTest extends TestCase
             'targetTable' => $this->company,
         ];
         $called = false;
-        $this->company->getEventManager()->on('Model.beforeFind', function ($event, $query, $options) use (&$called) {
+        $this->company->getEventManager()->on('Model.beforeFind', function ($event, $query, $options) use (&$called): void {
             $this->assertSame('more', $options['something']);
             $called = true;
         });
@@ -404,10 +374,8 @@ class BelongsToTest extends TestCase
     /**
      * Test that failing to add the foreignKey to the list of fields will
      * still attach associated data.
-     *
-     * @return void
      */
-    public function testAttachToNoFieldsSelected()
+    public function testAttachToNoFieldsSelected(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors');
@@ -425,10 +393,8 @@ class BelongsToTest extends TestCase
 
     /**
      * Test that not selecting join keys with strategy=select fails
-     *
-     * @return void
      */
-    public function testAttachToNoForeignKeySelect()
+    public function testAttachToNoForeignKeySelect(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors')->setStrategy('select');
@@ -454,10 +420,8 @@ class BelongsToTest extends TestCase
     /**
      * Test that formatResults in a joined association finder doesn't dirty
      * the root entity.
-     *
-     * @return void
      */
-    public function testAttachToFormatResultsNoDirtyResults()
+    public function testAttachToFormatResultsNoDirtyResults(): void
     {
         $this->setAppNamespace('TestApp');
         $articles = $this->getTableLocator()->get('Articles');

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -52,8 +52,6 @@ class HasManyTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -99,10 +97,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that foreignKey() returns the correct configured value
-     *
-     * @return void
      */
-    public function testSetForeignKey()
+    public function testSetForeignKey(): void
     {
         $assoc = new HasMany('Articles', [
             'sourceTable' => $this->author,
@@ -114,10 +110,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that foreignKey generation ignores database names in target table.
-     *
-     * @return void
      */
-    public function testForeignKeyIgnoreDatabaseName()
+    public function testForeignKeyIgnoreDatabaseName(): void
     {
         $this->author->setTable('schema.authors');
         $assoc = new HasMany('Articles', [
@@ -128,10 +122,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that the association reports it can be joined
-     *
-     * @return void
      */
-    public function testCanBeJoined()
+    public function testCanBeJoined(): void
     {
         $assoc = new HasMany('Test');
         $this->assertFalse($assoc->canBeJoined());
@@ -139,10 +131,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests setSort() method
-     *
-     * @return void
      */
-    public function testSetSort()
+    public function testSetSort(): void
     {
         $assoc = new HasMany('Test');
         $this->assertNull($assoc->getSort());
@@ -152,10 +142,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests requiresKeys() method
-     *
-     * @return void
      */
-    public function testRequiresKeys()
+    public function testRequiresKeys(): void
     {
         $assoc = new HasMany('Test');
         $this->assertTrue($assoc->requiresKeys());
@@ -169,10 +157,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that HasMany can't use the join strategy
-     *
-     * @return void
      */
-    public function testStrategyFailure()
+    public function testStrategyFailure(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid strategy "join" was provided');
@@ -182,10 +168,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test the eager loader method with no extra options
-     *
-     * @return void
      */
-    public function testEagerLoader()
+    public function testEagerLoader(): void
     {
         $config = [
             'sourceTable' => $this->author,
@@ -223,10 +207,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test the eager loader method with default query clauses
-     *
-     * @return void
      */
-    public function testEagerLoaderWithDefaults()
+    public function testEagerLoaderWithDefaults(): void
     {
         $config = [
             'sourceTable' => $this->author,
@@ -257,10 +239,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test the eager loader method with overridden query clauses
-     *
-     * @return void
      */
-    public function testEagerLoaderWithOverrides()
+    public function testEagerLoaderWithOverrides(): void
     {
         $config = [
             'sourceTable' => $this->author,
@@ -315,10 +295,8 @@ class HasManyTest extends TestCase
     /**
      * Test that failing to add the foreignKey to the list of fields will throw an
      * exception
-     *
-     * @return void
      */
-    public function testEagerLoaderFieldsException()
+    public function testEagerLoaderFieldsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('You are required to select the "Articles.author_id"');
@@ -343,10 +321,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that eager loader accepts a queryBuilder option
-     *
-     * @return void
      */
-    public function testEagerLoaderWithQueryBuilder()
+    public function testEagerLoaderWithQueryBuilder(): void
     {
         $config = [
             'sourceTable' => $this->author,
@@ -394,10 +370,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test the eager loader method with no extra options
-     *
-     * @return void
      */
-    public function testEagerLoaderMultipleKeys()
+    public function testEagerLoaderMultipleKeys(): void
     {
         $config = [
             'sourceTable' => $this->author,
@@ -457,10 +431,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that not selecting join keys fails with an error
-     *
-     * @return void
      */
-    public function testEagerloaderNoForeignKeys()
+    public function testEagerloaderNoForeignKeys(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles');
@@ -476,10 +448,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test cascading deletes.
-     *
-     * @return void
      */
-    public function testCascadeDelete()
+    public function testCascadeDelete(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $config = [
@@ -504,10 +474,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test cascading deletes with a finder
-     *
-     * @return void
      */
-    public function testCascadeDeleteFinder()
+    public function testCascadeDeleteFinder(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $config = [
@@ -535,10 +503,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test cascading delete with has many.
-     *
-     * @return void
      */
-    public function testCascadeDeleteCallbacks()
+    public function testCascadeDeleteCallbacks(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $config = [
@@ -562,10 +528,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test cascading delete with a rule preventing deletion
-     *
-     * @return void
      */
-    public function testCascadeDeleteCallbacksRuleFailure()
+    public function testCascadeDeleteCallbacksRuleFailure(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $config = [
@@ -576,7 +540,7 @@ class HasManyTest extends TestCase
         ];
         $association = new HasMany('Articles', $config);
         $articles = $association->getTarget();
-        $articles->getEventManager()->on('Model.buildRules', function ($event, $rules) {
+        $articles->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
             $rules->addDelete(function () {
                 return false;
             });
@@ -592,10 +556,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that saveAssociated() ignores non entity values.
-     *
-     * @return void
      */
-    public function testSaveAssociatedOnlyEntities()
+    public function testSaveAssociatedOnlyEntities(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['saveAssociated'])
@@ -624,10 +586,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that property is being set using the constructor options.
-     *
-     * @return void
      */
-    public function testPropertyOption()
+    public function testPropertyOption(): void
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new HasMany('Thing', $config);
@@ -636,10 +596,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that plugin names are omitted from property()
-     *
-     * @return void
      */
-    public function testPropertyNoPlugin()
+    public function testPropertyNoPlugin(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\Table')
             ->disableOriginalConstructor()
@@ -654,10 +612,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that the ValueBinder is reset when using strategy = Association::STRATEGY_SUBQUERY
-     *
-     * @return void
      */
-    public function testValueBinderUpdateOnSubQueryStrategy()
+    public function testValueBinderUpdateOnSubQueryStrategy(): void
     {
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->hasMany('Articles', [
@@ -685,9 +641,8 @@ class HasManyTest extends TestCase
      *
      * @param array $expected The expected join clause.
      * @param \Cake\ORM\Query $query The query to check.
-     * @return void
      */
-    protected function assertJoin($expected, $query)
+    protected function assertJoin($expected, $query): void
     {
         if ($this->autoQuote) {
             $driver = $query->getConnection()->getDriver();
@@ -707,9 +662,8 @@ class HasManyTest extends TestCase
      *
      * @param \Cake\Database\QueryExpression $expected The expected where clause.
      * @param \Cake\ORM\Query $query The query to check.
-     * @return void
      */
-    protected function assertWhereClause($expected, $query)
+    protected function assertWhereClause($expected, $query): void
     {
         if ($this->autoQuote) {
             $quoter = new IdentifierQuoter($query->getConnection()->getDriver());
@@ -723,9 +677,8 @@ class HasManyTest extends TestCase
      *
      * @param \Cake\Database\QueryExpression $expected The expected where clause.
      * @param \Cake\ORM\Query $query The query to check.
-     * @return void
      */
-    protected function assertOrderClause($expected, $query)
+    protected function assertOrderClause($expected, $query): void
     {
         if ($this->autoQuote) {
             $quoter = new IdentifierQuoter($query->getConnection()->getDriver());
@@ -739,9 +692,8 @@ class HasManyTest extends TestCase
      *
      * @param array $expected Array of expected fields.
      * @param \Cake\ORM\Query $query The query to check.
-     * @return void
      */
-    protected function assertSelectClause($expected, $query)
+    protected function assertSelectClause($expected, $query): void
     {
         if ($this->autoQuote) {
             $connection = $query->getConnection();
@@ -755,10 +707,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that unlinking calls the right methods
-     *
-     * @return void
      */
-    public function testUnlinkSuccess()
+    public function testUnlinkSuccess(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $assoc = $this->author->hasMany('Articles', [
@@ -781,10 +731,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that unlink with an empty array does nothing
-     *
-     * @return void
      */
-    public function testUnlinkWithEmptyArray()
+    public function testUnlinkWithEmptyArray(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $assoc = $this->author->hasMany('Articles', [
@@ -806,10 +754,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that link only uses a single database transaction
-     *
-     * @return void
      */
-    public function testLinkUsesSingleTransaction()
+    public function testLinkUsesSingleTransaction(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $assoc = $this->author->hasMany('Articles', [
@@ -823,7 +769,7 @@ class HasManyTest extends TestCase
         $this->assertCount(0, $initial);
 
         // Ensure that after each model is saved, we are still within a transaction.
-        $listenerAfterSave = function ($e, $entity, $options) use ($articles) {
+        $listenerAfterSave = function ($e, $entity, $options) use ($articles): void {
             $this->assertTrue(
                 $articles->getConnection()->inTransaction(),
                 'Multiple transactions used to save associated models.'
@@ -841,10 +787,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that saveAssociated() fails on non-empty, non-iterable value
-     *
-     * @return void
      */
-    public function testSaveAssociatedNotEmptyNotIterable()
+    public function testSaveAssociatedNotEmptyNotIterable(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not save comments, it cannot be traversed');
@@ -880,9 +824,8 @@ class HasManyTest extends TestCase
      *
      * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
-     * @return void
      */
-    public function testSaveAssociatedEmptySetWithAppendStrategyDoesNotAffectAssociatedRecordsOnCreate($value)
+    public function testSaveAssociatedEmptySetWithAppendStrategyDoesNotAffectAssociatedRecordsOnCreate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $association = $articles->hasMany('Comments', [
@@ -906,9 +849,8 @@ class HasManyTest extends TestCase
      *
      * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
-     * @return void
      */
-    public function testSaveAssociatedEmptySetWithAppendStrategyDoesNotAffectAssociatedRecordsOnUpdate($value)
+    public function testSaveAssociatedEmptySetWithAppendStrategyDoesNotAffectAssociatedRecordsOnUpdate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $association = $articles->hasMany('Comments', [
@@ -937,9 +879,8 @@ class HasManyTest extends TestCase
      *
      * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
-     * @return void
      */
-    public function testSaveAssociatedEmptySetWithReplaceStrategyDoesNotAffectAssociatedRecordsOnCreate($value)
+    public function testSaveAssociatedEmptySetWithReplaceStrategyDoesNotAffectAssociatedRecordsOnCreate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $association = $articles->hasMany('Comments', [
@@ -963,9 +904,8 @@ class HasManyTest extends TestCase
      *
      * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
-     * @return void
      */
-    public function testSaveAssociatedEmptySetWithReplaceStrategyRemovesAssociatedRecordsOnUpdate($value)
+    public function testSaveAssociatedEmptySetWithReplaceStrategyRemovesAssociatedRecordsOnUpdate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $association = $articles->hasMany('Comments', [
@@ -991,10 +931,8 @@ class HasManyTest extends TestCase
     /**
      * Test that the associated entities are not saved when there's any rule
      * that fail on them and the errors are correctly set on the original entity.
-     *
-     * @return void
      */
-    public function testSaveAssociatedWithFailedRuleOnAssociated()
+    public function testSaveAssociatedWithFailedRuleOnAssociated(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->hasMany('Comments');
@@ -1032,10 +970,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests that providing an invalid strategy throws an exception
-     *
-     * @return void
      */
-    public function testInvalidSaveStrategy()
+    public function testInvalidSaveStrategy(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $articles = $this->getTableLocator()->get('Articles');
@@ -1046,10 +982,8 @@ class HasManyTest extends TestCase
 
     /**
      * Tests saveStrategy
-     *
-     * @return void
      */
-    public function testSetSaveStrategy()
+    public function testSetSaveStrategy(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
@@ -1060,10 +994,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that save works with replace saveStrategy and are not deleted once they are not null
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategy()
+    public function testSaveReplaceSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_REPLACE]);
@@ -1093,10 +1025,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that save works with replace saveStrategy conditions
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyClosureConditions()
+    public function testSaveReplaceSaveStrategyClosureConditions(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles')
@@ -1136,10 +1066,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that save works with replace saveStrategy, replacing the already persisted entities even if no new entities are passed
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyNotAdding()
+    public function testSaveReplaceSaveStrategyNotAdding(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles', ['saveStrategy' => 'replace']);
@@ -1166,10 +1094,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that save works with append saveStrategy not deleting or setting null anything
-     *
-     * @return void
      */
-    public function testSaveAppendSaveStrategy()
+    public function testSaveAppendSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles', ['saveStrategy' => 'append']);
@@ -1200,10 +1126,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that save has append as the default save strategy
-     *
-     * @return void
      */
-    public function testSaveDefaultSaveStrategy()
+    public function testSaveDefaultSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_APPEND]);
@@ -1212,10 +1136,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that the associated entities are unlinked and deleted when they are dependent
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyDependent()
+    public function testSaveReplaceSaveStrategyDependent(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_REPLACE, 'dependent' => true]);
@@ -1246,10 +1168,8 @@ class HasManyTest extends TestCase
     /**
      * Test that the associated entities are unlinked and deleted when they are dependent
      * when associated entities array is indexed by string keys
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyDependentWithStringKeys()
+    public function testSaveReplaceSaveStrategyDependentWithStringKeys(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_REPLACE, 'dependent' => true]);
@@ -1283,10 +1203,8 @@ class HasManyTest extends TestCase
      * Test that the associated entities are unlinked and deleted when they are dependent
      *
      * In the future this should change and apply the finder.
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyDependentWithConditions()
+    public function testSaveReplaceSaveStrategyDependentWithConditions(): void
     {
         $this->getTableLocator()->clear();
         $this->setAppNamespace('TestApp');
@@ -1335,10 +1253,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that the associated entities are unlinked and deleted when they have a not nullable foreign key
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyNotNullable()
+    public function testSaveReplaceSaveStrategyNotNullable(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->hasMany('Comments', ['saveStrategy' => HasMany::SAVE_REPLACE]);
@@ -1375,10 +1291,8 @@ class HasManyTest extends TestCase
 
     /**
      * Test that the associated entities are unlinked and deleted when they have a not nullable foreign key
-     *
-     * @return void
      */
-    public function testSaveReplaceSaveStrategyAdding()
+    public function testSaveReplaceSaveStrategyAdding(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->hasMany('Comments', ['saveStrategy' => HasMany::SAVE_REPLACE]);
@@ -1423,10 +1337,8 @@ class HasManyTest extends TestCase
     /**
      * Tests that dependent, non-cascading deletes are using the association
      * conditions for deleting associated records.
-     *
-     * @return void
      */
-    public function testHasManyNonCascadingUnlinkDeleteUsesAssociationConditions()
+    public function testHasManyNonCascadingUnlinkDeleteUsesAssociationConditions(): void
     {
         $Articles = $this->getTableLocator()->get('Articles');
         $Comments = $Articles->hasMany('Comments', [
@@ -1484,10 +1396,8 @@ class HasManyTest extends TestCase
     /**
      * Tests that non-dependent, non-cascading deletes are using the association
      * conditions for updating associated records.
-     *
-     * @return void
      */
-    public function testHasManyNonDependentNonCascadingUnlinkUpdateUsesAssociationConditions()
+    public function testHasManyNonDependentNonCascadingUnlinkUpdateUsesAssociationConditions(): void
     {
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->associations()->removeAll();

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -42,8 +42,6 @@ class HasOneTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,10 +53,8 @@ class HasOneTest extends TestCase
 
     /**
      * Tests that setForeignKey() returns the correct configured value
-     *
-     * @return void
      */
-    public function testSetForeignKey()
+    public function testSetForeignKey(): void
     {
         $assoc = new HasOne('Profiles', [
             'sourceTable' => $this->user,
@@ -70,10 +66,8 @@ class HasOneTest extends TestCase
 
     /**
      * Tests that the association reports it can be joined
-     *
-     * @return void
      */
-    public function testCanBeJoined()
+    public function testCanBeJoined(): void
     {
         $assoc = new HasOne('Test');
         $this->assertTrue($assoc->canBeJoined());
@@ -82,10 +76,8 @@ class HasOneTest extends TestCase
     /**
      * Tests that the correct join and fields are attached to a query depending on
      * the association config
-     *
-     * @return void
      */
-    public function testAttachTo()
+    public function testAttachTo(): void
     {
         $config = [
             'foreignKey' => 'user_id',
@@ -106,10 +98,8 @@ class HasOneTest extends TestCase
 
     /**
      * Tests that it is possible to avoid fields inclusion for the associated table
-     *
-     * @return void
      */
-    public function testAttachToNoFields()
+    public function testAttachToNoFields(): void
     {
         $config = [
             'sourceTable' => $this->user,
@@ -125,10 +115,8 @@ class HasOneTest extends TestCase
     /**
      * Tests that using hasOne with a table having a multi column primary
      * key will work if the foreign key is passed
-     *
-     * @return void
      */
-    public function testAttachToMultiPrimaryKey()
+    public function testAttachToMultiPrimaryKey(): void
     {
         $selectTypeMap = new TypeMap([
             'Profiles.id' => 'integer',
@@ -179,10 +167,8 @@ class HasOneTest extends TestCase
     /**
      * Tests that using hasOne with a table having a multi column primary
      * key will work if the foreign key is passed
-     *
-     * @return void
      */
-    public function testAttachToMultiPrimaryKeyMismatch()
+    public function testAttachToMultiPrimaryKeyMismatch(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
@@ -202,10 +188,8 @@ class HasOneTest extends TestCase
 
     /**
      * Test that saveAssociated() ignores non entity values.
-     *
-     * @return void
      */
-    public function testSaveAssociatedOnlyEntities()
+    public function testSaveAssociatedOnlyEntities(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['saveAssociated'])
@@ -232,10 +216,8 @@ class HasOneTest extends TestCase
 
     /**
      * Tests that property is being set using the constructor options.
-     *
-     * @return void
      */
-    public function testPropertyOption()
+    public function testPropertyOption(): void
     {
         $config = ['propertyName' => 'thing_placeholder'];
         $association = new HasOne('Thing', $config);
@@ -244,10 +226,8 @@ class HasOneTest extends TestCase
 
     /**
      * Test that plugin names are omitted from property()
-     *
-     * @return void
      */
-    public function testPropertyNoPlugin()
+    public function testPropertyNoPlugin(): void
     {
         $config = [
             'sourceTable' => $this->user,
@@ -260,10 +240,8 @@ class HasOneTest extends TestCase
     /**
      * Tests that attaching an association to a query will trigger beforeFind
      * for the target table
-     *
-     * @return void
      */
-    public function testAttachToBeforeFind()
+    public function testAttachToBeforeFind(): void
     {
         $config = [
             'foreignKey' => 'user_id',
@@ -273,7 +251,7 @@ class HasOneTest extends TestCase
         $query = $this->user->query();
 
         $this->listenerCalled = false;
-        $this->profile->getEventManager()->on('Model.beforeFind', function ($event, $query, $options, $primary) {
+        $this->profile->getEventManager()->on('Model.beforeFind', function ($event, $query, $options, $primary): void {
             $this->listenerCalled = true;
             $this->assertInstanceOf('Cake\Event\Event', $event);
             $this->assertInstanceOf('Cake\ORM\Query', $query);
@@ -288,10 +266,8 @@ class HasOneTest extends TestCase
     /**
      * Tests that attaching an association to a query will trigger beforeFind
      * for the target table
-     *
-     * @return void
      */
-    public function testAttachToBeforeFindExtraOptions()
+    public function testAttachToBeforeFindExtraOptions(): void
     {
         $config = [
             'foreignKey' => 'user_id',
@@ -302,7 +278,7 @@ class HasOneTest extends TestCase
         $opts = new \ArrayObject(['something' => 'more']);
         $this->profile->getEventManager()->on(
             'Model.beforeFind',
-            function ($event, $query, $options, $primary) use ($opts) {
+            function ($event, $query, $options, $primary) use ($opts): void {
                 $this->listenerCalled = true;
                 $this->assertInstanceOf('Cake\Event\Event', $event);
                 $this->assertInstanceOf('Cake\ORM\Query', $query);
@@ -320,10 +296,8 @@ class HasOneTest extends TestCase
 
     /**
      * Test cascading deletes.
-     *
-     * @return void
      */
-    public function testCascadeDelete()
+    public function testCascadeDelete(): void
     {
         $config = [
             'dependent' => true,
@@ -334,7 +308,7 @@ class HasOneTest extends TestCase
         ];
         $association = new HasOne('Profiles', $config);
 
-        $this->profile->getEventManager()->on('Model.beforeDelete', function () {
+        $this->profile->getEventManager()->on('Model.beforeDelete', function (): void {
             $this->fail('Callbacks should not be triggered when callbacks do not cascade.');
         });
 
@@ -355,10 +329,8 @@ class HasOneTest extends TestCase
 
     /**
      * Test cascading delete with has one.
-     *
-     * @return void
      */
-    public function testCascadeDeleteCallbacks()
+    public function testCascadeDeleteCallbacks(): void
     {
         $config = [
             'dependent' => true,
@@ -386,10 +358,8 @@ class HasOneTest extends TestCase
 
     /**
      * Test cascading delete with a rule preventing deletion
-     *
-     * @return void
      */
-    public function testCascadeDeleteCallbacksRuleFailure()
+    public function testCascadeDeleteCallbacksRuleFailure(): void
     {
         $config = [
             'dependent' => true,
@@ -399,7 +369,7 @@ class HasOneTest extends TestCase
         ];
         $association = new HasOne('Profiles', $config);
         $profiles = $association->getTarget();
-        $profiles->getEventManager()->on('Model.buildRules', function ($event, $rules) {
+        $profiles->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
             $rules->addDelete(function () {
                 return false;
             });

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -36,8 +36,6 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,10 +45,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test the constructor.
-     *
-     * @return void
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $this->assertSame($this->getTableLocator(), $this->associations->getTableLocator());
 
@@ -61,10 +57,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test the simple add/has and get methods.
-     *
-     * @return void
      */
-    public function testAddHasRemoveAndGet()
+    public function testAddHasRemoveAndGet(): void
     {
         $this->assertFalse($this->associations->has('users'));
         $this->assertFalse($this->associations->has('Users'));
@@ -87,10 +81,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test the load method.
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $this->associations->load(BelongsTo::class, 'Users');
         $this->assertTrue($this->associations->has('Users'));
@@ -100,10 +92,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test the load method with custom locator.
-     *
-     * @return void
      */
-    public function testLoadCustomLocator()
+    public function testLoadCustomLocator(): void
     {
         $locator = $this->createMock(LocatorInterface::class);
         $this->associations->load(BelongsTo::class, 'Users', [
@@ -116,10 +106,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test load invalid class.
-     *
-     * @return void
      */
-    public function testLoadInvalid()
+    public function testLoadInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The association must extend `Cake\ORM\Association` class, `stdClass` given.');
@@ -129,10 +117,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test removeAll method
-     *
-     * @return void
      */
-    public function testRemoveAll()
+    public function testRemoveAll(): void
     {
         $this->assertEmpty($this->associations->keys());
 
@@ -147,10 +133,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test getting associations by property.
-     *
-     * @return void
      */
-    public function testGetByProperty()
+    public function testGetByProperty(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['table'])
@@ -168,10 +152,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test associations with plugin names.
-     *
-     * @return void
      */
-    public function testAddHasRemoveGetWithPlugin()
+    public function testAddHasRemoveGetWithPlugin(): void
     {
         $this->assertFalse($this->associations->has('Photos.Photos'));
         $this->assertFalse($this->associations->has('Photos'));
@@ -184,10 +166,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test keys()
-     *
-     * @return void
      */
-    public function testKeys()
+    public function testKeys(): void
     {
         $belongsTo = new BelongsTo('');
         $this->associations->add('Users', $belongsTo);
@@ -217,7 +197,7 @@ class AssociationCollectionTest extends TestCase
      * @param string $belongsToManyStr
      * @dataProvider associationCollectionType
      */
-    public function testGetByType($belongsToStr, $belongsToManyStr)
+    public function testGetByType($belongsToStr, $belongsToManyStr): void
     {
         $belongsTo = new BelongsTo('');
         $this->associations->add('Users', $belongsTo);
@@ -232,10 +212,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Type should return empty array.
-     *
-     * @return void
      */
-    public function hasTypeReturnsEmptyArray()
+    public function hasTypeReturnsEmptyArray(): void
     {
         foreach (['HasMany', 'hasMany', 'FooBar', 'DoesNotExist'] as $value) {
             $this->assertSame([], $this->associations->getByType($value));
@@ -244,10 +222,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * test cascading deletes.
-     *
-     * @return void
      */
-    public function testCascadeDelete()
+    public function testCascadeDelete(): void
     {
         $mockOne = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
             ->setConstructorArgs([''])
@@ -277,10 +253,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test saving parent associations
-     *
-     * @return void
      */
-    public function testSaveParents()
+    public function testSaveParents(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['table'])
@@ -327,10 +301,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test saving filtered parent associations.
-     *
-     * @return void
      */
-    public function testSaveParentsFiltered()
+    public function testSaveParentsFiltered(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['table'])
@@ -377,10 +349,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Test saving filtered child associations.
-     *
-     * @return void
      */
-    public function testSaveChildrenFiltered()
+    public function testSaveChildrenFiltered(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->addMethods(['table'])
@@ -428,7 +398,7 @@ class AssociationCollectionTest extends TestCase
     /**
      * Test exceptional case.
      */
-    public function testErrorOnUnknownAlias()
+    public function testErrorOnUnknownAlias(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot save Profiles, it is not associated to Users');
@@ -450,10 +420,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Tests the normalizeKeys method
-     *
-     * @return void
      */
-    public function testNormalizeKeys()
+    public function testNormalizeKeys(): void
     {
         $this->assertSame([], $this->associations->normalizeKeys([]));
         $this->assertSame([], $this->associations->normalizeKeys(false));
@@ -471,10 +439,8 @@ class AssociationCollectionTest extends TestCase
 
     /**
      * Ensure that the association collection can be iterated.
-     *
-     * @return void
      */
-    public function testAssociationsCanBeIterated()
+    public function testAssociationsCanBeIterated(): void
     {
         $belongsTo = new BelongsTo('');
         $this->associations->add('Users', $belongsTo);

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -35,10 +35,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that it is possible to get associations as a property
-     *
-     * @return void
      */
-    public function testAssociationAsProperty()
+    public function testAssociationAsProperty(): void
     {
         $articles = $this->getTableLocator()->get('articles');
         $articles->hasMany('comments');
@@ -52,10 +50,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that getting a bad property throws exception
-     *
-     * @return void
      */
-    public function testGetBadAssociation()
+    public function testGetBadAssociation(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('You have not defined');
@@ -65,10 +61,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Test that find() with empty conditions generates valid SQL
-     *
-     * @return void
      */
-    public function testFindEmptyConditions()
+    public function testFindEmptyConditions(): void
     {
         $table = $this->getTableLocator()->get('Users');
         $table->hasMany('Articles', [
@@ -81,10 +75,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that the proxied updateAll will preserve conditions set for the association
-     *
-     * @return void
      */
-    public function testUpdateAllFromAssociation()
+    public function testUpdateAllFromAssociation(): void
     {
         $articles = $this->getTableLocator()->get('articles');
         $comments = $this->getTableLocator()->get('comments');
@@ -96,10 +88,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that the proxied updateAll uses the association finder
-     *
-     * @return void
      */
-    public function testUpdateAllFromAssociationFinder()
+    public function testUpdateAllFromAssociationFinder(): void
     {
         $this->setAppNamespace('TestApp');
 
@@ -121,10 +111,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that the proxied deleteAll preserves conditions set for the association
-     *
-     * @return void
      */
-    public function testDeleteAllFromAssociationConditions()
+    public function testDeleteAllFromAssociationConditions(): void
     {
         $articles = $this->getTableLocator()->get('articles');
         $comments = $this->getTableLocator()->get('comments');
@@ -136,10 +124,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that the proxied deleteAll uses the association finder
-     *
-     * @return void
      */
-    public function testDeleteAllFromAssociationFinder()
+    public function testDeleteAllFromAssociationFinder(): void
     {
         $this->setAppNamespace('TestApp');
 
@@ -159,10 +145,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that it is possible to get associations as a property
-     *
-     * @return void
      */
-    public function testAssociationAsPropertyProxy()
+    public function testAssociationAsPropertyProxy(): void
     {
         $articles = $this->getTableLocator()->get('articles');
         $authors = $this->getTableLocator()->get('authors');
@@ -174,10 +158,8 @@ class AssociationProxyTest extends TestCase
 
     /**
      * Tests that methods are proxied from the Association to the target table
-     *
-     * @return void
      */
-    public function testAssociationMethodProxy()
+    public function testAssociationMethodProxy(): void
     {
         $articles = $this->getTableLocator()->get('articles');
         $mock = $this->getMockBuilder('Cake\ORM\Table')

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -40,8 +40,6 @@ class AssociationTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -67,10 +65,8 @@ class AssociationTest extends TestCase
     /**
      * Tests that _options acts as a callback where subclasses can add their own
      * initialization code based on the passed configuration array
-     *
-     * @return void
      */
-    public function testOptionsIsCalled()
+    public function testOptionsIsCalled(): void
     {
         $options = ['foo' => 'bar'];
         $this->association->expects($this->once())->method('_options')->with($options);
@@ -79,10 +75,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setName()
-     *
-     * @return void
      */
-    public function testSetName()
+    public function testSetName(): void
     {
         $this->assertSame('Foo', $this->association->getName());
         $this->assertSame($this->association, $this->association->setName('Bar'));
@@ -91,10 +85,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setName() succeeds before the target table is resolved.
-     *
-     * @return void
      */
-    public function testSetNameBeforeTarget()
+    public function testSetNameBeforeTarget(): void
     {
         $this->association->setName('Bar');
         $this->assertSame('Bar', $this->association->getName());
@@ -102,10 +94,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setName() fails after the target table is resolved.
-     *
-     * @return void
      */
-    public function testSetNameAfterTarget()
+    public function testSetNameAfterTarget(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Association name "Bar" does not match target table alias');
@@ -115,10 +105,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setName() succeeds if name equals target table alias.
-     *
-     * @return void
      */
-    public function testSetNameToTargetAlias()
+    public function testSetNameToTargetAlias(): void
     {
         $alias = $this->association->getTarget()->getAlias();
         $this->association->setName($alias);
@@ -128,10 +116,8 @@ class AssociationTest extends TestCase
     /**
      * Test that _className property is set to alias when "className" config
      * if not explicitly set.
-     *
-     * @return void
      */
-    public function testSetttingClassNameFromAlias()
+    public function testSetttingClassNameFromAlias(): void
     {
         $association = $this->getMockBuilder(Association::class)
             ->onlyMethods(['type', 'eagerLoader', 'cascadeDelete', 'isOwningSide', 'saveAssociated'])
@@ -143,10 +129,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setClassName() succeeds before the target table is resolved.
-     *
-     * @return void
      */
-    public function testSetClassNameBeforeTarget()
+    public function testSetClassNameBeforeTarget(): void
     {
         $this->assertSame(TestTable::class, $this->association->getClassName());
         $this->assertSame($this->association, $this->association->setClassName(AuthorsTable::class));
@@ -155,10 +139,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setClassName() fails after the target table is resolved.
-     *
-     * @return void
      */
-    public function testSetClassNameAfterTarget()
+    public function testSetClassNameAfterTarget(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The class name "' . AuthorsTable::class . '" doesn\'t match the target table class name of');
@@ -168,10 +150,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setClassName() fails after the target table is resolved.
-     *
-     * @return void
      */
-    public function testSetClassNameWithShortSyntaxAfterTarget()
+    public function testSetClassNameWithShortSyntaxAfterTarget(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The class name "Authors" doesn\'t match the target table class name of');
@@ -181,10 +161,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setClassName() succeeds if name equals target table's class name.
-     *
-     * @return void
      */
-    public function testSetClassNameToTargetClassName()
+    public function testSetClassNameToTargetClassName(): void
     {
         $className = get_class($this->association->getTarget());
         $this->association->setClassName($className);
@@ -193,10 +171,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setClassName() succeeds if the short name resolves to the target table's class name.
-     *
-     * @return void
      */
-    public function testSetClassNameWithShortSyntaxToTargetClassName()
+    public function testSetClassNameWithShortSyntaxToTargetClassName(): void
     {
         Configure::write('App.namespace', 'TestApp');
 
@@ -209,10 +185,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that className() returns the correct (unnormalized) className
-     *
-     * @return void
      */
-    public function testClassNameUnnormalized()
+    public function testClassNameUnnormalized(): void
     {
         $config = [
             'className' => 'Test',
@@ -231,10 +205,8 @@ class AssociationTest extends TestCase
     /**
      * Tests that an exception is thrown when invalid target table is fetched
      * from a registry.
-     *
-     * @return void
      */
-    public function testInvalidTableFetchedFromRegistry()
+    public function testInvalidTableFetchedFromRegistry(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->getTableLocator()->get('Test');
@@ -255,10 +227,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that a descendant table could be fetched from a registry.
-     *
-     * @return void
      */
-    public function testTargetTableDescendant()
+    public function testTargetTableDescendant(): void
     {
         $this->getTableLocator()->get('Test', [
             'className' => TestTable::class,
@@ -282,10 +252,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that cascadeCallbacks() returns the correct configured value
-     *
-     * @return void
      */
-    public function testSetCascadeCallbacks()
+    public function testSetCascadeCallbacks(): void
     {
         $this->assertFalse($this->association->getCascadeCallbacks());
         $this->assertSame($this->association, $this->association->setCascadeCallbacks(true));
@@ -294,10 +262,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests the bindingKey method as a setter/getter
-     *
-     * @return void
      */
-    public function testSetBindingKey()
+    public function testSetBindingKey(): void
     {
         $this->assertSame($this->association, $this->association->setBindingKey('foo_id'));
         $this->assertSame('foo_id', $this->association->getBindingKey());
@@ -305,10 +271,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests the bindingKey() method when called with its defaults
-     *
-     * @return void
      */
-    public function testBindingKeyDefault()
+    public function testBindingKeyDefault(): void
     {
         $this->source->setPrimaryKey(['id', 'site_id']);
         $this->association
@@ -322,10 +286,8 @@ class AssociationTest extends TestCase
     /**
      * Tests the bindingKey() method when the association source is not the
      * owning side
-     *
-     * @return void
      */
-    public function testBindingDefaultNoOwningSide()
+    public function testBindingDefaultNoOwningSide(): void
     {
         $target = new Table();
         $target->setPrimaryKey(['foo', 'site_id']);
@@ -341,10 +303,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests setForeignKey()
-     *
-     * @return void
      */
-    public function testSetForeignKey()
+    public function testSetForeignKey(): void
     {
         $this->assertSame('a_key', $this->association->getForeignKey());
         $this->assertSame($this->association, $this->association->setForeignKey('another_key'));
@@ -353,10 +313,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests setConditions()
-     *
-     * @return void
      */
-    public function testSetConditions()
+    public function testSetConditions(): void
     {
         $this->assertEquals(['field' => 'value'], $this->association->getConditions());
         $conds = ['another_key' => 'another value'];
@@ -366,20 +324,16 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that canBeJoined() returns the correct configured value
-     *
-     * @return void
      */
-    public function testCanBeJoined()
+    public function testCanBeJoined(): void
     {
         $this->assertTrue($this->association->canBeJoined());
     }
 
     /**
      * Tests that setTarget()
-     *
-     * @return void
      */
-    public function testSetTarget()
+    public function testSetTarget(): void
     {
         $table = $this->association->getTarget();
         $this->assertInstanceOf(TestTable::class, $table);
@@ -391,10 +345,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that target() returns the correct Table object for plugins
-     *
-     * @return void
      */
-    public function testTargetPlugin()
+    public function testTargetPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $config = [
@@ -435,10 +387,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that source() returns the correct Table object
-     *
-     * @return void
      */
-    public function testSetSource()
+    public function testSetSource(): void
     {
         $table = $this->association->getSource();
         $this->assertSame($this->source, $table);
@@ -450,10 +400,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests setJoinType method
-     *
-     * @return void
      */
-    public function testSetJoinType()
+    public function testSetJoinType(): void
     {
         $this->assertSame('INNER', $this->association->getJoinType());
         $this->assertSame($this->association, $this->association->setJoinType('LEFT'));
@@ -462,10 +410,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests property method
-     *
-     * @return void
      */
-    public function testSetProperty()
+    public function testSetProperty(): void
     {
         $this->assertSame('foo', $this->association->getProperty());
         $this->assertSame($this->association, $this->association->setProperty('thing'));
@@ -474,10 +420,8 @@ class AssociationTest extends TestCase
 
     /**
      * Test that warning is shown if property name clashes with table field.
-     *
-     * @return void
      */
-    public function testPropertyNameClash()
+    public function testPropertyNameClash(): void
     {
         $this->expectWarning();
         $this->expectWarningMessageMatches('/^Association property name "foo" clashes with field of same name of table "test"/');
@@ -487,10 +431,8 @@ class AssociationTest extends TestCase
 
     /**
      * Test that warning is not shown if "propertyName" option is explicitly specified.
-     *
-     * @return void
      */
-    public function testPropertyNameExplicitySet()
+    public function testPropertyNameExplicitySet(): void
     {
         $this->source->setSchema(['foo' => ['type' => 'string']]);
 
@@ -516,10 +458,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests strategy method
-     *
-     * @return void
      */
-    public function testSetStrategy()
+    public function testSetStrategy(): void
     {
         $this->assertSame('join', $this->association->getStrategy());
 
@@ -532,10 +472,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that providing an invalid strategy throws an exception
-     *
-     * @return void
      */
-    public function testInvalidStrategy()
+    public function testInvalidStrategy(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->association->setStrategy('anotherThing');
@@ -543,10 +481,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests test setFinder() method
-     *
-     * @return void
      */
-    public function testSetFinderMethod()
+    public function testSetFinderMethod(): void
     {
         $this->assertSame('all', $this->association->getFinder());
         $this->assertSame($this->association, $this->association->setFinder('published'));
@@ -555,10 +491,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that `finder` is a valid option for the association constructor
-     *
-     * @return void
      */
-    public function testFinderInConstructor()
+    public function testFinderInConstructor(): void
     {
         $config = [
             'className' => TestTable::class,
@@ -582,10 +516,8 @@ class AssociationTest extends TestCase
     /**
      * Tests that the defined custom finder is used when calling find
      * in the association
-     *
-     * @return void
      */
-    public function testCustomFinderIsUsed()
+    public function testCustomFinderIsUsed(): void
     {
         $this->association->setFinder('published');
         $this->assertEquals(
@@ -596,10 +528,8 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that `locator` is a valid option for the association constructor
-     *
-     * @return void
      */
-    public function testLocatorInConstructor()
+    public function testLocatorInConstructor(): void
     {
         $locator = $this->getMockBuilder('Cake\ORM\Locator\LocatorInterface')->getMock();
         $config = [

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -40,9 +40,8 @@ class BehaviorRegressionTest extends TestCase
      * Tests that the tree behavior and the translations behavior play together
      *
      * @see https://github.com/cakephp/cakephp/issues/5982
-     * @return void
      */
-    public function testTreeAndTranslateIntegration()
+    public function testTreeAndTranslateIntegration(): void
     {
         $connection = ConnectionManager::get('test');
         $this->skipIf(

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -51,8 +51,6 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -90,8 +88,6 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -102,10 +98,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing simple counter caching when adding a record
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
@@ -131,10 +125,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing simple counter caching when adding a record
-     *
-     * @return void
      */
-    public function testAddIgnore()
+    public function testAddIgnore(): void
     {
         $this->post->belongsTo('Users');
 
@@ -155,10 +147,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing simple counter caching when adding a record
-     *
-     * @return void
      */
-    public function testAddScope()
+    public function testAddScope(): void
     {
         $this->post->belongsTo('Users');
 
@@ -181,10 +171,7 @@ class CounterCacheBehaviorTest extends TestCase
         $this->assertSame(2, $after->get('posts_published'));
     }
 
-    /**
-     * @return void
-     */
-    public function testSaveWithNullForeignKey()
+    public function testSaveWithNullForeignKey(): void
     {
         $this->comment->belongsTo('Users');
 
@@ -204,10 +191,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing simple counter caching when deleting a record
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $this->post->belongsTo('Users');
 
@@ -228,10 +213,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing simple counter caching when deleting a record
-     *
-     * @return void
      */
-    public function testDeleteIgnore()
+    public function testDeleteIgnore(): void
     {
         $this->post->belongsTo('Users');
 
@@ -253,10 +236,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing update simple counter caching when updating a record association
-     *
-     * @return void
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $this->post->belongsTo('Users');
         $this->post->belongsTo('Categories');
@@ -311,10 +292,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing counter cache with custom find
-     *
-     * @return void
      */
-    public function testCustomFind()
+    public function testCustomFind(): void
     {
         $this->post->belongsTo('Users');
 
@@ -337,10 +316,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing counter cache with lambda returning number
-     *
-     * @return void
      */
-    public function testLambdaNumber()
+    public function testLambdaNumber(): void
     {
         $this->post->belongsTo('Users');
 
@@ -368,10 +345,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing counter cache with lambda returning false
-     *
-     * @return void
      */
-    public function testLambdaFalse()
+    public function testLambdaFalse(): void
     {
         $this->post->belongsTo('Users');
 
@@ -399,10 +374,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing counter cache with lambda returning number and changing of related ID
-     *
-     * @return void
      */
-    public function testLambdaNumberUpdate()
+    public function testLambdaNumberUpdate(): void
     {
         $this->post->belongsTo('Users');
 
@@ -438,10 +411,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing counter cache with lambda returning a subquery
-     *
-     * @return void
      */
-    public function testLambdaSubquery()
+    public function testLambdaSubquery(): void
     {
         $this->post->belongsTo('Users');
 
@@ -466,10 +437,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing multiple counter cache when adding a record
-     *
-     * @return void
      */
-    public function testMultiple()
+    public function testMultiple(): void
     {
         $this->post->belongsTo('Users');
 
@@ -498,10 +467,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Tests to see that the binding key configuration is respected.
-     *
-     * @return void
      */
-    public function testBindingKey()
+    public function testBindingKey(): void
     {
         $this->post->hasMany('UserCategoryPosts', [
             'bindingKey' => ['category_id', 'user_id'],
@@ -527,10 +494,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing the ignore if dirty option
-     *
-     * @return void
      */
-    public function testIgnoreDirty()
+    public function testIgnoreDirty(): void
     {
         $this->post->belongsTo('Users');
         $this->comment->belongsTo('Users');
@@ -573,10 +538,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Testing the ignore if dirty option with just one field set to ignoreDirty
-     *
-     * @return void
      */
-    public function testIgnoreDirtyMixed()
+    public function testIgnoreDirtyMixed(): void
     {
         $this->post->belongsTo('Users');
         $this->comment->belongsTo('Users');
@@ -615,10 +578,8 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Get a new Entity
-     *
-     * @return Entity
      */
-    protected function _getEntity()
+    protected function _getEntity(): Entity
     {
         return new Entity([
             'title' => 'Test 123',
@@ -628,20 +589,16 @@ class CounterCacheBehaviorTest extends TestCase
 
     /**
      * Returns entity for user
-     *
-     * @return Entity
      */
-    protected function _getUser(int $id = 1)
+    protected function _getUser(int $id = 1): Entity
     {
         return $this->user->get($id);
     }
 
     /**
      * Returns entity for category
-     *
-     * @return Entity
      */
-    protected function _getCategory(int $id = 1)
+    protected function _getCategory(int $id = 1): Entity
     {
         return $this->category->find('all')->where(['id' => $id])->first();
     }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -56,10 +56,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * Sanity check Implemented events
-     *
-     * @return void
      */
-    public function testImplementedEventsDefault()
+    public function testImplementedEventsDefault(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -74,10 +72,8 @@ class TimestampBehaviorTest extends TestCase
      * testImplementedEventsCustom
      *
      * The behavior allows for handling any event - test an example
-     *
-     * @return void
      */
-    public function testImplementedEventsCustom()
+    public function testImplementedEventsCustom(): void
     {
         $table = $this->getTable();
         $settings = ['events' => ['Something.special' => ['date_specialed' => 'always']]];
@@ -92,10 +88,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testCreatedAbsent
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testCreatedAbsent()
+    public function testCreatedAbsent(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -114,10 +109,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testCreatedPresent
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testCreatedPresent()
+    public function testCreatedPresent(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -136,10 +130,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testCreatedNotNew
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testCreatedNotNew()
+    public function testCreatedNotNew(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -158,10 +151,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testModifiedAbsent
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testModifiedAbsent()
+    public function testModifiedAbsent(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -181,10 +173,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testModifiedPresent
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testModifiedPresent()
+    public function testModifiedPresent(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -205,10 +196,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * test that timestamp creation doesn't fail on missing columns
-     *
-     * @return void
      */
-    public function testModifiedMissingColumn()
+    public function testModifiedMissingColumn(): void
     {
         $table = $this->getTable();
         $table->getSchema()->removeColumn('created')->removeColumn('modified');
@@ -228,10 +217,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testUseImmutable
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testUseImmutable()
+    public function testUseImmutable(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -253,10 +241,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * tests using non-DateTimeType throws runtime exception
-     *
-     * @return void
      */
-    public function testNonDateTimeTypeException()
+    public function testNonDateTimeTypeException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('TimestampBehavior only supports columns of type DateTimeType.');
@@ -279,10 +265,9 @@ class TimestampBehaviorTest extends TestCase
     /**
      * testInvalidEventConfig
      *
-     * @return void
      * @triggers Model.beforeSave
      */
-    public function testInvalidEventConfig()
+    public function testInvalidEventConfig(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid');
@@ -297,10 +282,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testGetTimestamp
-     *
-     * @return void
      */
-    public function testGetTimestamp()
+    public function testGetTimestamp(): void
     {
         $table = $this->getTable();
         $behavior = new TimestampBehavior($table);
@@ -318,10 +301,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testGetTimestampPersists
-     *
-     * @return void
      */
-    public function testGetTimestampPersists()
+    public function testGetTimestampPersists(): void
     {
         $table = $this->getTable();
         $behavior = new TimestampBehavior($table);
@@ -338,10 +319,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testGetTimestampRefreshes
-     *
-     * @return void
      */
-    public function testGetTimestampRefreshes()
+    public function testGetTimestampRefreshes(): void
     {
         $table = $this->getTable();
         $behavior = new TimestampBehavior($table);
@@ -358,10 +337,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testSetTimestampExplicit
-     *
-     * @return void
      */
-    public function testSetTimestampExplicit()
+    public function testSetTimestampExplicit(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -379,10 +356,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testTouch
-     *
-     * @return void
      */
-    public function testTouch()
+    public function testTouch(): void
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
@@ -402,10 +377,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testTouchNoop
-     *
-     * @return void
      */
-    public function testTouchNoop()
+    public function testTouchNoop(): void
     {
         $table = $this->getTable();
         $config = [
@@ -429,10 +402,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * testTouchCustomEvent
-     *
-     * @return void
      */
-    public function testTouchCustomEvent()
+    public function testTouchCustomEvent(): void
     {
         $table = $this->getTable();
         $settings = ['events' => ['Something.special' => ['date_specialed' => 'always']]];
@@ -453,10 +424,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * Test that calling save, triggers an insert including the created and updated field values
-     *
-     * @return void
      */
-    public function testSaveTriggersInsert()
+    public function testSaveTriggersInsert(): void
     {
         $this->loadFixtures('Users');
 
@@ -483,10 +452,8 @@ class TimestampBehaviorTest extends TestCase
 
     /**
      * Helper method to get Table instance with created/modified column
-     *
-     * @return \Cake\ORM\Table
      */
-    protected function getTable()
+    protected function getTable(): Table
     {
         $schema = [
             'created' => ['type' => 'datetime'],

--- a/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/ORM/Behavior/Translate/TranslateTraitTest.php
@@ -27,10 +27,8 @@ class TranslateTraitTest extends TestCase
 {
     /**
      * Tests that missing translation entries are created automatically
-     *
-     * @return void
      */
-    public function testTranslationCreate()
+    public function testTranslationCreate(): void
     {
         $entity = new TranslateTestEntity();
         $entity->translation('eng')->set('title', 'My Title');
@@ -45,10 +43,8 @@ class TranslateTraitTest extends TestCase
 
     /**
      * Tests that modifying existing translation entries work
-     *
-     * @return void
      */
-    public function testTranslationModify()
+    public function testTranslationModify(): void
     {
         $entity = new TranslateTestEntity();
         $entity->set('_translations', [
@@ -61,10 +57,8 @@ class TranslateTraitTest extends TestCase
 
     /**
      * Tests empty translations.
-     *
-     * @return void
      */
-    public function testTranslationEmpty()
+    public function testTranslationEmpty(): void
     {
         $entity = new TranslateTestEntity();
         $entity->set('_translations', [
@@ -79,10 +73,8 @@ class TranslateTraitTest extends TestCase
      * Tests that just accessing the translation will mark the property as dirty, this
      * is to facilitate the saving process by not having to remember to mark the property
      * manually
-     *
-     * @return void
      */
-    public function testTranslationDirty()
+    public function testTranslationDirty(): void
     {
         $entity = new TranslateTestEntity();
         $entity->set('_translations', [

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -52,8 +52,6 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * setUpBeforeClass
-     *
-     * @return void
      */
     public static function setUpBeforeClass(): void
     {
@@ -64,8 +62,6 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * tearDownAfterClass
-     *
-     * @return void
      */
     public static function tearDownAfterClass(): void
     {
@@ -79,10 +75,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      *
      * The hasOneAlias is used for the has-one translation, the translationTable is used
      * with findTranslations
-     *
-     * @return void
      */
-    public function testDefaultAliases()
+    public function testDefaultAliases(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->getTable();
@@ -107,10 +101,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Check things are setup correctly by default for plugin models
-     *
-     * @return void
      */
-    public function testDefaultPluginAliases()
+    public function testDefaultPluginAliases(): void
     {
         $table = $this->getTableLocator()->get('SomeRandomPlugin.Articles');
 
@@ -151,7 +143,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * which is used to determine the the translation table/association name only in the
      * shadow translate behavior
      */
-    public function testAutoReferenceName()
+    public function testAutoReferenceName(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->getTable();
@@ -179,10 +171,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * The parent test is EAV specific. Test that the config reflects the referenceName -
      * which is used to determine the the translation table/association name only in the
      * shadow translate behavior
-     *
-     * @return void
      */
-    public function testChangingReferenceName()
+    public function testChangingReferenceName(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->getTable();
@@ -211,10 +201,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * Allow usage without specifying fields explicitly
      *
      * Fields are only detected when necessary, one of those times is a fine with fields.
-     *
-     * @return void
      */
-    public function testAutoFieldDetection()
+    public function testAutoFieldDetection(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -233,10 +221,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * testTranslationTableConfig
-     *
-     * @return void
      */
-    public function testTranslationTableConfig()
+    public function testTranslationTableConfig(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -255,10 +241,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * By inspecting the sql generated, verify that if there is a need for the translation
      * table to be included in the query it is present, and when there is no clear need -
      * that it is not.
-     *
-     * @return void
      */
-    public function testNoUnnecessaryJoins()
+    public function testNoUnnecessaryJoins(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -289,10 +273,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Join when translations are necessary
-     *
-     * @return void
      */
-    public function testNecessaryJoinsSelect()
+    public function testNecessaryJoinsSelect(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -322,10 +304,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Join when translations are necessary
-     *
-     * @return void
      */
-    public function testNecessaryJoinsWhere()
+    public function testNecessaryJoinsWhere(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -341,10 +321,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Join when translations are necessary
-     *
-     * @return void
      */
-    public function testNecessaryJoinsConfig()
+    public function testNecessaryJoinsConfig(): void
     {
         $table = $this->getTableLocator()->get('Articles');
 
@@ -375,10 +353,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * testTraversingWhereClauseWithNonStringField
-     *
-     * @return void
      */
-    public function testTraversingWhereClauseWithNonStringField()
+    public function testTraversingWhereClauseWithNonStringField(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -397,10 +373,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Join when translations are necessary
-     *
-     * @return void
      */
-    public function testNecessaryJoinsOrder()
+    public function testNecessaryJoinsOrder(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -427,10 +401,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * Different locales are used on each table object just to make any resulting
      * confusion easier to identify as neither the original or translated values
      * overlap between the two records.
-     *
-     * @return void
      */
-    public function testSelfJoin()
+    public function testSelfJoin(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -470,10 +442,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Verify it is not necessary for a translated field to exist in the master table
-     *
-     * @return void
      */
-    public function testVirtualTranslationField()
+    public function testVirtualTranslationField(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -493,10 +463,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests that after deleting a translated entity, all translations are also removed
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -511,10 +479,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * testNoAmbiguousFields
-     *
-     * @return void
      */
-    public function testNoAmbiguousFields()
+    public function testNoAmbiguousFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -535,10 +501,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * testNoAmbiguousConditions
-     *
-     * @return void
      */
-    public function testNoAmbiguousConditions()
+    public function testNoAmbiguousConditions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -559,10 +523,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * testNoAmbiguousOrder
-     *
-     * @return void
      */
-    public function testNoAmbiguousOrder()
+    public function testNoAmbiguousOrder(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -586,10 +548,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * If results are unhydrated, it should still work
-     *
-     * @return void
      */
-    public function testUnhydratedResults()
+    public function testUnhydratedResults(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -603,10 +563,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * A find containing another association should act the same whether translated or not
-     *
-     * @return void
      */
-    public function testFindWithAssociations()
+    public function testFindWithAssociations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -638,10 +596,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Test that when finding BTM associations, the contained BTM data is also translated.
-     *
-     * @return void
      */
-    public function testFindWithBTMAssociations()
+    public function testFindWithBTMAssociations(): void
     {
         $Articles = $this->getTableLocator()->get('Articles');
         $Tags = $this->getTableLocator()->get('Tags');
@@ -705,20 +661,16 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * that's incompatible with the shadow-translate behavior, since the schema
      * dictates what fields to expect to be translated and doesn't permit any EAV
      * style translations
-     *
-     * @return void
      */
-    public function testFindTranslations()
+    public function testFindTranslations(): void
     {
         $this->assertTrue(true, 'Skipped');
     }
 
     /**
      * By default empty translations should be honored
-     *
-     * @return void
      */
-    public function testEmptyTranslationsDefaultBehavior()
+    public function testEmptyTranslationsDefaultBehavior(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -732,10 +684,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests that allowEmptyTranslations takes effect
-     *
-     * @return void
      */
-    public function testEmptyTranslations()
+    public function testEmptyTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -751,10 +701,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests using FunctionExpression
-     *
-     * @return void
      */
-    public function testUsingFunctionExpression()
+    public function testUsingFunctionExpression(): void
     {
         $this->skipIf(
             ConnectionManager::get('test')->getDriver() instanceof Postgres,
@@ -795,10 +743,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * With a standard baked model the accessible property is defined, that'll mean that
      * Setting fields such as id and locale will fail by default due to mass-assignment
      * protection. An exception is thrown if that happens
-     *
-     * @return void
      */
-    public function testSaveWithAccessibleFalse()
+    public function testSaveWithAccessibleFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->setEntityClass(TranslateBakedArticle::class);
@@ -812,10 +758,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests translationField method for translated fields.
-     *
-     * @return void
      */
-    public function testTranslationFieldForTranslatedFields()
+    public function testTranslationFieldForTranslatedFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -865,10 +809,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      *
      * Had to override this method because the core method has a wacky check
      * for "description" field which doesn't even exist in ArticleFixture.
-     *
-     * @return void
      */
-    public function testSaveExistingRecordWithTranslatesField()
+    public function testSaveExistingRecordWithTranslatesField(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -906,10 +848,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Test save new entity with _translations field
-     *
-     * @return void
      */
-    public function testSaveNewRecordWithTranslatesField()
+    public function testSaveNewRecordWithTranslatesField(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -957,10 +897,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testAllowEmptyFalse()
+    public function testAllowEmptyFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title'], 'allowEmptyTranslations' => false]);
@@ -987,10 +925,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests adding new translation to a record with a missing translation
-     *
-     * @return void
      */
-    public function testAllowEmptyFalseWithNull()
+    public function testAllowEmptyFalseWithNull(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'description'], 'allowEmptyTranslations' => false]);
@@ -1017,10 +953,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testMixedAllowEmptyFalse()
+    public function testMixedAllowEmptyFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body'], 'allowEmptyTranslations' => false]);
@@ -1050,10 +984,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testMultipleAllowEmptyFalse()
+    public function testMultipleAllowEmptyFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body'], 'allowEmptyTranslations' => false]);
@@ -1095,10 +1027,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
 
     /**
      * Test buildMarshalMap() builds new entities.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapBuildEntities()
+    public function testBuildMarshalMapBuildEntities(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         // Unlike test case of core Translate behavior "fields" is not set to
@@ -1131,9 +1061,8 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      * Used in the config tests to verify that a simple find still works
      *
      * @param string $tableAlias
-     * @return void
      */
-    protected function _testFind($tableAlias = 'Articles')
+    protected function _testFind($tableAlias = 'Articles'): void
     {
         $table = $this->getTableLocator()->get($tableAlias);
         $table->setLocale('eng');

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Behavior;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 use Cake\Database\Driver\Mysql;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
@@ -60,9 +61,8 @@ class TranslateBehaviorTest extends TestCase
      * Returns an array with all the translations found for a set of records
      *
      * @param \Traversable|array $data
-     * @return \Cake\Collection\CollectionInterface
      */
-    protected function _extractTranslations($data)
+    protected function _extractTranslations($data): CollectionInterface
     {
         return (new Collection($data))->map(function (EntityInterface $row) {
             $translations = $row->get('_translations');
@@ -78,10 +78,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that custom translation tables are respected
-     *
-     * @return void
      */
-    public function testCustomTranslationTable()
+    public function testCustomTranslationTable(): void
     {
         ConnectionManager::setConfig('custom_i18n_datasource', ['url' => getenv('DB_URL')]);
 
@@ -105,10 +103,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that the strategy can be changed for i18n
-     *
-     * @return void
      */
-    public function testStrategy()
+    public function testStrategy(): void
     {
         $table = $this->getTableLocator()->get('Articles');
 
@@ -125,10 +121,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that fields from a translated model are overridden
-     *
-     * @return void
      */
-    public function testFindSingleLocale()
+    public function testFindSingleLocale(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -161,10 +155,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that iterating in a formatResults() does not drop data.
-     *
-     * @return void
      */
-    public function testFindTranslationsFormatResultsIteration()
+    public function testFindTranslationsFormatResultsIteration(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -192,10 +184,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that fields from a translated model use the I18n class locale
      * and that it propagates to associated models
-     *
-     * @return void
      */
-    public function testFindSingleLocaleAssociatedEnv()
+    public function testFindSingleLocaleAssociatedEnv(): void
     {
         I18n::setLocale('eng');
 
@@ -295,10 +285,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that fields from a translated model are not overridden if translation
      * is null
-     *
-     * @return void
      */
-    public function testFindSingleLocaleWithNullTranslation()
+    public function testFindSingleLocaleWithNullTranslation(): void
     {
         $table = $this->getTableLocator()->get('Comments');
         $table->addBehavior('Translate', ['fields' => ['comment']]);
@@ -313,10 +301,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that overriding fields with the translate behavior works when
      * using conditions and that all other columns are preserved
-     *
-     * @return void
      */
-    public function testFindSingleLocaleWithgetConditions()
+    public function testFindSingleLocaleWithgetConditions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -341,10 +327,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests the locale setter/getter.
-     *
-     * @return void
      */
-    public function testSetGetLocale()
+    public function testSetGetLocale(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
@@ -363,10 +347,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests translationField method for translated fields.
-     *
-     * @return void
      */
-    public function testTranslationFieldForTranslatedFields()
+    public function testTranslationFieldForTranslatedFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -414,10 +396,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests translationField method for other fields.
-     *
-     * @return void
      */
-    public function testTranslationFieldForOtherFields()
+    public function testTranslationFieldForOtherFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -429,10 +409,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that translating fields work when other formatters are used
-     *
-     * @return void
      */
-    public function testFindList()
+    public function testFindList(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -445,10 +423,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that the query count return the correct results
-     *
-     * @return void
      */
-    public function testFindCount()
+    public function testFindCount(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -459,10 +435,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that it is possible to get all translated fields at once
-     *
-     * @return void
      */
-    public function testFindTranslations()
+    public function testFindTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -500,10 +474,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that it is possible to request just a few translations
-     *
-     * @return void
      */
-    public function testFindFilteredTranslations()
+    public function testFindFilteredTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -538,10 +510,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that it is possible to combine find('list') and find('translations')
-     *
-     * @return void
      */
-    public function testFindTranslationsList()
+    public function testFindTranslationsList(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -563,10 +533,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that you can both override fields and find all translations
-     *
-     * @return void
      */
-    public function testFindTranslationsWithFieldOverriding()
+    public function testFindTranslationsWithFieldOverriding(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -602,10 +570,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that fields can be overridden in a hasMany association
-     *
-     * @return void
      */
-    public function testFindSingleLocaleHasMany()
+    public function testFindSingleLocaleHasMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -632,10 +598,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that it is possible to bring translations from hasMany relations
-     *
-     * @return void
      */
-    public function testTranslationsHasMany()
+    public function testTranslationsHasMany(): void
     {
         // This test fails on mysql8 + php8 due to no data in the tables
         // We have been unable to explain the behavior so disabling for now
@@ -681,10 +645,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that it is possible to both override fields with a translation and
      * also find separately other translations
-     *
-     * @return void
      */
-    public function testTranslationsHasManyWithOverride()
+    public function testTranslationsHasManyWithOverride(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -734,10 +696,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that it is possible to translate belongsTo associations
-     *
-     * @return void
      */
-    public function testFindSingleLocaleBelongsto()
+    public function testFindSingleLocaleBelongsto(): void
     {
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
         $table = $this->getTableLocator()->get('Articles');
@@ -784,10 +744,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that it is possible to translate belongsTo associations using loadInto
-     *
-     * @return void
      */
-    public function testFindSingleLocaleBelongstoLoadInto()
+    public function testFindSingleLocaleBelongstoLoadInto(): void
     {
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
         $table = $this->getTableLocator()->get('Articles');
@@ -813,10 +771,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that it is possible to translate belongsToMany associations
-     *
-     * @return void
      */
-    public function testFindSingleLocaleBelongsToMany()
+    public function testFindSingleLocaleBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $specialTags */
@@ -836,10 +792,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that parent entity isn't dirty when containing a translated association
-     *
-     * @return void
      */
-    public function testGetAssociationNotDirtyBelongsTo()
+    public function testGetAssociationNotDirtyBelongsTo(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $authors */
@@ -864,10 +818,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that parent entity isn't dirty when containing a translated association
-     *
-     * @return void
      */
-    public function testGetAssociationNotDirtyHasOne()
+    public function testGetAssociationNotDirtyHasOne(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasOne('Articles');
@@ -889,10 +841,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that updating an existing record translations work
-     *
-     * @return void
      */
-    public function testUpdateSingleLocale()
+    public function testUpdateSingleLocale(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -927,10 +877,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testInsertNewTranslations()
+    public function testInsertNewTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -959,10 +907,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testAllowEmptyFalse()
+    public function testAllowEmptyFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title'], 'allowEmptyTranslations' => false]);
@@ -989,10 +935,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests adding new translation to a record with a missing translation
-     *
-     * @return void
      */
-    public function testAllowEmptyFalseWithNull()
+    public function testAllowEmptyFalseWithNull(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'description'], 'allowEmptyTranslations' => false]);
@@ -1019,10 +963,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testMixedAllowEmptyFalse()
+    public function testMixedAllowEmptyFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body'], 'allowEmptyTranslations' => false]);
@@ -1063,10 +1005,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests adding new translation to a record
-     *
-     * @return void
      */
-    public function testMultipleAllowEmptyFalse()
+    public function testMultipleAllowEmptyFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body'], 'allowEmptyTranslations' => false]);
@@ -1128,10 +1068,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that it is possible to use the _locale property to specify the language
      * to use for saving an entity
-     *
-     * @return void
      */
-    public function testUpdateTranslationWithLocaleInEntity()
+    public function testUpdateTranslationWithLocaleInEntity(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1157,10 +1095,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that translations are added to the whitelist of associations to be
      * saved
-     *
-     * @return void
      */
-    public function testSaveTranslationWithAssociationWhitelist()
+    public function testSaveTranslationWithAssociationWhitelist(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -1179,10 +1115,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that after deleting a translated entity, all translations are also removed
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1198,10 +1132,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests saving multiple translations at once when the translations already
      * exist in the database
-     *
-     * @return void
      */
-    public function testSaveMultipleTranslations()
+    public function testSaveMultipleTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1222,10 +1154,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests saving multiple existing translations and adding new ones
-     *
-     * @return void
      */
-    public function testSaveMultipleNewTranslations()
+    public function testSaveMultipleNewTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1251,10 +1181,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that iterating a resultset twice when using the translations finder
      * will not cause any errors nor information loss
-     *
-     * @return void
      */
-    public function testUseCountInFindTranslations()
+    public function testUseCountInFindTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1268,10 +1196,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that multiple translations saved when having a default locale
      * are correctly saved
-     *
-     * @return void
      */
-    public function testSavingWithNonDefaultLocale()
+    public function testSavingWithNonDefaultLocale(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1295,10 +1221,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that translation queries are added to union queries as well.
-     *
-     * @return void
      */
-    public function testTranslationWithUnionQuery()
+    public function testTranslationWithUnionQuery(): void
     {
         $table = $this->getTableLocator()->get('Comments');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
@@ -1316,10 +1240,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests the use of `referenceName` config option.
-     *
-     * @return void
      */
-    public function testAutoReferenceName()
+    public function testAutoReferenceName(): void
     {
         $table = $this->getTableLocator()->get('Articles');
 
@@ -1347,10 +1269,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests the use of unconventional `referenceName` config option.
-     *
-     * @return void
      */
-    public function testChangingReferenceName()
+    public function testChangingReferenceName(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->setAlias('FavoritePost');
@@ -1378,10 +1298,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that onlyTranslated will remove records from the result set
      * if they are not fully translated
-     *
-     * @return void
      */
-    public function testFilterUntranslated()
+    public function testFilterUntranslated(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
@@ -1402,10 +1320,8 @@ class TranslateBehaviorTest extends TestCase
      * Tests that records not translated in the current locale will not be
      * present in the results for the translations finder, and also proves
      * that this can be overridden.
-     *
-     * @return void
      */
-    public function testFilterUntranslatedWithFinder()
+    public function testFilterUntranslatedWithFinder(): void
     {
         $table = $this->getTableLocator()->get('Comments');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
@@ -1432,10 +1348,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that allowEmptyTranslations takes effect
-     *
-     * @return void
      */
-    public function testEmptyTranslations()
+    public function testEmptyTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         /** @var \Cake\ORM\Table|\Cake\ORM\Behavior\TranslateBehavior $table */
@@ -1450,10 +1364,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test save with clean translate fields
-     *
-     * @return void
      */
-    public function testSaveWithCleanFields()
+    public function testSaveWithCleanFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title']]);
@@ -1469,10 +1381,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test save new entity with _translations field
-     *
-     * @return void
      */
-    public function testSaveNewRecordWithTranslatesField()
+    public function testSaveNewRecordWithTranslatesField(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -1518,10 +1428,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests adding new translation to a record where the only field is the translated one and it's not the default locale
-     *
-     * @return void
      */
-    public function testSaveNewRecordWithOnlyTranslationsNotDefaultLocale()
+    public function testSaveNewRecordWithOnlyTranslationsNotDefaultLocale(): void
     {
         $table = $this->getTableLocator()->get('Sections');
         $table->addBehavior('Translate', [
@@ -1556,10 +1464,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Test that existing records can be updated when only translations
      * are modified/dirty.
-     *
-     * @return void
      */
-    public function testSaveExistingRecordOnlyTranslations()
+    public function testSaveExistingRecordOnlyTranslations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1589,10 +1495,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test update entity with _translations field.
-     *
-     * @return void
      */
-    public function testSaveExistingRecordWithTranslatesField()
+    public function testSaveExistingRecordWithTranslatesField(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1631,10 +1535,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that default locale saves ok.
-     *
-     * @return void
      */
-    public function testSaveDefaultLocale()
+    public function testSaveDefaultLocale(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -1657,10 +1559,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Test that when `defaultLocale` feature is disabled translations table
      * is always used.
-     *
-     * @return void
      */
-    public function testSaveDefaultLocaleFalse()
+    public function testSaveDefaultLocaleFalse(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -1705,10 +1605,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that translations are added to the whitelist of associations to be
      * saved
-     *
-     * @return void
      */
-    public function testSaveTranslationDefaultLocale()
+    public function testSaveTranslationDefaultLocale(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -1740,10 +1638,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Test that no properties are enabled when the translations
      * option is off.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapTranslationsOff()
+    public function testBuildMarshalMapTranslationsOff(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1756,10 +1652,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test building a marshal map with translations on.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapTranslationsOn()
+    public function testBuildMarshalMapTranslationsOn(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1777,10 +1671,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test marshalling non-array data
-     *
-     * @return void
      */
-    public function testBuildMarshalMapNonArrayData()
+    public function testBuildMarshalMapNonArrayData(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1796,10 +1688,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test buildMarshalMap() builds new entities.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapBuildEntities()
+    public function testBuildMarshalMapBuildEntities(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
@@ -1828,10 +1718,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that validation errors are added to the original entity.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapBuildEntitiesValidationErrors()
+    public function testBuildMarshalMapBuildEntitiesValidationErrors(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -1869,10 +1757,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that marshalling updates existing translation entities.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapUpdateExistingEntities()
+    public function testBuildMarshalMapUpdateExistingEntities(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -1911,10 +1797,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that updating translation records works with validations.
-     *
-     * @return void
      */
-    public function testBuildMarshalMapUpdateEntitiesValidationErrors()
+    public function testBuildMarshalMapUpdateEntitiesValidationErrors(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
@@ -1955,10 +1839,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that the behavior uses associations' locator.
-     *
-     * @return void
      */
-    public function testDefaultTableLocator()
+    public function testDefaultTableLocator(): void
     {
         $locator = new TableLocator();
 
@@ -1977,10 +1859,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Test that the behavior uses a custom locator.
-     *
-     * @return void
      */
-    public function testCustomTableLocator()
+    public function testCustomTableLocator(): void
     {
         $locator = new TableLocator();
 
@@ -2000,10 +1880,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that using deep matching doesn't cause an association property to be created.
-     *
-     * @return void
      */
-    public function testDeepMatchingDoesNotCreateAssociationProperty()
+    public function testDeepMatchingDoesNotCreateAssociationProperty(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -2029,10 +1907,8 @@ class TranslateBehaviorTest extends TestCase
 
     /**
      * Tests that the _locale property is set on the entity in the _matchingData property.
-     *
-     * @return void
      */
-    public function testLocalePropertyIsSetInMatchingData()
+    public function testLocalePropertyIsSetInMatchingData(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -2055,10 +1931,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that the _locale property is set on the entity in the _matchingData property
      * when using deep matching.
-     *
-     * @return void
      */
-    public function testLocalePropertyIsSetInMatchingDataWhenUsingDeepMatching()
+    public function testLocalePropertyIsSetInMatchingDataWhenUsingDeepMatching(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -2087,10 +1961,8 @@ class TranslateBehaviorTest extends TestCase
     /**
      * Tests that the _locale property is set on the entity in the _matchingData property
      * when using contained matching.
-     *
-     * @return void
      */
-    public function testLocalePropertyIsSetInMatchingDataWhenUsingContainedMatching()
+    public function testLocalePropertyIsSetInMatchingDataWhenUsingContainedMatching(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('Articles');

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -39,9 +39,6 @@ class TreeBehaviorTest extends TestCase
      */
     protected $table;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -55,10 +52,8 @@ class TreeBehaviorTest extends TestCase
      *
      * Make sure the assert method acts as you'd expect, this is the expected
      * initial db state
-     *
-     * @return void
      */
-    public function testAssertMpttValues()
+    public function testAssertMpttValues(): void
     {
         $expected = [
             ' 1:20 -  1:electronics',
@@ -109,10 +104,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the find('path') method
-     *
-     * @return void
      */
-    public function testFindPath()
+    public function testFindPath(): void
     {
         $nodes = $this->table->find('path', ['for' => 9]);
         $this->assertEquals([1, 6, 9], $nodes->extract('id')->toArray());
@@ -146,10 +139,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the childCount() method
-     *
-     * @return void
      */
-    public function testChildCount()
+    public function testChildCount(): void
     {
         // direct children for the root node
         $table = $this->table;
@@ -181,10 +172,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests that childCount will provide the correct lft and rght values
-     *
-     * @return void
      */
-    public function testChildCountNoTreeColumns()
+    public function testChildCountNoTreeColumns(): void
     {
         $table = $this->table;
         $node = $table->get(6);
@@ -196,10 +185,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the childCount() plus callable scoping
-     *
-     * @return void
      */
-    public function testScopeCallable()
+    public function testScopeCallable(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', [
@@ -213,10 +200,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the find('children') method
-     *
-     * @return void
      */
-    public function testFindChildren()
+    public function testFindChildren(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -238,10 +223,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the find('children') plus scope=null
-     *
-     * @return void
      */
-    public function testScopeNull()
+    public function testScopeNull(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree');
@@ -253,10 +236,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests that find('children') will throw an exception if the node was not found
-     *
-     * @return void
      */
-    public function testFindChildrenException()
+    public function testFindChildrenException(): void
     {
         $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $table = $this->getTableLocator()->get('MenuLinkTrees');
@@ -266,17 +247,15 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the find('treeList') method
-     *
-     * @return void
      */
-    public function testFindTreeList()
+    public function testFindTreeList(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $query = $table->find('treeList');
 
         $result = null;
-        $query->clause('order')->iterateParts(function ($dir, $field) use (&$result) {
+        $query->clause('order')->iterateParts(function ($dir, $field) use (&$result): void {
             $result = $field;
         });
         $this->assertSame('MenuLinkTrees.lft', $result);
@@ -297,10 +276,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the find('treeList') method after moveUp, moveDown
-     *
-     * @return void
      */
-    public function testFindTreeListAfterMove()
+    public function testFindTreeListAfterMove(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -336,10 +313,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the find('treeList') method with custom options
-     *
-     * @return void
      */
-    public function testFindTreeListCustom()
+    public function testFindTreeListCustom(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -361,10 +336,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the testFormatTreeListCustom() method.
-     *
-     * @return void
      */
-    public function testFormatTreeListCustom()
+    public function testFormatTreeListCustom(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree');
@@ -391,10 +364,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the moveUp() method
-     *
-     * @return void
      */
-    public function testMoveUp()
+    public function testMoveUp(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -448,10 +419,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a node with no siblings
-     *
-     * @return void
      */
-    public function testMoveLeaf()
+    public function testMoveLeaf(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -472,10 +441,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a node to the top
-     *
-     * @return void
      */
-    public function testMoveTop()
+    public function testMoveTop(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -495,10 +462,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a node with no lft and rght
-     *
-     * @return void
      */
-    public function testMoveNoTreeColumns()
+    public function testMoveNoTreeColumns(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -522,10 +487,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the moveDown() method
-     *
-     * @return void
      */
-    public function testMoveDown()
+    public function testMoveDown(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -577,10 +540,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a node that has no siblings
-     *
-     * @return void
      */
-    public function testMoveLeafDown()
+    public function testMoveLeafDown(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -601,10 +562,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a node to the bottom
-     *
-     * @return void
      */
-    public function testMoveToBottom()
+    public function testMoveToBottom(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -625,10 +584,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a node with no lft and rght columns
-     *
-     * @return void
      */
-    public function testMoveDownNoTreeColumns()
+    public function testMoveDownNoTreeColumns(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -650,7 +607,7 @@ class TreeBehaviorTest extends TestCase
         $this->assertMpttValues($expected, $table);
     }
 
-    public function testMoveDownMultiplePositions()
+    public function testMoveDownMultiplePositions(): void
     {
         $node = $this->table->moveDown($this->table->get(3), 2);
         $this->assertEquals(['lft' => 7, 'rght' => 8], $node->extract(['lft', 'rght']));
@@ -672,10 +629,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the recover function
-     *
-     * @return void
      */
-    public function testRecover()
+    public function testRecover(): void
     {
         $table = $this->table;
 
@@ -711,10 +666,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests the recover function with a custom scope
-     *
-     * @return void
      */
-    public function testRecoverScoped()
+    public function testRecoverScoped(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -752,10 +705,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test recover function with a custom order clause
-     *
-     * @return void
      */
-    public function testRecoverWithCustomOrder()
+    public function testRecoverWithCustomOrder(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu'], 'recoverOrder' => ['MenuLinkTrees.title' => 'desc']]);
@@ -777,10 +728,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests adding a new orphan node
-     *
-     * @return void
      */
-    public function testAddOrphan()
+    public function testAddOrphan(): void
     {
         $table = $this->table;
         $entity = new Entity(
@@ -810,10 +759,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests that adding a child node as a descendant of one of the roots works
-     *
-     * @return void
      */
-    public function testAddMiddle()
+    public function testAddMiddle(): void
     {
         $table = $this->table;
         $entity = new Entity(
@@ -843,10 +790,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests adding a leaf to the tree
-     *
-     * @return void
      */
-    public function testAddLeaf()
+    public function testAddLeaf(): void
     {
         $table = $this->table;
         $entity = new Entity(
@@ -876,10 +821,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests adding a root element to the tree when all other root elements have children
-     *
-     * @return void
      */
-    public function testAddRoot()
+    public function testAddRoot(): void
     {
         $table = $this->table;
 
@@ -913,10 +856,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests making a node its own parent as an existing entity
-     *
-     * @return void
      */
-    public function testReParentSelf()
+    public function testReParentSelf(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot set a node\'s parent as itself');
@@ -927,10 +868,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests making a node its own parent as a new entity.
-     *
-     * @return void
      */
-    public function testReParentSelfNewEntity()
+    public function testReParentSelfNewEntity(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot set a node\'s parent as itself');
@@ -942,10 +881,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a subtree to the right
-     *
-     * @return void
      */
-    public function testReParentSubTreeRight()
+    public function testReParentSubTreeRight(): void
     {
         $table = $this->table;
         $entity = $table->get(2);
@@ -972,10 +909,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a subtree to the left
-     *
-     * @return void
      */
-    public function testReParentSubTreeLeft()
+    public function testReParentSubTreeLeft(): void
     {
         $table = $this->table;
         $entity = $table->get(6);
@@ -1002,10 +937,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test moving a leaft to the left
-     *
-     * @return void
      */
-    public function testReParentLeafLeft()
+    public function testReParentLeafLeft(): void
     {
         $table = $this->table;
         $entity = $table->get(10);
@@ -1032,10 +965,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test moving a leaf to the left
-     *
-     * @return void
      */
-    public function testReParentLeafRight()
+    public function testReParentLeafRight(): void
     {
         $table = $this->table;
         $entity = $table->get(5);
@@ -1064,10 +995,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a subtree with a node having no lft and rght columns
-     *
-     * @return void
      */
-    public function testReParentNoTreeColumns()
+    public function testReParentNoTreeColumns(): void
     {
         $table = $this->table;
         $entity = $table->get(6);
@@ -1096,10 +1025,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a subtree as a new root
-     *
-     * @return void
      */
-    public function testRootingSubTree()
+    public function testRootingSubTree(): void
     {
         $table = $this->table;
         $entity = $table->get(2);
@@ -1126,10 +1053,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests moving a subtree with no tree columns
-     *
-     * @return void
      */
-    public function testRootingNoTreeColumns()
+    public function testRootingNoTreeColumns(): void
     {
         $table = $this->table;
         $entity = $table->get(2);
@@ -1158,10 +1083,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests that trying to create a cycle throws an exception
-     *
-     * @return void
      */
-    public function testReparentCycle()
+    public function testReparentCycle(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot use node "5" as parent for entity "2"');
@@ -1173,10 +1096,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests deleting a leaf in the tree
-     *
-     * @return void
      */
-    public function testDeleteLeaf()
+    public function testDeleteLeaf(): void
     {
         $table = $this->table;
         $entity = $table->get(4);
@@ -1199,10 +1120,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests deleting a subtree
-     *
-     * @return void
      */
-    public function testDeleteSubTree()
+    public function testDeleteSubTree(): void
     {
         $table = $this->table;
         $entity = $table->get(6);
@@ -1221,10 +1140,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests deleting a subtree in a scoped tree
-     *
-     * @return void
      */
-    public function testDeleteSubTreeScopedTree()
+    public function testDeleteSubTreeScopedTree(): void
     {
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
@@ -1258,10 +1175,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test deleting a root node
-     *
-     * @return void
      */
-    public function testDeleteRoot()
+    public function testDeleteRoot(): void
     {
         $table = $this->table;
         $entity = $table->get(1);
@@ -1275,10 +1190,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test deleting a node with no tree columns
-     *
-     * @return void
      */
-    public function testDeleteRootNoTreeColumns()
+    public function testDeleteRootNoTreeColumns(): void
     {
         $table = $this->table;
         $entity = $table->get(1);
@@ -1294,10 +1207,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests that a leaf can be taken out of the tree and put in as a root
-     *
-     * @return void
      */
-    public function testRemoveFromLeafFromTree()
+    public function testRemoveFromLeafFromTree(): void
     {
         $table = $this->table;
         $entity = $table->get(10);
@@ -1325,10 +1236,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test removing a middle node from a tree
-     *
-     * @return void
      */
-    public function testRemoveMiddleNodeFromTree()
+    public function testRemoveMiddleNodeFromTree(): void
     {
         $table = $this->table;
         $entity = $table->get(6);
@@ -1356,10 +1265,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests removing the root of a tree
-     *
-     * @return void
      */
-    public function testRemoveRootFromTree()
+    public function testRemoveRootFromTree(): void
     {
         $table = $this->table;
         $entity = $table->get(1);
@@ -1388,10 +1295,8 @@ class TreeBehaviorTest extends TestCase
     /**
      * Tests that using associations having tree fields in the schema
      * does not generate SQL errors
-     *
-     * @return void
      */
-    public function testFindPathWithAssociation()
+    public function testFindPathWithAssociation(): void
     {
         $table = $this->table;
         $this->getTableLocator()->get('FriendlyTrees', [
@@ -1409,10 +1314,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Tests getting the depth level of a node in the tree.
-     *
-     * @return void
      */
-    public function testGetLevel()
+    public function testGetLevel(): void
     {
         $entity = $this->table->get(8);
         $result = $this->table->getLevel($entity);
@@ -1430,10 +1333,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test setting level for new nodes
-     *
-     * @return void
      */
-    public function testSetLevelNewNode()
+    public function testSetLevelNewNode(): void
     {
         $this->table->behaviors()->Tree->setConfig('level', 'depth');
 
@@ -1455,10 +1356,8 @@ class TreeBehaviorTest extends TestCase
 
     /**
      * Test setting level for existing nodes
-     *
-     * @return void
      */
-    public function testSetLevelExistingNode()
+    public function testSetLevelExistingNode(): void
     {
         $this->table->behaviors()->Tree->setConfig('level', 'depth');
 
@@ -1499,9 +1398,8 @@ class TreeBehaviorTest extends TestCase
      * @param array $expected tree state to be expected
      * @param \Cake\ORM\Table $table Table instance
      * @param \Cake\ORM\Query $query Optional query object
-     * @return void
      */
-    public function assertMpttValues($expected, $table, $query = null)
+    public function assertMpttValues($expected, $table, $query = null): void
     {
         $query = $query ?: $table->find();
         $primaryKey = $table->getPrimaryKey();

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -33,8 +33,6 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,8 +45,6 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -59,10 +55,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test classname resolution.
-     *
-     * @return void
      */
-    public function testClassName()
+    public function testClassName(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -79,10 +73,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test loading behaviors.
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $config = ['alias' => 'Sluggable', 'replacement' => '-'];
@@ -96,10 +88,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() binding listeners.
-     *
-     * @return void
      */
-    public function testLoadBindEvents()
+    public function testLoadBindEvents(): void
     {
         $result = $this->EventManager->listeners('Model.beforeFind');
         $this->assertCount(0, $result);
@@ -113,10 +103,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() with enabled = false
-     *
-     * @return void
      */
-    public function testLoadEnabledFalse()
+    public function testLoadEnabledFalse(): void
     {
         $result = $this->EventManager->listeners('Model.beforeFind');
         $this->assertCount(0, $result);
@@ -128,10 +116,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test loading plugin behaviors
-     *
-     * @return void
      */
-    public function testLoadPlugin()
+    public function testLoadPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Behaviors->load('TestPlugin.PersisterOne');
@@ -149,10 +135,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() on undefined class
-     *
-     * @return void
      */
-    public function testLoadMissingClass()
+    public function testLoadMissingClass(): void
     {
         $this->expectException(\Cake\ORM\Exception\MissingBehaviorException::class);
         $this->Behaviors->load('DoesNotExist');
@@ -160,10 +144,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() duplicate method error
-     *
-     * @return void
      */
-    public function testLoadDuplicateMethodError()
+    public function testLoadDuplicateMethodError(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"');
@@ -173,10 +155,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() duplicate method aliasing
-     *
-     * @return void
      */
-    public function testLoadDuplicateMethodAliasing()
+    public function testLoadDuplicateMethodAliasing(): void
     {
         $this->Behaviors->load('Tree');
         $this->Behaviors->load('Duplicate', [
@@ -192,10 +172,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() duplicate finder error
-     *
-     * @return void
      */
-    public function testLoadDuplicateFinderError()
+    public function testLoadDuplicateFinderError(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"');
@@ -205,10 +183,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test load() duplicate finder aliasing
-     *
-     * @return void
      */
-    public function testLoadDuplicateFinderAliasing()
+    public function testLoadDuplicateFinderAliasing(): void
     {
         $this->Behaviors->load('Tree');
         $this->Behaviors->load('Duplicate', [
@@ -221,10 +197,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * test hasMethod()
-     *
-     * @return void
      */
-    public function testHasMethod()
+    public function testHasMethod(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $this->Behaviors->load('TestPlugin.PersisterOne');
@@ -247,10 +221,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test hasFinder() method.
-     *
-     * @return void
      */
-    public function testHasFinder()
+    public function testHasFinder(): void
     {
         $this->Behaviors->load('Sluggable');
 
@@ -268,10 +240,8 @@ class BehaviorRegistryTest extends TestCase
      *
      * Setup a behavior, then replace it with a mock to verify methods are called.
      * use dummy return values to verify the return value makes it back
-     *
-     * @return void
      */
-    public function testCall()
+    public function testCall(): void
     {
         $this->Behaviors->load('Sluggable');
         $mockedBehavior = $this->getMockBuilder('Cake\ORM\Behavior')
@@ -292,7 +262,7 @@ class BehaviorRegistryTest extends TestCase
     /**
      * Test errors on unknown methods.
      */
-    public function testCallError()
+    public function testCallError(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call "nope"');
@@ -305,10 +275,8 @@ class BehaviorRegistryTest extends TestCase
      *
      * Setup a behavior, then replace it with a mock to verify methods are called.
      * use dummy return values to verify the return value makes it back
-     *
-     * @return void
      */
-    public function testCallFinder()
+    public function testCallFinder(): void
     {
         $this->Behaviors->load('Sluggable');
         $mockedBehavior = $this->getMockBuilder('Cake\ORM\Behavior')
@@ -330,7 +298,7 @@ class BehaviorRegistryTest extends TestCase
     /**
      * Test errors on unknown methods.
      */
-    public function testCallFinderError()
+    public function testCallFinderError(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call finder "nope"');
@@ -341,7 +309,7 @@ class BehaviorRegistryTest extends TestCase
     /**
      * Test errors on unloaded behavior methods.
      */
-    public function testUnloadBehaviorThenCall()
+    public function testUnloadBehaviorThenCall(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call "slugify" it does not belong to any attached behavior.');
@@ -354,7 +322,7 @@ class BehaviorRegistryTest extends TestCase
     /**
      * Test errors on unloaded behavior finders.
      */
-    public function testUnloadBehaviorThenCallFinder()
+    public function testUnloadBehaviorThenCallFinder(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call finder "noslug" it does not belong to any attached behavior.');
@@ -366,10 +334,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test that unloading then reloading a behavior does not throw any errors.
-     *
-     * @return void
      */
-    public function testUnloadBehaviorThenReload()
+    public function testUnloadBehaviorThenReload(): void
     {
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
@@ -383,10 +349,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test that unloading a none existing behavior triggers an error.
-     *
-     * @return void
      */
-    public function testUnload()
+    public function testUnload(): void
     {
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
@@ -397,10 +361,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test that unloading a none existing behavior triggers an error.
-     *
-     * @return void
      */
-    public function testUnloadUnknown()
+    public function testUnloadUnknown(): void
     {
         $this->expectException(\Cake\ORM\Exception\MissingBehaviorException::class);
         $this->expectExceptionMessage('Behavior class FooBehavior could not be found.');
@@ -409,10 +371,8 @@ class BehaviorRegistryTest extends TestCase
 
     /**
      * Test setTable() method.
-     *
-     * @return void
      */
-    public function testSetTable()
+    public function testSetTable(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $table->expects($this->once())->method('getEventManager');

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -30,10 +30,8 @@ class BehaviorTest extends TestCase
 {
     /**
      * Test the side effects of the constructor.
-     *
-     * @return void
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $config = ['key' => 'value'];
@@ -43,10 +41,8 @@ class BehaviorTest extends TestCase
 
     /**
      * Test getting table instance.
-     *
-     * @return void
      */
-    public function testGetTable()
+    public function testGetTable(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
 
@@ -54,7 +50,7 @@ class BehaviorTest extends TestCase
         $this->assertSame($table, $behavior->table());
     }
 
-    public function testReflectionCache()
+    public function testReflectionCache(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test3Behavior($table);
@@ -72,10 +68,8 @@ class BehaviorTest extends TestCase
 
     /**
      * Test the default behavior of implementedEvents
-     *
-     * @return void
      */
-    public function testImplementedEvents()
+    public function testImplementedEvents(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new TestBehavior($table);
@@ -92,10 +86,8 @@ class BehaviorTest extends TestCase
 
     /**
      * Test that implementedEvents uses the priority setting.
-     *
-     * @return void
      */
-    public function testImplementedEventsWithPriority()
+    public function testImplementedEventsWithPriority(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new TestBehavior($table, ['priority' => 10]);
@@ -130,10 +122,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testImplementedMethods
-     *
-     * @return void
      */
-    public function testImplementedMethods()
+    public function testImplementedMethods(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table);
@@ -145,10 +135,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testImplementedMethodsAliased
-     *
-     * @return void
      */
-    public function testImplementedMethodsAliased()
+    public function testImplementedMethodsAliased(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
@@ -164,10 +152,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testImplementedMethodsDisabled
-     *
-     * @return void
      */
-    public function testImplementedMethodsDisabled()
+    public function testImplementedMethodsDisabled(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
@@ -179,10 +165,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testImplementedFinders
-     *
-     * @return void
      */
-    public function testImplementedFinders()
+    public function testImplementedFinders(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table);
@@ -194,10 +178,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testImplementedFindersAliased
-     *
-     * @return void
      */
-    public function testImplementedFindersAliased()
+    public function testImplementedFindersAliased(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
@@ -213,10 +195,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testImplementedFindersDisabled
-     *
-     * @return void
      */
-    public function testImplementedFindersDisabled()
+    public function testImplementedFindersDisabled(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
@@ -229,10 +209,8 @@ class BehaviorTest extends TestCase
      * testVerifyConfig
      *
      * Don't expect an exception to be thrown
-     *
-     * @return void
      */
-    public function testVerifyConfig()
+    public function testVerifyConfig(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table);
@@ -244,10 +222,8 @@ class BehaviorTest extends TestCase
      * testVerifyConfigImplementedFindersOverridden
      *
      * Simply don't expect an exception to be thrown
-     *
-     * @return void
      */
-    public function testVerifyConfigImplementedFindersOverridden()
+    public function testVerifyConfigImplementedFindersOverridden(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
@@ -261,10 +237,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testVerifyImplementedFindersInvalid
-     *
-     * @return void
      */
-    public function testVerifyImplementedFindersInvalid()
+    public function testVerifyImplementedFindersInvalid(): void
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The method findNotDefined is not callable on class ' . Test2Behavior::class);
@@ -281,10 +255,8 @@ class BehaviorTest extends TestCase
      * testVerifyConfigImplementedMethodsOverridden
      *
      * Don't expect an exception to be thrown
-     *
-     * @return void
      */
-    public function testVerifyConfigImplementedMethodsOverridden()
+    public function testVerifyConfigImplementedMethodsOverridden(): void
     {
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table);
@@ -299,10 +271,8 @@ class BehaviorTest extends TestCase
 
     /**
      * testVerifyImplementedMethodsInvalid
-     *
-     * @return void
      */
-    public function testVerifyImplementedMethodsInvalid()
+    public function testVerifyImplementedMethodsInvalid(): void
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The method iDoNotExist is not callable on class ' . Test2Behavior::class);

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -39,7 +39,7 @@ class BindingKeyTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderJoinable()
+    public function strategiesProviderJoinable(): array
     {
         return [['join'], ['select']];
     }
@@ -49,7 +49,7 @@ class BindingKeyTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderExternal()
+    public function strategiesProviderExternal(): array
     {
         return [['subquery'], ['select']];
     }
@@ -58,9 +58,8 @@ class BindingKeyTest extends TestCase
      * Tests that bindingKey can be used in belongsTo associations
      *
      * @dataProvider strategiesProviderJoinable
-     * @return void
      */
-    public function testBelongsto(string $strategy)
+    public function testBelongsto(string $strategy): void
     {
         $users = $this->getTableLocator()->get('Users');
         $users->belongsTo('AuthUsers', [
@@ -90,9 +89,8 @@ class BindingKeyTest extends TestCase
      * Tests that bindingKey can be used in hasOne associations
      *
      * @dataProvider strategiesProviderJoinable
-     * @return void
      */
-    public function testHasOne(string $strategy)
+    public function testHasOne(string $strategy): void
     {
         $users = $this->getTableLocator()->get('Users');
         $users->hasOne('SiteAuthors', [
@@ -114,9 +112,8 @@ class BindingKeyTest extends TestCase
      * Tests that bindingKey can be used in hasOne associations
      *
      * @dataProvider strategiesProviderExternal
-     * @return void
      */
-    public function testHasMany(string $strategy)
+    public function testHasMany(string $strategy): void
     {
         $users = $this->getTableLocator()->get('Users');
         $authors = $users->hasMany('SiteAuthors', [

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -43,7 +43,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
         TypeFactory::setMap($map);
     }
 
-    public function testCustomTypesCanBeUsedInFixtures()
+    public function testCustomTypesCanBeUsedInFixtures(): void
     {
         $table = $this->getTableLocator()->get('ColumnSchemaAwareTypeValues');
 
@@ -55,7 +55,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testCustomTypeCanProcessColumnInfo()
+    public function testCustomTypeCanProcessColumnInfo(): void
     {
         $column = $this->getTableLocator()->get('ColumnSchemaAwareTypeValues')->getSchema()->getColumn('val');
 
@@ -64,7 +64,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
         $this->assertSame('Custom schema aware type comment', $column['comment']);
     }
 
-    public function testCustomTypeReceivesAllColumnDefinitionKeys()
+    public function testCustomTypeReceivesAllColumnDefinitionKeys(): void
     {
         $table = $this->getTableLocator()->get('ColumnSchemaAwareTypeValues');
 

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -52,8 +52,6 @@ class CompositeKeysTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -66,7 +64,7 @@ class CompositeKeysTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderHasOne()
+    public function strategiesProviderHasOne(): array
     {
         return [['join'], ['select']];
     }
@@ -76,7 +74,7 @@ class CompositeKeysTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderHasMany()
+    public function strategiesProviderHasMany(): array
     {
         return [['subquery'], ['select']];
     }
@@ -86,7 +84,7 @@ class CompositeKeysTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderBelongsTo()
+    public function strategiesProviderBelongsTo(): array
     {
         return [['join'], ['select']];
     }
@@ -96,7 +94,7 @@ class CompositeKeysTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderBelongsToMany()
+    public function strategiesProviderBelongsToMany(): array
     {
         return [['subquery'], ['select']];
     }
@@ -105,9 +103,8 @@ class CompositeKeysTest extends TestCase
      * Test that you cannot save rows with composite keys if some columns are missing.
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewErrorCompositeKeyNoIncrement()
+    public function testSaveNewErrorCompositeKeyNoIncrement(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing');
@@ -122,9 +119,8 @@ class CompositeKeysTest extends TestCase
      * SQLite is skipped because it doesn't support autoincrement composite keys.
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewCompositeKeyIncrement()
+    public function testSaveNewCompositeKeyIncrement(): void
     {
         $this->skipIfSqlite();
         $table = $this->getTableLocator()->get('CompositeIncrements');
@@ -139,9 +135,8 @@ class CompositeKeysTest extends TestCase
      * correctly nested when multiple foreignKeys are used
      *
      * @dataProvider strategiesProviderHasMany
-     * @return void
      */
-    public function testHasManyEager(string $strategy)
+    public function testHasManyEager(string $strategy): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->hasMany('SiteArticles', [
@@ -215,9 +210,8 @@ class CompositeKeysTest extends TestCase
      * foreignKeys are used
      *
      * @dataProvider strategiesProviderBelongsToMany
-     * @return void
      */
-    public function testBelongsToManyEager(string $strategy)
+    public function testBelongsToManyEager(string $strategy): void
     {
         $articles = $this->getTableLocator()->get('SiteArticles');
         $tags = $this->getTableLocator()->get('SiteTags');
@@ -303,9 +297,8 @@ class CompositeKeysTest extends TestCase
      * Tests loading belongsTo with composite keys
      *
      * @dataProvider strategiesProviderBelongsTo
-     * @return void
      */
-    public function testBelongsToEager(string $strategy)
+    public function testBelongsToEager(string $strategy): void
     {
         $table = $this->getTableLocator()->get('SiteArticles');
         $table->belongsTo('SiteAuthors', [
@@ -352,9 +345,8 @@ class CompositeKeysTest extends TestCase
      * Tests loading hasOne with composite keys
      *
      * @dataProvider strategiesProviderHasOne
-     * @return void
      */
-    public function testHasOneEager(string $strategy)
+    public function testHasOneEager(string $strategy): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->hasOne('SiteArticles', [
@@ -403,9 +395,8 @@ class CompositeKeysTest extends TestCase
      * if the entity has composite primary key
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewEntity()
+    public function testSaveNewEntity(): void
     {
         $entity = new Entity([
             'id' => 5,
@@ -427,9 +418,8 @@ class CompositeKeysTest extends TestCase
      * if the entity has composite primary key
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewEntityMissingKey()
+    public function testSaveNewEntityMissingKey(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing. Got (5, ), expecting (id, site_id)');
@@ -445,10 +435,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Test simple delete with composite primary key
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->save(new Entity(['id' => 1, 'site_id' => 2]));
@@ -462,10 +450,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Test delete with dependent records having composite keys
-     *
-     * @return void
      */
-    public function testDeleteDependent()
+    public function testDeleteDependent(): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->hasMany('SiteArticles', [
@@ -487,10 +473,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Test generating a list of entities from a list of composite ids
-     *
-     * @return void
      */
-    public function testOneGenerateBelongsToManyEntitiesFromIds()
+    public function testOneGenerateBelongsToManyEntitiesFromIds(): void
     {
         $articles = $this->getTableLocator()->get('SiteArticles');
         $articles->setEntityClass(OpenArticleEntity::class);
@@ -529,10 +513,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Tests find('list') with composite keys
-     *
-     * @return void
      */
-    public function testFindListCompositeKeys()
+    public function testFindListCompositeKeys(): void
     {
         $table = new Table([
             'table' => 'site_authors',
@@ -580,10 +562,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Tests find('threaded') with composite keys
-     *
-     * @return void
      */
-    public function testFindThreadedCompositeKeys()
+    public function testFindThreadedCompositeKeys(): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $query = $this->getMockBuilder('Cake\ORM\Query')
@@ -671,10 +651,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Tests that loadInto() is capable of handling composite primary keys
-     *
-     * @return void
      */
-    public function testLoadInto()
+    public function testLoadInto(): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $tags = $this->getTableLocator()->get('SiteTags');
@@ -694,10 +672,8 @@ class CompositeKeysTest extends TestCase
     /**
      * Tests that loadInto() is capable of handling composite primary keys
      * when loading belongsTo associations
-     *
-     * @return void
      */
-    public function testLoadIntoWithBelongsTo()
+    public function testLoadIntoWithBelongsTo(): void
     {
         $table = $this->getTableLocator()->get('SiteArticles');
         $table->belongsTo('SiteAuthors', [
@@ -716,10 +692,8 @@ class CompositeKeysTest extends TestCase
     /**
      * Tests that loadInto() is capable of handling composite primary keys
      * when loading into multiple entities
-     *
-     * @return void
      */
-    public function testLoadIntoMany()
+    public function testLoadIntoMany(): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
         $table->hasMany('SiteArticles', [
@@ -741,10 +715,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Tests notMatching() with a belongsToMany association
-     *
-     * @return void
      */
-    public function testNotMatchingBelongsToMany()
+    public function testNotMatchingBelongsToMany(): void
     {
         $driver = $this->connection->getDriver();
 
@@ -784,10 +756,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Helper method to skip tests when connection is SQLite.
-     *
-     * @return void
      */
-    public function skipIfSqlite()
+    public function skipIfSqlite(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlite,

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -32,8 +32,6 @@ class EagerLoaderTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -130,10 +128,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests that fully defined belongsTo and hasOne relationships are joined correctly
-     *
-     * @return void
      */
-    public function testContainToJoinsOneLevel()
+    public function testContainToJoinsOneLevel(): void
     {
         $contains = [
             'clients' => [
@@ -232,10 +228,8 @@ class EagerLoaderTest extends TestCase
     /**
      * Tests setting containments using dot notation, additionally proves that options
      * are not overwritten when combining dot notation and array notation
-     *
-     * @return void
      */
-    public function testContainDotNotation()
+    public function testContainDotNotation(): void
     {
         $loader = new EagerLoader();
         $loader->contain([
@@ -267,10 +261,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests setting containments using direct key value pairs works just as with key array.
-     *
-     * @return void
      */
-    public function testContainKeyValueNotation()
+    public function testContainKeyValueNotation(): void
     {
         $loader = new EagerLoader();
         $loader->contain([
@@ -288,12 +280,10 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests that it is possible to pass a function as the array value for contain
-     *
-     * @return void
      */
-    public function testContainClosure()
+    public function testContainClosure(): void
     {
-        $builder = function ($query) {
+        $builder = function ($query): void {
         };
         $loader = new EagerLoader();
         $loader->contain([
@@ -321,12 +311,10 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests using the same signature as matching with contain
-     *
-     * @return void
      */
-    public function testContainSecondSignature()
+    public function testContainSecondSignature(): void
     {
-        $builder = function ($query) {
+        $builder = function ($query): void {
         };
         $loader = new EagerLoader();
         $loader->contain('clients', $builder);
@@ -341,14 +329,12 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests passing an array of associations with a query builder
-     *
-     * @return void
      */
-    public function testContainSecondSignatureInvalid()
+    public function testContainSecondSignatureInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $builder = function ($query) {
+        $builder = function ($query): void {
         };
         $loader = new EagerLoader();
         $loader->contain(['clients'], $builder);
@@ -363,10 +349,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests that query builders are stacked
-     *
-     * @return void
      */
-    public function testContainMergeBuilders()
+    public function testContainMergeBuilders(): void
     {
         $loader = new EagerLoader();
         $loader->contain([
@@ -388,10 +372,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Test that fields for contained models are aliased and added to the select clause
-     *
-     * @return void
      */
-    public function testContainToFieldsPredefined()
+    public function testContainToFieldsPredefined(): void
     {
         $contains = [
             'clients' => [
@@ -422,10 +404,8 @@ class EagerLoaderTest extends TestCase
     /**
      * Tests that default fields for associations are added to the select clause when
      * none is specified
-     *
-     * @return void
      */
-    public function testContainToFieldsDefault()
+    public function testContainToFieldsDefault(): void
     {
         $contains = ['clients' => ['orders']];
 
@@ -467,10 +447,8 @@ class EagerLoaderTest extends TestCase
     /**
      * Tests that the path for getting to a deep association is materialized in an
      * array key
-     *
-     * @return void
      */
-    public function testNormalizedPath()
+    public function testNormalizedPath(): void
     {
         $contains = [
             'clients' => [
@@ -518,10 +496,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests that the paths for matching containments point to _matchingData.
-     *
-     * @return void
      */
-    public function testNormalizedMatchingPath()
+    public function testNormalizedMatchingPath(): void
     {
         $loader = new EagerLoader();
         $loader->setMatching('clients');
@@ -533,10 +509,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Tests that the paths for deep matching containments point to _matchingData.
-     *
-     * @return void
      */
-    public function testNormalizedDeepMatchingPath()
+    public function testNormalizedDeepMatchingPath(): void
     {
         $loader = new EagerLoader();
         $loader->setMatching('clients.orders');
@@ -552,10 +526,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Test clearing containments but not matching joins.
-     *
-     * @return void
      */
-    public function testClearContain()
+    public function testClearContain(): void
     {
         $contains = [
             'clients' => [
@@ -581,10 +553,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Test for enableAutoFields()
-     *
-     * @return void
      */
-    public function testEnableAutoFields()
+    public function testEnableAutoFields(): void
     {
         $loader = new EagerLoader();
         $this->assertTrue($loader->isAutoFieldsEnabled());
@@ -599,7 +569,7 @@ class EagerLoaderTest extends TestCase
      * @param array $elements
      * @return array
      */
-    protected function _quoteArray($elements)
+    protected function _quoteArray($elements): array
     {
         if ($this->connection->getDriver()->isAutoQuotingEnabled()) {
             $quoter = function ($e) {
@@ -617,10 +587,8 @@ class EagerLoaderTest extends TestCase
 
     /**
      * Asserts that matching('something') and setMatching('something') return consistent type.
-     *
-     * @return void
      */
-    public function testSetMatchingReturnType()
+    public function testSetMatchingReturnType(): void
     {
         $loader = new EagerLoader();
         $result = $loader->setMatching('clients');

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -28,10 +28,8 @@ class EntityTest extends TestCase
 {
     /**
      * Tests setting a single property in an entity without custom setters
-     *
-     * @return void
      */
-    public function testSetOneParamNoSetters()
+    public function testSetOneParamNoSetters(): void
     {
         $entity = new Entity();
         $this->assertNull($entity->getOriginal('foo'));
@@ -51,10 +49,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests setting multiple properties without custom setters
-     *
-     * @return void
      */
-    public function testSetMultiplePropertiesNoSetters()
+    public function testSetMultiplePropertiesNoSetters(): void
     {
         $entity = new Entity();
         $entity->setAccess('*', true);
@@ -80,10 +76,8 @@ class EntityTest extends TestCase
 
     /**
      * Test that getOriginal() retains falsey values.
-     *
-     * @return void
      */
-    public function testGetOriginal()
+    public function testGetOriginal(): void
     {
         $entity = new Entity(
             ['false' => false, 'null' => null, 'zero' => 0, 'empty' => ''],
@@ -103,10 +97,8 @@ class EntityTest extends TestCase
 
     /**
      * Test extractOriginal()
-     *
-     * @return void
      */
-    public function testExtractOriginal()
+    public function testExtractOriginal(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -141,10 +133,8 @@ class EntityTest extends TestCase
 
     /**
      * Test that all original values are returned properly
-     *
-     * @return void
      */
-    public function testExtractOriginalValues()
+    public function testExtractOriginalValues(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -165,10 +155,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests setting a single property using a setter function
-     *
-     * @return void
      */
-    public function testSetOneParamWithSetter()
+    public function testSetOneParamWithSetter(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_setName'])
@@ -186,10 +174,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests setting multiple properties using a setter function
-     *
-     * @return void
      */
-    public function testMultipleWithSetter()
+    public function testMultipleWithSetter(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_setName', '_setStuff'])
@@ -216,10 +202,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that it is possible to bypass the setters
-     *
-     * @return void
      */
-    public function testBypassSetters()
+    public function testBypassSetters(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_setName', '_setStuff'])
@@ -241,10 +225,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that the constructor will set initial properties
-     *
-     * @return void
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['set'])
@@ -266,10 +248,8 @@ class EntityTest extends TestCase
     /**
      * Tests that the constructor will set initial properties and pass the guard
      * option along
-     *
-     * @return void
      */
-    public function testConstructorWithGuard()
+    public function testConstructorWithGuard(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['set'])
@@ -283,10 +263,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests getting properties with no custom getters
-     *
-     * @return void
      */
-    public function testGetNoGetters()
+    public function testGetNoGetters(): void
     {
         $entity = new Entity(['id' => 1, 'foo' => 'bar']);
         $this->assertSame(1, $entity->get('id'));
@@ -295,10 +273,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests get with custom getter
-     *
-     * @return void
      */
-    public function testGetCustomGetters()
+    public function testGetCustomGetters(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_getName'])
@@ -316,10 +292,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests get with custom getter
-     *
-     * @return void
      */
-    public function testGetCustomGettersAfterSet()
+    public function testGetCustomGettersAfterSet(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_getName'])
@@ -340,10 +314,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that the get cache is cleared by unsetProperty.
-     *
-     * @return void
      */
-    public function testGetCacheClearedByUnset()
+    public function testGetCacheClearedByUnset(): void
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder(Entity::class)
@@ -362,10 +334,8 @@ class EntityTest extends TestCase
 
     /**
      * Test getting camelcased virtual fields.
-     *
-     * @return void
      */
-    public function testGetCamelCasedProperties()
+    public function testGetCamelCasedProperties(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_getListIdName'])
@@ -381,10 +351,8 @@ class EntityTest extends TestCase
 
     /**
      * Test magic property setting with no custom setter
-     *
-     * @return void
      */
-    public function testMagicSet()
+    public function testMagicSet(): void
     {
         $entity = new Entity();
         $entity->name = 'Jones';
@@ -395,10 +363,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests magic set with custom setter function
-     *
-     * @return void
      */
-    public function testMagicSetWithSetter()
+    public function testMagicSetWithSetter(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_setName'])
@@ -416,10 +382,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests magic set with custom setter function using a Title cased property
-     *
-     * @return void
      */
-    public function testMagicSetWithSetterTitleCase()
+    public function testMagicSetWithSetterTitleCase(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_setName'])
@@ -438,10 +402,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the magic getter with a custom getter function
-     *
-     * @return void
      */
-    public function testMagicGetWithGetter()
+    public function testMagicGetWithGetter(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_getName'])
@@ -459,10 +421,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests magic get with custom getter function using a Title cased property
-     *
-     * @return void
      */
-    public function testMagicGetWithGetterTitleCase()
+    public function testMagicGetWithGetterTitleCase(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_getName'])
@@ -481,10 +441,8 @@ class EntityTest extends TestCase
 
     /**
      * Test indirectly modifying internal properties
-     *
-     * @return void
      */
-    public function testIndirectModification()
+    public function testIndirectModification(): void
     {
         $entity = new Entity();
         $entity->things = ['a', 'b'];
@@ -494,10 +452,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests has() method
-     *
-     * @return void
      */
-    public function testHas()
+    public function testHas(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'Juan', 'foo' => null]);
         $this->assertTrue($entity->has('id'));
@@ -520,10 +476,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests unsetProperty one property at a time
-     *
-     * @return void
      */
-    public function testUnset()
+    public function testUnset(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar']);
         $entity->unset('id');
@@ -535,10 +489,8 @@ class EntityTest extends TestCase
 
     /**
      * Unsetting a property should not mark it as dirty.
-     *
-     * @return void
      */
-    public function testUnsetMakesClean()
+    public function testUnsetMakesClean(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar']);
         $this->assertTrue($entity->isDirty('name'));
@@ -548,10 +500,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests unsetProperty with multiple properties
-     *
-     * @return void
      */
-    public function testUnsetMultiple()
+    public function testUnsetMultiple(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'bar', 'thing' => 2]);
         $entity->unset(['id', 'thing']);
@@ -562,10 +512,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the magic __isset() method
-     *
-     * @return void
      */
-    public function testMagicIsset()
+    public function testMagicIsset(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'Juan', 'foo' => null]);
         $this->assertTrue(isset($entity->id));
@@ -576,10 +524,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the magic __unset() method
-     *
-     * @return void
      */
-    public function testMagicUnset()
+    public function testMagicUnset(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['unset'])
@@ -592,12 +538,10 @@ class EntityTest extends TestCase
 
     /**
      * Tests the deprecated unsetProperty() method
-     *
-     * @return void
      */
-    public function testUnsetDeprecated()
+    public function testUnsetDeprecated(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $entity = new Entity();
             $entity->foo = 'foo';
 
@@ -608,10 +552,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests isset with array access
-     *
-     * @return void
      */
-    public function testIssetArrayAccess()
+    public function testIssetArrayAccess(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'Juan', 'foo' => null]);
         $this->assertArrayHasKey('id', $entity);
@@ -622,10 +564,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests get property with array access
-     *
-     * @return void
      */
-    public function testGetArrayAccess()
+    public function testGetArrayAccess(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['get'])
@@ -644,10 +584,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests set with array access
-     *
-     * @return void
      */
-    public function testSetArrayAccess()
+    public function testSetArrayAccess(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['set'])
@@ -668,10 +606,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests unset with array access
-     *
-     * @return void
      */
-    public function testUnsetArrayAccess()
+    public function testUnsetArrayAccess(): void
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder(Entity::class)
@@ -687,10 +623,8 @@ class EntityTest extends TestCase
      * Tests that the method cache will only report the methods for the called class,
      * this is, calling methods defined in another entity will not cause a fatal error
      * when trying to call directly an inexistent method in another class
-     *
-     * @return void
      */
-    public function testMethodCache()
+    public function testMethodCache(): void
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder(Entity::class)
@@ -711,10 +645,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that long properties in the entity are inflected correctly
-     *
-     * @return void
      */
-    public function testSetGetLongPropertyNames()
+    public function testSetGetLongPropertyNames(): void
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder(Entity::class)
@@ -728,10 +660,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests serializing an entity as JSON
-     *
-     * @return void
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
         $entity = new Entity($data);
@@ -740,10 +670,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests serializing an entity as PHP
-     *
-     * @return void
      */
-    public function testPhpSerialize()
+    public function testPhpSerialize(): void
     {
         $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
         $entity = new Entity($data);
@@ -754,10 +682,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that jsonSerialize is called recursively for contained entities
-     *
-     * @return void
      */
-    public function testJsonSerializeRecursive()
+    public function testJsonSerializeRecursive(): void
     {
         $phone = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['jsonSerialize'])
@@ -771,10 +697,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the extract method
-     *
-     * @return void
      */
-    public function testExtract()
+    public function testExtract(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -796,10 +720,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests isDirty() method on a newly created object
-     *
-     * @return void
      */
-    public function testIsDirty()
+    public function testIsDirty(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -826,10 +748,8 @@ class EntityTest extends TestCase
 
     /**
      * Test setDirty().
-     *
-     * @return void
      */
-    public function testSetDirty()
+    public function testSetDirty(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -848,10 +768,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests dirty() when altering properties values and adding new ones
-     *
-     * @return void
      */
-    public function testDirtyChangingProperties()
+    public function testDirtyChangingProperties(): void
     {
         $entity = new Entity([
             'title' => 'Foo',
@@ -872,10 +790,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests extract only dirty properties
-     *
-     * @return void
      */
-    public function testExtractDirty()
+    public function testExtractDirty(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -891,10 +807,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the getDirty method
-     *
-     * @return void
      */
-    public function testGetDirty()
+    public function testGetDirty(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -913,10 +827,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the clean method
-     *
-     * @return void
      */
-    public function testClean()
+    public function testClean(): void
     {
         $entity = new Entity([
             'id' => 1,
@@ -935,10 +847,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the isNew method
-     *
-     * @return void
      */
-    public function testIsNew()
+    public function testIsNew(): void
     {
         $data = [
             'id' => 1,
@@ -957,10 +867,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the constructor when passing the markClean option
-     *
-     * @return void
      */
-    public function testConstructorWithClean()
+    public function testConstructorWithClean(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['clean'])
@@ -979,10 +887,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the constructor when passing the markClean option
-     *
-     * @return void
      */
-    public function testConstructorWithMarkNew()
+    public function testConstructorWithMarkNew(): void
     {
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['setNew', 'clean'])
@@ -1001,10 +907,8 @@ class EntityTest extends TestCase
 
     /**
      * Test toArray method.
-     *
-     * @return void
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
         $entity = new Entity($data);
@@ -1014,10 +918,8 @@ class EntityTest extends TestCase
 
     /**
      * Test toArray recursive.
-     *
-     * @return void
      */
-    public function testToArrayRecursive()
+    public function testToArrayRecursive(): void
     {
         $data = ['id' => 1, 'name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
         $user = new Extending($data);
@@ -1044,10 +946,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that an entity with entities and other misc types can be properly toArray'd
-     *
-     * @return void
      */
-    public function testToArrayMixed()
+    public function testToArrayMixed(): void
     {
         $test = new Entity([
             'id' => 1,
@@ -1068,10 +968,8 @@ class EntityTest extends TestCase
 
     /**
      * Test that get accessors are called when converting to arrays.
-     *
-     * @return void
      */
-    public function testToArrayWithAccessor()
+    public function testToArrayWithAccessor(): void
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder(Entity::class)
@@ -1089,10 +987,8 @@ class EntityTest extends TestCase
 
     /**
      * Test that toArray respects hidden properties.
-     *
-     * @return void
      */
-    public function testToArrayHiddenProperties()
+    public function testToArrayHiddenProperties(): void
     {
         $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
@@ -1102,10 +998,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests setting hidden properties.
-     *
-     * @return void
      */
-    public function testSetHidden()
+    public function testSetHidden(): void
     {
         $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
@@ -1122,10 +1016,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests setting hidden properties with merging.
-     *
-     * @return void
      */
-    public function testSetHiddenWithMerge()
+    public function testSetHiddenWithMerge(): void
     {
         $data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
@@ -1146,10 +1038,8 @@ class EntityTest extends TestCase
 
     /**
      * Test toArray includes 'virtual' properties.
-     *
-     * @return void
      */
-    public function testToArrayVirtualProperties()
+    public function testToArrayVirtualProperties(): void
     {
         /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
         $entity = $this->getMockBuilder(Entity::class)
@@ -1176,10 +1066,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the getVisible() method
-     *
-     * @return void
      */
-    public function testGetVisible()
+    public function testGetVisible(): void
     {
         $entity = new Entity();
         $entity->foo = 'foo';
@@ -1191,10 +1079,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests setting virtual properties with merging.
-     *
-     * @return void
      */
-    public function testSetVirtualWithMerge()
+    public function testSetVirtualWithMerge(): void
     {
         $data = ['virtual' => 'sauce', 'name' => 'mark', 'id' => 1];
         $entity = new Entity($data);
@@ -1215,10 +1101,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests error getters and setters
-     *
-     * @return void
      */
-    public function testGetErrorAndSetError()
+    public function testGetErrorAndSetError(): void
     {
         $entity = new Entity();
         $this->assertEmpty($entity->getErrors());
@@ -1245,10 +1129,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests reading errors from nested validator
-     *
-     * @return void
      */
-    public function testGetErrorNested()
+    public function testGetErrorNested(): void
     {
         $entity = new Entity();
         $entity->setError('options', ['subpages' => ['_empty' => 'required']]);
@@ -1264,10 +1146,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that it is possible to get errors for nested entities
-     *
-     * @return void
      */
-    public function testErrorsDeep()
+    public function testErrorsDeep(): void
     {
         $user = new Entity();
         $owner = new NonExtending();
@@ -1305,10 +1185,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that check if hasErrors() works
-     *
-     * @return void
      */
-    public function testHasErrors()
+    public function testHasErrors(): void
     {
         $entity = new Entity();
         $hasErrors = $entity->hasErrors();
@@ -1344,10 +1222,8 @@ class EntityTest extends TestCase
 
     /**
      * Test that errors can be read with a path.
-     *
-     * @return void
      */
-    public function testErrorPathReading()
+    public function testErrorPathReading(): void
     {
         $assoc = new Entity();
         $assoc2 = new NonExtending();
@@ -1376,10 +1252,8 @@ class EntityTest extends TestCase
     /**
      * Tests that changing the value of a property will remove errors
      * stored for it
-     *
-     * @return void
      */
-    public function testDirtyRemovesError()
+    public function testDirtyRemovesError(): void
     {
         $entity = new Entity(['a' => 'b']);
         $entity->setError('a', 'is not good');
@@ -1393,10 +1267,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that marking an entity as clean will remove errors too
-     *
-     * @return void
      */
-    public function testCleanRemovesErrors()
+    public function testCleanRemovesErrors(): void
     {
         $entity = new Entity(['a' => 'b']);
         $entity->setError('a', 'is not good');
@@ -1406,10 +1278,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests getAccessible() method
-     *
-     * @return void
      */
-    public function testGetAccessible()
+    public function testGetAccessible(): void
     {
         $entity = new Entity();
         $entity->setAccess('*', false);
@@ -1425,10 +1295,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests isAccessible() and setAccess() methods
-     *
-     * @return void
      */
-    public function testIsAccessible()
+    public function testIsAccessible(): void
     {
         $entity = new Entity();
         $entity->setAccess('*', false);
@@ -1454,10 +1322,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that an array can be used to set
-     *
-     * @return void
      */
-    public function testAccessibleAsArray()
+    public function testAccessibleAsArray(): void
     {
         $entity = new Entity();
         $entity->setAccess(['foo', 'bar', 'baz'], true);
@@ -1478,10 +1344,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that a wildcard can be used for setting accessible properties
-     *
-     * @return void
      */
-    public function testAccessibleWildcard()
+    public function testAccessibleWildcard(): void
     {
         $entity = new Entity();
         $entity->setAccess(['foo', 'bar', 'baz'], true);
@@ -1504,10 +1368,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that only accessible properties can be set
-     *
-     * @return void
      */
-    public function testSetWithAccessible()
+    public function testSetWithAccessible(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
         $options = ['guard' => true];
@@ -1525,10 +1387,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that only accessible properties can be set
-     *
-     * @return void
      */
-    public function testSetWithAccessibleWithArray()
+    public function testSetWithAccessibleWithArray(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
         $options = ['guard' => true];
@@ -1546,10 +1406,8 @@ class EntityTest extends TestCase
 
     /**
      * Test that accessible() and single property setting works.
-     *
-     * @return void
      */
-    public function testSetWithAccessibleSingleProperty()
+    public function testSetWithAccessibleSingleProperty(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
         $entity->setAccess('*', false);
@@ -1568,10 +1426,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests the entity's __toString method
-     *
-     * @return void
      */
-    public function testToString()
+    public function testToString(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
         $this->assertEquals(json_encode($entity, JSON_PRETTY_PRINT), (string)$entity);
@@ -1579,10 +1435,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $entity = new Entity(['foo' => 'bar'], ['markClean' => true]);
         $entity->somethingElse = 'value';
@@ -1614,7 +1468,7 @@ class EntityTest extends TestCase
     /**
      * Test the source getter
      */
-    public function testGetAndSetSource()
+    public function testGetAndSetSource(): void
     {
         $entity = new Entity();
         $this->assertSame('', $entity->getSource());
@@ -1634,10 +1488,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests that trying to get an empty property name throws exception
-     *
-     * @return void
      */
-    public function testEmptyProperties()
+    public function testEmptyProperties(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $entity = new Entity();
@@ -1648,9 +1500,8 @@ class EntityTest extends TestCase
      * Tests that setting an empty property name does nothing
      *
      * @dataProvider emptyNamesProvider
-     * @return void
      */
-    public function testSetEmptyPropertyName(?string $property)
+    public function testSetEmptyPropertyName(?string $property): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $entity = new Entity();
@@ -1659,10 +1510,8 @@ class EntityTest extends TestCase
 
     /**
      * Provides empty values
-     *
-     * @return void
      */
-    public function testIsDirtyFromClone()
+    public function testIsDirtyFromClone(): void
     {
         $entity = new Entity(
             ['a' => 1, 'b' => 2],
@@ -1682,10 +1531,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests getInvalid and setInvalid
-     *
-     * @return void
      */
-    public function testGetSetInvalid()
+    public function testGetSetInvalid(): void
     {
         $entity = new Entity();
         $return = $entity->setInvalid([
@@ -1720,10 +1567,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests getInvalidField
-     *
-     * @return void
      */
-    public function testGetSetInvalidField()
+    public function testGetSetInvalidField(): void
     {
         $entity = new Entity();
         $return = $entity->setInvalidField('title', 'albert');
@@ -1737,10 +1582,8 @@ class EntityTest extends TestCase
 
     /**
      * Tests getInvalidFieldNull
-     *
-     * @return void
      */
-    public function testGetInvalidFieldNull()
+    public function testGetInvalidFieldNull(): void
     {
         $entity = new Entity();
         $this->assertNull($entity->getInvalidField('foo'));
@@ -1748,10 +1591,8 @@ class EntityTest extends TestCase
 
     /**
      * Test the isEmpty() check
-     *
-     * @return void
      */
-    public function testIsEmpty()
+    public function testIsEmpty(): void
     {
         $entity = new Entity([
             'array' => ['foo' => 'bar'],
@@ -1782,10 +1623,8 @@ class EntityTest extends TestCase
 
     /**
      * Test hasValue()
-     *
-     * @return void
      */
-    public function testHasValue()
+    public function testHasValue(): void
     {
         $entity = new Entity([
             'array' => ['foo' => 'bar'],

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -32,8 +32,6 @@ class LocatorAwareTraitTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -44,10 +42,8 @@ class LocatorAwareTraitTest extends TestCase
 
     /**
      * Tests testGetTableLocator method
-     *
-     * @return void
      */
-    public function testGetTableLocator()
+    public function testGetTableLocator(): void
     {
         $tableLocator = $this->subject->getTableLocator();
         $this->assertSame($this->getTableLocator(), $tableLocator);
@@ -55,10 +51,8 @@ class LocatorAwareTraitTest extends TestCase
 
     /**
      * Tests testSetTableLocator method
-     *
-     * @return void
      */
-    public function testSetTableLocator()
+    public function testSetTableLocator(): void
     {
         $newLocator = $this->getMockBuilder(LocatorInterface::class)->getMock();
         $this->subject->setTableLocator($newLocator);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -41,8 +41,6 @@ class TableLocatorTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -54,8 +52,6 @@ class TableLocatorTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -65,10 +61,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test getConfig() method.
-     *
-     * @return void
      */
-    public function testGetConfig()
+    public function testGetConfig(): void
     {
         $this->assertEquals([], $this->_locator->getConfig('Tests'));
 
@@ -86,10 +80,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test getConfig() method with plugin syntax aliases
-     *
-     * @return void
      */
-    public function testConfigPlugin()
+    public function testConfigPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -104,10 +96,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test calling getConfig() on existing instances throws an error.
-     *
-     * @return void
      */
-    public function testConfigOnDefinedInstance()
+    public function testConfigOnDefinedInstance(): void
     {
         $users = $this->_locator->get('Users');
         $this->assertNotEmpty($users);
@@ -120,10 +110,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test the exists() method.
-     *
-     * @return void
      */
-    public function testExists()
+    public function testExists(): void
     {
         $this->assertFalse($this->_locator->exists('Articles'));
 
@@ -137,10 +125,8 @@ class TableLocatorTest extends TestCase
     /**
      * Tests the casing and locator. Using table name directly is not
      * the same as using conventional aliases anymore.
-     *
-     * @return void
      */
-    public function testCasing()
+    public function testCasing(): void
     {
         $this->assertFalse($this->_locator->exists('Articles'));
 
@@ -157,10 +143,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test the exists() method with plugin-prefixed models.
-     *
-     * @return void
      */
-    public function testExistsPlugin()
+    public function testExistsPlugin(): void
     {
         $this->assertFalse($this->_locator->exists('Comments'));
         $this->assertFalse($this->_locator->exists('TestPlugin.Comments'));
@@ -176,10 +160,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test getting instances from the registry.
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $result = $this->_locator->get('Articles', [
             'table' => 'my_articles',
@@ -199,10 +181,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Are auto-models instantiated correctly? How about when they have an alias?
-     *
-     * @return void
      */
-    public function testGetFallbacks()
+    public function testGetFallbacks(): void
     {
         $result = $this->_locator->get('Droids');
         $this->assertInstanceOf(Table::class, $result);
@@ -235,7 +215,7 @@ class TableLocatorTest extends TestCase
         $this->assertSame('Stuff', $result->getAlias());
     }
 
-    public function testExceptionForAliasWhenFallbackTurnedOff()
+    public function testExceptionForAliasWhenFallbackTurnedOff(): void
     {
         $this->expectException(MissingTableClassException::class);
         $this->expectExceptionMessage('Table class for alias `Droids` could not be found.');
@@ -243,7 +223,7 @@ class TableLocatorTest extends TestCase
         $this->_locator->get('Droids', ['allowFallbackClass' => false]);
     }
 
-    public function testExceptionForFQCNWhenFallbackTurnedOff()
+    public function testExceptionForFQCNWhenFallbackTurnedOff(): void
     {
         $this->expectException(MissingTableClassException::class);
         $this->expectExceptionMessage('Table class `App\Model\DroidsTable` could not be found.');
@@ -253,10 +233,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test that get() uses config data set with getConfig()
-     *
-     * @return void
      */
-    public function testGetWithgetConfig()
+    public function testGetWithgetConfig(): void
     {
         $this->_locator->setConfig('Articles', [
             'table' => 'my_articles',
@@ -267,10 +245,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test that get() uses config data set with getConfig()
-     *
-     * @return void
      */
-    public function testGetWithConnectionName()
+    public function testGetWithConnectionName(): void
     {
         ConnectionManager::alias('test', 'testing');
         $result = $this->_locator->get('Articles', [
@@ -282,10 +258,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test that get() uses config data `className` set with getConfig()
-     *
-     * @return void
      */
-    public function testGetWithConfigClassName()
+    public function testGetWithConfigClassName(): void
     {
         $this->_locator->setConfig('MyUsersTableAlias', [
             'className' => MyUsersTable::class,
@@ -296,10 +270,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test get with config throws an exception if the alias exists already.
-     *
-     * @return void
      */
-    public function testGetExistingWithConfigData()
+    public function testGetExistingWithConfigData(): void
     {
         $users = $this->_locator->get('Users');
         $this->assertNotEmpty($users);
@@ -313,10 +285,8 @@ class TableLocatorTest extends TestCase
     /**
      * Test get() can be called several times with the same option without
      * throwing an exception.
-     *
-     * @return void
      */
-    public function testGetWithSameOption()
+    public function testGetWithSameOption(): void
     {
         $result = $this->_locator->get('Users', ['className' => MyUsersTable::class]);
         $result2 = $this->_locator->get('Users', ['className' => MyUsersTable::class]);
@@ -326,10 +296,8 @@ class TableLocatorTest extends TestCase
     /**
      * Tests that tables can be instantiated based on conventions
      * and using plugin notation
-     *
-     * @return void
      */
-    public function testGetWithConventions()
+    public function testGetWithConventions(): void
     {
         $table = $this->_locator->get('articles');
         $this->assertInstanceOf('TestApp\Model\Table\ArticlesTable', $table);
@@ -344,10 +312,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test get() with plugin syntax aliases
-     *
-     * @return void
      */
-    public function testGetPlugin()
+    public function testGetPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $table = $this->_locator->get('TestPlugin.TestPluginComments');
@@ -370,10 +336,8 @@ class TableLocatorTest extends TestCase
      * Test get() with same-alias models in different plugins
      *
      * There should be no internal cache-confusion
-     *
-     * @return void
      */
-    public function testGetMultiplePlugins()
+    public function testGetMultiplePlugins(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
 
@@ -396,10 +360,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test get() with plugin aliases + className option.
-     *
-     * @return void
      */
-    public function testGetPluginWithClassNameOption()
+    public function testGetPluginWithClassNameOption(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $table = $this->_locator->get('Comments', [
@@ -417,10 +379,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test get() with full namespaced classname
-     *
-     * @return void
      */
-    public function testGetPluginWithFullNamespaceName()
+    public function testGetPluginWithFullNamespaceName(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $class = 'TestPlugin\Model\Table\TestPluginCommentsTable';
@@ -435,10 +395,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Tests that table options can be pre-configured for the factory method
-     *
-     * @return void
      */
-    public function testConfigAndBuild()
+    public function testConfigAndBuild(): void
     {
         $this->_locator->clear();
         $map = $this->_locator->getConfig();
@@ -478,10 +436,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Tests that table options can be pre-configured with a single validator
-     *
-     * @return void
      */
-    public function testConfigWithSingleValidator()
+    public function testConfigWithSingleValidator(): void
     {
         $validator = new Validator();
 
@@ -493,10 +449,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Tests that table options can be pre-configured with multiple validators
-     *
-     * @return void
      */
-    public function testConfigWithMultipleValidators()
+    public function testConfigWithMultipleValidators(): void
     {
         $validator1 = new Validator();
         $validator2 = new Validator();
@@ -518,10 +472,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test setting an instance.
-     *
-     * @return void
      */
-    public function testSet()
+    public function testSet(): void
     {
         $mock = $this->getMockBuilder(Table::class)->getMock();
         $this->assertSame($mock, $this->_locator->set('Articles', $mock));
@@ -530,10 +482,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Test setting an instance with plugin syntax aliases
-     *
-     * @return void
      */
-    public function testSetPlugin()
+    public function testSetPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -545,10 +495,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Tests genericInstances
-     *
-     * @return void
      */
-    public function testGenericInstances()
+    public function testGenericInstances(): void
     {
         $foos = $this->_locator->get('Foos');
         $bars = $this->_locator->get('Bars');
@@ -559,10 +507,8 @@ class TableLocatorTest extends TestCase
 
     /**
      * Tests remove an instance
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $first = $this->_locator->get('Comments');
 
@@ -584,10 +530,8 @@ class TableLocatorTest extends TestCase
      * plugin-prefixed model, or app model.
      * Removing an app model should not affect any other
      * plugin-prefixed model.
-     *
-     * @return void
      */
-    public function testRemovePlugin()
+    public function testRemovePlugin(): void
     {
         $this->loadPlugins(['TestPlugin', 'TestPluginTwo']);
 
@@ -626,10 +570,8 @@ class TableLocatorTest extends TestCase
      * testCustomLocation
      *
      * Tests that the correct table is returned when non-standard namespace is defined.
-     *
-     * @return void
      */
-    public function testCustomLocation()
+    public function testCustomLocation(): void
     {
         $locator = new TableLocator(['Infrastructure/Table']);
 
@@ -641,10 +583,8 @@ class TableLocatorTest extends TestCase
      * testCustomLocationPlugin
      *
      * Tests that the correct plugin table is returned when non-standard namespace is defined.
-     *
-     * @return void
      */
-    public function testCustomLocationPlugin()
+    public function testCustomLocationPlugin(): void
     {
         $locator = new TableLocator(['Infrastructure/Table']);
 
@@ -656,10 +596,8 @@ class TableLocatorTest extends TestCase
      * testCustomLocationDefaultWhenNone
      *
      * Tests that the default table is returned when no namespace is defined.
-     *
-     * @return void
      */
-    public function testCustomLocationDefaultWhenNone()
+    public function testCustomLocationDefaultWhenNone(): void
     {
         $locator = new TableLocator([]);
 
@@ -671,10 +609,8 @@ class TableLocatorTest extends TestCase
      * testCustomLocationDefaultWhenMissing
      *
      * Tests that the default table is returned when the class cannot be found in a non-standard namespace.
-     *
-     * @return void
      */
-    public function testCustomLocationDefaultWhenMissing()
+    public function testCustomLocationDefaultWhenMissing(): void
     {
         $locator = new TableLocator(['Infrastructure/Table']);
 
@@ -686,10 +622,8 @@ class TableLocatorTest extends TestCase
      * testCustomLocationMultiple
      *
      * Tests that the correct table is returned when multiple namespaces are defined.
-     *
-     * @return void
      */
-    public function testCustomLocationMultiple()
+    public function testCustomLocationMultiple(): void
     {
         $locator = new TableLocator([
             'Infrastructure/Table',
@@ -704,10 +638,8 @@ class TableLocatorTest extends TestCase
      * testAddLocation
      *
      * Tests that adding a namespace takes effect.
-     *
-     * @return void
      */
-    public function testAddLocation()
+    public function testAddLocation(): void
     {
         $locator = new TableLocator([]);
 
@@ -721,7 +653,7 @@ class TableLocatorTest extends TestCase
         $this->assertInstanceOf(AddressesTable::class, $table);
     }
 
-    public function testSetFallbackClassName()
+    public function testSetFallbackClassName(): void
     {
         $this->_locator->setFallbackClassName(ArticlesTable::class);
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -70,8 +70,6 @@ class MarshallerTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -100,8 +98,6 @@ class MarshallerTest extends TestCase
 
     /**
      * Teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -111,10 +107,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() in a simple use.
-     *
-     * @return void
      */
-    public function testOneSimple()
+    public function testOneSimple(): void
     {
         $data = [
             'title' => 'My title',
@@ -134,10 +128,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that marshalling an entity with numeric key in data array
-     *
-     * @return void
      */
-    public function testOneWithNumericField()
+    public function testOneWithNumericField(): void
     {
         $data = [
             'sample',
@@ -154,10 +146,8 @@ class MarshallerTest extends TestCase
     /**
      * Test that marshalling an entity with '' for pk values results
      * in no pk value being set.
-     *
-     * @return void
      */
-    public function testOneEmptyStringPrimaryKey()
+    public function testOneEmptyStringPrimaryKey(): void
     {
         $data = [
             'id' => '',
@@ -175,10 +165,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test marshalling datetime/date field.
-     *
-     * @return void
      */
-    public function testOneWithDatetimeField()
+    public function testOneWithDatetimeField(): void
     {
         $data = [
             'comment' => 'My Comment text',
@@ -225,10 +213,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Ensure that marshalling casts reasonably.
-     *
-     * @return void
      */
-    public function testOneOnlyCastMatchingData()
+    public function testOneOnlyCastMatchingData(): void
     {
         $data = [
             'title' => 'My title',
@@ -247,10 +233,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() follows mass-assignment rules.
-     *
-     * @return void
      */
-    public function testOneAccessibleProperties()
+    public function testOneAccessibleProperties(): void
     {
         $data = [
             'title' => 'My title',
@@ -269,10 +253,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() supports accessibleFields option
-     *
-     * @return void
      */
-    public function testOneAccessibleFieldsOption()
+    public function testOneAccessibleFieldsOption(): void
     {
         $data = [
             'title' => 'My title',
@@ -298,10 +280,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() with an invalid association
-     *
-     * @return void
      */
-    public function testOneInvalidAssociation()
+    public function testOneInvalidAssociation(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot marshal data for "Derp" association. It is not associated with "Articles".');
@@ -322,10 +302,8 @@ class MarshallerTest extends TestCase
     /**
      * Test that one() correctly handles an association beforeMarshal
      * making the association empty.
-     *
-     * @return void
      */
-    public function testOneAssociationBeforeMarshalMutation()
+    public function testOneAssociationBeforeMarshalMutation(): void
     {
         $users = $this->getTableLocator()->get('Users');
         $articles = $this->getTableLocator()->get('Articles');
@@ -333,7 +311,7 @@ class MarshallerTest extends TestCase
         $users->hasOne('Articles', [
             'foreignKey' => 'author_id',
         ]);
-        $articles->getEventManager()->on('Model.beforeMarshal', function ($event, $data, $options) {
+        $articles->getEventManager()->on('Model.beforeMarshal', function ($event, $data, $options): void {
             // Blank the association, so it doesn't become dirty.
             unset($data['not_a_real_field']);
         });
@@ -363,10 +341,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() supports accessibleFields option for associations
-     *
-     * @return void
      */
-    public function testOneAccessibleFieldsOptionForAssociations()
+    public function testOneAccessibleFieldsOptionForAssociations(): void
     {
         $data = [
             'title' => 'My title',
@@ -394,10 +370,8 @@ class MarshallerTest extends TestCase
 
     /**
      * test one() with a wrapping model name.
-     *
-     * @return void
      */
-    public function testOneWithAdditionalName()
+    public function testOneWithAdditionalName(): void
     {
         $data = [
             'title' => 'Original Title',
@@ -424,10 +398,8 @@ class MarshallerTest extends TestCase
 
     /**
      * test one() with association data.
-     *
-     * @return void
      */
-    public function testOneAssociationsSingle()
+    public function testOneAssociationsSingle(): void
     {
         $data = [
             'title' => 'My title',
@@ -461,10 +433,8 @@ class MarshallerTest extends TestCase
 
     /**
      * test one() with association data.
-     *
-     * @return void
      */
-    public function testOneAssociationsMany()
+    public function testOneAssociationsMany(): void
     {
         $data = [
             'title' => 'My title',
@@ -498,10 +468,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test building the _joinData entity for belongstomany associations.
-     *
-     * @return void
      */
-    public function testOneBelongsToManyJoinData()
+    public function testOneBelongsToManyJoinData(): void
     {
         $data = [
             'title' => 'My title',
@@ -538,10 +506,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that the onlyIds option restricts to only accepting ids for belongs to many associations.
-     *
-     * @return void
      */
-    public function testOneBelongsToManyOnlyIdsRejectArray()
+    public function testOneBelongsToManyOnlyIdsRejectArray(): void
     {
         $data = [
             'title' => 'My title',
@@ -561,10 +527,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that the onlyIds option restricts to only accepting ids for belongs to many associations.
-     *
-     * @return void
      */
-    public function testOneBelongsToManyOnlyIdsWithIds()
+    public function testOneBelongsToManyOnlyIdsWithIds(): void
     {
         $data = [
             'title' => 'My title',
@@ -584,10 +548,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test marshalling nested associations on the _joinData structure.
-     *
-     * @return void
      */
-    public function testOneBelongsToManyJoinDataAssociated()
+    public function testOneBelongsToManyJoinDataAssociated(): void
     {
         $data = [
             'title' => 'My title',
@@ -632,10 +594,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() with with id and _joinData.
-     *
-     * @return void
      */
-    public function testOneBelongsToManyJoinDataAssociatedWithIds()
+    public function testOneBelongsToManyJoinDataAssociatedWithIds(): void
     {
         $data = [
             'title' => 'My title',
@@ -695,10 +655,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test belongsToMany association with mixed data and _joinData
-     *
-     * @return void
      */
-    public function testOneBelongsToManyWithMixedJoinData()
+    public function testOneBelongsToManyWithMixedJoinData(): void
     {
         $data = [
             'title' => 'My title',
@@ -729,7 +687,7 @@ class MarshallerTest extends TestCase
         $this->assertSame(1, $result->tags[1]->_joinData->active);
     }
 
-    public function testOneBelongsToManyWithNestedAssociations()
+    public function testOneBelongsToManyWithNestedAssociations(): void
     {
         $this->tags->belongsToMany('Articles');
         $data = [
@@ -777,10 +735,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test belongsToMany association with mixed data and _joinData
-     *
-     * @return void
      */
-    public function testBelongsToManyAddingNewExisting()
+    public function testBelongsToManyAddingNewExisting(): void
     {
         $this->tags->setEntityClass(OpenTag::class);
         $data = [
@@ -829,10 +785,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test belongsToMany association with mixed data and _joinData
-     *
-     * @return void
      */
-    public function testBelongsToManyWithMixedJoinDataOutOfOrder()
+    public function testBelongsToManyWithMixedJoinDataOutOfOrder(): void
     {
         $data = [
             'title' => 'My title',
@@ -873,10 +827,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test belongsToMany association with scalars
-     *
-     * @return void
      */
-    public function testBelongsToManyInvalidData()
+    public function testBelongsToManyInvalidData(): void
     {
         $data = [
             'title' => 'My title',
@@ -901,10 +853,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test belongsToMany association with mixed data array
-     *
-     * @return void
      */
-    public function testBelongsToManyWithMixedData()
+    public function testBelongsToManyWithMixedData(): void
     {
         $data = [
             'title' => 'My title',
@@ -946,10 +896,8 @@ class MarshallerTest extends TestCase
      * Test belongsToMany association with the ForceNewTarget to force saving
      * new records on the target tables with BTM relationships when the primaryKey(s)
      * of the target table is specified.
-     *
-     * @return void
      */
-    public function testBelongsToManyWithForceNew()
+    public function testBelongsToManyWithForceNew(): void
     {
         $data = [
             'title' => 'Fourth Article',
@@ -979,10 +927,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test HasMany association with _ids attribute
-     *
-     * @return void
      */
-    public function testOneHasManyWithIds()
+    public function testOneHasManyWithIds(): void
     {
         $data = [
             'title' => 'article',
@@ -1001,10 +947,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that the onlyIds option restricts to only accepting ids for hasmany associations.
-     *
-     * @return void
      */
-    public function testOneHasManyOnlyIdsRejectArray()
+    public function testOneHasManyOnlyIdsRejectArray(): void
     {
         $data = [
             'title' => 'article',
@@ -1024,10 +968,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that the onlyIds option restricts to only accepting ids for hasmany associations.
-     *
-     * @return void
      */
-    public function testOneHasManyOnlyIdsWithIds()
+    public function testOneHasManyOnlyIdsWithIds(): void
     {
         $data = [
             'title' => 'article',
@@ -1047,10 +989,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test HasMany association with invalid data
-     *
-     * @return void
      */
-    public function testOneHasManyInvalidData()
+    public function testOneHasManyInvalidData(): void
     {
         $data = [
             'title' => 'new title',
@@ -1071,10 +1011,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() with deeper associations.
-     *
-     * @return void
      */
-    public function testOneDeepAssociations()
+    public function testOneDeepAssociations(): void
     {
         $data = [
             'comment' => 'First post',
@@ -1103,10 +1041,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test many() with a simple set of data.
-     *
-     * @return void
      */
-    public function testManySimple()
+    public function testManySimple(): void
     {
         $data = [
             ['comment' => 'First post', 'user_id' => 2],
@@ -1124,10 +1060,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test many() with some invalid data
-     *
-     * @return void
      */
-    public function testManyInvalidData()
+    public function testManyInvalidData(): void
     {
         $data = [
             ['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
@@ -1142,10 +1076,8 @@ class MarshallerTest extends TestCase
 
     /**
      * test many() with nested associations.
-     *
-     * @return void
      */
-    public function testManyAssociations()
+    public function testManyAssociations(): void
     {
         $data = [
             [
@@ -1182,10 +1114,8 @@ class MarshallerTest extends TestCase
     /**
      * Test if exception is raised when called with [associated => NonExistentAssociation]
      * Previously such association were simply ignored
-     *
-     * @return void
      */
-    public function testManyInvalidAssociation()
+    public function testManyInvalidAssociation(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $data = [
@@ -1210,10 +1140,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test generating a list of entities from a list of ids.
-     *
-     * @return void
      */
-    public function testOneGenerateBelongsToManyEntitiesFromIds()
+    public function testOneGenerateBelongsToManyEntitiesFromIds(): void
     {
         $data = [
             'title' => 'Haz tags',
@@ -1264,10 +1192,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge() in a simple use.
-     *
-     * @return void
      */
-    public function testMergeSimple()
+    public function testMergeSimple(): void
     {
         $data = [
             'title' => 'My title',
@@ -1292,10 +1218,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge() with accessibleFields options
-     *
-     * @return void
      */
-    public function testMergeAccessibleFields()
+    public function testMergeAccessibleFields(): void
     {
         $data = [
             'title' => 'My title',
@@ -1336,9 +1260,8 @@ class MarshallerTest extends TestCase
      *
      * @dataProvider emptyProvider
      * @param mixed $value
-     * @return void
      */
-    public function testMergeFalseyValues($value)
+    public function testMergeFalseyValues($value): void
     {
         $marshall = new Marshaller($this->articles);
         $entity = new Entity();
@@ -1352,10 +1275,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge() doesn't dirty values that were null and are null again.
-     *
-     * @return void
      */
-    public function testMergeUnchangedNullValue()
+    public function testMergeUnchangedNullValue(): void
     {
         $data = [
             'title' => 'My title',
@@ -1377,10 +1298,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge() doesn't dirty objects which are equal.
-     *
-     * @return void
      */
-    public function testMergeWithSameObjectValue()
+    public function testMergeWithSameObjectValue(): void
     {
         $created = new FrozenTime('2020-10-29');
         $entity = new Entity([
@@ -1403,10 +1322,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that merge respects the entity accessible methods
-     *
-     * @return void
      */
-    public function testMergeWhitelist()
+    public function testMergeWhitelist(): void
     {
         $data = [
             'title' => 'My title',
@@ -1435,10 +1352,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge() with an invalid association
-     *
-     * @return void
      */
-    public function testMergeInvalidAssociation()
+    public function testMergeInvalidAssociation(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot marshal data for "Derp" association. It is not associated with "Articles".');
@@ -1464,9 +1379,8 @@ class MarshallerTest extends TestCase
      * Test merge when fields contains an association.
      *
      * @param $fields
-     * @return void
      */
-    public function testMergeWithSingleAssociationAndFields()
+    public function testMergeWithSingleAssociationAndFields(): void
     {
         $user = new Entity([
            'username' => 'user',
@@ -1498,10 +1412,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that fields with the same value are not marked as dirty
-     *
-     * @return void
      */
-    public function testMergeDirty()
+    public function testMergeDirty(): void
     {
         $marshall = new Marshaller($this->articles);
         $entity = new Entity([
@@ -1530,10 +1442,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests merging data into an associated entity
-     *
-     * @return void
      */
-    public function testMergeWithSingleAssociation()
+    public function testMergeWithSingleAssociation(): void
     {
         $user = new Entity([
             'username' => 'mark',
@@ -1567,10 +1477,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that new associated entities can be created when merging data into
      * a parent entity
-     *
-     * @return void
      */
-    public function testMergeCreateAssociation()
+    public function testMergeCreateAssociation(): void
     {
         $entity = new Entity([
             'title' => 'My Title',
@@ -1599,10 +1507,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge when an association has been replaced with null
-     *
-     * @return void
      */
-    public function testMergeAssociationNullOut()
+    public function testMergeAssociationNullOut(): void
     {
         $user = new Entity([
             'id' => 1,
@@ -1634,10 +1540,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests merging one to many associations
-     *
-     * @return void
      */
-    public function testMergeMultipleAssociations()
+    public function testMergeMultipleAssociations(): void
     {
         $user = new Entity(['username' => 'mark', 'password' => 'secret']);
         $comment1 = new Entity(['id' => 1, 'comment' => 'A comment']);
@@ -1714,10 +1618,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that merging data to a hasMany association with _ids works.
-     *
-     * @return void
      */
-    public function testMergeHasManyEntitiesFromIds()
+    public function testMergeHasManyEntitiesFromIds(): void
     {
         $entity = $this->articles->get(1, ['contain' => ['Comments']]);
         $this->assertNotEmpty($entity->comments);
@@ -1738,10 +1640,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that merging data to a hasMany association using onlyIds restricts operations.
-     *
-     * @return void
      */
-    public function testMergeHasManyEntitiesFromIdsOnlyIds()
+    public function testMergeHasManyEntitiesFromIdsOnlyIds(): void
     {
         $entity = $this->articles->get(1, ['contain' => ['Comments']]);
         $this->assertNotEmpty($entity->comments);
@@ -1766,10 +1666,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that merging data to an entity containing belongsToMany and _ids
      * will just overwrite the data
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyEntitiesFromIds()
+    public function testMergeBelongsToManyEntitiesFromIds(): void
     {
         $entity = new Entity([
             'title' => 'Haz tags',
@@ -1800,10 +1698,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that merging data to an entity containing belongsToMany and _ids
      * will not generate conflicting queries when associations are automatically selected
-     *
-     * @return void
      */
-    public function testMergeFromIdsWithAutoAssociation()
+    public function testMergeFromIdsWithAutoAssociation(): void
     {
         $entity = new Entity([
             'title' => 'Haz tags',
@@ -1822,7 +1718,7 @@ class MarshallerTest extends TestCase
         $entity->clean();
 
         // Adding a forced join to have another table with the same column names
-        $this->articles->Tags->getEventManager()->on('Model.beforeFind', function ($e, $query) {
+        $this->articles->Tags->getEventManager()->on('Model.beforeFind', function ($e, $query): void {
             $left = new IdentifierExpression('Tags.id');
             $right = new IdentifierExpression('a.id');
             $query->leftJoin(['a' => 'tags'], $query->newExpr()->eq($left, $right));
@@ -1838,10 +1734,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that merging data to an entity containing belongsToMany and _ids
      * with additional association conditions works.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyFromIdsWithConditions()
+    public function testMergeBelongsToManyFromIdsWithConditions(): void
     {
         $this->articles->belongsToMany('Tags', [
             'conditions' => ['ArticleTags.article_id' => 1],
@@ -1873,10 +1767,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that merging data to an entity containing belongsToMany as an array
      * with additional association conditions works.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyFromArrayWithConditions()
+    public function testMergeBelongsToManyFromArrayWithConditions(): void
     {
         $this->articles->belongsToMany('Tags', [
             'conditions' => ['ArticleTags.article_id' => 1],
@@ -1915,10 +1807,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that merging data to an entity containing belongsToMany and _ids
      * will ignore empty values.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyEntitiesFromIdsEmptyValue()
+    public function testMergeBelongsToManyEntitiesFromIdsEmptyValue(): void
     {
         $entity = new Entity([
             'title' => 'Haz tags',
@@ -1956,10 +1846,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that the ids option restricts to only accepting ids for belongs to many associations.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyOnlyIdsRejectArray()
+    public function testMergeBelongsToManyOnlyIdsRejectArray(): void
     {
         $entity = new Entity([
             'title' => 'Haz tags',
@@ -1988,10 +1876,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that the ids option restricts to only accepting ids for belongs to many associations.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyOnlyIdsWithIds()
+    public function testMergeBelongsToManyOnlyIdsWithIds(): void
     {
         $entity = new Entity([
             'title' => 'Haz tags',
@@ -2020,10 +1906,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that invalid _joinData (scalar data) is not marshalled.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyJoinDataScalar()
+    public function testMergeBelongsToManyJoinDataScalar(): void
     {
         $this->getTableLocator()->clear();
         $articles = $this->getTableLocator()->get('Articles');
@@ -2049,10 +1933,8 @@ class MarshallerTest extends TestCase
     /**
      * Test merging the _joinData entity for belongstomany associations when * is not
      * accessible.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyJoinDataNotAccessible()
+    public function testMergeBelongsToManyJoinDataNotAccessible(): void
     {
         $this->getTableLocator()->clear();
         $articles = $this->getTableLocator()->get('Articles');
@@ -2085,10 +1967,8 @@ class MarshallerTest extends TestCase
     /**
      * Test that _joinData is marshalled consistently with both
      * new and existing records
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyHandleJoinDataConsistently()
+    public function testMergeBelongsToManyHandleJoinDataConsistently(): void
     {
         $this->getTableLocator()->clear();
         $articles = $this->getTableLocator()->get('Articles');
@@ -2128,10 +2008,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merging belongsToMany data doesn't create 'new' entities.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyJoinDataAssociatedWithIds()
+    public function testMergeBelongsToManyJoinDataAssociatedWithIds(): void
     {
         $data = [
             'title' => 'My title',
@@ -2185,10 +2063,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merging the _joinData entity for belongstomany associations.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyJoinData()
+    public function testMergeBelongsToManyJoinData(): void
     {
         $data = [
             'title' => 'My title',
@@ -2247,10 +2123,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merging associations inside _joinData
-     *
-     * @return void
      */
-    public function testMergeJoinDataAssociations()
+    public function testMergeJoinDataAssociations(): void
     {
         $data = [
             'title' => 'My title',
@@ -2322,10 +2196,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that merging belongsToMany association doesn't erase _joinData
      * on existing objects.
-     *
-     * @return void
      */
-    public function testMergeBelongsToManyIdsRetainJoinData()
+    public function testMergeBelongsToManyIdsRetainJoinData(): void
     {
         $this->articles->belongsToMany('Tags');
         $entity = $this->articles->get(1, ['contain' => ['Tags']]);
@@ -2352,10 +2224,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test mergeMany() with a simple set of data.
-     *
-     * @return void
      */
-    public function testMergeManySimple()
+    public function testMergeManySimple(): void
     {
         $entities = [
             new OpenArticleEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2]),
@@ -2382,10 +2252,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test mergeMany() with some invalid data
-     *
-     * @return void
      */
-    public function testMergeManyInvalidData()
+    public function testMergeManyInvalidData(): void
     {
         $entities = [
             new OpenArticleEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2]),
@@ -2409,10 +2277,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that only records found in the data array are returned, those that cannot
      * be matched are discarded
-     *
-     * @return void
      */
-    public function testMergeManyWithAppend()
+    public function testMergeManyWithAppend(): void
     {
         $entities = [
             new OpenArticleEntity(['comment' => 'First post', 'user_id' => 2]),
@@ -2441,10 +2307,8 @@ class MarshallerTest extends TestCase
      *
      * The articles_tags table has a composite primary key, and should be
      * handled correctly.
-     *
-     * @return void
      */
-    public function testMergeManyCompositeKey()
+    public function testMergeManyCompositeKey(): void
     {
         $articlesTags = $this->getTableLocator()->get('ArticlesTags');
 
@@ -2469,10 +2333,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test mergeMany() with forced contain to ensure aliases are used in queries.
-     *
-     * @return void
      */
-    public function testMergeManyExistingQueryAliases()
+    public function testMergeManyExistingQueryAliases(): void
     {
         $entities = [
             new OpenArticleEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2], ['markClean' => true]),
@@ -2493,10 +2355,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test mergeMany() when the exist check returns nothing.
-     *
-     * @return void
      */
-    public function testMergeManyExistQueryFails()
+    public function testMergeManyExistQueryFails(): void
     {
         $entities = [
             new Entity(['id' => 1, 'comment' => 'First post', 'user_id' => 2]),
@@ -2525,10 +2385,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests merge with data types that need to be marshalled
-     *
-     * @return void
      */
-    public function testMergeComplexType()
+    public function testMergeComplexType(): void
     {
         $entity = new Entity(
             ['comment' => 'My Comment text'],
@@ -2549,10 +2407,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that it is possible to pass a fields option to the marshaller
-     *
-     * @return void
      */
-    public function testOneWithFields()
+    public function testOneWithFields(): void
     {
         $data = [
             'title' => 'My title',
@@ -2569,10 +2425,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test one() with translations
-     *
-     * @return void
      */
-    public function testOneWithTranslations()
+    public function testOneWithTranslations(): void
     {
         $this->articles->addBehavior('Translate', [
             'fields' => ['title', 'body'],
@@ -2612,10 +2466,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that it is possible to pass a fields option to the merge method
-     *
-     * @return void
      */
-    public function testMergeWithFields()
+    public function testMergeWithFields(): void
     {
         $data = [
             'title' => 'My title',
@@ -2646,10 +2498,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that many() also receives a fields option
-     *
-     * @return void
      */
-    public function testManyFields()
+    public function testManyFields(): void
     {
         $data = [
             ['comment' => 'First post', 'user_id' => 2, 'foo' => 'bar'],
@@ -2666,10 +2516,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that many() also receives a fields option
-     *
-     * @return void
      */
-    public function testMergeManyFields()
+    public function testMergeManyFields(): void
     {
         $entities = [
             new OpenArticleEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2]),
@@ -2697,10 +2545,8 @@ class MarshallerTest extends TestCase
 
     /**
      * test marshalling association data while passing a fields
-     *
-     * @return void
      */
-    public function testAssociationsFields()
+    public function testAssociationsFields(): void
     {
         $data = [
             'title' => 'My title',
@@ -2731,10 +2577,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests merging associated data with a fields
-     *
-     * @return void
      */
-    public function testMergeAssociationWithfields()
+    public function testMergeAssociationWithfields(): void
     {
         $user = new Entity([
             'username' => 'mark',
@@ -2772,10 +2616,8 @@ class MarshallerTest extends TestCase
     /**
      * Test marshalling nested associations on the _joinData structure
      * while having a fields
-     *
-     * @return void
      */
-    public function testJoinDataWhiteList()
+    public function testJoinDataWhiteList(): void
     {
         $data = [
             'title' => 'My title',
@@ -2831,10 +2673,8 @@ class MarshallerTest extends TestCase
     /**
      * Test merging the _joinData entity for belongstomany associations
      * while passing a whitelist
-     *
-     * @return void
      */
-    public function testMergeJoinDataWithFields()
+    public function testMergeJoinDataWithFields(): void
     {
         $data = [
             'title' => 'My title',
@@ -2894,10 +2734,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests marshalling with validation errors
-     *
-     * @return void
      */
-    public function testValidationFail()
+    public function testValidationFail(): void
     {
         $data = [
             'title' => 'Thing',
@@ -2912,10 +2750,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test that invalid validate options raise exceptions
-     *
-     * @return void
      */
-    public function testValidateInvalidType()
+    public function testValidateInvalidType(): void
     {
         $this->expectException(\RuntimeException::class);
         $data = ['title' => 'foo'];
@@ -2927,10 +2763,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that associations are validated and custom validators can be used
-     *
-     * @return void
      */
-    public function testValidateWithAssociationsAndCustomValidator()
+    public function testValidateWithAssociationsAndCustomValidator(): void
     {
         $data = [
             'title' => 'foo',
@@ -2973,10 +2807,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that validation can be bypassed
-     *
-     * @return void
      */
-    public function testSkipValidation()
+    public function testSkipValidation(): void
     {
         $data = [
             'title' => 'foo',
@@ -3005,10 +2837,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that it is possible to pass a validator directly in the options
-     *
-     * @return void
      */
-    public function testPassingCustomValidator()
+    public function testPassingCustomValidator(): void
     {
         $data = [
             'title' => 'Thing',
@@ -3024,10 +2854,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Tests that invalid property is being filled when data cannot be patched into an entity.
-     *
-     * @return void
      */
-    public function testValidationWithInvalidFilled()
+    public function testValidationWithInvalidFilled(): void
     {
         $data = [
             'title' => 'foo',
@@ -3043,10 +2871,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge with validation error
-     *
-     * @return void
      */
-    public function testMergeWithValidation()
+    public function testMergeWithValidation(): void
     {
         $data = [
             'title' => 'My title',
@@ -3088,10 +2914,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge with validation and create or update validation rules
-     *
-     * @return void
      */
-    public function testMergeWithCreate()
+    public function testMergeWithCreate(): void
     {
         $data = [
             'title' => 'My title',
@@ -3126,10 +2950,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge() with translate behavior integration
-     *
-     * @return void
      */
-    public function testMergeWithTranslations()
+    public function testMergeWithTranslations(): void
     {
         $this->articles->addBehavior('Translate', [
             'fields' => ['title', 'body'],
@@ -3169,10 +2991,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test Model.beforeMarshal event.
-     *
-     * @return void
      */
-    public function testBeforeMarshalEvent()
+    public function testBeforeMarshalEvent(): void
     {
         $data = [
             'title' => 'My title',
@@ -3187,7 +3007,7 @@ class MarshallerTest extends TestCase
 
         $this->articles->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data, $options) {
+            function ($e, $data, $options): void {
                 $this->assertArrayHasKey('validate', $options);
                 $data['title'] = 'Modified title';
                 $data['user']['username'] = 'robert';
@@ -3206,10 +3026,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test Model.beforeMarshal event on associated tables.
-     *
-     * @return void
      */
-    public function testBeforeMarshalEventOnAssociations()
+    public function testBeforeMarshalEventOnAssociations(): void
     {
         $data = [
             'title' => 'My title',
@@ -3234,7 +3052,7 @@ class MarshallerTest extends TestCase
         // Assert event options are correct
         $this->articles->Users->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data, $options) {
+            function ($e, $data, $options): void {
                 $this->assertArrayHasKey('validate', $options);
                 $this->assertTrue($options['validate']);
 
@@ -3248,28 +3066,28 @@ class MarshallerTest extends TestCase
 
         $this->articles->Users->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data, $options) {
+            function ($e, $data, $options): void {
                 $data['secret'] = 'h45h3d';
             }
         );
 
         $this->articles->Comments->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data) {
+            function ($e, $data): void {
                 $data['comment'] .= ' (modified)';
             }
         );
 
         $this->articles->Tags->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data) {
+            function ($e, $data): void {
                 $data['tag'] .= ' (modified)';
             }
         );
 
         $this->articles->Tags->junction()->getEventManager()->on(
             'Model.beforeMarshal',
-            function ($e, $data) {
+            function ($e, $data): void {
                 $data['modified_by'] = 1;
             }
         );
@@ -3289,10 +3107,8 @@ class MarshallerTest extends TestCase
 
     /**
      * Test Model.afterMarshal event.
-     *
-     * @return void
      */
-    public function testAfterMarshalEvent()
+    public function testAfterMarshalEvent(): void
     {
         $data = [
             'title' => 'original title',
@@ -3307,7 +3123,7 @@ class MarshallerTest extends TestCase
 
         $this->articles->getEventManager()->on(
             'Model.afterMarshal',
-            function ($e, $entity, $data, $options) {
+            function ($e, $entity, $data, $options): void {
                 $this->assertInstanceOf('Cake\ORM\Entity', $entity);
                 $this->assertArrayHasKey('validate', $options);
                 $this->assertFalse($options['isMerge']);
@@ -3333,10 +3149,8 @@ class MarshallerTest extends TestCase
     /**
      * Test Model.afterMarshal event on patchEntity.
      * when $options['fields'] is set and is empty
-     *
-     * @return void
      */
-    public function testAfterMarshalEventOnPatchEntity()
+    public function testAfterMarshalEventOnPatchEntity(): void
     {
         $data = [
             'title' => 'original title',
@@ -3351,7 +3165,7 @@ class MarshallerTest extends TestCase
 
         $this->articles->getEventManager()->on(
             'Model.afterMarshal',
-            function ($e, $entity, $data, $options) {
+            function ($e, $entity, $data, $options): void {
                 $this->assertInstanceOf('Cake\ORM\Entity', $entity);
                 $this->assertArrayHasKey('validate', $options);
                 $this->assertTrue($options['isMerge']);
@@ -3389,10 +3203,8 @@ class MarshallerTest extends TestCase
     /**
      * Tests that patching an association resulting in no changes, will
      * not mark the parent entity as dirty
-     *
-     * @return void
      */
-    public function testAssociationNoChanges()
+    public function testAssociationNoChanges(): void
     {
         $options = ['markClean' => true, 'isNew' => false];
         $entity = new Entity([
@@ -3423,10 +3235,8 @@ class MarshallerTest extends TestCase
     /**
      * Test that primary key meta data is being read from the table
      * and not the schema reflection when handling belongsToMany associations.
-     *
-     * @return void
      */
-    public function testEnsurePrimaryKeyBeingReadFromTableForHandlingEmptyStringPrimaryKey()
+    public function testEnsurePrimaryKeyBeingReadFromTableForHandlingEmptyStringPrimaryKey(): void
     {
         $data = [
             'id' => '',
@@ -3446,10 +3256,8 @@ class MarshallerTest extends TestCase
     /**
      * Test that primary key meta data is being read from the table
      * and not the schema reflection when handling belongsToMany associations.
-     *
-     * @return void
      */
-    public function testEnsurePrimaryKeyBeingReadFromTableWhenLoadingBelongsToManyRecordsByPrimaryKey()
+    public function testEnsurePrimaryKeyBeingReadFromTableWhenLoadingBelongsToManyRecordsByPrimaryKey(): void
     {
         $data = [
             'tags' => [
@@ -3491,7 +3299,7 @@ class MarshallerTest extends TestCase
     /**
      * Tests that ID values are being bound with the correct type when loading associated records.
      */
-    public function testInvalidTypesWhenLoadingAssociatedByIds()
+    public function testInvalidTypesWhenLoadingAssociatedByIds(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
@@ -3511,7 +3319,7 @@ class MarshallerTest extends TestCase
     /**
      * Tests that composite ID values are being bound with the correct type when loading associated records.
      */
-    public function testInvalidTypesWhenLoadingAssociatedByCompositeIds()
+    public function testInvalidTypesWhenLoadingAssociatedByCompositeIds(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot convert value of type `string` to integer');

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -53,10 +53,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test for https://github.com/cakephp/cakephp/issues/3087
-     *
-     * @return void
      */
-    public function testSelectTimestampColumn()
+    public function testSelectTimestampColumn(): void
     {
         $this->loadFixtures('Users');
         $table = $this->getTableLocator()->get('users');
@@ -68,10 +66,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that EagerLoader does not try to create queries for associations having no
      * keys to compare against
-     *
-     * @return void
      */
-    public function testEagerLoadingFromEmptyResults()
+    public function testEagerLoadingFromEmptyResults(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
@@ -82,10 +78,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that eagerloading associations with aliased fields works.
-     *
-     * @return void
      */
-    public function testEagerLoadingAliasedAssociationFields()
+    public function testEagerLoadingAliasedAssociationFields(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -109,10 +103,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that eagerloading and hydration works for associations that have
      * different aliases in the association and targetTable
-     *
-     * @return void
      */
-    public function testEagerLoadingMismatchingAliasInBelongsTo()
+    public function testEagerLoadingMismatchingAliasInBelongsTo(): void
     {
         $this->loadFixtures('Articles', 'Users');
         $table = $this->getTableLocator()->get('Articles');
@@ -130,10 +122,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that eagerloading and hydration works for associations that have
      * different aliases in the association and targetTable
-     *
-     * @return void
      */
-    public function testEagerLoadingMismatchingAliasInHasOne()
+    public function testEagerLoadingMismatchingAliasInHasOne(): void
     {
         $this->loadFixtures('Articles', 'Users');
         $articles = $this->getTableLocator()->get('Articles');
@@ -150,10 +140,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that eagerloading belongsToMany with find list fails with a helpful message.
-     *
-     * @return void
      */
-    public function testEagerLoadingBelongsToManyList()
+    public function testEagerLoadingBelongsToManyList(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
@@ -169,10 +157,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that eagerloading and hydration works for associations that have
      * different aliases in the association and targetTable
-     *
-     * @return void
      */
-    public function testEagerLoadingNestedMatchingCalls()
+    public function testEagerLoadingNestedMatchingCalls(): void
     {
         $this->loadFixtures('Articles', 'Authors', 'Tags', 'ArticlesTags', 'AuthorsTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -207,10 +193,8 @@ class QueryRegressionTest extends TestCase
      * naturally be attached to the query instead of eagerly loaded. What should
      * happen here is that One of the duplicates will be changed to be loaded using
      * an extra query, but yielding the same results
-     *
-     * @return void
      */
-    public function testDuplicateAttachableAliases()
+    public function testDuplicateAttachableAliases(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags', 'Authors');
         $this->getTableLocator()->get('Stuff', ['table' => 'tags']);
@@ -245,10 +229,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test for https://github.com/cakephp/cakephp/issues/3410
-     *
-     * @return void
      */
-    public function testNullableTimeColumn()
+    public function testNullableTimeColumn(): void
     {
         $this->loadFixtures('Users');
         $table = $this->getTableLocator()->get('users');
@@ -261,10 +243,8 @@ class QueryRegressionTest extends TestCase
      * Test for https://github.com/cakephp/cakephp/issues/3626
      *
      * Checks that join data is actually created and not tried to be updated every time
-     *
-     * @return void
      */
-    public function testCreateJointData()
+    public function testCreateJointData(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -294,10 +274,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that the junction table instance taken from both sides of a belongsToMany
      * relationship is actually the same object.
-     *
-     * @return void
      */
-    public function testReciprocalBelongsToMany()
+    public function testReciprocalBelongsToMany(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -316,10 +294,8 @@ class QueryRegressionTest extends TestCase
      *
      * Makes sure that the belongsToMany association is not overwritten with conflicting information
      * by any of the sides when the junction() function is invoked
-     *
-     * @return void
      */
-    public function testReciprocalBelongsToManyNoOverwrite()
+    public function testReciprocalBelongsToManyNoOverwrite(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -358,9 +334,8 @@ class QueryRegressionTest extends TestCase
      *
      * @dataProvider strategyProvider
      * @param string $strategy
-     * @return void
      */
-    public function testBelongsToManyDeepSave($strategy)
+    public function testBelongsToManyDeepSave($strategy): void
     {
         $this->loadFixtures('Articles', 'Tags', 'SpecialTags', 'Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -419,9 +394,8 @@ class QueryRegressionTest extends TestCase
      * during a  save operation
      *
      * @see https://github.com/cakephp/cakephp/issues/3803
-     * @return void
      */
-    public function testSaveWithCallbacks()
+    public function testSaveWithCallbacks(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -440,10 +414,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Test that save() works with entities containing expressions
      * as properties.
-     *
-     * @return void
      */
-    public function testSaveWithExpressionProperty()
+    public function testSaveWithExpressionProperty(): void
     {
         $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
@@ -457,9 +429,8 @@ class QueryRegressionTest extends TestCase
      * data is not removed because of excessive associations filtering.
      *
      * @see https://github.com/cakephp/cakephp/issues/4009
-     * @return void
      */
-    public function testBelongsToManyDeepSave2()
+    public function testBelongsToManyDeepSave2(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -514,10 +485,8 @@ class QueryRegressionTest extends TestCase
     /**
      * An integration test that spot checks that associations use the
      * correct alias names to generate queries.
-     *
-     * @return void
      */
-    public function testPluginAssociationQueryGeneration()
+    public function testPluginAssociationQueryGeneration(): void
     {
         $this->loadFixtures('Articles', 'Comments', 'Authors');
         $this->loadPlugins(['TestPlugin']);
@@ -547,9 +516,8 @@ class QueryRegressionTest extends TestCase
      * the associations are selected.
      *
      * @see https://github.com/cakephp/cakephp/issues/4454
-     * @return void
      */
-    public function testAssociationChainOrder()
+    public function testAssociationChainOrder(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags', 'Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -576,10 +544,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that offset/limit are elided from subquery loads.
-     *
-     * @return void
      */
-    public function testAssociationSubQueryNoOffset()
+    public function testAssociationSubQueryNoOffset(): void
     {
         $this->loadFixtures('Articles', 'Translates');
         $table = $this->getTableLocator()->get('Articles');
@@ -597,9 +563,8 @@ class QueryRegressionTest extends TestCase
      * Tests that using the subquery strategy in a deep association returns the right results
      *
      * @see https://github.com/cakephp/cakephp/issues/4484
-     * @return void
      */
-    public function testDeepBelongsToManySubqueryStrategy()
+    public function testDeepBelongsToManySubqueryStrategy(): void
     {
         $this->loadFixtures('Authors', 'Tags', 'Articles', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Authors');
@@ -620,9 +585,8 @@ class QueryRegressionTest extends TestCase
      * Tests that using the subquery strategy in a deep association returns the right results
      *
      * @see https://github.com/cakephp/cakephp/issues/5769
-     * @return void
      */
-    public function testDeepBelongsToManySubqueryStrategy2()
+    public function testDeepBelongsToManySubqueryStrategy2(): void
     {
         $this->loadFixtures('Articles', 'Authors', 'Tags', 'Authors', 'AuthorsTags');
         $table = $this->getTableLocator()->get('Authors');
@@ -651,9 +615,8 @@ class QueryRegressionTest extends TestCase
      * seamlessly with either select or subquery.
      *
      * @see https://github.com/cakephp/cakephp/issues/6781
-     * @return void
      */
-    public function testDeepHasManyEitherStrategy()
+    public function testDeepHasManyEitherStrategy(): void
     {
         $this->loadFixtures('Tags', 'FeaturedTags', 'TagsTranslations');
         $tags = $this->getTableLocator()->get('Tags');
@@ -697,9 +660,8 @@ class QueryRegressionTest extends TestCase
      * the correct results
      *
      * @see https://github.com/cakephp/cakephp/issues/4511
-     * @return void
      */
-    public function testCountWithContain()
+    public function testCountWithContain(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -717,9 +679,8 @@ class QueryRegressionTest extends TestCase
      * Tests that getting the count of a query with bind is correct
      *
      * @see https://github.com/cakephp/cakephp/issues/8466
-     * @return void
      */
-    public function testCountWithBind()
+    public function testCountWithBind(): void
     {
         $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
@@ -735,10 +696,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test count() with inner join containments.
-     *
-     * @return void
      */
-    public function testCountWithInnerJoinContain()
+    public function testCountWithInnerJoinContain(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -753,7 +712,7 @@ class QueryRegressionTest extends TestCase
         $this->assertNotFalse($result);
 
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) {
+            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
                 $query->contain(['Authors']);
             });
 
@@ -763,10 +722,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that bind in subqueries works.
-     *
-     * @return void
      */
-    public function testSubqueryBind()
+    public function testSubqueryBind(): void
     {
         $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
@@ -788,10 +745,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Test that deep containments don't generate empty entities for
      * intermediary relations.
-     *
-     * @return void
      */
-    public function testContainNoEmptyAssociatedObjects()
+    public function testContainNoEmptyAssociatedObjects(): void
     {
         $this->loadFixtures('Comments', 'Users', 'Articles');
         $comments = $this->getTableLocator()->get('Comments');
@@ -820,9 +775,8 @@ class QueryRegressionTest extends TestCase
      * Tests that using a comparison expression inside an OR condition works
      *
      * @see https://github.com/cakephp/cakephp/issues/5081
-     * @return void
      */
-    public function testOrConditionsWithExpression()
+    public function testOrConditionsWithExpression(): void
     {
         $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
@@ -842,9 +796,8 @@ class QueryRegressionTest extends TestCase
      * Tests that calling count on a query having a union works correctly
      *
      * @see https://github.com/cakephp/cakephp/issues/5107
-     * @return void
      */
-    public function testCountWithUnionQuery()
+    public function testCountWithUnionQuery(): void
     {
         $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
@@ -856,10 +809,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Integration test when selecting no fields on the primary table.
-     *
-     * @return void
      */
-    public function testSelectNoFieldsOnPrimaryAlias()
+    public function testSelectNoFieldsOnPrimaryAlias(): void
     {
         $this->loadFixtures('Articles', 'Users');
         $table = $this->getTableLocator()->get('Articles');
@@ -875,9 +826,8 @@ class QueryRegressionTest extends TestCase
      * does not emit notice errors.
      *
      * @see https://github.com/cakephp/cakephp/issues/12766
-     * @return void
      */
-    public function testAliasedAggregateFieldTypeConversionSafe()
+    public function testAliasedAggregateFieldTypeConversionSafe(): void
     {
         $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
@@ -899,10 +849,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that calling first on the query results will not remove all other results
      * from the set.
-     *
-     * @return void
      */
-    public function testFirstOnResultSet()
+    public function testFirstOnResultSet(): void
     {
         $this->loadFixtures('Articles');
         $results = $this->getTableLocator()->get('Articles')->find()->all();
@@ -915,9 +863,8 @@ class QueryRegressionTest extends TestCase
      * Checks that matching and contain can be called for the same belongsTo association
      *
      * @see https://github.com/cakephp/cakephp/issues/5463
-     * @return void
      */
-    public function testFindMatchingAndContain()
+    public function testFindMatchingAndContain(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -936,9 +883,8 @@ class QueryRegressionTest extends TestCase
      * Checks that matching and contain can be called for the same belongsTo association
      *
      * @see https://github.com/cakephp/cakephp/issues/5463
-     * @return void
      */
-    public function testFindMatchingAndContainWithSubquery()
+    public function testFindMatchingAndContainWithSubquery(): void
     {
         $this->loadFixtures('Articles', 'Authors', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('authors');
@@ -958,9 +904,8 @@ class QueryRegressionTest extends TestCase
      * Tests that matching does not overwrite associations in contain
      *
      * @see https://github.com/cakephp/cakephp/issues/5584
-     * @return void
      */
-    public function testFindMatchingOverwrite()
+    public function testFindMatchingOverwrite(): void
     {
         $this->loadFixtures('Articles', 'Comments', 'Tags', 'ArticlesTags');
         $comments = $this->getTableLocator()->get('Comments');
@@ -988,9 +933,8 @@ class QueryRegressionTest extends TestCase
      * Tests that matching does not overwrite associations in contain
      *
      * @see https://github.com/cakephp/cakephp/issues/5584
-     * @return void
      */
-    public function testFindMatchingOverwrite2()
+    public function testFindMatchingOverwrite2(): void
     {
         $this->loadFixtures('Articles', 'Comments', 'Tags', 'ArticlesTags', 'Authors');
         $comments = $this->getTableLocator()->get('Comments');
@@ -1014,10 +958,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that trying to contain an inexistent association
      * throws an exception and not a fatal error.
-     *
-     * @return void
      */
-    public function testQueryNotFatalError()
+    public function testQueryNotFatalError(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->loadFixtures('Comments');
@@ -1030,9 +972,8 @@ class QueryRegressionTest extends TestCase
      * works correctly.
      *
      * @see https://github.com/cakephp/cakephp/issues/5721
-     * @return void
      */
-    public function testFindMatchingWithContain()
+    public function testFindMatchingWithContain(): void
     {
         $this->loadFixtures('Articles', 'Comments', 'Users');
         $comments = $this->getTableLocator()->get('Comments');
@@ -1057,10 +998,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that HasMany associations don't use duplicate PK values.
-     *
-     * @return void
      */
-    public function testHasManyEagerLoadingUniqueKey()
+    public function testHasManyEagerLoadingUniqueKey(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('ArticlesTags');
@@ -1085,9 +1024,8 @@ class QueryRegressionTest extends TestCase
      * does not trigger any errors and fetches the right results.
      *
      * @see https://github.com/cakephp/cakephp/issues/6214
-     * @return void
      */
-    public function testContainWithNoFields()
+    public function testContainWithNoFields(): void
     {
         $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Comments');
@@ -1105,9 +1043,8 @@ class QueryRegressionTest extends TestCase
      * Tests that find() and contained associations using computed fields doesn't error out.
      *
      * @see https://github.com/cakephp/cakephp/issues/9326
-     * @return void
      */
-    public function testContainWithComputedField()
+    public function testContainWithComputedField(): void
     {
         $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Users');
@@ -1132,9 +1069,8 @@ class QueryRegressionTest extends TestCase
      * will no trigger any errors and fetch the right results
      *
      * @see https://github.com/cakephp/cakephp/issues/6223
-     * @return void
      */
-    public function testMatchingWithNoFields()
+    public function testMatchingWithNoFields(): void
     {
         $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Users');
@@ -1151,10 +1087,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that empty conditions in a matching clause don't cause errors.
-     *
-     * @return void
      */
-    public function testMatchingEmptyQuery()
+    public function testMatchingEmptyQuery(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
@@ -1177,10 +1111,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that using a subquery as part of an expression will not make invalid SQL
-     *
-     * @return void
      */
-    public function testSubqueryInSelectExpression()
+    public function testSubqueryInSelectExpression(): void
     {
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
@@ -1206,9 +1138,8 @@ class QueryRegressionTest extends TestCase
      * Tests calling last on an empty table
      *
      * @see https://github.com/cakephp/cakephp/issues/6683
-     * @return void
      */
-    public function testFindLastOnEmptyTable()
+    public function testFindLastOnEmptyTable(): void
     {
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
@@ -1221,9 +1152,8 @@ class QueryRegressionTest extends TestCase
      * Tests calling contain in a nested closure
      *
      * @see https://github.com/cakephp/cakephp/issues/7591
-     * @return void
      */
-    public function testContainInNestedClosure()
+    public function testContainInNestedClosure(): void
     {
         $this->loadFixtures('Comments', 'Articles', 'Authors', 'Tags', 'AuthorsTags');
         $table = $this->getTableLocator()->get('Comments');
@@ -1242,10 +1172,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Test that the typemaps used in function expressions
      * create the correct results.
-     *
-     * @return void
      */
-    public function testTypemapInFunctions()
+    public function testTypemapInFunctions(): void
     {
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
@@ -1269,10 +1197,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Test that the typemaps used in function expressions
      * create the correct results.
-     *
-     * @return void
      */
-    public function testTypemapInFunctions2()
+    public function testTypemapInFunctions2(): void
     {
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
@@ -1286,10 +1212,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that contain queries map types correctly.
-     *
-     * @return void
      */
-    public function testBooleanConditionsInContain()
+    public function testBooleanConditionsInContain(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'SpecialTags');
         $table = $this->getTableLocator()->get('Articles');
@@ -1312,10 +1236,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that contain queries map types correctly.
-     *
-     * @return void
      */
-    public function testComplexTypesInJoinedWhere()
+    public function testComplexTypesInJoinedWhere(): void
     {
         $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Users');
@@ -1335,10 +1257,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that nested contain queries map types correctly.
-     *
-     * @return void
      */
-    public function testComplexNestedTypesInJoinedWhere()
+    public function testComplexNestedTypesInJoinedWhere(): void
     {
         $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
@@ -1364,10 +1284,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that matching queries map types correctly.
-     *
-     * @return void
      */
-    public function testComplexTypesInJoinedWhereWithMatching()
+    public function testComplexTypesInJoinedWhereWithMatching(): void
     {
         $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
@@ -1403,10 +1321,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that notMatching queries map types correctly.
-     *
-     * @return void
      */
-    public function testComplexTypesInJoinedWhereWithNotMatching()
+    public function testComplexTypesInJoinedWhereWithNotMatching(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $Tags = $this->getTableLocator()->get('Tags');
@@ -1428,10 +1344,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that innerJoinWith queries map types correctly.
-     *
-     * @return void
      */
-    public function testComplexTypesInJoinedWhereWithInnerJoinWith()
+    public function testComplexTypesInJoinedWhereWithInnerJoinWith(): void
     {
         $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
@@ -1467,10 +1381,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test that leftJoinWith queries map types correctly.
-     *
-     * @return void
      */
-    public function testComplexTypesInJoinedWhereWithLeftJoinWith()
+    public function testComplexTypesInJoinedWhereWithLeftJoinWith(): void
     {
         $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
@@ -1507,10 +1419,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that it is possible to contain to fetch
      * associations off of a junction table.
-     *
-     * @return void
      */
-    public function testBelongsToManyJoinDataAssociation()
+    public function testBelongsToManyJoinDataAssociation(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Tags', 'SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
@@ -1540,10 +1450,8 @@ class QueryRegressionTest extends TestCase
      * Tests that it is possible to use matching with dot notation
      * even when part of the part of the path in the dot notation is
      * shared for two different calls
-     *
-     * @return void
      */
-    public function testDotNotationNotOverride()
+    public function testDotNotationNotOverride(): void
     {
         $this->loadFixtures('Comments', 'Articles', 'Tags', 'Authors', 'SpecialTags');
         $table = $this->getTableLocator()->get('Comments');
@@ -1568,10 +1476,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Test expression based ordering with unions.
-     *
-     * @return void
      */
-    public function testComplexOrderWithUnion()
+    public function testComplexOrderWithUnion(): void
     {
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
@@ -1596,10 +1502,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Test that associations that are loaded with subqueries
      * do not cause errors when the subquery has a limit & order clause.
-     *
-     * @return void
      */
-    public function testEagerLoadOrderAndSubquery()
+    public function testEagerLoadOrderAndSubquery(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $table = $this->getTableLocator()->get('Articles');
@@ -1619,10 +1523,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that having bound placeholders in the order clause does not result
      * in an error when trying to count a query.
-     *
-     * @return void
      */
-    public function testCountWithComplexOrderBy()
+    public function testCountWithComplexOrderBy(): void
     {
         $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
@@ -1652,9 +1554,8 @@ class QueryRegressionTest extends TestCase
      * where clause of a query
      *
      * @see https://github.com/cakephp/cakephp/issues/7943
-     * @return void
      */
-    public function testFunctionInWhereClause()
+    public function testFunctionInWhereClause(): void
     {
         $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
@@ -1667,10 +1568,8 @@ class QueryRegressionTest extends TestCase
     /**
      * Tests that `notMatching()` can be used on `belongsToMany`
      * associations without passing a query builder callback.
-     *
-     * @return void
      */
-    public function testNotMatchingForBelongsToManyWithoutQueryBuilder()
+    public function testNotMatchingForBelongsToManyWithoutQueryBuilder(): void
     {
         $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
 
@@ -1689,9 +1588,8 @@ class QueryRegressionTest extends TestCase
      * Tests deep formatters get the right object type when applied in a beforeFind
      *
      * @see https://github.com/cakephp/cakephp/issues/9787
-     * @return void
      */
-    public function testFormatDeepDistantAssociationRecords2()
+    public function testFormatDeepDistantAssociationRecords2(): void
     {
         $this->loadFixtures('Authors', 'Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('authors');
@@ -1712,7 +1610,7 @@ class QueryRegressionTest extends TestCase
 
         $query = $table->find()->contain(['articles.articlesTags.tags']);
 
-        $query->mapReduce(function ($row, $key, $mr) {
+        $query->mapReduce(function ($row, $key, $mr): void {
             foreach ((array)$row->articles as $article) {
                 foreach ((array)$article->articles_tags as $articleTag) {
                     $mr->emit($articleTag->tag->name);
@@ -1726,10 +1624,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that subqueries can be used with function expressions.
-     *
-     * @return void
      */
-    public function testFunctionExpressionWithSubquery()
+    public function testFunctionExpressionWithSubquery(): void
     {
         $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
@@ -1756,10 +1652,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that correlated subqueries can be used with function expressions.
-     *
-     * @return void
      */
-    public function testFunctionExpressionWithCorrelatedSubquery()
+    public function testFunctionExpressionWithCorrelatedSubquery(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -1787,10 +1681,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that subqueries can be used with multi argument function expressions.
-     *
-     * @return void
      */
-    public function testMultiArgumentFunctionExpressionWithSubquery()
+    public function testMultiArgumentFunctionExpressionWithSubquery(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -1821,10 +1713,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that correlated subqueries can be used with multi argument function expressions.
-     *
-     * @return void
      */
-    public function testMultiArgumentFunctionExpressionWithCorrelatedSubquery()
+    public function testMultiArgumentFunctionExpressionWithCorrelatedSubquery(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -1858,10 +1748,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that subqueries can be used with function expressions that are being transpiled.
-     *
-     * @return void
      */
-    public function testTranspiledFunctionExpressionWithSubquery()
+    public function testTranspiledFunctionExpressionWithSubquery(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
@@ -1888,10 +1776,8 @@ class QueryRegressionTest extends TestCase
 
     /**
      * Tests that correlated subqueries can be used with function expressions that are being transpiled.
-     *
-     * @return void
      */
-    public function testTranspiledFunctionExpressionWithCorrelatedSubquery()
+    public function testTranspiledFunctionExpressionWithCorrelatedSubquery(): void
     {
         $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -71,8 +71,6 @@ class QueryTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -124,7 +122,7 @@ class QueryTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderHasMany()
+    public function strategiesProviderHasMany(): array
     {
         return [['subquery'], ['select']];
     }
@@ -134,7 +132,7 @@ class QueryTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderBelongsTo()
+    public function strategiesProviderBelongsTo(): array
     {
         return [['join'], ['select']];
     }
@@ -144,17 +142,15 @@ class QueryTest extends TestCase
      *
      * @return array
      */
-    public function strategiesProviderBelongsToMany()
+    public function strategiesProviderBelongsToMany(): array
     {
         return [['subquery'], ['select']];
     }
 
     /**
      * Test getRepository() method.
-     *
-     * @return void
      */
-    public function testGetRepository()
+    public function testGetRepository(): void
     {
         $query = new Query($this->connection, $this->table);
 
@@ -167,9 +163,8 @@ class QueryTest extends TestCase
      * and results are not hydrated
      *
      * @dataProvider strategiesProviderBelongsTo
-     * @return void
      */
-    public function testContainResultFetchingOneLevel(string $strategy)
+    public function testContainResultFetchingOneLevel(string $strategy): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $table->belongsTo('authors', ['strategy' => $strategy]);
@@ -225,9 +220,8 @@ class QueryTest extends TestCase
      * association objects in order to perform eager loading with select strategy
      *
      * @dataProvider strategiesProviderHasMany
-     * @return void
      */
-    public function testHasManyEagerLoadingNoHydration(string $strategy)
+    public function testHasManyEagerLoadingNoHydration(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
         $this->getTableLocator()->get('articles');
@@ -304,9 +298,8 @@ class QueryTest extends TestCase
      * both hydrating and not hydrating the results.
      *
      * @dataProvider strategiesProviderHasMany
-     * @return void
      */
-    public function testHasManyEagerLoadingCount(string $strategy)
+    public function testHasManyEagerLoadingCount(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
         $this->getTableLocator()->get('articles');
@@ -335,9 +328,8 @@ class QueryTest extends TestCase
      * Tests that it is possible to set fields & order in a hasMany result set
      *
      * @dataProvider strategiesProviderHasMany
-     * @return void
      */
-    public function testHasManyEagerLoadingFieldsAndOrderNoHydration(string $strategy)
+    public function testHasManyEagerLoadingFieldsAndOrderNoHydration(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
         $this->getTableLocator()->get('articles');
@@ -387,9 +379,8 @@ class QueryTest extends TestCase
      * Tests that deep associations can be eagerly loaded
      *
      * @dataProvider strategiesProviderHasMany
-     * @return void
      */
-    public function testHasManyEagerLoadingDeep(string $strategy)
+    public function testHasManyEagerLoadingDeep(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
         $article = $this->getTableLocator()->get('articles');
@@ -461,9 +452,8 @@ class QueryTest extends TestCase
      * model in the query
      *
      * @dataProvider strategiesProviderHasMany
-     * @return void
      */
-    public function testHasManyEagerLoadingFromSecondaryTable(string $strategy)
+    public function testHasManyEagerLoadingFromSecondaryTable(string $strategy): void
     {
         $author = $this->getTableLocator()->get('authors');
         $article = $this->getTableLocator()->get('articles');
@@ -567,9 +557,8 @@ class QueryTest extends TestCase
      * association objects in order to perform eager loading with select strategy
      *
      * @dataProvider strategiesProviderBelongsToMany
-     * @return void
      */
-    public function testBelongsToManyEagerLoadingNoHydration(string $strategy)
+    public function testBelongsToManyEagerLoadingNoHydration(string $strategy): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $this->getTableLocator()->get('Tags');
@@ -685,10 +674,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that tables results can be filtered by the result of a HasMany
-     *
-     * @return void
      */
-    public function testFilteringByHasManyNoHydration()
+    public function testFilteringByHasManyNoHydration(): void
     {
         $query = new Query($this->connection, $this->table);
         $table = $this->getTableLocator()->get('Articles');
@@ -726,10 +713,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that tables results can be filtered by the result of a HasMany
-     *
-     * @return void
      */
-    public function testFilteringByHasManyHydration()
+    public function testFilteringByHasManyHydration(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = new Query($this->connection, $table);
@@ -750,10 +735,8 @@ class QueryTest extends TestCase
      * Tests that BelongsToMany associations are correctly eager loaded.
      * Also that the query object passes the correct parent model keys to the
      * association objects in order to perform eager loading with select strategy
-     *
-     * @return void
      */
-    public function testFilteringByBelongsToManyNoHydration()
+    public function testFilteringByBelongsToManyNoHydration(): void
     {
         $query = new Query($this->connection, $this->table);
         $table = $this->getTableLocator()->get('Articles');
@@ -819,10 +802,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to filter by deep associations
-     *
-     * @return void
      */
-    public function testMatchingDotNotation()
+    public function testMatchingDotNotation(): void
     {
         $query = new Query($this->connection, $this->table);
         $table = $this->getTableLocator()->get('authors');
@@ -867,10 +848,8 @@ class QueryTest extends TestCase
 
     /**
      * Test setResult()
-     *
-     * @return void
      */
-    public function testSetResult()
+    public function testSetResult(): void
     {
         $query = new Query($this->connection, $this->table);
 
@@ -884,10 +863,8 @@ class QueryTest extends TestCase
 
     /**
      * Test clearResult()
-     *
-     * @return void
      */
-    public function testClearResult()
+    public function testClearResult(): void
     {
         $article = $this->getTableLocator()->get('articles');
         $query = new Query($this->connection, $article);
@@ -913,10 +890,8 @@ class QueryTest extends TestCase
     /**
      * Tests that applying array options to a query will convert them
      * to equivalent function calls with the correspondent array values
-     *
-     * @return void
      */
-    public function testApplyOptions()
+    public function testApplyOptions(): void
     {
         $this->table->belongsTo('articles');
         $typeMap = new TypeMap([
@@ -982,10 +957,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that page is applied after limit.
-     *
-     * @return void
      */
-    public function testApplyOptionsPageIsLast()
+    public function testApplyOptionsPageIsLast(): void
     {
         $query = new Query($this->connection, $this->table);
         $opts = [
@@ -999,10 +972,8 @@ class QueryTest extends TestCase
 
     /**
      * ApplyOptions should ignore null values.
-     *
-     * @return void
      */
-    public function testApplyOptionsIgnoreNull()
+    public function testApplyOptionsIgnoreNull(): void
     {
         $options = [
             'fields' => null,
@@ -1014,10 +985,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests getOptions() method
-     *
-     * @return void
      */
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $options = ['doABarrelRoll' => true, 'fields' => ['id', 'name']];
         $query = new Query($this->connection, $this->table);
@@ -1032,14 +1001,12 @@ class QueryTest extends TestCase
 
     /**
      * Tests registering mappers with mapReduce()
-     *
-     * @return void
      */
-    public function testMapReduceOnlyMapper()
+    public function testMapReduceOnlyMapper(): void
     {
-        $mapper1 = function () {
+        $mapper1 = function (): void {
         };
-        $mapper2 = function () {
+        $mapper2 = function (): void {
         };
         $query = new Query($this->connection, $this->table);
         $this->assertSame($query, $query->mapReduce($mapper1));
@@ -1061,18 +1028,16 @@ class QueryTest extends TestCase
 
     /**
      * Tests registering mappers and reducers with mapReduce()
-     *
-     * @return void
      */
-    public function testMapReduceBothMethods()
+    public function testMapReduceBothMethods(): void
     {
-        $mapper1 = function () {
+        $mapper1 = function (): void {
         };
-        $mapper2 = function () {
+        $mapper2 = function (): void {
         };
-        $reducer1 = function () {
+        $reducer1 = function (): void {
         };
-        $reducer2 = function () {
+        $reducer2 = function (): void {
         };
         $query = new Query($this->connection, $this->table);
         $this->assertSame($query, $query->mapReduce($mapper1, $reducer1));
@@ -1093,18 +1058,16 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to overwrite previous map reducers
-     *
-     * @return void
      */
-    public function testOverwriteMapReduce()
+    public function testOverwriteMapReduce(): void
     {
-        $mapper1 = function () {
+        $mapper1 = function (): void {
         };
-        $mapper2 = function () {
+        $mapper2 = function (): void {
         };
-        $reducer1 = function () {
+        $reducer1 = function (): void {
         };
-        $reducer2 = function () {
+        $reducer2 = function (): void {
         };
         $query = new Query($this->connection, $this->table);
         $this->assertEquals($query, $query->mapReduce($mapper1, $reducer1));
@@ -1122,22 +1085,20 @@ class QueryTest extends TestCase
 
     /**
      * Tests that multiple map reducers can be stacked
-     *
-     * @return void
      */
-    public function testResultsAreWrappedInMapReduce()
+    public function testResultsAreWrappedInMapReduce(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
         $query->select(['a' => 'id'])->limit(2)->order(['id' => 'ASC']);
-        $query->mapReduce(function ($v, $k, $mr) {
+        $query->mapReduce(function ($v, $k, $mr): void {
             $mr->emit($v['a']);
         });
         $query->mapReduce(
-            function ($v, $k, $mr) {
+            function ($v, $k, $mr): void {
                 $mr->emitIntermediate($v, $k);
             },
-            function ($v, $k, $mr) {
+            function ($v, $k, $mr): void {
                 $mr->emit($v[0] + 1);
             }
         );
@@ -1147,10 +1108,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests first() method when the query has not been executed before
-     *
-     * @return void
      */
-    public function testFirstDirtyQuery()
+    public function testFirstDirtyQuery(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
@@ -1163,10 +1122,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that first can be called again on an already executed query
-     *
-     * @return void
      */
-    public function testFirstCleanQuery()
+    public function testFirstCleanQuery(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
@@ -1179,10 +1136,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that first() will not execute the same query twice
-     *
-     * @return void
      */
-    public function testFirstSameResult()
+    public function testFirstSameResult(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
@@ -1196,15 +1151,13 @@ class QueryTest extends TestCase
 
     /**
      * Tests that first can be called against a query with a mapReduce
-     *
-     * @return void
      */
-    public function testFirstMapReduce()
+    public function testFirstMapReduce(): void
     {
-        $map = function ($row, $key, $mapReduce) {
+        $map = function ($row, $key, $mapReduce): void {
             $mapReduce->emitIntermediate($row['id'], 'id');
         };
-        $reduce = function ($values, $key, $mapReduce) {
+        $reduce = function ($values, $key, $mapReduce): void {
             $mapReduce->emit(array_sum($values));
         };
 
@@ -1220,10 +1173,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that first can be called on an unbuffered query
-     *
-     * @return void
      */
-    public function testFirstUnbuffered()
+    public function testFirstUnbuffered(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = new Query($this->connection, $table);
@@ -1238,10 +1189,8 @@ class QueryTest extends TestCase
     /**
      * Test to show that when results bufferring is enabled if ResultSet gets
      * decorated by ResultSetDecorator it gets wrapped in a BufferedIterator instance.
-     *
-     * @return void
      */
-    public function testBufferedDecoratedResultSet()
+    public function testBufferedDecoratedResultSet(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = new Query($this->connection, $table);
@@ -1259,10 +1208,8 @@ class QueryTest extends TestCase
 
     /**
      * Testing hydrating a result set into Entity objects
-     *
-     * @return void
      */
-    public function testHydrateSimple()
+    public function testHydrateSimple(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
@@ -1283,10 +1230,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that has many results are also hydrated correctly
-     *
-     * @return void
      */
-    public function testHydrateHasMany()
+    public function testHydrateHasMany(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $this->getTableLocator()->get('articles');
@@ -1325,10 +1270,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that belongsToMany associations are also correctly hydrated
-     *
-     * @return void
      */
-    public function testHydrateBelongsToMany()
+    public function testHydrateBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $this->getTableLocator()->get('Tags');
@@ -1372,10 +1315,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that belongsToMany associations are also correctly hydrated
-     *
-     * @return void
      */
-    public function testFormatResultsBelongsToMany()
+    public function testFormatResultsBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $this->getTableLocator()->get('Tags');
@@ -1386,7 +1327,7 @@ class QueryTest extends TestCase
 
         $articlesTags
             ->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) {
+            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
                 $query->formatResults(function ($results) {
                     foreach ($results as $result) {
                         $result->beforeFind = true;
@@ -1442,9 +1383,8 @@ class QueryTest extends TestCase
      * Tests that belongsTo relations are correctly hydrated
      *
      * @dataProvider strategiesProviderBelongsTo
-     * @return void
      */
-    public function testHydrateBelongsTo(string $strategy)
+    public function testHydrateBelongsTo(string $strategy): void
     {
         $table = $this->getTableLocator()->get('articles');
         $this->getTableLocator()->get('authors');
@@ -1467,9 +1407,8 @@ class QueryTest extends TestCase
      * Tests that deeply nested associations are also hydrated correctly
      *
      * @dataProvider strategiesProviderBelongsTo
-     * @return void
      */
-    public function testHydrateDeep(string $strategy)
+    public function testHydrateDeep(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
         $article = $this->getTableLocator()->get('articles');
@@ -1494,10 +1433,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to use a custom entity class
-     *
-     * @return void
      */
-    public function testHydrateCustomObject()
+    public function testHydrateCustomObject(): void
     {
         $class = $this->getMockClass('Cake\ORM\Entity', ['fakeMethod']);
         $table = $this->getTableLocator()->get('articles', [
@@ -1523,10 +1460,8 @@ class QueryTest extends TestCase
     /**
      * Tests that has many results are also hydrated correctly
      * when specified a custom entity class
-     *
-     * @return void
      */
-    public function testHydrateHasManyCustomEntity()
+    public function testHydrateHasManyCustomEntity(): void
     {
         $authorEntity = $this->getMockClass('Cake\ORM\Entity', ['foo']);
         $articleEntity = $this->getMockClass('Cake\ORM\Entity', ['foo']);
@@ -1564,10 +1499,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that belongsTo relations are correctly hydrated into a custom entity class
-     *
-     * @return void
      */
-    public function testHydrateBelongsToCustomEntity()
+    public function testHydrateBelongsToCustomEntity(): void
     {
         $authorEntity = $this->getMockClass('Cake\ORM\Entity', ['foo']);
         $table = $this->getTableLocator()->get('articles');
@@ -1588,10 +1521,8 @@ class QueryTest extends TestCase
 
     /**
      * Test getting counts from queries.
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $result = $table->find('all')->count();
@@ -1610,10 +1541,8 @@ class QueryTest extends TestCase
 
     /**
      * Test getting counts from queries with contain.
-     *
-     * @return void
      */
-    public function testCountWithContain()
+    public function testCountWithContain(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -1630,10 +1559,8 @@ class QueryTest extends TestCase
 
     /**
      * Test getting counts from queries with contain.
-     *
-     * @return void
      */
-    public function testCountWithSubselect()
+    public function testCountWithSubselect(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -1662,10 +1589,8 @@ class QueryTest extends TestCase
 
     /**
      * Test getting counts with complex fields.
-     *
-     * @return void
      */
-    public function testCountWithExpressions()
+    public function testCountWithExpressions(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
@@ -1682,15 +1607,13 @@ class QueryTest extends TestCase
 
     /**
      * test count with a beforeFind.
-     *
-     * @return void
      */
-    public function testCountBeforeFind()
+    public function testCountBeforeFind(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) {
+            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
                 $query
                     ->limit(1)
                     ->order(['Articles.title' => 'DESC']);
@@ -1703,15 +1626,13 @@ class QueryTest extends TestCase
 
     /**
      * Tests that beforeFind is only ever called once, even if you trigger it again in the beforeFind
-     *
-     * @return void
      */
-    public function testBeforeFindCalledOnce()
+    public function testBeforeFindCalledOnce(): void
     {
         $callCount = 0;
         $table = $this->getTableLocator()->get('Articles');
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) use (&$callCount) {
+            ->on('Model.beforeFind', function (EventInterface $event, $query) use (&$callCount): void {
                 $valueBinder = new ValueBinder();
                 $query->sql($valueBinder);
                 $callCount++;
@@ -1725,10 +1646,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that count() returns correct results with group by.
-     *
-     * @return void
      */
-    public function testCountWithGroup()
+    public function testCountWithGroup(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $query = $table->find('all');
@@ -1741,10 +1660,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to provide a callback for calculating the count
      * of a query
-     *
-     * @return void
      */
-    public function testCountWithCustomCounter()
+    public function testCountWithCustomCounter(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $query = $table->find('all');
@@ -1764,10 +1681,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that RAND() returns correct results.
-     *
-     * @return void
      */
-    public function testSelectRandom()
+    public function testSelectRandom(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $query = $table
@@ -1784,10 +1699,8 @@ class QueryTest extends TestCase
 
     /**
      * Test update method.
-     *
-     * @return void
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $table = $this->getTableLocator()->get('articles');
 
@@ -1802,10 +1715,8 @@ class QueryTest extends TestCase
 
     /**
      * Test update method.
-     *
-     * @return void
      */
-    public function testUpdateWithTableExpression()
+    public function testUpdateWithTableExpression(): void
     {
         $this->skipIf(!$this->connection->getDriver() instanceof Mysql);
         $table = $this->getTableLocator()->get('articles');
@@ -1823,10 +1734,8 @@ class QueryTest extends TestCase
 
     /**
      * Test insert method.
-     *
-     * @return void
      */
-    public function testInsert()
+    public function testInsert(): void
     {
         $table = $this->getTableLocator()->get('articles');
 
@@ -1844,10 +1753,8 @@ class QueryTest extends TestCase
 
     /**
      * Test delete method.
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $table = $this->getTableLocator()->get('articles');
 
@@ -1897,10 +1804,8 @@ class QueryTest extends TestCase
 
     /**
      * testClearContain
-     *
-     * @return void
      */
-    public function testClearContain()
+    public function testClearContain(): void
     {
         /** @var \Cake\ORM\Query $query */
         $query = $this->getMockBuilder('Cake\ORM\Query')
@@ -1930,9 +1835,8 @@ class QueryTest extends TestCase
      * @dataProvider collectionMethodsProvider
      * @param mixed $arg
      * @param mixed $return
-     * @return void
      */
-    public function testCollectionProxy(string $method, $arg, $return)
+    public function testCollectionProxy(string $method, $arg, $return): void
     {
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['all'])
@@ -1957,10 +1861,8 @@ class QueryTest extends TestCase
     /**
      * Tests that calling an nonexistent method in query throws an
      * exception
-     *
-     * @return void
      */
-    public function testCollectionProxyBadMethod()
+    public function testCollectionProxyBadMethod(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Unknown method "derpFilter"');
@@ -1969,10 +1871,8 @@ class QueryTest extends TestCase
 
     /**
      * cache() should fail on non select queries.
-     *
-     * @return void
      */
-    public function testCacheErrorOnNonSelect()
+    public function testCacheErrorOnNonSelect(): void
     {
         $this->expectException(\RuntimeException::class);
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
@@ -1983,10 +1883,8 @@ class QueryTest extends TestCase
 
     /**
      * Integration test for query caching.
-     *
-     * @return void
      */
-    public function testCacheReadIntegration()
+    public function testCacheReadIntegration(): void
     {
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['execute'])
@@ -2014,10 +1912,8 @@ class QueryTest extends TestCase
 
     /**
      * Integration test for query caching.
-     *
-     * @return void
      */
-    public function testCacheWriteIntegration()
+    public function testCacheWriteIntegration(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = new Query($this->connection, $table);
@@ -2041,10 +1937,8 @@ class QueryTest extends TestCase
     /**
      * Integration test for query caching using a real cache engine and
      * a formatResults callback
-     *
-     * @return void
      */
-    public function testCacheIntegrationWithFormatResults()
+    public function testCacheIntegrationWithFormatResults(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = new Query($this->connection, $table);
@@ -2066,10 +1960,8 @@ class QueryTest extends TestCase
 
     /**
      * Test overwriting the contained associations.
-     *
-     * @return void
      */
-    public function testContainOverwrite()
+    public function testContainOverwrite(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -2088,10 +1980,8 @@ class QueryTest extends TestCase
 
     /**
      * Integration test to show filtering associations using contain and a closure
-     *
-     * @return void
      */
-    public function testContainWithClosure()
+    public function testContainWithClosure(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2116,10 +2006,8 @@ class QueryTest extends TestCase
     /**
      * Integration test that uses the contain signature that is the same as the
      * matching signature
-     *
-     * @return void
      */
-    public function testContainSecondSignature()
+    public function testContainSecondSignature(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2142,10 +2030,8 @@ class QueryTest extends TestCase
     /**
      * Integration test to ensure that filtering associations with the queryBuilder
      * option works.
-     *
-     * @return void
      */
-    public function testContainWithQueryBuilderHasManyError()
+    public function testContainWithQueryBuilderHasManyError(): void
     {
         $this->expectException(\RuntimeException::class);
         $table = $this->getTableLocator()->get('Authors');
@@ -2166,10 +2052,8 @@ class QueryTest extends TestCase
     /**
      * Integration test to ensure that filtering associations with the queryBuilder
      * option works.
-     *
-     * @return void
      */
-    public function testContainWithQueryBuilderJoinableAssociation()
+    public function testContainWithQueryBuilderJoinableAssociation(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasOne('Articles');
@@ -2205,10 +2089,8 @@ class QueryTest extends TestCase
 
     /**
      * Test containing associations that have empty conditions.
-     *
-     * @return void
      */
-    public function testContainAssociationWithEmptyConditions()
+    public function testContainAssociationWithEmptyConditions(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors', [
@@ -2223,14 +2105,12 @@ class QueryTest extends TestCase
 
     /**
      * Tests the formatResults method
-     *
-     * @return void
      */
-    public function testFormatResults()
+    public function testFormatResults(): void
     {
-        $callback1 = function () {
+        $callback1 = function (): void {
         };
-        $callback2 = function () {
+        $callback2 = function (): void {
         };
         $table = $this->getTableLocator()->get('authors');
         $query = new Query($this->connection, $table);
@@ -2250,10 +2130,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that results formatters do receive the query object.
-     *
-     * @return void
      */
-    public function testResultFormatterReceivesTheQueryObject()
+    public function testResultFormatterReceivesTheQueryObject(): void
     {
         $resultFormatterQuery = null;
 
@@ -2273,10 +2151,8 @@ class QueryTest extends TestCase
      * Tests that when using `beforeFind` events, results formatters for
      * queries of joined associations do receive the source query, not the
      * association target query.
-     *
-     * @return void
      */
-    public function testResultFormatterReceivesTheSourceQueryForJoinedAssociationsWhenUsingBeforeFind()
+    public function testResultFormatterReceivesTheSourceQueryForJoinedAssociationsWhenUsingBeforeFind(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $authors = $articles->belongsTo('Authors');
@@ -2286,7 +2162,7 @@ class QueryTest extends TestCase
 
         $authors->getEventManager()->on(
             'Model.beforeFind',
-            function ($event, Query $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery) {
+            function ($event, Query $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery): void {
                 $resultFormatterTargetQuery = $targetQuery;
 
                 $targetQuery->formatResults(function ($results, $query) use (&$resultFormatterSourceQuery) {
@@ -2312,10 +2188,8 @@ class QueryTest extends TestCase
      * Tests that when using `contain()` callables, results formatters for
      * queries of joined associations do receive the source query, not the
      * association target query.
-     *
-     * @return void
      */
-    public function testResultFormatterReceivesTheSourceQueryForJoinedAssociationWhenUsingContainCallables()
+    public function testResultFormatterReceivesTheSourceQueryForJoinedAssociationWhenUsingContainCallables(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors');
@@ -2349,10 +2223,8 @@ class QueryTest extends TestCase
      * Tests that when using `beforeFind` events, results formatters for
      * queries of non-joined associations do receive the association target
      * query, not the source query.
-     *
-     * @return void
      */
-    public function testResultFormatterReceivesTheTargetQueryForNonJoinedAssociationsWhenUsingBeforeFind()
+    public function testResultFormatterReceivesTheTargetQueryForNonJoinedAssociationsWhenUsingBeforeFind(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $articles->belongsToMany('Tags');
@@ -2362,7 +2234,7 @@ class QueryTest extends TestCase
 
         $tags->getEventManager()->on(
             'Model.beforeFind',
-            function ($event, Query $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery) {
+            function ($event, Query $targetQuery) use (&$resultFormatterTargetQuery, &$resultFormatterSourceQuery): void {
                 $resultFormatterTargetQuery = $targetQuery;
 
                 $targetQuery->formatResults(function ($results, $query) use (&$resultFormatterSourceQuery) {
@@ -2388,10 +2260,8 @@ class QueryTest extends TestCase
      * Tests that when using `contain()` callables, results formatters for
      * queries of non-joined associations do receive the association target
      * query, not the source query.
-     *
-     * @return void
      */
-    public function testResultFormatterReceivesTheTargetQueryForNonJoinedAssociationsWhenUsingContainCallables()
+    public function testResultFormatterReceivesTheTargetQueryForNonJoinedAssociationsWhenUsingContainCallables(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Tags');
@@ -2423,10 +2293,8 @@ class QueryTest extends TestCase
 
     /**
      * Test fetching results from a qurey with a custom formatter
-     *
-     * @return void
      */
-    public function testQueryWithFormatter()
+    public function testQueryWithFormatter(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $query = new Query($this->connection, $table);
@@ -2440,10 +2308,8 @@ class QueryTest extends TestCase
 
     /**
      * Test fetching results from a qurey with a two custom formatters
-     *
-     * @return void
      */
-    public function testQueryWithStackedFormatters()
+    public function testQueryWithStackedFormatters(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $query = new Query($this->connection, $table);
@@ -2469,10 +2335,8 @@ class QueryTest extends TestCase
     /**
      * Tests that getting results from a query having a contained association
      * will not attach joins twice if count() is called on it afterwards
-     *
-     * @return void
      */
-    public function testCountWithContainCallingAll()
+    public function testCountWithContainCallingAll(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsTo('authors');
@@ -2490,10 +2354,8 @@ class QueryTest extends TestCase
      * Verify that only one count query is issued
      * A subsequent request for the count will take the previously
      * returned value
-     *
-     * @return void
      */
-    public function testCountCache()
+    public function testCountCache(): void
     {
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->disableOriginalConstructor()
@@ -2514,10 +2376,8 @@ class QueryTest extends TestCase
     /**
      * If the query is dirty the cached value should be ignored
      * and a new count query issued
-     *
-     * @return void
      */
-    public function testCountCacheDirty()
+    public function testCountCacheDirty(): void
     {
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->disableOriginalConstructor()
@@ -2543,10 +2403,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to apply formatters inside the query builder
      * for belongsTo associations
-     *
-     * @return void
      */
-    public function testFormatBelongsToRecords()
+    public function testFormatBelongsToRecords(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsTo('authors');
@@ -2582,10 +2440,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests it is possible to apply formatters to deep relations.
-     *
-     * @return void
      */
-    public function testFormatDeepAssociationRecords()
+    public function testFormatDeepAssociationRecords(): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');
         $table->belongsTo('Articles');
@@ -2630,10 +2486,8 @@ class QueryTest extends TestCase
     /**
      * Tests that formatters cna be applied to deep associations that are fetched using
      * additional queries
-     *
-     * @return void
      */
-    public function testFormatDeepDistantAssociationRecords()
+    public function testFormatDeepDistantAssociationRecords(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2653,7 +2507,7 @@ class QueryTest extends TestCase
             },
         ]);
 
-        $query->mapReduce(function ($row, $key, $mr) {
+        $query->mapReduce(function ($row, $key, $mr): void {
             foreach ((array)$row->articles as $article) {
                 foreach ((array)$article->articles_tags as $articleTag) {
                     $mr->emit($articleTag->tag->name);
@@ -2667,10 +2521,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that custom finders are applied to associations when using the proxies
-     *
-     * @return void
      */
-    public function testCustomFinderInBelongsTo()
+    public function testCustomFinderInBelongsTo(): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');
         $table->belongsTo('Articles', [
@@ -2688,10 +2540,8 @@ class QueryTest extends TestCase
     /**
      * Test finding fields on the non-default table that
      * have the same name as the primary table.
-     *
-     * @return void
      */
-    public function testContainSelectedFields()
+    public function testContainSelectedFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -2708,10 +2558,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to attach more association when using a query
      * builder for other associations
-     *
-     * @return void
      */
-    public function testContainInAssociationQuery()
+    public function testContainInAssociationQuery(): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');
         $table->belongsTo('Articles');
@@ -2732,10 +2580,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to apply more `matching` conditions inside query
      * builders for associations
-     *
-     * @return void
      */
-    public function testContainInAssociationMatching()
+    public function testContainInAssociationMatching(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2756,10 +2602,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2772,7 +2616,7 @@ class QueryTest extends TestCase
             ->formatResults(function ($results) {
                 return $results;
             })
-            ->mapReduce(function ($item, $key, $mr) {
+            ->mapReduce(function ($item, $key, $mr): void {
                 $mr->emit($item);
             });
 
@@ -2825,10 +2669,8 @@ class QueryTest extends TestCase
     /**
      * Tests that the eagerLoaded function works and is transmitted correctly to eagerly
      * loaded associations
-     *
-     * @return void
      */
-    public function testEagerLoaded()
+    public function testEagerLoaded(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2841,12 +2683,12 @@ class QueryTest extends TestCase
         ]);
         $this->assertFalse($query->isEagerLoaded());
 
-        $table->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary) {
+        $table->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary): void {
             $this->assertTrue($primary);
         });
 
         $this->getTableLocator()->get('articles')
-            ->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary) {
+            ->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary): void {
                 $this->assertFalse($primary);
             });
         $query->all();
@@ -2855,10 +2697,8 @@ class QueryTest extends TestCase
     /**
      * Tests that the isEagerLoaded function works and is transmitted correctly to eagerly
      * loaded associations
-     *
-     * @return void
      */
-    public function testIsEagerLoaded()
+    public function testIsEagerLoaded(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2871,12 +2711,12 @@ class QueryTest extends TestCase
         ]);
         $this->assertFalse($query->isEagerLoaded());
 
-        $table->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary) {
+        $table->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary): void {
             $this->assertTrue($primary);
         });
 
         $this->getTableLocator()->get('articles')
-            ->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary) {
+            ->getEventManager()->on('Model.beforeFind', function ($e, $q, $o, $primary): void {
                 $this->assertFalse($primary);
             });
         $query->all();
@@ -2884,10 +2724,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that columns from manual joins are also contained in the result set
-     *
-     * @return void
      */
-    public function testColumnsFromJoin()
+    public function testColumnsFromJoin(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $query = $table->find();
@@ -2915,9 +2753,8 @@ class QueryTest extends TestCase
      * chain for contain
      *
      * @dataProvider strategiesProviderBelongsTo
-     * @return void
      */
-    public function testRepeatedAssociationAliases(string $strategy)
+    public function testRepeatedAssociationAliases(string $strategy): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');
         $table->belongsTo('Articles', ['strategy' => $strategy]);
@@ -2939,10 +2776,8 @@ class QueryTest extends TestCase
     /**
      * Tests that a hasOne association using the select strategy will still have the
      * key present in the results when no match is found
-     *
-     * @return void
      */
-    public function testAssociationKeyPresent()
+    public function testAssociationKeyPresent(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasOne('ArticlesTags', ['strategy' => 'select']);
@@ -2956,10 +2791,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that queries can be serialized to JSON to get the results
-     *
-     * @return void
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $this->assertEquals(
@@ -2970,10 +2803,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that addFields() works in the basic case.
-     *
-     * @return void
      */
-    public function testAutoFields()
+    public function testAutoFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $result = $table->find('all')
@@ -2989,10 +2820,8 @@ class QueryTest extends TestCase
 
     /**
      * Test autoFields with auto fields.
-     *
-     * @return void
      */
-    public function testAutoFieldsWithAssociations()
+    public function testAutoFieldsWithAssociations(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -3013,10 +2842,8 @@ class QueryTest extends TestCase
 
     /**
      * Test autoFields in contain query builder
-     *
-     * @return void
      */
-    public function testAutoFieldsWithContainQueryBuilder()
+    public function testAutoFieldsWithContainQueryBuilder(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -3043,10 +2870,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that autofields works with count()
-     *
-     * @return void
      */
-    public function testAutoFieldsCount()
+    public function testAutoFieldsCount(): void
     {
         $table = $this->getTableLocator()->get('Articles');
 
@@ -3060,10 +2885,8 @@ class QueryTest extends TestCase
 
     /**
      * test that cleanCopy makes a cleaned up clone.
-     *
-     * @return void
      */
-    public function testCleanCopy()
+    public function testCleanCopy(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -3096,10 +2919,8 @@ class QueryTest extends TestCase
 
     /**
      * test that cleanCopy retains bindings
-     *
-     * @return void
      */
-    public function testCleanCopyRetainsBindings()
+    public function testCleanCopyRetainsBindings(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
@@ -3116,15 +2937,13 @@ class QueryTest extends TestCase
 
     /**
      * test that cleanCopy makes a cleaned up clone with a beforeFind.
-     *
-     * @return void
      */
-    public function testCleanCopyBeforeFind()
+    public function testCleanCopyBeforeFind(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
         $table->getEventManager()
-            ->on('Model.beforeFind', function (EventInterface $event, $query) {
+            ->on('Model.beforeFind', function (EventInterface $event, $query): void {
                 $query
                     ->limit(5)
                     ->order(['Articles.title' => 'DESC']);
@@ -3145,10 +2964,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that finder options sent through via contain are sent to custom finder for belongsTo associations.
-     *
-     * @return void
      */
-    public function testContainFinderBelongsTo()
+    public function testContainFinderBelongsTo(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo(
@@ -3179,10 +2996,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that finder options sent through via contain are sent to custom finder for hasMany associations.
-     *
-     * @return void
      */
-    public function testContainFinderHasMany()
+    public function testContainFinderHasMany(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany(
@@ -3252,10 +3067,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that using a closure for a custom finder for contain works.
-     *
-     * @return void
      */
-    public function testContainFinderHasManyClosure()
+    public function testContainFinderHasManyClosure(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany(
@@ -3285,10 +3098,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to bind arguments to a query and it will return the right
      * results
-     *
-     * @return void
      */
-    public function testCustomBindings()
+    public function testCustomBindings(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find()->where(['id >' => 1]);
@@ -3303,10 +3114,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to pass a custom join type for an association when
      * using contain
-     *
-     * @return void
      */
-    public function testContainWithCustomJoinType()
+    public function testContainWithCustomJoinType(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -3328,10 +3137,8 @@ class QueryTest extends TestCase
      * containments array. In this case, no inner join will be made and for that
      * reason, the parent association will not be filtered as the strategy changed
      * from join to select.
-     *
-     * @return void
      */
-    public function testContainWithStrategyOverride()
+    public function testContainWithStrategyOverride(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors', [
@@ -3355,10 +3162,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to call matching and contain on the same
      * association.
-     *
-     * @return void
      */
-    public function testMatchingWithContain()
+    public function testMatchingWithContain(): void
     {
         $query = new Query($this->connection, $this->table);
         $table = $this->getTableLocator()->get('authors');
@@ -3381,10 +3186,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to call matching and contain on the same
      * association with only one level of depth.
-     *
-     * @return void
      */
-    public function testNotSoFarMatchingWithContainOnTheSameAssociation()
+    public function testNotSoFarMatchingWithContainOnTheSameAssociation(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsToMany('tags');
@@ -3403,10 +3206,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that it is possible to find large numeric values.
-     *
-     * @return void
      */
-    public function testSelectLargeNumbers()
+    public function testSelectLargeNumbers(): void
     {
         // Sqlite only supports maximum 16 digits for decimals.
         $this->skipIf($this->connection->getDriver() instanceof Sqlite);
@@ -3456,10 +3257,8 @@ class QueryTest extends TestCase
     /**
      * Tests that select() can be called with Table and Association
      * instance
-     *
-     * @return void
      */
-    public function testSelectWithTableAndAssociationInstance()
+    public function testSelectWithTableAndAssociationInstance(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsTo('authors');
@@ -3488,10 +3287,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that simple aliased field have results typecast.
-     *
-     * @return void
      */
-    public function testSelectTypeInferSimpleAliases()
+    public function testSelectTypeInferSimpleAliases(): void
     {
         $table = $this->getTableLocator()->get('comments');
         $result = $table
@@ -3504,10 +3301,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that isEmpty() can be called on a query
-     *
-     * @return void
      */
-    public function testIsEmpty()
+    public function testIsEmpty(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $this->assertFalse($table->find()->isEmpty());
@@ -3517,10 +3312,8 @@ class QueryTest extends TestCase
     /**
      * Tests that leftJoinWith() creates a left join with a given association and
      * that no fields from such association are loaded.
-     *
-     * @return void
      */
-    public function testLeftJoinWith()
+    public function testLeftJoinWith(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -3563,10 +3356,8 @@ class QueryTest extends TestCase
     /**
      * Tests that leftJoinWith() creates a left join with a given association and
      * that no fields from such association are loaded.
-     *
-     * @return void
      */
-    public function testLeftJoinWithNested()
+    public function testLeftJoinWithNested(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $articles = $table->hasMany('articles');
@@ -3594,10 +3385,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that leftJoinWith() can be used with select()
-     *
-     * @return void
      */
-    public function testLeftJoinWithSelect()
+    public function testLeftJoinWithSelect(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $articles = $table->hasMany('articles');
@@ -3626,10 +3415,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests that leftJoinWith() can be used with autofields()
-     *
-     * @return void
      */
-    public function testLeftJoinWithAutoFields()
+    public function testLeftJoinWithAutoFields(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsTo('authors');
@@ -3645,10 +3432,8 @@ class QueryTest extends TestCase
 
     /**
      * Test leftJoinWith and contain on optional association
-     *
-     * @return void
      */
-    public function testLeftJoinWithAndContainOnOptionalAssociation()
+    public function testLeftJoinWithAndContainOnOptionalAssociation(): void
     {
         $table = $this->getTableLocator()->get('Articles', ['table' => 'articles']);
         $table->belongsTo('Authors');
@@ -3738,10 +3523,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests innerJoinWith()
-     *
-     * @return void
      */
-    public function testInnerJoinWith()
+    public function testInnerJoinWith(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -3761,10 +3544,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests innerJoinWith() with nested associations
-     *
-     * @return void
      */
-    public function testInnerJoinWithNested()
+    public function testInnerJoinWithNested(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $articles = $table->hasMany('articles');
@@ -3785,10 +3566,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests innerJoinWith() with select
-     *
-     * @return void
      */
-    public function testInnerJoinWithSelect()
+    public function testInnerJoinWithSelect(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -3809,10 +3588,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests contain() in query returned by innerJoinWith throws exception.
-     *
-     * @return void
      */
-    public function testInnerJoinWithContain()
+    public function testInnerJoinWithContain(): void
     {
         $comments = $this->getTableLocator()->get('Comments');
         $articles = $comments->belongsTo('Articles');
@@ -3831,10 +3608,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests notMatching() with and without conditions
-     *
-     * @return void
      */
-    public function testNotMatching()
+    public function testNotMatching(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -3868,10 +3643,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests notMatching() with a belongsToMany association
-     *
-     * @return void
      */
-    public function testNotMatchingBelongsToMany()
+    public function testNotMatchingBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsToMany('tags');
@@ -3905,10 +3678,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests notMatching() with a deeply nested belongsToMany association.
-     *
-     * @return void
      */
-    public function testNotMatchingDeep()
+    public function testNotMatchingDeep(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $articles = $table->hasMany('articles');
@@ -3938,10 +3709,8 @@ class QueryTest extends TestCase
     /**
      * Tests that it is possible to nest a notMatching call inside another
      * eagerloader function.
-     *
-     * @return void
      */
-    public function testNotMatchingNested()
+    public function testNotMatchingNested(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $articles = $table->hasMany('articles');
@@ -3974,10 +3743,8 @@ class QueryTest extends TestCase
 
     /**
      * Test to see that the excluded fields are not in the select clause
-     *
-     * @return void
      */
-    public function testSelectAllExcept()
+    public function testSelectAllExcept(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $result = $table
@@ -3996,10 +3763,8 @@ class QueryTest extends TestCase
     /**
      * Test that the excluded fields are not included
      * in the final query result.
-     *
-     * @return void
      */
-    public function testSelectAllExceptWithContains()
+    public function testSelectAllExceptWithContains(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -4023,10 +3788,8 @@ class QueryTest extends TestCase
     /**
      * Test what happens if you call selectAllExcept() more
      * than once.
-     *
-     * @return void
      */
-    public function testSelectAllExceptWithMulitpleCalls()
+    public function testSelectAllExceptWithMulitpleCalls(): void
     {
         $table = $this->getTableLocator()->get('Articles');
 
@@ -4072,10 +3835,8 @@ class QueryTest extends TestCase
 
     /**
      * Test that given the wrong first parameter, Invalid argument exception is thrown
-     *
-     * @return void
      */
-    public function testSelectAllExceptThrowsInvalidArgument()
+    public function testSelectAllExceptThrowsInvalidArgument(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $this->expectException(\InvalidArgumentException::class);
@@ -4087,10 +3848,8 @@ class QueryTest extends TestCase
     /**
      * Tests that using Having on an aggregated field returns the correct result
      * model in the query
-     *
-     * @return void
      */
-    public function testHavingOnAnAggregatedField()
+    public function testHavingOnAnAggregatedField(): void
     {
         $post = $this->getTableLocator()->get('posts');
 
@@ -4118,8 +3877,6 @@ class QueryTest extends TestCase
 
     /**
      * Tests ORM query using with CTE.
-     *
-     * @return void
      */
     public function testWith(): void
     {
@@ -4191,10 +3948,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests subquery() copies connection by default.
-     *
-     * @return void
      */
-    public function testSubqueryConnection()
+    public function testSubqueryConnection(): void
     {
         $subquery = Query::subquery($this->table);
         $this->assertEquals($this->table->getConnection(), $subquery->getConnection());
@@ -4202,10 +3957,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests subquery() disables aliasing.
-     *
-     * @return void
      */
-    public function testSubqueryAliasing()
+    public function testSubqueryAliasing(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $subquery = Query::subquery($articles);
@@ -4226,10 +3979,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests subquery() in where clause.
-     *
-     * @return void
      */
-    public function testSubqueryWhereClause()
+    public function testSubqueryWhereClause(): void
     {
         $subquery = Query::subquery($this->getTableLocator()->get('Authors'))
             ->select(['Authors.id'])
@@ -4246,10 +3997,8 @@ class QueryTest extends TestCase
 
     /**
      * Tests subquery() in join clause.
-     *
-     * @return void
      */
-    public function testSubqueryJoinClause()
+    public function testSubqueryJoinClause(): void
     {
         $subquery = Query::subquery($this->getTableLocator()->get('Articles'))
             ->select(['author_id']);
@@ -4269,10 +4018,8 @@ class QueryTest extends TestCase
     /**
      * Tests that queries that fetch associated data in separate queries do properly
      * inherit the hydration and results casting mode of the parent query.
-     *
-     * @return void
      */
-    public function testSelectLoaderAssociationsInheritHydrationAndResultsCastingMode()
+    public function testSelectLoaderAssociationsInheritHydrationAndResultsCastingMode(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -47,8 +47,6 @@ class ResultSetTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -68,10 +66,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that result sets can be rewound and re-used.
-     *
-     * @return void
      */
-    public function testRewind()
+    public function testRewind(): void
     {
         $query = $this->table->find('all');
         $results = $query->all();
@@ -87,10 +83,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that streaming results cannot be rewound
-     *
-     * @return void
      */
-    public function testRewindStreaming()
+    public function testRewindStreaming(): void
     {
         $query = $this->table->find('all')->enableBufferedResults(false);
         $results = $query->all();
@@ -109,10 +103,8 @@ class ResultSetTest extends TestCase
      *
      * Compare the results of a query with the results iterated, with
      * those of a different query that have been serialized/unserialized.
-     *
-     * @return void
      */
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $query = $this->table->find('all');
         $results = $query->all();
@@ -127,10 +119,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test iteration after serialization
-     *
-     * @return void
      */
-    public function testIteratorAfterSerializationNoHydration()
+    public function testIteratorAfterSerializationNoHydration(): void
     {
         $query = $this->table->find('all')->enableHydration(false);
         $results = unserialize(serialize($query->all()));
@@ -143,10 +133,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test iteration after serialization
-     *
-     * @return void
      */
-    public function testIteratorAfterSerializationHydrated()
+    public function testIteratorAfterSerializationHydrated(): void
     {
         $query = $this->table->find('all');
         $results = unserialize(serialize($query->all()));
@@ -163,10 +151,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test converting resultsets into JSON
-     *
-     * @return void
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $query = $this->table->find('all');
         $results = $query->all();
@@ -177,10 +163,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test first() method with a statement backed result set.
-     *
-     * @return void
      */
-    public function testFirst()
+    public function testFirst(): void
     {
         $query = $this->table->find('all');
         $results = $query->enableHydration(false)->all();
@@ -194,10 +178,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test first() method with a result set that has been unserialized
-     *
-     * @return void
      */
-    public function testFirstAfterSerialize()
+    public function testFirstAfterSerialize(): void
     {
         $query = $this->table->find('all');
         $results = $query->enableHydration(false)->all();
@@ -212,10 +194,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test the countable interface.
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $query = $this->table->find('all');
         $results = $query->all();
@@ -225,10 +205,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test the countable interface after unserialize
-     *
-     * @return void
      */
-    public function testCountAfterSerialize()
+    public function testCountAfterSerialize(): void
     {
         $query = $this->table->find('all');
         $results = $query->all();
@@ -239,10 +217,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Integration test to show methods from CollectionTrait work
-     *
-     * @return void
      */
-    public function testGroupBy()
+    public function testGroupBy(): void
     {
         $query = $this->table->find('all');
         $results = $query->all()->groupBy('author_id')->toArray();
@@ -265,10 +241,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $query = $this->table->find('all');
         $results = $query->all();
@@ -280,10 +254,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that eagerLoader leaves empty associations unpopulated.
-     *
-     * @return void
      */
-    public function testBelongsToEagerLoaderLeavesEmptyAssociation()
+    public function testBelongsToEagerLoaderLeavesEmptyAssociation(): void
     {
         $comments = $this->getTableLocator()->get('Comments');
         $comments->belongsTo('Articles');
@@ -308,10 +280,8 @@ class ResultSetTest extends TestCase
     /**
      * Test showing associated record is preserved when selecting only field with
      * null value if auto fields is disabled.
-     *
-     * @return void
      */
-    public function testBelongsToEagerLoaderWithAutoFieldsFalse()
+    public function testBelongsToEagerLoaderWithAutoFieldsFalse(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
 
@@ -340,10 +310,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that eagerLoader leaves empty associations unpopulated.
-     *
-     * @return void
      */
-    public function testHasOneEagerLoaderLeavesEmptyAssociation()
+    public function testHasOneEagerLoaderLeavesEmptyAssociation(): void
     {
         $this->table->hasOne('Comments');
 
@@ -368,10 +336,8 @@ class ResultSetTest extends TestCase
     /**
      * Test that fetching rows does not fail when no fields were selected
      * on the default alias.
-     *
-     * @return void
      */
-    public function testFetchMissingDefaultAlias()
+    public function testFetchMissingDefaultAlias(): void
     {
         $comments = $this->getTableLocator()->get('Comments');
         $query = $comments->find()->select(['Other__field' => 'test']);
@@ -392,10 +358,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that associations have source() correctly set.
-     *
-     * @return void
      */
-    public function testSourceOnContainAssociations()
+    public function testSourceOnContainAssociations(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $comments = $this->getTableLocator()->get('TestPlugin.Comments');
@@ -418,10 +382,8 @@ class ResultSetTest extends TestCase
     /**
      * Ensure that isEmpty() on a ResultSet doesn't result in loss
      * of records. This behavior is provided by CollectionTrait.
-     *
-     * @return void
      */
-    public function testIsEmptyDoesNotConsumeData()
+    public function testIsEmptyDoesNotConsumeData(): void
     {
         $table = $this->getTableLocator()->get('Comments');
         $query = $table->find()
@@ -435,10 +397,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that ResultSet
-     *
-     * @return void
      */
-    public function testCollectionMinAndMax()
+    public function testCollectionMinAndMax(): void
     {
         $query = $this->table->find('all');
 
@@ -454,10 +414,8 @@ class ResultSetTest extends TestCase
 
     /**
      * Test that ResultSet
-     *
-     * @return void
      */
-    public function testCollectionMinAndMaxWithAggregateField()
+    public function testCollectionMinAndMaxWithAggregateField(): void
     {
         $query = $this->table->find();
         $query->select([
@@ -472,9 +430,8 @@ class ResultSetTest extends TestCase
 
     /**
      * @see https://github.com/cakephp/cakephp/issues/14676
-     * @return void
      */
-    public function testQueryLoggingForSelectsWithZeroRows()
+    public function testQueryLoggingForSelectsWithZeroRows(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
 

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -53,8 +53,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -72,8 +70,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tear down.
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -97,7 +93,6 @@ class LinkConstraintTest extends TestCase
      * @dataProvider invalidConstructorArgumentOneDataProvider
      * @param mixed $value
      * @param string $actualType
-     * @return void
      */
     public function testInvalidConstructorArgumentOne($value, $actualType): void
     {
@@ -114,7 +109,6 @@ class LinkConstraintTest extends TestCase
      * Tests that an exception is thrown when passing an invalid value for the `$requiredLinkStatus` argument.
      *
      * @dataProvider invalidConstructorArgumentOneDataProvider
-     * @return void
      */
     public function testInvalidConstructorArgumentTwo(): void
     {
@@ -126,8 +120,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that an exception is thrown when an association with the given name doesn't exist.
-     *
-     * @return void
      */
     public function testNonExistentAssociation(): void
     {
@@ -147,8 +139,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that an exception is thrown when the checked entity doesn't contain all primary key values.
-     *
-     * @return void
      */
     public function testMissingPrimaryKeyValues(): void
     {
@@ -161,7 +151,7 @@ class LinkConstraintTest extends TestCase
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->hasMany('Comments');
 
-        $Articles->getEventManager()->on('Model.beforeRules', function (Event $event) {
+        $Articles->getEventManager()->on('Model.beforeRules', function (Event $event): void {
             $event->getSubject()->setPrimaryKey(['id', 'nonexistent']);
         });
 
@@ -177,8 +167,6 @@ class LinkConstraintTest extends TestCase
     /**
      * Tests that an exception is thrown when the number of the extracted primary keys in the check entity doesn't
      * match the required number of primary key parts.
-     *
-     * @return void
      */
     public function testNonMatchingKeyFields(): void
     {
@@ -227,7 +215,6 @@ class LinkConstraintTest extends TestCase
      *
      * @dataProvider invalidRepositoryOptionsDataProvider
      * @param mixed $options
-     * @return void
      */
     public function testInvalidRepository($options): void
     {
@@ -250,8 +237,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a required `belongsTo` link exists.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaBelongsToIsLinked(): void
     {
@@ -271,8 +256,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a required `belongsTo` link does not exist.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaBelongsToIsNotLinked(): void
     {
@@ -308,8 +291,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a required `belongsToMany` link exists.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaBelongsToManyToIsLinked(): void
     {
@@ -328,8 +309,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a required `belongsToMany` link does not exist.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaBelongsToManyIsNotLinked(): void
     {
@@ -362,8 +341,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a required `hasMany` link exists.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaHasManyIsLinked(): void
     {
@@ -383,8 +360,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a required `hasMany` link does not exist.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaHasManyIsNotLinked(): void
     {
@@ -414,8 +389,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a required `hasOne` link exists.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaHasOneIsLinked(): void
     {
@@ -435,8 +408,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a required `hasOne` link does not exist.
-     *
-     * @return void
      */
     public function testMustBeLinkedViaHasOneIsNotLinked(): void
     {
@@ -466,8 +437,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a prohibited `belongsTo` link does not exist.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaBelongsToIsNotLinked(): void
     {
@@ -492,8 +461,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a prohibited `belongsTo` link exists.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaBelongsToIsLinked(): void
     {
@@ -522,8 +489,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a prohibited `belongsToMany` link does not exist.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaBelongsToManyIsNotLinked(): void
     {
@@ -545,8 +510,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a prohibited `belongsToMany` link exists.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaBelongsToManyIsLinked(): void
     {
@@ -574,8 +537,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a prohibited `hasMany` link does not exist.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaHasManyIsNotLinked(): void
     {
@@ -594,8 +555,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a prohibited `hasMany` link exists.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaHasManyIsLinked(): void
     {
@@ -624,8 +583,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule succeeds when a prohibited `hasOne` link does not exist.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaHasOneIsNotLinked(): void
     {
@@ -644,8 +601,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that the rule fails when a prohibited `hasOne` link exists.
-     *
-     * @return void
      */
     public function testMustNotBeLinkedViaHasOneIsLinked(): void
     {
@@ -674,8 +629,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with disabled foreign keys and expression conditions works.
-     *
-     * @return void
      */
     public function testDisabledForeignKeyAndSubQueryConditionsWithMustNotBeLinkedIsNotLinked(): void
     {
@@ -713,8 +666,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with disabled foreign keys and expression conditions works.
-     *
-     * @return void
      */
     public function testDisabledForeignKeyAndSubQueryConditionsWithMustNotBeLinkedIsLinked(): void
     {
@@ -762,8 +713,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with array conditions works.
-     *
-     * @return void
      */
     public function testConditionsWithMustNotBeLinkedIsNotLinked(): void
     {
@@ -786,8 +735,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with array conditions works.
-     *
-     * @return void
      */
     public function testConditionsWithMustNotBeLinkedIsLinked(): void
     {
@@ -820,8 +767,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with conditions that are referencing the main table works.
-     *
-     * @return void
      */
     public function testConditionsReferencingParentColumnWithMustNotBeLinkedIsNotLinked(): void
     {
@@ -858,8 +803,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with conditions that are referencing the main table works.
-     *
-     * @return void
      */
     public function testConditionsReferencingParentColumnWithMustNotBeLinkedIsLinked(): void
     {
@@ -895,8 +838,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with custom finders works.
-     *
-     * @return void
      */
     public function testFinderWithMustNotBeLinkedIsNotLinked(): void
     {
@@ -928,8 +869,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using associations with custom finders works.
-     *
-     * @return void
      */
     public function testFinderWithMustNotBeLinkedIsLinked(): void
     {
@@ -960,8 +899,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using association instances works.
-     *
-     * @return void
      */
     public function testAssociationInstanceWithMustBeLinkedIsLinked(): void
     {
@@ -981,8 +918,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests that using association instances works.
-     *
-     * @return void
      */
     public function testAssociationInstanceWithMustBeLinkedIsNotLinked(): void
     {
@@ -1018,8 +953,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests implicit delete operations on `hasMany` associations.
-     *
-     * @return void
      */
     public function testImplicitHasManyDeleteErrors(): void
     {
@@ -1061,8 +994,6 @@ class LinkConstraintTest extends TestCase
 
     /**
      * Tests implicit delete operations on `belongsToMany` junction associations.
-     *
-     * @return void
      */
     public function testImplicitBelongsToManyJunctionDeleteErrors(): void
     {

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -46,9 +46,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests saving belongsTo association and get a validation error
      *
      * @group save
-     * @return void
      */
-    public function testsSaveBelongsToWithValidationError()
+    public function testsSaveBelongsToWithValidationError(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -85,9 +84,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * abort the saving process
      *
      * @group save
-     * @return void
      */
-    public function testSaveHasOneWithValidationError()
+    public function testSaveHasOneWithValidationError(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -123,10 +121,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests saving multiple entities in a hasMany association and getting and
      * error while saving one of them. It should abort all the save operation
      * when options are set to defaults
-     *
-     * @return void
      */
-    public function testSaveHasManyWithErrorsAtomic()
+    public function testSaveHasManyWithErrorsAtomic(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -172,10 +168,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests that it is possible to continue saving hasMany associations
      * even if any of the records fail validation when atomic is set
      * to false
-     *
-     * @return void
      */
-    public function testSaveHasManyWithErrorsNonAtomic()
+    public function testSaveHasManyWithErrorsNonAtomic(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -217,9 +211,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests saving belongsToMany records with a validation error in a joint entity
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsToManyWithValidationErrorInJointEntity()
+    public function testSaveBelongsToManyWithValidationErrorInJointEntity(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -257,9 +250,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * and atomic set to false
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsToManyWithValidationErrorInJointEntityNonAtomic()
+    public function testSaveBelongsToManyWithValidationErrorInJointEntityNonAtomic(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -297,9 +289,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Test adding rule with name
      *
      * @group save
-     * @return void
      */
-    public function testAddingRuleWithName()
+    public function testAddingRuleWithName(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -321,10 +312,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Ensure that add(isUnique()) only invokes a rule once.
-     *
-     * @return void
      */
-    public function testIsUniqueRuleSingleInvocation()
+    public function testIsUniqueRuleSingleInvocation(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -347,9 +336,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the isUnique domain rule
      *
      * @group save
-     * @return void
      */
-    public function testIsUniqueDomainRule()
+    public function testIsUniqueDomainRule(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -374,9 +362,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests isUnique with multiple fields
      *
      * @group save
-     * @return void
      */
-    public function testIsUniqueMultipleFields()
+    public function testIsUniqueMultipleFields(): void
     {
         $entity = new Entity([
             'author_id' => 1,
@@ -397,10 +384,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests isUnique with non-unique null values
-     *
-     * @return void
      */
-    public function testIsUniqueNonUniqueNulls()
+    public function testIsUniqueNonUniqueNulls(): void
     {
         $table = $this->getTableLocator()->get('UniqueAuthors');
         $rules = $table->rulesChecker();
@@ -420,9 +405,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests isUnique with allowMultipleNulls
      *
      * @group save
-     * @return void
      */
-    public function testIsUniqueAllowMultipleNulls()
+    public function testIsUniqueAllowMultipleNulls(): void
     {
         $this->skipIf(ConnectionManager::get('test')->getDriver() instanceof Sqlserver);
 
@@ -454,9 +438,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the existsIn domain rule
      *
      * @group save
-     * @return void
      */
-    public function testExistsInDomainRule()
+    public function testExistsInDomainRule(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -474,10 +457,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Ensure that add(existsIn()) only invokes a rule once.
-     *
-     * @return void
      */
-    public function testExistsInRuleSingleInvocation()
+    public function testExistsInRuleSingleInvocation(): void
     {
         $entity = new Entity([
             'title' => 'larry',
@@ -502,9 +483,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the existsIn domain rule when passing an object
      *
      * @group save
-     * @return void
      */
-    public function testExistsInDomainRuleWithObject()
+    public function testExistsInDomainRuleWithObject(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -521,10 +501,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * ExistsIn uses the schema to verify that nullable fields are ok.
-     *
-     * @return void
      */
-    public function testExistsInNullValue()
+    public function testExistsInNullValue(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -545,10 +523,8 @@ class RulesCheckerIntegrationTest extends TestCase
      *
      * This use case is important for saving records and their
      * associated belongsTo records in one pass.
-     *
-     * @return void
      */
-    public function testExistsInNotNullValueNewEntity()
+    public function testExistsInNotNullValueNewEntity(): void
     {
         $entity = new Entity([
             'name' => 'A Category',
@@ -566,10 +542,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests exists in uses the bindingKey of the association
-     *
-     * @return void
      */
-    public function testExistsInWithBindingKey()
+    public function testExistsInWithBindingKey(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -595,9 +569,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests existsIn with invalid associations
      *
      * @group save
-     * @return void
      */
-    public function testExistsInInvalidAssociation()
+    public function testExistsInInvalidAssociation(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('ExistsIn rule for \'author_id\' is invalid. \'NotValid\' is not associated with \'Cake\ORM\Table\'.');
@@ -616,10 +589,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests existsIn does not prevent new entities from saving if parent entity is new
-     *
-     * @return void
      */
-    public function testExistsInHasManyNewEntities()
+    public function testExistsInHasManyNewEntities(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -648,10 +619,8 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests existsIn does not prevent new entities from saving if parent entity is new,
      * getting the parent entity from the association
-     *
-     * @return void
      */
-    public function testExistsInHasManyNewEntitiesViaAssociation()
+    public function testExistsInHasManyNewEntitiesViaAssociation(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
@@ -678,9 +647,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the checkRules save option
      *
      * @group save
-     * @return void
      */
-    public function testSkipRulesChecking()
+    public function testSkipRulesChecking(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -698,9 +666,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the beforeRules event
      *
      * @group save
-     * @return void
      */
-    public function testUseBeforeRules()
+    public function testUseBeforeRules(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -738,9 +705,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the afterRules event
      *
      * @group save
-     * @return void
      */
-    public function testUseAfterRules()
+    public function testUseAfterRules(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -779,9 +745,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests that rules can be changed using the buildRules event
      *
      * @group save
-     * @return void
      */
-    public function testUseBuildRulesEvent()
+    public function testUseBuildRulesEvent(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -789,7 +754,7 @@ class RulesCheckerIntegrationTest extends TestCase
         ]);
 
         $table = $this->getTableLocator()->get('Articles');
-        $table->getEventManager()->on('Model.buildRules', function (EventInterface $event, RulesChecker $rules) {
+        $table->getEventManager()->on('Model.buildRules', function (EventInterface $event, RulesChecker $rules): void {
             $rules->add($rules->existsIn('author_id', $this->getTableLocator()->get('Authors'), 'Nope'));
         });
 
@@ -800,9 +765,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests isUnique with untouched fields
      *
      * @group save
-     * @return void
      */
-    public function testIsUniqueWithCleanFields()
+    public function testIsUniqueWithCleanFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $entity = $table->get(1);
@@ -820,9 +784,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests isUnique rule with conflicting columns
      *
      * @group save
-     * @return void
      */
-    public function testIsUniqueAliasPrefix()
+    public function testIsUniqueAliasPrefix(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -834,7 +797,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
         $rules->add($rules->isUnique(['author_id']));
 
-        $table->Authors->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query) {
+        $table->Authors->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query): void {
             $query->leftJoin(['a2' => 'authors']);
         });
 
@@ -846,9 +809,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the existsIn rule when passing non dirty fields
      *
      * @group save
-     * @return void
      */
-    public function testExistsInWithCleanFields()
+    public function testExistsInWithCleanFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -866,9 +828,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the existsIn with conflicting columns
      *
      * @group save
-     * @return void
      */
-    public function testExistsInAliasPrefix()
+    public function testExistsInAliasPrefix(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -880,7 +841,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
         $rules->add($rules->existsIn('author_id', 'Authors'));
 
-        $table->Authors->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query) {
+        $table->Authors->getEventManager()->on('Model.beforeFind', function (EventInterface $event, $query): void {
             $query->leftJoin(['a2' => 'authors']);
         });
 
@@ -890,10 +851,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that using an array in existsIn() sets the error message correctly
-     *
-     * @return void
      */
-    public function testExistsInErrorWithArrayField()
+    public function testExistsInErrorWithArrayField(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -911,10 +870,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to null
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOn()
+    public function testExistsInAllowNullableNullsOn(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -934,10 +891,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to null
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOff()
+    public function testExistsInAllowNullableNullsOff(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -957,10 +912,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to null
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsDefaultValue()
+    public function testExistsInAllowNullableNullsDefaultValue(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -978,10 +931,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to null
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsCustomMessage()
+    public function testExistsInAllowNullableNullsCustomMessage(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1003,10 +954,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to 1
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOnAllKeysSet()
+    public function testExistsInAllowNullableNullsOnAllKeysSet(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1024,10 +973,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to 1
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOffAllKeysSet()
+    public function testExistsInAllowNullableNullsOffAllKeysSet(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1045,10 +992,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to 1
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOnAllKeysCustomMessage()
+    public function testExistsInAllowNullableNullsOnAllKeysCustomMessage(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1068,10 +1013,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls flag with author id set to 99999999 (does not exist)
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOnInvalidKey()
+    public function testExistsInAllowNullableNullsOnInvalidKey(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1093,10 +1036,8 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests new allowNullableNulls flag with author id set to 99999999 (does not exist)
      * and site_id set to 99999999 (does not exist)
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOnInvalidKeys()
+    public function testExistsInAllowNullableNullsOnInvalidKeys(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1118,10 +1059,8 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests new allowNullableNulls flag with author id set to 1 (does exist)
      * and site_id set to 99999999 (does not exist)
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsOnInvalidKeySecond()
+    public function testExistsInAllowNullableNullsOnInvalidKeySecond(): void
     {
         $entity = new Entity([
             'id' => 10,
@@ -1142,10 +1081,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests new allowNullableNulls with saveMany
-     *
-     * @return void
      */
-    public function testExistsInAllowNullableNullsSaveMany()
+    public function testExistsInAllowNullableNullsSaveMany(): void
     {
         $entities = [
             new Entity([
@@ -1182,9 +1119,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests using rules to prevent delete operations
      *
      * @group delete
-     * @return void
      */
-    public function testDeleteRules()
+    public function testDeleteRules(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $rules = $table->rulesChecker();
@@ -1200,9 +1136,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Checks that it is possible to pass custom options to rules when saving
      *
      * @group save
-     * @return void
      */
-    public function testCustomOptionsPassingSave()
+    public function testCustomOptionsPassingSave(): void
     {
         $entity = new Entity([
             'name' => 'jose',
@@ -1224,9 +1159,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests passing custom options to rules from delete
      *
      * @group delete
-     * @return void
      */
-    public function testCustomOptionsPassingDelete()
+    public function testCustomOptionsPassingDelete(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $rules = $table->rulesChecker();
@@ -1245,9 +1179,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Test adding rules that return error string
      *
      * @group save
-     * @return void
      */
-    public function testCustomErrorMessageFromRule()
+    public function testCustomErrorMessageFromRule(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -1267,9 +1200,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Test adding rules with no errorField do not accept strings
      *
      * @group save
-     * @return void
      */
-    public function testCustomErrorMessageFromRuleNoErrorField()
+    public function testCustomErrorMessageFromRuleNoErrorField(): void
     {
         $entity = new Entity([
             'name' => 'larry',
@@ -1290,9 +1222,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * as the foreign key for the association was automatically validated already.
      *
      * @group save
-     * @return void
      */
-    public function testAvoidExistsInOnAutomaticSaving()
+    public function testAvoidExistsInOnAutomaticSaving(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -1330,9 +1261,8 @@ class RulesCheckerIntegrationTest extends TestCase
      * Tests the existsIn domain rule respects the conditions set for the associations
      *
      * @group save
-     * @return void
      */
-    public function testExistsInDomainRuleWithAssociationConditions()
+    public function testExistsInDomainRuleWithAssociationConditions(): void
     {
         $entity = new Entity([
             'title' => 'An Article',
@@ -1352,10 +1282,8 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that associated items have a count of X.
-     *
-     * @return void
      */
-    public function testCountOfAssociatedItems()
+    public function testCountOfAssociatedItems(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -1404,8 +1332,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that an exception is thrown when passing an invalid value for the `$association` argument.
-     *
-     * @return void
      */
     public function testIsLinkedToInvalidArgumentOne(): void
     {
@@ -1421,8 +1347,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that an exception is thrown when passing an invalid value for the `$association` argument.
-     *
-     * @return void
      */
     public function testIsNotLinkedToInvalidArgumentOne(): void
     {
@@ -1438,8 +1362,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the error field name is inferred from the association name in case no name is provided.
-     *
-     * @return void
      */
     public function testIsLinkedToInferFieldFromAssociationName(): void
     {
@@ -1471,8 +1393,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the error field name is inferred from the association name in case no name is provided.
-     *
-     * @return void
      */
     public function testIsNotLinkedToInferFieldFromAssociationName(): void
     {
@@ -1499,8 +1419,6 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests that the error field name is inferred from the association name in case no name is provided,
      * and no repository is available at the time of creating the rule.
-     *
-     * @return void
      */
     public function testIsLinkedToInferFieldFromAssociationNameWithNoRepositoryAvailable(): void
     {
@@ -1540,8 +1458,6 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests that the error field name is inferred from the association name in case no name is provided,
      * and no repository is available at the time of creating the rule.
-     *
-     * @return void
      */
     public function testIsNotLinkedToInferFieldFromAssociationNameWithNoRepositoryAvailable(): void
     {
@@ -1574,8 +1490,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the error field name is inferred from the association object in case no name is provided.
-     *
-     * @return void
      */
     public function testIsLinkedToInferFieldFromAssociationObject(): void
     {
@@ -1607,8 +1521,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the error field name is inferred from the association object in case no name is provided.
-     *
-     * @return void
      */
     public function testIsNotLinkedToInferFieldFromAssociationObject(): void
     {
@@ -1634,8 +1546,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the custom error field name is being used.
-     *
-     * @return void
      */
     public function testIsLinkedToWithCustomField(): void
     {
@@ -1667,8 +1577,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the custom error field name is being used.
-     *
-     * @return void
      */
     public function testIsNotLinkedToWithCustomField(): void
     {
@@ -1694,8 +1602,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the custom error message is being used.
-     *
-     * @return void
      */
     public function testIsLinkedToWithCustomMessage(): void
     {
@@ -1727,8 +1633,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the custom error message is being used.
-     *
-     * @return void
      */
     public function testIsNotLinkedToWithCustomMessage(): void
     {
@@ -1754,8 +1658,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the default error message can be translated.
-     *
-     * @return void
      */
     public function testIsLinkedToMessageWithI18n(): void
     {
@@ -1799,8 +1701,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the default error message can be translated.
-     *
-     * @return void
      */
     public function testIsNotLinkedToMessageWithI18n(): void
     {
@@ -1839,8 +1739,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the default error message works without I18n.
-     *
-     * @return void
      */
     public function testIsLinkedToMessageWithoutI18n(): void
     {
@@ -1866,7 +1764,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         \Closure::bind(
-            function () use ($rulesChecker) {
+            function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,
@@ -1892,8 +1790,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the default error message works without I18n.
-     *
-     * @return void
      */
     public function testIsNotLinkedToMessageWithoutI18n(): void
     {
@@ -1913,7 +1809,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         \Closure::bind(
-            function () use ($rulesChecker) {
+            function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,
@@ -1940,8 +1836,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the rule can pass.
-     *
-     * @return void
      */
     public function testIsLinkedToIsLinked(): void
     {
@@ -1961,8 +1855,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that the rule can pass.
-     *
-     * @return void
      */
     public function testIsNotLinkedToIsNotLinked(): void
     {

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -43,8 +43,6 @@ class SaveOptionsBuilderTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,10 +60,8 @@ class SaveOptionsBuilderTest extends TestCase
 
     /**
      * testAssociatedChecks
-     *
-     * @return void
      */
-    public function testAssociatedChecks()
+    public function testAssociatedChecks(): void
     {
         $expected = [
             'associated' => [
@@ -149,10 +145,8 @@ class SaveOptionsBuilderTest extends TestCase
 
     /**
      * testBuilder
-     *
-     * @return void
      */
-    public function testBuilder()
+    public function testBuilder(): void
     {
         $expected = [
             'associated' => [
@@ -191,10 +185,8 @@ class SaveOptionsBuilderTest extends TestCase
 
     /**
      * testParseOptionsArray
-     *
-     * @return void
      */
-    public function testParseOptionsArray()
+    public function testParseOptionsArray(): void
     {
         $options = [
             'associated' => [
@@ -218,10 +210,8 @@ class SaveOptionsBuilderTest extends TestCase
 
     /**
      * testSettingCustomOptions
-     *
-     * @return void
      */
-    public function testSettingCustomOptions()
+    public function testSettingCustomOptions(): void
     {
         $expected = [
             'myOption' => true,

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -37,8 +37,6 @@ class TableComplexIdTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class TableComplexIdTest extends TestCase
 
     /**
      * teardown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -60,10 +56,8 @@ class TableComplexIdTest extends TestCase
 
     /**
      * Test saving new records sets uuids
-     *
-     * @return void
      */
-    public function testSaveNew()
+    public function testSaveNew(): void
     {
         $now = new DateTime('now');
         $entity = new Entity([
@@ -80,10 +74,8 @@ class TableComplexIdTest extends TestCase
 
     /**
      * Test saving existing records works
-     *
-     * @return void
      */
-    public function testSaveUpdate()
+    public function testSaveUpdate(): void
     {
         $id = new DateTime('now');
         $entity = new Entity([
@@ -102,10 +94,8 @@ class TableComplexIdTest extends TestCase
 
     /**
      * Test delete with string pk.
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $table = $this->getTableLocator()->get('DateKeys');
         $entity = new Entity([

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -34,8 +34,6 @@ class TableRegistryTest extends TestCase
     /**
      * Remember original instance to set it back on tearDown() just to make sure
      * other tests are not broken.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -45,8 +43,6 @@ class TableRegistryTest extends TestCase
 
     /**
      * tear down
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -69,10 +65,8 @@ class TableRegistryTest extends TestCase
 
     /**
      * Test testSetLocator() method.
-     *
-     * @return void
      */
-    public function testSetLocator()
+    public function testSetLocator(): void
     {
         $locator = $this->_setMockLocator();
 
@@ -81,20 +75,16 @@ class TableRegistryTest extends TestCase
 
     /**
      * Test testSetLocator() method.
-     *
-     * @return void
      */
-    public function testGetLocator()
+    public function testGetLocator(): void
     {
         $this->assertInstanceOf('Cake\ORM\Locator\LocatorInterface', TableRegistry::getTableLocator());
     }
 
     /**
      * Test that locator() method is returning TableLocator by default.
-     *
-     * @return void
      */
-    public function testLocatorDefault()
+    public function testLocatorDefault(): void
     {
         $locator = TableRegistry::getTableLocator();
         $this->assertInstanceOf('Cake\ORM\Locator\TableLocator', $locator);
@@ -102,10 +92,8 @@ class TableRegistryTest extends TestCase
 
     /**
      * Test the get() method.
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $locator = $this->_setMockLocator();
         $locator->expects($this->once())->method('get')->with('Test', []);
@@ -115,10 +103,8 @@ class TableRegistryTest extends TestCase
 
     /**
      * Test the get() method.
-     *
-     * @return void
      */
-    public function testSet()
+    public function testSet(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
 
@@ -130,10 +116,8 @@ class TableRegistryTest extends TestCase
 
     /**
      * Test the remove() method.
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $locator = $this->_setMockLocator();
         $locator->expects($this->once())->method('remove')->with('Test');
@@ -143,10 +127,8 @@ class TableRegistryTest extends TestCase
 
     /**
      * Test the clear() method.
-     *
-     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
         $locator = $this->_setMockLocator();
         $locator->expects($this->once())->method('clear');

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -38,15 +38,14 @@ class TableRegressionTest extends TestCase
      * in the afterSave callback
      *
      * @see https://github.com/cakephp/cakephp/issues/9079
-     * @return void
      */
-    public function testAfterSaveRollbackTransaction()
+    public function testAfterSaveRollbackTransaction(): void
     {
         $this->expectException(\Cake\ORM\Exception\RolledbackTransactionException::class);
         $table = $this->getTableLocator()->get('Authors');
         $table->getEventManager()->on(
             'Model.afterSave',
-            function () use ($table) {
+            function () use ($table): void {
                 $table->getConnection()->rollback();
             }
         );
@@ -56,10 +55,8 @@ class TableRegressionTest extends TestCase
 
     /**
      * Ensure that saving to a table with no primary key fails.
-     *
-     * @return void
      */
-    public function testSaveNoPrimaryKeyException()
+    public function testSaveNoPrimaryKeyException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('primary key');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -95,9 +95,6 @@ class TableTest extends TestCase
      */
     protected $articlesTypeMap;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -182,8 +179,6 @@ class TableTest extends TestCase
 
     /**
      * teardown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -193,10 +188,8 @@ class TableTest extends TestCase
 
     /**
      * Tests query creation wrappers.
-     *
-     * @return void
      */
-    public function testTableQuery()
+    public function testTableQuery(): void
     {
         $table = new Table(['table' => 'users']);
 
@@ -216,10 +209,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the table method
-     *
-     * @return void
      */
-    public function testTableMethod()
+    public function testTableMethod(): void
     {
         $table = new Table(['table' => 'users']);
         $this->assertSame('users', $table->getTable());
@@ -246,10 +237,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the setAlias method
-     *
-     * @return void
      */
-    public function testSetAlias()
+    public function testSetAlias(): void
     {
         $table = new Table(['alias' => 'users']);
         $this->assertSame('users', $table->getAlias());
@@ -273,10 +262,8 @@ class TableTest extends TestCase
 
     /**
      * Test that aliasField() works.
-     *
-     * @return void
      */
-    public function testAliasField()
+    public function testAliasField(): void
     {
         $table = new Table(['alias' => 'Users']);
         $this->assertSame('Users.id', $table->aliasField('id'));
@@ -286,10 +273,8 @@ class TableTest extends TestCase
 
     /**
      * Tests setConnection method
-     *
-     * @return void
      */
-    public function testSetConnection()
+    public function testSetConnection(): void
     {
         $table = new Table(['table' => 'users']);
         $this->assertSame($this->connection, $table->getConnection());
@@ -299,10 +284,8 @@ class TableTest extends TestCase
 
     /**
      * Tests primaryKey method
-     *
-     * @return void
      */
-    public function testSetPrimaryKey()
+    public function testSetPrimaryKey(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -321,10 +304,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that name will be selected as a displayField
-     *
-     * @return void
      */
-    public function testDisplayFieldName()
+    public function testDisplayFieldName(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -338,10 +319,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that title will be selected as a displayField
-     *
-     * @return void
      */
-    public function testDisplayFieldTitle()
+    public function testDisplayFieldTitle(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -355,10 +334,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that label will be selected as a displayField
-     *
-     * @return void
      */
-    public function testDisplayFieldLabel()
+    public function testDisplayFieldLabel(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -372,10 +349,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that no displayField will fallback to primary key
-     *
-     * @return void
      */
-    public function testDisplayFallback()
+    public function testDisplayFallback(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -393,10 +368,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that displayField can be changed
-     *
-     * @return void
      */
-    public function testDisplaySet()
+    public function testDisplaySet(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -413,10 +386,8 @@ class TableTest extends TestCase
 
     /**
      * Tests schema method
-     *
-     * @return void
      */
-    public function testSetSchema()
+    public function testSetSchema(): void
     {
         $schema = $this->connection->getSchemaCollection()->describe('users');
         $table = new Table([
@@ -440,10 +411,8 @@ class TableTest extends TestCase
 
     /**
      * Tests schema method with long identifiers
-     *
-     * @return void
      */
-    public function testSetSchemaLongIdentifiers()
+    public function testSetSchemaLongIdentifiers(): void
     {
         $schema = new TableSchema('long_identifiers', [
             'this_is_invalid_because_it_is_very_very_very_long' => [
@@ -471,10 +440,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that _initializeSchema can be used to alter the database schema
-     *
-     * @return void
      */
-    public function testSchemaInitialize()
+    public function testSchemaInitialize(): void
     {
         $schema = $this->connection->getSchemaCollection()->describe('users');
         $table = $this->getMockBuilder(Table::class)
@@ -498,10 +465,8 @@ class TableTest extends TestCase
     /**
      * Tests that all fields for a table are added by default in a find when no
      * other fields are specified
-     *
-     * @return void
      */
-    public function testFindAllNoFieldsAndNoHydration()
+    public function testFindAllNoFieldsAndNoHydration(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -534,10 +499,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to select only a few fields when finding over a table
-     *
-     * @return void
      */
-    public function testFindAllSomeFieldsNoHydration()
+    public function testFindAllSomeFieldsNoHydration(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -572,10 +535,8 @@ class TableTest extends TestCase
     /**
      * Tests that the query will automatically casts complex conditions to the correct
      * types when the columns belong to the default table
-     *
-     * @return void
      */
-    public function testFindAllConditionAutoTypes()
+    public function testFindAllConditionAutoTypes(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -610,10 +571,8 @@ class TableTest extends TestCase
 
     /**
      * Test that beforeFind events can mutate the query.
-     *
-     * @return void
      */
-    public function testFindBeforeFindEventMutateQuery()
+    public function testFindBeforeFindEventMutateQuery(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -621,7 +580,7 @@ class TableTest extends TestCase
         ]);
         $table->getEventManager()->on(
             'Model.beforeFind',
-            function (EventInterface $event, $query, $options) {
+            function (EventInterface $event, $query, $options): void {
                 $query->limit(1);
             }
         );
@@ -633,10 +592,8 @@ class TableTest extends TestCase
     /**
      * Test that beforeFind events are fired and can stop the find and
      * return custom results.
-     *
-     * @return void
      */
-    public function testFindBeforeFindEventOverrideReturn()
+    public function testFindBeforeFindEventOverrideReturn(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -645,7 +602,7 @@ class TableTest extends TestCase
         $expected = ['One', 'Two', 'Three'];
         $table->getEventManager()->on(
             'Model.beforeFind',
-            function (EventInterface $event, $query, $options) use ($expected) {
+            function (EventInterface $event, $query, $options) use ($expected): void {
                 $query->setResult($expected);
                 $event->stopPropagation();
             }
@@ -658,10 +615,8 @@ class TableTest extends TestCase
 
     /**
      * Test that the getAssociation() method supports the dot syntax.
-     *
-     * @return void
      */
-    public function testAssociationDotSyntax()
+    public function testAssociationDotSyntax(): void
     {
         $sections = $this->getTableLocator()->get('Sections');
         $members = $this->getTableLocator()->get('Members');
@@ -680,7 +635,7 @@ class TableTest extends TestCase
         );
     }
 
-    public function testGetAssociationWithIncorrectCasing()
+    public function testGetAssociationWithIncorrectCasing(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -695,10 +650,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that the getAssociation() method throws an exception on nonexistent ones.
-     *
-     * @return void
      */
-    public function testGetAssociationNonExistent()
+    public function testGetAssociationNonExistent(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The `FooBar` association is not defined on `Sections`.');
@@ -708,10 +661,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that belongsTo() creates and configures correctly the association
-     *
-     * @return void
      */
-    public function testBelongsTo()
+    public function testBelongsTo(): void
     {
         $options = ['foreignKey' => 'fake_id', 'conditions' => ['a' => 'b']];
         $table = new Table(['table' => 'dates']);
@@ -726,10 +677,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that hasOne() creates and configures correctly the association
-     *
-     * @return void
      */
-    public function testHasOne()
+    public function testHasOne(): void
     {
         $options = ['foreignKey' => 'user_id', 'conditions' => ['b' => 'c']];
         $table = new Table(['table' => 'users']);
@@ -744,10 +693,8 @@ class TableTest extends TestCase
 
     /**
      * Test has one with a plugin model
-     *
-     * @return void
      */
-    public function testHasOnePlugin()
+    public function testHasOnePlugin(): void
     {
         $options = ['className' => 'TestPlugin.Comments'];
         $table = new Table(['table' => 'users']);
@@ -774,10 +721,8 @@ class TableTest extends TestCase
 
     /**
      * testNoneUniqueAssociationsSameClass
-     *
-     * @return void
      */
-    public function testNoneUniqueAssociationsSameClass()
+    public function testNoneUniqueAssociationsSameClass(): void
     {
         $Users = new Table(['table' => 'users']);
         $options = ['className' => 'Comments'];
@@ -798,10 +743,8 @@ class TableTest extends TestCase
 
     /**
      * Test associations which refer to the same table multiple times
-     *
-     * @return void
      */
-    public function testSelfJoinAssociations()
+    public function testSelfJoinAssociations(): void
     {
         $Categories = $this->getTableLocator()->get('Categories');
         $options = ['className' => 'Categories'];
@@ -853,10 +796,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that hasMany() creates and configures correctly the association
-     *
-     * @return void
      */
-    public function testHasMany()
+    public function testHasMany(): void
     {
         $options = [
             'foreignKey' => 'author_id',
@@ -876,10 +817,8 @@ class TableTest extends TestCase
 
     /**
      * testHasManyWithClassName
-     *
-     * @return void
      */
-    public function testHasManyWithClassName()
+    public function testHasManyWithClassName(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments', [
@@ -935,10 +874,8 @@ class TableTest extends TestCase
 
     /**
      * Ensure associations use the plugin-prefixed model
-     *
-     * @return void
      */
-    public function testHasManyPluginOverlap()
+    public function testHasManyPluginOverlap(): void
     {
         $this->getTableLocator()->get('Comments');
         $this->loadPlugins(['TestPlugin']);
@@ -953,10 +890,8 @@ class TableTest extends TestCase
     /**
      * Ensure associations use the plugin-prefixed model
      * even if specified with config
-     *
-     * @return void
      */
-    public function testHasManyPluginOverlapConfig()
+    public function testHasManyPluginOverlapConfig(): void
     {
         $this->getTableLocator()->get('Comments');
         $this->loadPlugins(['TestPlugin']);
@@ -970,10 +905,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that BelongsToMany() creates and configures correctly the association
-     *
-     * @return void
      */
-    public function testBelongsToMany()
+    public function testBelongsToMany(): void
     {
         $options = [
             'foreignKey' => 'thing_id',
@@ -995,10 +928,8 @@ class TableTest extends TestCase
 
     /**
      * Test addAssociations()
-     *
-     * @return void
      */
-    public function testAddAssociations()
+    public function testAddAssociations(): void
     {
         $params = [
             'belongsTo' => [
@@ -1046,10 +977,8 @@ class TableTest extends TestCase
 
     /**
      * Test basic multi row updates.
-     *
-     * @return void
      */
-    public function testUpdateAll()
+    public function testUpdateAll(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1072,7 +1001,7 @@ class TableTest extends TestCase
     /**
      * Test that exceptions from the Query bubble up.
      */
-    public function testUpdateAllFailure()
+    public function testUpdateAllFailure(): void
     {
         $this->expectException(DatabaseException::class);
         $table = $this->getMockBuilder(Table::class)
@@ -1096,10 +1025,8 @@ class TableTest extends TestCase
 
     /**
      * Test deleting many records.
-     *
-     * @return void
      */
-    public function testDeleteAll()
+    public function testDeleteAll(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1115,10 +1042,8 @@ class TableTest extends TestCase
 
     /**
      * Test deleting many records with conditions using the alias
-     *
-     * @return void
      */
-    public function testDeleteAllAliasedConditions()
+    public function testDeleteAllAliasedConditions(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1136,7 +1061,7 @@ class TableTest extends TestCase
     /**
      * Test that exceptions from the Query bubble up.
      */
-    public function testDeleteAllFailure()
+    public function testDeleteAllFailure(): void
     {
         $this->expectException(DatabaseException::class);
         $table = $this->getMockBuilder(Table::class)
@@ -1160,10 +1085,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that array options are passed to the query object using applyOptions
-     *
-     * @return void
      */
-    public function testFindApplyOptions()
+    public function testFindApplyOptions(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['query', 'findAll'])
@@ -1194,10 +1117,8 @@ class TableTest extends TestCase
 
     /**
      * Tests find('list')
-     *
-     * @return void
      */
-    public function testFindListNoHydration()
+    public function testFindListNoHydration(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1245,10 +1166,8 @@ class TableTest extends TestCase
 
     /**
      * Tests find('threaded')
-     *
-     * @return void
      */
-    public function testFindThreadedNoHydration()
+    public function testFindThreadedNoHydration(): void
     {
         $table = new Table([
             'table' => 'categories',
@@ -1318,10 +1237,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that finders can be stacked
-     *
-     * @return void
      */
-    public function testStackingFinders()
+    public function testStackingFinders(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['find', 'findList'])
@@ -1351,10 +1268,8 @@ class TableTest extends TestCase
 
     /**
      * Tests find('threaded') with hydrated results
-     *
-     * @return void
      */
-    public function testFindThreadedHydrated()
+    public function testFindThreadedHydrated(): void
     {
         $table = new Table([
             'table' => 'categories',
@@ -1377,10 +1292,8 @@ class TableTest extends TestCase
 
     /**
      * Tests find('list') with hydrated records
-     *
-     * @return void
      */
-    public function testFindListHydrated()
+    public function testFindListHydrated(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1417,10 +1330,8 @@ class TableTest extends TestCase
 
     /**
      * Test that find('list') only selects required fields.
-     *
-     * @return void
      */
-    public function testFindListSelectedFields()
+    public function testFindListSelectedFields(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1481,10 +1392,8 @@ class TableTest extends TestCase
 
     /**
      * test that find('list') does not auto add fields to select if using virtual properties
-     *
-     * @return void
      */
-    public function testFindListWithVirtualField()
+    public function testFindListWithVirtualField(): void
     {
         $table = new Table([
             'table' => 'users',
@@ -1512,10 +1421,8 @@ class TableTest extends TestCase
 
     /**
      * Test find('list') with value field from associated table
-     *
-     * @return void
      */
-    public function testFindListWithAssociatedTable()
+    public function testFindListWithAssociatedTable(): void
     {
         $articles = new Table([
             'table' => 'articles',
@@ -1538,10 +1445,8 @@ class TableTest extends TestCase
 
     /**
      * Test the default entityClass.
-     *
-     * @return void
      */
-    public function testEntityClassDefault()
+    public function testEntityClassDefault(): void
     {
         $table = new Table();
         $this->assertSame('Cake\ORM\Entity', $table->getEntityClass());
@@ -1550,10 +1455,8 @@ class TableTest extends TestCase
     /**
      * Tests that using a simple string for entityClass will try to
      * load the class from the App namespace
-     *
-     * @return void
      */
-    public function testTableClassInApp()
+    public function testTableClassInApp(): void
     {
         $class = $this->getMockClass('Cake\ORM\Entity');
 
@@ -1568,10 +1471,8 @@ class TableTest extends TestCase
 
     /**
      * Test that entity class inflection works for compound nouns
-     *
-     * @return void
      */
-    public function testEntityClassInflection()
+    public function testEntityClassInflection(): void
     {
         $class = $this->getMockClass('Cake\ORM\Entity');
 
@@ -1593,10 +1494,8 @@ class TableTest extends TestCase
     /**
      * Tests that using a simple string for entityClass will try to
      * load the class from the Plugin namespace when using plugin notation
-     *
-     * @return void
      */
-    public function testTableClassInPlugin()
+    public function testTableClassInPlugin(): void
     {
         $class = $this->getMockClass('Cake\ORM\Entity');
 
@@ -1615,10 +1514,8 @@ class TableTest extends TestCase
     /**
      * Tests that using a simple string for entityClass will throw an exception
      * when the class does not exist in the namespace
-     *
-     * @return void
      */
-    public function testTableClassNonExistent()
+    public function testTableClassNonExistent(): void
     {
         $this->expectException(\Cake\ORM\Exception\MissingEntityException::class);
         $this->expectExceptionMessage('Entity class FooUser could not be found.');
@@ -1629,10 +1526,8 @@ class TableTest extends TestCase
     /**
      * Tests getting the entityClass based on conventions for the entity
      * namespace
-     *
-     * @return void
      */
-    public function testTableClassConventionForAPP()
+    public function testTableClassConventionForAPP(): void
     {
         $table = new \TestApp\Model\Table\ArticlesTable();
         $this->assertSame('TestApp\Model\Entity\Article', $table->getEntityClass());
@@ -1640,10 +1535,8 @@ class TableTest extends TestCase
 
     /**
      * Tests setting a entity class object using the setter method
-     *
-     * @return void
      */
-    public function testSetEntityClass()
+    public function testSetEntityClass(): void
     {
         $table = new Table();
         $class = '\\' . $this->getMockClass('Cake\ORM\Entity');
@@ -1654,10 +1547,8 @@ class TableTest extends TestCase
     /**
      * Proves that associations, even though they are lazy loaded, will fetch
      * records using the correct table class and hydrate with the correct entity
-     *
-     * @return void
      */
-    public function testReciprocalBelongsToLoading()
+    public function testReciprocalBelongsToLoading(): void
     {
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
@@ -1669,10 +1560,8 @@ class TableTest extends TestCase
     /**
      * Proves that associations, even though they are lazy loaded, will fetch
      * records using the correct table class and hydrate with the correct entity
-     *
-     * @return void
      */
-    public function testReciprocalHasManyLoading()
+    public function testReciprocalHasManyLoading(): void
     {
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
@@ -1687,10 +1576,8 @@ class TableTest extends TestCase
     /**
      * Tests that the correct table and entity are loaded for the join association in
      * a belongsToMany setup
-     *
-     * @return void
      */
-    public function testReciprocalBelongsToMany()
+    public function testReciprocalBelongsToMany(): void
     {
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
@@ -1705,10 +1592,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that recently fetched entities are always clean
-     *
-     * @return void
      */
-    public function testFindCleanEntities()
+    public function testFindCleanEntities(): void
     {
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
@@ -1733,10 +1618,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that recently fetched entities are marked as not new
-     *
-     * @return void
      */
-    public function testFindPersistedEntities()
+    public function testFindPersistedEntities(): void
     {
         $table = new \TestApp\Model\Table\ArticlesTable([
             'connection' => $this->connection,
@@ -1754,10 +1637,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the exists function
-     *
-     * @return void
      */
-    public function testExists()
+    public function testExists(): void
     {
         $table = $this->getTableLocator()->get('users');
         $this->assertTrue($table->exists(['id' => 1]));
@@ -1767,10 +1648,8 @@ class TableTest extends TestCase
 
     /**
      * Test adding a behavior to a table.
-     *
-     * @return void
      */
-    public function testAddBehavior()
+    public function testAddBehavior(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\BehaviorRegistry')
             ->disableOriginalConstructor()
@@ -1789,10 +1668,8 @@ class TableTest extends TestCase
 
     /**
      * Test adding a behavior that is a duplicate.
-     *
-     * @return void
      */
-    public function testAddBehaviorDuplicate()
+    public function testAddBehaviorDuplicate(): void
     {
         $table = new Table(['table' => 'articles']);
         $this->assertSame($table, $table->addBehavior('Sluggable', ['test' => 'value']));
@@ -1807,10 +1684,8 @@ class TableTest extends TestCase
 
     /**
      * Test removing a behavior from a table.
-     *
-     * @return void
      */
-    public function testRemoveBehavior()
+    public function testRemoveBehavior(): void
     {
         $mock = $this->getMockBuilder('Cake\ORM\BehaviorRegistry')
             ->disableOriginalConstructor()
@@ -1829,10 +1704,8 @@ class TableTest extends TestCase
 
     /**
      * Test adding multiple behaviors to a table.
-     *
-     * @return void
      */
-    public function testAddBehaviors()
+    public function testAddBehaviors(): void
     {
         $table = new Table(['table' => 'comments']);
         $behaviors = [
@@ -1858,10 +1731,8 @@ class TableTest extends TestCase
 
     /**
      * Test getting a behavior instance from a table.
-     *
-     * @return void
      */
-    public function testBehaviors()
+    public function testBehaviors(): void
     {
         $table = $this->getTableLocator()->get('article');
         $result = $table->behaviors();
@@ -1870,10 +1741,8 @@ class TableTest extends TestCase
 
     /**
      * Test that the getBehavior() method retrieves a behavior from the table registry.
-     *
-     * @return void
      */
-    public function testGetBehavior()
+    public function testGetBehavior(): void
     {
         $table = new Table(['table' => 'comments']);
         $table->addBehavior('Sluggable');
@@ -1883,10 +1752,8 @@ class TableTest extends TestCase
     /**
      * Test that the getBehavior() method will throw an exception when you try to
      * get a behavior that does not exist.
-     *
-     * @return void
      */
-    public function testGetBehaviorThrowsExceptionForMissingBehavior()
+    public function testGetBehaviorThrowsExceptionForMissingBehavior(): void
     {
         $table = new Table(['table' => 'comments']);
 
@@ -1900,7 +1767,7 @@ class TableTest extends TestCase
     /**
      * Ensure exceptions are raised on missing behaviors.
      */
-    public function testAddBehaviorMissing()
+    public function testAddBehaviorMissing(): void
     {
         $this->expectException(\Cake\ORM\Exception\MissingBehaviorException::class);
         $table = $this->getTableLocator()->get('article');
@@ -1909,10 +1776,8 @@ class TableTest extends TestCase
 
     /**
      * Test mixin methods from behaviors.
-     *
-     * @return void
      */
-    public function testCallBehaviorMethod()
+    public function testCallBehaviorMethod(): void
     {
         $table = $this->getTableLocator()->get('article');
         $table->addBehavior('Sluggable');
@@ -1921,10 +1786,8 @@ class TableTest extends TestCase
 
     /**
      * Test you can alias a behavior method
-     *
-     * @return void
      */
-    public function testCallBehaviorAliasedMethod()
+    public function testCallBehaviorAliasedMethod(): void
     {
         $table = $this->getTableLocator()->get('article');
         $table->addBehavior('Sluggable', ['implementedMethods' => ['wednesday' => 'slugify']]);
@@ -1933,10 +1796,8 @@ class TableTest extends TestCase
 
     /**
      * Test finder methods from behaviors.
-     *
-     * @return void
      */
-    public function testCallBehaviorFinder()
+    public function testCallBehaviorFinder(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->addBehavior('Sluggable');
@@ -1948,10 +1809,8 @@ class TableTest extends TestCase
 
     /**
      * testCallBehaviorAliasedFinder
-     *
-     * @return void
      */
-    public function testCallBehaviorAliasedFinder()
+    public function testCallBehaviorAliasedFinder(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->addBehavior('Sluggable', ['implementedFinders' => ['special' => 'findNoSlug']]);
@@ -1963,10 +1822,8 @@ class TableTest extends TestCase
 
     /**
      * Test implementedEvents
-     *
-     * @return void
      */
-    public function testImplementedEvents()
+    public function testImplementedEvents(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -1999,9 +1856,8 @@ class TableTest extends TestCase
      * Tests that it is possible to insert a new row using the save method
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewEntity()
+    public function testSaveNewEntity(): void
     {
         $entity = new Entity([
             'username' => 'superuser',
@@ -2021,9 +1877,8 @@ class TableTest extends TestCase
      * Test that saving a new empty entity does nothing.
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewEmptyEntity()
+    public function testSaveNewEmptyEntity(): void
     {
         $entity = new Entity();
         $table = $this->getTableLocator()->get('users');
@@ -2034,9 +1889,8 @@ class TableTest extends TestCase
      * Test that saving a new empty entity does not call exists.
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewEntityNoExists()
+    public function testSaveNewEntityNoExists(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -2059,9 +1913,8 @@ class TableTest extends TestCase
      * Test that saving a new entity with a Primary Key set does call exists.
      *
      * @group save
-     * @return void
      */
-    public function testSavePrimaryKeyEntityExists()
+    public function testSavePrimaryKeyEntityExists(): void
     {
         $this->skipIfSqlServer();
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
@@ -2084,9 +1937,8 @@ class TableTest extends TestCase
      * Test that saving a new entity with a Primary Key set does not call exists when checkExisting is false.
      *
      * @group save
-     * @return void
      */
-    public function testSavePrimaryKeyEntityNoExists()
+    public function testSavePrimaryKeyEntityNoExists(): void
     {
         $this->skipIfSqlServer();
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
@@ -2110,9 +1962,8 @@ class TableTest extends TestCase
      * are not present in the table schema when saving
      *
      * @group save
-     * @return void
      */
-    public function testSaveEntityOnlySchemaFields()
+    public function testSaveEntityOnlySchemaFields(): void
     {
         $entity = new Entity([
             'username' => 'superuser',
@@ -2134,9 +1985,8 @@ class TableTest extends TestCase
      * Tests that it is possible to modify data from the beforeSave callback
      *
      * @group save
-     * @return void
      */
-    public function testBeforeSaveModifyData()
+    public function testBeforeSaveModifyData(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2144,7 +1994,7 @@ class TableTest extends TestCase
             'created' => new Time('2013-10-10 00:00'),
             'updated' => new Time('2013-10-10 00:00'),
         ]);
-        $listener = function ($event, EntityInterface $entity, $options) use ($data) {
+        $listener = function ($event, EntityInterface $entity, $options) use ($data): void {
             $this->assertSame($data, $entity);
             $entity->set('password', 'foo');
         };
@@ -2159,9 +2009,8 @@ class TableTest extends TestCase
      * Tests that it is possible to modify the options array in beforeSave
      *
      * @group save
-     * @return void
      */
-    public function testBeforeSaveModifyOptions()
+    public function testBeforeSaveModifyOptions(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2170,10 +2019,10 @@ class TableTest extends TestCase
             'created' => new Time('2013-10-10 00:00'),
             'updated' => new Time('2013-10-10 00:00'),
         ]);
-        $listener1 = function ($event, $entity, $options) {
+        $listener1 = function ($event, $entity, $options): void {
             $options['crazy'] = true;
         };
-        $listener2 = function ($event, $entity, $options) {
+        $listener2 = function ($event, $entity, $options): void {
             $this->assertTrue($options['crazy']);
         };
         $table->getEventManager()->on('Model.beforeSave', $listener1);
@@ -2190,9 +2039,8 @@ class TableTest extends TestCase
      * the save operation failed
      *
      * @group save
-     * @return void
      */
-    public function testBeforeSaveStopEvent()
+    public function testBeforeSaveStopEvent(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2217,9 +2065,8 @@ class TableTest extends TestCase
      * value then save() returns false.
      *
      * @group save
-     * @return void
      */
-    public function testBeforeSaveStopEventWithNoResult()
+    public function testBeforeSaveStopEventWithNoResult(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2227,7 +2074,7 @@ class TableTest extends TestCase
             'created' => new Time('2013-10-10 00:00'),
             'updated' => new Time('2013-10-10 00:00'),
         ]);
-        $listener = function (EventInterface $event, $entity) {
+        $listener = function (EventInterface $event, $entity): void {
             $event->stopPropagation();
         };
         $table->getEventManager()->on('Model.beforeSave', $listener);
@@ -2236,9 +2083,8 @@ class TableTest extends TestCase
 
     /**
      * @group save
-     * @return void
      */
-    public function testBeforeSaveException()
+    public function testBeforeSaveException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The beforeSave callback must return `false` or `EntityInterface` instance. Got `integer` instead.');
@@ -2262,9 +2108,8 @@ class TableTest extends TestCase
      * Asserts that afterSave callback is called on successful save
      *
      * @group save
-     * @return void
      */
-    public function testAfterSave()
+    public function testAfterSave(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = $table->get(1);
@@ -2272,7 +2117,7 @@ class TableTest extends TestCase
         $data->username = 'newusername';
 
         $called = false;
-        $listener = function ($e, EntityInterface $entity, $options) use ($data, &$called) {
+        $listener = function ($e, EntityInterface $entity, $options) use ($data, &$called): void {
             $this->assertSame($data, $entity);
             $this->assertTrue($entity->isDirty());
             $called = true;
@@ -2280,7 +2125,7 @@ class TableTest extends TestCase
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, EntityInterface $entity, $options) use ($data, &$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, EntityInterface $entity, $options) use ($data, &$calledAfterCommit): void {
             $this->assertSame($data, $entity);
             $this->assertTrue($entity->isDirty());
             $this->assertNotSame($data->get('username'), $data->getOriginal('username'));
@@ -2295,10 +2140,8 @@ class TableTest extends TestCase
 
     /**
      * Asserts that afterSaveCommit is also triggered for non-atomic saves
-     *
-     * @return void
      */
-    public function testAfterSaveCommitForNonAtomic()
+    public function testAfterSaveCommitForNonAtomic(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2308,14 +2151,14 @@ class TableTest extends TestCase
         ]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use ($data, &$called) {
+        $listener = function ($e, $entity, $options) use ($data, &$called): void {
             $this->assertSame($data, $entity);
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit): void {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
@@ -2328,10 +2171,8 @@ class TableTest extends TestCase
 
     /**
      * Asserts the afterSaveCommit is not triggered if transaction is running.
-     *
-     * @return void
      */
-    public function testAfterSaveCommitWithTransactionRunning()
+    public function testAfterSaveCommitWithTransactionRunning(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2341,7 +2182,7 @@ class TableTest extends TestCase
         ]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called) {
+        $listener = function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listener);
@@ -2354,10 +2195,8 @@ class TableTest extends TestCase
 
     /**
      * Asserts the afterSaveCommit is not triggered if transaction is running.
-     *
-     * @return void
      */
-    public function testAfterSaveCommitWithNonAtomicAndTransactionRunning()
+    public function testAfterSaveCommitWithNonAtomicAndTransactionRunning(): void
     {
         $table = $this->getTableLocator()->get('users');
         $data = new Entity([
@@ -2367,7 +2206,7 @@ class TableTest extends TestCase
         ]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called) {
+        $listener = function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listener);
@@ -2382,9 +2221,8 @@ class TableTest extends TestCase
      * Asserts that afterSave callback not is called on unsuccessful save
      *
      * @group save
-     * @return void
      */
-    public function testAfterSaveNotCalled()
+    public function testAfterSaveNotCalled(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -2412,13 +2250,13 @@ class TableTest extends TestCase
             ->will($this->returnValue(0));
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called) {
+        $listener = function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterSave', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit): void {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerAfterCommit);
@@ -2432,9 +2270,8 @@ class TableTest extends TestCase
      * Asserts that afterSaveCommit callback is triggered only for primary table
      *
      * @group save
-     * @return void
      */
-    public function testAfterSaveCommitTriggeredOnlyForPrimaryTable()
+    public function testAfterSaveCommitTriggeredOnlyForPrimaryTable(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -2448,13 +2285,13 @@ class TableTest extends TestCase
         $table->belongsTo('authors');
 
         $calledForArticle = false;
-        $listenerForArticle = function ($e, $entity, $options) use (&$calledForArticle) {
+        $listenerForArticle = function ($e, $entity, $options) use (&$calledForArticle): void {
             $calledForArticle = true;
         };
         $table->getEventManager()->on('Model.afterSaveCommit', $listenerForArticle);
 
         $calledForAuthor = false;
-        $listenerForAuthor = function ($e, $entity, $options) use (&$calledForAuthor) {
+        $listenerForAuthor = function ($e, $entity, $options) use (&$calledForAuthor): void {
             $calledForAuthor = true;
         };
         $table->authors->getEventManager()->on('Model.afterSaveCommit', $listenerForAuthor);
@@ -2470,9 +2307,8 @@ class TableTest extends TestCase
      * Test that you cannot save rows without a primary key.
      *
      * @group save
-     * @return void
      */
-    public function testSaveNewErrorOnNoPrimaryKey()
+    public function testSaveNewErrorOnNoPrimaryKey(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot insert row in "users" table, it has no primary key');
@@ -2490,9 +2326,8 @@ class TableTest extends TestCase
      * Tests that save is wrapped around a transaction
      *
      * @group save
-     * @return void
      */
-    public function testAtomicSave()
+    public function testAtomicSave(): void
     {
         $config = ConnectionManager::getConfig('test');
 
@@ -2525,9 +2360,8 @@ class TableTest extends TestCase
      * Tests that save will rollback the transaction in the case of an exception
      *
      * @group save
-     * @return void
      */
-    public function testAtomicSaveRollback()
+    public function testAtomicSaveRollback(): void
     {
         $this->expectException(\PDOException::class);
         $connection = $this->getMockBuilder('Cake\Database\Connection')
@@ -2567,9 +2401,8 @@ class TableTest extends TestCase
      * Tests that save will rollback the transaction in the case of an exception
      *
      * @group save
-     * @return void
      */
-    public function testAtomicSaveRollbackOnFailure()
+    public function testAtomicSaveRollbackOnFailure(): void
     {
         $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->onlyMethods(['begin', 'rollback'])
@@ -2615,9 +2448,8 @@ class TableTest extends TestCase
      * to the database
      *
      * @group save
-     * @return void
      */
-    public function testSaveOnlyDirtyProperties()
+    public function testSaveOnlyDirtyProperties(): void
     {
         $entity = new Entity([
             'username' => 'superuser',
@@ -2643,9 +2475,8 @@ class TableTest extends TestCase
      * Tests that a recently saved entity is marked as clean
      *
      * @group save
-     * @return void
      */
-    public function testASavedEntityIsClean()
+    public function testASavedEntityIsClean(): void
     {
         $entity = new Entity([
             'username' => 'superuser',
@@ -2665,9 +2496,8 @@ class TableTest extends TestCase
      * Tests that a recently saved entity is marked as not new
      *
      * @group save
-     * @return void
      */
-    public function testASavedEntityIsNotNew()
+    public function testASavedEntityIsNotNew(): void
     {
         $entity = new Entity([
             'username' => 'superuser',
@@ -2685,9 +2515,8 @@ class TableTest extends TestCase
      * or update a row
      *
      * @group save
-     * @return void
      */
-    public function testSaveUpdateAuto()
+    public function testSaveUpdateAuto(): void
     {
         $entity = new Entity([
             'id' => 2,
@@ -2709,10 +2538,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that beforeFind gets the correct isNew() state for the entity
-     *
-     * @return void
      */
-    public function testBeforeSaveGetsCorrectPersistance()
+    public function testBeforeSaveGetsCorrectPersistance(): void
     {
         $entity = new Entity([
             'id' => 2,
@@ -2720,7 +2547,7 @@ class TableTest extends TestCase
         ]);
         $table = $this->getTableLocator()->get('users');
         $called = false;
-        $listener = function (EventInterface $event, $entity) use (&$called) {
+        $listener = function (EventInterface $event, $entity) use (&$called): void {
             $this->assertFalse($entity->isNew());
             $called = true;
         };
@@ -2734,9 +2561,8 @@ class TableTest extends TestCase
      * method from trying to infer the entity's actual status.
      *
      * @group save
-     * @return void
      */
-    public function testSaveUpdateWithHint()
+    public function testSaveUpdateWithHint(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -2757,9 +2583,8 @@ class TableTest extends TestCase
      * attributes to change
      *
      * @group save
-     * @return void
      */
-    public function testSaveUpdatePrimaryKeyNotModified()
+    public function testSaveUpdatePrimaryKeyNotModified(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -2800,9 +2625,8 @@ class TableTest extends TestCase
      * but still return success
      *
      * @group save
-     * @return void
      */
-    public function testUpdateNoChange()
+    public function testUpdateNoChange(): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -2822,9 +2646,8 @@ class TableTest extends TestCase
      *
      * @group save
      * @group integration
-     * @return void
      */
-    public function testUpdateDirtyNoActualChanges()
+    public function testUpdateDirtyNoActualChanges(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $entity = $table->get(1);
@@ -2838,9 +2661,8 @@ class TableTest extends TestCase
      * Tests that failing to pass a primary key to save will result in exception
      *
      * @group save
-     * @return void
      */
-    public function testUpdateNoPrimaryButOtherKeys()
+    public function testUpdateNoPrimaryButOtherKeys(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
@@ -2857,10 +2679,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveMany() with entities array
-     *
-     * @return void
      */
-    public function testSaveManyArray()
+    public function testSaveManyArray(): void
     {
         $entities = [
             new Entity(['name' => 'admad']),
@@ -2868,7 +2688,7 @@ class TableTest extends TestCase
         ];
 
         $timesCalled = 0;
-        $listener = function ($e, $entity, $options) use (&$timesCalled) {
+        $listener = function ($e, $entity, $options) use (&$timesCalled): void {
             $timesCalled++;
         };
         $table = $this->getTableLocator()
@@ -2889,10 +2709,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveMany() with ResultSet instance
-     *
-     * @return void
      */
-    public function testSaveManyResultSet()
+    public function testSaveManyResultSet(): void
     {
         $table = $this->getTableLocator()->get('authors');
 
@@ -2912,10 +2730,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveMany() with failed save
-     *
-     * @return void
      */
-    public function testSaveManyFailed()
+    public function testSaveManyFailed(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $expectedCount = $table->find()->count();
@@ -2935,10 +2751,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveMany() with failed save due to an exception
-     *
-     * @return void
      */
-    public function testSaveManyFailedWithException()
+    public function testSaveManyFailedWithException(): void
     {
         $table = $this->getTableLocator()
             ->get('authors');
@@ -2947,7 +2761,7 @@ class TableTest extends TestCase
             new Entity(['name' => 'jose']),
         ];
 
-        $table->getEventManager()->on('Model.beforeSave', function (EventInterface $event, EntityInterface $entity) {
+        $table->getEventManager()->on('Model.beforeSave', function (EventInterface $event, EntityInterface $entity): void {
             if ($entity->name === 'jose') {
                 throw new \Exception('Oh noes');
             }
@@ -2966,10 +2780,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveManyOrFail() with entities array
-     *
-     * @return void
      */
-    public function testSaveManyOrFailArray()
+    public function testSaveManyOrFailArray(): void
     {
         $entities = [
             new Entity(['name' => 'admad']),
@@ -2988,10 +2800,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveManyOrFail() with ResultSet instance
-     *
-     * @return void
      */
-    public function testSaveManyOrFailResultSet()
+    public function testSaveManyOrFailResultSet(): void
     {
         $table = $this->getTableLocator()->get('authors');
 
@@ -3011,10 +2821,8 @@ class TableTest extends TestCase
 
     /**
      * Test saveManyOrFail() with failed save
-     *
-     * @return void
      */
-    public function testSaveManyOrFailFailed()
+    public function testSaveManyOrFailFailed(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $entities = [
@@ -3030,10 +2838,8 @@ class TableTest extends TestCase
 
     /**
      * Test simple delete.
-     *
-     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $table = $this->getTableLocator()->get('users');
         $conditions = [
@@ -3054,10 +2860,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete with dependent records
-     *
-     * @return void
      */
-    public function testDeleteDependent()
+    public function testDeleteDependent(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasOne('articles', [
@@ -3079,10 +2883,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete with dependent records
-     *
-     * @return void
      */
-    public function testDeleteDependentHasMany()
+    public function testDeleteDependentHasMany(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles', [
@@ -3092,7 +2894,7 @@ class TableTest extends TestCase
         ]);
 
         $articles = $table->getAssociation('articles')->getTarget();
-        $articles->getEventManager()->on('Model.buildRules', function ($event, $rules) {
+        $articles->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
             $rules->addDelete(function ($entity) {
                 if ($entity->author_id === 3) {
                     return false;
@@ -3132,10 +2934,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete with dependent = false does not cascade.
-     *
-     * @return void
      */
-    public function testDeleteNoDependentNoCascade()
+    public function testDeleteNoDependentNoCascade(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('article', [
@@ -3154,10 +2954,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete with BelongsToMany
-     *
-     * @return void
      */
-    public function testDeleteBelongsToMany()
+    public function testDeleteBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsToMany('tag', [
@@ -3176,10 +2974,8 @@ class TableTest extends TestCase
     /**
      * Test delete with dependent records belonging to an aliased
      * belongsToMany association.
-     *
-     * @return void
      */
-    public function testDeleteDependentAliased()
+    public function testDeleteDependentAliased(): void
     {
         $Authors = $this->getTableLocator()->get('authors');
         $Authors->associations()->removeAll();
@@ -3201,10 +2997,8 @@ class TableTest extends TestCase
 
     /**
      * Test that cascading associations are deleted first.
-     *
-     * @return void
      */
-    public function testDeleteAssociationsCascadingCallbacksOrder()
+    public function testDeleteAssociationsCascadingCallbacksOrder(): void
     {
         $sections = $this->getTableLocator()->get('Sections');
         $members = $this->getTableLocator()->get('Members');
@@ -3235,14 +3029,12 @@ class TableTest extends TestCase
     /**
      * Test that primary record is not deleted if junction record deletion fails
      * when cascadeCallbacks is enabled.
-     *
-     * @return void
      */
-    public function testDeleteBelongsToManyDependentFailure()
+    public function testDeleteBelongsToManyDependentFailure(): void
     {
         $sections = $this->getTableLocator()->get('Sections');
         $sectionsMembers = $this->getTableLocator()->get('SectionsMembers');
-        $sectionsMembers->getEventManager()->on('Model.buildRules', function ($event, $rules) {
+        $sectionsMembers->getEventManager()->on('Model.buildRules', function ($event, $rules): void {
             $rules->addDelete(function () {
                 return false;
             });
@@ -3265,10 +3057,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete callbacks
-     *
-     * @return void
      */
-    public function testDeleteCallbacks()
+    public function testDeleteCallbacks(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
         $options = new \ArrayObject(['atomic' => true, 'checkRules' => false, '_primary' => true]);
@@ -3305,10 +3095,8 @@ class TableTest extends TestCase
 
     /**
      * Test afterDeleteCommit is also called for non-atomic delete
-     *
-     * @return void
      */
-    public function testDeleteCallbacksNonAtomic()
+    public function testDeleteCallbacksNonAtomic(): void
     {
         $table = $this->getTableLocator()->get('users');
 
@@ -3316,14 +3104,14 @@ class TableTest extends TestCase
         $options = new \ArrayObject(['atomic' => false, 'checkRules' => false]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use ($data, &$called) {
+        $listener = function ($e, $entity, $options) use ($data, &$called): void {
             $this->assertSame($data, $entity);
             $called = true;
         };
         $table->getEventManager()->on('Model.afterDelete', $listener);
 
         $calledAfterCommit = false;
-        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit) {
+        $listenerAfterCommit = function ($e, $entity, $options) use (&$calledAfterCommit): void {
             $calledAfterCommit = true;
         };
         $table->getEventManager()->on('Model.afterDeleteCommit', $listenerAfterCommit);
@@ -3335,10 +3123,8 @@ class TableTest extends TestCase
 
     /**
      * Test that afterDeleteCommit is only triggered for primary table
-     *
-     * @return void
      */
-    public function testAfterDeleteCommitTriggeredOnlyForPrimaryTable()
+    public function testAfterDeleteCommitTriggeredOnlyForPrimaryTable(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasOne('articles', [
@@ -3347,13 +3133,13 @@ class TableTest extends TestCase
         ]);
 
         $called = false;
-        $listener = function ($e, $entity, $options) use (&$called) {
+        $listener = function ($e, $entity, $options) use (&$called): void {
             $called = true;
         };
         $table->getEventManager()->on('Model.afterDeleteCommit', $listener);
 
         $called2 = false;
-        $listener = function ($e, $entity, $options) use (&$called2) {
+        $listener = function ($e, $entity, $options) use (&$called2): void {
             $called2 = true;
         };
         $table->articles->getEventManager()->on('Model.afterDeleteCommit', $listener);
@@ -3367,10 +3153,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete beforeDelete can abort the delete.
-     *
-     * @return void
      */
-    public function testDeleteBeforeDeleteAbort()
+    public function testDeleteBeforeDeleteAbort(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
         $options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
@@ -3392,10 +3176,8 @@ class TableTest extends TestCase
 
     /**
      * Test delete beforeDelete return result
-     *
-     * @return void
      */
-    public function testDeleteBeforeDeleteReturnResult()
+    public function testDeleteBeforeDeleteReturnResult(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
         $options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
@@ -3418,10 +3200,8 @@ class TableTest extends TestCase
 
     /**
      * Test deleting new entities does nothing.
-     *
-     * @return void
      */
-    public function testDeleteIsNew()
+    public function testDeleteIsNew(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
 
@@ -3440,10 +3220,8 @@ class TableTest extends TestCase
 
     /**
      * Test simple delete.
-     *
-     * @return void
      */
-    public function testDeleteMany()
+    public function testDeleteMany(): void
     {
         $table = $this->getTableLocator()->get('users');
         $entities = $table->find()->limit(2)->all()->toArray();
@@ -3458,10 +3236,8 @@ class TableTest extends TestCase
 
     /**
      * Test simple delete.
-     *
-     * @return void
      */
-    public function testDeleteManyOrFail()
+    public function testDeleteManyOrFail(): void
     {
         $table = $this->getTableLocator()->get('users');
         $entities = $table->find()->limit(2)->all()->toArray();
@@ -3476,10 +3252,8 @@ class TableTest extends TestCase
 
     /**
      * test hasField()
-     *
-     * @return void
      */
-    public function testHasField()
+    public function testHasField(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $this->assertFalse($table->hasField('nope'), 'Should not be there.');
@@ -3489,10 +3263,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that there exists a default validator
-     *
-     * @return void
      */
-    public function testValidatorDefault()
+    public function testValidatorDefault(): void
     {
         $table = new Table();
         $validator = $table->getValidator();
@@ -3504,10 +3276,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that there exists a validator defined in a behavior.
-     *
-     * @return void
      */
-    public function testValidatorBehavior()
+    public function testValidatorBehavior(): void
     {
         $table = new Table();
         $table->addBehavior('Validation');
@@ -3519,10 +3289,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to define custom validator methods
-     *
-     * @return void
      */
-    public function testValidationWithDefiner()
+    public function testValidationWithDefiner(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->addMethods(['validationForOtherStuff'])
@@ -3537,10 +3305,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that a RuntimeException is thrown if the custom validator does not return an Validator instance
-     *
-     * @return void
      */
-    public function testValidationWithBadDefiner()
+    public function testValidationWithBadDefiner(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->addMethods(['validationBad'])
@@ -3559,10 +3325,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that a RuntimeException is thrown if the custom validator method does not exist.
-     *
-     * @return void
      */
-    public function testValidatorWithMissingMethod()
+    public function testValidatorWithMissingMethod(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The Cake\ORM\Table::validationMissing() validation method does not exists.');
@@ -3572,10 +3336,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to set a custom validator under a name
-     *
-     * @return void
      */
-    public function testValidatorSetter()
+    public function testValidatorSetter(): void
     {
         $table = new Table();
         $validator = new \Cake\Validation\Validator();
@@ -3586,10 +3348,8 @@ class TableTest extends TestCase
 
     /**
      * Tests hasValidator method.
-     *
-     * @return void
      */
-    public function testHasValidator()
+    public function testHasValidator(): void
     {
         $table = new Table();
         $this->assertTrue($table->hasValidator('default'));
@@ -3602,10 +3362,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that the source of an existing Entity is the same as a new one
-     *
-     * @return void
      */
-    public function testEntitySourceExistingAndNew()
+    public function testEntitySourceExistingAndNew(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $table = $this->getTableLocator()->get('TestPlugin.Authors');
@@ -3619,10 +3377,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that calling an entity with an empty array will run validation.
-     *
-     * @return void
      */
-    public function testNewEntityAndValidation()
+    public function testNewEntityAndValidation(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->getValidator()->requirePresence('title');
@@ -3634,10 +3390,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that creating an entity will not run any validation.
-     *
-     * @return void
      */
-    public function testCreateEntityAndValidation()
+    public function testCreateEntityAndValidation(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->getValidator()->requirePresence('title');
@@ -3648,10 +3402,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findByXX method.
-     *
-     * @return void
      */
-    public function testMagicFindDefaultToAll()
+    public function testMagicFindDefaultToAll(): void
     {
         $table = $this->getTableLocator()->get('Users');
 
@@ -3664,10 +3416,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findByXX errors on missing arguments.
-     *
-     * @return void
      */
-    public function testMagicFindError()
+    public function testMagicFindError(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Not enough arguments for magic finder. Got 0 required 1');
@@ -3678,10 +3428,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findByXX errors on missing arguments.
-     *
-     * @return void
      */
-    public function testMagicFindErrorMissingField()
+    public function testMagicFindErrorMissingField(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Not enough arguments for magic finder. Got 1 required 2');
@@ -3692,10 +3440,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findByXX errors when there is a mix of or & and.
-     *
-     * @return void
      */
-    public function testMagicFindErrorMixOfOperators()
+    public function testMagicFindErrorMixOfOperators(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot mix "and" & "or" in a magic finder. Use find() instead.');
@@ -3706,10 +3452,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findByXX method.
-     *
-     * @return void
      */
-    public function testMagicFindFirstAnd()
+    public function testMagicFindFirstAnd(): void
     {
         $table = $this->getTableLocator()->get('Users');
 
@@ -3722,10 +3466,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findByXX method.
-     *
-     * @return void
      */
-    public function testMagicFindFirstOr()
+    public function testMagicFindFirstOr(): void
     {
         $table = $this->getTableLocator()->get('Users');
 
@@ -3746,10 +3488,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findAllByXX method.
-     *
-     * @return void
      */
-    public function testMagicFindAll()
+    public function testMagicFindAll(): void
     {
         $table = $this->getTableLocator()->get('Articles');
 
@@ -3763,10 +3503,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findAllByXX method.
-     *
-     * @return void
      */
-    public function testMagicFindAllAnd()
+    public function testMagicFindAllAnd(): void
     {
         $table = $this->getTableLocator()->get('Users');
 
@@ -3782,10 +3520,8 @@ class TableTest extends TestCase
 
     /**
      * Test magic findAllByXX method.
-     *
-     * @return void
      */
-    public function testMagicFindAllOr()
+    public function testMagicFindAllOr(): void
     {
         $table = $this->getTableLocator()->get('Users');
 
@@ -3803,10 +3539,8 @@ class TableTest extends TestCase
 
     /**
      * Test the behavior method.
-     *
-     * @return void
      */
-    public function testBehaviorIntrospection()
+    public function testBehaviorIntrospection(): void
     {
         $table = $this->getTableLocator()->get('users');
 
@@ -3819,9 +3553,8 @@ class TableTest extends TestCase
      * Tests saving belongsTo association
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsTo()
+    public function testSaveBelongsTo(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -3844,9 +3577,8 @@ class TableTest extends TestCase
      * Tests saving hasOne association
      *
      * @group save
-     * @return void
      */
-    public function testSaveHasOne()
+    public function testSaveHasOne(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -3871,9 +3603,8 @@ class TableTest extends TestCase
      * if they are entities.
      *
      * @group save
-     * @return void
      */
-    public function testSaveOnlySaveAssociatedEntities()
+    public function testSaveOnlySaveAssociatedEntities(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -3895,10 +3626,8 @@ class TableTest extends TestCase
 
     /**
      * Tests saving multiple entities in a hasMany association
-     *
-     * @return void
      */
-    public function testSaveHasMany()
+    public function testSaveHasMany(): void
     {
         $entity = new Entity([
             'name' => 'Jose',
@@ -3928,10 +3657,8 @@ class TableTest extends TestCase
 
     /**
      * Tests overwriting hasMany associations in an integration scenario.
-     *
-     * @return void
      */
-    public function testSaveHasManyOverwrite()
+    public function testSaveHasManyOverwrite(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -3958,9 +3685,8 @@ class TableTest extends TestCase
      * Tests saving belongsToMany records
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsToMany()
+    public function testSaveBelongsToMany(): void
     {
         $entity = new Entity([
             'title' => 'A Title',
@@ -3992,9 +3718,8 @@ class TableTest extends TestCase
      * Tests saving belongsToMany records when record exists.
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsToManyJoinDataOnExistingRecord()
+    public function testSaveBelongsToManyJoinDataOnExistingRecord(): void
     {
         $tags = $this->getTableLocator()->get('Tags');
         $table = $this->getTableLocator()->get('Articles');
@@ -4019,10 +3744,8 @@ class TableTest extends TestCase
 
     /**
      * Test that belongsToMany can be saved with _joinData data.
-     *
-     * @return void
      */
-    public function testSaveBelongsToManyJoinData()
+    public function testSaveBelongsToManyJoinData(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $article = $articles->get(1, ['contain' => ['Tags']]);
@@ -4040,10 +3763,8 @@ class TableTest extends TestCase
     /**
      * Test to check that association condition are used when fetching existing
      * records to decide which records to unlink.
-     *
-     * @return void
      */
-    public function testPolymorphicBelongsToManySave()
+    public function testPolymorphicBelongsToManySave(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Tags', [
@@ -4115,9 +3836,8 @@ class TableTest extends TestCase
      * Tests saving belongsToMany records can delete all links.
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsToManyDeleteAllLinks()
+    public function testSaveBelongsToManyDeleteAllLinks(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -4140,9 +3860,8 @@ class TableTest extends TestCase
      * Tests saving belongsToMany records can delete some links.
      *
      * @group save
-     * @return void
      */
-    public function testSaveBelongsToManyDeleteSomeLinks()
+    public function testSaveBelongsToManyDeleteSomeLinks(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
@@ -4168,10 +3887,8 @@ class TableTest extends TestCase
 
     /**
      * Test that belongsToMany ignores non-entity data.
-     *
-     * @return void
      */
-    public function testSaveBelongsToManyIgnoreNonEntityData()
+    public function testSaveBelongsToManyIgnoreNonEntityData(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $article = $articles->get(1, ['contain' => ['Tags']]);
@@ -4186,9 +3903,8 @@ class TableTest extends TestCase
      * Test that a save call takes a SaveOptionBuilder object as well.
      *
      * @group save
-     * @return void
      */
-    public function testSaveWithOptionBuilder()
+    public function testSaveWithOptionBuilder(): void
     {
         $articles = new Table([
             'table' => 'articles',
@@ -4239,9 +3955,8 @@ class TableTest extends TestCase
      * Tests that saving a persisted and clean entity will is a no-op
      *
      * @group save
-     * @return void
      */
-    public function testSaveCleanEntity()
+    public function testSaveCleanEntity(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['_processSave'])
@@ -4258,9 +3973,8 @@ class TableTest extends TestCase
      * Integration test to show how to append a new tag to an article
      *
      * @group save
-     * @return void
      */
-    public function testBelongsToManyIntegration()
+    public function testBelongsToManyIntegration(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -4283,9 +3997,8 @@ class TableTest extends TestCase
      * while having control of the options passed to each level of the save
      *
      * @group save
-     * @return void
      */
-    public function testSaveDeepAssociationOptions()
+    public function testSaveDeepAssociationOptions(): void
     {
         $articles = $this->getMockBuilder(Table::class)
             ->onlyMethods(['_insert'])
@@ -4356,10 +4069,7 @@ class TableTest extends TestCase
         ]));
     }
 
-    /**
-     * @return void
-     */
-    public function testBelongsToFluentInterface()
+    public function testBelongsToFluentInterface(): void
     {
         /** @var \TestApp\Model\Table\ArticlesTable $articles */
         $articles = $this->getMockBuilder(Table::class)
@@ -4387,10 +4097,7 @@ class TableTest extends TestCase
         $this->assertSame('articles', $articles->getTable());
     }
 
-    /**
-     * @return void
-     */
-    public function testHasOneFluentInterface()
+    public function testHasOneFluentInterface(): void
     {
         /** @var \TestApp\Model\Table\AuthorsTable $authors */
         $authors = $this->getMockBuilder(Table::class)
@@ -4416,10 +4123,7 @@ class TableTest extends TestCase
         $this->assertSame('authors', $authors->getTable());
     }
 
-    /**
-     * @return void
-     */
-    public function testHasManyFluentInterface()
+    public function testHasManyFluentInterface(): void
     {
         /** @var \TestApp\Model\Table\AuthorsTable $authors */
         $authors = $this->getMockBuilder(Table::class)
@@ -4447,10 +4151,7 @@ class TableTest extends TestCase
         $this->assertSame('authors', $authors->getTable());
     }
 
-    /**
-     * @return void
-     */
-    public function testBelongsToManyFluentInterface()
+    public function testBelongsToManyFluentInterface(): void
     {
         /** @var \TestApp\Model\Table\AuthorsTable $authors */
         $authors = $this->getMockBuilder(Table::class)
@@ -4480,10 +4181,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for linking entities with belongsToMany
-     *
-     * @return void
      */
-    public function testLinkBelongsToMany()
+    public function testLinkBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -4520,10 +4219,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for linking entities with HasMany
-     *
-     * @return void
      */
-    public function testLinkHasMany()
+    public function testLinkHasMany(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -4559,10 +4256,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for linking entities with HasMany combined with ReplaceSaveStrategy. It must append, not unlinking anything
-     *
-     * @return void
      */
-    public function testLinkHasManyReplaceSaveStrategy()
+    public function testLinkHasManyReplaceSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -4611,10 +4306,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for linking entities with HasMany. The input contains already linked entities and they should not appeat duplicated
-     *
-     * @return void
      */
-    public function testLinkHasManyExisting()
+    public function testLinkHasManyExisting(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -4666,10 +4359,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for unlinking entities with HasMany. The association property must be cleaned
-     *
-     * @return void
      */
-    public function testUnlinkHasManyCleanProperty()
+    public function testUnlinkHasManyCleanProperty(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -4714,10 +4405,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for unlinking entities with HasMany. The association property must stay unchanged
-     *
-     * @return void
      */
-    public function testUnlinkHasManyNotCleanProperty()
+    public function testUnlinkHasManyNotCleanProperty(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -4764,10 +4453,8 @@ class TableTest extends TestCase
      * Integration test for unlinking entities with HasMany.
      * Checking that no error happens when the hasMany property is originally
      * null
-     *
-     * @return void
      */
-    public function testUnlinkHasManyEmpty()
+    public function testUnlinkHasManyEmpty(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -4782,10 +4469,8 @@ class TableTest extends TestCase
     /**
      * Integration test for replacing entities which depend on their source entity with HasMany and failing transaction. False should be returned when
      * unlinking fails while replacing even when cascadeCallbacks is enabled
-     *
-     * @return void
      */
-    public function testReplaceHasManyOnErrorDependentCascadeCallbacks()
+    public function testReplaceHasManyOnErrorDependentCascadeCallbacks(): void
     {
         $articles = $this->getMockBuilder(Table::class)
             ->onlyMethods(['delete'])
@@ -4869,10 +4554,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for replacing entities with HasMany and an empty target list. The transaction must be successful
-     *
-     * @return void
      */
-    public function testReplaceHasManyEmptyList()
+    public function testReplaceHasManyEmptyList(): void
     {
         $authors = new Table([
             'connection' => $this->connection,
@@ -4912,10 +4595,8 @@ class TableTest extends TestCase
     /**
      * Integration test for replacing entities with HasMany and no already persisted entities. The transaction must be successful.
      * Replace operation should prevent considering 0 changed records an error when they are not found in the table
-     *
-     * @return void
      */
-    public function testReplaceHasManyNoPersistedEntities()
+    public function testReplaceHasManyNoPersistedEntities(): void
     {
         $authors = new Table([
             'connection' => $this->connection,
@@ -4953,10 +4634,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test for replacing entities with HasMany.
-     *
-     * @return void
      */
-    public function testReplaceHasMany()
+    public function testReplaceHasMany(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
@@ -5012,10 +4691,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test to show how to unlink a single record from a belongsToMany
-     *
-     * @return void
      */
-    public function testUnlinkBelongsToMany()
+    public function testUnlinkBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -5034,10 +4711,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test to show how to unlink multiple records from a belongsToMany
-     *
-     * @return void
      */
-    public function testUnlinkBelongsToManyMultiple()
+    public function testUnlinkBelongsToManyMultiple(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -5056,10 +4731,8 @@ class TableTest extends TestCase
     /**
      * Integration test to show how to unlink multiple records from a belongsToMany
      * providing some of the joint
-     *
-     * @return void
      */
-    public function testUnlinkBelongsToManyPassingJoint()
+    public function testUnlinkBelongsToManyPassingJoint(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -5082,10 +4755,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test to show how to replace records from a belongsToMany
-     *
-     * @return void
      */
-    public function testReplacelinksBelongsToMany()
+    public function testReplacelinksBelongsToMany(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -5112,10 +4783,8 @@ class TableTest extends TestCase
 
     /**
      * Integration test to show how remove all links from a belongsToMany
-     *
-     * @return void
      */
-    public function testReplacelinksBelongsToManyWithEmpty()
+    public function testReplacelinksBelongsToManyWithEmpty(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -5134,10 +4803,8 @@ class TableTest extends TestCase
     /**
      * Integration test to show how to replace records from a belongsToMany
      * passing the joint property along in the target entity
-     *
-     * @return void
      */
-    public function testReplacelinksBelongsToManyWithJoint()
+    public function testReplacelinksBelongsToManyWithJoint(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
@@ -5164,10 +4831,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToImplicitBelongsToManyDeletesUsingSaveReplace()
+    public function testOptionsBeingPassedToImplicitBelongsToManyDeletesUsingSaveReplace(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
@@ -5179,7 +4844,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5203,10 +4868,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToInternalSaveCallsUsingBelongsToManyLink()
+    public function testOptionsBeingPassedToInternalSaveCallsUsingBelongsToManyLink(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $articles->belongsToMany('Tags');
@@ -5214,7 +4877,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5240,10 +4903,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToInternalSaveCallsUsingBelongsToManyUnlink()
+    public function testOptionsBeingPassedToInternalSaveCallsUsingBelongsToManyUnlink(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $articles->belongsToMany('Tags');
@@ -5251,7 +4912,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5272,10 +4933,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToInternalSaveAndDeleteCallsUsingBelongsToManyReplaceLinks()
+    public function testOptionsBeingPassedToInternalSaveAndDeleteCallsUsingBelongsToManyReplaceLinks(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $articles->belongsToMany('Tags');
@@ -5284,13 +4943,13 @@ class TableTest extends TestCase
         $actualDeleteOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
                 $actualSaveOptions = $options->getArrayCopy();
             }
         );
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
                 $actualDeleteOptions = $options->getArrayCopy();
             }
         );
@@ -5328,10 +4987,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToImplicitHasManyDeletesUsingSaveReplace()
+    public function testOptionsBeingPassedToImplicitHasManyDeletesUsingSaveReplace(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
 
@@ -5343,7 +5000,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5368,10 +5025,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToInternalSaveCallsUsingHasManyLink()
+    public function testOptionsBeingPassedToInternalSaveCallsUsingHasManyLink(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $authors->hasMany('Articles');
@@ -5379,7 +5034,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5409,10 +5064,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToInternalSaveCallsUsingHasManyUnlink()
+    public function testOptionsBeingPassedToInternalSaveCallsUsingHasManyUnlink(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $authors->hasMany('Articles');
@@ -5422,7 +5075,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5445,10 +5098,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that options are being passed through to the internal table method calls.
-     *
-     * @return void
      */
-    public function testOptionsBeingPassedToInternalSaveAndDeleteCallsUsingHasManyReplace()
+    public function testOptionsBeingPassedToInternalSaveAndDeleteCallsUsingHasManyReplace(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $authors->hasMany('Articles');
@@ -5459,13 +5110,13 @@ class TableTest extends TestCase
         $actualDeleteOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
                 $actualSaveOptions = $options->getArrayCopy();
             }
         );
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
                 $actualDeleteOptions = $options->getArrayCopy();
             }
         );
@@ -5509,10 +5160,8 @@ class TableTest extends TestCase
 
     /**
      * Tests backwards compatibility of the the `$options` argument, formerly `$cleanProperty`.
-     *
-     * @return void
      */
-    public function testBackwardsCompatibilityForBelongsToManyUnlinkCleanPropertyOption()
+    public function testBackwardsCompatibilityForBelongsToManyUnlinkCleanPropertyOption(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $articles->belongsToMany('Tags');
@@ -5520,7 +5169,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5539,10 +5188,8 @@ class TableTest extends TestCase
 
     /**
      * Tests backwards compatibility of the the `$options` argument, formerly `$cleanProperty`.
-     *
-     * @return void
      */
-    public function testBackwardsCompatibilityForHasManyUnlinkCleanPropertyOption()
+    public function testBackwardsCompatibilityForHasManyUnlinkCleanPropertyOption(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $authors->hasMany('Articles');
@@ -5552,7 +5199,7 @@ class TableTest extends TestCase
         $actualOptions = null;
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
             }
         );
@@ -5573,10 +5220,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to call find with no arguments
-     *
-     * @return void
      */
-    public function testSimplifiedFind()
+    public function testSimplifiedFind(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['callFinder'])
@@ -5606,9 +5251,8 @@ class TableTest extends TestCase
      *
      * @dataProvider providerForTestGet
      * @param array $options
-     * @return void
      */
-    public function testGet($options)
+    public function testGet($options): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['callFinder', 'query'])
@@ -5656,9 +5300,8 @@ class TableTest extends TestCase
      *
      * @dataProvider providerForTestGetWithCustomFinder
      * @param array $options
-     * @return void
      */
-    public function testGetWithCustomFinder($options)
+    public function testGetWithCustomFinder($options): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['callFinder', 'query'])
@@ -5715,9 +5358,8 @@ class TableTest extends TestCase
      * @param array $options
      * @param string $cacheKey
      * @param string $cacheConfig
-     * @return void
      */
-    public function testGetWithCache($options, $cacheKey, $cacheConfig)
+    public function testGetWithCache($options, $cacheKey, $cacheConfig): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['callFinder', 'query'])
@@ -5758,10 +5400,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that get() will throw an exception if the record was not found
-     *
-     * @return void
      */
-    public function testGetNotFoundException()
+    public function testGetNotFoundException(): void
     {
         $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
         $this->expectExceptionMessage('Record not found in table "articles"');
@@ -5775,10 +5415,8 @@ class TableTest extends TestCase
 
     /**
      * Test that an exception is raised when there are not enough keys.
-     *
-     * @return void
      */
-    public function testGetExceptionOnNoData()
+    public function testGetExceptionOnNoData(): void
     {
         $this->expectException(\Cake\Datasource\Exception\InvalidPrimaryKeyException::class);
         $this->expectExceptionMessage('Record not found in table "articles" with primary key [NULL]');
@@ -5792,10 +5430,8 @@ class TableTest extends TestCase
 
     /**
      * Test that an exception is raised when there are too many keys.
-     *
-     * @return void
      */
-    public function testGetExceptionOnTooMuchData()
+    public function testGetExceptionOnTooMuchData(): void
     {
         $this->expectException(\Cake\Datasource\Exception\InvalidPrimaryKeyException::class);
         $this->expectExceptionMessage('Record not found in table "articles" with primary key [1, \'two\']');
@@ -5810,10 +5446,8 @@ class TableTest extends TestCase
     /**
      * Tests that patchEntity delegates the task to the marshaller and passed
      * all associations
-     *
-     * @return void
      */
-    public function testPatchEntityMarshallerUsage()
+    public function testPatchEntityMarshallerUsage(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['marshaller'])
@@ -5838,10 +5472,8 @@ class TableTest extends TestCase
     /**
      * Tests patchEntity in a simple scenario. The tests for Marshaller cover
      * patch scenarios in more depth.
-     *
-     * @return void
      */
-    public function testPatchEntity()
+    public function testPatchEntity(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $entity = new Entity(['title' => 'old title'], ['markNew' => false]);
@@ -5855,10 +5487,8 @@ class TableTest extends TestCase
     /**
      * Tests that patchEntities delegates the task to the marshaller and passed
      * all associations
-     *
-     * @return void
      */
-    public function testPatchEntitiesMarshallerUsage()
+    public function testPatchEntitiesMarshallerUsage(): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['marshaller'])
@@ -5883,10 +5513,8 @@ class TableTest extends TestCase
     /**
      * Tests patchEntities in a simple scenario. The tests for Marshaller cover
      * patch scenarios in more depth.
-     *
-     * @return void
      */
-    public function testPatchEntities()
+    public function testPatchEntities(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $entities = $table->find()->limit(2)->toArray();
@@ -5904,10 +5532,8 @@ class TableTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $articles = $this->getTableLocator()->get('articles');
         $articles->addBehavior('Timestamp');
@@ -5941,15 +5567,13 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate creates a new entity, and then finds that entity.
-     *
-     * @return void
      */
-    public function testFindOrCreateNewEntity()
+    public function testFindOrCreateNewEntity(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
         $callbackExecuted = false;
-        $firstArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) use (&$callbackExecuted) {
+        $firstArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) use (&$callbackExecuted): void {
             $this->assertInstanceOf(EntityInterface::class, $article);
             $article->body = 'New body';
             $callbackExecuted = true;
@@ -5960,7 +5584,7 @@ class TableTest extends TestCase
         $this->assertSame('Not there', $firstArticle->title);
         $this->assertSame('New body', $firstArticle->body);
 
-        $secondArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article) {
+        $secondArticle = $articles->findOrCreate(['title' => 'Not there'], function ($article): void {
             $this->fail('Should not be called for existing entities.');
         });
         $this->assertFalse($secondArticle->isNew());
@@ -5971,14 +5595,12 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate finds fixture data.
-     *
-     * @return void
      */
-    public function testFindOrCreateExistingEntity()
+    public function testFindOrCreateExistingEntity(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
-        $article = $articles->findOrCreate(['title' => 'First Article'], function ($article) {
+        $article = $articles->findOrCreate(['title' => 'First Article'], function ($article): void {
             $this->fail('Should not be called for existing entities.');
         });
         $this->assertFalse($article->isNew());
@@ -5988,17 +5610,15 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate uses the search conditions as defaults for new entity.
-     *
-     * @return void
      */
-    public function testFindOrCreateDefaults()
+    public function testFindOrCreateDefaults(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
         $callbackExecuted = false;
         $article = $articles->findOrCreate(
             ['author_id' => 2, 'title' => 'First Article'],
-            function ($article) use (&$callbackExecuted) {
+            function ($article) use (&$callbackExecuted): void {
                 $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
                 $article->set(['published' => 'N', 'body' => 'New body']);
                 $callbackExecuted = true;
@@ -6021,10 +5641,8 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate adds new entity without using a callback.
-     *
-     * @return void
      */
-    public function testFindOrCreateNoCallable()
+    public function testFindOrCreateNoCallable(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
@@ -6036,20 +5654,18 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate executes search conditions as a callable.
-     *
-     * @return void
      */
-    public function testFindOrCreateSearchCallable()
+    public function testFindOrCreateSearchCallable(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
         $calledOne = false;
         $calledTwo = false;
-        $article = $articles->findOrCreate(function ($query) use (&$calledOne) {
+        $article = $articles->findOrCreate(function ($query) use (&$calledOne): void {
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $query->where(['title' => 'Something Else']);
             $calledOne = true;
-        }, function ($article) use (&$calledTwo) {
+        }, function ($article) use (&$calledTwo): void {
             $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
             $article->title = 'Set Defaults Here';
             $calledTwo = true;
@@ -6063,14 +5679,12 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate options disable defaults.
-     *
-     * @return void
      */
-    public function testFindOrCreateNoDefaults()
+    public function testFindOrCreateNoDefaults(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
-        $article = $articles->findOrCreate(['title' => 'A New Article', 'published' => 'Y'], function ($article) {
+        $article = $articles->findOrCreate(['title' => 'A New Article', 'published' => 'Y'], function ($article): void {
             $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
             $article->title = 'A Different Title';
         }, ['defaults' => false]);
@@ -6082,21 +5696,19 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate executes callable inside transaction.
-     *
-     * @return void
      */
-    public function testFindOrCreateTransactions()
+    public function testFindOrCreateTransactions(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->getEventManager()->on('Model.afterSaveCommit', function (EventInterface $event, EntityInterface $entity, ArrayObject $options) {
+        $articles->getEventManager()->on('Model.afterSaveCommit', function (EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
             $entity->afterSaveCommit = true;
         });
 
-        $article = $articles->findOrCreate(function ($query) {
+        $article = $articles->findOrCreate(function ($query): void {
             $this->assertInstanceOf('Cake\ORM\Query', $query);
             $query->where(['title' => 'Find Something New']);
             $this->assertTrue($this->connection->inTransaction());
-        }, function ($article) {
+        }, function ($article): void {
             $this->assertInstanceOf('Cake\Datasource\EntityInterface', $article);
             $article->title = 'Success';
             $this->assertTrue($this->connection->inTransaction());
@@ -6109,18 +5721,16 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate executes callable without transaction.
-     *
-     * @return void
      */
-    public function testFindOrCreateNoTransaction()
+    public function testFindOrCreateNoTransaction(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
 
-        $article = $articles->findOrCreate(function (Query $query) {
+        $article = $articles->findOrCreate(function (Query $query): void {
             $this->assertInstanceOf(Query::class, $query);
             $query->where(['title' => 'Find Something New']);
             $this->assertFalse($this->connection->inTransaction());
-        }, function ($article) {
+        }, function ($article): void {
             $this->assertInstanceOf(EntityInterface::class, $article);
             $this->assertFalse($this->connection->inTransaction());
             $article->title = 'Success';
@@ -6133,10 +5743,8 @@ class TableTest extends TestCase
     /**
      * Test that findOrCreate throws a PersistenceFailedException when it cannot save
      * an entity created from $search
-     *
-     * @return void
      */
-    public function testFindOrCreateWithInvalidEntity()
+    public function testFindOrCreateWithInvalidEntity(): void
     {
         $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage(
@@ -6154,10 +5762,8 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate allows patching of all $search keys
-     *
-     * @return void
      */
-    public function testFindOrCreateAccessibleFields()
+    public function testFindOrCreateAccessibleFields(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->setEntityClass(ProtectedEntity::class);
@@ -6172,10 +5778,8 @@ class TableTest extends TestCase
 
     /**
      * Test that findOrCreate cannot accidentally bypass required validation.
-     *
-     * @return void
      */
-    public function testFindOrCreatePartialValidation()
+    public function testFindOrCreatePartialValidation(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->setEntityClass(ProtectedEntity::class);
@@ -6195,13 +5799,11 @@ class TableTest extends TestCase
 
     /**
      * Test that creating a table fires the initialize event.
-     *
-     * @return void
      */
-    public function testInitializeEvent()
+    public function testInitializeEvent(): void
     {
         $count = 0;
-        $cb = function (EventInterface $event) use (&$count) {
+        $cb = function (EventInterface $event) use (&$count): void {
             $count++;
         };
         EventManager::instance()->on('Model.initialize', $cb);
@@ -6213,10 +5815,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the hasFinder method
-     *
-     * @return void
      */
-    public function testHasFinder()
+    public function testHasFinder(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->addBehavior('Sluggable');
@@ -6228,13 +5828,11 @@ class TableTest extends TestCase
 
     /**
      * Tests that calling validator() trigger the buildValidator event
-     *
-     * @return void
      */
-    public function testBuildValidatorEvent()
+    public function testBuildValidatorEvent(): void
     {
         $count = 0;
-        $cb = function (EventInterface $event) use (&$count) {
+        $cb = function (EventInterface $event) use (&$count): void {
             $count++;
         };
         EventManager::instance()->on('Model.buildValidator', $cb);
@@ -6248,10 +5846,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the validateUnique method with different combinations
-     *
-     * @return void
      */
-    public function testValidateUnique()
+    public function testValidateUnique(): void
     {
         $table = $this->getTableLocator()->get('Users');
         $validator = new Validator();
@@ -6285,10 +5881,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the validateUnique method with scope
-     *
-     * @return void
      */
-    public function testValidateUniqueScope()
+    public function testValidateUniqueScope(): void
     {
         $table = $this->getTableLocator()->get('Users');
         $validator = new Validator();
@@ -6309,10 +5903,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the validateUnique method with options
-     *
-     * @return void
      */
-    public function testValidateUniqueMultipleNulls()
+    public function testValidateUniqueMultipleNulls(): void
     {
         $entity = new Entity([
             'id' => 9,
@@ -6345,10 +5937,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that the callbacks receive the expected types of arguments.
-     *
-     * @return void
      */
-    public function testCallbackArgumentTypes()
+    public function testCallbackArgumentTypes(): void
     {
         $table = $this->getTableLocator()->get('articles');
         $table->belongsTo('authors');
@@ -6358,7 +5948,7 @@ class TableTest extends TestCase
         $associationBeforeFindCount = 0;
         $table->getAssociation('authors')->getTarget()->getEventManager()->on(
             'Model.beforeFind',
-            function (EventInterface $event, Query $query, ArrayObject $options, $primary) use (&$associationBeforeFindCount) {
+            function (EventInterface $event, Query $query, ArrayObject $options, $primary) use (&$associationBeforeFindCount): void {
                 $this->assertIsBool($primary);
                 $associationBeforeFindCount++;
             }
@@ -6367,7 +5957,7 @@ class TableTest extends TestCase
         $beforeFindCount = 0;
         $eventManager->on(
             'Model.beforeFind',
-            function (EventInterface $event, Query $query, ArrayObject $options, $primary) use (&$beforeFindCount) {
+            function (EventInterface $event, Query $query, ArrayObject $options, $primary) use (&$beforeFindCount): void {
                 $this->assertIsBool($primary);
                 $beforeFindCount++;
             }
@@ -6379,7 +5969,7 @@ class TableTest extends TestCase
         $buildValidatorCount = 0;
         $eventManager->on(
             'Model.buildValidator',
-            $callback = function (EventInterface $event, Validator $validator, $name) use (&$buildValidatorCount) {
+            $callback = function (EventInterface $event, Validator $validator, $name) use (&$buildValidatorCount): void {
                 $this->assertIsString($name);
                 $buildValidatorCount++;
             }
@@ -6394,20 +5984,20 @@ class TableTest extends TestCase
         $afterSaveCount = 0;
         $eventManager->on(
             'Model.buildRules',
-            function (EventInterface $event, RulesChecker $rules) use (&$buildRulesCount) {
+            function (EventInterface $event, RulesChecker $rules) use (&$buildRulesCount): void {
                 $buildRulesCount++;
             }
         );
         $eventManager->on(
             'Model.beforeRules',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation) use (&$beforeRulesCount) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation) use (&$beforeRulesCount): void {
                 $this->assertIsString($operation);
                 $beforeRulesCount++;
             }
         );
         $eventManager->on(
             'Model.afterRules',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation) use (&$afterRulesCount) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation) use (&$afterRulesCount): void {
                 $this->assertIsBool($result);
                 $this->assertIsString($operation);
                 $afterRulesCount++;
@@ -6415,13 +6005,13 @@ class TableTest extends TestCase
         );
         $eventManager->on(
             'Model.beforeSave',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeSaveCount) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeSaveCount): void {
                 $beforeSaveCount++;
             }
         );
         $eventManager->on(
             'Model.afterSave',
-            $afterSaveCallback = function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount) {
+            $afterSaveCallback = function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount): void {
                 $afterSaveCount++;
             }
         );
@@ -6437,13 +6027,13 @@ class TableTest extends TestCase
         $afterDeleteCount = 0;
         $eventManager->on(
             'Model.beforeDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeDeleteCount) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeDeleteCount): void {
                 $beforeDeleteCount++;
             }
         );
         $eventManager->on(
             'Model.afterDelete',
-            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterDeleteCount) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterDeleteCount): void {
                 $afterDeleteCount++;
             }
         );
@@ -6454,10 +6044,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that calling newEmptyEntity() on a table sets the right source alias.
-     *
-     * @return void
      */
-    public function testSetEntitySource()
+    public function testSetEntitySource(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $this->assertSame('Articles', $table->newEmptyEntity()->getSource());
@@ -6472,9 +6060,8 @@ class TableTest extends TestCase
      * actually save it as a new entity
      *
      * @group save
-     * @return void
      */
-    public function testSaveWithClonedEntity()
+    public function testSaveWithClonedEntity(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $article = $table->get(1);
@@ -6492,10 +6079,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that the _ids notation can be used for HasMany
-     *
-     * @return void
      */
-    public function testSaveHasManyWithIds()
+    public function testSaveHasManyWithIds(): void
     {
         $data = [
             'username' => 'lux',
@@ -6517,10 +6102,8 @@ class TableTest extends TestCase
      * Tests that on second save, entities for the has many relation are not marked
      * as dirty unnecessarily. This helps avoid wasteful database statements and makes
      * for a cleaner transaction log
-     *
-     * @return void
      */
-    public function testSaveHasManyNoWasteSave()
+    public function testSaveHasManyNoWasteSave(): void
     {
         $data = [
             'username' => 'lux',
@@ -6537,7 +6120,7 @@ class TableTest extends TestCase
         $counter = 0;
         $userTable->Comments
             ->getEventManager()
-            ->on('Model.afterSave', function (EventInterface $event, $entity) use (&$counter) {
+            ->on('Model.afterSave', function (EventInterface $event, $entity) use (&$counter): void {
                 if ($entity->isDirty()) {
                     $counter++;
                 }
@@ -6554,10 +6137,8 @@ class TableTest extends TestCase
      * Tests that on second save, entities for the belongsToMany relation are not marked
      * as dirty unnecessarily. This helps avoid wasteful database statements and makes
      * for a cleaner transaction log
-     *
-     * @return void
      */
-    public function testSaveBelongsToManyNoWasteSave()
+    public function testSaveBelongsToManyNoWasteSave(): void
     {
         $data = [
             'title' => 'foo',
@@ -6574,7 +6155,7 @@ class TableTest extends TestCase
         $counter = 0;
         $table->Tags->junction()
             ->getEventManager()
-            ->on('Model.afterSave', function (EventInterface $event, $entity) use (&$counter) {
+            ->on('Model.afterSave', function (EventInterface $event, $entity) use (&$counter): void {
                 if ($entity->isDirty()) {
                     $counter++;
                 }
@@ -6592,9 +6173,8 @@ class TableTest extends TestCase
      * key casted to the right type
      *
      * @group save
-     * @return void
      */
-    public function testSaveCorrectPrimaryKeyType()
+    public function testSaveCorrectPrimaryKeyType(): void
     {
         $entity = new Entity([
             'username' => 'superuser',
@@ -6609,10 +6189,8 @@ class TableTest extends TestCase
 
     /**
      * Tests entity clean()
-     *
-     * @return void
      */
-    public function testEntityClean()
+    public function testEntityClean(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $validator = $table->getValidator()->requirePresence('body');
@@ -6638,10 +6216,8 @@ class TableTest extends TestCase
 
     /**
      * Tests the loadInto() method
-     *
-     * @return void
      */
-    public function testLoadIntoEntity()
+    public function testLoadIntoEntity(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('SiteArticles');
@@ -6658,10 +6234,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to pass conditions and fields to loadInto()
-     *
-     * @return void
      */
-    public function testLoadIntoWithConditions()
+    public function testLoadIntoWithConditions(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('SiteArticles');
@@ -6683,10 +6257,8 @@ class TableTest extends TestCase
 
     /**
      * Tests loadInto() with a belongsTo association
-     *
-     * @return void
      */
-    public function testLoadBelongsTo()
+    public function testLoadBelongsTo(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
@@ -6702,10 +6274,8 @@ class TableTest extends TestCase
     /**
      * Tests that it is possible to post-load associations for many entities at
      * the same time
-     *
-     * @return void
      */
-    public function testLoadIntoMany()
+    public function testLoadIntoMany(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('SiteArticles');
@@ -6726,10 +6296,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that saveOrFail triggers an exception on not successful save
-     *
-     * @return void
      */
-    public function testSaveOrFail()
+    public function testSaveOrFail(): void
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure.');
@@ -6744,10 +6312,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that saveOrFail displays useful messages on output, especially in tests for CLI.
-     *
-     * @return void
      */
-    public function testSaveOrFailErrorDisplay()
+    public function testSaveOrFailErrorDisplay(): void
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure. Found the following errors (field.0: "Some message", multiple.one: "One", multiple.two: "Two")');
@@ -6764,10 +6330,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that saveOrFail with nested errors
-     *
-     * @return void
      */
-    public function testSaveOrFailNestedError()
+    public function testSaveOrFailNestedError(): void
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure. Found the following errors (articles.0.title.0: "Bad value")');
@@ -6788,10 +6352,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that saveOrFail returns the right entity
-     *
-     * @return void
      */
-    public function testSaveOrFailGetEntity()
+    public function testSaveOrFailGetEntity(): void
     {
         $entity = new Entity([
             'foo' => 'bar',
@@ -6807,10 +6369,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that deleteOrFail triggers an exception on not successful delete
-     *
-     * @return void
      */
-    public function testDeleteOrFail()
+    public function testDeleteOrFail(): void
     {
         $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity delete failure.');
@@ -6824,10 +6384,8 @@ class TableTest extends TestCase
 
     /**
      * Tests that deleteOrFail returns the right entity
-     *
-     * @return void
      */
-    public function testDeleteOrFailGetEntity()
+    public function testDeleteOrFailGetEntity(): void
     {
         $entity = new Entity([
             'id' => 999,
@@ -6843,10 +6401,8 @@ class TableTest extends TestCase
 
     /**
      * Test getting the save options builder.
-     *
-     * @return void
      */
-    public function getSaveOptionsBuilder()
+    public function getSaveOptionsBuilder(): void
     {
         $table = $this->getTableLocator()->get('Authors');
         $result = $table->getSaveOptionsBuilder();
@@ -6855,10 +6411,8 @@ class TableTest extends TestCase
 
     /**
      * Helper method to skip tests when connection is SQLServer.
-     *
-     * @return void
      */
-    public function skipIfSqlServer()
+    public function skipIfSqlServer(): void
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver,

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -37,8 +37,6 @@ class TableUuidTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -60,9 +58,8 @@ class TableUuidTest extends TestCase
      * Test saving new records sets uuids
      *
      * @dataProvider uuidTableProvider
-     * @return void
      */
-    public function testSaveNew(string $tableName)
+    public function testSaveNew(string $tableName): void
     {
         $entity = new Entity([
             'name' => 'shiny new',
@@ -81,9 +78,8 @@ class TableUuidTest extends TestCase
      * Test saving new records allows manual uuids
      *
      * @dataProvider uuidTableProvider
-     * @return void
      */
-    public function testSaveNewSpecificId(string $tableName)
+    public function testSaveNewSpecificId(string $tableName): void
     {
         $id = Text::uuid();
         $entity = new Entity([
@@ -105,9 +101,8 @@ class TableUuidTest extends TestCase
      * Test saving existing records works
      *
      * @dataProvider uuidTableProvider
-     * @return void
      */
-    public function testSaveUpdate(string $tableName)
+    public function testSaveUpdate(string $tableName): void
     {
         $id = '481fc6d0-b920-43e0-a40d-6d1740cf8569';
         $entity = new Entity([
@@ -129,9 +124,8 @@ class TableUuidTest extends TestCase
      * Test delete with string pk.
      *
      * @dataProvider uuidTableProvider
-     * @return void
      */
-    public function testGetById(string $tableName)
+    public function testGetById(string $tableName): void
     {
         $table = $this->getTableLocator()->get($tableName);
         $entity = $table->find('all')->firstOrFail();
@@ -144,9 +138,8 @@ class TableUuidTest extends TestCase
      * Test delete with string pk.
      *
      * @dataProvider uuidTableProvider
-     * @return void
      */
-    public function testDelete(string $tableName)
+    public function testDelete(string $tableName): void
     {
         $table = $this->getTableLocator()->get($tableName);
         $entity = $table->find('all')->firstOrFail();
@@ -160,9 +153,8 @@ class TableUuidTest extends TestCase
      * Tests that sql server does not error when an empty uuid is bound
      *
      * @dataProvider uuidTableProvider
-     * @return void
      */
-    public function testEmptyUuid(string $tableName)
+    public function testEmptyUuid(string $tableName): void
     {
         $id = '';
         $table = $this->getTableLocator()->get($tableName);

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -30,8 +30,6 @@ class AssetTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -45,15 +43,13 @@ class AssetTest extends TestCase
 
         static::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks();
         });
     }
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -64,10 +60,8 @@ class AssetTest extends TestCase
 
     /**
      * test assetTimestamp application
-     *
-     * @return void
      */
-    public function testAssetTimestamp()
+    public function testAssetTimestamp(): void
     {
         Configure::write('Foo.bar', 'test');
         Configure::write('Asset.timestamp', false);
@@ -104,10 +98,8 @@ class AssetTest extends TestCase
 
     /**
      * test assetUrl application
-     *
-     * @return void
      */
-    public function testAssetUrl()
+    public function testAssetUrl(): void
     {
         Router::connect('/{controller}/{action}/*');
 
@@ -143,10 +135,8 @@ class AssetTest extends TestCase
 
     /**
      * Test assetUrl and data uris
-     *
-     * @return void
      */
-    public function testAssetUrlDataUri()
+    public function testAssetUrlDataUri(): void
     {
         $request = Router::getRequest()
             ->withAttribute('base', 'subdir')
@@ -165,10 +155,8 @@ class AssetTest extends TestCase
 
     /**
      * Test assetUrl with no rewriting.
-     *
-     * @return void
      */
-    public function testAssetUrlNoRewrite()
+    public function testAssetUrlNoRewrite(): void
     {
         $request = Router::getRequest()
             ->withAttribute('base', '/cake_dev/index.php')
@@ -183,10 +171,8 @@ class AssetTest extends TestCase
 
     /**
      * Test assetUrl with plugins.
-     *
-     * @return void
      */
-    public function testAssetUrlPlugin()
+    public function testAssetUrlPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -201,10 +187,8 @@ class AssetTest extends TestCase
 
     /**
      * Tests assetUrl() with full base URL.
-     *
-     * @return void
      */
-    public function testAssetUrlFullBase()
+    public function testAssetUrlFullBase(): void
     {
         $result = Asset::url('img/foo.jpg', ['fullBase' => true]);
         $this->assertSame(Router::fullBaseUrl() . '/img/foo.jpg', $result);
@@ -215,10 +199,8 @@ class AssetTest extends TestCase
 
     /**
      * test assetUrl and Asset.timestamp = force
-     *
-     * @return void
      */
-    public function testAssetUrlTimestampForce()
+    public function testAssetUrlTimestampForce(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -228,10 +210,8 @@ class AssetTest extends TestCase
 
     /**
      * Test assetTimestamp with timestamp option overriding `Asset.timestamp` in Configure.
-     *
-     * @return void
      */
-    public function testAssetTimestampConfigureOverride()
+    public function testAssetTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -242,10 +222,8 @@ class AssetTest extends TestCase
 
     /**
      * test assetTimestamp with plugins and themes
-     *
-     * @return void
      */
-    public function testAssetTimestampPluginsAndThemes()
+    public function testAssetTimestampPluginsAndThemes(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
@@ -268,10 +246,8 @@ class AssetTest extends TestCase
 
     /**
      * test script()
-     *
-     * @return void
      */
-    public function testScript()
+    public function testScript(): void
     {
         Router::connect('/{controller}/{action}/*');
 
@@ -281,10 +257,8 @@ class AssetTest extends TestCase
 
     /**
      * Test script and Asset.timestamp = force
-     *
-     * @return void
      */
-    public function testScriptTimestampForce()
+    public function testScriptTimestampForce(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -294,10 +268,8 @@ class AssetTest extends TestCase
 
     /**
      * Test script with timestamp option overriding `Asset.timestamp` in Configure
-     *
-     * @return void
      */
-    public function testScriptTimestampConfigureOverride()
+    public function testScriptTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -308,10 +280,8 @@ class AssetTest extends TestCase
 
     /**
      * test image()
-     *
-     * @return void
      */
-    public function testImage()
+    public function testImage(): void
     {
         $result = Asset::imageUrl('foo.jpg');
         $this->assertSame('/img/foo.jpg', $result);
@@ -337,10 +307,8 @@ class AssetTest extends TestCase
 
     /**
      * Test image with `Asset.timestamp` = force
-     *
-     * @return void
      */
-    public function testImageTimestampForce()
+    public function testImageTimestampForce(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -350,10 +318,8 @@ class AssetTest extends TestCase
 
     /**
      * Test image with timestamp option overriding `Asset.timestamp` in Configure
-     *
-     * @return void
      */
-    public function testImageTimestampConfigureOverride()
+    public function testImageTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -364,10 +330,8 @@ class AssetTest extends TestCase
 
     /**
      * test css
-     *
-     * @return void
      */
-    public function testCss()
+    public function testCss(): void
     {
         $result = Asset::cssUrl('style');
         $this->assertSame('/css/style.css', $result);
@@ -375,10 +339,8 @@ class AssetTest extends TestCase
 
     /**
      * Test css with `Asset.timestamp` = force
-     *
-     * @return void
      */
-    public function testCssTimestampForce()
+    public function testCssTimestampForce(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -388,10 +350,8 @@ class AssetTest extends TestCase
 
     /**
      * Test image with timestamp option overriding `Asset.timestamp` in Configure
-     *
-     * @return void
      */
-    public function testCssTimestampConfigureOverride()
+    public function testCssTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -402,10 +362,8 @@ class AssetTest extends TestCase
 
     /**
      * Test generating paths with webroot().
-     *
-     * @return void
      */
-    public function testWebrootPaths()
+    public function testWebrootPaths(): void
     {
         $result = Asset::webroot('/img/cake.power.gif');
         $expected = '/img/cake.power.gif';
@@ -445,10 +403,8 @@ class AssetTest extends TestCase
 
     /**
      * Test plugin based assets will NOT use the plugin name
-     *
-     * @return void
      */
-    public function testPluginAssetsPrependImageBaseUrl()
+    public function testPluginAssetsPrependImageBaseUrl(): void
     {
         $cdnPrefix = 'https://cdn.example.com/';
         $imageBaseUrl = Configure::read('App.imageBaseUrl');

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -28,8 +28,6 @@ class AssetMiddlewareTest extends TestCase
 {
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -39,8 +37,6 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -50,10 +46,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * test that the if modified since header generates 304 responses
-     *
-     * @return void
      */
-    public function testCheckIfModifiedHeader()
+    public function testCheckIfModifiedHeader(): void
     {
         $modified = filemtime(TEST_APP . 'Plugin/TestPlugin/webroot/root.js');
         $request = ServerRequestFactory::fromGlobals([
@@ -72,10 +66,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * test missing plugin assets.
-     *
-     * @return void
      */
-    public function testMissingPluginAsset()
+    public function testMissingPluginAsset(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/test_plugin/not_found.js']);
         $handler = new TestRequestHandler();
@@ -123,7 +115,7 @@ class AssetMiddlewareTest extends TestCase
      *
      * @dataProvider assetProvider
      */
-    public function testPluginAsset(string $url, string $expectedFile)
+    public function testPluginAsset(string $url, string $expectedFile): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => $url]);
         $handler = new TestRequestHandler();
@@ -137,10 +129,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * Test headers with plugin assets
-     *
-     * @return void
      */
-    public function testPluginAssetHeaders()
+    public function testPluginAssetHeaders(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/test_plugin/root.js']);
         $handler = new TestRequestHandler();
@@ -176,10 +166,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * Test that // results in a 404
-     *
-     * @return void
      */
-    public function test404OnDoubleSlash()
+    public function test404OnDoubleSlash(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '//index.php']);
         $handler = new TestRequestHandler();
@@ -191,10 +179,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * Test that .. results in a 404
-     *
-     * @return void
      */
-    public function test404OnDoubleDot()
+    public function test404OnDoubleDot(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/test_plugin/../webroot/root.js']);
         $handler = new TestRequestHandler();
@@ -206,10 +192,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * Test that hidden filenames result in a 404
-     *
-     * @return void
      */
-    public function test404OnHiddenFile()
+    public function test404OnHiddenFile(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/test_plugin/.hiddenfile']);
         $handler = new TestRequestHandler();
@@ -221,10 +205,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * Test that hidden filenames result in a 404
-     *
-     * @return void
      */
-    public function test404OnHiddenFolder()
+    public function test404OnHiddenFolder(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/test_plugin/.hiddenfolder/some.js']);
         $handler = new TestRequestHandler();

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Routing\Middleware;
 use Cake\Cache\Cache;
 use Cake\Cache\InvalidArgumentException as CacheInvalidArgumentException;
 use Cake\Core\Configure;
+use Cake\Core\HttpApplicationInterface;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\RouteBuilder;
@@ -39,8 +40,6 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -54,12 +53,10 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test redirect responses from redirect routes
-     *
-     * @return void
      */
-    public function testRedirectResponse()
+    public function testRedirectResponse(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->redirect('/testpath', '/pages');
         });
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
@@ -75,12 +72,10 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test redirects with additional headers
-     *
-     * @return void
      */
-    public function testRedirectResponseWithHeaders()
+    public function testRedirectResponseWithHeaders(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->redirect('/testpath', '/pages');
         });
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
@@ -96,10 +91,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test that Router sets parameters
-     *
-     * @return void
      */
-    public function testRouterSetParams()
+    public function testRouterSetParams(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
         $handler = new TestRequestHandler(function ($req) {
@@ -121,10 +114,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test routing middleware does wipe off existing params keys.
-     *
-     * @return void
      */
-    public function testPreservingExistingParams()
+    public function testPreservingExistingParams(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
         $request = $request->withAttribute('params', ['_csrfToken' => 'i-am-groot']);
@@ -147,10 +138,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test middleware invoking hook method
-     *
-     * @return void
      */
-    public function testRoutesHookInvokedOnApp()
+    public function testRoutesHookInvokedOnApp(): void
     {
         Router::reload();
 
@@ -177,10 +166,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test that pluginRoutes hook is called
-     *
-     * @return void
      */
-    public function testRoutesHookCallsPluginHook()
+    public function testRoutesHookCallsPluginHook(): void
     {
         Router::reload();
 
@@ -198,10 +185,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test that routing is not applied if a controller exists already
-     *
-     * @return void
      */
-    public function testRouterNoopOnController()
+    public function testRouterNoopOnController(): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
         $request = $request->withAttribute('params', ['controller' => 'Articles']);
@@ -217,7 +202,7 @@ class RoutingMiddlewareTest extends TestCase
     /**
      * Test missing routes not being caught.
      */
-    public function testMissingRouteNotCaught()
+    public function testMissingRouteNotCaught(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/missing']);
@@ -227,10 +212,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test route with _method being parsed correctly.
-     *
-     * @return void
      */
-    public function testFakedRequestMethodParsed()
+    public function testFakedRequestMethodParsed(): void
     {
         Router::connect('/articles-patch', [
             'controller' => 'Articles',
@@ -266,12 +249,10 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test invoking simple scoped middleware
-     *
-     * @return void
      */
-    public function testInvokeScopedMiddleware()
+    public function testInvokeScopedMiddleware(): void
     {
-        Router::scope('/api', function (RouteBuilder $routes) {
+        Router::scope('/api', function (RouteBuilder $routes): void {
             $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
@@ -309,12 +290,10 @@ class RoutingMiddlewareTest extends TestCase
      *
      * Scoped middleware should be able to generate a response
      * and abort lower layers.
-     *
-     * @return void
      */
-    public function testInvokeScopedMiddlewareReturnResponse()
+    public function testInvokeScopedMiddlewareReturnResponse(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
@@ -329,7 +308,7 @@ class RoutingMiddlewareTest extends TestCase
             $routes->applyMiddleware('first');
             $routes->connect('/', ['controller' => 'Home']);
 
-            $routes->scope('/api', function (RouteBuilder $routes) {
+            $routes->scope('/api', function (RouteBuilder $routes): void {
                 $routes->applyMiddleware('second');
                 $routes->connect('/articles', ['controller' => 'Articles']);
             });
@@ -339,7 +318,7 @@ class RoutingMiddlewareTest extends TestCase
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => '/api/articles',
         ]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function ($req): void {
             $this->fail('Should not be invoked as first should be ignored.');
         });
         $middleware = new RoutingMiddleware($this->app());
@@ -350,12 +329,10 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test control flow in scoped middleware.
-     *
-     * @return void
      */
-    public function testInvokeScopedMiddlewareReturnResponseMainScope()
+    public function testInvokeScopedMiddlewareReturnResponseMainScope(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
@@ -370,7 +347,7 @@ class RoutingMiddlewareTest extends TestCase
             $routes->applyMiddleware('first');
             $routes->connect('/', ['controller' => 'Home']);
 
-            $routes->scope('/api', function (RouteBuilder $routes) {
+            $routes->scope('/api', function (RouteBuilder $routes): void {
                 $routes->applyMiddleware('second');
                 $routes->connect('/articles', ['controller' => 'Articles']);
             });
@@ -380,7 +357,7 @@ class RoutingMiddlewareTest extends TestCase
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => '/',
         ]);
-        $handler = new TestRequestHandler(function ($req) {
+        $handler = new TestRequestHandler(function ($req): void {
             $this->fail('Should not be invoked as first should be ignored.');
         });
         $middleware = new RoutingMiddleware($this->app());
@@ -396,11 +373,10 @@ class RoutingMiddlewareTest extends TestCase
      * in the first context.
      *
      * @dataProvider scopedMiddlewareUrlProvider
-     * @return void
      */
-    public function testInvokeScopedMiddlewareIsolatedScopes(string $url, array $expected)
+    public function testInvokeScopedMiddlewareIsolatedScopes(string $url, array $expected): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
@@ -412,12 +388,12 @@ class RoutingMiddlewareTest extends TestCase
                 return $handler->handle($request);
             });
 
-            $routes->scope('/api', function (RouteBuilder $routes) {
+            $routes->scope('/api', function (RouteBuilder $routes): void {
                 $routes->applyMiddleware('first');
                 $routes->connect('/ping', ['controller' => 'Pings']);
             });
 
-            $routes->scope('/api', function (RouteBuilder $routes) {
+            $routes->scope('/api', function (RouteBuilder $routes): void {
                 $routes->applyMiddleware('second');
                 $routes->connect('/version', ['controller' => 'Version']);
             });
@@ -452,10 +428,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test we store route collection in cache.
-     *
-     * @return void
      */
-    public function testCacheRoutes()
+    public function testCacheRoutes(): void
     {
         $cacheConfigName = '_cake_router_';
         Cache::setConfig($cacheConfigName, [
@@ -479,10 +453,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test we don't cache routes if cache is disabled.
-     *
-     * @return void
      */
-    public function testCacheNotUsedIfCacheDisabled()
+    public function testCacheNotUsedIfCacheDisabled(): void
     {
         $cacheConfigName = '_cake_router_';
         Cache::drop($cacheConfigName);
@@ -509,10 +481,8 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * Test cache name is used
-     *
-     * @return void
      */
-    public function testCacheConfigNotFound()
+    public function testCacheConfigNotFound(): void
     {
         $this->expectException(CacheInvalidArgumentException::class);
         $this->expectExceptionMessage('The "notfound" cache configuration does not exist.');
@@ -533,9 +503,8 @@ class RoutingMiddlewareTest extends TestCase
      * Create a stub application for testing.
      *
      * @param callable|null $handleCallback Callback for "handle" method.
-     * @return \Cake\Core\HttpApplicationInterface
      */
-    protected function app($handleCallback = null)
+    protected function app($handleCallback = null): HttpApplicationInterface
     {
         $mock = $this->createMock(Application::class);
         $mock->method('routes')

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -27,10 +27,8 @@ class DashedRouteTest extends TestCase
 {
     /**
      * test that routes match their pattern.
-     *
-     * @return void
      */
-    public function testMatchBasic()
+    public function testMatchBasic(): void
     {
         $route = new DashedRoute('/{controller}/{action}/{id}', ['plugin' => null]);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView', 'plugin' => null]);
@@ -139,10 +137,8 @@ class DashedRouteTest extends TestCase
 
     /**
      * test the parse method of DashedRoute.
-     *
-     * @return void
      */
-    public function testParse()
+    public function testParse(): void
     {
         $route = new DashedRoute('/{controller}/{action}/{id}', [], ['id' => Router::ID]);
         $route->compile();
@@ -193,10 +189,7 @@ class DashedRouteTest extends TestCase
         $this->assertEquals(['tv_shows'], $result['pass']);
     }
 
-    /**
-     * @return void
-     */
-    public function testMatchThenParse()
+    public function testMatchThenParse(): void
     {
         $route = new DashedRoute('/plugin/{controller}/{action}', [
             'plugin' => 'Vendor/PluginName',

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -28,10 +28,8 @@ class EntityRouteTest extends TestCase
 {
     /**
      * test that route keys take precedence to object properties.
-     *
-     * @return void
      */
-    public function testMatchRouteKeyPrecedence()
+    public function testMatchRouteKeyPrecedence(): void
     {
         $entity = new Article([
             'category_id' => 2,
@@ -56,10 +54,8 @@ class EntityRouteTest extends TestCase
 
     /**
      * test that routes match their pattern.
-     *
-     * @return void
      */
-    public function testMatchEntityObject()
+    public function testMatchEntityObject(): void
     {
         $entity = new Article([
             'category_id' => 2,
@@ -83,10 +79,8 @@ class EntityRouteTest extends TestCase
 
     /**
      * test that routes match their pattern.
-     *
-     * @return void
      */
-    public function testMatchUnderscoreBetweenVar()
+    public function testMatchUnderscoreBetweenVar(): void
     {
         $entity = new Article([
             'category_id' => 2,
@@ -110,10 +104,8 @@ class EntityRouteTest extends TestCase
 
     /**
      * test that routes match their pattern.
-     *
-     * @return void
      */
-    public function testMatchingArray()
+    public function testMatchingArray(): void
     {
         $entity = [
             'category_id' => 2,
@@ -139,7 +131,7 @@ class EntityRouteTest extends TestCase
     /**
      * Test invalid entity option value
      */
-    public function testInvalidEntityValueException()
+    public function testInvalidEntityValueException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Route `/` expects the URL option `_entity` to be an array or object implementing \ArrayAccess, but `string` passed.');

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -27,10 +27,8 @@ class InflectedRouteTest extends TestCase
 {
     /**
      * test that routes match their pattern.
-     *
-     * @return void
      */
-    public function testMatchBasic()
+    public function testMatchBasic(): void
     {
         $route = new InflectedRoute('/{controller}/{action}/{id}', ['plugin' => null]);
         $result = $route->match(['controller' => 'Posts', 'action' => 'my_view', 'plugin' => null]);
@@ -139,10 +137,8 @@ class InflectedRouteTest extends TestCase
 
     /**
      * test the parse method of InflectedRoute.
-     *
-     * @return void
      */
-    public function testParse()
+    public function testParse(): void
     {
         $route = new InflectedRoute('/{controller}/{action}/{id}', [], ['id' => Router::ID]);
         $route->compile();
@@ -195,10 +191,8 @@ class InflectedRouteTest extends TestCase
 
     /**
      * Test that parse() checks methods.
-     *
-     * @return void
      */
-    public function testParseMethodMatch()
+    public function testParseMethodMatch(): void
     {
         $route = new InflectedRoute('/{controller}/{action}', ['_method' => 'POST']);
         $this->assertNull($route->parse('/blog_posts/add_new', 'GET'));
@@ -208,10 +202,7 @@ class InflectedRouteTest extends TestCase
         $this->assertSame('add_new', $result['action']);
     }
 
-    /**
-     * @return void
-     */
-    public function testMatchThenParse()
+    public function testMatchThenParse(): void
     {
         $route = new InflectedRoute('/plugin/{controller}/{action}', [
             'plugin' => 'Vendor/PluginName',

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -28,8 +28,6 @@ class PluginShortRouteTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -40,10 +38,8 @@ class PluginShortRouteTest extends TestCase
 
     /**
      * test the parsing of routes.
-     *
-     * @return void
      */
-    public function testParsing()
+    public function testParsing(): void
     {
         $route = new PluginShortRoute('/{plugin}', ['action' => 'index'], ['plugin' => 'foo|bar']);
 
@@ -58,10 +54,8 @@ class PluginShortRouteTest extends TestCase
 
     /**
      * test the reverse routing of the plugin shortcut URLs.
-     *
-     * @return void
      */
-    public function testMatch()
+    public function testMatch(): void
     {
         $route = new PluginShortRoute('/{plugin}', ['action' => 'index'], ['plugin' => 'foo|bar']);
 

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -29,8 +29,6 @@ class RedirectRouteTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test match
-     *
-     * @return void
      */
-    public function testMatch()
+    public function testMatch(): void
     {
         $route = new RedirectRoute('/home', ['controller' => 'Posts']);
         $this->assertNull($route->match(['controller' => 'Posts', 'action' => 'index']));
@@ -54,10 +50,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test parse failure
-     *
-     * @return void
      */
-    public function testParseMiss()
+    public function testParseMiss(): void
     {
         $route = new RedirectRoute('/home', ['controller' => 'Posts']);
         $this->assertNull($route->parse('/nope'));
@@ -66,10 +60,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test the parsing of routes.
-     *
-     * @return void
      */
-    public function testParseSimple()
+    public function testParseSimple(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Posts');
@@ -80,10 +72,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test the parsing of routes.
-     *
-     * @return void
      */
-    public function testParseRedirectOption()
+    public function testParseRedirectOption(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Posts');
@@ -94,10 +84,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test the parsing of routes.
-     *
-     * @return void
      */
-    public function testParseArray()
+    public function testParseArray(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Posts');
@@ -108,10 +96,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting to an external url
-     *
-     * @return void
      */
-    public function testParseAbsolute()
+    public function testParseAbsolute(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://google.com');
@@ -122,10 +108,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with a status code
-     *
-     * @return void
      */
-    public function testParseStatusCode()
+    public function testParseStatusCode(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Posts/view');
@@ -136,10 +120,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with the persist option
-     *
-     * @return void
      */
-    public function testParsePersist()
+    public function testParsePersist(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Posts/view/2');
@@ -150,10 +132,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with persist and a base directory
-     *
-     * @return void
      */
-    public function testParsePersistBaseDirectory()
+    public function testParsePersistBaseDirectory(): void
     {
         $request = new ServerRequest([
             'base' => '/basedir',
@@ -170,10 +150,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with persist and string target URLs
-     *
-     * @return void
      */
-    public function testParsePersistStringUrl()
+    public function testParsePersistStringUrl(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/test');
@@ -184,10 +162,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with persist and passed args
-     *
-     * @return void
      */
-    public function testParsePersistPassedArgs()
+    public function testParsePersistPassedArgs(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Tags/add/passme');
@@ -198,10 +174,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting without persist and passed args
-     *
-     * @return void
      */
-    public function testParseNoPersistPassedArgs()
+    public function testParseNoPersistPassedArgs(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Tags/add');
@@ -212,10 +186,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with patterns
-     *
-     * @return void
      */
-    public function testParsePersistPatterns()
+    public function testParsePersistPatterns(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/Tags/add');
@@ -226,10 +198,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * test redirecting with patterns and a routed target
-     *
-     * @return void
      */
-    public function testParsePersistMatchesAnotherRoute()
+    public function testParsePersistMatchesAnotherRoute(): void
     {
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/nl/preferred_controllers');
@@ -241,10 +211,8 @@ class RedirectRouteTest extends TestCase
 
     /**
      * Test setting HTTP status
-     *
-     * @return void
      */
-    public function testSetStatus()
+    public function testSetStatus(): void
     {
         $route = new RedirectRoute('/home', ['controller' => 'Posts']);
         $result = $route->setStatus(302);

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -30,8 +30,6 @@ class RouteTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -39,9 +37,9 @@ class RouteTest extends TestCase
         Configure::write('Routing', ['prefixes' => []]);
     }
 
-    public function testDeprecatedPlaceholders()
+    public function testDeprecatedPlaceholders(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $route = new Route('/:controller/:action/:id');
             $route->compile();
 
@@ -51,10 +49,8 @@ class RouteTest extends TestCase
 
     /**
      * Test the construction of a Route
-     *
-     * @return void
      */
-    public function testConstruction()
+    public function testConstruction(): void
     {
         $route = new Route('/{controller}/{action}/{id}', [], ['id' => '[0-9]+']);
 
@@ -64,7 +60,7 @@ class RouteTest extends TestCase
         $this->assertFalse($route->compiled());
     }
 
-    public function testConstructionWithInvalidMethod()
+    public function testConstructionWithInvalidMethod(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
@@ -73,10 +69,8 @@ class RouteTest extends TestCase
 
     /**
      * Test set middleware in the constructor
-     *
-     * @return void
      */
-    public function testConstructorSetMiddleware()
+    public function testConstructorSetMiddleware(): void
     {
         $route = new Route('/{controller}/{action}/*', [], ['_middleware' => ['auth', 'cookie']]);
         $this->assertSame(['auth', 'cookie'], $route->getMiddleware());
@@ -84,10 +78,8 @@ class RouteTest extends TestCase
 
     /**
      * Test Route compiling.
-     *
-     * @return void
      */
-    public function testBasicRouteCompiling()
+    public function testBasicRouteCompiling(): void
     {
         $route = new Route('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
         $result = $route->compile();
@@ -123,10 +115,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that single letter placeholders work.
-     *
-     * @return void
      */
-    public function testRouteCompileSmallPlaceholders()
+    public function testRouteCompileSmallPlaceholders(): void
     {
         $route = new Route(
             '/fighters/{id}/move/{x}/{y}',
@@ -148,10 +138,8 @@ class RouteTest extends TestCase
 
     /**
      * Test route compile with brace format.
-     *
-     * @return void
      */
-    public function testRouteCompileBraces()
+    public function testRouteCompileBraces(): void
     {
         $route = new Route(
             '/fighters/{id}/move/{x}/{y}',
@@ -187,10 +175,8 @@ class RouteTest extends TestCase
 
     /**
      * Test route compile with brace format.
-     *
-     * @return void
      */
-    public function testRouteCompileBracesVariableName()
+    public function testRouteCompileBracesVariableName(): void
     {
         $route = new Route(
             '/fighters/{0id}',
@@ -211,10 +197,8 @@ class RouteTest extends TestCase
 
     /**
      * Test route compile with brace format.
-     *
-     * @return void
      */
-    public function testRouteCompileBracesInvalid()
+    public function testRouteCompileBracesInvalid(): void
     {
         $route = new Route(
             '/fighters/{ id }',
@@ -231,10 +215,8 @@ class RouteTest extends TestCase
 
     /**
      * Test route compile with mixed placeholder types brace format.
-     *
-     * @return void
      */
-    public function testRouteCompileMixedPlaceholders()
+    public function testRouteCompileMixedPlaceholders(): void
     {
         $route = new Route(
             '/images/{open/{id}',
@@ -269,10 +251,8 @@ class RouteTest extends TestCase
 
     /**
      * Test parsing routes with extensions.
-     *
-     * @return void
      */
-    public function testRouteParsingWithExtensions()
+    public function testRouteParsingWithExtensions(): void
     {
         $route = new Route(
             '/{controller}/{action}/*',
@@ -302,7 +282,7 @@ class RouteTest extends TestCase
     /**
      * @return array
      */
-    public function provideMatchParseExtension()
+    public function provideMatchParseExtension(): array
     {
         return [
             ['/foo/bar.xml', ['/foo/bar', 'xml'], ['xml', 'json', 'xml.gz']],
@@ -321,10 +301,9 @@ class RouteTest extends TestCase
      * @param string $url
      * @param array $expected
      * @param array $ext
-     * @return void
      * @dataProvider provideMatchParseExtension
      */
-    public function testMatchParseExtension($url, array $expected, array $ext)
+    public function testMatchParseExtension($url, array $expected, array $ext): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', [], ['_ext' => $ext]);
         $result = $route->parseExtension($url);
@@ -334,7 +313,7 @@ class RouteTest extends TestCase
     /**
      * @return array
      */
-    public function provideNoMatchParseExtension()
+    public function provideNoMatchParseExtension(): array
     {
         return [
             ['/foo/bar', ['xml']],
@@ -351,10 +330,9 @@ class RouteTest extends TestCase
      *
      * @param string $url
      * @param array $ext
-     * @return void
      * @dataProvider provideNoMatchParseExtension
      */
-    public function testNoMatchParseExtension($url, array $ext)
+    public function testNoMatchParseExtension($url, array $ext): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', [], ['_ext' => $ext]);
         [$outUrl, $outExt] = $route->parseExtension($url);
@@ -364,10 +342,8 @@ class RouteTest extends TestCase
 
     /**
      * Expects extensions to be set
-     *
-     * @return void
      */
-    public function testSetExtensions()
+    public function testSetExtensions(): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', []);
         $this->assertEquals([], $route->getExtensions());
@@ -384,10 +360,8 @@ class RouteTest extends TestCase
 
     /**
      * Expects extensions to be return.
-     *
-     * @return void
      */
-    public function testGetExtensions()
+    public function testGetExtensions(): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', []);
         $this->assertEquals([], $route->getExtensions());
@@ -403,10 +377,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that route parameters that overlap don't cause errors.
-     *
-     * @return void
      */
-    public function testRouteParameterOverlap()
+    public function testRouteParameterOverlap(): void
     {
         $route = new Route('/invoices/add/{idd}/{id}', ['controller' => 'Invoices', 'action' => 'add']);
         $result = $route->compile();
@@ -419,10 +391,8 @@ class RouteTest extends TestCase
 
     /**
      * Test compiling routes with keys that have patterns
-     *
-     * @return void
      */
-    public function testRouteCompilingWithParamPatterns()
+    public function testRouteCompilingWithParamPatterns(): void
     {
         $route = new Route(
             '/{controller}/{action}/{id}',
@@ -489,10 +459,8 @@ class RouteTest extends TestCase
 
     /**
      * Test route with unicode
-     *
-     * @return void
      */
-    public function testCompileWithUnicodePatterns()
+    public function testCompileWithUnicodePatterns(): void
     {
         $route = new Route(
             '/test/{slug}',
@@ -514,10 +482,8 @@ class RouteTest extends TestCase
     /**
      * Test more complex route compiling & parsing with mid route greedy stars
      * and optional routing parameters
-     *
-     * @return void
      */
-    public function testComplexRouteCompilingAndParsing()
+    public function testComplexRouteCompilingAndParsing(): void
     {
         $route = new Route(
             '/posts/{month}/{day}/{year}/*',
@@ -574,10 +540,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that routes match their pattern.
-     *
-     * @return void
      */
-    public function testMatchBasic()
+    public function testMatchBasic(): void
     {
         $route = new Route('/{controller}/{action}/{id}', ['plugin' => null]);
         $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'plugin' => null]);
@@ -655,10 +619,8 @@ class RouteTest extends TestCase
 
     /**
      * Test match() with persist option
-     *
-     * @return void
      */
-    public function testMatchWithPersistOption()
+    public function testMatchWithPersistOption(): void
     {
         $context = [
             'params' => ['lang' => 'en'],
@@ -673,10 +635,8 @@ class RouteTest extends TestCase
 
     /**
      * Test match() with _host and other keys.
-     *
-     * @return void
      */
-    public function testMatchWithHostKeys()
+    public function testMatchWithHostKeys(): void
     {
         $context = [
             '_host' => 'foo.com',
@@ -747,10 +707,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that the _host option sets the default host.
-     *
-     * @return void
      */
-    public function testMatchWithHostOption()
+    public function testMatchWithHostOption(): void
     {
         $route = new Route(
             '/fallback',
@@ -766,10 +724,8 @@ class RouteTest extends TestCase
 
     /**
      * Test wildcard host options
-     *
-     * @return void
      */
-    public function testMatchWithHostWildcardOption()
+    public function testMatchWithHostWildcardOption(): void
     {
         $route = new Route(
             '/fallback',
@@ -824,10 +780,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that non-greedy routes fail with extra passed args
-     *
-     * @return void
      */
-    public function testMatchGreedyRouteFailurePassedArg()
+    public function testMatchGreedyRouteFailurePassedArg(): void
     {
         $route = new Route('/{controller}/{action}', ['plugin' => null]);
         $result = $route->match(['controller' => 'Posts', 'action' => 'view', '0']);
@@ -840,10 +794,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that falsey values do not interrupt a match.
-     *
-     * @return void
      */
-    public function testMatchWithFalseyValues()
+    public function testMatchWithFalseyValues(): void
     {
         $route = new Route('/{controller}/{action}/*', ['plugin' => null]);
         $result = $route->match([
@@ -854,10 +806,8 @@ class RouteTest extends TestCase
 
     /**
      * Test match() with greedy routes, and passed args.
-     *
-     * @return void
      */
-    public function testMatchWithPassedArgs()
+    public function testMatchWithPassedArgs(): void
     {
         $route = new Route('/{controller}/{action}/*', ['plugin' => null]);
 
@@ -887,10 +837,8 @@ class RouteTest extends TestCase
     /**
      * Test that the pass option lets you use positional arguments for the
      * route elements that were named.
-     *
-     * @return void
      */
-    public function testMatchWithPassOption()
+    public function testMatchWithPassOption(): void
     {
         $route = new Route(
             '/blog/{id}-{slug}',
@@ -933,10 +881,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that match() with pass and greedy routes.
-     *
-     * @return void
      */
-    public function testMatchWithPassOptionGreedy()
+    public function testMatchWithPassOptionGreedy(): void
     {
         $route = new Route(
             '/blog/{id}-{slug}/*',
@@ -968,10 +914,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that extensions work.
-     *
-     * @return void
      */
-    public function testMatchWithExtension()
+    public function testMatchWithExtension(): void
     {
         $route = new Route('/{controller}/{action}');
         $result = $route->match([
@@ -1016,10 +960,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that match with patterns works.
-     *
-     * @return void
      */
-    public function testMatchWithPatterns()
+    public function testMatchWithPatterns(): void
     {
         $route = new Route('/{controller}/{action}/{id}', ['plugin' => null], ['id' => '[0-9]+']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'view', 'id' => 'foo']);
@@ -1040,10 +982,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that match() with multibyte pattern
-     *
-     * @return void
      */
-    public function testMatchWithMultibytePattern()
+    public function testMatchWithMultibytePattern(): void
     {
         $route = new Route(
             '/articles/{action}/{id}',
@@ -1060,10 +1000,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that match() matches explicit GET routes
-     *
-     * @return void
      */
-    public function testMatchWithExplicitGet()
+    public function testMatchWithExplicitGet(): void
     {
         $route = new Route(
             '/anything',
@@ -1078,10 +1016,8 @@ class RouteTest extends TestCase
 
     /**
      * Test separartor.
-     *
-     * @return void
      */
-    public function testQueryStringGeneration()
+    public function testQueryStringGeneration(): void
     {
         $route = new Route('/{controller}/{action}/*');
 
@@ -1106,10 +1042,8 @@ class RouteTest extends TestCase
     /**
      * Ensure that parseRequest() calls parse() as that is required
      * for backwards compat
-     *
-     * @return void
      */
-    public function testParseRequestDelegates()
+    public function testParseRequestDelegates(): void
     {
         /** @var \Cake\Routing\Route\Route|\PHPUnit\Framework\MockObject\MockObject $route */
         $route = $this->getMockBuilder('Cake\Routing\Route\Route')
@@ -1134,10 +1068,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that parseRequest() applies host conditions
-     *
-     * @return void
      */
-    public function testParseRequestHostConditions()
+    public function testParseRequestHostConditions(): void
     {
         $route = new Route(
             '/fallback',
@@ -1180,10 +1112,8 @@ class RouteTest extends TestCase
 
     /**
      * test the parse method of Route.
-     *
-     * @return void
      */
-    public function testParse()
+    public function testParse(): void
     {
         $route = new Route(
             '/{controller}/{action}/{id}',
@@ -1225,10 +1155,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that :key elements are urldecoded
-     *
-     * @return void
      */
-    public function testParseUrlDecodeElements()
+    public function testParseUrlDecodeElements(): void
     {
         $route = new Route(
             '/{controller}/{slug}',
@@ -1248,10 +1176,8 @@ class RouteTest extends TestCase
 
     /**
      * Test numerically indexed defaults, get appended to pass
-     *
-     * @return void
      */
-    public function testParseWithPassDefaults()
+    public function testParseWithPassDefaults(): void
     {
         $route = new Route('/{controller}', ['action' => 'display', 'home']);
         $result = $route->parse('/Posts', 'GET');
@@ -1266,10 +1192,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that middleware is returned from parse()
-     *
-     * @return void
      */
-    public function testParseWithMiddleware()
+    public function testParseWithMiddleware(): void
     {
         $route = new Route('/{controller}', ['action' => 'display', 'home']);
         $route->setMiddleware(['auth', 'cookie']);
@@ -1286,10 +1210,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that http header conditions can cause route failures.
-     *
-     * @return void
      */
-    public function testParseWithHttpHeaderConditions()
+    public function testParseWithHttpHeaderConditions(): void
     {
         $route = new Route('/sample', ['controller' => 'Posts', 'action' => 'index', '_method' => 'POST']);
         $this->assertNull($route->parse('/sample', 'GET'));
@@ -1307,10 +1229,8 @@ class RouteTest extends TestCase
     /**
      * Test that http header conditions can cause route failures.
      * And that http method names are normalized.
-     *
-     * @return void
      */
-    public function testParseWithMultipleHttpMethodConditions()
+    public function testParseWithMultipleHttpMethodConditions(): void
     {
         $route = new Route('/sample', [
             'controller' => 'Posts',
@@ -1331,10 +1251,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that http header conditions can work with URL generation
-     *
-     * @return void
      */
-    public function testMatchWithMultipleHttpMethodConditions()
+    public function testMatchWithMultipleHttpMethodConditions(): void
     {
         $route = new Route('/sample', [
             'controller' => 'Posts',
@@ -1378,10 +1296,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that patterns work for {action}
-     *
-     * @return void
      */
-    public function testPatternOnAction()
+    public function testPatternOnAction(): void
     {
         $route = new Route(
             '/blog/{action}/*',
@@ -1409,10 +1325,8 @@ class RouteTest extends TestCase
 
     /**
      * Test the parseArgs method
-     *
-     * @return void
      */
-    public function testParsePassedArgument()
+    public function testParsePassedArgument(): void
     {
         $route = new Route('/{controller}/{action}/*');
         $result = $route->parse('/Posts/edit/1/2/0', 'GET');
@@ -1427,10 +1341,8 @@ class RouteTest extends TestCase
 
     /**
      * Test matching of parameters where one parameter name starts with another parameter name
-     *
-     * @return void
      */
-    public function testMatchSimilarParameters()
+    public function testMatchSimilarParameters(): void
     {
         $route = new Route('/{thisParam}/{thisParamIsLonger}');
 
@@ -1446,10 +1358,8 @@ class RouteTest extends TestCase
 
     /**
      * Test match() with trailing ** style routes.
-     *
-     * @return void
      */
-    public function testMatchTrailing()
+    public function testMatchTrailing(): void
     {
         $route = new Route('/pages/**', ['controller' => 'Pages', 'action' => 'display']);
         $id = 'test/ spaces/漢字/la†în';
@@ -1464,10 +1374,8 @@ class RouteTest extends TestCase
 
     /**
      * Test match handles optional keys
-     *
-     * @return void
      */
-    public function testMatchNullValueOptionalKey()
+    public function testMatchNullValueOptionalKey(): void
     {
         $route = new Route('/path/{optional}/fixed');
         $this->assertSame('/path/fixed', $route->match(['optional' => null]));
@@ -1478,10 +1386,8 @@ class RouteTest extends TestCase
 
     /**
      * Test matching fails on required keys (controller/action)
-     *
-     * @return void
      */
-    public function testMatchControllerRequiredKeys()
+    public function testMatchControllerRequiredKeys(): void
     {
         $route = new Route('/{controller}/', ['action' => 'index']);
         $this->assertNull($route->match(['controller' => null, 'action' => 'index']));
@@ -1492,10 +1398,8 @@ class RouteTest extends TestCase
 
     /**
      * Test restructuring args with pass key
-     *
-     * @return void
      */
-    public function testPassArgRestructure()
+    public function testPassArgRestructure(): void
     {
         $route = new Route('/{controller}/{action}/{slug}', [], [
             'pass' => ['slug'],
@@ -1513,10 +1417,8 @@ class RouteTest extends TestCase
 
     /**
      * Test the /** special type on parsing.
-     *
-     * @return void
      */
-    public function testParseTrailing()
+    public function testParseTrailing(): void
     {
         $route = new Route('/{controller}/{action}/**');
         $result = $route->parse('/Posts/index/1/2/3/foo:bar', 'GET');
@@ -1540,10 +1442,8 @@ class RouteTest extends TestCase
 
     /**
      * Test the /** special type on parsing - UTF8.
-     *
-     * @return void
      */
-    public function testParseTrailingUTF8()
+    public function testParseTrailingUTF8(): void
     {
         $route = new Route('/category/**', ['controller' => 'Categories', 'action' => 'index']);
         $result = $route->parse('/category/%D9%85%D9%88%D8%A8%D8%A7%DB%8C%D9%84', 'GET');
@@ -1558,10 +1458,8 @@ class RouteTest extends TestCase
 
     /**
      * Test getName();
-     *
-     * @return void
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $route = new Route('/foo/bar', [], ['_name' => 'testing']);
         $this->assertSame('', $route->getName());
@@ -1590,10 +1488,8 @@ class RouteTest extends TestCase
 
     /**
      * Test getName() with plugins.
-     *
-     * @return void
      */
-    public function testGetNamePlugins()
+    public function testGetNamePlugins(): void
     {
         $route = new Route(
             '/a/{controller}/{action}',
@@ -1616,10 +1512,8 @@ class RouteTest extends TestCase
 
     /**
      * Test getName() with prefixes.
-     *
-     * @return void
      */
-    public function testGetNamePrefix()
+    public function testGetNamePrefix(): void
     {
         $route = new Route(
             '/admin/{controller}/{action}',
@@ -1648,10 +1542,8 @@ class RouteTest extends TestCase
 
     /**
      * Test that utf-8 patterns work for {section}
-     *
-     * @return void
      */
-    public function testUTF8PatternOnSection()
+    public function testUTF8PatternOnSection(): void
     {
         $route = new Route(
             '/{section}',
@@ -1688,10 +1580,9 @@ class RouteTest extends TestCase
     /**
      * Test getting the static path for a route.
      *
-     * @return void
      * @deprecated
      */
-    public function testStaticPath()
+    public function testStaticPath(): void
     {
         $route = new Route('/pages/:id/*', ['controller' => 'Pages', 'action' => 'display']);
         $this->assertSame('/pages/', $route->staticPath());
@@ -1705,10 +1596,8 @@ class RouteTest extends TestCase
 
     /**
      * Test getting the static path for a route.
-     *
-     * @return void
      */
-    public function testStaticPathBrace()
+    public function testStaticPathBrace(): void
     {
         $route = new Route('/*', ['controller' => 'Pages', 'action' => 'display']);
         $this->assertSame('/', $route->staticPath());
@@ -1731,10 +1620,8 @@ class RouteTest extends TestCase
 
     /**
      * Test for __set_state magic method on CakeRoute
-     *
-     * @return void
      */
-    public function testSetState()
+    public function testSetState(): void
     {
         $route = Route::__set_state([
             'keys' => [],
@@ -1762,10 +1649,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting the method on a route.
-     *
-     * @return void
      */
-    public function testSetMethods()
+    public function testSetMethods(): void
     {
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
         $result = $route->setMethods(['put']);
@@ -1779,10 +1664,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting the method on a route to an invalid method
-     *
-     * @return void
      */
-    public function testSetMethodsInvalid()
+    public function testSetMethodsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
@@ -1792,10 +1675,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting patterns through the method
-     *
-     * @return void
      */
-    public function testSetPatterns()
+    public function testSetPatterns(): void
     {
         $route = new Route('/reviews/{date}/{id}', ['controller' => 'Reviews', 'action' => 'view']);
         $result = $route->setPatterns([
@@ -1814,10 +1695,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting patterns enables multibyte mode
-     *
-     * @return void
      */
-    public function testSetPatternsMultibyte()
+    public function testSetPatternsMultibyte(): void
     {
         $route = new Route('/reviews/{accountid}/{slug}', ['controller' => 'Reviews', 'action' => 'view']);
         $result = $route->setPatterns([
@@ -1831,10 +1710,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting host requirements
-     *
-     * @return void
      */
-    public function testSetHost()
+    public function testSetHost(): void
     {
         $route = new Route('/reviews', ['controller' => 'Reviews', 'action' => 'index']);
         $result = $route->setHost('blog.example.com');
@@ -1855,10 +1732,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting pass parameters
-     *
-     * @return void
      */
-    public function testSetPass()
+    public function testSetPass(): void
     {
         $route = new Route('/reviews/{date}/{id}', ['controller' => 'Reviews', 'action' => 'view']);
         $result = $route->setPass(['date', 'id']);
@@ -1868,10 +1743,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting persisted parameters
-     *
-     * @return void
      */
-    public function testSetPersist()
+    public function testSetPersist(): void
     {
         $route = new Route('/reviews/{date}/{id}', ['controller' => 'Reviews', 'action' => 'view']);
         $result = $route->setPersist(['date']);
@@ -1881,10 +1754,8 @@ class RouteTest extends TestCase
 
     /**
      * Test setting/getting middleware.
-     *
-     * @return void
      */
-    public function testSetMiddleware()
+    public function testSetMiddleware(): void
     {
         $route = new Route('/reviews/{date}/{id}', ['controller' => 'Reviews', 'action' => 'view']);
         $result = $route->setMiddleware(['auth', 'cookie']);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -38,8 +38,6 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Teardown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -60,10 +56,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test path()
-     *
-     * @return void
      */
-    public function testPath()
+    public function testPath(): void
     {
         $routes = new RouteBuilder($this->collection, '/some/path');
         $this->assertSame('/some/path', $routes->path());
@@ -80,10 +74,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test params()
-     *
-     * @return void
      */
-    public function testParams()
+    public function testParams(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $this->assertEquals(['prefix' => 'Api'], $routes->params());
@@ -91,10 +83,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test getting connected routes.
-     *
-     * @return void
      */
-    public function testRoutes()
+    public function testRoutes(): void
     {
         $routes = new RouteBuilder($this->collection, '/l');
         $routes->connect('/{controller}', ['action' => 'index']);
@@ -108,10 +98,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test setting default route class
-     *
-     * @return void
      */
-    public function testRouteClass()
+    public function testRouteClass(): void
     {
         $routes = new RouteBuilder(
             $this->collection,
@@ -138,10 +126,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting an instance routes.
-     *
-     * @return void
      */
-    public function testConnectInstance()
+    public function testConnectInstance(): void
     {
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
 
@@ -154,10 +140,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting basic routes.
-     *
-     * @return void
      */
-    public function testConnectBasic()
+    public function testConnectBasic(): void
     {
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
 
@@ -172,10 +156,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that compiling a route results in an trailing / optional pattern.
-     *
-     * @return void
      */
-    public function testConnectTrimTrailingSlash()
+    public function testConnectTrimTrailingSlash(): void
     {
         $routes = new RouteBuilder($this->collection, '/articles', ['controller' => 'Articles']);
         $routes->connect('/', ['action' => 'index']);
@@ -193,10 +175,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connect() with short string syntax
-     *
-     * @return void
      */
-    public function testConnectShortStringInvalid()
+    public function testConnectShortStringInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $routes = new RouteBuilder($this->collection, '/');
@@ -205,10 +185,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connect() with short string syntax
-     *
-     * @return void
      */
-    public function testConnectShortString()
+    public function testConnectShortString(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/my-articles/view', 'Articles::view');
@@ -228,10 +206,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connect() with short string syntax
-     *
-     * @return void
      */
-    public function testConnectShortStringPrefix()
+    public function testConnectShortStringPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/admin/bookmarks', 'Admin/Bookmarks::index');
@@ -252,10 +228,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connect() with short string syntax
-     *
-     * @return void
      */
-    public function testConnectShortStringPlugin()
+    public function testConnectShortStringPlugin(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/blog/articles/view', 'Blog.Articles::view');
@@ -275,10 +249,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connect() with short string syntax
-     *
-     * @return void
      */
-    public function testConnectShortStringPluginPrefix()
+    public function testConnectShortStringPluginPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/admin/blog/articles/view', 'Vendor/Blog.Management/Admin/Articles::view');
@@ -299,10 +271,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test if a route name already exist
-     *
-     * @return void
      */
-    public function testNameExists()
+    public function testNameExists(): void
     {
         $routes = new RouteBuilder($this->collection, '/l', ['prefix' => 'Api']);
         $this->assertFalse($routes->nameExists('myRouteName'));
@@ -313,10 +283,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test setExtensions() and getExtensions().
-     *
-     * @return void
      */
-    public function testExtensions()
+    public function testExtensions(): void
     {
         $routes = new RouteBuilder($this->collection, '/l');
         $this->assertSame($routes, $routes->setExtensions(['html']));
@@ -325,10 +293,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test extensions being connected to routes.
-     *
-     * @return void
      */
-    public function testConnectExtensions()
+    public function testConnectExtensions(): void
     {
         $routes = new RouteBuilder(
             $this->collection,
@@ -352,10 +318,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test adding additional extensions will be merged with current.
-     *
-     * @return void
      */
-    public function testConnectExtensionsAdd()
+    public function testConnectExtensionsAdd(): void
     {
         $routes = new RouteBuilder(
             $this->collection,
@@ -374,10 +338,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * test that setExtensions() accepts a string.
-     *
-     * @return void
      */
-    public function testExtensionsString()
+    public function testExtensionsString(): void
     {
         $routes = new RouteBuilder($this->collection, '/l');
         $routes->setExtensions('json');
@@ -387,10 +349,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test error on invalid route class
-     *
-     * @return void
      */
-    public function testConnectErrorInvalidRouteClass()
+    public function testConnectErrorInvalidRouteClass(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Route class not found, or route class is not a subclass of');
@@ -405,10 +365,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test conflicting parameters raises an exception.
-     *
-     * @return void
      */
-    public function testConnectConflictingParameters()
+    public function testConnectConflictingParameters(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('You cannot define routes that conflict with the scope.');
@@ -418,10 +376,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting redirect routes.
-     *
-     * @return void
      */
-    public function testRedirect()
+    public function testRedirect(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->redirect('/p/{id}', ['controller' => 'Posts', 'action' => 'view'], ['status' => 301]);
@@ -442,10 +398,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test using a custom route class for redirect routes.
-     *
-     * @return void
      */
-    public function testRedirectWithCustomRouteClass()
+    public function testRedirectWithCustomRouteClass(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
 
@@ -457,13 +411,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with prefix()
-     *
-     * @return void
      */
-    public function testPrefix()
+    public function testPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
-        $res = $routes->prefix('admin', ['param' => 'value'], function (RouteBuilder $r) {
+        $res = $routes->prefix('admin', ['param' => 'value'], function (RouteBuilder $r): void {
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertSame('/path/admin', $r->path());
@@ -474,13 +426,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with prefix()
-     *
-     * @return void
      */
-    public function testPrefixWithNoParams()
+    public function testPrefixWithNoParams(): void
     {
         $routes = new RouteBuilder($this->collection, '/path', ['key' => 'value']);
-        $res = $routes->prefix('admin', function (RouteBuilder $r) {
+        $res = $routes->prefix('admin', function (RouteBuilder $r): void {
             $this->assertInstanceOf(RouteBuilder::class, $r);
             $this->assertCount(0, $this->collection->routes());
             $this->assertSame('/path/admin', $r->path());
@@ -491,13 +441,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with prefix()
-     *
-     * @return void
      */
-    public function testNestedPrefix()
+    public function testNestedPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'Admin']);
-        $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function (RouteBuilder $r) {
+        $res = $routes->prefix('api', ['_namePrefix' => 'api:'], function (RouteBuilder $r): void {
             $this->assertSame('/admin/api', $r->path());
             $this->assertEquals(['prefix' => 'Admin/Api'], $r->params());
             $this->assertSame('api:', $r->namePrefix());
@@ -507,17 +455,15 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with prefix()
-     *
-     * @return void
      */
-    public function testPathWithDotInPrefix()
+    public function testPathWithDotInPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/admin', ['prefix' => 'Admin']);
-        $res = $routes->prefix('Api', function (RouteBuilder $r) {
-            $r->prefix('v10', ['path' => '/v1.0'], function (RouteBuilder $r2) {
+        $res = $routes->prefix('Api', function (RouteBuilder $r): void {
+            $r->prefix('v10', ['path' => '/v1.0'], function (RouteBuilder $r2): void {
                 $this->assertSame('/admin/api/v1.0', $r2->path());
                 $this->assertEquals(['prefix' => 'Admin/Api/V10'], $r2->params());
-                $r2->prefix('b1', ['path' => '/beta.1'], function (RouteBuilder $r3) {
+                $r2->prefix('b1', ['path' => '/beta.1'], function (RouteBuilder $r3): void {
                     $this->assertSame('/admin/api/v1.0/beta.1', $r3->path());
                     $this->assertEquals(['prefix' => 'Admin/Api/V10/B1'], $r3->params());
                 });
@@ -528,13 +474,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with plugin()
-     *
-     * @return void
      */
-    public function testPlugin()
+    public function testPlugin(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
-        $res = $routes->plugin('Contacts', function (RouteBuilder $r) {
+        $res = $routes->plugin('Contacts', function (RouteBuilder $r): void {
             $this->assertSame('/b/contacts', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
 
@@ -550,13 +494,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with plugin() + path option
-     *
-     * @return void
      */
-    public function testPluginPathOption()
+    public function testPluginPathOption(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
-        $routes->plugin('Contacts', ['path' => '/people'], function (RouteBuilder $r) {
+        $routes->plugin('Contacts', ['path' => '/people'], function (RouteBuilder $r): void {
             $this->assertSame('/b/people', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
         });
@@ -564,29 +506,25 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test creating sub-scopes with plugin() + namePrefix option
-     *
-     * @return void
      */
-    public function testPluginNamePrefix()
+    public function testPluginNamePrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
-        $routes->plugin('Contacts', ['_namePrefix' => 'contacts.'], function (RouteBuilder $r) {
+        $routes->plugin('Contacts', ['_namePrefix' => 'contacts.'], function (RouteBuilder $r): void {
             $this->assertEquals('contacts.', $r->namePrefix());
         });
 
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->namePrefix('default.');
-        $routes->plugin('Blog', ['_namePrefix' => 'blog.'], function (RouteBuilder $r) {
+        $routes->plugin('Blog', ['_namePrefix' => 'blog.'], function (RouteBuilder $r): void {
             $this->assertEquals('default.blog.', $r->namePrefix(), 'Should combine nameprefix');
         });
     }
 
     /**
      * Test connecting resources.
-     *
-     * @return void
      */
-    public function testResources()
+    public function testResources(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', ['_ext' => 'json']);
@@ -605,13 +543,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources with a path
-     *
-     * @return void
      */
-    public function testResourcesPathOption()
+    public function testResourcesPathOption(): void
     {
         $routes = new RouteBuilder($this->collection, '/api');
-        $routes->resources('Articles', ['path' => 'posts'], function (RouteBuilder $routes) {
+        $routes->resources('Articles', ['path' => 'posts'], function (RouteBuilder $routes): void {
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();
@@ -627,10 +563,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources with a prefix
-     *
-     * @return void
      */
-    public function testResourcesPrefix()
+    public function testResourcesPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->resources('Articles', ['prefix' => 'Rest']);
@@ -640,10 +574,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that resource prefixes work within a prefixed scope.
-     *
-     * @return void
      */
-    public function testResourcesNestedPrefix()
+    public function testResourcesNestedPrefix(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', ['prefix' => 'Rest']);
@@ -660,10 +592,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources with the inflection option
-     *
-     * @return void
      */
-    public function testResourcesInflection()
+    public function testResourcesInflection(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('BlogPosts', ['_ext' => 'json', 'inflect' => 'dasherize']);
@@ -681,16 +611,14 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting nested resources with the inflection option
-     *
-     * @return void
      */
-    public function testResourcesNestedInflection()
+    public function testResourcesNestedInflection(): void
     {
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->resources(
             'NetworkObjects',
             ['inflect' => 'dasherize'],
-            function (RouteBuilder $routes) {
+            function (RouteBuilder $routes): void {
                 $routes->resources('Attributes');
             }
         );
@@ -705,10 +633,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources with additional mappings
-     *
-     * @return void
      */
-    public function testResourcesMappings()
+    public function testResourcesMappings(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', [
@@ -741,10 +667,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources with restricted mappings.
-     *
-     * @return void
      */
-    public function testResourcesWithMapOnly()
+    public function testResourcesWithMapOnly(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->resources('Articles', [
@@ -766,12 +690,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources.
-     *
-     * @return void
      */
-    public function testResourcesInScope()
+    public function testResourcesInScope(): void
     {
-        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes) {
+        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });
@@ -797,10 +719,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test resource parsing.
-     *
-     * @return void
      */
-    public function testResourcesParsing()
+    public function testResourcesParsing(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->resources('Articles');
@@ -833,10 +753,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test the only option of RouteBuilder.
-     *
-     * @return void
      */
-    public function testResourcesOnlyString()
+    public function testResourcesOnlyString(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->resources('Articles', ['only' => 'index']);
@@ -848,10 +766,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test the only option of RouteBuilder.
-     *
-     * @return void
      */
-    public function testResourcesOnlyArray()
+    public function testResourcesOnlyArray(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->resources('Articles', ['only' => ['index', 'delete']]);
@@ -869,10 +785,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test the actions option of RouteBuilder.
-     *
-     * @return void
      */
-    public function testResourcesActions()
+    public function testResourcesActions(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->resources('Articles', [
@@ -891,13 +805,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test nesting resources
-     *
-     * @return void
      */
-    public function testResourcesNested()
+    public function testResourcesNested(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
-        $routes->resources('Articles', function (RouteBuilder $routes) {
+        $routes->resources('Articles', function (RouteBuilder $routes): void {
             $this->assertSame('/api/articles/', $routes->path());
             $this->assertEquals(['prefix' => 'Api'], $routes->params());
 
@@ -909,10 +821,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting fallback routes.
-     *
-     * @return void
      */
-    public function testFallbacks()
+    public function testFallbacks(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->fallbacks();
@@ -925,10 +835,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting fallback routes with specific route class
-     *
-     * @return void
      */
-    public function testFallbacksWithClass()
+    public function testFallbacksWithClass(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->fallbacks('InflectedRoute');
@@ -941,10 +849,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting fallback routes after setting default route class.
-     *
-     * @return void
      */
-    public function testDefaultRouteClassFallbacks()
+    public function testDefaultRouteClassFallbacks(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
         $routes->setRouteClass('TestApp\Routing\Route\DashedRoute');
@@ -956,13 +862,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test adding a scope.
-     *
-     * @return void
      */
-    public function testScope()
+    public function testScope(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
-        $routes->scope('/v1', ['version' => 1], function (RouteBuilder $routes) {
+        $routes->scope('/v1', ['version' => 1], function (RouteBuilder $routes): void {
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'Api', 'version' => 1], $routes->params());
         });
@@ -970,13 +874,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test adding a scope with action in the scope
-     *
-     * @return void
      */
-    public function testScopeWithAction()
+    public function testScopeWithAction(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
-        $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function (RouteBuilder $routes) {
+        $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function (RouteBuilder $routes): void {
             $routes->connect('/shared', ['shared' => true]);
             $routes->get('/exclusive', ['exclusive' => true]);
         });
@@ -991,10 +893,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that exception is thrown if callback is not a valid callable.
-     *
-     * @return void
      */
-    public function testScopeException()
+    public function testScopeException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Need a valid callable to connect routes. Got `string` instead.');
@@ -1005,10 +905,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that nested scopes inherit middleware.
-     *
-     * @return void
      */
-    public function testScopeInheritMiddleware()
+    public function testScopeInheritMiddleware(): void
     {
         $routes = new RouteBuilder(
             $this->collection,
@@ -1016,7 +914,7 @@ class RouteBuilderTest extends TestCase
             ['prefix' => 'Api'],
             ['middleware' => ['auth']]
         );
-        $routes->scope('/v1', function (RouteBuilder $routes) {
+        $routes->scope('/v1', function (RouteBuilder $routes): void {
             $this->assertSame(['auth'], $routes->getMiddleware(), 'Should inherit middleware');
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'Api'], $routes->params());
@@ -1025,13 +923,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test using name prefixes.
-     *
-     * @return void
      */
-    public function testNamePrefixes()
+    public function testNamePrefixes(): void
     {
         $routes = new RouteBuilder($this->collection, '/api', [], ['namePrefix' => 'api:']);
-        $routes->scope('/v1', ['version' => 1, '_namePrefix' => 'v1:'], function (RouteBuilder $routes) {
+        $routes->scope('/v1', ['version' => 1, '_namePrefix' => 'v1:'], function (RouteBuilder $routes): void {
             $this->assertSame('api:v1:', $routes->namePrefix());
             $routes->connect('/ping', ['controller' => 'Pings'], ['_name' => 'ping']);
 
@@ -1046,12 +942,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test adding middleware to the collection.
-     *
-     * @return void
      */
-    public function testRegisterMiddleware()
+    public function testRegisterMiddleware(): void
     {
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $result = $routes->registerMiddleware('test', $func);
@@ -1063,12 +957,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test middleware group
-     *
-     * @return void
      */
-    public function testMiddlewareGroup()
+    public function testMiddlewareGroup(): void
     {
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func);
@@ -1082,14 +974,12 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test overlap between middleware name and group name
-     *
-     * @return void
      */
-    public function testMiddlewareGroupOverlap()
+    public function testMiddlewareGroupOverlap(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot add middleware group \'test\'. A middleware by this name has already been registered.');
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func);
@@ -1098,10 +988,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test applying middleware to a scope when it doesn't exist
-     *
-     * @return void
      */
-    public function testApplyMiddlewareInvalidName()
+    public function testApplyMiddlewareInvalidName(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot apply \'bad\' middleware or middleware group. Use registerMiddleware() to register middleware');
@@ -1111,12 +999,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test applying middleware to a scope
-     *
-     * @return void
      */
-    public function testApplyMiddleware()
+    public function testApplyMiddleware(): void
     {
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1128,12 +1014,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that applyMiddleware() merges with previous data.
-     *
-     * @return void
      */
-    public function testApplyMiddlewareMerges()
+    public function testApplyMiddlewareMerges(): void
     {
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1146,12 +1030,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that applyMiddleware() uses unique middleware set
-     *
-     * @return void
      */
-    public function testApplyMiddlewareUnique()
+    public function testApplyMiddlewareUnique(): void
     {
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1165,12 +1047,10 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test applying middleware results in middleware attached to the route.
-     *
-     * @return void
      */
-    public function testApplyMiddlewareAttachToRoutes()
+    public function testApplyMiddlewareAttachToRoutes(): void
     {
-        $func = function () {
+        $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->registerMiddleware('test', $func)
@@ -1201,9 +1081,8 @@ class RouteBuilderTest extends TestCase
      * Test that the HTTP method helpers create the right kind of routes.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testHttpMethods(string $method)
+    public function testHttpMethods(string $method): void
     {
         $routes = new RouteBuilder($this->collection, '/', [], ['namePrefix' => 'app:']);
         $route = $routes->{strtolower($method)}(
@@ -1225,9 +1104,8 @@ class RouteBuilderTest extends TestCase
      * Test that the HTTP method helpers create the right kind of routes.
      *
      * @dataProvider httpMethodProvider
-     * @return void
      */
-    public function testHttpMethodsStringTarget(string $method)
+    public function testHttpMethodsStringTarget(string $method): void
     {
         $routes = new RouteBuilder($this->collection, '/', [], ['namePrefix' => 'app:']);
         $route = $routes->{strtolower($method)}(
@@ -1247,13 +1125,11 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Integration test for http method helpers and route fluent method
-     *
-     * @return void
      */
-    public function testHttpMethodIntegration()
+    public function testHttpMethodIntegration(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->scope('/', function (RouteBuilder $routes) {
+        $routes->scope('/', function (RouteBuilder $routes): void {
             $routes->get('/faq/{page}', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
                 ->setPatterns(['page' => '[a-z0-9_]+'])
                 ->setHost('docs.example.com');
@@ -1271,10 +1147,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test loading routes from a missing plugin
-     *
-     * @return void
      */
-    public function testLoadPluginBadPlugin()
+    public function testLoadPluginBadPlugin(): void
     {
         $this->expectException(\Cake\Core\Exception\MissingPluginException::class);
         $routes = new RouteBuilder($this->collection, '/');
@@ -1283,10 +1157,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test loading routes with success
-     *
-     * @return void
      */
-    public function testLoadPlugin()
+    public function testLoadPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $routes = new RouteBuilder($this->collection, '/');

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -32,8 +32,6 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parse() throws an error on unknown routes.
-     *
-     * @return void
      */
-    public function testParseMissingRoute()
+    public function testParseMissingRoute(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "/" could not be found');
@@ -60,10 +56,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parse() throws an error on known routes called with unknown methods.
-     *
-     * @return void
      */
-    public function testParseMissingRouteMethod()
+    public function testParseMissingRouteMethod(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $this->expectExceptionMessage('A "POST" route matching "/b" could not be found');
@@ -78,10 +72,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parsing routes.
-     *
-     * @return void
      */
-    public function testParse()
+    public function testParse(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
@@ -137,10 +129,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parsing routes with and without _name.
-     *
-     * @return void
      */
-    public function testParseWithNameParameter()
+    public function testParseWithNameParameter(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
@@ -199,10 +189,8 @@ class RouteCollectionTest extends TestCase
     /**
      * Test that parse decodes URL data before matching.
      * This is important for multibyte URLs that pass through URL rewriting.
-     *
-     * @return void
      */
-    public function testParseEncodedBytesInFixedSegment()
+    public function testParseEncodedBytesInFixedSegment(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/ден/{day}-{month}', ['controller' => 'Events', 'action' => 'index']);
@@ -227,10 +215,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test that parsing checks all the related path scopes.
-     *
-     * @return void
      */
-    public function testParseFallback()
+    public function testParseFallback(): void
     {
         $routes = new RouteBuilder($this->collection, '/', []);
 
@@ -252,10 +238,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parseRequest() throws an error on unknown routes.
-     *
-     * @return void
      */
-    public function testParseRequestMissingRoute()
+    public function testParseRequestMissingRoute(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "/" could not be found');
@@ -270,10 +254,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parseRequest() checks host conditions
-     *
-     * @return void
      */
-    public function testParseRequestCheckHostCondition()
+    public function testParseRequestCheckHostCondition(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect(
@@ -340,7 +322,7 @@ class RouteCollectionTest extends TestCase
      *
      * @dataProvider hostProvider
      */
-    public function testParseRequestCheckHostConditionFail(string $host)
+    public function testParseRequestCheckHostConditionFail(string $host): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "/fallback" could not be found');
@@ -362,10 +344,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parsing routes.
-     *
-     * @return void
      */
-    public function testParseRequest()
+    public function testParseRequest(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
@@ -425,10 +405,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parsing routes that match non-ascii urls
-     *
-     * @return void
      */
-    public function testParseRequestUnicode()
+    public function testParseRequestUnicode(): void
     {
         $routes = new RouteBuilder($this->collection, '/b', []);
         $routes->connect('/alta/confirmación', ['controller' => 'Media', 'action' => 'confirm']);
@@ -451,10 +429,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test match() throws an error on unknown routes.
-     *
-     * @return void
      */
-    public function testMatchError()
+    public function testMatchError(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "array (');
@@ -471,10 +447,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test matching routes.
-     *
-     * @return void
      */
-    public function testMatch()
+    public function testMatch(): void
     {
         $context = [
             '_base' => '/',
@@ -497,10 +471,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test matching routes with names
-     *
-     * @return void
      */
-    public function testMatchNamed()
+    public function testMatchNamed(): void
     {
         $context = [
             '_base' => '/',
@@ -520,10 +492,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test match() throws an error on named routes that fail to match
-     *
-     * @return void
      */
-    public function testMatchNamedError()
+    public function testMatchNamedError(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $this->expectExceptionMessage('A named route was found for `fail`, but matching failed');
@@ -540,10 +510,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test matching routes with names and failing
-     *
-     * @return void
      */
-    public function testMatchNamedMissingError()
+    public function testMatchNamedMissingError(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         $context = [
@@ -559,10 +527,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test matching plugin routes.
-     *
-     * @return void
      */
-    public function testMatchPlugin()
+    public function testMatchPlugin(): void
     {
         $context = [
             '_base' => '/',
@@ -581,10 +547,8 @@ class RouteCollectionTest extends TestCase
      *
      * Connect the admin route after the non prefixed version, this means
      * the non-prefix route would have a more specific name (users:index)
-     *
-     * @return void
      */
-    public function testMatchPrefixSpecificity()
+    public function testMatchPrefixSpecificity(): void
     {
         $context = [
             '_base' => '/',
@@ -615,10 +579,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test getting named routes.
-     *
-     * @return void
      */
-    public function testNamed()
+    public function testNamed(): void
     {
         $routes = new RouteBuilder($this->collection, '/l');
         $routes->connect('/{controller}', ['action' => 'index'], ['_name' => 'cntrl']);
@@ -632,10 +594,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test the add() and routes() method.
-     *
-     * @return void
      */
-    public function testAddingRoutes()
+    public function testAddingRoutes(): void
     {
         $one = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
         $two = new Route('/', ['controller' => 'Dashboards', 'action' => 'display']);
@@ -650,10 +610,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test the add() with some _name.
-     *
-     * @return void
      */
-    public function testAddingDuplicateNamedRoutes()
+    public function testAddingDuplicateNamedRoutes(): void
     {
         $this->expectException(\Cake\Routing\Exception\DuplicateNamedRouteException::class);
         $one = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
@@ -664,10 +622,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test basic setExtension and its getter.
-     *
-     * @return void
      */
-    public function testSetExtensions()
+    public function testSetExtensions(): void
     {
         $this->assertEquals([], $this->collection->getExtensions());
 
@@ -683,12 +639,10 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test adding middleware to the collection.
-     *
-     * @return void
      */
-    public function testRegisterMiddleware()
+    public function testRegisterMiddleware(): void
     {
-        $result = $this->collection->registerMiddleware('closure', function () {
+        $result = $this->collection->registerMiddleware('closure', function (): void {
         });
         $this->assertSame($result, $this->collection);
 
@@ -706,12 +660,10 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test adding a middleware group to the collection.
-     *
-     * @return void
      */
-    public function testMiddlewareGroup()
+    public function testMiddlewareGroup(): void
     {
-        $this->collection->registerMiddleware('closure', function () {
+        $this->collection->registerMiddleware('closure', function (): void {
         });
 
         $mock = $this->getMockBuilder('\stdClass')
@@ -727,12 +679,10 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test adding a middleware group with the same name overwrites the original list
-     *
-     * @return void
      */
-    public function testMiddlewareGroupOverwrite()
+    public function testMiddlewareGroupOverwrite(): void
     {
-        $stub = function () {
+        $stub = function (): void {
         };
         $this->collection->registerMiddleware('closure', $stub);
         $result = $this->collection->registerMiddleware('callable', $stub);
@@ -745,10 +695,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test adding ab unregistered middleware to a middleware group fails.
-     *
-     * @return void
      */
-    public function testMiddlewareGroupUnregisteredMiddleware()
+    public function testMiddlewareGroupUnregisteredMiddleware(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot add \'bad\' middleware to group \'group\'. It has not been registered.');

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -34,8 +34,6 @@ class RouterTest extends TestCase
 {
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -46,8 +44,6 @@ class RouterTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -58,12 +54,10 @@ class RouterTest extends TestCase
 
     /**
      * testFullBaseUrl method
-     *
-     * @return void
      */
-    public function testBaseUrl()
+    public function testBaseUrl(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks();
         });
         $this->assertMatchesRegularExpression('/^http(s)?:\/\//', Router::url('/', true));
@@ -73,12 +67,10 @@ class RouterTest extends TestCase
 
     /**
      * Tests that the base URL can be changed at runtime.
-     *
-     * @return void
      */
-    public function testFullBaseURL()
+    public function testFullBaseURL(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks();
         });
         Router::fullBaseUrl('http://example.com');
@@ -92,10 +84,8 @@ class RouterTest extends TestCase
     /**
      * Test that Router uses App.base to build URL's when there are no stored
      * request objects.
-     *
-     * @return void
      */
-    public function testBaseUrlWithBasePath()
+    public function testBaseUrlWithBasePath(): void
     {
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
@@ -105,14 +95,12 @@ class RouterTest extends TestCase
     /**
      * Test that Router uses App.base to build URL's when there are no stored
      * request objects.
-     *
-     * @return void
      */
-    public function testBaseUrlWithBasePathArrayUrl()
+    public function testBaseUrlWithBasePathArrayUrl(): void
     {
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->get('/{controller}', ['action' => 'index']);
         });
 
@@ -134,10 +122,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that Router uses the correct url including base path for requesting the current actions.
-     *
-     * @return void
      */
-    public function testCurrentUrlWithBasePath()
+    public function testCurrentUrlWithBasePath(): void
     {
         Router::fullBaseUrl('http://example.com');
         $request = new ServerRequest([
@@ -158,10 +144,8 @@ class RouterTest extends TestCase
     /**
      * Test that full base URL can be generated from request context too if
      * App.fullBaseUrl is not set.
-     *
-     * @return void
      */
-    public function testFullBaseURLFromRequest()
+    public function testFullBaseURLFromRequest(): void
     {
         Configure::write('App.fullBaseUrl', false);
         $server = [
@@ -175,10 +159,8 @@ class RouterTest extends TestCase
 
     /**
      * testRouteExists method
-     *
-     * @return void
      */
-    public function testRouteExists()
+    public function testRouteExists(): void
     {
         Router::connect('/posts/{action}', ['controller' => 'Posts']);
         $this->assertTrue(Router::routeExists(['controller' => 'Posts', 'action' => 'view']));
@@ -188,10 +170,8 @@ class RouterTest extends TestCase
 
     /**
      * testMultipleResourceRoute method
-     *
-     * @return void
      */
-    public function testMultipleResourceRoute()
+    public function testMultipleResourceRoute(): void
     {
         Router::connect('/{controller}', ['action' => 'index', '_method' => ['GET', 'POST']]);
 
@@ -220,12 +200,10 @@ class RouterTest extends TestCase
 
     /**
      * testGenerateUrlResourceRoute method
-     *
-     * @return void
      */
-    public function testGenerateUrlResourceRoute()
+    public function testGenerateUrlResourceRoute(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->resources('Posts');
         });
 
@@ -275,10 +253,8 @@ class RouterTest extends TestCase
 
     /**
      * testUrlNormalization method
-     *
-     * @return void
      */
-    public function testUrlNormalization()
+    public function testUrlNormalization(): void
     {
         Router::connect('/{controller}/{action}');
 
@@ -346,10 +322,8 @@ class RouterTest extends TestCase
 
     /**
      * Test generating urls with base paths.
-     *
-     * @return void
      */
-    public function testUrlGenerationWithBasePath()
+    public function testUrlGenerationWithBasePath(): void
     {
         Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
@@ -388,10 +362,8 @@ class RouterTest extends TestCase
 
     /**
      * Test url() with _host option routes with request context
-     *
-     * @return void
      */
-    public function testUrlGenerationHostOptionRequestContext()
+    public function testUrlGenerationHostOptionRequestContext(): void
     {
         $server = [
             'HTTP_HOST' => 'foo.example.com',
@@ -416,10 +388,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that catch all routes work with a variety of falsey inputs.
-     *
-     * @return void
      */
-    public function testUrlCatchAllRoute()
+    public function testUrlCatchAllRoute(): void
     {
         Router::connect('/*', ['controller' => 'Categories', 'action' => 'index']);
         $result = Router::url(['controller' => 'Categories', 'action' => 'index', '0']);
@@ -441,10 +411,8 @@ class RouterTest extends TestCase
 
     /**
      * test generation of basic urls.
-     *
-     * @return void
      */
-    public function testUrlGenerationBasic()
+    public function testUrlGenerationBasic(): void
     {
         /**
          * @var string $ID
@@ -550,10 +518,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that generated names for routes are case-insensitive.
-     *
-     * @return void
      */
-    public function testRouteNameCasing()
+    public function testRouteNameCasing(): void
     {
         Router::connect('/articles/{id}', ['controller' => 'Articles', 'action' => 'view']);
         Router::connect('/{controller}/{action}/*', [], ['routeClass' => 'InflectedRoute']);
@@ -564,10 +530,8 @@ class RouterTest extends TestCase
 
     /**
      * Test generation of routes with query string parameters.
-     *
-     * @return void
      */
-    public function testUrlGenerationWithQueryStrings()
+    public function testUrlGenerationWithQueryStrings(): void
     {
         Router::connect('/{controller}/{action}/*');
 
@@ -597,10 +561,8 @@ class RouterTest extends TestCase
 
     /**
      * test that regex validation of keyed route params is working.
-     *
-     * @return void
      */
-    public function testUrlGenerationWithRegexQualifiedParams()
+    public function testUrlGenerationWithRegexQualifiedParams(): void
     {
         Router::connect(
             '{language}/galleries',
@@ -691,10 +653,8 @@ class RouterTest extends TestCase
 
     /**
      * Test URL generation with an admin prefix
-     *
-     * @return void
      */
-    public function testUrlGenerationWithPrefix()
+    public function testUrlGenerationWithPrefix(): void
     {
         Router::reload();
 
@@ -867,13 +827,11 @@ class RouterTest extends TestCase
 
     /**
      * Test URL generation inside a prefixed plugin.
-     *
-     * @return void
      */
-    public function testUrlGenerationPrefixedPlugin()
+    public function testUrlGenerationPrefixedPlugin(): void
     {
-        Router::prefix('admin', function (RouteBuilder $routes) {
-            $routes->plugin('MyPlugin', function (RouteBuilder $routes) {
+        Router::prefix('admin', function (RouteBuilder $routes): void {
+            $routes->plugin('MyPlugin', function (RouteBuilder $routes): void {
                 $routes->fallbacks('InflectedRoute');
             });
         });
@@ -890,13 +848,11 @@ class RouterTest extends TestCase
 
     /**
      * Test URL generation with multiple prefixes.
-     *
-     * @return void
      */
-    public function testUrlGenerationMultiplePrefixes()
+    public function testUrlGenerationMultiplePrefixes(): void
     {
-        Router::prefix('admin', function (RouteBuilder $routes) {
-            $routes->prefix('backoffice', function (RouteBuilder $routes) {
+        Router::prefix('admin', function (RouteBuilder $routes): void {
+            $routes->prefix('backoffice', function (RouteBuilder $routes): void {
                 $routes->fallbacks('InflectedRoute');
             });
         });
@@ -911,10 +867,8 @@ class RouterTest extends TestCase
 
     /**
      * testUrlGenerationWithExtensions method
-     *
-     * @return void
      */
-    public function testUrlGenerationWithExtensions()
+    public function testUrlGenerationWithExtensions(): void
     {
         Router::connect('/{controller}', ['action' => 'index']);
         Router::connect('/{controller}/{action}');
@@ -961,13 +915,11 @@ class RouterTest extends TestCase
 
     /**
      * test url() when the current request has an extension.
-     *
-     * @return void
      */
-    public function testUrlGenerationWithExtensionInCurrentRequest()
+    public function testUrlGenerationWithExtensionInCurrentRequest(): void
     {
         Router::extensions('rss');
-        Router::scope('/', function (RouteBuilder $r) {
+        Router::scope('/', function (RouteBuilder $r): void {
             $r->fallbacks('InflectedRoute');
         });
         $request = new ServerRequest([
@@ -996,7 +948,7 @@ class RouterTest extends TestCase
     /**
      * Test url generation with named routes.
      */
-    public function testUrlGenerationNamedRoute()
+    public function testUrlGenerationNamedRoute(): void
     {
         Router::connect(
             '/users',
@@ -1038,10 +990,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that using invalid names causes exceptions.
-     *
-     * @return void
      */
-    public function testNamedRouteException()
+    public function testNamedRouteException(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
@@ -1054,10 +1004,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that using duplicate names causes exceptions.
-     *
-     * @return void
      */
-    public function testDuplicateNamedRouteException()
+    public function testDuplicateNamedRouteException(): void
     {
         $this->expectException(\Cake\Routing\Exception\DuplicateNamedRouteException::class);
         Router::connect(
@@ -1079,10 +1027,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that url filters are applied to url params.
-     *
-     * @return void
      */
-    public function testUrlGenerationWithUrlFilter()
+    public function testUrlGenerationWithUrlFilter(): void
     {
         Router::connect('/{lang}/{controller}/{action}/*');
         $request = new ServerRequest([
@@ -1115,10 +1061,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that url filter failure gives better errors
-     *
-     * @return void
      */
-    public function testUrlGenerationWithUrlFilterFailureClosure()
+    public function testUrlGenerationWithUrlFilterFailureClosure(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches(
@@ -1136,7 +1080,7 @@ class RouterTest extends TestCase
         ]);
         Router::setRequest($request);
 
-        Router::addUrlFilter(function ($url, $request) {
+        Router::addUrlFilter(function ($url, $request): void {
             throw new RuntimeException('nope');
         });
         Router::url(['controller' => 'Posts', 'action' => 'index', 'lang' => 'en']);
@@ -1144,10 +1088,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that url filter failure gives better errors
-     *
-     * @return void
      */
-    public function testUrlGenerationWithUrlFilterFailureMethod()
+    public function testUrlGenerationWithUrlFilterFailureMethod(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches(
@@ -1174,17 +1116,15 @@ class RouterTest extends TestCase
      *
      * @throws \RuntimeException
      */
-    public function badFilter()
+    public function badFilter(): void
     {
         throw new RuntimeException('nope');
     }
 
     /**
      * Test url param persistence.
-     *
-     * @return void
      */
-    public function testUrlParamPersistence()
+    public function testUrlParamPersistence(): void
     {
         Router::connect('/{lang}/{controller}/{action}/*', [], ['persist' => ['lang']]);
         $request = new ServerRequest([
@@ -1204,10 +1144,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that plain strings urls work
-     *
-     * @return void
      */
-    public function testUrlGenerationPlainString()
+    public function testUrlGenerationPlainString(): void
     {
         $mailto = 'mailto:mark@example.com';
         $result = Router::url($mailto);
@@ -1224,10 +1162,8 @@ class RouterTest extends TestCase
 
     /**
      * test that you can leave active plugin routes with plugin = null
-     *
-     * @return void
      */
-    public function testCanLeavePlugin()
+    public function testCanLeavePlugin(): void
     {
         Router::connect('/admin/{controller}', ['action' => 'index', 'prefix' => 'Admin']);
         Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
@@ -1248,10 +1184,8 @@ class RouterTest extends TestCase
 
     /**
      * testUrlParsing method
-     *
-     * @return void
      */
-    public function testUrlParsing()
+    public function testUrlParsing(): void
     {
         /**
          * @var string $ID
@@ -1526,10 +1460,8 @@ class RouterTest extends TestCase
 
     /**
      * test parseRequest
-     *
-     * @return void
      */
-    public function testParseRequest()
+    public function testParseRequest(): void
     {
         Router::connect('/articles/{action}/*', ['controller' => 'Articles']);
         $request = new ServerRequest(['url' => '/articles/view/1']);
@@ -1546,10 +1478,8 @@ class RouterTest extends TestCase
 
     /**
      * testUuidRoutes method
-     *
-     * @return void
      */
-    public function testUuidRoutes()
+    public function testUuidRoutes(): void
     {
         Router::connect(
             '/subjects/add/{category_id}',
@@ -1570,10 +1500,8 @@ class RouterTest extends TestCase
 
     /**
      * testRouteSymmetry method
-     *
-     * @return void
      */
-    public function testRouteSymmetry()
+    public function testRouteSymmetry(): void
     {
         Router::connect(
             '/{extra}/page/{slug}/*',
@@ -1636,7 +1564,7 @@ class RouterTest extends TestCase
     /**
      * Test exceptions when parsing fails.
      */
-    public function testParseError()
+    public function testParseError(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
@@ -1646,10 +1574,9 @@ class RouterTest extends TestCase
     /**
      * Test parse and reverse symmetry
      *
-     * @return void
      * @dataProvider parseReverseSymmetryData
      */
-    public function testParseReverseSymmetry(string $url)
+    public function testParseReverseSymmetry(string $url): void
     {
         $this->_connectDefaultRoutes();
         $this->assertSame($url, Router::reverse(Router::parseRequest($this->makeRequest($url, 'GET')) + ['url' => []]));
@@ -1660,7 +1587,7 @@ class RouterTest extends TestCase
      *
      * @return array
      */
-    public function parseReverseSymmetryData()
+    public function parseReverseSymmetryData(): array
     {
         return [
             ['/controller/action'],
@@ -1672,10 +1599,8 @@ class RouterTest extends TestCase
 
     /**
      * testSetExtensions method
-     *
-     * @return void
      */
-    public function testSetExtensions()
+    public function testSetExtensions(): void
     {
         Router::extensions('rss', false);
         $this->assertContains('rss', Router::extensions());
@@ -1693,18 +1618,16 @@ class RouterTest extends TestCase
 
     /**
      * Test that route builders propagate extensions to the top.
-     *
-     * @return void
      */
-    public function testExtensionsWithScopedRoutes()
+    public function testExtensionsWithScopedRoutes(): void
     {
         Router::extensions(['json']);
 
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->setExtensions('rss');
             $routes->connect('/', ['controller' => 'Pages', 'action' => 'index']);
 
-            $routes->scope('/api', function (RouteBuilder $routes) {
+            $routes->scope('/api', function (RouteBuilder $routes): void {
                 $routes->setExtensions('xml');
                 $routes->connect('/docs', ['controller' => 'ApiDocs', 'action' => 'index']);
             });
@@ -1715,12 +1638,10 @@ class RouterTest extends TestCase
 
     /**
      * Test connecting resources.
-     *
-     * @return void
      */
-    public function testResourcesInScope()
+    public function testResourcesInScope(): void
     {
-        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes) {
+        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });
@@ -1746,10 +1667,8 @@ class RouterTest extends TestCase
 
     /**
      * testExtensionParsing method
-     *
-     * @return void
      */
-    public function testExtensionParsing()
+    public function testExtensionParsing(): void
     {
         Router::extensions('rss', false);
         $this->_connectDefaultRoutes();
@@ -1850,10 +1769,9 @@ class RouterTest extends TestCase
     /**
      * Test newer style automatically generated prefix routes.
      *
-     * @return void
      * @see testUrlGenerationWithAutoPrefixes
      */
-    public function testUrlGenerationWithAutoPrefixes()
+    public function testUrlGenerationWithAutoPrefixes(): void
     {
         Router::reload();
         Router::connect('/protected/{controller}/{action}/*', ['prefix' => 'Protected']);
@@ -1908,10 +1826,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that the ssl option works.
-     *
-     * @return void
      */
-    public function testGenerationWithSslOption()
+    public function testGenerationWithSslOption(): void
     {
         Router::fullBaseUrl('http://app.test');
         Router::connect('/{controller}/{action}/*');
@@ -1937,10 +1853,8 @@ class RouterTest extends TestCase
 
     /**
      * Test ssl option when the current request is ssl.
-     *
-     * @return void
      */
-    public function testGenerateWithSslInSsl()
+    public function testGenerateWithSslInSsl(): void
     {
         Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
@@ -1967,10 +1881,8 @@ class RouterTest extends TestCase
 
     /**
      * test that prefix routes persist when they are in the current request.
-     *
-     * @return void
      */
-    public function testPrefixRoutePersistence()
+    public function testPrefixRoutePersistence(): void
     {
         Router::reload();
         Router::connect('/protected/{controller}/{action}', ['prefix' => 'Protected']);
@@ -2002,10 +1914,8 @@ class RouterTest extends TestCase
 
     /**
      * test that setting a prefix override the current one
-     *
-     * @return void
      */
-    public function testPrefixOverride()
+    public function testPrefixOverride(): void
     {
         Router::connect('/admin/{controller}/{action}', ['prefix' => 'Admin']);
         Router::connect('/protected/{controller}/{action}', ['prefix' => 'Protected']);
@@ -2036,10 +1946,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that well known route parameters are passed through.
-     *
-     * @return void
      */
-    public function testRouteParamDefaults()
+    public function testRouteParamDefaults(): void
     {
         Router::connect('/cache/*', ['prefix' => false, 'plugin' => true, 'controller' => 0, 'action' => 1]);
 
@@ -2064,10 +1972,8 @@ class RouterTest extends TestCase
 
     /**
      * testRemoveBase method
-     *
-     * @return void
      */
-    public function testRemoveBase()
+    public function testRemoveBase(): void
     {
         Router::connect('/{controller}/{action}');
         $request = new ServerRequest([
@@ -2090,10 +1996,8 @@ class RouterTest extends TestCase
 
     /**
      * testPagesUrlParsing method
-     *
-     * @return void
      */
-    public function testPagesUrlParsing()
+    public function testPagesUrlParsing(): void
     {
         Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
         Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
@@ -2148,10 +2052,8 @@ class RouterTest extends TestCase
 
     /**
      * test that requests with a trailing dot don't loose the do.
-     *
-     * @return void
      */
-    public function testParsingWithTrailingPeriod()
+    public function testParsingWithTrailingPeriod(): void
     {
         Router::reload();
         Router::connect('/{controller}/{action}/*');
@@ -2164,10 +2066,8 @@ class RouterTest extends TestCase
 
     /**
      * test that requests with a trailing dot don't loose the do.
-     *
-     * @return void
      */
-    public function testParsingWithTrailingPeriodAndParseExtensions()
+    public function testParsingWithTrailingPeriodAndParseExtensions(): void
     {
         Router::reload();
         Router::connect('/{controller}/{action}/*');
@@ -2181,10 +2081,8 @@ class RouterTest extends TestCase
 
     /**
      * test that patterns work for {action}
-     *
-     * @return void
      */
-    public function testParsingWithPatternOnAction()
+    public function testParsingWithPatternOnAction(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
@@ -2208,10 +2106,8 @@ class RouterTest extends TestCase
 
     /**
      * Test parseRoutePath() with valid strings
-     *
-     * @return void
      */
-    public function testParseRoutePath()
+    public function testParseRoutePath(): void
     {
         $expected = [
             'controller' => 'Bookmarks',
@@ -2270,10 +2166,9 @@ class RouterTest extends TestCase
     /**
      * Test parseRoutePath() with invalid strings
      *
-     * @return void
      * @dataProvider invalidRoutePathProvider
      */
-    public function testParseInvalidRoutePath(string $value)
+    public function testParseInvalidRoutePath(string $value): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not parse a string route path');
@@ -2284,8 +2179,6 @@ class RouterTest extends TestCase
     /**
      * Tests that convenience wrapper urlArray() works as the internal
      * Router::parseRoutePath() does.
-     *
-     * @return void
      */
     public function testUrlArray(): void
     {
@@ -2319,10 +2212,8 @@ class RouterTest extends TestCase
 
     /**
      * Test url() works with patterns on {action}
-     *
-     * @return void
      */
-    public function testUrlPatternOnAction()
+    public function testUrlPatternOnAction(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect(
@@ -2340,10 +2231,8 @@ class RouterTest extends TestCase
 
     /**
      * testParsingWithLiteralPrefixes method
-     *
-     * @return void
      */
-    public function testParsingWithLiteralPrefixes()
+    public function testParsingWithLiteralPrefixes(): void
     {
         Router::reload();
         $adminParams = ['prefix' => 'Admin'];
@@ -2407,10 +2296,8 @@ class RouterTest extends TestCase
 
     /**
      * Tests URL generation with flags and prefixes in and out of context
-     *
-     * @return void
      */
-    public function testUrlWritingWithPrefixes()
+    public function testUrlWritingWithPrefixes(): void
     {
         Router::connect('/company/{controller}/{action}/*', ['prefix' => 'Company']);
         Router::connect('/{action}', ['controller' => 'Users']);
@@ -2437,10 +2324,8 @@ class RouterTest extends TestCase
 
     /**
      * test url generation with prefixes and custom routes
-     *
-     * @return void
      */
-    public function testUrlWritingWithPrefixesAndCustomRoutes()
+    public function testUrlWritingWithPrefixesAndCustomRoutes(): void
     {
         Router::connect(
             '/admin/login',
@@ -2466,10 +2351,8 @@ class RouterTest extends TestCase
 
     /**
      * testPassedArgsOrder method
-     *
-     * @return void
      */
-    public function testPassedArgsOrder()
+    public function testPassedArgsOrder(): void
     {
         Router::connect('/test-passed/*', ['controller' => 'Pages', 'action' => 'display', 'home']);
         Router::connect('/test2/*', ['controller' => 'Pages', 'action' => 'display', 2]);
@@ -2490,10 +2373,8 @@ class RouterTest extends TestCase
 
     /**
      * testRegexRouteMatching method
-     *
-     * @return void
      */
-    public function testRegexRouteMatching()
+    public function testRegexRouteMatching(): void
     {
         Router::connect('/{locale}/{controller}/{action}/*', [], ['locale' => 'dan|eng']);
 
@@ -2511,10 +2392,8 @@ class RouterTest extends TestCase
 
     /**
      * testRegexRouteMatching method
-     *
-     * @return void
      */
-    public function testRegexRouteMatchUrl()
+    public function testRegexRouteMatchUrl(): void
     {
         $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
         Router::connect('/{locale}/{controller}/{action}/*', [], ['locale' => 'dan|eng']);
@@ -2541,10 +2420,8 @@ class RouterTest extends TestCase
 
     /**
      * test using a custom route class for route connection
-     *
-     * @return void
      */
-    public function testUsingCustomRouteClass()
+    public function testUsingCustomRouteClass(): void
     {
         $this->loadPlugins(['TestPlugin']);
         Router::connect(
@@ -2566,10 +2443,8 @@ class RouterTest extends TestCase
 
     /**
      * test using custom route class in PluginDot notation
-     *
-     * @return void
      */
-    public function testUsingCustomRouteClassPluginDotSyntax()
+    public function testUsingCustomRouteClassPluginDotSyntax(): void
     {
         $this->loadPlugins(['TestPlugin']);
         Router::connect(
@@ -2583,16 +2458,14 @@ class RouterTest extends TestCase
 
     /**
      * test that route classes must extend \Cake\Routing\Route\Route
-     *
-     * @return void
      */
-    public function testCustomRouteException()
+    public function testCustomRouteException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Router::connect('/{controller}', [], ['routeClass' => 'Object']);
     }
 
-    public function testReverseLocalized()
+    public function testReverseLocalized(): void
     {
         Router::reload();
         Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
@@ -2607,7 +2480,7 @@ class RouterTest extends TestCase
         $this->assertSame('/eng/Posts/view/1', $result);
     }
 
-    public function testReverseArrayQuery()
+    public function testReverseArrayQuery(): void
     {
         Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $params = [
@@ -2632,7 +2505,7 @@ class RouterTest extends TestCase
         $this->assertSame('/eng/Posts/view/1', $result);
     }
 
-    public function testReverseCakeRequestQuery()
+    public function testReverseCakeRequestQuery(): void
     {
         Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $request = new ServerRequest([
@@ -2650,9 +2523,9 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testReverseFull()
+    public function testReverseFull(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks();
         });
         $params = [
@@ -2668,10 +2541,8 @@ class RouterTest extends TestCase
 
     /**
      * Test that extensions work with Router::reverse()
-     *
-     * @return void
      */
-    public function testReverseWithExtension()
+    public function testReverseWithExtension(): void
     {
         Router::connect('/{controller}/{action}/*');
         Router::extensions('json', false);
@@ -2690,7 +2561,7 @@ class RouterTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testReverseToArrayQuery()
+    public function testReverseToArrayQuery(): void
     {
         Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $params = [
@@ -2711,7 +2582,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testReverseToArrayRequestQuery()
+    public function testReverseToArrayRequestQuery(): void
     {
         Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $request = new ServerRequest([
@@ -2739,10 +2610,8 @@ class RouterTest extends TestCase
 
     /**
      * test get request.
-     *
-     * @return void
      */
-    public function testGetRequest()
+    public function testGetRequest(): void
     {
         $requestA = new ServerRequest(['url' => '/']);
         Router::setRequest($requestA);
@@ -2755,10 +2624,8 @@ class RouterTest extends TestCase
 
     /**
      * test that a route object returning a full URL is not modified.
-     *
-     * @return void
      */
-    public function testUrlFullUrlReturnFromRoute()
+    public function testUrlFullUrlReturnFromRoute(): void
     {
         $url = 'http://example.com/posts/view/1';
 
@@ -2777,10 +2644,8 @@ class RouterTest extends TestCase
 
     /**
      * test protocol in url
-     *
-     * @return void
      */
-    public function testUrlProtocol()
+    public function testUrlProtocol(): void
     {
         $url = 'http://example.com';
         $this->assertSame($url, Router::url($url));
@@ -2819,10 +2684,8 @@ class RouterTest extends TestCase
 
     /**
      * Testing that patterns on the {action} param work properly.
-     *
-     * @return void
      */
-    public function testPatternOnAction()
+    public function testPatternOnAction(): void
     {
         $route = new Route(
             '/blog/{action}/*',
@@ -2850,12 +2713,10 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() method
-     *
-     * @return void
      */
-    public function testScope()
+    public function testScope(): void
     {
-        Router::scope('/path', ['param' => 'value'], function (RouteBuilder $routes) {
+        Router::scope('/path', ['param' => 'value'], function (RouteBuilder $routes): void {
             $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
             $this->assertSame('', $routes->namePrefix());
@@ -2866,10 +2727,8 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() method
-     *
-     * @return void
      */
-    public function testScopeError()
+    public function testScopeError(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Router::scope('/path', 'derpy');
@@ -2878,13 +2737,11 @@ class RouterTest extends TestCase
     /**
      * Test to ensure that extensions defined in scopes don't leak.
      * And that global extensions are propagated.
-     *
-     * @return void
      */
-    public function testScopeExtensionsContained()
+    public function testScopeExtensionsContained(): void
     {
         Router::extensions(['json']);
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $this->assertEquals(['json'], $routes->getExtensions(), 'Should default to global extensions.');
             $routes->setExtensions(['rss']);
 
@@ -2898,13 +2755,13 @@ class RouterTest extends TestCase
 
         $this->assertEquals(['json', 'rss'], array_values(Router::extensions()));
 
-        Router::scope('/api', function (RouteBuilder $routes) {
+        Router::scope('/api', function (RouteBuilder $routes): void {
             $this->assertEquals(['json'], $routes->getExtensions(), 'Should default to global extensions.');
 
             $routes->setExtensions(['json', 'csv']);
             $routes->connect('/export', []);
 
-            $routes->scope('/v1', function (RouteBuilder $routes) {
+            $routes->scope('/v1', function (RouteBuilder $routes): void {
                 $this->assertEquals(['json', 'csv'], $routes->getExtensions());
             });
         });
@@ -2914,13 +2771,11 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() options
-     *
-     * @return void
      */
-    public function testScopeOptions()
+    public function testScopeOptions(): void
     {
         $options = ['param' => 'value', 'routeClass' => 'InflectedRoute', 'extensions' => ['json']];
-        Router::scope('/path', $options, function (RouteBuilder $routes) {
+        Router::scope('/path', $options, function (RouteBuilder $routes): void {
             $this->assertSame('InflectedRoute', $routes->getRouteClass());
             $this->assertSame(['json'], $routes->getExtensions());
             $this->assertSame('/path', $routes->path());
@@ -2930,12 +2785,10 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() method
-     *
-     * @return void
      */
-    public function testScopeNamePrefix()
+    public function testScopeNamePrefix(): void
     {
-        Router::scope('/path', ['param' => 'value', '_namePrefix' => 'path:'], function (RouteBuilder $routes) {
+        Router::scope('/path', ['param' => 'value', '_namePrefix' => 'path:'], function (RouteBuilder $routes): void {
             $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
             $this->assertSame('path:', $routes->namePrefix());
@@ -2946,17 +2799,15 @@ class RouterTest extends TestCase
 
     /**
      * Test that prefix() creates a scope.
-     *
-     * @return void
      */
-    public function testPrefix()
+    public function testPrefix(): void
     {
-        Router::prefix('admin', function (RouteBuilder $routes) {
+        Router::prefix('admin', function (RouteBuilder $routes): void {
             $this->assertSame('/admin', $routes->path());
             $this->assertEquals(['prefix' => 'Admin'], $routes->params());
         });
 
-        Router::prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes) {
+        Router::prefix('admin', ['_namePrefix' => 'admin:'], function (RouteBuilder $routes): void {
             $this->assertSame('admin:', $routes->namePrefix());
             $this->assertEquals(['prefix' => 'Admin'], $routes->params());
         });
@@ -2964,17 +2815,15 @@ class RouterTest extends TestCase
 
     /**
      * Test that prefix() accepts options
-     *
-     * @return void
      */
-    public function testPrefixOptions()
+    public function testPrefixOptions(): void
     {
-        Router::prefix('admin', ['param' => 'value'], function (RouteBuilder $routes) {
+        Router::prefix('admin', ['param' => 'value'], function (RouteBuilder $routes): void {
             $this->assertSame('/admin', $routes->path());
             $this->assertEquals(['prefix' => 'Admin', 'param' => 'value'], $routes->params());
         });
 
-        Router::prefix('CustomPath', ['path' => '/custom-path'], function (RouteBuilder $routes) {
+        Router::prefix('CustomPath', ['path' => '/custom-path'], function (RouteBuilder $routes): void {
             $this->assertSame('/custom-path', $routes->path());
             $this->assertEquals(['prefix' => 'CustomPath'], $routes->params());
         });
@@ -2982,12 +2831,10 @@ class RouterTest extends TestCase
 
     /**
      * Test that plugin() creates a scope.
-     *
-     * @return void
      */
-    public function testPlugin()
+    public function testPlugin(): void
     {
-        Router::plugin('DebugKit', function (RouteBuilder $routes) {
+        Router::plugin('DebugKit', function (RouteBuilder $routes): void {
             $this->assertSame('/debug-kit', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
         });
@@ -2995,27 +2842,23 @@ class RouterTest extends TestCase
 
     /**
      * Test that plugin() accepts options
-     *
-     * @return void
      */
-    public function testPluginOptions()
+    public function testPluginOptions(): void
     {
-        Router::plugin('DebugKit', ['path' => '/debugger'], function (RouteBuilder $routes) {
+        Router::plugin('DebugKit', ['path' => '/debugger'], function (RouteBuilder $routes): void {
             $this->assertSame('/debugger', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
         });
 
-        Router::plugin('Contacts', ['_namePrefix' => 'contacts:'], function (RouteBuilder $routes) {
+        Router::plugin('Contacts', ['_namePrefix' => 'contacts:'], function (RouteBuilder $routes): void {
             $this->assertSame('contacts:', $routes->namePrefix());
         });
     }
 
     /**
      * Test setting default route class.
-     *
-     * @return void
      */
-    public function testDefaultRouteClass()
+    public function testDefaultRouteClass(): void
     {
         Router::connect('/{controller}', ['action' => 'index']);
         $result = Router::url(['controller' => 'FooBar', 'action' => 'index']);
@@ -3034,7 +2877,7 @@ class RouterTest extends TestCase
 
         Router::reload();
         Router::defaultRouteClass('DashedRoute');
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks();
         });
 
@@ -3044,10 +2887,8 @@ class RouterTest extends TestCase
 
     /**
      * Test setting the request context.
-     *
-     * @return void
      */
-    public function testSetRequestContextCakePHP()
+    public function testSetRequestContextCakePHP(): void
     {
         Router::connect('/{controller}/{action}/*');
         $request = new ServerRequest([
@@ -3067,10 +2908,8 @@ class RouterTest extends TestCase
 
     /**
      * Test setting the request context.
-     *
-     * @return void
      */
-    public function testSetRequestContextPsr()
+    public function testSetRequestContextPsr(): void
     {
         $server = [
             'DOCUMENT_ROOT' => '/Users/markstory/Sites',
@@ -3097,10 +2936,8 @@ class RouterTest extends TestCase
 
     /**
      * Test getting the route collection
-     *
-     * @return void
      */
-    public function testGetRouteCollection()
+    public function testGetRouteCollection(): void
     {
         $collection = Router::getRouteCollection();
         $this->assertInstanceOf(RouteCollection::class, $collection);
@@ -3109,10 +2946,8 @@ class RouterTest extends TestCase
 
     /**
      * Test getting a route builder instance.
-     *
-     * @return void
      */
-    public function testCreateRouteBuilder()
+    public function testCreateRouteBuilder(): void
     {
         $builder = Router::createRouteBuilder('/api');
         $this->assertInstanceOf(RouteBuilder::class, $builder);
@@ -3128,10 +2963,8 @@ class RouterTest extends TestCase
 
     /**
      * test connect() with short string syntax
-     *
-     * @return void
      */
-    public function testConnectShortStringSyntax()
+    public function testConnectShortStringSyntax(): void
     {
         Router::connect('/admin/articles/view', 'Admin/Articles::view');
         $result = Router::parseRequest($this->makeRequest('/admin/articles/view', 'GET'));
@@ -3149,10 +2982,8 @@ class RouterTest extends TestCase
 
     /**
      * test url() with a string route path
-     *
-     * @return void
      */
-    public function testUrlGenerationWithPathUrl()
+    public function testUrlGenerationWithPathUrl(): void
     {
         Router::connect('/articles', 'Articles::index');
         Router::connect('/articles/view/*', 'Articles::view');
@@ -3188,10 +3019,8 @@ class RouterTest extends TestCase
 
     /**
      * test url() with a string route path doesn't take parameters from current request
-     *
-     * @return void
      */
-    public function testUrlGenerationWithRoutePathWithContext()
+    public function testUrlGenerationWithRoutePathWithContext(): void
     {
         Router::connect('/articles', 'Articles::index');
         Router::connect('/articles/view/*', 'Articles::view');
@@ -3263,10 +3092,9 @@ class RouterTest extends TestCase
      * Test url() doesn't let override parts of string route path
      *
      * @param array $params
-     * @return void
      * @dataProvider invalidRoutePathParametersArrayProvider
      */
-    public function testUrlGenerationOverridingShortString(array $params)
+    public function testUrlGenerationOverridingShortString(array $params): void
     {
         Router::connect('/articles', 'Articles::index');
 
@@ -3280,10 +3108,9 @@ class RouterTest extends TestCase
      * Test url() doesn't let override parts of string route path from `_path` key
      *
      * @param array $params
-     * @return void
      * @dataProvider invalidRoutePathParametersArrayProvider
      */
-    public function testUrlGenerationOverridingPathKey(array $params)
+    public function testUrlGenerationOverridingPathKey(array $params): void
     {
         Router::connect('/articles', 'Articles::index');
 
@@ -3295,12 +3122,10 @@ class RouterTest extends TestCase
 
     /**
      * Connect some fallback routes for testing router behavior.
-     *
-     * @return void
      */
-    protected function _connectDefaultRoutes()
+    protected function _connectDefaultRoutes(): void
     {
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks('InflectedRoute');
         });
     }
@@ -3310,9 +3135,8 @@ class RouterTest extends TestCase
      *
      * @param string $url The URL to create a request for
      * @param string $method The HTTP method to use.
-     * @return \Cake\Http\ServerRequest
      */
-    protected function makeRequest($url, $method)
+    protected function makeRequest($url, $method): ServerRequest
     {
         $request = new ServerRequest([
             'url' => $url,

--- a/tests/TestCase/Shell/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Shell/Helper/ProgressHelperTest.php
@@ -43,8 +43,6 @@ class ProgressHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,10 +55,8 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test using the helper manually.
-     *
-     * @return void
      */
-    public function testInit()
+    public function testInit(): void
     {
         $helper = $this->helper->init([
             'total' => 200,
@@ -72,7 +68,7 @@ class ProgressHelperTest extends TestCase
     /**
      * Test that a callback is required.
      */
-    public function testOutputFailure()
+    public function testOutputFailure(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->helper->output(['not a callback']);
@@ -80,12 +76,10 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test that the callback is invoked until 100 is reached.
-     *
-     * @return void
      */
-    public function testOutputSuccess()
+    public function testOutputSuccess(): void
     {
-        $this->helper->output([function (ProgressHelper $progress) {
+        $this->helper->output([function (ProgressHelper $progress): void {
             $progress->increment(20);
         }]);
         $expected = [
@@ -107,15 +101,13 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test output with options
-     *
-     * @return void
      */
-    public function testOutputSuccessOptions()
+    public function testOutputSuccessOptions(): void
     {
         $this->helper->output([
             'total' => 10,
             'width' => 20,
-            'callback' => function (ProgressHelper $progress) {
+            'callback' => function (ProgressHelper $progress): void {
                 $progress->increment(2);
             },
         ]);
@@ -138,10 +130,8 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test using the helper manually.
-     *
-     * @return void
      */
-    public function testIncrementAndRender()
+    public function testIncrementAndRender(): void
     {
         $this->helper->init();
 
@@ -167,10 +157,8 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test using the helper chained.
-     *
-     * @return void
      */
-    public function testIncrementAndRenderChained()
+    public function testIncrementAndRenderChained(): void
     {
         $this->helper->init()
             ->increment(20)
@@ -193,10 +181,8 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test negative numbers
-     *
-     * @return void
      */
-    public function testIncrementWithNegatives()
+    public function testIncrementWithNegatives(): void
     {
         $this->helper->init();
 
@@ -222,10 +208,8 @@ class ProgressHelperTest extends TestCase
 
     /**
      * Test increment and draw with options
-     *
-     * @return void
      */
-    public function testIncrementWithOptions()
+    public function testIncrementWithOptions(): void
     {
         $this->helper->init([
             'total' => 10,
@@ -252,10 +236,8 @@ class ProgressHelperTest extends TestCase
     /**
      * Test increment and draw with value that makes the pad
      * be a float
-     *
-     * @return void
      */
-    public function testIncrementFloatPad()
+    public function testIncrementFloatPad(): void
     {
         $this->helper->init([
             'total' => 50,

--- a/tests/TestCase/Shell/Helper/TableHelperTest.php
+++ b/tests/TestCase/Shell/Helper/TableHelperTest.php
@@ -43,8 +43,6 @@ class TableHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,10 +55,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output
-     *
-     * @return void
      */
-    public function testOutputDefaultOutput()
+    public function testOutputDefaultOutput(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -85,10 +81,8 @@ class TableHelperTest extends TestCase
      * When outputting entities or other structured data,
      * headers shouldn't need to have the same keys as it is
      * annoying to use.
-     *
-     * @return void
      */
-    public function testOutputInconsistentKeys()
+    public function testOutputInconsistentKeys(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -109,10 +103,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test that output works when data contains just empty strings.
-     *
-     * @return void
      */
-    public function testOutputEmptyStrings()
+    public function testOutputEmptyStrings(): void
     {
         $data = [
             ['Header 1', 'Header', 'Empty'],
@@ -134,7 +126,7 @@ class TableHelperTest extends TestCase
     /**
      * Test that output works when data contains nulls.
      */
-    public function testNullValues()
+    public function testNullValues(): void
     {
         $data = [
             ['Header 1', 'Header', 'Empty'],
@@ -155,10 +147,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output with multi-byte characters
-     *
-     * @return void
      */
-    public function testOutputUtf8()
+    public function testOutputUtf8(): void
     {
         $data = [
             ['Header 1', 'Head', 'Long Header'],
@@ -179,10 +169,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output with multi-byte characters
-     *
-     * @return void
      */
-    public function testOutputFullwidth()
+    public function testOutputFullwidth(): void
     {
         $data = [
             ['Header 1', 'Head', 'Long Header'],
@@ -203,10 +191,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output without headers
-     *
-     * @return void
      */
-    public function testOutputWithoutHeaderStyle()
+    public function testOutputWithoutHeaderStyle(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -228,10 +214,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output with different header style
-     *
-     * @return void
      */
-    public function testOutputWithDifferentHeaderStyle()
+    public function testOutputWithDifferentHeaderStyle(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -253,10 +237,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output without table headers
-     *
-     * @return void
      */
-    public function testOutputWithoutHeaders()
+    public function testOutputWithoutHeaders(): void
     {
         $data = [
             ['short', 'Longish thing', 'short'],
@@ -275,10 +257,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output with formatted cells
-     *
-     * @return void
      */
-    public function testOutputWithFormattedCells()
+    public function testOutputWithFormattedCells(): void
     {
         $data = [
             ['short', 'Longish thing', '<info>short</info>'],
@@ -297,10 +277,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output with row separator
-     *
-     * @return void
      */
-    public function testOutputWithRowSeparator()
+    public function testOutputWithRowSeparator(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -323,10 +301,8 @@ class TableHelperTest extends TestCase
 
     /**
      * Test output with row separator and no headers
-     *
-     * @return void
      */
-    public function testOutputWithRowSeparatorAndHeaders()
+    public function testOutputWithRowSeparatorAndHeaders(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -350,7 +326,7 @@ class TableHelperTest extends TestCase
     /**
      * Test output when there is no data.
      */
-    public function testOutputWithNoData()
+    public function testOutputWithNoData(): void
     {
         $this->helper->output([]);
         $this->assertEquals([], $this->stub->messages());
@@ -359,7 +335,7 @@ class TableHelperTest extends TestCase
     /**
      * Test output with a header but no data.
      */
-    public function testOutputWithHeaderAndNoData()
+    public function testOutputWithHeaderAndNoData(): void
     {
         $data = [
             ['Header 1', 'Header', 'Long Header'],
@@ -376,7 +352,7 @@ class TableHelperTest extends TestCase
     /**
      * Test no data when headers are disabled.
      */
-    public function testOutputHeaderDisabledNoData()
+    public function testOutputHeaderDisabledNoData(): void
     {
         $this->helper->setConfig(['header' => false]);
         $this->helper->output([]);
@@ -386,7 +362,7 @@ class TableHelperTest extends TestCase
     /**
      * Right-aligned text style test.
      */
-    public function testTextRightStyle()
+    public function testTextRightStyle(): void
     {
         $data = [
             ['Item', 'Price per piece (yen)'],
@@ -408,7 +384,7 @@ class TableHelperTest extends TestCase
     /**
      * Right-aligned text style test.(If there is text rightside the text-right tag)
      */
-    public function testTextRightsideTheTextRightTag()
+    public function testTextRightsideTheTextRightTag(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $data = [
@@ -421,7 +397,7 @@ class TableHelperTest extends TestCase
     /**
      * Right-aligned text style test.(If there is text leftside the text-right tag)
      */
-    public function testTextLeftsideTheTextRightTag()
+    public function testTextLeftsideTheTextRightTag(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $data = [
@@ -434,7 +410,7 @@ class TableHelperTest extends TestCase
     /**
      * Table row column of type integer should be cast to string
      */
-    public function testRowValueInteger()
+    public function testRowValueInteger(): void
     {
         $data = [
             ['Item', 'Quantity'],
@@ -455,7 +431,7 @@ class TableHelperTest extends TestCase
     /**
      * Table row column of type null should be cast to empty string
      */
-    public function testRowValueNull()
+    public function testRowValueNull(): void
     {
         $data = [
             ['Item', 'Quantity'],

--- a/tests/TestCase/TestSuite/AssertHtmlTest.php
+++ b/tests/TestCase/TestSuite/AssertHtmlTest.php
@@ -26,10 +26,8 @@ class AssertHtmlTest extends TestCase
 {
     /**
      * Test whitespace after HTML tags
-     *
-     * @return void
      */
-    public function testAssertHtmlWhitespaceAfter()
+    public function testAssertHtmlWhitespaceAfter(): void
     {
         $input = <<<HTML
 <div class="wrapper">
@@ -50,10 +48,8 @@ HTML;
 
     /**
      * Test whitespace inside HTML tags
-     *
-     * @return void
      */
-    public function testAssertHtmlInnerWhitespace()
+    public function testAssertHtmlInnerWhitespace(): void
     {
         $input = <<<HTML
 <div class="widget">
@@ -74,10 +70,8 @@ HTML;
 
     /**
      * test assertHtml works with single and double quotes
-     *
-     * @return void
      */
-    public function testAssertHtmlQuoting()
+    public function testAssertHtmlQuoting(): void
     {
         $input = '<a href="/test.html" class="active">My link</a>';
         $pattern = [
@@ -126,10 +120,8 @@ HTML;
 
     /**
      * Test that assertHtml runs quickly.
-     *
-     * @return void
      */
-    public function testAssertHtmlRuntimeComplexity()
+    public function testAssertHtmlRuntimeComplexity(): void
     {
         $pattern = [
             'div' => [
@@ -154,10 +146,8 @@ HTML;
 
     /**
      * test that assertHtml knows how to handle correct quoting.
-     *
-     * @return void
      */
-    public function testAssertHtmlQuotes()
+    public function testAssertHtmlQuotes(): void
     {
         $input = '<a href="/test.html" class="active">My link</a>';
         $pattern = [
@@ -186,10 +176,8 @@ HTML;
 
     /**
      * testNumericValuesInExpectationForAssertHtml
-     *
-     * @return void
      */
-    public function testNumericValuesInExpectationForAssertHtml()
+    public function testNumericValuesInExpectationForAssertHtml(): void
     {
         $value = 220985;
 
@@ -236,10 +224,8 @@ HTML;
 
     /**
      * test assertions fail when attributes are wrong.
-     *
-     * @return void
      */
-    public function testBadAssertHtmlInvalidAttribute()
+    public function testBadAssertHtmlInvalidAttribute(): void
     {
         $input = '<a href="/test.html" class="active">My link</a>';
         $pattern = [
@@ -260,10 +246,8 @@ HTML;
 
     /**
      * test assertion failure on incomplete HTML
-     *
-     * @return void
      */
-    public function testBadAssertHtmlMissingTags()
+    public function testBadAssertHtmlMissingTags(): void
     {
         $input = '<a href="/test.html" class="active">My link</a>';
         $pattern = [

--- a/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -28,8 +28,6 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -40,10 +38,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec when using the command runner
-     *
-     * @return void
      */
-    public function testExecWithCommandRunner()
+    public function testExecWithCommandRunner(): void
     {
         $this->useCommandRunner();
         $this->exec('');
@@ -55,10 +51,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec
-     *
-     * @return void
      */
-    public function testExec()
+    public function testExec(): void
     {
         $this->exec('sample');
 
@@ -68,10 +62,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests that exec catches a StopException
-     *
-     * @return void
      */
-    public function testExecShellWithStopException()
+    public function testExecShellWithStopException(): void
     {
         $this->exec('integration abort_shell');
         $this->assertExitCode(Command::CODE_ERROR);
@@ -81,10 +73,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests that exec catches a StopException
-     *
-     * @return void
      */
-    public function testExecCommandWithStopException()
+    public function testExecCommandWithStopException(): void
     {
         $this->useCommandRunner();
         $this->exec('abort_command');
@@ -94,10 +84,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests that exec with a format specifier
-     *
-     * @return void
      */
-    public function testExecCommandWithFormatSpecifier()
+    public function testExecCommandWithFormatSpecifier(): void
     {
         $this->useCommandRunner();
         $this->exec('format_specifier_command');
@@ -107,10 +95,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests a valid core command
-     *
-     * @return void
      */
-    public function testExecCoreCommand()
+    public function testExecCoreCommand(): void
     {
         $this->useCommandRunner();
         $this->exec('routes');
@@ -120,10 +106,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec with an arg and an option
-     *
-     * @return void
      */
-    public function testExecWithArgsAndOption()
+    public function testExecWithArgsAndOption(): void
     {
         $this->exec('integration args_and_options arg --opt="some string"');
 
@@ -135,10 +119,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec with missing required argument
-     *
-     * @return void
      */
-    public function testExecWithMissingRequiredArg()
+    public function testExecWithMissingRequiredArg(): void
     {
         $this->exec('integration args_and_options');
 
@@ -150,10 +132,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec with input
-     *
-     * @return void
      */
-    public function testExecWithInput()
+    public function testExecWithInput(): void
     {
         $this->exec('integration bridge', ['javascript']);
 
@@ -163,10 +143,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec with fewer inputs than questions
-     *
-     * @return void
      */
-    public function testExecWithMissingInput()
+    public function testExecWithMissingInput(): void
     {
         $this->expectException(MissingConsoleInputException::class);
         $this->expectExceptionMessage('no more input');
@@ -175,10 +153,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests exec with multiple inputs
-     *
-     * @return void
      */
-    public function testExecWithMultipleInput()
+    public function testExecWithMultipleInput(): void
     {
         $this->exec('integration bridge', ['cake', 'blue']);
 
@@ -186,7 +162,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
         $this->assertExitCode(Command::CODE_SUCCESS);
     }
 
-    public function testExecWithMockServiceDependencies()
+    public function testExecWithMockServiceDependencies(): void
     {
         $this->mockService(stdClass::class, function () {
             return json_decode('{"console-mock":true}');
@@ -200,10 +176,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests assertOutputRegExp assertion
-     *
-     * @return void
      */
-    public function testAssertOutputRegExp()
+    public function testAssertOutputRegExp(): void
     {
         $this->exec('sample');
 
@@ -212,10 +186,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests assertErrorRegExp assertion
-     *
-     * @return void
      */
-    public function testAssertErrorRegExp()
+    public function testAssertErrorRegExp(): void
     {
         $this->exec('integration args_and_options');
 
@@ -224,10 +196,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
 
     /**
      * tests commandStringToArgs
-     *
-     * @return void
      */
-    public function testCommandStringToArgs()
+    public function testCommandStringToArgs(): void
     {
         $result = $this->commandStringToArgs('command --something=nothing --with-spaces="quote me on that" \'quoted \"arg\"\'');
         $expected = [
@@ -255,7 +225,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
      * @param mixed ...$rest
      * @dataProvider assertionFailureMessagesProvider
      */
-    public function testAssertionFailureMessages($assertion, $message, $command, ...$rest)
+    public function testAssertionFailureMessages($assertion, $message, $command, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessageMatches('#' . preg_quote($message, '#') . '.?#');

--- a/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredTest.php
@@ -16,10 +16,8 @@ class EventFiredTest extends TestCase
 {
     /**
      * tests EventFired constraint
-     *
-     * @return void
      */
-    public function testMatches()
+    public function testMatches(): void
     {
         $manager = EventManager::instance();
         $manager->setEventList(new EventList());

--- a/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
@@ -17,10 +17,8 @@ class EventFiredWithTest extends TestCase
 {
     /**
      * tests EventFiredWith constraint
-     *
-     * @return void
      */
-    public function testMatches()
+    public function testMatches(): void
     {
         $manager = EventManager::instance();
         $manager->setEventList(new EventList());
@@ -60,10 +58,8 @@ class EventFiredWithTest extends TestCase
 
     /**
      * tests trying to assert data key=>value when an event is fired multiple times
-     *
-     * @return void
      */
-    public function testMatchesInvalid()
+    public function testMatchesInvalid(): void
     {
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $manager = EventManager::instance();

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -35,8 +35,6 @@ class EmailTraitTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -60,8 +58,6 @@ class EmailTraitTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -74,10 +70,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * tests assertions against any emails that were sent
-     *
-     * @return void
      */
-    public function testSingleAssertions()
+    public function testSingleAssertions(): void
     {
         $this->sendEmails();
 
@@ -106,10 +100,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * tests multiple email assertions
-     *
-     * @return void
      */
-    public function testMultipleAssertions()
+    public function testMultipleAssertions(): void
     {
         $this->assertNoMailSent();
 
@@ -138,10 +130,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * tests assertNoMailSent fails when no mail is sent
-     *
-     * @return void
      */
-    public function testAssertNoMailSentFailure()
+    public function testAssertNoMailSentFailure(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that no emails were sent.');
@@ -152,10 +142,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * tests assertMailContainsHtml fails appropriately
-     *
-     * @return void
      */
-    public function testAssertContainsHtmlFailure()
+    public function testAssertContainsHtmlFailure(): void
     {
         $this->expectException(AssertionFailedError::class);
 
@@ -166,10 +154,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * tests assertMailContainsText fails appropriately
-     *
-     * @return void
      */
-    public function testAssertContainsTextFailure()
+    public function testAssertContainsTextFailure(): void
     {
         $this->expectException(AssertionFailedError::class);
 
@@ -180,10 +166,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * Tests asserting using RegExp characters doesn't break the assertion
-     *
-     * @return void
      */
-    public function testAssertUsingRegExpCharacters()
+    public function testAssertUsingRegExpCharacters(): void
     {
         (new Mailer())
             ->setTo('to3@example.com')
@@ -201,7 +185,7 @@ class EmailTraitTest extends TestCase
      * @param array $params Assertion params
      * @dataProvider failureMessageDataProvider
      */
-    public function testFailureMessages($assertion, $expectedMessage, $params)
+    public function testFailureMessages($assertion, $expectedMessage, $params): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage($expectedMessage);
@@ -238,10 +222,8 @@ class EmailTraitTest extends TestCase
 
     /**
      * sends some emails
-     *
-     * @return void
      */
-    private function sendEmails()
+    private function sendEmails(): void
     {
         (new Mailer())
             ->setSender(['sender@example.com' => 'Sender'])

--- a/tests/TestCase/TestSuite/Fixture/CollectionResetStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/CollectionResetStrategyTest.php
@@ -24,10 +24,8 @@ class CollectionResetStrategyTest extends TestCase
 {
     /**
      * Test that setupTest calls items.
-     *
-     * @return void
      */
-    public function testSetupTest()
+    public function testSetupTest(): void
     {
         $one = $this->getMockBuilder(ResetStrategyInterface::class)->getMock();
         $two = $this->getMockBuilder(ResetStrategyInterface::class)->getMock();
@@ -43,10 +41,8 @@ class CollectionResetStrategyTest extends TestCase
 
     /**
      * Test that teardownTest calls items.
-     *
-     * @return void
      */
-    public function testTeardownTest()
+    public function testTeardownTest(): void
     {
         $one = $this->getMockBuilder(ResetStrategyInterface::class)->getMock();
         $two = $this->getMockBuilder(ResetStrategyInterface::class)->getMock();

--- a/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureDataManagerTest.php
@@ -33,8 +33,6 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -73,9 +71,8 @@ class FixtureDataManagerTest extends TestCase
      *
      * @dataProvider invalidProvider
      * @param string $name Fixture name
-     * @return void
      */
-    public function testSetupTestErrorOnUnknown($name)
+    public function testSetupTestErrorOnUnknown($name): void
     {
         $manager = new FixtureDataManager();
         $this->fixtures = [$name];
@@ -104,9 +101,8 @@ class FixtureDataManagerTest extends TestCase
      *
      * @dataProvider validProvider
      * @param string $name The fixture name
-     * @return void
      */
-    public function testSetupTestLoads($name)
+    public function testSetupTestLoads($name): void
     {
         $this->setAppNamespace();
         // Also loads TestPlugin
@@ -123,10 +119,8 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * Test that setupTest() loads fixtures.
-     *
-     * @return void
      */
-    public function testSetupTestLoadsMultipleFixtures()
+    public function testSetupTestLoadsMultipleFixtures(): void
     {
         $manager = new FixtureDataManager();
         $this->autoFixtures = false;
@@ -140,10 +134,8 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * loadSingle on a known fixture.
-     *
-     * @return void
      */
-    public function testLoadSingleValid()
+    public function testLoadSingleValid(): void
     {
         $manager = new FixtureDataManager();
         $this->autoFixtures = false;
@@ -160,10 +152,8 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * loadSingle on a unknown fixture.
-     *
-     * @return void
      */
-    public function testLoadSingleInvalid()
+    public function testLoadSingleInvalid(): void
     {
         $manager = new FixtureDataManager();
         $this->autoFixtures = false;
@@ -175,10 +165,8 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * Test load() via setupTest()
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $manager = new FixtureDataManager();
         $manager->setupTest($this);
@@ -197,10 +185,8 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * Test getInserted()
-     *
-     * @return void
      */
-    public function testGetInserted()
+    public function testGetInserted(): void
     {
         $manager = new FixtureDataManager();
         $manager->setupTest($this);
@@ -211,10 +197,8 @@ class FixtureDataManagerTest extends TestCase
 
     /**
      * Test getInserted() with autoFixtures
-     *
-     * @return void
      */
-    public function testGetInsertedAutofixtures()
+    public function testGetInsertedAutofixtures(): void
     {
         $manager = new FixtureDataManager();
         $this->autoFixtures = false;

--- a/tests/TestCase/TestSuite/Fixture/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaCleanerTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestCase;
 
 class SchemaCleanerTest extends TestCase
 {
-    public function testForeignKeyConstruction()
+    public function testForeignKeyConstruction(): void
     {
         $connection = ConnectionManager::get('test');
 
@@ -43,7 +43,7 @@ class SchemaCleanerTest extends TestCase
         (new SchemaCleaner())->dropTables('test', ['test_table','test_table2']);
     }
 
-    public function testDropSchema()
+    public function testDropSchema(): void
     {
         $connection = ConnectionManager::get('test');
         /** @var SchemaDialect $dialect */
@@ -66,7 +66,7 @@ class SchemaCleanerTest extends TestCase
         $this->assertSame($initialNumberOfTables, $tables, 'The test tables should be dropped.');
     }
 
-    public function testTruncateSchema()
+    public function testTruncateSchema(): void
     {
         [$table1, $table2] = $this->createSchemas();
 
@@ -79,7 +79,7 @@ class SchemaCleanerTest extends TestCase
         $this->assertTestTableExistsWithCount($table2, 0);
     }
 
-    private function assertTestTableExistsWithCount(string $table, int $count)
+    private function assertTestTableExistsWithCount(string $table, int $count): void
     {
         $this->assertSame(
             $count,

--- a/tests/TestCase/TestSuite/Fixture/SchemaGeneratorTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaGeneratorTest.php
@@ -26,10 +26,8 @@ class SchemaGeneratorTest extends TestCase
 {
     /**
      * test reload on a table subset.
-     *
-     * @return void
      */
-    public function testReload()
+    public function testReload(): void
     {
         $generator = new SchemaGenerator(__DIR__ . '/test_schema.php', 'test');
 

--- a/tests/TestCase/TestSuite/Fixture/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaManagerTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 
 class SchemaManagerTest extends TestCase
 {
-    public function testCreateFromOneFile()
+    public function testCreateFromOneFile(): void
     {
         $connection = ConnectionManager::get('test');
 
@@ -44,7 +44,7 @@ class SchemaManagerTest extends TestCase
         (new SchemaCleaner())->dropTables('test', [$tableName]);
     }
 
-    public function testCreateFromMultipleFiles()
+    public function testCreateFromMultipleFiles(): void
     {
         $connection = ConnectionManager::get('test');
         $tables = [
@@ -74,13 +74,13 @@ class SchemaManagerTest extends TestCase
         (new SchemaCleaner())->dropTables('test', $tables);
     }
 
-    public function testCreateFromNonExistentFile()
+    public function testCreateFromNonExistentFile(): void
     {
         $this->expectException(\RuntimeException::class);
         SchemaManager::create('test', 'foo');
     }
 
-    public function testCreateFromCorruptedFile()
+    public function testCreateFromCorruptedFile(): void
     {
         $query = 'This is no valid SQL';
         $tmpFile = tempnam(sys_get_temp_dir(), 'SchemaManagerTest');

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -26,10 +26,8 @@ class TransactionStrategyTest extends TestCase
 
     /**
      * Test that beforeTest starts a transaction that afterTest closes.
-     *
-     * @return void
      */
-    public function testTransactionWrapping()
+    public function testTransactionWrapping(): void
     {
         $users = TableRegistry::get('Users');
 

--- a/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
@@ -29,10 +29,8 @@ class TruncationStrategyTest extends TestCase
 
     /**
      * Test that beforeTest truncates tables from the previous test
-     *
-     * @return void
      */
-    public function testSetupSimple()
+    public function testSetupSimple(): void
     {
         $articles = TableRegistry::get('Articles');
         $articlesTags = TableRegistry::get('ArticlesTags');

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -43,8 +43,6 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -66,10 +64,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading core fixtures.
-     *
-     * @return void
      */
-    public function testFixturizeCore()
+    public function testFixturizeCore(): void
     {
         $this->cleanup = ['articles'];
 
@@ -88,10 +84,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test logging depends on fixture manager debug.
-     *
-     * @return void
      */
-    public function testLogSchemaWithDebug()
+    public function testLogSchemaWithDebug(): void
     {
         $db = ConnectionManager::get('test');
         $restore = $db->isQueryLoggingEnabled();
@@ -122,10 +116,8 @@ class FixtureManagerTest extends TestCase
     /**
      * Test that if a table already exists in the test database, it will dropped
      * before being recreated
-     *
-     * @return void
      */
-    public function testResetDbIfTableExists()
+    public function testResetDbIfTableExists(): void
     {
         $db = ConnectionManager::get('test');
         $restore = $db->isQueryLoggingEnabled();
@@ -162,10 +154,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading fixtures with constraints.
-     *
-     * @return void
      */
-    public function testFixturizeCoreConstraint()
+    public function testFixturizeCoreConstraint(): void
     {
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf($driver instanceof Sqlserver, 'This fails in SQLServer');
@@ -194,10 +184,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading plugin fixtures.
-     *
-     * @return void
      */
-    public function testFixturizePlugin()
+    public function testFixturizePlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -218,10 +206,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading plugin fixtures.
-     *
-     * @return void
      */
-    public function testFixturizePluginSubdirectory()
+    public function testFixturizePluginSubdirectory(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -242,10 +228,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading plugin fixtures from a vendor namespaced plugin
-     *
-     * @return void
      */
-    public function testFixturizeVendorPlugin()
+    public function testFixturizeVendorPlugin(): void
     {
         $this->cleanup = ['articles'];
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
@@ -265,10 +249,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading fixtures with fully-qualified namespaces.
-     *
-     * @return void
      */
-    public function testFixturizeClassName()
+    public function testFixturizeClassName(): void
     {
         $this->cleanup = ['articles'];
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
@@ -288,7 +270,7 @@ class FixtureManagerTest extends TestCase
     /**
      * Test that unknown types are handled gracefully.
      */
-    public function testFixturizeInvalidType()
+    public function testFixturizeInvalidType(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Referenced fixture class "Test\Fixture\Derp.DerpFixture" not found. Fixture "Derp.Derp" was referenced');
@@ -305,10 +287,8 @@ class FixtureManagerTest extends TestCase
      * Ensure that FixtureManager uses connection aliases
      * protecting 'live' tables from being wiped by mistakes in
      * fixture connection names.
-     *
-     * @return void
      */
-    public function testLoadConnectionAliasUsage()
+    public function testLoadConnectionAliasUsage(): void
     {
         $connection = ConnectionManager::get('test');
         $statement = $this->getMockBuilder('Cake\Database\StatementInterface')
@@ -356,10 +336,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test loading fixtures using loadSingle()
-     *
-     * @return void
      */
-    public function testLoadSingle()
+    public function testLoadSingle(): void
     {
         $this->cleanup = ['comments', 'users'];
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')
@@ -396,10 +374,8 @@ class FixtureManagerTest extends TestCase
 
     /**
      * Test exception on load
-     *
-     * @return void
      */
-    public function testExceptionOnLoad()
+    public function testExceptionOnLoad(): void
     {
         $this->cleanup = ['products'];
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
@@ -412,7 +388,7 @@ class FixtureManagerTest extends TestCase
             ->getMock();
         $manager->expects($this->any())
             ->method('_runOperation')
-            ->will($this->returnCallback(function () {
+            ->will($this->returnCallback(function (): void {
                 throw new PDOException('message');
             }));
 
@@ -433,16 +409,15 @@ class FixtureManagerTest extends TestCase
      * Test exception on load fixture
      *
      * @dataProvider loadErrorMessageProvider
-     * @return void
      */
-    public function testExceptionOnLoadFixture(string $method, string $expectedMessage)
+    public function testExceptionOnLoadFixture(string $method, string $expectedMessage): void
     {
         $fixture = $this->getMockBuilder('Cake\Test\Fixture\ProductsFixture')
             ->onlyMethods(['drop', 'create', $method])
             ->getMock();
         $fixture->expects($this->once())
             ->method($method)
-            ->will($this->returnCallback(function () {
+            ->will($this->returnCallback(function (): void {
                 throw new PDOException('message');
             }));
 

--- a/tests/TestCase/TestSuite/FixtureSchemaExtensionTest.php
+++ b/tests/TestCase/TestSuite/FixtureSchemaExtensionTest.php
@@ -26,10 +26,8 @@ class FixtureSchemaExtensionTest extends TestCase
 {
     /**
      * Test connection aliasing during construction.
-     *
-     * @return void
      */
-    public function testConnectionAliasing()
+    public function testConnectionAliasing(): void
     {
         $this->skipIf(!extension_loaded('pdo_sqlite'), 'Requires SQLite extension');
         ConnectionManager::setConfig('test_fixture_schema', [

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -52,8 +52,6 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -62,7 +60,7 @@ class IntegrationTestTraitTest extends TestCase
 
         Router::reload();
         Router::extensions(['json']);
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookie', new EncryptedCookieMiddleware(['secrets'], $this->key));
             $routes->applyMiddleware('cookie');
 
@@ -72,12 +70,12 @@ class IntegrationTestTraitTest extends TestCase
             $routes->options('/options/{controller}/{action}', []);
             $routes->connect('/{controller}/{action}/*', []);
         });
-        Router::scope('/cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes) {
+        Router::scope('/cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware());
             $routes->applyMiddleware('cookieCsrf');
             $routes->connect('/posts/{action}', ['controller' => 'Posts']);
         });
-        Router::scope('/session-csrf/', ['csrf' => 'session'], function (RouteBuilder $routes) {
+        Router::scope('/session-csrf/', ['csrf' => 'session'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('sessionCsrf', new SessionCsrfProtectionMiddleware());
             $routes->applyMiddleware('sessionCsrf');
             $routes->connect('/posts/{action}/', ['controller' => 'Posts']);
@@ -88,10 +86,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Tests that all data that used by the request is cast to strings
-     *
-     * @return void
      */
-    public function testDataCastToString()
+    public function testDataCastToString(): void
     {
         $data = [
             'title' => 'Blog Post',
@@ -151,10 +147,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test building a request.
-     *
-     * @return void
      */
-    public function testRequestBuilding()
+    public function testRequestBuilding(): void
     {
         $this->configRequest([
             'headers' => [
@@ -185,10 +179,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test request building adds csrf tokens
-     *
-     * @return void
      */
-    public function testRequestBuildingCsrfTokens()
+    public function testRequestBuildingCsrfTokens(): void
     {
         $this->enableCsrfToken();
         $request = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
@@ -210,10 +202,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test multiple actions using CSRF tokens don't fail
-     *
-     * @return void
      */
-    public function testEnableCsrfMultipleRequests()
+    public function testEnableCsrfMultipleRequests(): void
     {
         $this->enableCsrfToken();
         $first = $this->_buildRequest('/tasks/add', 'POST', ['title' => 'First post']);
@@ -237,10 +227,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test building a request, with query parameters
-     *
-     * @return void
      */
-    public function testRequestBuildingQueryParameters()
+    public function testRequestBuildingQueryParameters(): void
     {
         $request = $this->_buildRequest('/tasks/view?archived=yes', 'GET', []);
 
@@ -254,7 +242,7 @@ class IntegrationTestTraitTest extends TestCase
      *
      * @see CookieComponentControllerTest
      */
-    public function testCookieEncrypted()
+    public function testCookieEncrypted(): void
     {
         Security::setSalt($this->key);
         $this->cookieEncrypted('KeyOfCookie', 'Encrypted with aes by default');
@@ -264,10 +252,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending get request and using default `test_app/config/routes.php`.
-     *
-     * @return void
      */
-    public function testGetUsingApplicationWithPluginRoutes()
+    public function testGetUsingApplicationWithPluginRoutes(): void
     {
         // first clean routes to have Router::$initailized === false
         Router::reload();
@@ -281,10 +267,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending get request and using default `test_app/config/routes.php`.
-     *
-     * @return void
      */
-    public function testGetUsingApplicationWithDefaultRoutes()
+    public function testGetUsingApplicationWithDefaultRoutes(): void
     {
         // first clean routes to have Router::$initialized === false
         Router::reload();
@@ -296,7 +280,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertSame('5', $this->_getBodyAsString());
     }
 
-    public function testExceptionsInMiddlewareJsonView()
+    public function testExceptionsInMiddlewareJsonView(): void
     {
         Router::reload();
         Router::connect('/json_response/api_get_data', [
@@ -316,10 +300,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending head requests.
-     *
-     * @return void
      */
-    public function testHead()
+    public function testHead(): void
     {
         $this->assertNull($this->_response);
 
@@ -331,10 +313,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending head requests.
-     *
-     * @return void
      */
-    public function testHeadMethodRoute()
+    public function testHeadMethodRoute(): void
     {
         $this->head('/head/request_action/test_request_action');
         $this->assertResponseSuccess();
@@ -342,10 +322,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending options requests.
-     *
-     * @return void
      */
-    public function testOptions()
+    public function testOptions(): void
     {
         $this->assertNull($this->_response);
 
@@ -357,10 +335,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending options requests.
-     *
-     * @return void
      */
-    public function testOptionsMethodRoute()
+    public function testOptionsMethodRoute(): void
     {
         $this->options('/options/request_action/test_request_action');
         $this->assertResponseSuccess();
@@ -368,10 +344,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending get requests sets the request method
-     *
-     * @return void
      */
-    public function testGetSpecificRouteHttpServer()
+    public function testGetSpecificRouteHttpServer(): void
     {
         $this->get('/get/request_action/test_request_action');
         $this->assertResponseOk();
@@ -380,10 +354,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test customizing the app class.
-     *
-     * @return void
      */
-    public function testConfigApplication()
+    public function testConfigApplication(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot load `TestApp\MissingApp` for use in integration');
@@ -393,10 +365,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending get requests with Http\Server
-     *
-     * @return void
      */
-    public function testGetHttpServer()
+    public function testGetHttpServer(): void
     {
         $this->assertNull($this->_response);
 
@@ -409,10 +379,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests get query string data
-     *
-     * @return void
      */
-    public function testGetQueryStringHttpServer()
+    public function testGetQueryStringHttpServer(): void
     {
         $this->configRequest(['headers' => ['Content-Type' => 'text/plain']]);
         $this->get('/request_action/params_pass?q=query');
@@ -427,10 +395,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests get query string data
-     *
-     * @return void
      */
-    public function testGetQueryStringSetsHere()
+    public function testGetQueryStringSetsHere(): void
     {
         $this->configRequest(['headers' => ['Content-Type' => 'text/plain']]);
         $this->get('/request_action/params_pass?q=query');
@@ -446,10 +412,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests get cookies
-     *
-     * @return void
      */
-    public function testGetCookiesHttpServer()
+    public function testGetCookiesHttpServer(): void
     {
         $this->configRequest(['cookies' => ['split_test' => 'abc']]);
         $this->get('/request_action/cookie_pass');
@@ -460,10 +424,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests receive post data
-     *
-     * @return void
      */
-    public function testPostDataHttpServer()
+    public function testPostDataHttpServer(): void
     {
         $this->post('/request_action/post_pass', ['title' => 'value']);
         $data = json_decode('' . $this->_response->getBody());
@@ -473,10 +435,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests receive put data
-     *
-     * @return void
      */
-    public function testPutDataFormUrlEncoded()
+    public function testPutDataFormUrlEncoded(): void
     {
         $this->configRequest([
             'headers' => [
@@ -491,10 +451,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the uploaded files are passed correctly to the request
-     *
-     * @return void
      */
-    public function testUploadedFiles()
+    public function testUploadedFiles(): void
     {
         $this->configRequest([
             'files' => [
@@ -544,10 +502,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests receive encoded data.
-     *
-     * @return void
      */
-    public function testInputDataHttpServer()
+    public function testInputDataHttpServer(): void
     {
         $this->post('/request_action/input_test', '{"hello":"world"}');
         if ($this->_response->getBody()->isSeekable()) {
@@ -559,10 +515,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests receive encoded data.
-     *
-     * @return void
      */
-    public function testInputDataSecurityToken()
+    public function testInputDataSecurityToken(): void
     {
         $this->enableSecurityToken();
 
@@ -573,10 +527,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that the PSR7 requests get cookies
-     *
-     * @return void
      */
-    public function testSessionHttpServer()
+    public function testSessionHttpServer(): void
     {
         $this->session(['foo' => 'session data']);
         $this->get('/request_action/session_test');
@@ -587,10 +539,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending requests stores references to controller/view/layout.
-     *
-     * @return void
      */
-    public function testRequestSetsProperties()
+    public function testRequestSetsProperties(): void
     {
         $this->post('/posts/index');
         $this->assertInstanceOf('Cake\Controller\Controller', $this->_controller);
@@ -606,10 +556,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test PSR7 requests store references to controller/view/layout
-     *
-     * @return void
      */
-    public function testRequestSetsPropertiesHttpServer()
+    public function testRequestSetsPropertiesHttpServer(): void
     {
         $this->post('/posts/index');
         $this->assertInstanceOf('Cake\Controller\Controller', $this->_controller);
@@ -625,10 +573,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Tests URLs containing extensions.
-     *
-     * @return void
      */
-    public function testRequestWithExt()
+    public function testRequestWithExt(): void
     {
         $this->get(['controller' => 'Posts', 'action' => 'ajax', '_ext' => 'json']);
 
@@ -637,10 +583,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Assert that the stored template doesn't change when cells are rendered.
-     *
-     * @return void
      */
-    public function testAssertTemplateAfterCellRender()
+    public function testAssertTemplateAfterCellRender(): void
     {
         $this->get('/posts/get');
         $this->assertStringContainsString('templates' . DS . 'Posts' . DS . 'get.php', $this->_viewName);
@@ -650,10 +594,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test array URLs
-     *
-     * @return void
      */
-    public function testArrayUrls()
+    public function testArrayUrls(): void
     {
         $this->post(['controller' => 'Posts', 'action' => 'index', '_method' => 'POST']);
         $this->assertResponseOk();
@@ -662,10 +604,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test array URL with host
-     *
-     * @return void
      */
-    public function testArrayUrlWithHost()
+    public function testArrayUrlWithHost(): void
     {
         $this->get([
             'controller' => 'Posts',
@@ -680,10 +620,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test array URLs with an empty router.
-     *
-     * @return void
      */
-    public function testArrayUrlsEmptyRouter()
+    public function testArrayUrlsEmptyRouter(): void
     {
         Router::reload();
         $this->assertEmpty(Router::getRouteCollection()->routes());
@@ -695,10 +633,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test flash and cookie assertions
-     *
-     * @return void
      */
-    public function testFlashSessionAndCookieAsserts()
+    public function testFlashSessionAndCookieAsserts(): void
     {
         $this->post('/posts/index');
 
@@ -709,10 +645,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test flash and cookie assertions
-     *
-     * @return void
      */
-    public function testFlashSessionAndCookieAssertsHttpServer()
+    public function testFlashSessionAndCookieAssertsHttpServer(): void
     {
         $this->post('/posts/index');
 
@@ -724,10 +658,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test flash assertions stored with enableRememberFlashMessages() after a
      * redirect.
-     *
-     * @return void
      */
-    public function testFlashAssertionsAfterRedirect()
+    public function testFlashAssertionsAfterRedirect(): void
     {
         $this->get('/posts/someRedirect');
 
@@ -739,10 +671,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test flash assertions stored with enableRememberFlashMessages() after they
      * are rendered
-     *
-     * @return void
      */
-    public function testFlashAssertionsAfterRender()
+    public function testFlashAssertionsAfterRender(): void
     {
         $this->enableRetainFlashMessages();
         $this->get('/posts/index/with_flash');
@@ -755,10 +685,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test flash assertions stored with enableRememberFlashMessages() even if
      * no view is rendered
-     *
-     * @return void
      */
-    public function testFlashAssertionsWithNoRender()
+    public function testFlashAssertionsWithNoRender(): void
     {
         $this->enableRetainFlashMessages();
         $this->get('/posts/flashNoRender');
@@ -771,10 +699,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * If multiple requests occur in the same test method
      * flash messages should be retained.
-     *
-     * @return void
      */
-    public function testFlashAssertionMultipleRequests()
+    public function testFlashAssertionMultipleRequests(): void
     {
         $this->enableRetainFlashMessages();
         $this->disableErrorHandlerMiddleware();
@@ -791,10 +717,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test flash assertions stored with enableRememberFlashMessages() even if
      * the controller clears flash data in `beforeRender`
-     *
-     * @return void
      */
-    public function testFlashAssertionsRemoveInBeforeRender()
+    public function testFlashAssertionsRemoveInBeforeRender(): void
     {
         $this->enableRetainFlashMessages();
         $this->get('/posts/index/with_flash/?clear=true');
@@ -806,10 +730,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Tests assertCookieNotSet assertion
-     *
-     * @return void
      */
-    public function testAssertCookieNotSet()
+    public function testAssertCookieNotSet(): void
     {
         $this->cookie('test', 'value');
         $this->get('/cookie_component_test/remove_cookie/test');
@@ -818,10 +740,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Tests the failure message for assertCookieNotSet
-     *
-     * @return void
      */
-    public function testCookieNotSetFailure()
+    public function testCookieNotSetFailure(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that \'remember_me\' cookie is not set');
@@ -832,10 +752,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Tests the failure message for assertCookieNotSet when no
      * response whas generated
-     *
-     * @return void
      */
-    public function testCookieNotSetFailureNoResponse()
+    public function testCookieNotSetFailureNoResponse(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('No response set, cannot assert content.');
@@ -844,10 +762,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test error handling and error page rendering.
-     *
-     * @return void
      */
-    public function testPostAndErrorHandling()
+    public function testPostAndErrorHandling(): void
     {
         $this->post('/request_action/error_method');
         $this->assertResponseNotEmpty();
@@ -857,10 +773,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test posting to a secured form action.
-     *
-     * @return void
      */
-    public function testPostSecuredForm()
+    public function testPostSecuredForm(): void
     {
         $this->enableSecurityToken();
         $data = [
@@ -874,10 +788,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test posting to a secured form action with nested data.
-     *
-     * @return void
      */
-    public function testPostSecuredFormNestedData()
+    public function testPostSecuredFormNestedData(): void
     {
         $this->enableSecurityToken();
         $data = [
@@ -894,10 +806,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test posting to a secured form action with unlocked fields
-     *
-     * @return void
      */
-    public function testPostSecuredFormUnlockedFieldsFails()
+    public function testPostSecuredFormUnlockedFieldsFails(): void
     {
         $this->enableSecurityToken();
         $data = [
@@ -915,10 +825,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test posting to a secured form action with unlocked fields
-     *
-     * @return void
      */
-    public function testPostSecuredFormUnlockedFieldsWithSet()
+    public function testPostSecuredFormUnlockedFieldsWithSet(): void
     {
         $this->enableSecurityToken();
         $data = [
@@ -937,10 +845,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test posting to a secured form action.
-     *
-     * @return void
      */
-    public function testPostSecuredFormWithQuery()
+    public function testPostSecuredFormWithQuery(): void
     {
         $this->enableSecurityToken();
         $data = [
@@ -955,10 +861,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test posting to a secured form action with a query that has a part that
      * will be encoded by the security component
-     *
-     * @return void
      */
-    public function testPostSecuredFormWithUnencodedQuery()
+    public function testPostSecuredFormWithUnencodedQuery(): void
     {
         $this->enableSecurityToken();
         $data = [
@@ -972,10 +876,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test posting to a secured form action action.
-     *
-     * @return void
      */
-    public function testPostSecuredFormFailure()
+    public function testPostSecuredFormFailure(): void
     {
         $data = [
             'title' => 'Some title',
@@ -987,10 +889,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for cookie based CSRF token protection success
-     *
-     * @return void
      */
-    public function testPostCookieCsrfSuccess()
+    public function testPostCookieCsrfSuccess(): void
     {
         $this->enableCsrfToken();
         $data = [
@@ -1003,10 +903,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for cookie based CSRF token protection fail
-     *
-     * @return void
      */
-    public function testPostCookieCsrfFailure()
+    public function testPostCookieCsrfFailure(): void
     {
         $this->enableCsrfToken();
         $data = [
@@ -1020,10 +918,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for session based CSRF token protection success
-     *
-     * @return void
      */
-    public function testPostSessionCsrfSuccess()
+    public function testPostSessionCsrfSuccess(): void
     {
         $this->enableCsrfToken();
         $data = [
@@ -1036,10 +932,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for session based CSRF token protection fail
-     *
-     * @return void
      */
-    public function testPostSessionCsrfFailure()
+    public function testPostSessionCsrfFailure(): void
     {
         $this->enableCsrfToken();
         $data = [
@@ -1053,12 +947,10 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for session based CSRF token protection success with specified cookie name
-     *
-     * @return void
      */
-    public function testPostSessionCsrfSuccessWithSetCookieName()
+    public function testPostSessionCsrfSuccessWithSetCookieName(): void
     {
-        Router::scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes) {
+        Router::scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                 [
                     'cookieName' => 'customCsrfToken',
@@ -1078,12 +970,10 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for session based CSRF token protection fail with specified cookie name
-     *
-     * @return void
      */
-    public function testPostSessionCsrfFailureWithSetCookieName()
+    public function testPostSessionCsrfFailureWithSetCookieName(): void
     {
-        Router::scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes) {
+        Router::scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                 [
                     'cookieName' => 'customCsrfToken',
@@ -1104,10 +994,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that exceptions being thrown are handled correctly.
-     *
-     * @return void
      */
-    public function testWithExpectedException()
+    public function testWithExpectedException(): void
     {
         $this->get('/tests_apps/throw_exception');
         $this->assertResponseCode(500);
@@ -1115,10 +1003,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that exceptions being thrown are handled correctly by the psr7 stack.
-     *
-     * @return void
      */
-    public function testWithExpectedExceptionHttpServer()
+    public function testWithExpectedExceptionHttpServer(): void
     {
         $this->get('/tests_apps/throw_exception');
         $this->assertResponseCode(500);
@@ -1126,10 +1012,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that exceptions being thrown are handled correctly.
-     *
-     * @return void
      */
-    public function testWithUnexpectedException()
+    public function testWithUnexpectedException(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->get('/tests_apps/throw_exception');
@@ -1138,10 +1022,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test redirecting and integration tests.
-     *
-     * @return void
      */
-    public function testRedirect()
+    public function testRedirect(): void
     {
         $this->post('/tests_apps/redirect_to');
         $this->assertResponseSuccess();
@@ -1150,10 +1032,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test redirecting and psr7 stack
-     *
-     * @return void
      */
-    public function testRedirectHttpServer()
+    public function testRedirectHttpServer(): void
     {
         $this->post('/tests_apps/redirect_to');
         $this->assertResponseCode(302);
@@ -1162,10 +1042,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test redirecting and integration tests.
-     *
-     * @return void
      */
-    public function testRedirectPermanent()
+    public function testRedirectPermanent(): void
     {
         $this->post('/tests_apps/redirect_to_permanent');
         $this->assertResponseSuccess();
@@ -1174,10 +1052,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the responseOk status assertion
-     *
-     * @return void
      */
-    public function testAssertResponseStatusCodes()
+    public function testAssertResponseStatusCodes(): void
     {
         $this->_response = new Response();
 
@@ -1214,10 +1090,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the location header assertion.
-     *
-     * @return void
      */
-    public function testAssertRedirect()
+    public function testAssertRedirect(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Location', 'http://localhost/get/tasks/index');
@@ -1231,10 +1105,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the location header assertion.
-     *
-     * @return void
      */
-    public function testAssertRedirectEquals()
+    public function testAssertRedirectEquals(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Location', '/get/tasks/index');
@@ -1248,10 +1120,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the location header assertion string not contains
-     *
-     * @return void
      */
-    public function testAssertRedirectNotContains()
+    public function testAssertRedirectNotContains(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Location', 'http://localhost/tasks/index');
@@ -1260,10 +1130,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the location header assertion.
-     *
-     * @return void
      */
-    public function testAssertNoRedirect()
+    public function testAssertNoRedirect(): void
     {
         $this->_response = new Response();
 
@@ -1272,10 +1140,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the location header assertion.
-     *
-     * @return void
      */
-    public function testAssertNoRedirectFail()
+    public function testAssertNoRedirectFail(): void
     {
         $test = new AssertIntegrationTestCase('testBadAssertNoRedirect');
         $result = $test->run();
@@ -1286,10 +1152,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the location header assertion string contains
-     *
-     * @return void
      */
-    public function testAssertRedirectContains()
+    public function testAssertRedirectContains(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Location', 'http://localhost/tasks/index');
@@ -1299,10 +1163,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the header assertion.
-     *
-     * @return void
      */
-    public function testAssertHeader()
+    public function testAssertHeader(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Etag', 'abc123');
@@ -1312,10 +1174,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the header contains assertion.
-     *
-     * @return void
      */
-    public function testAssertHeaderContains()
+    public function testAssertHeaderContains(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Etag', 'abc123');
@@ -1325,10 +1185,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the header not contains assertion.
-     *
-     * @return void
      */
-    public function testAssertHeaderNotContains()
+    public function testAssertHeaderNotContains(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withHeader('Etag', 'abc123');
@@ -1338,10 +1196,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the content type assertion.
-     *
-     * @return void
      */
-    public function testAssertContentType()
+    public function testAssertContentType(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withType('json');
@@ -1352,10 +1208,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that type() in an action sets the content-type header.
-     *
-     * @return void
      */
-    public function testContentTypeInAction()
+    public function testContentTypeInAction(): void
     {
         $this->get('/tests_apps/set_type');
         $this->assertHeader('Content-Type', 'application/json');
@@ -1365,10 +1219,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the content assertion.
-     *
-     * @return void
      */
-    public function testAssertResponseEquals()
+    public function testAssertResponseEquals(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1378,10 +1230,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the negated content assertion.
-     *
-     * @return void
      */
-    public function testAssertResponseNotEquals()
+    public function testAssertResponseNotEquals(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1391,10 +1241,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the content assertion.
-     *
-     * @return void
      */
-    public function testAssertResponseContains()
+    public function testAssertResponseContains(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1404,10 +1252,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the content assertion with no case sensitivity.
-     *
-     * @return void
      */
-    public function testAssertResponseContainsWithIgnoreCaseFlag()
+    public function testAssertResponseContainsWithIgnoreCaseFlag(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1417,10 +1263,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the negated content assertion.
-     *
-     * @return void
      */
-    public function testAssertResponseNotContains()
+    public function testAssertResponseNotContains(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1430,10 +1274,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the content regexp assertion.
-     *
-     * @return void
      */
-    public function testAssertResponseRegExp()
+    public function testAssertResponseRegExp(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1443,10 +1285,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the content regexp assertion failing
-     *
-     * @return void
      */
-    public function testAssertResponseRegExpNoResponse()
+    public function testAssertResponseRegExpNoResponse(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('No response set');
@@ -1455,10 +1295,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the negated content regexp assertion.
-     *
-     * @return void
      */
-    public function testAssertResponseNotRegExp()
+    public function testAssertResponseNotRegExp(): void
     {
         $this->_response = new Response();
         $this->_response = $this->_response->withStringBody('Some content');
@@ -1468,10 +1306,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test negated content regexp assertion failing
-     *
-     * @return void
      */
-    public function testAssertResponseNotRegExpNoResponse()
+    public function testAssertResponseNotRegExpNoResponse(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('No response set');
@@ -1484,10 +1320,8 @@ class IntegrationTestTraitTest extends TestCase
      *
      * The return value is passed to testEventManagerReset2 as
      * an arguments.
-     *
-     * @return \Cake\Event\EventManager
      */
-    public function testEventManagerReset1()
+    public function testEventManagerReset1(): EventManager
     {
         $eventManager = EventManager::instance();
         $this->assertInstanceOf('Cake\Event\EventManager', $eventManager);
@@ -1499,9 +1333,8 @@ class IntegrationTestTraitTest extends TestCase
      * Test if the EventManager is reset between tests.
      *
      * @depends testEventManagerReset1
-     * @return void
      */
-    public function testEventManagerReset2(EventManager $prevEventManager)
+    public function testEventManagerReset2(EventManager $prevEventManager): void
     {
         $this->assertInstanceOf('Cake\Event\EventManager', $prevEventManager);
         $this->assertNotSame($prevEventManager, EventManager::instance());
@@ -1509,10 +1342,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending file in requests.
-     *
-     * @return void
      */
-    public function testSendFile()
+    public function testSendFile(): void
     {
         $this->get('/posts/file');
         $this->assertFileResponse(TEST_APP . 'TestApp' . DS . 'Controller' . DS . 'PostsController.php');
@@ -1520,10 +1351,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test sending file with psr7 stack
-     *
-     * @return void
      */
-    public function testSendFileHttpServer()
+    public function testSendFileHttpServer(): void
     {
         $this->get('/posts/file');
         $this->assertFileResponse(TEST_APP . 'TestApp' . DS . 'Controller' . DS . 'PostsController.php');
@@ -1531,10 +1360,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that assertFile requires a response
-     *
-     * @return void
      */
-    public function testAssertFileNoResponse()
+    public function testAssertFileNoResponse(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('No response set, cannot assert content');
@@ -1543,10 +1370,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that assertFile requires a file
-     *
-     * @return void
      */
-    public function testAssertFileNoFile()
+    public function testAssertFileNoFile(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that file was sent.');
@@ -1557,10 +1382,8 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test disabling the error handler middleware with exceptions
      * in controllers.
-     *
-     * @return void
      */
-    public function testDisableErrorHandlerMiddleware()
+    public function testDisableErrorHandlerMiddleware(): void
     {
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('oh no!');
@@ -1571,10 +1394,9 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * tests getting a secure action while passing a query string
      *
-     * @return void
      * @dataProvider methodsProvider
      */
-    public function testSecureWithQueryString(string $method)
+    public function testSecureWithQueryString(string $method): void
     {
         $this->enableSecurityToken();
         $this->{$method}('/posts/securePost/?ids[]=1&ids[]=2');
@@ -1584,10 +1406,9 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Tests flash assertions
      *
-     * @return void
      * @throws \PHPUnit\Exception
      */
-    public function testAssertFlashMessage()
+    public function testAssertFlashMessage(): void
     {
         $this->get('/posts/stacked_flash');
 
@@ -1613,10 +1434,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Tests asserting flash messages without first sending a request
-     *
-     * @return void
      */
-    public function testAssertFlashMessageWithoutSendingRequest()
+    public function testAssertFlashMessageWithoutSendingRequest(): void
     {
         $this->expectException(AssertionFailedError::class);
         $message = 'There is no stored session data. Perhaps you need to run a request?';
@@ -1635,7 +1454,7 @@ class IntegrationTestTraitTest extends TestCase
      * @param mixed ...$rest
      * @dataProvider assertionFailureMessagesProvider
      */
-    public function testAssertionFailureMessages($assertion, $message, $url, ...$rest)
+    public function testAssertionFailureMessages($assertion, $message, $url, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage($message);
@@ -1730,10 +1549,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test assertCookieNotSet is creating a verbose message
-     *
-     * @return void
      */
-    public function testAssertCookieNotSetVerbose()
+    public function testAssertCookieNotSetVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
@@ -1744,10 +1561,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test assertNoRedirect is creating a verbose message
-     *
-     * @return void
      */
-    public function testAssertNoRedirectVerbose()
+    public function testAssertNoRedirectVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
@@ -1758,10 +1573,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the header assertion generating a verbose message.
-     *
-     * @return void
      */
-    public function testAssertHeaderVerbose()
+    public function testAssertHeaderVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
@@ -1771,10 +1584,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the assertResponseNotEquals generates a verbose message.
-     *
-     * @return void
      */
-    public function testAssertResponseNotEqualsVerbose()
+    public function testAssertResponseNotEqualsVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
@@ -1785,10 +1596,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test the assertResponseRegExp generates a verbose message.
-     *
-     * @return void
      */
-    public function testAssertResponseRegExpVerbose()
+    public function testAssertResponseRegExpVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
@@ -1802,9 +1611,8 @@ class IntegrationTestTraitTest extends TestCase
      *
      * @dataProvider assertionFailureSessionVerboseProvider
      * @param mixed ...$rest
-     * @return void
      */
-    public function testAssertSessionRelatedVerboseMessages(string $assertMethod, ...$rest)
+    public function testAssertSessionRelatedVerboseMessages(string $assertMethod, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Possibly related to OutOfBoundsException: "oh no!"');
@@ -1830,10 +1638,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test viewVariable not found
-     *
-     * @return void
      */
-    public function testViewVariableNotFoundShouldReturnNull()
+    public function testViewVariableNotFoundShouldReturnNull(): void
     {
         $this->_controller = new Controller();
         $this->assertNull($this->viewVariable('notFound'));
@@ -1841,10 +1647,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Integration test for a controller with action dependencies.
-     *
-     * @return void
      */
-    public function testHandleWithContainerDependencies()
+    public function testHandleWithContainerDependencies(): void
     {
         $this->get('/dependencies/requiredDep');
         $this->assertResponseOk();
@@ -1853,10 +1657,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that mockService() injects into controllers.
-     *
-     * @return void
      */
-    public function testHandleWithMockServices()
+    public function testHandleWithMockServices(): void
     {
         $this->mockService(stdClass::class, function () {
             return json_decode('{"mock":true}');
@@ -1868,10 +1670,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that mockService() injects into controllers.
-     *
-     * @return void
      */
-    public function testHandleWithMockServicesOverwrite()
+    public function testHandleWithMockServicesOverwrite(): void
     {
         $this->mockService(stdClass::class, function () {
             return json_decode('{"first":true}');
@@ -1886,10 +1686,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test that removeMock() unsets mocks
-     *
-     * @return void
      */
-    public function testHandleWithMockServicesUnset()
+    public function testHandleWithMockServicesUnset(): void
     {
         $this->mockService(stdClass::class, function () {
             return json_decode('{"first":true}');

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -41,7 +41,7 @@ class TestCaseTest extends TestCase
     /**
      * tests trying to assertEventFired without configuring an event list
      */
-    public function testEventFiredMisconfiguredEventList()
+    public function testEventFiredMisconfiguredEventList(): void
     {
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $manager = EventManager::instance();
@@ -51,7 +51,7 @@ class TestCaseTest extends TestCase
     /**
      * tests trying to assertEventFired without configuring an event list
      */
-    public function testEventFiredWithMisconfiguredEventList()
+    public function testEventFiredWithMisconfiguredEventList(): void
     {
         $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $manager = EventManager::instance();
@@ -60,10 +60,8 @@ class TestCaseTest extends TestCase
 
     /**
      * tests assertEventFiredWith
-     *
-     * @return void
      */
-    public function testEventFiredWith()
+    public function testEventFiredWith(): void
     {
         $manager = EventManager::instance();
         $manager->setEventList(new EventList());
@@ -88,10 +86,8 @@ class TestCaseTest extends TestCase
 
     /**
      * tests assertEventFired
-     *
-     * @return void
      */
-    public function testEventFired()
+    public function testEventFired(): void
     {
         $manager = EventManager::instance();
         $manager->setEventList(new EventList());
@@ -112,10 +108,8 @@ class TestCaseTest extends TestCase
 
     /**
      * testSkipIf
-     *
-     * @return void
      */
-    public function testSkipIf()
+    public function testSkipIf(): void
     {
         $test = new FixturizedTestCase('testSkipIfTrue');
         $result = $test->run();
@@ -128,13 +122,11 @@ class TestCaseTest extends TestCase
 
     /**
      * test withErrorReporting
-     *
-     * @return void
      */
-    public function testWithErrorReporting()
+    public function testWithErrorReporting(): void
     {
         $errorLevel = error_reporting();
-        $this->withErrorReporting(E_USER_WARNING, function () {
+        $this->withErrorReporting(E_USER_WARNING, function (): void {
               $this->assertSame(E_USER_WARNING, error_reporting());
         });
         $this->assertSame($errorLevel, error_reporting());
@@ -142,16 +134,14 @@ class TestCaseTest extends TestCase
 
     /**
      * test withErrorReporting with exceptions
-     *
-     * @return void
      */
-    public function testWithErrorReportingWithException()
+    public function testWithErrorReportingWithException(): void
     {
         $this->expectException(AssertionFailedError::class);
 
         $errorLevel = error_reporting();
         try {
-            $this->withErrorReporting(E_USER_WARNING, function () {
+            $this->withErrorReporting(E_USER_WARNING, function (): void {
                 $this->assertSame(1, 2);
             });
         } finally {
@@ -161,20 +151,16 @@ class TestCaseTest extends TestCase
 
     /**
      * Test that TestCase::setUp() backs up values.
-     *
-     * @return void
      */
-    public function testSetupBackUpValues()
+    public function testSetupBackUpValues(): void
     {
         $this->assertArrayHasKey('debug', $this->_configure);
     }
 
     /**
      * test assertTextNotEquals()
-     *
-     * @return void
      */
-    public function testAssertTextNotEquals()
+    public function testAssertTextNotEquals(): void
     {
         $one = "\r\nOne\rTwooo";
         $two = "\nOne\nTwo";
@@ -183,10 +169,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextEquals()
-     *
-     * @return void
      */
-    public function testAssertTextEquals()
+    public function testAssertTextEquals(): void
     {
         $one = "\r\nOne\rTwo";
         $two = "\nOne\nTwo";
@@ -195,10 +179,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextStartsWith()
-     *
-     * @return void
      */
-    public function testAssertTextStartsWith()
+    public function testAssertTextStartsWith(): void
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
 
@@ -212,10 +194,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextStartsNotWith()
-     *
-     * @return void
      */
-    public function testAssertTextStartsNotWith()
+    public function testAssertTextStartsNotWith(): void
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
 
@@ -224,10 +204,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextEndsWith()
-     *
-     * @return void
      */
-    public function testAssertTextEndsWith()
+    public function testAssertTextEndsWith(): void
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
 
@@ -237,10 +215,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextEndsNotWith()
-     *
-     * @return void
      */
-    public function testAssertTextEndsNotWith()
+    public function testAssertTextEndsNotWith(): void
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
 
@@ -250,10 +226,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextContains()
-     *
-     * @return void
      */
-    public function testAssertTextContains()
+    public function testAssertTextContains(): void
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
 
@@ -265,10 +239,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test assertTextNotContains()
-     *
-     * @return void
      */
-    public function testAssertTextNotContains()
+    public function testAssertTextNotContains(): void
     {
         $stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
 
@@ -277,10 +249,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test testAssertWithinRange()
-     *
-     * @return void
      */
-    public function testAssertWithinRange()
+    public function testAssertWithinRange(): void
     {
         $this->assertWithinRange(21, 22, 1, 'Not within range');
         $this->assertWithinRange(21.3, 22.2, 1.0, 'Not within range');
@@ -288,10 +258,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test testAssertNotWithinRange()
-     *
-     * @return void
      */
-    public function testAssertNotWithinRange()
+    public function testAssertNotWithinRange(): void
     {
         $this->assertNotWithinRange(21, 23, 1, 'Within range');
         $this->assertNotWithinRange(21.3, 22.2, 0.7, 'Within range');
@@ -299,10 +267,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test getMockForModel()
-     *
-     * @return void
      */
-    public function testGetMockForModel()
+    public function testGetMockForModel(): void
     {
         static::setAppNamespace();
         // No methods will be mocked if $methods argument of getMockForModel() is empty.
@@ -341,10 +307,8 @@ class TestCaseTest extends TestCase
 
     /**
      * Test getMockForModel on secondary datasources.
-     *
-     * @return void
      */
-    public function testGetMockForModelSecondaryDatasource()
+    public function testGetMockForModelSecondaryDatasource(): void
     {
         ConnectionManager::alias('test', 'secondary');
 
@@ -354,10 +318,8 @@ class TestCaseTest extends TestCase
 
     /**
      * test getMockForModel() with plugin models
-     *
-     * @return void
      */
-    public function testGetMockForModelWithPlugin()
+    public function testGetMockForModelWithPlugin(): void
     {
         static::setAppNamespace();
         $this->loadPlugins(['TestPlugin']);
@@ -390,10 +352,8 @@ class TestCaseTest extends TestCase
 
     /**
      * testGetMockForModelTable
-     *
-     * @return void
      */
-    public function testGetMockForModelTable()
+    public function testGetMockForModelTable(): void
     {
         $Mock = $this->getMockForModel(
             'Table',
@@ -428,10 +388,8 @@ class TestCaseTest extends TestCase
 
     /**
      * Test getting a table mock that doesn't have a preset table name sets the proper name
-     *
-     * @return void
      */
-    public function testGetMockForModelSetTable()
+    public function testGetMockForModelSetTable(): void
     {
         static::setAppNamespace();
         ConnectionManager::alias('test', 'custom_i18n_datasource');
@@ -446,10 +404,8 @@ class TestCaseTest extends TestCase
 
     /**
      * Test loadRoutes() helper
-     *
-     * @return void
      */
-    public function testLoadRoutes()
+    public function testLoadRoutes(): void
     {
         $url = ['controller' => 'Articles', 'action' => 'index'];
         try {
@@ -466,10 +422,8 @@ class TestCaseTest extends TestCase
 
     /**
      * Test getting the state reset manager.
-     *
-     * @return void
      */
-    public function testGetResetStrategySuccess()
+    public function testGetResetStrategySuccess(): void
     {
         $instance = $this->getResetStrategy();
         $this->assertInstanceOf(ResetStrategyInterface::class, $instance);
@@ -478,10 +432,8 @@ class TestCaseTest extends TestCase
 
     /**
      * Test getting the state reset manager when class is invalid
-     *
-     * @return void
      */
-    public function testGetResetStrategyMissingClass()
+    public function testGetResetStrategyMissingClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot find class `NotThere`');
@@ -491,10 +443,8 @@ class TestCaseTest extends TestCase
 
     /**
      * Test getting the state reset manager when class is invalid
-     *
-     * @return void
      */
-    public function testGetStateResetInvalidClass()
+    public function testGetStateResetInvalidClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('does not implement the required');

--- a/tests/TestCase/TestSuite/TestConnectionManagerTest.php
+++ b/tests/TestCase/TestSuite/TestConnectionManagerTest.php
@@ -22,7 +22,7 @@ use Cake\TestSuite\TestConnectionManager;
 
 class TestConnectionManagerTest extends TestCase
 {
-    public function testAliasConnections()
+    public function testAliasConnections(): void
     {
         ConnectionManager::dropAlias('default');
 

--- a/tests/TestCase/TestSuite/TestEmailTransportTest.php
+++ b/tests/TestCase/TestSuite/TestEmailTransportTest.php
@@ -26,8 +26,6 @@ class TestEmailTransportTest extends TestCase
 {
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,8 +55,6 @@ class TestEmailTransportTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -72,10 +68,8 @@ class TestEmailTransportTest extends TestCase
 
     /**
      * tests replaceAllTransports
-     *
-     * @return void
      */
-    public function testReplaceAllTransports()
+    public function testReplaceAllTransports(): void
     {
         TestEmailTransport::replaceAllTransports();
 
@@ -88,10 +82,8 @@ class TestEmailTransportTest extends TestCase
 
     /**
      * tests sending an email through the transport, getting it, and clearing all emails
-     *
-     * @return void
      */
-    public function testSendGetAndClear()
+    public function testSendGetAndClear(): void
     {
         TestEmailTransport::replaceAllTransports();
 

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -41,8 +41,6 @@ class TestFixtureTest extends TestCase
 
     /**
      * Set up
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -52,8 +50,6 @@ class TestFixtureTest extends TestCase
 
     /**
      * Tear down
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -63,10 +59,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test initializing a static fixture
-     *
-     * @return void
      */
-    public function testInitStaticFixture()
+    public function testInitStaticFixture(): void
     {
         $Fixture = new ArticlesFixture();
         $this->assertSame('articles', $Fixture->table);
@@ -92,10 +86,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test import fixture initialization
-     *
-     * @return void
      */
-    public function testInitImport()
+    public function testInitImport(): void
     {
         $fixture = new ImportsFixture();
         $fixture->fields = $fixture->records = null;
@@ -117,10 +109,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test import fixture initialization
-     *
-     * @return void
      */
-    public function testInitImportModel()
+    public function testInitImportModel(): void
     {
         $fixture = new ImportsFixture();
         $fixture->fields = $fixture->records = null;
@@ -143,10 +133,8 @@ class TestFixtureTest extends TestCase
     /**
      * test schema reflection without $import or $fields and without the table existing
      * it will throw an exception
-     *
-     * @return void
      */
-    public function testInitNoImportNoFieldsException()
+    public function testInitNoImportNoFieldsException(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`: the table does not exist.');
@@ -156,10 +144,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test schema reflection without $import or $fields will reflect the schema
-     *
-     * @return void
      */
-    public function testInitNoImportNoFields()
+    public function testInitNoImportNoFields(): void
     {
         $db = ConnectionManager::get('test');
         $table = new TableSchema('letters', [
@@ -194,10 +180,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test create method
-     *
-     * @return void
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $fixture = new ArticlesFixture();
         $db = $this->getMockBuilder('Cake\Database\Connection')
@@ -224,10 +208,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test create method, trigger error
-     *
-     * @return void
      */
-    public function testCreateError()
+    public function testCreateError(): void
     {
         $this->expectError();
         $fixture = new ArticlesFixture();
@@ -248,10 +230,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test the insert method
-     *
-     * @return void
      */
-    public function testInsert()
+    public function testInsert(): void
     {
         $fixture = new ArticlesFixture();
 
@@ -301,10 +281,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test the insert method
-     *
-     * @return void
      */
-    public function testInsertImport()
+    public function testInsertImport(): void
     {
         $fixture = new ImportsFixture();
 
@@ -348,10 +326,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * test the insert method
-     *
-     * @return void
      */
-    public function testInsertStrings()
+    public function testInsertStrings(): void
     {
         $fixture = new StringsTestsFixture();
 
@@ -401,10 +377,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * Test the drop method
-     *
-     * @return void
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         $fixture = new ArticlesFixture();
 
@@ -431,10 +405,8 @@ class TestFixtureTest extends TestCase
 
     /**
      * Test the truncate method.
-     *
-     * @return void
      */
-    public function testTruncate()
+    public function testTruncate(): void
     {
         $fixture = new ArticlesFixture();
 

--- a/tests/TestCase/TestSuite/TestSessionTest.php
+++ b/tests/TestCase/TestSuite/TestSessionTest.php
@@ -31,9 +31,6 @@ class TestSessionTest extends TestCase
      */
     protected $session;
 
-    /**
-     * @return void
-     */
     public function setUp(): void
     {
         parent::setUp();
@@ -50,8 +47,6 @@ class TestSessionTest extends TestCase
 
     /**
      * Tests read()
-     *
-     * @return void
      */
     public function testRead(): void
     {
@@ -64,8 +59,6 @@ class TestSessionTest extends TestCase
 
     /**
      * Tests check()
-     *
-     * @return void
      */
     public function testCheck(): void
     {

--- a/tests/TestCase/TestSuite/TestSuiteTest.php
+++ b/tests/TestCase/TestSuite/TestSuiteTest.php
@@ -26,10 +26,8 @@ class TestSuiteTest extends TestCase
 {
     /**
      * testAddTestDirectory
-     *
-     * @return void
      */
-    public function testAddTestDirectory()
+    public function testAddTestDirectory(): void
     {
         $testFolder = CORE_TEST_CASES . DS . 'TestSuite';
         $count = count(glob($testFolder . DS . '*Test.php'));
@@ -46,10 +44,8 @@ class TestSuiteTest extends TestCase
 
     /**
      * testAddTestDirectoryRecursive
-     *
-     * @return void
      */
-    public function testAddTestDirectoryRecursive()
+    public function testAddTestDirectoryRecursive(): void
     {
         $testFolder = CORE_TEST_CASES . DS . 'Cache';
         $count = count(glob($testFolder . DS . '*Test.php'));
@@ -67,10 +63,8 @@ class TestSuiteTest extends TestCase
 
     /**
      * testAddTestDirectoryRecursiveWithHidden
-     *
-     * @return void
      */
-    public function testAddTestDirectoryRecursiveWithHidden()
+    public function testAddTestDirectoryRecursiveWithHidden(): void
     {
         $this->skipIf(!is_writable(TMP), 'Cant addTestDirectoryRecursiveWithHidden unless the tmp folder is writable.');
 
@@ -96,10 +90,8 @@ class TestSuiteTest extends TestCase
 
     /**
      * testAddTestDirectoryRecursiveWithNonPhp
-     *
-     * @return void
      */
-    public function testAddTestDirectoryRecursiveWithNonPhp()
+    public function testAddTestDirectoryRecursiveWithNonPhp(): void
     {
         $this->skipIf(!is_writable(TMP), 'Cant addTestDirectoryRecursiveWithNonPhp unless the tmp folder is writable.');
 

--- a/tests/TestCase/Utility/Crypto/OpenSslTest.php
+++ b/tests/TestCase/Utility/Crypto/OpenSslTest.php
@@ -31,8 +31,6 @@ class OpenSslTest extends TestCase
 
     /**
      * Setup function.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class OpenSslTest extends TestCase
 
     /**
      * Test encrypt/decrypt.
-     *
-     * @return void
      */
-    public function testEncryptDecrypt()
+    public function testEncryptDecrypt(): void
     {
         $txt = 'The quick brown fox';
         $key = 'This key is enough bytes';
@@ -58,10 +54,8 @@ class OpenSslTest extends TestCase
 
     /**
      * Test that changing the key causes decryption to fail.
-     *
-     * @return void
      */
-    public function testDecryptKeyFailure()
+    public function testDecryptKeyFailure(): void
     {
         $txt = 'The quick brown fox';
         $key = 'This key is enough bytes';

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -32,7 +32,7 @@ class HashTest extends TestCase
      *
      * @return array
      */
-    public static function articleData()
+    public static function articleData(): array
     {
         return [
             [
@@ -148,10 +148,8 @@ class HashTest extends TestCase
 
     /**
      * Data provider
-     *
-     * @return array
      */
-    public static function articleDataObject()
+    public static function articleDataObject(): ArrayObject
     {
         return new ArrayObject([
             new Entity([
@@ -270,7 +268,7 @@ class HashTest extends TestCase
      *
      * @return array
      */
-    public static function articleDataSets()
+    public static function articleDataSets(): array
     {
         return [
             [static::articleData()],
@@ -283,7 +281,7 @@ class HashTest extends TestCase
      *
      * @return array
      */
-    public static function userData()
+    public static function userData(): array
     {
         return [
             [
@@ -321,10 +319,8 @@ class HashTest extends TestCase
 
     /**
      * Test get()
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $data = ['abc', 'def'];
 
@@ -397,10 +393,8 @@ class HashTest extends TestCase
 
     /**
      * Test that get() can extract '' key data.
-     *
-     * @return void
      */
-    public function testGetEmptyKey()
+    public function testGetEmptyKey(): void
     {
         $data = [
             '' => 'some value',
@@ -411,10 +405,8 @@ class HashTest extends TestCase
 
     /**
      * Test get() for invalid $data type
-     *
-     * @return void
      */
-    public function testGetInvalidData()
+    public function testGetInvalidData(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid data type, must be an array or \ArrayAccess instance.');
@@ -423,10 +415,8 @@ class HashTest extends TestCase
 
     /**
      * Test get() with an invalid path
-     *
-     * @return void
      */
-    public function testGetInvalidPath()
+    public function testGetInvalidPath(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Hash::get(['one' => 'two'], true);
@@ -434,10 +424,8 @@ class HashTest extends TestCase
 
     /**
      * Test dimensions.
-     *
-     * @return void
      */
-    public function testDimensions()
+    public function testDimensions(): void
     {
         $result = Hash::dimensions([]);
         $this->assertSame($result, 0);
@@ -465,10 +453,8 @@ class HashTest extends TestCase
 
     /**
      * Test maxDimensions
-     *
-     * @return void
      */
-    public function testMaxDimensions()
+    public function testMaxDimensions(): void
     {
         $data = [];
         $result = Hash::maxDimensions($data);
@@ -519,10 +505,8 @@ class HashTest extends TestCase
 
     /**
      * Tests Hash::flatten
-     *
-     * @return void
      */
-    public function testFlatten()
+    public function testFlatten(): void
     {
         $data = ['Larry', 'Curly', 'Moe'];
         $result = Hash::flatten($data);
@@ -589,10 +573,8 @@ class HashTest extends TestCase
 
     /**
      * Test diff();
-     *
-     * @return void
      */
-    public function testDiff()
+    public function testDiff(): void
     {
         $a = [
             0 => ['name' => 'main'],
@@ -672,10 +654,8 @@ class HashTest extends TestCase
 
     /**
      * Test merge()
-     *
-     * @return void
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $result = Hash::merge(['foo'], ['bar']);
         $this->assertSame($result, ['foo', 'bar']);
@@ -733,10 +713,8 @@ class HashTest extends TestCase
 
     /**
      * Test that merge() works with variadic arguments.
-     *
-     * @return void
      */
-    public function testMergeVariadic()
+    public function testMergeVariadic(): void
     {
         $result = Hash::merge(
             ['hkuc' => ['lion']],
@@ -781,10 +759,8 @@ class HashTest extends TestCase
 
     /**
      * test normalizing arrays
-     *
-     * @return void
      */
-    public function testNormalize()
+    public function testNormalize(): void
     {
         $result = Hash::normalize(['one', 'two', 'three']);
         $expected = ['one' => null, 'two' => null, 'three' => null];
@@ -809,10 +785,8 @@ class HashTest extends TestCase
 
     /**
      * testContains method
-     *
-     * @return void
      */
-    public function testContains()
+    public function testContains(): void
     {
         $data = ['apple', 'bee', 'cyclops'];
         $this->assertTrue(Hash::contains($data, ['apple']));
@@ -854,10 +828,8 @@ class HashTest extends TestCase
 
     /**
      * testFilter method
-     *
-     * @return void
      */
-    public function testFilter()
+    public function testFilter(): void
     {
         $result = Hash::filter([
             '0',
@@ -897,10 +869,8 @@ class HashTest extends TestCase
 
     /**
      * testNumericArrayCheck method
-     *
-     * @return void
      */
-    public function testNumeric()
+    public function testNumeric(): void
     {
         $data = ['one'];
         $this->assertTrue(Hash::numeric(array_keys($data)));
@@ -938,10 +908,8 @@ class HashTest extends TestCase
 
     /**
      * Test passing invalid argument type
-     *
-     * @return void
      */
-    public function testExtractInvalidArgument()
+    public function testExtractInvalidArgument(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid data type, must be an array or \ArrayAccess instance.');
@@ -953,9 +921,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractSingleValueWithFilteringByAnotherField($data)
+    public function testExtractSingleValueWithFilteringByAnotherField($data): void
     {
         $result = Hash::extract($data, '{*}.Article[id=1].title');
         $this->assertSame([0 => 'First Article'], $result);
@@ -969,9 +936,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractBasic($data)
+    public function testExtractBasic($data): void
     {
         $result = Hash::extract($data, '');
         $this->assertSame($data, $result);
@@ -991,9 +957,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractNumericKey($data)
+    public function testExtractNumericKey($data): void
     {
         $result = Hash::extract($data, '{n}.Article.title');
         $expected = [
@@ -1012,10 +977,8 @@ class HashTest extends TestCase
 
     /**
      * Test the {n} selector with inconsistent arrays
-     *
-     * @return void
      */
-    public function testExtractNumericMixedKeys()
+    public function testExtractNumericMixedKeys(): void
     {
         $data = [
             'User' => [
@@ -1070,10 +1033,8 @@ class HashTest extends TestCase
 
     /**
      * Test the {n} selector with non-zero based arrays
-     *
-     * @return void
      */
-    public function testExtractNumericNonZero()
+    public function testExtractNumericNonZero(): void
     {
         $data = [
             1 => [
@@ -1129,9 +1090,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractStringKey($data)
+    public function testExtractStringKey($data): void
     {
         $result = Hash::extract($data, '{n}.{s}.user');
         $expected = [
@@ -1149,10 +1109,8 @@ class HashTest extends TestCase
 
     /**
      * Test wildcard matcher
-     *
-     * @return void
      */
-    public function testExtractWildcard()
+    public function testExtractWildcard(): void
     {
         $data = [
             '02000009C5560001' => ['name' => 'Mr. Alphanumeric'],
@@ -1198,9 +1156,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractAttributePresence($data)
+    public function testExtractAttributePresence($data): void
     {
         $result = Hash::extract($data, '{n}.Article[published]');
         $expected = [$data[1]['Article']];
@@ -1216,9 +1173,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractAttributeEquality($data)
+    public function testExtractAttributeEquality($data): void
     {
         $result = Hash::extract($data, '{n}.Article[id=3]');
         $expected = [$data[2]['Article']];
@@ -1237,10 +1193,8 @@ class HashTest extends TestCase
 
     /**
      * Test extracting based on attributes with boolean values.
-     *
-     * @return void
      */
-    public function testExtractAttributeBoolean()
+    public function testExtractAttributeBoolean(): void
     {
         $usersArray = [
             [
@@ -1301,10 +1255,8 @@ class HashTest extends TestCase
 
     /**
      * Test that attribute matchers don't cause errors on scalar data.
-     *
-     * @return void
      */
-    public function testExtractAttributeEqualityOnScalarValue()
+    public function testExtractAttributeEqualityOnScalarValue(): void
     {
         $dataArray = [
             'Entity' => [
@@ -1334,9 +1286,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractAttributeComparison($data)
+    public function testExtractAttributeComparison($data): void
     {
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id > 2]');
         $expected = [$data[0]['Comment'][1]];
@@ -1364,9 +1315,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractAttributeMultiple($data)
+    public function testExtractAttributeMultiple($data): void
     {
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id > 2][id=1]');
         $this->assertEmpty($result);
@@ -1382,9 +1332,8 @@ class HashTest extends TestCase
      *
      * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
-     * @return void
      */
-    public function testExtractAttributePattern($data)
+    public function testExtractAttributePattern($data): void
     {
         $result = Hash::extract($data, '{n}.Article[title=/^First/]');
         $expected = [$data[0]['Article']];
@@ -1397,10 +1346,8 @@ class HashTest extends TestCase
 
     /**
      * Test that extract() + matching can hit null things.
-     *
-     * @return void
      */
-    public function testExtractMatchesNull()
+    public function testExtractMatchesNull(): void
     {
         $data = [
             'Country' => [
@@ -1433,10 +1380,8 @@ class HashTest extends TestCase
 
     /**
      * Test extracting attributes with string
-     *
-     * @return void
      */
-    public function testExtractAttributeString()
+    public function testExtractAttributeString(): void
     {
         $data = [
             ['value' => 0],
@@ -1463,10 +1408,8 @@ class HashTest extends TestCase
 
     /**
      * Test that uneven keys are handled correctly.
-     *
-     * @return void
      */
-    public function testExtractUnevenKeys()
+    public function testExtractUnevenKeys(): void
     {
         $data = [
             'Level1' => [
@@ -1531,10 +1474,8 @@ class HashTest extends TestCase
 
     /**
      * Tests that objects as values handled correctly.
-     *
-     * @return void
      */
-    public function testExtractObjects()
+    public function testExtractObjects(): void
     {
         $data = [
             'root' => [
@@ -1557,10 +1498,8 @@ class HashTest extends TestCase
 
     /**
      * testSort method
-     *
-     * @return void
      */
-    public function testSort()
+    public function testSort(): void
     {
         $result = Hash::sort([], '{n}.name');
         $this->assertSame([], $result);
@@ -1710,10 +1649,8 @@ class HashTest extends TestCase
 
     /**
      * Test sort() with numeric option.
-     *
-     * @return void
      */
-    public function testSortNumeric()
+    public function testSortNumeric(): void
     {
         $items = [
             ['Item' => ['price' => '155,000']],
@@ -1745,10 +1682,8 @@ class HashTest extends TestCase
 
     /**
      * Test natural sorting.
-     *
-     * @return void
      */
-    public function testSortNatural()
+    public function testSortNatural(): void
     {
         $items = [
             ['Item' => ['image' => 'img1.jpg']],
@@ -1780,10 +1715,8 @@ class HashTest extends TestCase
 
     /**
      * Test sort() with locale option.
-     *
-     * @return void
      */
-    public function testSortLocale()
+    public function testSortLocale(): void
     {
         // get the current locale
         $oldLocale = setlocale(LC_COLLATE, '0');
@@ -1813,10 +1746,8 @@ class HashTest extends TestCase
 
     /**
      * Test that sort() with 'natural' type will fallback to 'regular' as SORT_NATURAL is introduced in PHP 5.4
-     *
-     * @return void
      */
-    public function testSortNaturalFallbackToRegular()
+    public function testSortNaturalFallbackToRegular(): void
     {
         $a = [
             0 => ['Person' => ['name' => 'Jeff']],
@@ -1832,10 +1763,8 @@ class HashTest extends TestCase
 
     /**
      * test sorting with out of order keys.
-     *
-     * @return void
      */
-    public function testSortWithOutOfOrderKeys()
+    public function testSortWithOutOfOrderKeys(): void
     {
         $data = [
             9 => ['class' => 510, 'test2' => 2],
@@ -1860,10 +1789,8 @@ class HashTest extends TestCase
 
     /**
      * test sorting with string keys.
-     *
-     * @return void
      */
-    public function testSortString()
+    public function testSortString(): void
     {
         $toSort = [
             'four' => ['number' => 4, 'some' => 'foursome'],
@@ -1898,10 +1825,8 @@ class HashTest extends TestCase
 
     /**
      * test sorting with string ignoring case.
-     *
-     * @return void
      */
-    public function testSortStringIgnoreCase()
+    public function testSortStringIgnoreCase(): void
     {
         $toSort = [
             ['Item' => ['name' => 'bar']],
@@ -1921,10 +1846,8 @@ class HashTest extends TestCase
 
     /**
      * test regular sorting ignoring case.
-     *
-     * @return void
      */
-    public function testSortRegularIgnoreCase()
+    public function testSortRegularIgnoreCase(): void
     {
         $toSort = [
             ['Item' => ['name' => 'bar']],
@@ -1944,10 +1867,8 @@ class HashTest extends TestCase
 
     /**
      * Test sorting on a nested key that is sometimes undefined.
-     *
-     * @return void
      */
-    public function testSortSparse()
+    public function testSortSparse(): void
     {
         $data = [
             [
@@ -1997,10 +1918,8 @@ class HashTest extends TestCase
 
     /**
      * Test insert()
-     *
-     * @return void
      */
-    public function testInsertSimple()
+    public function testInsertSimple(): void
     {
         $a = [
             'pages' => ['name' => 'page'],
@@ -2031,10 +1950,8 @@ class HashTest extends TestCase
 
     /**
      * Test inserting with multiple values.
-     *
-     * @return void
      */
-    public function testInsertMulti()
+    public function testInsertMulti(): void
     {
         $data = static::articleData();
 
@@ -2077,10 +1994,8 @@ class HashTest extends TestCase
 
     /**
      * Test that insert() can insert data over a string value.
-     *
-     * @return void
      */
-    public function testInsertOverwriteStringValue()
+    public function testInsertOverwriteStringValue(): void
     {
         $data = [
             'Some' => [
@@ -2100,10 +2015,8 @@ class HashTest extends TestCase
 
     /**
      * Test remove() method.
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $a = [
             'pages' => ['name' => 'page'],
@@ -2208,10 +2121,8 @@ class HashTest extends TestCase
 
     /**
      * Test removing multiple values.
-     *
-     * @return void
      */
-    public function testRemoveMulti()
+    public function testRemoveMulti(): void
     {
         $data = static::articleData();
 
@@ -2255,10 +2166,8 @@ class HashTest extends TestCase
 
     /**
      * testCheck method
-     *
-     * @return void
      */
-    public function testCheck()
+    public function testCheck(): void
     {
         $set = [
             'My Index 1' => ['First' => 'The first item'],
@@ -2285,10 +2194,8 @@ class HashTest extends TestCase
 
     /**
      * testCombine method
-     *
-     * @return void
      */
-    public function testCombine()
+    public function testCombine(): void
     {
         $result = Hash::combine([], '{n}.User.id', '{n}.User.Data');
         $this->assertEmpty($result);
@@ -2320,10 +2227,8 @@ class HashTest extends TestCase
 
     /**
      * test combine() with null key path.
-     *
-     * @return void
      */
-    public function testCombineWithNullKeyPath()
+    public function testCombineWithNullKeyPath(): void
     {
         $result = Hash::combine([], null, '{n}.User.Data');
         $this->assertEmpty($result);
@@ -2355,10 +2260,8 @@ class HashTest extends TestCase
 
     /**
      * test combine() giving errors on key/value length mismatches.
-     *
-     * @return void
      */
-    public function testCombineErrorMissingValue()
+    public function testCombineErrorMissingValue(): void
     {
         $this->expectException(\RuntimeException::class);
         $data = [
@@ -2370,10 +2273,8 @@ class HashTest extends TestCase
 
     /**
      * test combine() giving errors on key/value length mismatches.
-     *
-     * @return void
      */
-    public function testCombineErrorMissingKey()
+    public function testCombineErrorMissingKey(): void
     {
         $this->expectException(\RuntimeException::class);
         $data = [
@@ -2385,10 +2286,8 @@ class HashTest extends TestCase
 
     /**
      * test combine() with a group path.
-     *
-     * @return void
      */
-    public function testCombineWithGroupPath()
+    public function testCombineWithGroupPath(): void
     {
         $a = static::userData();
 
@@ -2491,10 +2390,8 @@ class HashTest extends TestCase
 
     /**
      * Test combine with formatting rules.
-     *
-     * @return void
      */
-    public function testCombineWithFormatting()
+    public function testCombineWithFormatting(): void
     {
         $a = static::userData();
 
@@ -2575,10 +2472,8 @@ class HashTest extends TestCase
 
     /**
      * testFormat method
-     *
-     * @return void
      */
-    public function testFormat()
+    public function testFormat(): void
     {
         $data = static::userData();
 
@@ -2609,10 +2504,8 @@ class HashTest extends TestCase
 
     /**
      * testFormattingNullValues method
-     *
-     * @return void
      */
-    public function testFormatNullValues()
+    public function testFormatNullValues(): void
     {
         $data = [
             ['Person' => [
@@ -2637,10 +2530,8 @@ class HashTest extends TestCase
 
     /**
      * Test map()
-     *
-     * @return void
      */
-    public function testMap()
+    public function testMap(): void
     {
         $data = static::articleData();
 
@@ -2651,10 +2542,8 @@ class HashTest extends TestCase
 
     /**
      * testApply
-     *
-     * @return void
      */
-    public function testApply()
+    public function testApply(): void
     {
         $data = static::articleData();
 
@@ -2664,10 +2553,8 @@ class HashTest extends TestCase
 
     /**
      * Test reduce()
-     *
-     * @return void
      */
-    public function testReduce()
+    public function testReduce(): void
     {
         $data = static::articleData();
 
@@ -2701,10 +2588,8 @@ class HashTest extends TestCase
     /**
      * test Hash nest with a normal model result set. For kicks rely on Hash nest detecting the key names
      * automatically
-     *
-     * @return void
      */
-    public function testNestModel()
+    public function testNestModel(): void
     {
         $input = [
             [
@@ -2849,10 +2734,8 @@ class HashTest extends TestCase
 
     /**
      * test Hash nest with a normal model result set, and a nominated root id
-     *
-     * @return void
      */
-    public function testNestModelExplicitRoot()
+    public function testNestModelExplicitRoot(): void
     {
         $input = [
             [
@@ -2960,10 +2843,8 @@ class HashTest extends TestCase
 
     /**
      * test Hash nest with a 1d array - this method should be able to handle any type of array input
-     *
-     * @return void
      */
-    public function testNest1Dimensional()
+    public function testNest1Dimensional(): void
     {
         $input = [
             [
@@ -3071,10 +2952,8 @@ class HashTest extends TestCase
      *
      * The result should be the same as the input.
      * For an easier comparison, unset all the empty children arrays from the result
-     *
-     * @return void
      */
-    public function testMissingParent()
+    public function testMissingParent(): void
     {
         $input = [
             [
@@ -3120,10 +2999,8 @@ class HashTest extends TestCase
 
     /**
      * Tests that nest() throws an InvalidArgumentException when providing an invalid input.
-     *
-     * @return void
      */
-    public function testNestInvalid()
+    public function testNestInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $input = [
@@ -3140,10 +3017,8 @@ class HashTest extends TestCase
 
     /**
      * testMergeDiff method
-     *
-     * @return void
      */
-    public function testMergeDiff()
+    public function testMergeDiff(): void
     {
         $first = [
             'ModelOne' => [
@@ -3242,10 +3117,8 @@ class HashTest extends TestCase
 
     /**
      * Test mergeDiff() with scalar elements.
-     *
-     * @return void
      */
-    public function testMergeDiffWithScalarValue()
+    public function testMergeDiffWithScalarValue(): void
     {
         $result = Hash::mergeDiff(['a' => 'value'], ['a' => ['value']]);
         $this->assertSame(['a' => 'value'], $result);
@@ -3256,10 +3129,8 @@ class HashTest extends TestCase
 
     /**
      * Tests Hash::expand
-     *
-     * @return void
      */
-    public function testExpand()
+    public function testExpand(): void
     {
         $data = ['My', 'Array', 'To', 'Flatten'];
         $flat = Hash::flatten($data);
@@ -3315,10 +3186,8 @@ class HashTest extends TestCase
 
     /**
      * Test that flattening a large complex set doesn't loop forever.
-     *
-     * @return void
      */
-    public function testFlattenInfiniteLoop()
+    public function testFlattenInfiniteLoop(): void
     {
         $data = [
             'Order.ASI' => '0',

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -77,8 +77,6 @@ class InflectorTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -90,9 +88,8 @@ class InflectorTest extends TestCase
      * testInflectingSingulars method
      *
      * @dataProvider singularizeProvider
-     * @return void
      */
-    public function testInflectingSingulars(string $singular, string $plural)
+    public function testInflectingSingulars(string $singular, string $plural): void
     {
         $this->assertSame($singular, Inflector::singularize($plural));
     }
@@ -197,10 +194,8 @@ class InflectorTest extends TestCase
 
     /**
      * Test that overlapping irregulars don't collide.
-     *
-     * @return void
      */
-    public function testSingularizeMultiWordIrregular()
+    public function testSingularizeMultiWordIrregular(): void
     {
         Inflector::rules('irregular', [
             'pregunta_frecuente' => 'preguntas_frecuentes',
@@ -221,9 +216,8 @@ class InflectorTest extends TestCase
      * testInflectingPlurals method
      *
      * @dataProvider pluralizeProvider
-     * @return void
      */
-    public function testInflectingPlurals(string $plural, string $singular)
+    public function testInflectingPlurals(string $plural, string $singular): void
     {
         $this->assertSame($plural, Inflector::pluralize($singular));
     }
@@ -313,10 +307,8 @@ class InflectorTest extends TestCase
 
     /**
      * Test that overlapping irregulars don't collide.
-     *
-     * @return void
      */
-    public function testPluralizeMultiWordIrregular()
+    public function testPluralizeMultiWordIrregular(): void
     {
         Inflector::rules('irregular', [
             'pregunta_frecuente' => 'preguntas_frecuentes',
@@ -335,10 +327,8 @@ class InflectorTest extends TestCase
 
     /**
      * testInflectingMultiWordIrregulars
-     *
-     * @return void
      */
-    public function testInflectingMultiWordIrregulars()
+    public function testInflectingMultiWordIrregulars(): void
     {
         // unset the default rules in order to avoid them possibly matching
         // the words in case the irregular regex won't match, the tests
@@ -361,10 +351,8 @@ class InflectorTest extends TestCase
 
     /**
      * testUnderscore method
-     *
-     * @return void
      */
-    public function testUnderscore()
+    public function testUnderscore(): void
     {
         $this->assertSame('test_thing', Inflector::underscore('TestThing'));
         $this->assertSame('test_thing', Inflector::underscore('testThing'));
@@ -386,10 +374,8 @@ class InflectorTest extends TestCase
 
     /**
      * testDasherized method
-     *
-     * @return void
      */
-    public function testDasherized()
+    public function testDasherized(): void
     {
         $this->assertSame('test-thing', Inflector::dasherize('TestThing'));
         $this->assertSame('test-thing', Inflector::dasherize('testThing'));
@@ -404,10 +390,8 @@ class InflectorTest extends TestCase
 
     /**
      * Demonstrate the expected output for bad inputs
-     *
-     * @return void
      */
-    public function testCamelize()
+    public function testCamelize(): void
     {
         $this->assertSame('TestThing', Inflector::camelize('test_thing'));
         $this->assertSame('Test-thing', Inflector::camelize('test-thing'));
@@ -426,10 +410,8 @@ class InflectorTest extends TestCase
 
     /**
      * testVariableNaming method
-     *
-     * @return void
      */
-    public function testVariableNaming()
+    public function testVariableNaming(): void
     {
         $this->assertSame('testField', Inflector::variable('test_field'));
         $this->assertSame('testFieLd', Inflector::variable('test_fieLd'));
@@ -439,10 +421,8 @@ class InflectorTest extends TestCase
 
     /**
      * testClassNaming method
-     *
-     * @return void
      */
-    public function testClassNaming()
+    public function testClassNaming(): void
     {
         $this->assertSame('ArtistsGenre', Inflector::classify('artists_genres'));
         $this->assertSame('FileSystem', Inflector::classify('file_systems'));
@@ -452,10 +432,8 @@ class InflectorTest extends TestCase
 
     /**
      * testTableNaming method
-     *
-     * @return void
      */
-    public function testTableNaming()
+    public function testTableNaming(): void
     {
         $this->assertSame('artists_genres', Inflector::tableize('ArtistsGenre'));
         $this->assertSame('file_systems', Inflector::tableize('FileSystem'));
@@ -465,10 +443,8 @@ class InflectorTest extends TestCase
 
     /**
      * testHumanization method
-     *
-     * @return void
      */
-    public function testHumanization()
+    public function testHumanization(): void
     {
         $this->assertSame('Posts', Inflector::humanize('posts'));
         $this->assertSame('Posts Tags', Inflector::humanize('posts_tags'));
@@ -479,10 +455,8 @@ class InflectorTest extends TestCase
 
     /**
      * testCustomPluralRule method
-     *
-     * @return void
      */
-    public function testCustomPluralRule()
+    public function testCustomPluralRule(): void
     {
         Inflector::rules('plural', ['/^(custom)$/i' => '\1izables']);
         Inflector::rules('uninflected', ['uninflectable']);
@@ -508,10 +482,8 @@ class InflectorTest extends TestCase
 
     /**
      * testCustomSingularRule method
-     *
-     * @return void
      */
-    public function testCustomSingularRule()
+    public function testCustomSingularRule(): void
     {
         Inflector::rules('uninflected', ['singulars']);
         Inflector::rules('singular', ['/(eple)r$/i' => '\1', '/(jente)r$/i' => '\1']);
@@ -536,10 +508,8 @@ class InflectorTest extends TestCase
 
     /**
      * test that setting new rules clears the inflector caches.
-     *
-     * @return void
      */
-    public function testRulesClearsCaches()
+    public function testRulesClearsCaches(): void
     {
         $this->assertSame('Banana', Inflector::singularize('Bananas'));
         $this->assertSame('bananas', Inflector::tableize('Banana'));
@@ -556,10 +526,8 @@ class InflectorTest extends TestCase
 
     /**
      * Test resetting inflection rules.
-     *
-     * @return void
      */
-    public function testCustomRuleWithReset()
+    public function testCustomRuleWithReset(): void
     {
         $uninflected = ['atlas', 'lapis', 'onibus', 'pires', 'virus', '.*x'];
         $pluralIrregular = ['as' => 'ases'];

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -27,10 +27,8 @@ class MergeVariablesTraitTest extends TestCase
 {
     /**
      * Test merging vars as a list.
-     *
-     * @return void
      */
-    public function testMergeVarsAsList()
+    public function testMergeVarsAsList(): void
     {
         $object = new Grandchild();
         $object->mergeVars(['listProperty']);
@@ -41,10 +39,8 @@ class MergeVariablesTraitTest extends TestCase
 
     /**
      * Test merging vars as an associative list.
-     *
-     * @return void
      */
-    public function testMergeVarsAsAssoc()
+    public function testMergeVarsAsAssoc(): void
     {
         $object = new Grandchild();
         $object->mergeVars(['assocProperty'], ['associative' => ['assocProperty']]);
@@ -60,10 +56,8 @@ class MergeVariablesTraitTest extends TestCase
     /**
      * Test merging variable in associated properties that contain
      * additional keys.
-     *
-     * @return void
      */
-    public function testMergeVarsAsAssocWithKeyValues()
+    public function testMergeVarsAsAssocWithKeyValues(): void
     {
         $object = new Grandchild();
         $object->mergeVars(['nestedProperty'], ['associative' => ['nestedProperty']]);
@@ -81,10 +75,8 @@ class MergeVariablesTraitTest extends TestCase
 
     /**
      * Test merging vars with mixed modes.
-     *
-     * @return void
      */
-    public function testMergeVarsMixedModes()
+    public function testMergeVarsMixedModes(): void
     {
         $object = new Grandchild();
         $object->mergeVars(['assocProperty', 'listProperty'], ['associative' => ['assocProperty']]);
@@ -103,10 +95,8 @@ class MergeVariablesTraitTest extends TestCase
     /**
      * Test that merging variables with booleans in the class hierarchy
      * doesn't cause issues.
-     *
-     * @return void
      */
-    public function testMergeVarsWithBoolean()
+    public function testMergeVarsWithBoolean(): void
     {
         $object = new Child();
         $object->mergeVars(['hasBoolean']);

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -28,10 +28,8 @@ class SecurityTest extends TestCase
 {
     /**
      * testHash method
-     *
-     * @return void
      */
-    public function testHash()
+    public function testHash(): void
     {
         $_hashType = Security::$hashType;
 
@@ -72,10 +70,8 @@ class SecurityTest extends TestCase
 
     /**
      * testInvalidHashTypeException
-     *
-     * @return void
      */
-    public function testInvalidHashTypeException()
+    public function testInvalidHashTypeException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/The hash type `doesnotexist` was not found. Available algorithms are: \w+/');
@@ -85,10 +81,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test encrypt/decrypt.
-     *
-     * @return void
      */
-    public function testEncryptDecrypt()
+    public function testEncryptDecrypt(): void
     {
         $txt = 'The quick brown fox';
         $key = 'This key is longer than 32 bytes long.';
@@ -100,10 +94,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test that changing the key causes decryption to fail.
-     *
-     * @return void
      */
-    public function testDecryptKeyFailure()
+    public function testDecryptKeyFailure(): void
     {
         $txt = 'The quick brown fox';
         $key = 'This key is longer than 32 bytes long.';
@@ -115,10 +107,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test that decrypt fails when there is an hmac error.
-     *
-     * @return void
      */
-    public function testDecryptHmacFailure()
+    public function testDecryptHmacFailure(): void
     {
         $txt = 'The quick brown fox';
         $key = 'This key is quite long and works well.';
@@ -132,10 +122,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test that changing the hmac salt will cause failures.
-     *
-     * @return void
      */
-    public function testDecryptHmacSaltFailure()
+    public function testDecryptHmacSaltFailure(): void
     {
         $txt = 'The quick brown fox';
         $key = 'This key is quite long and works well.';
@@ -148,10 +136,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test that short keys cause errors
-     *
-     * @return void
      */
-    public function testEncryptInvalidKey()
+    public function testEncryptInvalidKey(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.');
@@ -162,10 +148,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test encrypting falsey data
-     *
-     * @return void
      */
-    public function testEncryptDecryptFalseyData()
+    public function testEncryptDecryptFalseyData(): void
     {
         $key = 'This is a key that is long enough to be ok.';
 
@@ -178,10 +162,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test that short keys cause errors
-     *
-     * @return void
      */
-    public function testDecryptInvalidKey()
+    public function testDecryptInvalidKey(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.');
@@ -192,10 +174,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test that empty data cause errors
-     *
-     * @return void
      */
-    public function testDecryptInvalidData()
+    public function testDecryptInvalidData(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The data to decrypt cannot be empty.');
@@ -206,10 +186,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test engine
-     *
-     * @return void
      */
-    public function testEngineEquivalence()
+    public function testEngineEquivalence(): void
     {
         $restore = Security::engine();
         $newEngine = new OpenSsl();
@@ -222,10 +200,8 @@ class SecurityTest extends TestCase
 
     /**
      * Tests that the salt can be set and retrieved
-     *
-     * @return void
      */
-    public function testSalt()
+    public function testSalt(): void
     {
         Security::setSalt('foobarbaz');
         $this->assertSame('foobarbaz', Security::getSalt());
@@ -233,10 +209,8 @@ class SecurityTest extends TestCase
 
     /**
      * Tests that the salt can be set and retrieved
-     *
-     * @return void
      */
-    public function testGetSetSalt()
+    public function testGetSetSalt(): void
     {
         Security::setSalt('foobarbaz');
         $this->assertSame('foobarbaz', Security::getSalt());
@@ -244,10 +218,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test the randomBytes method.
-     *
-     * @return void
      */
-    public function testRandomBytes()
+    public function testRandomBytes(): void
     {
         $value = Security::randomBytes(16);
         $this->assertSame(16, strlen($value));
@@ -260,10 +232,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test the randomString method.
-     *
-     * @return void
      */
-    public function testRandomString()
+    public function testRandomString(): void
     {
         $value = Security::randomString(7);
         $this->assertSame(7, strlen($value));
@@ -276,10 +246,8 @@ class SecurityTest extends TestCase
 
     /**
      * Test the insecureRandomBytes method
-     *
-     * @return void
      */
-    public function testInsecureRandomBytes()
+    public function testInsecureRandomBytes(): void
     {
         $value = Security::insecureRandomBytes(16);
         $this->assertSame(16, strlen($value));
@@ -292,10 +260,8 @@ class SecurityTest extends TestCase
 
     /**
      * test constantEquals
-     *
-     * @return void
      */
-    public function testConstantEquals()
+    public function testConstantEquals(): void
     {
         $this->assertFalse(Security::constantEquals('abcde', null));
         $this->assertFalse(Security::constantEquals('abcde', false));

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -50,10 +50,8 @@ class TextTest extends TestCase
 
     /**
      * testUuidGeneration method
-     *
-     * @return void
      */
-    public function testUuidGeneration()
+    public function testUuidGeneration(): void
     {
         $result = Text::uuid();
         $pattern = '/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/';
@@ -63,10 +61,8 @@ class TextTest extends TestCase
 
     /**
      * testMultipleUuidGeneration method
-     *
-     * @return void
      */
-    public function testMultipleUuidGeneration()
+    public function testMultipleUuidGeneration(): void
     {
         $check = [];
         $count = mt_rand(10, 1000);
@@ -83,10 +79,8 @@ class TextTest extends TestCase
 
     /**
      * testInsert method
-     *
-     * @return void
      */
-    public function testInsert()
+    public function testInsert(): void
     {
         $string = 'some string';
         $expected = 'some string';
@@ -186,7 +180,7 @@ class TextTest extends TestCase
         $result = Text::insert($string, ['src' => 'foo', 'extra' => 'bar'], ['clean' => 'html']);
         $this->assertSame($expected, $result);
 
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $result = Text::insert('this is a ? string', ['test']);
             $expected = 'this is a test string';
             $this->assertSame($expected, $result);
@@ -220,7 +214,7 @@ class TextTest extends TestCase
         $expected = 'We are passing.';
         $this->assertSame($expected, $result);
 
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $result = Text::insert('?-pended result', ['Pre']);
             $expected = 'Pre-pended result';
             $this->assertSame($expected, $result);
@@ -262,10 +256,8 @@ class TextTest extends TestCase
 
     /**
      * test Clean Insert
-     *
-     * @return void
      */
-    public function testCleanInsert()
+    public function testCleanInsert(): void
     {
         $result = Text::cleanInsert(':incomplete', [
             'clean' => true, 'before' => ':', 'after' => '',
@@ -307,10 +299,8 @@ class TextTest extends TestCase
     /**
      * Tests that non-insertable variables (i.e. arrays) are skipped when used as values in
      * Text::insert().
-     *
-     * @return void
      */
-    public function testAutoIgnoreBadInsertData()
+    public function testAutoIgnoreBadInsertData(): void
     {
         $data = ['foo' => 'alpha', 'bar' => 'beta', 'fale' => []];
         $result = Text::insert('(:foo > :bar || :fale!)', $data, ['clean' => 'text']);
@@ -319,10 +309,8 @@ class TextTest extends TestCase
 
     /**
      * testTokenize method
-     *
-     * @return void
      */
-    public function testTokenize()
+    public function testTokenize(): void
     {
         $result = Text::tokenize('A,(short,boring test)');
         $expected = ['A', '(short,boring test)'];
@@ -354,7 +342,7 @@ class TextTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testReplaceWithQuestionMarkInString()
+    public function testReplaceWithQuestionMarkInString(): void
     {
         $string = ':a, :b and :c?';
         $expected = '2 and 3?';
@@ -366,9 +354,8 @@ class TextTest extends TestCase
      * test that wordWrap() works the same as built-in wordwrap function
      *
      * @dataProvider wordWrapProvider
-     * @return void
      */
-    public function testWordWrap(string $text, int $width, string $break = "\n", bool $cut = false)
+    public function testWordWrap(string $text, int $width, string $break = "\n", bool $cut = false): void
     {
         $result = Text::wordWrap($text, $width, $break, $cut);
         $expected = wordwrap($text, $width, $break, $cut);
@@ -400,10 +387,8 @@ class TextTest extends TestCase
 
     /**
      * test that wordWrap() properly handle unicode strings.
-     *
-     * @return void
      */
-    public function testWordWrapUnicodeAware()
+    public function testWordWrapUnicodeAware(): void
     {
         $text = 'Но вим омниюм факёльиси элыктрам, мюнырэ лэгыры векж ыт. Выльёт квюандо нюмквуам ты кюм. Зыд эю рыбюм.';
         $result = Text::wordWrap($text, 33, "\n", true);
@@ -428,10 +413,8 @@ TEXT;
 
     /**
      * test that wordWrap() properly handle newline characters.
-     *
-     * @return void
      */
-    public function testWordWrapNewlineAware()
+    public function testWordWrapNewlineAware(): void
     {
         $text = 'This is a line that is almost the 55 chars long.
 This is a new sentence which is manually newlined, but is so long it needs two lines.';
@@ -446,10 +429,8 @@ TEXT;
 
     /**
      * test wrap method.
-     *
-     * @return void
      */
-    public function testWrap()
+    public function testWrap(): void
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
         $result = Text::wrap($text, 33);
@@ -472,10 +453,8 @@ TEXT;
 
     /**
      * test wrap() indenting
-     *
-     * @return void
      */
-    public function testWrapIndent()
+    public function testWrapIndent(): void
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
         $result = Text::wrap($text, ['width' => 33, 'indent' => "\t", 'indentAt' => 1]);
@@ -489,10 +468,8 @@ TEXT;
 
     /**
      * test wrapBlock() identical to wrap()
-     *
-     * @return void
      */
-    public function testWrapBlockIndenticalToWrap()
+    public function testWrapBlockIndenticalToWrap(): void
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
         $result = Text::wrapBlock($text, 33);
@@ -506,10 +483,8 @@ TEXT;
 
     /**
      * test wrapBlock() indenting from first line
-     *
-     * @return void
      */
-    public function testWrapBlockWithIndentAt0()
+    public function testWrapBlockWithIndentAt0(): void
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
         $result = Text::wrapBlock($text, ['width' => 33, 'indent' => "\t", 'indentAt' => 0]);
@@ -524,10 +499,8 @@ TEXT;
 
     /**
      * test wrapBlock() indenting from second line
-     *
-     * @return void
      */
-    public function testWrapBlockWithIndentAt1()
+    public function testWrapBlockWithIndentAt1(): void
     {
         $text = 'This is the song that never ends. This is the song that never ends. This is the song that never ends.';
         $result = Text::wrapBlock($text, ['width' => 33, 'indent' => "\t", 'indentAt' => 1]);
@@ -542,10 +515,8 @@ TEXT;
 
     /**
      * test wrapBlock() indenting with multibyte caracters
-     *
-     * @return void
      */
-    public function testWrapBlockIndentWithMultibyte()
+    public function testWrapBlockIndentWithMultibyte(): void
     {
         $text = 'This is the song that never ends. 这是永远不会结束的歌曲。 This is the song that never ends.';
         $result = Text::wrapBlock($text, ['width' => 33, 'indent' => ' → ', 'indentAt' => 1]);
@@ -559,10 +530,8 @@ TEXT;
 
     /**
      * test isMultibyte() checking multibyte characters
-     *
-     * @return void
      */
-    public function testIsMultibyteString()
+    public function testIsMultibyteString(): void
     {
         $text = 'This is a test string without multi-bytes';
         $result = Text::isMultibyte($text);
@@ -575,10 +544,8 @@ TEXT;
 
     /**
      * testTruncate method
-     *
-     * @return void
      */
-    public function testTruncate()
+    public function testTruncate(): void
     {
         $text1 = 'The quick brown fox jumps over the lazy dog';
         $text2 = 'Heiz&ouml;lr&uuml;cksto&szlig;abd&auml;mpfung';
@@ -637,10 +604,8 @@ TEXT;
 
     /**
      * Test truncate() method with both exact and html.
-     *
-     * @return void
      */
-    public function testTruncateExactHtml()
+    public function testTruncateExactHtml(): void
     {
         $text = '<a href="http://example.org">hello</a> world';
         $expected = '<a href="http://example.org">hell..</a>';
@@ -662,10 +627,8 @@ TEXT;
 
     /**
      * testTruncate method with non utf8 sites
-     *
-     * @return void
      */
-    public function testTruncateLegacy()
+    public function testTruncateLegacy(): void
     {
         mb_internal_encoding('ISO-8859-1');
         $text = '<b>&copy; 2005-2007, Cake Software Foundation, Inc.</b><br />written by Alexander Wegener';
@@ -686,10 +649,8 @@ TEXT;
 
     /**
      * Test truncate() method with trimWidth
-     *
-     * @return void
      */
-    public function testTruncateTrimWidth()
+    public function testTruncateTrimWidth(): void
     {
         $text = 'The quick brown fox jumps over the lazy dog';
         $this->assertSame('The quick brown...', Text::truncate($text, 18, ['ellipsis' => '...', 'trimWidth' => false]));
@@ -719,10 +680,8 @@ HTML;
 
     /**
      * testTail method
-     *
-     * @return void
      */
-    public function testTail()
+    public function testTail(): void
     {
         $text1 = 'The quick brown fox jumps over the lazy dog';
         $text2 = 'Heiz&ouml;lr&uuml;cksto&szlig;abd&auml;mpfung';
@@ -763,10 +722,8 @@ HTML;
 
     /**
      * Tests highlight() method.
-     *
-     * @return void
      */
-    public function testHighlight()
+    public function testHighlight(): void
     {
         $text = 'This is a test text';
         $phrases = ['This', 'text'];
@@ -798,10 +755,8 @@ HTML;
 
     /**
      * Tests highlight() method with limit.
-     *
-     * @return void
      */
-    public function testHighlightLimit()
+    public function testHighlightLimit(): void
     {
         $text = 'This is a test text with some more text';
         $phrases = ['This', 'text'];
@@ -816,10 +771,8 @@ HTML;
 
     /**
      * testHighlightHtml method
-     *
-     * @return void
      */
-    public function testHighlightHtml()
+    public function testHighlightHtml(): void
     {
         $text1 = '<p>strongbow isn&rsquo;t real cider</p>';
         $text2 = '<p>strongbow <strong>isn&rsquo;t</strong> real cider</p>';
@@ -843,10 +796,8 @@ HTML;
 
     /**
      * testHighlightMulti method
-     *
-     * @return void
      */
-    public function testHighlightMulti()
+    public function testHighlightMulti(): void
     {
         $text = 'This is a test text';
         $phrases = ['This', 'text'];
@@ -857,10 +808,8 @@ HTML;
 
     /**
      * testHighlightCaseInsensitivity method
-     *
-     * @return void
      */
-    public function testHighlightCaseInsensitivity()
+    public function testHighlightCaseInsensitivity(): void
     {
         $text = 'This is a Test text';
         $expected = 'This is a <b>Test</b> text';
@@ -874,10 +823,8 @@ HTML;
 
     /**
      * testExcerpt method
-     *
-     * @return void
      */
-    public function testExcerpt()
+    public function testExcerpt(): void
     {
         $text = 'This is a phrase with test text to play with';
 
@@ -915,10 +862,8 @@ HTML;
 
     /**
      * testExcerptCaseInsensitivity method
-     *
-     * @return void
      */
-    public function testExcerptCaseInsensitivity()
+    public function testExcerptCaseInsensitivity(): void
     {
         $text = 'This is a phrase with test text to play with';
 
@@ -933,10 +878,8 @@ HTML;
 
     /**
      * testListGeneration method
-     *
-     * @return void
      */
-    public function testListGeneration()
+    public function testListGeneration(): void
     {
         $result = $this->Text->toList([]);
         $this->assertSame('', $result);
@@ -965,10 +908,8 @@ HTML;
 
     /**
      * testUtf8 method
-     *
-     * @return void
      */
-    public function testUtf8()
+    public function testUtf8(): void
     {
         $string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
         $result = Text::utf8($string);
@@ -1286,10 +1227,8 @@ HTML;
 
     /**
      * testAscii method
-     *
-     * @return void
      */
-    public function testAscii()
+    public function testAscii(): void
     {
         $input = [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
                             58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82,
@@ -1610,9 +1549,8 @@ HTML;
      *
      * @dataProvider filesizes
      * @param mixed $expected
-     * @return void
      */
-    public function testParseFileSize(array $params, $expected)
+    public function testParseFileSize(array $params, $expected): void
     {
         $result = Text::parseFileSize($params['size'], $params['default']);
         $this->assertSame($expected, $result);
@@ -1620,10 +1558,8 @@ HTML;
 
     /**
      * testparseFileSizeException
-     *
-     * @return void
      */
-    public function testParseFileSizeException()
+    public function testParseFileSizeException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Text::parseFileSize('bogus', false);
@@ -1634,7 +1570,7 @@ HTML;
      *
      * @return array
      */
-    public function filesizes()
+    public function filesizes(): array
     {
         return [
             [['size' => '512B', 'default' => false], 512],
@@ -1659,10 +1595,8 @@ HTML;
 
     /**
      * Test getting/setting default transliterator.
-     *
-     * @return void
      */
-    public function testGetSetTransliterator()
+    public function testGetSetTransliterator(): void
     {
         $this->assertNull(Text::getTransliterator());
 
@@ -1678,10 +1612,8 @@ HTML;
 
     /**
      * Test getting/setting default transliterator id.
-     *
-     * @return void
      */
-    public function testGetSetTransliteratorId()
+    public function testGetSetTransliteratorId(): void
     {
         $defaultTransliteratorId = 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove';
         $this->assertSame($defaultTransliteratorId, Text::getTransliteratorId());
@@ -1764,10 +1696,9 @@ HTML;
      * @param string $string String
      * @param \Transliterator|string|null $transliterator Transliterator
      * @param String $expected Expected string
-     * @return void
      * @dataProvider transliterateInputProvider
      */
-    public function testTransliterate($string, $transliterator, $expected)
+    public function testTransliterate($string, $transliterator, $expected): void
     {
         $result = Text::transliterate($string, $transliterator);
         $this->assertSame($expected, $result);
@@ -1884,10 +1815,9 @@ HTML;
      * @param string $string String
      * @param array $options Options
      * @param String $expected Expected string
-     * @return void
      * @dataProvider slugInputProvider
      */
-    public function testSlug($string, $options, $expected)
+    public function testSlug($string, $options, $expected): void
     {
         $result = Text::slug($string, $options);
         $this->assertSame($expected, $result);
@@ -1895,10 +1825,8 @@ HTML;
 
     /**
      * Text truncateByWidth method
-     *
-     * @return void
      */
-    public function testTruncateByWidth()
+    public function testTruncateByWidth(): void
     {
         $this->assertSame('<p>あ...', Text::truncateByWidth('<p>あいうえお</p>', 8));
         $this->assertSame('<p>あい...</p>', Text::truncateByWidth('<p>あいうえお</p>', 8, ['html' => true, 'ellipsis' => '...']));
@@ -1906,10 +1834,8 @@ HTML;
 
     /**
      * Test _strlen method
-     *
-     * @return void
      */
-    public function testStrlen()
+    public function testStrlen(): void
     {
         $method = new \ReflectionMethod('Cake\Utility\Text', '_strlen');
         $method->setAccessible(true);
@@ -1932,10 +1858,8 @@ HTML;
 
     /**
      * Test _substr method
-     *
-     * @return void
      */
-    public function testSubstr()
+    public function testSubstr(): void
     {
         $method = new \ReflectionMethod('Cake\Utility\Text', '_substr');
         $method->setAccessible(true);

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -47,8 +47,6 @@ class XmlTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -59,8 +57,6 @@ class XmlTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,7 +64,7 @@ class XmlTest extends TestCase
         Configure::write('App.encoding', $this->_appEncoding);
     }
 
-    public function testExceptionChainingForInvalidInput()
+    public function testExceptionChainingForInvalidInput(): void
     {
         try {
             $value = 'invalid-xml-input<<';
@@ -83,10 +79,8 @@ class XmlTest extends TestCase
 
     /**
      * testBuild method
-     *
-     * @return void
      */
-    public function testBuild()
+    public function testBuild(): void
     {
         $xml = '<tag>value</tag>';
         $obj = Xml::build($xml);
@@ -135,10 +129,8 @@ class XmlTest extends TestCase
 
     /**
      * test build() method with huge option
-     *
-     * @return void
      */
-    public function testBuildHuge()
+    public function testBuildHuge(): void
     {
         $xml = '<tag>value</tag>';
         $obj = Xml::build($xml, ['parseHuge' => true]);
@@ -148,10 +140,8 @@ class XmlTest extends TestCase
 
     /**
      * Test that the readFile option disables local file parsing.
-     *
-     * @return void
      */
-    public function testBuildFromFileWhenDisabled()
+    public function testBuildFromFileWhenDisabled(): void
     {
         $this->expectException(\Cake\Utility\Exception\XmlException::class);
         $xml = CORE_TESTS . 'Fixture/sample.xml';
@@ -160,10 +150,8 @@ class XmlTest extends TestCase
 
     /**
      * Test build() with a Collection instance.
-     *
-     * @return void
      */
-    public function testBuildCollection()
+    public function testBuildCollection(): void
     {
         $xml = new Collection(['tag' => 'value']);
         $obj = Xml::build($xml);
@@ -182,10 +170,8 @@ class XmlTest extends TestCase
 
     /**
      * Test build() with ORM\Entity instances wrapped in a Collection.
-     *
-     * @return void
      */
-    public function testBuildOrmEntity()
+    public function testBuildOrmEntity(): void
     {
         $user = new Entity(['username' => 'mark', 'email' => 'mark@example.com']);
         $xml = new Collection([
@@ -219,9 +205,8 @@ class XmlTest extends TestCase
      *
      * @dataProvider invalidDataProvider
      * @param mixed $value
-     * @return void
      */
-    public function testBuildInvalidData($value)
+    public function testBuildInvalidData($value): void
     {
         $this->expectException(\RuntimeException::class);
         Xml::build($value);
@@ -229,10 +214,8 @@ class XmlTest extends TestCase
 
     /**
      * Test that building SimpleXmlElement with invalid XML causes the right exception.
-     *
-     * @return void
      */
-    public function testBuildInvalidDataSimpleXml()
+    public function testBuildInvalidDataSimpleXml(): void
     {
         $this->expectException(\Cake\Utility\Exception\XmlException::class);
         $input = '<derp';
@@ -241,10 +224,8 @@ class XmlTest extends TestCase
 
     /**
      * test build with a single empty tag
-     *
-     * @return void
      */
-    public function testBuildEmptyTag()
+    public function testBuildEmptyTag(): void
     {
         try {
             Xml::build('<tag>');
@@ -256,10 +237,8 @@ class XmlTest extends TestCase
 
     /**
      * testLoadHtml method
-     *
-     * @return void
      */
-    public function testLoadHtml()
+    public function testLoadHtml(): void
     {
         $htmlFile = CORE_TESTS . 'Fixture/sample.html';
         $html = file_get_contents($htmlFile);
@@ -293,10 +272,8 @@ close to 5 million globally.
 
     /**
      * test loadHtml with a empty HTML string
-     *
-     * @return void
      */
-    public function testLoadHtmlEmptyHtml()
+    public function testLoadHtmlEmptyHtml(): void
     {
         $this->expectException(TypeError::class);
         Xml::loadHtml(null);
@@ -304,10 +281,8 @@ close to 5 million globally.
 
     /**
      * testFromArray method
-     *
-     * @return void
      */
-    public function testFromArray()
+    public function testFromArray(): void
     {
         $xml = ['tag' => 'value'];
         $obj = Xml::fromArray($xml);
@@ -463,10 +438,8 @@ XML;
 
     /**
      * Test fromArray() with zero values.
-     *
-     * @return void
      */
-    public function testFromArrayZeroValue()
+    public function testFromArrayZeroValue(): void
     {
         $xml = [
             'tag' => [
@@ -494,10 +467,8 @@ XML;
 
     /**
      * Test non-sequential keys in list types.
-     *
-     * @return void
      */
-    public function testFromArrayNonSequentialKeys()
+    public function testFromArrayNonSequentialKeys(): void
     {
         $xmlArray = [
             'Event' => [
@@ -532,10 +503,8 @@ XML;
 
     /**
      * testFromArrayPretty method
-     *
-     * @return void
      */
-    public function testFromArrayPretty()
+    public function testFromArrayPretty(): void
     {
         $xml = [
             'tags' => [
@@ -661,9 +630,8 @@ XML;
      *
      * @dataProvider invalidArrayDataProvider
      * @param mixed $value
-     * @return void
      */
-    public function testFromArrayFail($value)
+    public function testFromArrayFail($value): void
     {
         $this->expectException(\Exception::class);
         Xml::fromArray($value);
@@ -671,10 +639,8 @@ XML;
 
     /**
      * Test that there are not unterminated errors when building XML
-     *
-     * @return void
      */
-    public function testFromArrayUnterminatedError()
+    public function testFromArrayUnterminatedError(): void
     {
         $data = [
             'product_ID' => 'GENERT-DL',
@@ -707,10 +673,8 @@ XML;
 
     /**
      * testToArray method
-     *
-     * @return void
      */
-    public function testToArray()
+    public function testToArray(): void
     {
         $xml = '<tag>name</tag>';
         $obj = Xml::build($xml);
@@ -870,10 +834,8 @@ XML;
 
     /**
      * testRss
-     *
-     * @return void
      */
-    public function testRss()
+    public function testRss(): void
     {
         $rss = file_get_contents(CORE_TESTS . 'Fixture/rss.xml');
         $rssAsArray = Xml::toArray(Xml::build($rss));
@@ -946,10 +908,8 @@ XML;
 
     /**
      * testXmlRpc
-     *
-     * @return void
      */
-    public function testXmlRpc()
+    public function testXmlRpc(): void
     {
         $xml = Xml::build('<methodCall><methodName>test</methodName><params /></methodCall>');
         $expected = [
@@ -1032,10 +992,8 @@ XML;
 
     /**
      * testSoap
-     *
-     * @return void
      */
-    public function testSoap()
+    public function testSoap(): void
     {
         $xmlRequest = Xml::build(CORE_TESTS . 'Fixture/soap_request.xml', ['readFile' => true]);
         $expected = [
@@ -1091,10 +1049,8 @@ XML;
 
     /**
      * testNamespace
-     *
-     * @return void
      */
-    public function testNamespace()
+    public function testNamespace(): void
     {
         $xml = <<<XML
 <root xmlns:ns="http://cakephp.org">
@@ -1209,10 +1165,8 @@ XML;
 
     /**
      * test that CDATA blocks don't get screwed up by SimpleXml
-     *
-     * @return void
      */
-    public function testCdata()
+    public function testCdata(): void
     {
         $xml = '<' . '?xml version="1.0" encoding="UTF-8"?>' .
             '<people><name><![CDATA[ Mark ]]></name></people>';
@@ -1239,9 +1193,8 @@ XML;
      *
      * @dataProvider invalidToArrayDataProvider
      * @param mixed $value
-     * @return void
      */
-    public function testToArrayFail($value)
+    public function testToArrayFail($value): void
     {
         $this->expectException(\Cake\Utility\Exception\XmlException::class);
         Xml::toArray($value);
@@ -1249,10 +1202,8 @@ XML;
 
     /**
      * Test ampersand in text elements.
-     *
-     * @return void
      */
-    public function testAmpInText()
+    public function testAmpInText(): void
     {
         $data = [
             'outer' => [
@@ -1266,10 +1217,8 @@ XML;
 
     /**
      * Test that entity loading is disabled by default.
-     *
-     * @return void
      */
-    public function testNoEntityLoading()
+    public function testNoEntityLoading(): void
     {
         $file = str_replace(' ', '%20', CAKE . 'VERSION.txt');
         $xml = <<<XML
@@ -1287,9 +1236,8 @@ XML;
      * Test building Xml with valid class-name in value.
      *
      * @see https://github.com/cakephp/cakephp/pull/9754
-     * @return void
      */
-    public function testClassnameInValueRegressionTest()
+    public function testClassnameInValueRegressionTest(): void
     {
         $classname = self::class; // Will always be a valid class name
         $data = [
@@ -1308,7 +1256,7 @@ XML;
      * @ignore
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [];
     }

--- a/tests/TestCase/Validation/RulesProviderTest.php
+++ b/tests/TestCase/Validation/RulesProviderTest.php
@@ -29,10 +29,8 @@ class RulesProviderTest extends TestCase
      * Tests that RulesProvider proxies the method correctly and removes the
      * extra arguments that are passed according to the signature of validation
      * methods.
-     *
-     * @return void
      */
-    public function testProxyToValidation()
+    public function testProxyToValidation(): void
     {
         $provider = new RulesProvider();
         $this->assertTrue($provider->extension('foo.jpg', compact('provider')));
@@ -42,10 +40,8 @@ class RulesProviderTest extends TestCase
     /**
      * Tests that it is possible to use a custom object as the provider to
      * be decorated
-     *
-     * @return void
      */
-    public function testCustomObject()
+    public function testCustomObject(): void
     {
         $object = new CustomProvider();
 

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -26,40 +26,32 @@ class ValidationRuleTest extends TestCase
 {
     /**
      * Auxiliary method to test custom validators
-     *
-     * @return bool
      */
-    public function willFail()
+    public function willFail(): bool
     {
         return false;
     }
 
     /**
      * Auxiliary method to test custom validators
-     *
-     * @return bool
      */
-    public function willPass()
+    public function willPass(): bool
     {
         return true;
     }
 
     /**
      * Auxiliary method to test custom validators
-     *
-     * @return string
      */
-    public function willFail3()
+    public function willFail3(): string
     {
         return 'string';
     }
 
     /**
      * tests that passing custom validation methods work
-     *
-     * @return void
      */
-    public function testCustomMethods()
+    public function testCustomMethods(): void
     {
         $data = 'some data';
         $providers = ['default' => $this];
@@ -80,10 +72,8 @@ class ValidationRuleTest extends TestCase
 
     /**
      * Test using a custom validation method with no provider declared.
-     *
-     * @return void
      */
-    public function testCustomMethodNoProvider()
+    public function testCustomMethodNoProvider(): void
     {
         $data = 'some data';
         $context = ['field' => 'custom', 'newRecord' => true];
@@ -97,10 +87,8 @@ class ValidationRuleTest extends TestCase
 
     /**
      * Make sure errors are triggered when validation is missing.
-     *
-     * @return void
      */
-    public function testCustomMethodMissingError()
+    public function testCustomMethodMissingError(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to call method "totallyMissing" in "default" provider for field "test"');
@@ -114,10 +102,8 @@ class ValidationRuleTest extends TestCase
 
     /**
      * Tests that a rule can be skipped
-     *
-     * @return void
      */
-    public function testSkip()
+    public function testSkip(): void
     {
         $data = 'some data';
         $providers = ['default' => $this];
@@ -143,10 +129,8 @@ class ValidationRuleTest extends TestCase
 
     /**
      * Tests that the 'on' key can be a callable function
-     *
-     * @return void
      */
-    public function testCallableOn()
+    public function testCallableOn(): void
     {
         $data = 'some data';
         $providers = ['default' => $this];
@@ -176,10 +160,8 @@ class ValidationRuleTest extends TestCase
 
     /**
      * testGet
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $Rule = new ValidationRule(['rule' => 'willFail', 'message' => 'foo']);
 

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -29,10 +29,8 @@ class ValidationSetTest extends TestCase
 {
     /**
      * testGetRule method
-     *
-     * @return void
      */
-    public function testGetRule()
+    public function testGetRule(): void
     {
         $field = new ValidationSet();
         $field->add('notBlank', ['rule' => 'notBlank', 'message' => 'Can not be empty']);
@@ -44,10 +42,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * testGetRules method
-     *
-     * @return void
      */
-    public function testGetRules()
+    public function testGetRules(): void
     {
         $field = new ValidationSet();
         $field->add('notBlank', ['rule' => 'notBlank', 'message' => 'Can not be empty']);
@@ -59,10 +55,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Tests getting a rule from the set using array access
-     *
-     * @return void
      */
-    public function testArrayAccessGet()
+    public function testArrayAccessGet(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank'])
@@ -84,10 +78,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Tests checking a rule from the set using array access
-     *
-     * @return void
      */
-    public function testArrayAccessExists()
+    public function testArrayAccessExists(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank'])
@@ -102,10 +94,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Tests setting a rule in the set using array access
-     *
-     * @return void
      */
-    public function testArrayAccessSet()
+    public function testArrayAccessSet(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank']);
@@ -119,10 +109,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Tests unseting a rule from the set using array access
-     *
-     * @return void
      */
-    public function testArrayAccessUnset()
+    public function testArrayAccessUnset(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank'])
@@ -141,10 +129,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Tests it is possible to iterate a validation set object
-     *
-     * @return void
      */
-    public function testIterator()
+    public function testIterator(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank'])
@@ -170,10 +156,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Tests countable interface
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank'])
@@ -187,10 +171,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Test removeRule method
-     *
-     * @return void
      */
-    public function testRemoveRule()
+    public function testRemoveRule(): void
     {
         $set = (new ValidationSet())
             ->add('notBlank', ['rule' => 'notBlank'])
@@ -212,10 +194,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Test requirePresence and isPresenceRequired methods
-     *
-     * @return void
      */
-    public function testRequirePresence()
+    public function testRequirePresence(): void
     {
         $set = new ValidationSet();
 
@@ -230,10 +210,8 @@ class ValidationSetTest extends TestCase
 
     /**
      * Test allowEmpty and isEmptyAllowed methods
-     *
-     * @return void
      */
-    public function testAllowEmpty()
+    public function testAllowEmpty(): void
     {
         $set = new ValidationSet();
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -44,8 +44,6 @@ class ValidationTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,8 +55,6 @@ class ValidationTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -69,10 +65,8 @@ class ValidationTest extends TestCase
 
     /**
      * testNotEmpty method
-     *
-     * @return void
      */
-    public function testNotBlank()
+    public function testNotBlank(): void
     {
         $this->assertTrue(Validation::notBlank('abcdefg'));
         $this->assertTrue(Validation::notBlank('fasdf '));
@@ -91,10 +85,8 @@ class ValidationTest extends TestCase
 
     /**
      * testNotEmptyISO88591Encoding method
-     *
-     * @return void
      */
-    public function testNotBlankIso88591AppEncoding()
+    public function testNotBlankIso88591AppEncoding(): void
     {
         Configure::write('App.encoding', 'ISO-8859-1');
         $this->assertTrue(Validation::notBlank('abcdefg'));
@@ -109,10 +101,8 @@ class ValidationTest extends TestCase
 
     /**
      * testAlphaNumeric method
-     *
-     * @return void
      */
-    public function testAlphaNumeric()
+    public function testAlphaNumeric(): void
     {
         $this->assertTrue(Validation::alphaNumeric('frferrf'));
         $this->assertTrue(Validation::alphaNumeric('12234'));
@@ -136,20 +126,16 @@ class ValidationTest extends TestCase
 
     /**
      * testAlphaNumericPassedAsArray method
-     *
-     * @return void
      */
-    public function testAlphaNumericPassedAsArray()
+    public function testAlphaNumericPassedAsArray(): void
     {
         $this->assertFalse(Validation::alphaNumeric(['foo']));
     }
 
     /**
      * testNotAlphaNumeric method
-     *
-     * @return void
      */
-    public function testNotAlphaNumeric()
+    public function testNotAlphaNumeric(): void
     {
         $this->assertFalse(Validation::notAlphaNumeric('frferrf'));
         $this->assertFalse(Validation::notAlphaNumeric('12234'));
@@ -173,10 +159,8 @@ class ValidationTest extends TestCase
 
     /**
      * testAsciiAlphaNumeric method
-     *
-     * @return void
      */
-    public function testAsciiAlphaNumeric()
+    public function testAsciiAlphaNumeric(): void
     {
         $this->assertTrue(Validation::asciiAlphaNumeric('frferrf'));
         $this->assertTrue(Validation::asciiAlphaNumeric('12234'));
@@ -200,20 +184,16 @@ class ValidationTest extends TestCase
 
     /**
      * testAlphaNumericPassedAsArray method
-     *
-     * @return void
      */
-    public function testAsciiAlphaNumericPassedAsArray()
+    public function testAsciiAlphaNumericPassedAsArray(): void
     {
         $this->assertFalse(Validation::asciiAlphaNumeric(['foo']));
     }
 
     /**
      * testNotAlphaNumeric method
-     *
-     * @return void
      */
-    public function testNotAsciiAlphaNumeric()
+    public function testNotAsciiAlphaNumeric(): void
     {
         $this->assertFalse(Validation::notAsciiAlphaNumeric('frferrf'));
         $this->assertFalse(Validation::notAsciiAlphaNumeric('12234'));
@@ -236,10 +216,8 @@ class ValidationTest extends TestCase
 
     /**
      * testLengthBetween method
-     *
-     * @return void
      */
-    public function testLengthBetween()
+    public function testLengthBetween(): void
     {
         $this->assertTrue(Validation::lengthBetween('abcdefg', 1, 7));
         $this->assertTrue(Validation::lengthBetween('', 0, 7));
@@ -252,10 +230,8 @@ class ValidationTest extends TestCase
 
     /**
      * testCreditCard method
-     *
-     * @return void
      */
-    public function testCreditCard()
+    public function testCreditCard(): void
     {
         // American Express
         $this->assertTrue(Validation::creditCard('370482756063980', ['amex']));
@@ -706,10 +682,8 @@ class ValidationTest extends TestCase
 
     /**
      * testLuhn method
-     *
-     * @return void
      */
-    public function testLuhn()
+    public function testLuhn(): void
     {
         // American Express
         $this->assertTrue(Validation::luhn('370482756063980'));
@@ -760,10 +734,8 @@ class ValidationTest extends TestCase
 
     /**
      * testCustomRegexForCreditCard method
-     *
-     * @return void
      */
-    public function testCustomRegexForCreditCard()
+    public function testCustomRegexForCreditCard(): void
     {
         $this->assertTrue(Validation::creditCard('370482756063980', null, false, '/123321\\d{11}/'));
         $this->assertFalse(Validation::creditCard('1233210593374358', null, false, '/123321\\d{11}/'));
@@ -771,10 +743,8 @@ class ValidationTest extends TestCase
 
     /**
      * testCustomRegexForCreditCardWithLuhnCheck method
-     *
-     * @return void
      */
-    public function testCustomRegexForCreditCardWithLuhnCheck()
+    public function testCustomRegexForCreditCardWithLuhnCheck(): void
     {
         $this->assertTrue(Validation::creditCard('12332110426226941', null, true, '/123321\\d{11}/'));
         $this->assertFalse(Validation::creditCard('12332105933743585', null, true, '/123321\\d{11}/'));
@@ -784,10 +754,8 @@ class ValidationTest extends TestCase
 
     /**
      * testFastCreditCard method
-     *
-     * @return void
      */
-    public function testFastCreditCard()
+    public function testFastCreditCard(): void
     {
         // too short
         $this->assertFalse(Validation::creditCard('123456789012'));
@@ -813,10 +781,8 @@ class ValidationTest extends TestCase
 
     /**
      * testAllCreditCard method
-     *
-     * @return void
      */
-    public function testAllCreditCard()
+    public function testAllCreditCard(): void
     {
         // American Express
         $this->assertTrue(Validation::creditCard('370482756063980', 'all'));
@@ -864,10 +830,8 @@ class ValidationTest extends TestCase
 
     /**
      * testAllCreditCardDeep method
-     *
-     * @return void
      */
-    public function testAllCreditCardDeep()
+    public function testAllCreditCardDeep(): void
     {
         // American Express
         $this->assertTrue(Validation::creditCard('370482756063980', 'all', true));
@@ -915,10 +879,8 @@ class ValidationTest extends TestCase
 
     /**
      * testComparison method
-     *
-     * @return void
      */
-    public function testComparison()
+    public function testComparison(): void
     {
         $this->assertTrue(Validation::comparison(7, Validation::COMPARE_GREATER, 6));
         $this->assertTrue(Validation::comparison(6, Validation::COMPARE_LESS, 7));
@@ -944,10 +906,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test comparison casting values before comparisons.
-     *
-     * @return void
      */
-    public function testComparisonTypeChecks()
+    public function testComparisonTypeChecks(): void
     {
         $this->assertFalse(Validation::comparison('\x028', Validation::COMPARE_GREATER_OR_EQUAL, 1), 'hexish encoding fails');
         $this->assertFalse(Validation::comparison('0b010', Validation::COMPARE_GREATER_OR_EQUAL, 1), 'binary string data fails');
@@ -961,10 +921,8 @@ class ValidationTest extends TestCase
 
     /**
      * testCustom method
-     *
-     * @return void
      */
-    public function testCustom()
+    public function testCustom(): void
     {
         $this->assertTrue(Validation::custom('12345', '/(?<!\\S)\\d++(?!\\S)/'));
         $this->assertFalse(Validation::custom('Text', '/(?<!\\S)\\d++(?!\\S)/'));
@@ -977,10 +935,8 @@ class ValidationTest extends TestCase
 
     /**
      * testCustomAsArray method
-     *
-     * @return void
      */
-    public function testCustomAsArray()
+    public function testCustomAsArray(): void
     {
         $this->assertTrue(Validation::custom('12345', '/(?<!\\S)\\d++(?!\\S)/'));
         $this->assertFalse(Validation::custom('Text', '/(?<!\\S)\\d++(?!\\S)/'));
@@ -989,10 +945,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateTimeObject
-     *
-     * @return void
      */
-    public function testDateTimeObject()
+    public function testDateTimeObject(): void
     {
         $dateTime = new \DateTime();
         $this->assertTrue(Validation::date($dateTime));
@@ -1014,10 +968,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDdmmyyyy method
-     *
-     * @return void
      */
-    public function testDateDdmmyyyy()
+    public function testDateDdmmyyyy(): void
     {
         $this->assertTrue(Validation::date('27-12-0001', ['dmy']));
         $this->assertTrue(Validation::date('27-12-2006', ['dmy']));
@@ -1041,10 +993,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDdmmyyyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateDdmmyyyyLeapYear()
+    public function testDateDdmmyyyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('29-02-0004', ['dmy']));
         $this->assertTrue(Validation::date('29-02-2004', ['dmy']));
@@ -1059,10 +1009,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDdmmyy method
-     *
-     * @return void
      */
-    public function testDateDdmmyy()
+    public function testDateDdmmyy(): void
     {
         $this->assertTrue(Validation::date('27-12-06', ['dmy']));
         $this->assertTrue(Validation::date('27.12.06', ['dmy']));
@@ -1081,10 +1029,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDdmmyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateDdmmyyLeapYear()
+    public function testDateDdmmyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('29-02-04', ['dmy']));
         $this->assertTrue(Validation::date('29.02.04', ['dmy']));
@@ -1098,10 +1044,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDmyy method
-     *
-     * @return void
      */
-    public function testDateDmyy()
+    public function testDateDmyy(): void
     {
         $this->assertTrue(Validation::date('7-2-06', ['dmy']));
         $this->assertTrue(Validation::date('7.2.06', ['dmy']));
@@ -1119,10 +1063,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDmyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateDmyyLeapYear()
+    public function testDateDmyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('29-2-04', ['dmy']));
         $this->assertTrue(Validation::date('29.2.04', ['dmy']));
@@ -1136,10 +1078,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDmyyyy method
-     *
-     * @return void
      */
-    public function testDateDmyyyy()
+    public function testDateDmyyyy(): void
     {
         $this->assertTrue(Validation::date('1-1-0001', ['dmy']));
         $this->assertTrue(Validation::date('7-2-2006', ['dmy']));
@@ -1159,10 +1099,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDmyyyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateDmyyyyLeapYear()
+    public function testDateDmyyyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('29-2-0004', ['dmy']));
         $this->assertTrue(Validation::date('29-2-2004', ['dmy']));
@@ -1177,10 +1115,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMmddyyyy method
-     *
-     * @return void
      */
-    public function testDateMmddyyyy()
+    public function testDateMmddyyyy(): void
     {
         $this->assertTrue(Validation::date('01-01-0001', ['mdy']));
         $this->assertTrue(Validation::date('12-27-2006', ['mdy']));
@@ -1201,10 +1137,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMmddyyyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateMmddyyyyLeapYear()
+    public function testDateMmddyyyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('02-29-0004', ['mdy']));
         $this->assertTrue(Validation::date('02-29-2004', ['mdy']));
@@ -1219,10 +1153,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMmddyy method
-     *
-     * @return void
      */
-    public function testDateMmddyy()
+    public function testDateMmddyy(): void
     {
         $this->assertTrue(Validation::date('12-27-06', ['mdy']));
         $this->assertTrue(Validation::date('12.27.06', ['mdy']));
@@ -1241,10 +1173,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMmddyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateMmddyyLeapYear()
+    public function testDateMmddyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('02-29-04', ['mdy']));
         $this->assertTrue(Validation::date('02.29.04', ['mdy']));
@@ -1258,10 +1188,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMdyy method
-     *
-     * @return void
      */
-    public function testDateMdyy()
+    public function testDateMdyy(): void
     {
         $this->assertTrue(Validation::date('2-7-06', ['mdy']));
         $this->assertTrue(Validation::date('2.7.06', ['mdy']));
@@ -1279,10 +1207,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMdyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateMdyyLeapYear()
+    public function testDateMdyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('2-29-04', ['mdy']));
         $this->assertTrue(Validation::date('2.29.04', ['mdy']));
@@ -1296,10 +1222,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMdyyyy method
-     *
-     * @return void
      */
-    public function testDateMdyyyy()
+    public function testDateMdyyyy(): void
     {
         $this->assertTrue(Validation::date('1-1-0001', ['mdy']));
         $this->assertTrue(Validation::date('2-7-2006', ['mdy']));
@@ -1319,10 +1243,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMdyyyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateMdyyyyLeapYear()
+    public function testDateMdyyyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('2-29-0004', ['mdy']));
         $this->assertTrue(Validation::date('2-29-2004', ['mdy']));
@@ -1337,10 +1259,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateYyyymmdd method
-     *
-     * @return void
      */
-    public function testDateYyyymmdd()
+    public function testDateYyyymmdd(): void
     {
         $this->assertTrue(Validation::date('0001-01-01', ['ymd']));
         $this->assertTrue(Validation::date('0401-01-01', ['ymd']));
@@ -1358,10 +1278,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateYyyymmddLeapYear method
-     *
-     * @return void
      */
-    public function testDateYyyymmddLeapYear()
+    public function testDateYyyymmddLeapYear(): void
     {
         $this->assertTrue(Validation::date('0004-02-29', ['ymd']));
         $this->assertTrue(Validation::date('2004-02-29', ['ymd']));
@@ -1377,10 +1295,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateYymmdd method
-     *
-     * @return void
      */
-    public function testDateYymmdd()
+    public function testDateYymmdd(): void
     {
         $this->assertTrue(Validation::date('06-12-27', ['ymd']));
         $this->assertTrue(Validation::date('06.12.27', ['ymd']));
@@ -1399,10 +1315,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateYymmddLeapYear method
-     *
-     * @return void
      */
-    public function testDateYymmddLeapYear()
+    public function testDateYymmddLeapYear(): void
     {
         $this->assertTrue(Validation::date('0004-04-29', ['ymd']));
         $this->assertTrue(Validation::date('2004-02-29', ['ymd']));
@@ -1417,10 +1331,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDdMMMMyyyy method
-     *
-     * @return void
      */
-    public function testDateDdMMMMyyyy()
+    public function testDateDdMMMMyyyy(): void
     {
         $this->assertTrue(Validation::date('01 January 0001', ['dMy']));
         $this->assertTrue(Validation::date('27 December 2006', ['dMy']));
@@ -1431,10 +1343,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateDdMMMMyyyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateDdMMMMyyyyLeapYear()
+    public function testDateDdMMMMyyyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('29 February 0004', ['dMy']));
         $this->assertTrue(Validation::date('29 February 2004', ['dMy']));
@@ -1443,10 +1353,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMmmmDdyyyy method
-     *
-     * @return void
      */
-    public function testDateMmmmDdyyyy()
+    public function testDateMmmmDdyyyy(): void
     {
         $this->assertTrue(Validation::date('January 01, 0001', ['Mdy']));
         $this->assertTrue(Validation::date('December 27, 2006', ['Mdy']));
@@ -1460,10 +1368,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMmmmDdyyyyLeapYear method
-     *
-     * @return void
      */
-    public function testDateMmmmDdyyyyLeapYear()
+    public function testDateMmmmDdyyyyLeapYear(): void
     {
         $this->assertTrue(Validation::date('February 29, 0004', ['Mdy']));
         $this->assertTrue(Validation::date('February 29, 2004', ['Mdy']));
@@ -1475,10 +1381,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMy method
-     *
-     * @return void
      */
-    public function testDateMy()
+    public function testDateMy(): void
     {
         $this->assertTrue(Validation::date('January 0001', ['My']));
         $this->assertTrue(Validation::date('December 2006', ['My']));
@@ -1489,10 +1393,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateMyNumeric method
-     *
-     * @return void
      */
-    public function testDateMyNumeric()
+    public function testDateMyNumeric(): void
     {
         $this->assertTrue(Validation::date('01/0001', ['my']));
         $this->assertTrue(Validation::date('01/2006', ['my']));
@@ -1509,10 +1411,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateYmNumeric method
-     *
-     * @return void
      */
-    public function testDateYmNumeric()
+    public function testDateYmNumeric(): void
     {
         $this->assertTrue(Validation::date('0001/01', ['ym']));
         $this->assertTrue(Validation::date('2006/12', ['ym']));
@@ -1534,10 +1434,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateY method
-     *
-     * @return void
      */
-    public function testDateY()
+    public function testDateY(): void
     {
         $this->assertTrue(Validation::date('0001', ['y']));
         $this->assertTrue(Validation::date('1900', ['y']));
@@ -1555,10 +1453,8 @@ class ValidationTest extends TestCase
 
     /**
      * test date validation when passing an array
-     *
-     * @return void
      */
-    public function testDateArray()
+    public function testDateArray(): void
     {
         $date = ['year' => 2014, 'month' => 2, 'day' => 14];
         $this->assertTrue(Validation::date($date));
@@ -1571,10 +1467,8 @@ class ValidationTest extends TestCase
 
     /**
      * test datetime validation when passing an array
-     *
-     * @return void
      */
-    public function testDateTimeArray()
+    public function testDateTimeArray(): void
     {
         $date = [
             'year' => 2014,
@@ -1620,10 +1514,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test validating dates with multiple formats
-     *
-     * @return void
      */
-    public function testDateMultiple()
+    public function testDateMultiple(): void
     {
         $this->assertTrue(Validation::date('2011-12-31', ['ymd', 'dmy']));
         $this->assertTrue(Validation::date('31-12-2011', ['ymd', 'dmy']));
@@ -1631,10 +1523,8 @@ class ValidationTest extends TestCase
 
     /**
      * testTime method
-     *
-     * @return void
      */
-    public function testTime()
+    public function testTime(): void
     {
         $this->assertTrue(Validation::time('00:00'));
         $this->assertTrue(Validation::time('23:59'));
@@ -1661,10 +1551,8 @@ class ValidationTest extends TestCase
 
     /**
      * test time validation when passing an array
-     *
-     * @return void
      */
-    public function testTimeArray()
+    public function testTimeArray(): void
     {
         $date = ['hour' => 13, 'minute' => 14, 'second' => 15];
         $this->assertTrue(Validation::time($date));
@@ -1692,10 +1580,8 @@ class ValidationTest extends TestCase
 
     /**
      * Tests that it is possible to pass a median (AM, PM) to the dateTime validation
-     *
-     * @return void
      */
-    public function testDateTimeWithMeriadian()
+    public function testDateTimeWithMeriadian(): void
     {
         $this->assertTrue(Validation::dateTime('10/04/2007 1:50 AM', ['dmy']));
         $this->assertTrue(Validation::dateTime('12/04/2017 1:38 PM', ['dmy']));
@@ -1710,10 +1596,8 @@ class ValidationTest extends TestCase
 
     /**
      * Tests that it is possible to pass a date with a T separator
-     *
-     * @return void
      */
-    public function testDateTimeISO()
+    public function testDateTimeISO(): void
     {
         $this->assertTrue(Validation::dateTime('2007/10/04T01:50'));
         $this->assertTrue(Validation::dateTime('2017/12/04T15:38'));
@@ -1726,10 +1610,9 @@ class ValidationTest extends TestCase
     /**
      * Tests that it is possible to pass an ISO8601 value
      *
-     * @return void
      * @see Validation tests values credits: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
      */
-    public function testDateTimeISO8601()
+    public function testDateTimeISO8601(): void
     {
         // Valid ISO8601
         $this->assertTrue(Validation::iso8601('2007'));
@@ -1759,10 +1642,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test localizedTime
-     *
-     * @return void
      */
-    public function testLocalizedTime()
+    public function testLocalizedTime(): void
     {
         $locale = I18n::getLocale();
 
@@ -1800,10 +1681,8 @@ class ValidationTest extends TestCase
 
     /**
      * testBoolean method
-     *
-     * @return void
      */
-    public function testBoolean()
+    public function testBoolean(): void
     {
         $this->assertTrue(Validation::boolean('0'));
         $this->assertTrue(Validation::boolean('1'));
@@ -1820,10 +1699,8 @@ class ValidationTest extends TestCase
 
     /**
      * testBooleanWithOptions method
-     *
-     * @return void
      */
-    public function testBooleanWithOptions()
+    public function testBooleanWithOptions(): void
     {
         $this->assertTrue(Validation::boolean('0', ['0', '1']));
         $this->assertTrue(Validation::boolean('1', ['0', '1']));
@@ -1839,10 +1716,8 @@ class ValidationTest extends TestCase
 
     /**
      * testTruthy method
-     *
-     * @return void
      */
-    public function testTruthy()
+    public function testTruthy(): void
     {
         $this->assertTrue(Validation::truthy(1));
         $this->assertTrue(Validation::truthy(true));
@@ -1870,10 +1745,8 @@ class ValidationTest extends TestCase
 
     /**
      * testTruthy method
-     *
-     * @return void
      */
-    public function testFalsey()
+    public function testFalsey(): void
     {
         $this->assertTrue(Validation::falsey(0));
         $this->assertTrue(Validation::falsey(false));
@@ -1901,10 +1774,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDateCustomRegx method
-     *
-     * @return void
      */
-    public function testDateCustomRegx()
+    public function testDateCustomRegx(): void
     {
         $this->assertTrue(Validation::date('2006-12-27', null, '%^(19|20)[0-9]{2}[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])$%'));
         $this->assertFalse(Validation::date('12-27-2006', null, '%^(19|20)[0-9]{2}[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])$%'));
@@ -1912,10 +1783,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test numbers with any number of decimal places, including none.
-     *
-     * @return void
      */
-    public function testDecimalWithPlacesNull()
+    public function testDecimalWithPlacesNull(): void
     {
         $this->assertTrue(Validation::decimal('+1234.54321', null));
         $this->assertTrue(Validation::decimal('-1234.54321', null));
@@ -1946,10 +1815,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test numbers with any number of decimal places greater than 0, or a float|double.
-     *
-     * @return void
      */
-    public function testDecimalWithPlacesTrue()
+    public function testDecimalWithPlacesTrue(): void
     {
         $this->assertTrue(Validation::decimal('+1234.54321', true));
         $this->assertTrue(Validation::decimal('-1234.54321', true));
@@ -1980,10 +1847,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test numbers with exactly that many number of decimal places.
-     *
-     * @return void
      */
-    public function testDecimalWithPlacesNumeric()
+    public function testDecimalWithPlacesNumeric(): void
     {
         $this->assertTrue(Validation::decimal('.27', '2'));
         $this->assertTrue(Validation::decimal(0.27, 2));
@@ -2018,10 +1883,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test decimal() with invalid places parameter.
-     *
-     * @return void
      */
-    public function testDecimalWithInvalidPlaces()
+    public function testDecimalWithInvalidPlaces(): void
     {
         $this->assertFalse(Validation::decimal('.27', 'string'));
         $this->assertFalse(Validation::decimal(1234.5678, (array)true));
@@ -2030,10 +1893,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDecimalCustomRegex method
-     *
-     * @return void
      */
-    public function testDecimalCustomRegex()
+    public function testDecimalCustomRegex(): void
     {
         $this->assertTrue(Validation::decimal('1.54321', null, '/^[-+]?[0-9]+(\\.[0-9]+)?$/s'));
         $this->assertFalse(Validation::decimal('.54321', null, '/^[-+]?[0-9]+(\\.[0-9]+)?$/s'));
@@ -2041,10 +1902,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test localized floats with decimal.
-     *
-     * @return void
      */
-    public function testDecimalLocaleSet()
+    public function testDecimalLocaleSet(): void
     {
         $this->skipIf(DS === '\\', 'The locale is not supported in Windows and affects other tests.');
         $this->skipIf(Locale::setDefault('da_DK') === false, "The Danish locale isn't available.");
@@ -2061,10 +1920,8 @@ class ValidationTest extends TestCase
 
     /**
      * testEmail method
-     *
-     * @return void
      */
-    public function testEmail()
+    public function testEmail(): void
     {
         $this->assertTrue(Validation::email('abc.efg@domain.com'));
         $this->assertTrue(Validation::email('efg@domain.com'));
@@ -2146,10 +2003,8 @@ class ValidationTest extends TestCase
 
     /**
      * testEmailDeep method
-     *
-     * @return void
      */
-    public function testEmailDeep()
+    public function testEmailDeep(): void
     {
         $this->skipIf((bool)gethostbynamel('example.abcd'), 'Your DNS service responds for nonexistent domains, skipping deep email checks.');
 
@@ -2159,10 +2014,8 @@ class ValidationTest extends TestCase
 
     /**
      * testEmailCustomRegex method
-     *
-     * @return void
      */
-    public function testEmailCustomRegex()
+    public function testEmailCustomRegex(): void
     {
         $this->assertTrue(Validation::email('abc.efg@cakephp.org', null, '/^[A-Z0-9._%-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i'));
         $this->assertFalse(Validation::email('abc.efg@com.caphpkeinvalid', null, '/^[A-Z0-9._%-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i'));
@@ -2170,10 +2023,8 @@ class ValidationTest extends TestCase
 
     /**
      * testEqualTo method
-     *
-     * @return void
      */
-    public function testEqualTo()
+    public function testEqualTo(): void
     {
         $this->assertTrue(Validation::equalTo('1', '1'));
         $this->assertFalse(Validation::equalTo(1, '1'));
@@ -2185,10 +2036,8 @@ class ValidationTest extends TestCase
 
     /**
      * testIpV4 method
-     *
-     * @return void
      */
-    public function testIpV4()
+    public function testIpV4(): void
     {
         $this->assertTrue(Validation::ip('0.0.0.0', 'ipv4'));
         $this->assertTrue(Validation::ip('192.168.1.156'));
@@ -2201,10 +2050,8 @@ class ValidationTest extends TestCase
 
     /**
      * testIp v6
-     *
-     * @return void
      */
-    public function testIpv6()
+    public function testIpv6(): void
     {
         $this->assertTrue(Validation::ip('2001:0db8:85a3:0000:0000:8a2e:0370:7334', 'IPv6'));
         $this->assertTrue(Validation::ip('2001:db8:85a3:0:0:8a2e:370:7334', 'IPv6'));
@@ -2242,10 +2089,8 @@ class ValidationTest extends TestCase
 
     /**
      * testMaxLength method
-     *
-     * @return void
      */
-    public function testMaxLength()
+    public function testMaxLength(): void
     {
         $this->assertTrue(Validation::maxLength('ab', 3));
         $this->assertTrue(Validation::maxLength('abc', 3));
@@ -2258,10 +2103,8 @@ class ValidationTest extends TestCase
 
     /**
      * maxLengthBytes method
-     *
-     * @return void
      */
-    public function testMaxLengthBytes()
+    public function testMaxLengthBytes(): void
     {
         $this->assertTrue(Validation::maxLengthBytes('ab', 3));
         $this->assertTrue(Validation::maxLengthBytes('abc', 3));
@@ -2275,10 +2118,8 @@ class ValidationTest extends TestCase
 
     /**
      * testMinLength method
-     *
-     * @return void
      */
-    public function testMinLength()
+    public function testMinLength(): void
     {
         $this->assertFalse(Validation::minLength('ab', 3));
         $this->assertFalse(Validation::minLength('ÆΔΩЖÇ', 10));
@@ -2292,10 +2133,8 @@ class ValidationTest extends TestCase
 
     /**
      * minLengthBytes method
-     *
-     * @return void
      */
-    public function testMinLengthBytes()
+    public function testMinLengthBytes(): void
     {
         $this->assertFalse(Validation::minLengthBytes('ab', 3));
         $this->assertFalse(Validation::minLengthBytes('ÆΔΩЖÇ', 11));
@@ -2310,10 +2149,8 @@ class ValidationTest extends TestCase
 
     /**
      * testUrl method
-     *
-     * @return void
      */
-    public function testUrl()
+    public function testUrl(): void
     {
         $this->assertTrue(Validation::url('http://www.cakephp.org'));
         $this->assertTrue(Validation::url('http://cakephp.org'));
@@ -2386,7 +2223,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::url('[1::2::3]'));
     }
 
-    public function testUuid()
+    public function testUuid(): void
     {
         $this->assertTrue(Validation::uuid('00000000-0000-0000-0000-000000000000'));
         $this->assertTrue(Validation::uuid('550e8400-e29b-11d4-a716-446655440000'));
@@ -2401,10 +2238,8 @@ class ValidationTest extends TestCase
 
     /**
      * testInList method
-     *
-     * @return void
      */
-    public function testInList()
+    public function testInList(): void
     {
         $this->assertTrue(Validation::inList('one', ['one', 'two']));
         $this->assertTrue(Validation::inList('two', ['one', 'two']));
@@ -2431,10 +2266,8 @@ class ValidationTest extends TestCase
 
     /**
      * testRange method
-     *
-     * @return void
      */
-    public function testRange()
+    public function testRange(): void
     {
         $this->assertFalse(Validation::range(20, 100, 1));
         $this->assertTrue(Validation::range(20, 1, 100));
@@ -2451,10 +2284,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test range type checks
-     *
-     * @return void
      */
-    public function testRangeTypeChecks()
+    public function testRangeTypeChecks(): void
     {
         $this->assertFalse(Validation::range('\x028', 1, 5), 'hexish encoding fails');
         $this->assertFalse(Validation::range('0b010', 1, 5), 'binary string data fails');
@@ -2468,10 +2299,8 @@ class ValidationTest extends TestCase
 
     /**
      * testExtension method
-     *
-     * @return void
      */
-    public function testExtension()
+    public function testExtension(): void
     {
         $this->assertTrue(Validation::extension('extension.jpeg'));
         $this->assertTrue(Validation::extension('extension.JPEG'));
@@ -2521,7 +2350,7 @@ class ValidationTest extends TestCase
     /**
      * Test extension with a PSR7 object
      */
-    public function testExtensionPsr7()
+    public function testExtensionPsr7(): void
     {
         $file = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
 
@@ -2534,10 +2363,8 @@ class ValidationTest extends TestCase
 
     /**
      * testMoney method
-     *
-     * @return void
      */
-    public function testMoney()
+    public function testMoney(): void
     {
         $this->assertTrue(Validation::money('100'));
         $this->assertTrue(Validation::money('100.11'));
@@ -2575,10 +2402,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test Multiple Select Validation
-     *
-     * @return void
      */
-    public function testMultiple()
+    public function testMultiple(): void
     {
         $this->assertTrue(Validation::multiple([0, 1, 2, 3]));
         $this->assertTrue(Validation::multiple([50, 32, 22, 0]));
@@ -2630,10 +2455,8 @@ class ValidationTest extends TestCase
 
     /**
      * testNumeric method
-     *
-     * @return void
      */
-    public function testNumeric()
+    public function testNumeric(): void
     {
         $this->assertFalse(Validation::numeric('teststring'));
         $this->assertFalse(Validation::numeric('1.1test'));
@@ -2647,10 +2470,8 @@ class ValidationTest extends TestCase
 
     /**
      * testNaturalNumber method
-     *
-     * @return void
      */
-    public function testNaturalNumber()
+    public function testNaturalNumber(): void
     {
         $this->assertFalse(Validation::naturalNumber('teststring'));
         $this->assertFalse(Validation::naturalNumber('5.4'));
@@ -2669,10 +2490,8 @@ class ValidationTest extends TestCase
 
     /**
      * testDatetime method
-     *
-     * @return void
      */
-    public function testDatetime()
+    public function testDatetime(): void
     {
         $this->assertTrue(Validation::datetime('27-12-2006 01:00', 'dmy'));
         $this->assertTrue(Validation::datetime('27-12-2006 01:00', ['dmy']));
@@ -2699,10 +2518,8 @@ class ValidationTest extends TestCase
 
     /**
      * testMimeType method
-     *
-     * @return void
      */
-    public function testMimeType()
+    public function testMimeType(): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
 
@@ -2718,10 +2535,8 @@ class ValidationTest extends TestCase
 
     /**
      * testMimeTypeCaseInsensitive method
-     *
-     * @return void
      */
-    public function testMimeTypeCaseInsensitive()
+    public function testMimeTypeCaseInsensitive(): void
     {
         $algol68 = CORE_TESTS . 'Fixture/sample.a68';
 
@@ -2734,10 +2549,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test mimetype with a PSR7 object
-     *
-     * @return void
      */
-    public function testMimeTypePsr7()
+    public function testMimeTypePsr7(): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $file = new UploadedFile($image, 1000, UPLOAD_ERR_OK, 'cake.power.gif', 'image/lies');
@@ -2751,10 +2564,8 @@ class ValidationTest extends TestCase
 
     /**
      * testMimeTypeFalse method
-     *
-     * @return void
      */
-    public function testMimeTypeFalse()
+    public function testMimeTypeFalse(): void
     {
         $this->expectException(\RuntimeException::class);
         $image = CORE_TESTS . 'invalid-file.png';
@@ -2763,10 +2574,8 @@ class ValidationTest extends TestCase
 
     /**
      * testUploadError method
-     *
-     * @return void
      */
-    public function testUploadError()
+    public function testUploadError(): void
     {
         $this->assertTrue(Validation::uploadError(0));
         $this->assertTrue(Validation::uploadError(['error' => 0]));
@@ -2785,10 +2594,8 @@ class ValidationTest extends TestCase
 
     /**
      * testUploadError method with an UploadedFile
-     *
-     * @return void
      */
-    public function testUploadErrorPsr7()
+    public function testUploadErrorPsr7(): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $file = new UploadedFile($image, 1000, UPLOAD_ERR_OK, 'cake.power.gif', 'image/gif');
@@ -2801,10 +2608,8 @@ class ValidationTest extends TestCase
 
     /**
      * testFileSize method
-     *
-     * @return void
      */
-    public function testFileSize()
+    public function testFileSize(): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $this->assertTrue(Validation::fileSize($image, Validation::COMPARE_LESS, 1024));
@@ -2820,10 +2625,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test fileSize() with a PSR7 object.
-     *
-     * @return void
      */
-    public function testFileSizePsr7()
+    public function testFileSizePsr7(): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $file = new UploadedFile($image, 1000, UPLOAD_ERR_OK, 'cake.power.gif', 'image/gif');
@@ -2836,10 +2639,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test uploaded file validation.
-     *
-     * @return void
      */
-    public function testUploadedFileErrorCode()
+    public function testUploadedFileErrorCode(): void
     {
         $this->assertFalse(Validation::uploadedFile('derp'));
         $invalid = [
@@ -2864,9 +2665,8 @@ class ValidationTest extends TestCase
      * Test uploaded file validation.
      *
      * @dataProvider uploadedFileProvider
-     * @return void
      */
-    public function testUploadedFileArray(bool $expected, array $options)
+    public function testUploadedFileArray(bool $expected, array $options): void
     {
         $file = [
             'name' => 'cake.power.gif',
@@ -2880,10 +2680,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test uploaded file validation.
-     *
-     * @return void
      */
-    public function testUploadedFileNoFile()
+    public function testUploadedFileNoFile(): void
     {
         $file = [
             'name' => '',
@@ -2907,10 +2705,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test uploaded file validation.
-     *
-     * @return void
      */
-    public function testUploadedFileWithDifferentFileParametersOrder()
+    public function testUploadedFileWithDifferentFileParametersOrder(): void
     {
         $file = [
             'name' => 'cake.power.gif',
@@ -2946,9 +2742,8 @@ class ValidationTest extends TestCase
      * Test uploadedFile with a PSR7 object.
      *
      * @dataProvider uploadedFileProvider
-     * @return void
      */
-    public function testUploadedFilePsr7(bool $expected, array $options)
+    public function testUploadedFilePsr7(bool $expected, array $options): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';
         $file = new UploadedFile($image, 1000, UPLOAD_ERR_OK, 'cake.power.gif', 'image/gif');
@@ -2957,10 +2752,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test the compareFields method with equal result.
-     *
-     * @return void
      */
-    public function testCompareFieldsEqualTo()
+    public function testCompareFieldsEqualTo(): void
     {
         $context = [
             'data' => [
@@ -2991,10 +2784,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test the compareFields method with not equal result.
-     *
-     * @return void
      */
-    public function testCompareFieldsNotEqual()
+    public function testCompareFieldsNotEqual(): void
     {
         $context = [
             'data' => [
@@ -3016,12 +2807,10 @@ class ValidationTest extends TestCase
 
     /**
      * testContainsNonAlphaNumeric method
-     *
-     * @return void
      */
-    public function testContainNonAlphaNumeric()
+    public function testContainNonAlphaNumeric(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->assertFalse(Validation::containsNonAlphaNumeric('abcdefghijklmnopqrstuvwxyz'));
             $this->assertFalse(Validation::containsNonAlphaNumeric('ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
             $this->assertFalse(Validation::containsNonAlphaNumeric('0123456789'));
@@ -3075,10 +2864,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test the geoCoordinate method.
-     *
-     * @return void
      */
-    public function testGeoCoordinate()
+    public function testGeoCoordinate(): void
     {
         $this->assertTrue(Validation::geoCoordinate('51.165691, 10.451526'));
         $this->assertTrue(Validation::geoCoordinate('-25.274398, 133.775136'));
@@ -3091,10 +2878,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test the geoCoordinate method.
-     *
-     * @return void
      */
-    public function testLatitude()
+    public function testLatitude(): void
     {
         $this->assertTrue(Validation::latitude('0'));
         $this->assertTrue(Validation::latitude('0.000000'));
@@ -3104,10 +2889,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test the geoCoordinate method.
-     *
-     * @return void
      */
-    public function testLongitude()
+    public function testLongitude(): void
     {
         $this->assertTrue(Validation::longitude('0'));
         $this->assertTrue(Validation::longitude('0.000000'));
@@ -3118,10 +2901,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test isArray
-     *
-     * @return void
      */
-    public function testIsArray()
+    public function testIsArray(): void
     {
         $this->assertTrue(Validation::isArray([]));
         $this->assertTrue(Validation::isArray([1, 2, 3]));
@@ -3133,10 +2914,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test isScalar
-     *
-     * @return void
      */
-    public function testIsScalar()
+    public function testIsScalar(): void
     {
         $this->assertTrue(Validation::isScalar(1));
         $this->assertTrue(Validation::isScalar(0.0));
@@ -3150,10 +2929,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test isInteger
-     *
-     * @return void
      */
-    public function testIsInteger()
+    public function testIsInteger(): void
     {
         $this->assertTrue(Validation::isInteger(-10));
         $this->assertTrue(Validation::isInteger(0));
@@ -3177,10 +2954,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test ascii
-     *
-     * @return void
      */
-    public function testAscii()
+    public function testAscii(): void
     {
         $this->assertTrue(Validation::ascii('1 big blue bus.'));
         $this->assertTrue(Validation::ascii(',.<>[]{;/?\)()'));
@@ -3203,10 +2978,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test utf8 basic
-     *
-     * @return void
      */
-    public function testUtf8Basic()
+    public function testUtf8Basic(): void
     {
         $this->assertFalse(Validation::utf8([]));
         $this->assertFalse(Validation::utf8(1001));
@@ -3231,10 +3004,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test utf8 extended
-     *
-     * @return void
      */
-    public function testUtf8Extended()
+    public function testUtf8Extended(): void
     {
         $this->assertFalse(Validation::utf8([], ['extended' => true]));
         $this->assertFalse(Validation::utf8(1001, ['extended' => true]));
@@ -3259,10 +3030,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test numElements
-     *
-     * @return void
      */
-    public function testNumElements()
+    public function testNumElements(): void
     {
         $array = ['cake', 'php'];
         $this->assertTrue(Validation::numElements($array, Validation::COMPARE_EQUAL, 2));
@@ -3282,10 +3051,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test ImageSize InvalidArgumentException
-     *
-     * @return void
      */
-    public function testImageSizeInvalidArgumentException()
+    public function testImageSizeInvalidArgumentException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->assertTrue(Validation::imageSize([], []));
@@ -3293,10 +3060,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test imageSize
-     *
-     * @return void
      */
-    public function testImageSize()
+    public function testImageSize(): void
     {
         $image = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
         $upload = [
@@ -3341,10 +3106,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test imageSize with a PSR7 object
-     *
-     * @return void
      */
-    public function testImageSizePsr7()
+    public function testImageSizePsr7(): void
     {
         $image = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
         $upload = new UploadedFile($image, 5308, UPLOAD_ERR_OK, 'test.jpg', 'image/jpeg');
@@ -3359,10 +3122,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test imageHeight
-     *
-     * @return void
      */
-    public function testImageHeight()
+    public function testImageHeight(): void
     {
         $image = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
         $upload = [
@@ -3380,10 +3141,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test imageWidth
-     *
-     * @return void
      */
-    public function testImageWidth()
+    public function testImageWidth(): void
     {
         $image = WWW_ROOT . 'test_theme' . DS . 'img' . DS . 'test.jpg';
         $upload = [
@@ -3402,7 +3161,7 @@ class ValidationTest extends TestCase
     /**
      * Test hexColor
      */
-    public function testHexColor()
+    public function testHexColor(): void
     {
         $this->assertTrue(Validation::hexColor('#F01234'));
         $this->assertTrue(Validation::hexColor('#F56789'));
@@ -3416,7 +3175,7 @@ class ValidationTest extends TestCase
     /**
      * Test IBAN
      */
-    public function testIban()
+    public function testIban(): void
     {
         $this->assertTrue(Validation::iban('AD1200012030200359100100'));
         $this->assertTrue(Validation::iban('BA391290079401028494'));

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -31,10 +31,8 @@ class ValidatorTest extends TestCase
 {
     /**
      * tests getRequiredMessage
-     *
-     * @return void
      */
-    public function testGetRequiredMessage()
+    public function testGetRequiredMessage(): void
     {
         $validator = new Validator();
         $this->assertNull($validator->getRequiredMessage('field'));
@@ -50,10 +48,8 @@ class ValidatorTest extends TestCase
 
     /**
      * tests getNotEmptyMessage
-     *
-     * @return void
      */
-    public function testGetNotEmptyMessage()
+    public function testGetNotEmptyMessage(): void
     {
         $validator = new Validator();
         $this->assertNull($validator->getNotEmptyMessage('field'));
@@ -78,10 +74,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing you can dynamically add rules to a field
-     *
-     * @return void
      */
-    public function testAddingRulesToField()
+    public function testAddingRulesToField(): void
     {
         $validator = new Validator();
         $validator->add('title', 'not-blank', ['rule' => 'notBlank']);
@@ -108,10 +102,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing addNested field rules
-     *
-     * @return void
      */
-    public function testAddNestedSingle()
+    public function testAddNestedSingle(): void
     {
         $validator = new Validator();
         $inner = new Validator();
@@ -123,10 +115,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing addNested connects providers
-     *
-     * @return void
      */
-    public function testAddNestedSingleProviders()
+    public function testAddNestedSingleProviders(): void
     {
         $validator = new Validator();
         $validator->setProvider('test', $this);
@@ -145,10 +135,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing addNested with extra `$message` and `$when` params
-     *
-     * @return void
      */
-    public function testAddNestedWithExtra()
+    public function testAddNestedWithExtra(): void
     {
         $inner = new Validator();
         $inner->requirePresence('username');
@@ -175,10 +163,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing addNestedMany field rules
-     *
-     * @return void
      */
-    public function testAddNestedMany()
+    public function testAddNestedMany(): void
     {
         $validator = new Validator();
         $inner = new Validator();
@@ -190,10 +176,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing addNestedMany connects providers
-     *
-     * @return void
      */
-    public function testAddNestedManyProviders()
+    public function testAddNestedManyProviders(): void
     {
         $validator = new Validator();
         $validator->setProvider('test', $this);
@@ -212,10 +196,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing addNestedMany with extra `$message` and `$when` params
-     *
-     * @return void
      */
-    public function testAddNestedManyWithExtra()
+    public function testAddNestedManyWithExtra(): void
     {
         $inner = new Validator();
         $inner->requirePresence('body');
@@ -247,10 +229,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests that calling field will create a default validation set for it
-     *
-     * @return void
      */
-    public function testFieldDefault()
+    public function testFieldDefault(): void
     {
         $validator = new Validator();
         $this->assertFalse($validator->hasField('foo'));
@@ -263,10 +243,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests that field method can be used as a setter
-     *
-     * @return void
      */
-    public function testFieldSetter()
+    public function testFieldSetter(): void
     {
         $validator = new Validator();
         $validationSet = new ValidationSet();
@@ -276,10 +254,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the remove method
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $validator = new Validator();
         $validator->add('title', 'not-blank', ['rule' => 'notBlank']);
@@ -299,10 +275,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the requirePresence method
-     *
-     * @return void
      */
-    public function testRequirePresence()
+    public function testRequirePresence(): void
     {
         $validator = new Validator();
         $this->assertSame($validator, $validator->requirePresence('title'));
@@ -320,10 +294,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the requirePresence method
-     *
-     * @return void
      */
-    public function testRequirePresenceAsArray()
+    public function testRequirePresenceAsArray(): void
     {
         $validator = new Validator();
         $validator->requirePresence(['title', 'created']);
@@ -346,10 +318,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the requirePresence failure case
-     *
-     * @return void
      */
-    public function testRequirePresenceAsArrayFailure()
+    public function testRequirePresenceAsArrayFailure(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $validator = new Validator();
@@ -358,10 +328,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the requirePresence method when passing a callback
-     *
-     * @return void
      */
-    public function testRequirePresenceCallback()
+    public function testRequirePresenceCallback(): void
     {
         $validator = new Validator();
         $require = true;
@@ -381,10 +349,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the isPresenceRequired method
-     *
-     * @return void
      */
-    public function testIsPresenceRequired()
+    public function testIsPresenceRequired(): void
     {
         $validator = new Validator();
         $this->assertSame($validator, $validator->requirePresence('title'));
@@ -406,14 +372,12 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests errors generated when a field presence is required
-     *
-     * @return void
      */
-    public function testErrorsDeprecated()
+    public function testErrorsDeprecated(): void
     {
         $validator = new Validator();
         $validator->requirePresence('title');
-        $this->deprecated(function () use ($validator) {
+        $this->deprecated(function () use ($validator): void {
             $errors = $validator->errors(['foo' => 'something']);
             $expected = ['title' => ['_required' => 'This field is required']];
             $this->assertEquals($expected, $errors);
@@ -422,10 +386,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests errors generated when a field presence is required
-     *
-     * @return void
      */
-    public function testErrorsWithPresenceRequired()
+    public function testErrorsWithPresenceRequired(): void
     {
         $validator = new Validator();
         $validator->requirePresence('title');
@@ -441,10 +403,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test that validation on a certain condition generate errors
-     *
-     * @return void
      */
-    public function testErrorsWithPresenceRequiredOnCreate()
+    public function testErrorsWithPresenceRequiredOnCreate(): void
     {
         $validator = new Validator();
         $validator->requirePresence('id', 'update');
@@ -463,10 +423,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test that validate() can work with nested data.
-     *
-     * @return void
      */
-    public function testErrorsWithNestedFields()
+    public function testErrorsWithNestedFields(): void
     {
         $validator = new Validator();
         $user = new Validator();
@@ -500,10 +458,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test nested fields with many, but invalid data.
-     *
-     * @return void
      */
-    public function testErrorsWithNestedSingleInvalidType()
+    public function testErrorsWithNestedSingleInvalidType(): void
     {
         $validator = new Validator();
 
@@ -523,10 +479,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test nested fields with many, but invalid data.
-     *
-     * @return void
      */
-    public function testErrorsWithNestedManyInvalidType()
+    public function testErrorsWithNestedManyInvalidType(): void
     {
         $validator = new Validator();
 
@@ -546,10 +500,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test nested fields with many, but invalid data.
-     *
-     * @return void
      */
-    public function testErrorsWithNestedManySomeInvalid()
+    public function testErrorsWithNestedManySomeInvalid(): void
     {
         $validator = new Validator();
 
@@ -575,10 +527,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests custom error messages generated when a field presence is required
-     *
-     * @return void
      */
-    public function testCustomErrorsWithPresenceRequired()
+    public function testCustomErrorsWithPresenceRequired(): void
     {
         $validator = new Validator();
         $validator->requirePresence('title', true, 'Custom message');
@@ -589,10 +539,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests custom error messages generated when a field presence is required
-     *
-     * @return void
      */
-    public function testCustomErrorsWithPresenceRequiredAsArray()
+    public function testCustomErrorsWithPresenceRequiredAsArray(): void
     {
         $validator = new Validator();
         $validator->requirePresence(['title', 'content'], true, 'Custom message');
@@ -619,10 +567,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the testAllowEmptyFor method
-     *
-     * @return void
      */
-    public function testAllowEmptyFor()
+    public function testAllowEmptyFor(): void
     {
         $validator = new Validator();
         $validator
@@ -660,10 +606,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmpty method
-     *
-     * @return void
      */
-    public function testAllowEmpty()
+    public function testAllowEmpty(): void
     {
         $validator = new Validator();
         $this->assertSame($validator, $validator->allowEmptyString('title'));
@@ -678,10 +622,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmpty method with date/time fields.
-     *
-     * @return void
      */
-    public function testAllowEmptyWithDateTimeFields()
+    public function testAllowEmptyWithDateTimeFields(): void
     {
         $validator = new Validator();
         $validator->allowEmptyDate('created')
@@ -725,10 +667,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmpty method with file fields.
-     *
-     * @return void
      */
-    public function testAllowEmptyWithFileFields()
+    public function testAllowEmptyWithFileFields(): void
     {
         $validator = new Validator();
         $validator->allowEmptyFile('picture')
@@ -769,14 +709,12 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmpty as array method
-     *
-     * @return void
      */
-    public function testAllowEmptyAsArray()
+    public function testAllowEmptyAsArray(): void
     {
         $validator = new Validator();
 
-        $this->deprecated(function () use ($validator) {
+        $this->deprecated(function () use ($validator): void {
             $validator->allowEmpty([
                 'title',
                 'subject',
@@ -817,12 +755,10 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmpty failure case
-     *
-     * @return void
      */
-    public function testAllowEmptyAsArrayFailure()
+    public function testAllowEmptyAsArrayFailure(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->expectException(\InvalidArgumentException::class);
             $validator = new Validator();
             $validator->allowEmpty(['title' => 'derp', 'created' => false]);
@@ -831,10 +767,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmptyString method
-     *
-     * @return void
      */
-    public function testAllowEmptyString()
+    public function testAllowEmptyString(): void
     {
         $validator = new Validator();
         $validator->allowEmptyString('title')
@@ -876,7 +810,7 @@ class ValidatorTest extends TestCase
     /**
      * Test allowEmptyString with callback
      */
-    public function testAllowEmptyStringCallbackWhen()
+    public function testAllowEmptyStringCallbackWhen(): void
     {
         $validator = new Validator();
         $validator->allowEmptyString(
@@ -903,10 +837,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmptyArray method
-     *
-     * @return void
      */
-    public function testNotEmptyArray()
+    public function testNotEmptyArray(): void
     {
         $validator = new Validator();
         $validator->notEmptyArray('items', 'not empty');
@@ -937,10 +869,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmptyFile method
-     *
-     * @return void
      */
-    public function testAllowEmptyFile()
+    public function testAllowEmptyFile(): void
     {
         $validator = new Validator();
         $validator->allowEmptyFile('photo')
@@ -1013,10 +943,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmptyFile method
-     *
-     * @return void
      */
-    public function testNotEmptyFile()
+    public function testNotEmptyFile(): void
     {
         $validator = new Validator();
         $validator->notEmptyFile('photo', 'required field');
@@ -1063,7 +991,7 @@ class ValidatorTest extends TestCase
      *
      * @retrn void
      */
-    public function testNotEmptyFileUpdate()
+    public function testNotEmptyFileUpdate(): void
     {
         $validator = new Validator();
         $validator->notEmptyArray('photo', 'message', 'update');
@@ -1080,10 +1008,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmptyDate method
-     *
-     * @return void
      */
-    public function testAllowEmptyDate()
+    public function testAllowEmptyDate(): void
     {
         $validator = new Validator();
         $validator->allowEmptyDate('date')
@@ -1120,10 +1046,8 @@ class ValidatorTest extends TestCase
 
     /**
      * test allowEmptyDate() with an update condition
-     *
-     * @return void
      */
-    public function testAllowEmptyDateUpdate()
+    public function testAllowEmptyDateUpdate(): void
     {
         $validator = new Validator();
         $validator->allowEmptyArray('date', 'be valid', 'update');
@@ -1142,10 +1066,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmptyDate method
-     *
-     * @return void
      */
-    public function testNotEmptyDate()
+    public function testNotEmptyDate(): void
     {
         $validator = new Validator();
         $validator->notEmptyDate('date', 'required field');
@@ -1189,10 +1111,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test notEmptyDate with update mode
-     *
-     * @return void
      */
-    public function testNotEmptyDateUpdate()
+    public function testNotEmptyDateUpdate(): void
     {
         $validator = new Validator();
         $validator->notEmptyDate('date', 'message', 'update');
@@ -1207,10 +1127,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmptyTime method
-     *
-     * @return void
      */
-    public function testAllowEmptyTime()
+    public function testAllowEmptyTime(): void
     {
         $validator = new Validator();
         $validator->allowEmptyTime('time')
@@ -1247,10 +1165,8 @@ class ValidatorTest extends TestCase
 
     /**
      * test allowEmptyTime with condition
-     *
-     * @return void
      */
-    public function testAllowEmptyTimeCondition()
+    public function testAllowEmptyTimeCondition(): void
     {
         $validator = new Validator();
         $validator->allowEmptyTime('time', 'valid time', 'update');
@@ -1269,10 +1185,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmptyTime method
-     *
-     * @return void
      */
-    public function testNotEmptyTime()
+    public function testNotEmptyTime(): void
     {
         $validator = new Validator();
         $validator->notEmptyTime('time', 'required field');
@@ -1310,10 +1224,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test notEmptyTime with update mode
-     *
-     * @return void
      */
-    public function testNotEmptyTimeUpdate()
+    public function testNotEmptyTimeUpdate(): void
     {
         $validator = new Validator();
         $validator->notEmptyTime('time', 'message', 'update');
@@ -1328,10 +1240,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmptyDateTime method
-     *
-     * @return void
      */
-    public function testAllowEmptyDateTime()
+    public function testAllowEmptyDateTime(): void
     {
         $validator = new Validator();
         $validator->allowEmptyDate('published')
@@ -1370,10 +1280,8 @@ class ValidatorTest extends TestCase
 
     /**
      * test allowEmptyDateTime with a condition
-     *
-     * @return void
      */
-    public function testAllowEmptyDateTimeCondition()
+    public function testAllowEmptyDateTimeCondition(): void
     {
         $validator = new Validator();
         $validator->allowEmptyDateTime('published', 'datetime required', 'update');
@@ -1392,13 +1300,11 @@ class ValidatorTest extends TestCase
 
     /**
      * test allowEmptyDateTime with deprecated argument order
-     *
-     * @return void
      */
-    public function testAllowEmptyDateTimeDeprecated()
+    public function testAllowEmptyDateTimeDeprecated(): void
     {
         $validator = new Validator();
-        $this->deprecated(function () use ($validator) {
+        $this->deprecated(function () use ($validator): void {
             $validator->allowEmptyDateTime('published', 'datetime required', 'update');
         });
         $this->assertFalse($validator->isEmptyAllowed('published', true));
@@ -1416,10 +1322,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmptyDateTime method
-     *
-     * @return void
      */
-    public function testNotEmptyDateTime()
+    public function testNotEmptyDateTime(): void
     {
         $validator = new Validator();
         $validator->notEmptyDateTime('published', 'required field');
@@ -1467,10 +1371,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test notEmptyDateTime with update mode
-     *
-     * @return void
      */
-    public function testNotEmptyDateTimeUpdate()
+    public function testNotEmptyDateTimeUpdate(): void
     {
         $validator = new Validator();
         $validator->notEmptyDatetime('published', 'message', 'update');
@@ -1485,10 +1387,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test the notEmpty() method.
-     *
-     * @return void
      */
-    public function testNotEmpty()
+    public function testNotEmpty(): void
     {
         $validator = new Validator();
         $validator->notEmptyString('title');
@@ -1500,17 +1400,15 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmpty as array method
-     *
-     * @return void
      */
-    public function testNotEmptyAsArray()
+    public function testNotEmptyAsArray(): void
     {
         $validator = new Validator();
         $validator->notEmptyString('title')->notEmptyString('created');
         $this->assertFalse($validator->field('title')->isEmptyAllowed());
         $this->assertFalse($validator->field('created')->isEmptyAllowed());
 
-        $this->deprecated(function () use ($validator) {
+        $this->deprecated(function () use ($validator): void {
             $validator->notEmpty([
                 'title' => [
                     'when' => false,
@@ -1554,12 +1452,10 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmpty failure case
-     *
-     * @return void
      */
-    public function testNotEmptyAsArrayFailure()
+    public function testNotEmptyAsArrayFailure(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $this->expectException(\InvalidArgumentException::class);
             $validator = new Validator();
             $validator->notEmpty(['title' => 'derp', 'created' => false]);
@@ -1568,10 +1464,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test the notEmpty() method.
-     *
-     * @return void
      */
-    public function testNotEmptyModes()
+    public function testNotEmptyModes(): void
     {
         $validator = new Validator();
         $validator->notEmptyString('title', 'Need a title', 'create');
@@ -1593,10 +1487,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test interactions between notEmpty() and isAllowed().
-     *
-     * @return void
      */
-    public function testNotEmptyAndIsAllowed()
+    public function testNotEmptyAndIsAllowed(): void
     {
         $validator = new Validator();
         $validator->allowEmptyString('title')
@@ -1617,10 +1509,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the allowEmpty method when passing a callback
-     *
-     * @return void
      */
-    public function testAllowEmptyCallback()
+    public function testAllowEmptyCallback(): void
     {
         $validator = new Validator();
         $allow = true;
@@ -1639,10 +1529,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEmpty method when passing a callback
-     *
-     * @return void
      */
-    public function testNotEmptyCallback()
+    public function testNotEmptyCallback(): void
     {
         $validator = new Validator();
         $prevent = true;
@@ -1661,10 +1549,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the isEmptyAllowed method
-     *
-     * @return void
      */
-    public function testIsEmptyAllowed()
+    public function testIsEmptyAllowed(): void
     {
         $validator = new Validator();
         $this->assertSame($validator, $validator->allowEmptyString('title'));
@@ -1686,10 +1572,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests errors generated when a field is not allowed to be empty
-     *
-     * @return void
      */
-    public function testErrorsWithEmptyNotAllowed()
+    public function testErrorsWithEmptyNotAllowed(): void
     {
         $validator = new Validator();
         $validator->notEmptyString('title');
@@ -1713,10 +1597,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests custom error messages generated when a field is allowed to be empty
-     *
-     * @return void
      */
-    public function testCustomErrorsWithAllowedEmpty()
+    public function testCustomErrorsWithAllowedEmpty(): void
     {
         $validator = new Validator();
         $validator->allowEmptyString('title', 'Custom message', false);
@@ -1728,10 +1610,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests custom error messages generated when a field is not allowed to be empty
-     *
-     * @return void
      */
-    public function testCustomErrorsWithEmptyNotAllowed()
+    public function testCustomErrorsWithEmptyNotAllowed(): void
     {
         $validator = new Validator();
         $validator->notEmptyString('title', 'Custom message');
@@ -1742,10 +1622,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests errors generated when a field is allowed to be empty
-     *
-     * @return void
      */
-    public function testErrorsWithEmptyAllowed()
+    public function testErrorsWithEmptyAllowed(): void
     {
         $validator = new Validator();
         $validator->allowEmptyString('title');
@@ -1773,10 +1651,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test the provider() method
-     *
-     * @return void
      */
-    public function testProvider()
+    public function testProvider(): void
     {
         $validator = new Validator();
         $object = new \stdClass();
@@ -1791,7 +1667,7 @@ class ValidatorTest extends TestCase
         $this->assertEquals(new \Cake\Validation\RulesProvider(), $validator->getProvider('default'));
     }
 
-    public function testProviderWarning()
+    public function testProviderWarning(): void
     {
         $this->expectError();
         $this->expectErrorMessage('The provider must be an object or class name string. Got `array` instead.');
@@ -1803,10 +1679,8 @@ class ValidatorTest extends TestCase
     /**
      * Tests validate() method when using validators from the default provider, this proves
      * that it returns a default validation message and the custom one set in the rule
-     *
-     * @return void
      */
-    public function testErrorsFromDefaultProvider()
+    public function testErrorsFromDefaultProvider(): void
     {
         $validator = new Validator();
         $validator
@@ -1826,10 +1700,8 @@ class ValidatorTest extends TestCase
     /**
      * Tests using validation methods from different providers and returning the error
      * as a string
-     *
-     * @return void
      */
-    public function testErrorsFromCustomProvider()
+    public function testErrorsFromCustomProvider(): void
     {
         $validator = new Validator();
         $validator
@@ -1872,10 +1744,8 @@ class ValidatorTest extends TestCase
     /**
      * Tests that it is possible to pass extra arguments to the validation function
      * and it still gets the providers as last argument
-     *
-     * @return void
      */
-    public function testMethodsWithExtraArguments()
+    public function testMethodsWithExtraArguments(): void
     {
         $validator = new Validator();
         $validator->add('title', 'cool', [
@@ -1917,10 +1787,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests that it is possible to use a closure as a rule
-     *
-     * @return void
      */
-    public function testUsingClosureAsRule()
+    public function testUsingClosureAsRule(): void
     {
         $validator = new Validator();
         $validator->add('name', 'myRule', [
@@ -1936,8 +1804,6 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests that setting last globally will stop validating the rest of the rules
-     *
-     * @return void
      */
     public function testErrorsWithLastRuleGlobal(): void
     {
@@ -1957,10 +1823,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests that setting last to a rule will stop validating the rest of the rules
-     *
-     * @return void
      */
-    public function testErrorsWithLastRule()
+    public function testErrorsWithLastRule(): void
     {
         $validator = new Validator();
         $validator
@@ -1978,10 +1842,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests it is possible to get validation sets for a field using an array interface
-     *
-     * @return void
      */
-    public function testArrayAccessGet()
+    public function testArrayAccessGet(): void
     {
         $validator = new Validator();
         $validator
@@ -1993,10 +1855,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests it is possible to check for validation sets for a field using an array interface
-     *
-     * @return void
      */
-    public function testArrayAccessExists()
+    public function testArrayAccessExists(): void
     {
         $validator = new Validator();
         $validator
@@ -2009,10 +1869,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests it is possible to set validation rules for a field using an array interface
-     *
-     * @return void
      */
-    public function testArrayAccessSet()
+    public function testArrayAccessSet(): void
     {
         $validator = new Validator();
         $validator
@@ -2026,10 +1884,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests it is possible to unset validation rules
-     *
-     * @return void
      */
-    public function testArrayAccessUnset()
+    public function testArrayAccessUnset(): void
     {
         $validator = new Validator();
         $validator
@@ -2042,10 +1898,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the countable interface
-     *
-     * @return void
      */
-    public function testCount()
+    public function testCount(): void
     {
         $validator = new Validator();
         $validator
@@ -2056,10 +1910,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests adding rules via alternative syntax
-     *
-     * @return void
      */
-    public function testAddMultiple()
+    public function testAddMultiple(): void
     {
         $validator = new Validator();
         $validator->add('title', [
@@ -2078,14 +1930,12 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests adding rules via alternative syntax and numeric keys
-     *
-     * @return void
      */
-    public function testAddMultipleNumericKeyArrays()
+    public function testAddMultipleNumericKeyArrays(): void
     {
         $validator = new Validator();
 
-        $this->deprecated(function () use ($validator) {
+        $this->deprecated(function () use ($validator): void {
             $validator->add('title', [
                 [
                     'rule' => 'notBlank',
@@ -2104,10 +1954,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests adding rules via alternative syntax and numeric keys
-     *
-     * @return void
      */
-    public function testAddMultipleNumericKeyArraysInvalid()
+    public function testAddMultipleNumericKeyArraysInvalid(): void
     {
         $validator = new Validator();
         $validator->add('title', 'notBlank', ['rule' => 'notBlank']);
@@ -2128,10 +1976,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Integration test for compareWith validator.
-     *
-     * @return void
      */
-    public function testCompareWithIntegration()
+    public function testCompareWithIntegration(): void
     {
         $validator = new Validator();
         $validator->add('password', [
@@ -2148,10 +1994,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test debugInfo helper method.
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $validator = new Validator();
         $validator->setProvider('test', $this);
@@ -2193,10 +2037,8 @@ class ValidatorTest extends TestCase
     /**
      * Tests that the 'create' and 'update' modes are preserved when using
      * nested validators
-     *
-     * @return void
      */
-    public function testNestedValidatorCreate()
+    public function testNestedValidatorCreate(): void
     {
         $validator = new Validator();
         $inner = new Validator();
@@ -2209,10 +2051,8 @@ class ValidatorTest extends TestCase
     /**
      * Tests that the 'create' and 'update' modes are preserved when using
      * nested validators
-     *
-     * @return void
      */
-    public function testNestedManyValidatorCreate()
+    public function testNestedManyValidatorCreate(): void
     {
         $validator = new Validator();
         $inner = new Validator();
@@ -2224,10 +2064,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notBlank proxy method
-     *
-     * @return void
      */
-    public function testNotBlank()
+    public function testNotBlank(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notBlank');
@@ -2236,10 +2074,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the alphanumeric proxy method
-     *
-     * @return void
      */
-    public function testAlphanumeric()
+    public function testAlphanumeric(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'alphaNumeric');
@@ -2248,10 +2084,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notalphanumeric proxy method
-     *
-     * @return void
      */
-    public function testNotAlphanumeric()
+    public function testNotAlphanumeric(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notAlphaNumeric');
@@ -2260,10 +2094,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the asciialphanumeric proxy method
-     *
-     * @return void
      */
-    public function testAsciiAlphanumeric()
+    public function testAsciiAlphanumeric(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'asciiAlphaNumeric');
@@ -2272,10 +2104,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notalphanumeric proxy method
-     *
-     * @return void
      */
-    public function testNotAsciiAlphanumeric()
+    public function testNotAsciiAlphanumeric(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notAsciiAlphaNumeric');
@@ -2284,10 +2114,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the lengthBetween proxy method
-     *
-     * @return void
      */
-    public function testLengthBetween()
+    public function testLengthBetween(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lengthBetween', [5, 7], [5, 7]);
@@ -2296,10 +2124,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the lengthBetween proxy method
-     *
-     * @return void
      */
-    public function testLengthBetweenFailure()
+    public function testLengthBetweenFailure(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $validator = new Validator();
@@ -2308,10 +2134,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the creditCard proxy method
-     *
-     * @return void
      */
-    public function testCreditCard()
+    public function testCreditCard(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'creditCard', 'all', ['all', true], 'creditCard');
@@ -2320,10 +2144,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the greaterThan proxy method
-     *
-     * @return void
      */
-    public function testGreaterThan()
+    public function testGreaterThan(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThan', 5, [Validation::COMPARE_GREATER, 5], 'comparison');
@@ -2332,10 +2154,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the greaterThanOrEqual proxy method
-     *
-     * @return void
      */
-    public function testGreaterThanOrEqual()
+    public function testGreaterThanOrEqual(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanOrEqual', 5, [Validation::COMPARE_GREATER_OR_EQUAL, 5], 'comparison');
@@ -2344,10 +2164,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the lessThan proxy method
-     *
-     * @return void
      */
-    public function testLessThan()
+    public function testLessThan(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThan', 5, [Validation::COMPARE_LESS, 5], 'comparison');
@@ -2356,10 +2174,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the lessThanOrEqual proxy method
-     *
-     * @return void
      */
-    public function testLessThanOrEqual()
+    public function testLessThanOrEqual(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanOrEqual', 5, [Validation::COMPARE_LESS_OR_EQUAL, 5], 'comparison');
@@ -2368,10 +2184,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the equals proxy method
-     *
-     * @return void
      */
-    public function testEquals()
+    public function testEquals(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'equals', 5, [Validation::COMPARE_EQUAL, 5], 'comparison');
@@ -2381,10 +2195,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEquals proxy method
-     *
-     * @return void
      */
-    public function testNotEquals()
+    public function testNotEquals(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notEquals', 5, [Validation::COMPARE_NOT_EQUAL, 5], 'comparison');
@@ -2393,10 +2205,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the sameAs proxy method
-     *
-     * @return void
      */
-    public function testSameAs()
+    public function testSameAs(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', Validation::COMPARE_SAME], 'compareFields');
@@ -2406,10 +2216,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notSameAs proxy method
-     *
-     * @return void
      */
-    public function testNotSameAs()
+    public function testNotSameAs(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', Validation::COMPARE_NOT_SAME], 'compareFields');
@@ -2418,10 +2226,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the equalToField proxy method
-     *
-     * @return void
      */
-    public function testEqualToField()
+    public function testEqualToField(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'equalToField', 'other', ['other', Validation::COMPARE_EQUAL], 'compareFields');
@@ -2431,10 +2237,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the notEqualToField proxy method
-     *
-     * @return void
      */
-    public function testNotEqualToField()
+    public function testNotEqualToField(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', Validation::COMPARE_NOT_EQUAL], 'compareFields');
@@ -2443,10 +2247,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the greaterThanField proxy method
-     *
-     * @return void
      */
-    public function testGreaterThanField()
+    public function testGreaterThanField(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanField', 'other', ['other', Validation::COMPARE_GREATER], 'compareFields');
@@ -2456,10 +2258,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the greaterThanOrEqualToField proxy method
-     *
-     * @return void
      */
-    public function testGreaterThanOrEqualToField()
+    public function testGreaterThanOrEqualToField(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', Validation::COMPARE_GREATER_OR_EQUAL], 'compareFields');
@@ -2468,10 +2268,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the lessThanField proxy method
-     *
-     * @return void
      */
-    public function testLessThanField()
+    public function testLessThanField(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanField', 'other', ['other', Validation::COMPARE_LESS], 'compareFields');
@@ -2481,10 +2279,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the lessThanOrEqualToField proxy method
-     *
-     * @return void
      */
-    public function testLessThanOrEqualToField()
+    public function testLessThanOrEqualToField(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', Validation::COMPARE_LESS_OR_EQUAL], 'compareFields');
@@ -2493,12 +2289,10 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the containsNonAlphaNumeric proxy method
-     *
-     * @return void
      */
-    public function testContainsNonAlphaNumeric()
+    public function testContainsNonAlphaNumeric(): void
     {
-        $this->deprecated(function () {
+        $this->deprecated(function (): void {
             $validator = new Validator();
             $this->assertProxyMethod($validator, 'containsNonAlphaNumeric', 2, [2]);
             $this->assertNotEmpty($validator->validate(['username' => '$']));
@@ -2507,10 +2301,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the date proxy method
-     *
-     * @return void
      */
-    public function testDate()
+    public function testDate(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'date', ['ymd'], [['ymd']]);
@@ -2519,8 +2311,6 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the dateTime proxy method
-     *
-     * @return void
      */
     public function testDateTime(): void
     {
@@ -2534,10 +2324,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the time proxy method
-     *
-     * @return void
      */
-    public function testTime()
+    public function testTime(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'time');
@@ -2546,10 +2334,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the localizedTime proxy method
-     *
-     * @return void
      */
-    public function testLocalizedTime()
+    public function testLocalizedTime(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'localizedTime', 'date', ['date']);
@@ -2558,10 +2344,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the boolean proxy method
-     *
-     * @return void
      */
-    public function testBoolean()
+    public function testBoolean(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'boolean');
@@ -2570,10 +2354,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the decimal proxy method
-     *
-     * @return void
      */
-    public function testDecimal()
+    public function testDecimal(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'decimal', 2, [2]);
@@ -2582,10 +2364,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the IP proxy methods
-     *
-     * @return void
      */
-    public function testIps()
+    public function testIps(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'ip');
@@ -2600,10 +2380,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the minLength proxy method
-     *
-     * @return void
      */
-    public function testMinLength()
+    public function testMinLength(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'minLength', 2, [2]);
@@ -2612,10 +2390,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the minLengthBytes proxy method
-     *
-     * @return void
      */
-    public function testMinLengthBytes()
+    public function testMinLengthBytes(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'minLengthBytes', 11, [11]);
@@ -2624,10 +2400,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the maxLength proxy method
-     *
-     * @return void
      */
-    public function testMaxLength()
+    public function testMaxLength(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'maxLength', 2, [2]);
@@ -2636,10 +2410,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the maxLengthBytes proxy method
-     *
-     * @return void
      */
-    public function testMaxLengthBytes()
+    public function testMaxLengthBytes(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'maxLengthBytes', 9, [9]);
@@ -2648,10 +2420,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the numeric proxy method
-     *
-     * @return void
      */
-    public function testNumeric()
+    public function testNumeric(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'numeric');
@@ -2661,10 +2431,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the naturalNumber proxy method
-     *
-     * @return void
      */
-    public function testNaturalNumber()
+    public function testNaturalNumber(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'naturalNumber', null, [false]);
@@ -2673,10 +2441,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the nonNegativeInteger proxy method
-     *
-     * @return void
      */
-    public function testNonNegativeInteger()
+    public function testNonNegativeInteger(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'nonNegativeInteger', null, [true], 'naturalNumber');
@@ -2685,10 +2451,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the range proxy method
-     *
-     * @return void
      */
-    public function testRange()
+    public function testRange(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'range', [1, 4], [1, 4]);
@@ -2697,10 +2461,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the range failure case
-     *
-     * @return void
      */
-    public function testRangeFailure()
+    public function testRangeFailure(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $validator = new Validator();
@@ -2709,10 +2471,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the url proxy method
-     *
-     * @return void
      */
-    public function testUrl()
+    public function testUrl(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'url', null, [false]);
@@ -2721,10 +2481,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the urlWithProtocol proxy method
-     *
-     * @return void
      */
-    public function testUrlWithProtocol()
+    public function testUrlWithProtocol(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'urlWithProtocol', null, [true], 'url');
@@ -2733,10 +2491,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the inList proxy method
-     *
-     * @return void
      */
-    public function testInList()
+    public function testInList(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'inList', ['a', 'b'], [['a', 'b']]);
@@ -2745,10 +2501,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the uuid proxy method
-     *
-     * @return void
      */
-    public function testUuid()
+    public function testUuid(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'uuid');
@@ -2757,10 +2511,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the uploadedFile proxy method
-     *
-     * @return void
      */
-    public function testUploadedFile()
+    public function testUploadedFile(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'uploadedFile', ['foo' => 'bar'], [['foo' => 'bar']]);
@@ -2769,10 +2521,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the latlog proxy methods
-     *
-     * @return void
      */
-    public function testLatLong()
+    public function testLatLong(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'latLong', null, [], 'geoCoordinate');
@@ -2787,10 +2537,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the ascii proxy method
-     *
-     * @return void
      */
-    public function testAscii()
+    public function testAscii(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'ascii');
@@ -2799,10 +2547,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the utf8 proxy methods
-     *
-     * @return void
      */
-    public function testUtf8()
+    public function testUtf8(): void
     {
         // Grinning face
         $extended = 'some' . "\xf0\x9f\x98\x80" . 'value';
@@ -2815,10 +2561,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Test utf8extended proxy method.
-     *
-     * @return void
      */
-    public function testUtf8Extended()
+    public function testUtf8Extended(): void
     {
         // Grinning face
         $extended = 'some' . "\xf0\x9f\x98\x80" . 'value';
@@ -2831,10 +2575,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the email proxy method
-     *
-     * @return void
      */
-    public function testEmail()
+    public function testEmail(): void
     {
         $validator = new Validator();
         $validator->email('username');
@@ -2844,10 +2586,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the integer proxy method
-     *
-     * @return void
      */
-    public function testInteger()
+    public function testInteger(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'integer', null, [], 'isInteger');
@@ -2856,10 +2596,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the isArray proxy method
-     *
-     * @return void
      */
-    public function testIsArray()
+    public function testIsArray(): void
     {
         $validator = new Validator();
         $validator->isArray('username');
@@ -2869,10 +2607,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the scalar proxy method
-     *
-     * @return void
      */
-    public function testScalar()
+    public function testScalar(): void
     {
         $validator = new Validator();
         $validator->scalar('username');
@@ -2882,10 +2618,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the hexColor proxy method
-     *
-     * @return void
      */
-    public function testHexColor()
+    public function testHexColor(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'hexColor');
@@ -2895,10 +2629,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the multiple proxy method
-     *
-     * @return void
      */
-    public function testMultiple()
+    public function testMultiple(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod(
@@ -2922,10 +2654,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the hasAtLeast method
-     *
-     * @return void
      */
-    public function testHasAtLeast()
+    public function testHasAtLeast(): void
     {
         $validator = new Validator();
         $validator->hasAtLeast('things', 3);
@@ -2944,10 +2674,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the hasAtMost method
-     *
-     * @return void
      */
-    public function testHasAtMost()
+    public function testHasAtMost(): void
     {
         $validator = new Validator();
         $validator->hasAtMost('things', 3);
@@ -2962,10 +2690,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Tests the regex proxy method
-     *
-     * @return void
      */
-    public function testRegex()
+    public function testRegex(): void
     {
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'regex', '/(?<!\\S)\\d++(?!\\S)/', ['/(?<!\\S)\\d++(?!\\S)/'], 'custom');
@@ -2982,7 +2708,7 @@ class ValidatorTest extends TestCase
      * @param array $pass
      * @param string|null $name
      */
-    protected function assertProxyMethod($validator, $method, $extra = null, $pass = [], $name = null)
+    protected function assertProxyMethod($validator, $method, $extra = null, $pass = [], $name = null): void
     {
         $name = $name ?: $method;
         if ($extra !== null) {
@@ -3012,10 +2738,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing adding DefaultProvider
-     *
-     * @return void
      */
-    public function testAddingDefaultProvider()
+    public function testAddingDefaultProvider(): void
     {
         $validator = new Validator();
         $this->assertEmpty($validator->providers(), 'Providers should be empty');
@@ -3027,10 +2751,8 @@ class ValidatorTest extends TestCase
 
     /**
      * Testing getting DefaultProvider(s)
-     *
-     * @return void
      */
-    public function testGetDefaultProvider()
+    public function testGetDefaultProvider(): void
     {
         Validator::addDefaultProvider('test-provider', 'MyNameSpace\Validation\MyProvider');
         $this->assertEquals(Validator::getDefaultProvider('test-provider'), 'MyNameSpace\Validation\MyProvider', 'Default provider `test-provider` is missing');

--- a/tests/TestCase/Validation/stubs.php
+++ b/tests/TestCase/Validation/stubs.php
@@ -23,7 +23,7 @@ namespace Cake\Validation;
  * @param string $filename The file to check.
  * @return bool Whether or not the file exists.
  */
-function is_uploaded_file($filename)
+function is_uploaded_file($filename): bool
 {
     return file_exists($filename);
 }

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -41,8 +41,6 @@ class CellTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -56,8 +54,6 @@ class CellTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -68,10 +64,8 @@ class CellTest extends TestCase
 
     /**
      * Tests basic cell rendering.
-     *
-     * @return void
      */
-    public function testCellRender()
+    public function testCellRender(): void
     {
         $cell = $this->View->cell('Articles::teaserList');
         $render = "{$cell}";
@@ -89,10 +83,8 @@ class CellTest extends TestCase
 
     /**
      * Tests debug output.
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $cell = $this->View->cell('Articles::teaserList');
         $data = $cell->__debugInfo();
@@ -104,12 +96,10 @@ class CellTest extends TestCase
 
     /**
      * Test __toString() hitting an error when rendering views.
-     *
-     * @return void
      */
-    public function testCellImplictRenderWithError()
+    public function testCellImplictRenderWithError(): void
     {
-        $capture = function ($errno, $msg) {
+        $capture = function ($errno, $msg): void {
             restore_error_handler();
             $this->assertSame(E_USER_WARNING, $errno);
             $this->assertStringContainsString('Could not render cell - Cell template file', $msg);
@@ -126,10 +116,8 @@ class CellTest extends TestCase
      *
      * This test sets its own error handler, as PHPUnit won't convert
      * errors into exceptions when the caller is a __toString() method.
-     *
-     * @return void
      */
-    public function testCellWithArguments()
+    public function testCellWithArguments(): void
     {
         $cell = $this->View->cell('Articles::doEcho', ['msg1' => 'dummy', 'msg2' => ' message']);
         $render = "{$cell}";
@@ -138,10 +126,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that cell runs default action when none is provided.
-     *
-     * @return void
      */
-    public function testDefaultCellAction()
+    public function testDefaultCellAction(): void
     {
         $appCell = $this->View->cell('Articles');
 
@@ -155,10 +141,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that cell action setting the templatePath
-     *
-     * @return void
      */
-    public function testSettingCellTemplatePathFromAction()
+    public function testSettingCellTemplatePathFromAction(): void
     {
         $appCell = $this->View->cell('Articles::customTemplatePath');
 
@@ -169,10 +153,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that cell action setting the template using the ViewBuilder renders the correct template
-     *
-     * @return void
      */
-    public function testSettingCellTemplateFromActionViewBuilder()
+    public function testSettingCellTemplateFromActionViewBuilder(): void
     {
         $appCell = $this->View->cell('Articles::customTemplateViewBuilder');
 
@@ -182,10 +164,8 @@ class CellTest extends TestCase
 
     /**
      * Tests manual render() invocation.
-     *
-     * @return void
      */
-    public function testCellManualRender()
+    public function testCellManualRender(): void
     {
         /** @var \TestApp\View\Cell\ArticlesCell $cell */
         $cell = $this->View->cell('Articles::doEcho', ['msg1' => 'dummy', 'msg2' => ' message']);
@@ -197,10 +177,8 @@ class CellTest extends TestCase
 
     /**
      * Tests manual render() invocation with error
-     *
-     * @return void
      */
-    public function testCellManualRenderError()
+    public function testCellManualRenderError(): void
     {
         $cell = $this->View->cell('Articles');
 
@@ -223,10 +201,8 @@ class CellTest extends TestCase
 
     /**
      * Test rendering a cell with a theme.
-     *
-     * @return void
      */
-    public function testCellRenderThemed()
+    public function testCellRenderThemed(): void
     {
         $this->View->setTheme('TestTheme');
         $cell = $this->View->cell('Articles', ['msg' => 'hello world!']);
@@ -237,10 +213,8 @@ class CellTest extends TestCase
 
     /**
      * Test that a cell can render a plugin view.
-     *
-     * @return void
      */
-    public function testCellRenderPluginTemplate()
+    public function testCellRenderPluginTemplate(): void
     {
         $cell = $this->View->cell('Articles');
         $this->assertStringContainsString(
@@ -258,10 +232,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that using plugin's cells works.
-     *
-     * @return void
      */
-    public function testPluginCell()
+    public function testPluginCell(): void
     {
         $cell = $this->View->cell('TestPlugin.Dummy::echoThis', ['msg' => 'hello world!']);
         $this->assertStringContainsString('hello world!', "{$cell}");
@@ -269,10 +241,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that using namespaced cells works.
-     *
-     * @return void
      */
-    public function testNamespacedCell()
+    public function testNamespacedCell(): void
     {
         $cell = $this->View->cell('Admin/Menu');
         $this->assertStringContainsString('Admin Menu Cell', $cell->render());
@@ -280,10 +250,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that using namespaced cells in plugins works
-     *
-     * @return void
      */
-    public function testPluginNamespacedCell()
+    public function testPluginNamespacedCell(): void
     {
         $cell = $this->View->cell('TestPlugin.Admin/Menu');
         $this->assertStringContainsString('Test Plugin Admin Menu Cell', $cell->render());
@@ -291,10 +259,8 @@ class CellTest extends TestCase
 
     /**
      * Test that plugin cells can render other view templates.
-     *
-     * @return void
      */
-    public function testPluginCellAlternateTemplate()
+    public function testPluginCellAlternateTemplate(): void
     {
         $cell = $this->View->cell('TestPlugin.Dummy::echoThis', ['msg' => 'hello world!']);
         $cell->viewBuilder()->setTemplate('../../element/translate');
@@ -303,10 +269,8 @@ class CellTest extends TestCase
 
     /**
      * Test that plugin cells can render other view templates.
-     *
-     * @return void
      */
-    public function testPluginCellAlternateTemplateRenderParam()
+    public function testPluginCellAlternateTemplateRenderParam(): void
     {
         $cell = $this->View->cell('TestPlugin.Dummy::echoThis', ['msg' => 'hello world!']);
         $result = $cell->render('../../element/translate');
@@ -315,10 +279,8 @@ class CellTest extends TestCase
 
     /**
      * Tests that using an nonexistent cell throws an exception.
-     *
-     * @return void
      */
-    public function testNonExistentCell()
+    public function testNonExistentCell(): void
     {
         $this->expectException(\Cake\View\Exception\MissingCellException::class);
         $cell = $this->View->cell('TestPlugin.Void::echoThis', ['arg1' => 'v1']);
@@ -327,10 +289,8 @@ class CellTest extends TestCase
 
     /**
      * Tests missing method errors
-     *
-     * @return void
      */
-    public function testCellMissingMethod()
+    public function testCellMissingMethod(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Class TestApp\View\Cell\ArticlesCell does not have a "nope" method.');
@@ -340,10 +300,8 @@ class CellTest extends TestCase
 
     /**
      * Test that cell options are passed on.
-     *
-     * @return void
      */
-    public function testCellOptions()
+    public function testCellOptions(): void
     {
         $cell = $this->View->cell('Articles', [], ['limit' => 10, 'nope' => 'nope']);
         $this->assertSame(10, $cell->limit);
@@ -352,10 +310,8 @@ class CellTest extends TestCase
 
     /**
      * Test that cells get the helper configuration from the view that created them.
-     *
-     * @return void
      */
-    public function testCellInheritsHelperConfig()
+    public function testCellInheritsHelperConfig(): void
     {
         $request = new ServerRequest();
         $response = new Response();
@@ -369,10 +325,8 @@ class CellTest extends TestCase
 
     /**
      * Test that cells the view class name of a custom view passed on.
-     *
-     * @return void
      */
-    public function testCellInheritsCustomViewClass()
+    public function testCellInheritsCustomViewClass(): void
     {
         $request = new ServerRequest();
         $response = new Response();
@@ -385,10 +339,8 @@ class CellTest extends TestCase
 
     /**
      * Test that cells the view class name of a controller passed on.
-     *
-     * @return void
      */
-    public function testCellInheritsController()
+    public function testCellInheritsController(): void
     {
         $request = new ServerRequest();
         $response = new Response();
@@ -402,10 +354,8 @@ class CellTest extends TestCase
 
     /**
      * Test cached render.
-     *
-     * @return void
      */
-    public function testCachedRenderSimple()
+    public function testCachedRenderSimple(): void
     {
         Cache::setConfig('default', ['className' => 'Array']);
 
@@ -421,10 +371,8 @@ class CellTest extends TestCase
 
     /**
      * Test read cached cell.
-     *
-     * @return void
      */
-    public function testReadCachedCell()
+    public function testReadCachedCell(): void
     {
         Cache::setConfig('default', ['className' => 'Array']);
         Cache::write('cell_test_app_view_cell_articles_cell_display_default', 'from cache');
@@ -437,10 +385,8 @@ class CellTest extends TestCase
 
     /**
      * Test cached render array config
-     *
-     * @return void
      */
-    public function testCachedRenderArrayConfig()
+    public function testCachedRenderArrayConfig(): void
     {
         Cache::setConfig('cell', ['className' => 'Array']);
         Cache::write('my_key', 'from cache', 'cell');
@@ -455,10 +401,8 @@ class CellTest extends TestCase
 
     /**
      * Test cached render when using an action changing the template used
-     *
-     * @return void
      */
-    public function testCachedRenderSimpleCustomTemplate()
+    public function testCachedRenderSimpleCustomTemplate(): void
     {
         Cache::setConfig('default', ['className' => 'Array']);
 
@@ -475,10 +419,8 @@ class CellTest extends TestCase
     /**
      * Test that when the cell cache is enabled, the cell action is only invoke the first
      * time the cell is rendered
-     *
-     * @return void
      */
-    public function testCachedRenderSimpleCustomTemplateViewBuilder()
+    public function testCachedRenderSimpleCustomTemplateViewBuilder(): void
     {
         Cache::setConfig('default', ['className' => 'Array']);
         $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => ['key' => 'celltest']]);
@@ -494,10 +436,8 @@ class CellTest extends TestCase
     /**
      * Test that when the cell cache is enabled, the cell action is only invoke the first
      * time the cell is rendered
-     *
-     * @return void
      */
-    public function testACachedViewCellReRendersWhenGivenADifferentTemplate()
+    public function testACachedViewCellReRendersWhenGivenADifferentTemplate(): void
     {
         Cache::setConfig('default', ['className' => 'Array']);
         $cell = $this->View->cell('Articles::customTemplateViewBuilder', [], ['cache' => true]);

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -26,15 +26,13 @@ class ArrayContextTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
         parent::setUp();
     }
 
-    public function testGetRequiredMessage()
+    public function testGetRequiredMessage(): void
     {
         $context = new ArrayContext([
             'required' => [
@@ -53,10 +51,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test getting the primary key.
-     *
-     * @return void
      */
-    public function testPrimaryKey()
+    public function testPrimaryKey(): void
     {
         $context = new ArrayContext([]);
         $this->assertEquals([], $context->getPrimaryKey());
@@ -83,10 +79,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test isPrimaryKey.
-     *
-     * @return void
      */
-    public function testIsPrimaryKey()
+    public function testIsPrimaryKey(): void
     {
         $context = new ArrayContext([]);
         $this->assertFalse($context->isPrimaryKey('id'));
@@ -123,10 +117,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test the isCreate method.
-     *
-     * @return void
      */
-    public function testIsCreate()
+    public function testIsCreate(): void
     {
         $context = new ArrayContext([]);
         $this->assertTrue($context->isCreate());
@@ -149,7 +141,7 @@ class ArrayContextTest extends TestCase
     /**
      * Test reading values from data & defaults.
      */
-    public function testValPresent()
+    public function testValPresent(): void
     {
         $context = new ArrayContext([
             'data' => [
@@ -173,10 +165,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test getting values when the data and defaults are missing.
-     *
-     * @return void
      */
-    public function testValMissing()
+    public function testValMissing(): void
     {
         $context = new ArrayContext([]);
         $this->assertNull($context->val('Comments.field'));
@@ -187,10 +177,8 @@ class ArrayContextTest extends TestCase
      *
      * Tests includes making sure numeric elements are stripped but not keys beginning with numeric
      * value
-     *
-     * @return void
      */
-    public function testValDefault()
+    public function testValDefault(): void
     {
         $context = new ArrayContext([
             'defaults' => [
@@ -209,10 +197,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test isRequired
-     *
-     * @return void
      */
-    public function testIsRequired()
+    public function testIsRequired(): void
     {
         $context = new ArrayContext([
             'required' => [
@@ -231,10 +217,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test isRequired when the required key is omitted
-     *
-     * @return void
      */
-    public function testIsRequiredUndefined()
+    public function testIsRequiredUndefined(): void
     {
         $context = new ArrayContext([]);
         $this->assertNull($context->isRequired('Comments.field'));
@@ -242,10 +226,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test the type method.
-     *
-     * @return void
      */
-    public function testType()
+    public function testType(): void
     {
         $context = new ArrayContext([
             'schema' => [
@@ -264,10 +246,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test the type method when the data is missing.
-     *
-     * @return void
      */
-    public function testIsTypeUndefined()
+    public function testIsTypeUndefined(): void
     {
         $context = new ArrayContext([]);
         $this->assertNull($context->type('Comments.undefined'));
@@ -275,10 +255,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test fetching attributes.
-     *
-     * @return void
      */
-    public function testAttributes()
+    public function testAttributes(): void
     {
         $context = new ArrayContext([
             'schema' => [
@@ -300,10 +278,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test fetching errors.
-     *
-     * @return void
      */
-    public function testError()
+    public function testError(): void
     {
         $context = new ArrayContext([]);
         $this->assertEquals([], $context->error('Comments.empty'));
@@ -325,10 +301,8 @@ class ArrayContextTest extends TestCase
 
     /**
      * Test checking errors.
-     *
-     * @return void
      */
-    public function testHasError()
+    public function testHasError(): void
     {
         $context = new ArrayContext([
             'errors' => [

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -25,7 +25,7 @@ use Cake\View\Form\ContextFactory;
  */
 class ContextFactoryTest extends TestCase
 {
-    public function testGetException()
+    public function testGetException(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -41,8 +41,6 @@ class EntityContextTest extends TestCase
 
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,10 +49,8 @@ class EntityContextTest extends TestCase
 
     /**
      * tests getRequiredMessage
-     *
-     * @return void
      */
-    public function testGetRequiredMessage()
+    public function testGetRequiredMessage(): void
     {
         $this->_setupTables();
 
@@ -70,10 +66,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting entity back from context.
-     *
-     * @return void
      */
-    public function testEntity()
+    public function testEntity(): void
     {
         $row = new Article();
         $context = new EntityContext([
@@ -84,10 +78,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting primary key data.
-     *
-     * @return void
      */
-    public function testPrimaryKey()
+    public function testPrimaryKey(): void
     {
         $row = new Article();
         $context = new EntityContext([
@@ -98,10 +90,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isPrimaryKey
-     *
-     * @return void
      */
-    public function testIsPrimaryKey()
+    public function testIsPrimaryKey(): void
     {
         $this->_setupTables();
 
@@ -123,10 +113,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isCreate on a single entity.
-     *
-     * @return void
      */
-    public function testIsCreateSingle()
+    public function testIsCreateSingle(): void
     {
         $row = new Article();
         $context = new EntityContext([
@@ -146,9 +134,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testIsCreateCollection($collection)
+    public function testIsCreateCollection($collection): void
     {
         $context = new EntityContext([
             'entity' => $collection,
@@ -159,7 +146,7 @@ class EntityContextTest extends TestCase
     /**
      * Test an invalid table scope throws an error.
      */
-    public function testInvalidTable()
+    public function testInvalidTable(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to find table class for current entity');
@@ -172,7 +159,7 @@ class EntityContextTest extends TestCase
     /**
      * Tests that passing a plain entity will give an error as it cannot be matched
      */
-    public function testDefaultEntityError()
+    public function testDefaultEntityError(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to find table class for current entity');
@@ -183,10 +170,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Tests that the table can be derived from the entity source if it is present
-     *
-     * @return void
      */
-    public function testTableFromEntitySource()
+    public function testTableFromEntitySource(): void
     {
         $entity = new Entity();
         $entity->setSource('Articles');
@@ -199,10 +184,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test operations with no entity.
-     *
-     * @return void
      */
-    public function testOperationsNoEntity()
+    public function testOperationsNoEntity(): void
     {
         $context = new EntityContext([
             'table' => 'Articles',
@@ -221,10 +204,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test operations that lack a table argument.
-     *
-     * @return void
      */
-    public function testOperationsNoTableArg()
+    public function testOperationsNoTableArg(): void
     {
         $row = new Article([
             'title' => 'Test entity',
@@ -249,9 +230,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testCollectionOperationsNoTableArg($collection)
+    public function testCollectionOperationsNoTableArg($collection): void
     {
         $context = new EntityContext([
             'entity' => $collection,
@@ -298,9 +278,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testValOnCollections($collection)
+    public function testValOnCollections($collection): void
     {
         $context = new EntityContext([
             'entity' => $collection,
@@ -329,9 +308,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testValOnCollectionsWithRootName($collection)
+    public function testValOnCollectionsWithRootName($collection): void
     {
         $context = new EntityContext([
             'entity' => $collection,
@@ -358,9 +336,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testErrorsOnCollections($collection)
+    public function testErrorsOnCollections($collection): void
     {
         $context = new EntityContext([
             'entity' => $collection,
@@ -384,9 +361,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testSchemaOnCollections($collection)
+    public function testSchemaOnCollections($collection): void
     {
         $this->_setupTables();
         $context = new EntityContext([
@@ -413,9 +389,8 @@ class EntityContextTest extends TestCase
      *
      * @dataProvider collectionProvider
      * @param mixed $collection
-     * @return void
      */
-    public function testValidatorsOnCollections($collection)
+    public function testValidatorsOnCollections($collection): void
     {
         $this->_setupTables();
 
@@ -439,10 +414,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading data.
-     *
-     * @return void
      */
-    public function testValBasic()
+    public function testValBasic(): void
     {
         $row = new Article([
             'title' => 'Test entity',
@@ -464,10 +437,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading invalid data.
-     *
-     * @return void
      */
-    public function testValInvalid()
+    public function testValInvalid(): void
     {
         $row = new Article([
             'title' => 'Valid title',
@@ -484,10 +455,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test default values when entity is an array.
-     *
-     * @return void
      */
-    public function testValDefaultArray()
+    public function testValDefaultArray(): void
     {
         $context = new EntityContext([
             'entity' => new Article([
@@ -501,10 +470,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading array values from an entity.
-     *
-     * @return void
      */
-    public function testValGetArrayValue()
+    public function testValGetArrayValue(): void
     {
         $row = new Article([
             'title' => 'Test entity',
@@ -540,10 +507,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading values from associated entities.
-     *
-     * @return void
      */
-    public function testValAssociated()
+    public function testValAssociated(): void
     {
         $row = new Article([
             'title' => 'Test entity',
@@ -579,10 +544,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Tests that trying to get values from missing associations returns null
-     *
-     * @return void
      */
-    public function testValMissingAssociation()
+    public function testValMissingAssociation(): void
     {
         $row = new Article([
             'id' => 1,
@@ -599,10 +562,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading values from associated entities.
-     *
-     * @return void
      */
-    public function testValAssociatedHasMany()
+    public function testValAssociatedHasMany(): void
     {
         $row = new Article([
             'title' => 'First post',
@@ -629,10 +590,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading values for magic _ids input
-     *
-     * @return void
      */
-    public function testValAssociatedDefaultIds()
+    public function testValAssociatedDefaultIds(): void
     {
         $row = new Article([
             'title' => 'First post',
@@ -656,10 +615,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test reading values for magic _ids input
-     *
-     * @return void
      */
-    public function testValAssociatedCustomIds()
+    public function testValAssociatedCustomIds(): void
     {
         $this->_setupTables();
 
@@ -688,10 +645,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting default value from table schema.
-     *
-     * @return void
      */
-    public function testValSchemaDefault()
+    public function testValSchemaDefault(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $column = $table->getSchema()->getColumn('title');
@@ -708,10 +663,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting association default value from table schema.
-     *
-     * @return void
      */
-    public function testValAssociatedSchemaDefault()
+    public function testValAssociatedSchemaDefault(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $associatedTable = $table->hasMany('Comments')->getTarget();
@@ -729,10 +682,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting association join table default value from table schema.
-     *
-     * @return void
      */
-    public function testValAssociatedJoinTableSchemaDefault()
+    public function testValAssociatedJoinTableSchemaDefault(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $joinTable = $table
@@ -755,10 +706,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test validator for boolean fields.
-     *
-     * @return void
      */
-    public function testIsRequiredBooleanField()
+    public function testIsRequiredBooleanField(): void
     {
         $this->_setupTables();
 
@@ -782,10 +731,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test validator as a string.
-     *
-     * @return void
      */
-    public function testIsRequiredStringValidator()
+    public function testIsRequiredStringValidator(): void
     {
         $this->_setupTables();
 
@@ -805,10 +752,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isRequired on associated entities.
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedHasMany()
+    public function testIsRequiredAssociatedHasMany(): void
     {
         $this->_setupTables();
 
@@ -839,10 +784,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isRequired on associated entities with boolean fields
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedHasManyBoolean()
+    public function testIsRequiredAssociatedHasManyBoolean(): void
     {
         $this->_setupTables();
 
@@ -870,10 +813,8 @@ class EntityContextTest extends TestCase
      *
      * Ensures that missing associations use the correct entity class
      * so provider methods work correctly.
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedCustomValidator()
+    public function testIsRequiredAssociatedCustomValidator(): void
     {
         $this->_setupTables();
         $users = $this->getTableLocator()->get('Users');
@@ -899,10 +840,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isRequired on associated entities.
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedHasManyMissingObject()
+    public function testIsRequiredAssociatedHasManyMissingObject(): void
     {
         $this->_setupTables();
 
@@ -936,10 +875,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isRequired on associated entities with custom validators.
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedValidator()
+    public function testIsRequiredAssociatedValidator(): void
     {
         $this->_setupTables();
 
@@ -967,10 +904,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isRequired on associated entities.
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedBelongsTo()
+    public function testIsRequiredAssociatedBelongsTo(): void
     {
         $this->_setupTables();
 
@@ -993,10 +928,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test isRequired on associated join table entities.
-     *
-     * @return void
      */
-    public function testIsRequiredAssociatedJoinTable()
+    public function testIsRequiredAssociatedJoinTable(): void
     {
         $this->_setupTables();
 
@@ -1021,10 +954,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test type() basic
-     *
-     * @return void
      */
-    public function testType()
+    public function testType(): void
     {
         $this->_setupTables();
 
@@ -1045,10 +976,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting types for associated records.
-     *
-     * @return void
      */
-    public function testTypeAssociated()
+    public function testTypeAssociated(): void
     {
         $this->_setupTables();
 
@@ -1068,10 +997,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test getting types for associated join data records.
-     *
-     * @return void
      */
-    public function testTypeAssociatedJoinData()
+    public function testTypeAssociatedJoinData(): void
     {
         $this->_setupTables();
 
@@ -1102,10 +1029,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test attributes for fields.
-     *
-     * @return void
      */
-    public function testAttributes()
+    public function testAttributes(): void
     {
         $this->_setupTables();
 
@@ -1153,10 +1078,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test hasError
-     *
-     * @return void
      */
-    public function testHasError()
+    public function testHasError(): void
     {
         $this->_setupTables();
 
@@ -1180,10 +1103,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test hasError on associated records
-     *
-     * @return void
      */
-    public function testHasErrorAssociated()
+    public function testHasErrorAssociated(): void
     {
         $this->_setupTables();
 
@@ -1206,10 +1127,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test error
-     *
-     * @return void
      */
-    public function testError()
+    public function testError(): void
     {
         $this->_setupTables();
 
@@ -1239,10 +1158,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test error on associated entities.
-     *
-     * @return void
      */
-    public function testErrorAssociatedHasMany()
+    public function testErrorAssociatedHasMany(): void
     {
         $this->_setupTables();
 
@@ -1275,10 +1192,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test error on associated join table entities.
-     *
-     * @return void
      */
-    public function testErrorAssociatedJoinTable()
+    public function testErrorAssociatedJoinTable(): void
     {
         $this->_setupTables();
 
@@ -1304,10 +1219,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test error on nested validation
-     *
-     * @return void
      */
-    public function testErrorNestedValidator()
+    public function testErrorNestedValidator(): void
     {
         $this->_setupTables();
 
@@ -1327,10 +1240,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test error on nested validation
-     *
-     * @return void
      */
-    public function testErrorAssociatedNestedValidator()
+    public function testErrorAssociatedNestedValidator(): void
     {
         $this->_setupTables();
 
@@ -1360,10 +1271,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Setup tables for tests.
-     *
-     * @return void
      */
-    protected function _setupTables()
+    protected function _setupTables(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Users');
@@ -1425,10 +1334,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test the fieldnames method.
-     *
-     * @return void
      */
-    public function testFieldNames()
+    public function testFieldNames(): void
     {
         $context = new EntityContext([
             'entity' => new Entity(),
@@ -1440,10 +1347,8 @@ class EntityContextTest extends TestCase
 
     /**
      * Test automatic entity provider setting
-     *
-     * @return void
      */
-    public function testValidatorEntityProvider()
+    public function testValidatorEntityProvider(): void
     {
         $row = new Article([
             'title' => 'Test entity',

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -28,8 +28,6 @@ class FormContextTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -38,10 +36,8 @@ class FormContextTest extends TestCase
 
     /**
      * tests getRequiredMessage
-     *
-     * @return void
      */
-    public function testGetRequiredMessage()
+    public function testGetRequiredMessage(): void
     {
         $validator = new Validator();
         $validator->notEmptyString('title', 'Don\'t forget a title!');
@@ -59,10 +55,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test getting the primary key.
-     *
-     * @return void
      */
-    public function testPrimaryKey()
+    public function testPrimaryKey(): void
     {
         $context = new FormContext(['entity' => new Form()]);
         $this->assertEquals([], $context->getPrimaryKey());
@@ -70,10 +64,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test isPrimaryKey.
-     *
-     * @return void
      */
-    public function testIsPrimaryKey()
+    public function testIsPrimaryKey(): void
     {
         $context = new FormContext(['entity' => new Form()]);
         $this->assertFalse($context->isPrimaryKey('id'));
@@ -81,10 +73,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test the isCreate method.
-     *
-     * @return void
      */
-    public function testIsCreate()
+    public function testIsCreate(): void
     {
         $context = new FormContext(['entity' => new Form()]);
         $this->assertTrue($context->isCreate());
@@ -93,7 +83,7 @@ class FormContextTest extends TestCase
     /**
      * Test reading values from form data.
      */
-    public function testValPresent()
+    public function testValPresent(): void
     {
         $form = new Form();
         $form->setData(['title' => 'set title']);
@@ -105,10 +95,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test getting values when data and defaults are missing.
-     *
-     * @return void
      */
-    public function testValMissing()
+    public function testValMissing(): void
     {
         $context = new FormContext(['entity' => new Form()]);
         $this->assertNull($context->val('Comments.field'));
@@ -116,10 +104,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test getting default value
-     *
-     * @return void
      */
-    public function testValDefault()
+    public function testValDefault(): void
     {
         $form = new Form();
         $form->getSchema()->addField('name', ['default' => 'schema default']);
@@ -143,10 +129,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test isRequired
-     *
-     * @return void
      */
-    public function testIsRequired()
+    public function testIsRequired(): void
     {
         $form = new Form();
         $form->getValidator()
@@ -164,10 +148,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test the type method.
-     *
-     * @return void
      */
-    public function testType()
+    public function testType(): void
     {
         $form = new Form();
         $form->getSchema()
@@ -185,10 +167,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test the fieldNames method.
-     *
-     * @return void
      */
-    public function testFieldNames()
+    public function testFieldNames(): void
     {
         $form = new Form();
         $context = new FormContext([
@@ -212,10 +192,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test fetching attributes.
-     *
-     * @return void
      */
-    public function testAttributes()
+    public function testAttributes(): void
     {
         $form = new Form();
         $form->getSchema()
@@ -244,10 +222,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test fetching errors.
-     *
-     * @return void
      */
-    public function testError()
+    public function testError(): void
     {
         $nestedValidator = new Validator();
         $nestedValidator
@@ -289,10 +265,8 @@ class FormContextTest extends TestCase
 
     /**
      * Test checking errors.
-     *
-     * @return void
      */
-    public function testHasError()
+    public function testHasError(): void
     {
         $nestedValidator = new Validator();
         $nestedValidator

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -33,8 +33,6 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,17 +41,15 @@ class BreadcrumbsHelperTest extends TestCase
         $this->breadcrumbs = new BreadcrumbsHelper($view);
 
         Router::reload();
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks();
         });
     }
 
     /**
      * Test adding crumbs to the trail using add()
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
@@ -82,10 +78,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding multiple crumbs at once to the trail using add()
-     *
-     * @return void
      */
-    public function testAddMultiple()
+    public function testAddMultiple(): void
     {
         $this->breadcrumbs
             ->add([
@@ -131,10 +125,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to the trail using prepend()
-     *
-     * @return void
      */
-    public function testPrepend()
+    public function testPrepend(): void
     {
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
@@ -169,10 +161,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to the trail using prepend()
-     *
-     * @return void
      */
-    public function testPrependMultiple()
+    public function testPrependMultiple(): void
     {
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
@@ -209,10 +199,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test ability to empty crumbs list.
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         $this->breadcrumbs->add('Home', '/');
         $this->breadcrumbs->add('Products', '/products');
@@ -227,10 +215,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs to a specific index
-     *
-     * @return void
      */
-    public function testInsertAt()
+    public function testInsertAt(): void
     {
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
@@ -278,7 +264,7 @@ class BreadcrumbsHelperTest extends TestCase
     /**
      * Test adding crumbs to a specific index
      */
-    public function testInsertAtIndexOutOfBounds()
+    public function testInsertAtIndexOutOfBounds(): void
     {
         $this->expectException(\LogicException::class);
         $this->breadcrumbs
@@ -288,10 +274,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs before a specific one
-     *
-     * @return void
      */
-    public function testInsertBefore()
+    public function testInsertBefore(): void
     {
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
@@ -332,10 +316,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Test adding crumbs after a specific one
-     *
-     * @return void
      */
-    public function testInsertAfter()
+    public function testInsertAfter(): void
     {
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
@@ -376,10 +358,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Tests the render method
-     *
-     * @return void
      */
-    public function testRender()
+    public function testRender(): void
     {
         $this->assertSame('', $this->breadcrumbs->render());
 
@@ -428,10 +408,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Tests the render method with custom templates
-     *
-     * @return void
      */
-    public function testRenderCustomTemplate()
+    public function testRenderCustomTemplate(): void
     {
         $this->breadcrumbs = new BreadcrumbsHelper(new View(), [
             'templates' => [
@@ -469,10 +447,8 @@ class BreadcrumbsHelperTest extends TestCase
 
     /**
      * Tests the render method with template vars
-     *
-     * @return void
      */
-    public function testRenderCustomTemplateTemplateVars()
+    public function testRenderCustomTemplateTemplateVars(): void
     {
         $this->breadcrumbs = new BreadcrumbsHelper(new View(), [
             'templates' => [

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -36,8 +36,6 @@ class FlashHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -104,8 +102,6 @@ class FlashHelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -116,10 +112,8 @@ class FlashHelperTest extends TestCase
 
     /**
      * testFlash method
-     *
-     * @return void
      */
-    public function testFlash()
+    public function testFlash(): void
     {
         $result = $this->Flash->render();
         $expected = '<div class="message">This is a calling</div>';
@@ -143,10 +137,8 @@ class FlashHelperTest extends TestCase
 
     /**
      * test setting the element from the attrs.
-     *
-     * @return void
      */
-    public function testFlashElementInAttrs()
+    public function testFlashElementInAttrs(): void
     {
         $result = $this->Flash->render('notification', [
             'element' => 'flash_helper',
@@ -165,10 +157,8 @@ class FlashHelperTest extends TestCase
 
     /**
      * test using elements in plugins.
-     *
-     * @return void
      */
-    public function testFlashWithPluginElement()
+    public function testFlashWithPluginElement(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -179,10 +169,8 @@ class FlashHelperTest extends TestCase
 
     /**
      * test that when View theme is set, flash element from that theme (plugin) is used.
-     *
-     * @return void
      */
-    public function testFlashWithTheme()
+    public function testFlashWithTheme(): void
     {
         $this->loadPlugins(['TestTheme']);
 
@@ -195,10 +183,8 @@ class FlashHelperTest extends TestCase
     /**
      * Test that when rendering a stack, messages are displayed in their
      * respective element, in the order they were added in the stack
-     *
-     * @return void
      */
-    public function testFlashWithStack()
+    public function testFlashWithStack(): void
     {
         $result = $this->Flash->render('stack');
         $expected = [
@@ -217,10 +203,8 @@ class FlashHelperTest extends TestCase
     /**
      * test that when View prefix is set, flash element from that prefix
      * is used if available.
-     *
-     * @return void
      */
-    public function testFlashWithPrefix()
+    public function testFlashWithPrefix(): void
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
         $result = $this->Flash->render('flash');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -76,8 +76,6 @@ class FormHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -135,8 +133,6 @@ class FormHelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -146,10 +142,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test construct() with the templates option.
-     *
-     * @return void
      */
-    public function testConstructTemplatesFile()
+    public function testConstructTemplatesFile(): void
     {
         $helper = new FormHelper($this->View, [
             'templates' => 'htmlhelper_tags',
@@ -161,10 +155,8 @@ class FormHelperTest extends TestCase
     /**
      * Test that when specifying custom widgets the config array for that widget
      * is overwritten instead of merged.
-     *
-     * @return void
      */
-    public function testConstructWithWidgets()
+    public function testConstructWithWidgets(): void
     {
         $config = [
             'widgets' => [
@@ -179,10 +171,8 @@ class FormHelperTest extends TestCase
     /**
      * Test that when specifying custom widgets config file and it should be
      * added to widgets array. WidgetLocator will load widgets in constructor.
-     *
-     * @return void
      */
-    public function testConstructWithWidgetsConfig()
+    public function testConstructWithWidgetsConfig(): void
     {
         $helper = new FormHelper($this->View, ['widgets' => ['test_widgets']]);
         $locator = $helper->getWidgetLocator();
@@ -191,10 +181,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test setting the widget locator
-     *
-     * @return void
      */
-    public function testSetAndGetWidgetLocator()
+    public function testSetAndGetWidgetLocator(): void
     {
         $helper = new FormHelper($this->View);
         $locator = new WidgetLocator($helper->templater(), $this->View);
@@ -206,10 +194,8 @@ class FormHelperTest extends TestCase
     /**
      * Test overridding grouped input types which controls generation of "for"
      * attribute of labels.
-     *
-     * @return void
      */
-    public function testConstructWithGroupedInputTypes()
+    public function testConstructWithGroupedInputTypes(): void
     {
         $helper = new FormHelper($this->View, [
             'groupedInputTypes' => ['radio'],
@@ -221,10 +207,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test registering a new widget class and rendering it.
-     *
-     * @return void
      */
-    public function testAddWidgetAndRenderWidget()
+    public function testAddWidgetAndRenderWidget(): void
     {
         $data = [
             'val' => 1,
@@ -242,10 +226,8 @@ class FormHelperTest extends TestCase
     /**
      * Test that secureFields() of widget is called after calling render(),
      * not before.
-     *
-     * @return void
      */
-    public function testOrderForRenderingWidgetAndFetchingSecureFields()
+    public function testOrderForRenderingWidgetAndFetchingSecureFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => [],
@@ -276,10 +258,8 @@ class FormHelperTest extends TestCase
     /**
      * Test that empty string is not added to secure fields list when
      * rendering input widget without name.
-     *
-     * @return void
      */
-    public function testRenderingWidgetWithEmptyName()
+    public function testRenderingWidgetWithEmptyName(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -297,10 +277,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test registering an invalid widget class.
-     *
-     * @return void
      */
-    public function testAddWidgetInvalid()
+    public function testAddWidgetInvalid(): void
     {
         $this->expectException(\RuntimeException::class);
         $mock = new \stdClass();
@@ -310,10 +288,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test adding a new context class.
-     *
-     * @return void
      */
-    public function testAddContextProvider()
+    public function testAddContextProvider(): void
     {
         $context = 'My data';
         $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
@@ -330,10 +306,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test replacing a context class.
-     *
-     * @return void
      */
-    public function testAddContextProviderReplace()
+    public function testAddContextProviderReplace(): void
     {
         $entity = new Article();
         $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
@@ -347,10 +321,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test overriding a context class.
-     *
-     * @return void
      */
-    public function testAddContextProviderAdd()
+    public function testAddContextProviderAdd(): void
     {
         $entity = new Article();
         $stub = $this->getMockBuilder('Cake\View\Form\ContextInterface')->getMock();
@@ -369,7 +341,7 @@ class FormHelperTest extends TestCase
      *
      * @return array
      */
-    public function contextSelectionProvider()
+    public function contextSelectionProvider(): array
     {
         $entity = new Article();
         $collection = new Collection([$entity]);
@@ -399,9 +371,8 @@ class FormHelperTest extends TestCase
      *
      * @dataProvider contextSelectionProvider
      * @param mixed $data
-     * @return void
      */
-    public function testCreateContextSelectionBuiltIn($data, string $class)
+    public function testCreateContextSelectionBuiltIn($data, string $class): void
     {
         $this->loadFixtures('Articles');
         $this->Form->create($data);
@@ -426,10 +397,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test creating file forms.
-     *
-     * @return void
      */
-    public function testCreateFile()
+    public function testCreateFile(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create(null, ['type' => 'file']);
@@ -447,10 +416,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test creating GET forms.
-     *
-     * @return void
      */
-    public function testCreateGet()
+    public function testCreateGet(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create(null, ['type' => 'get']);
@@ -465,10 +432,8 @@ class FormHelperTest extends TestCase
      * Test explicit method/enctype options.
      *
      * Explicit method overwrites inferred method from 'type'
-     *
-     * @return void
      */
-    public function testCreateExplicitMethodEnctype()
+    public function testCreateExplicitMethodEnctype(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create(null, [
@@ -487,10 +452,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test create() with the templates option.
-     *
-     * @return void
      */
-    public function testCreateTemplatesArray()
+    public function testCreateTemplatesArray(): void
     {
         $result = $this->Form->create($this->article, [
             'templates' => [
@@ -510,10 +473,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test create() with the templates option.
-     *
-     * @return void
      */
-    public function testCreateTemplatesFile()
+    public function testCreateTemplatesFile(): void
     {
         $result = $this->Form->create($this->article, [
             'templates' => 'htmlhelper_tags',
@@ -526,10 +487,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test that create() and end() restore templates.
-     *
-     * @return void
      */
-    public function testCreateEndRestoreTemplates()
+    public function testCreateEndRestoreTemplates(): void
     {
         $this->Form->create($this->article, [
             'templates' => ['input' => 'custom input element'],
@@ -540,10 +499,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test using template vars in various templates used by control() method.
-     *
-     * @return void
      */
-    public function testControlTemplateVars()
+    public function testControlTemplateVars(): void
     {
         $result = $this->Form->control('text', [
             'templates' => [
@@ -575,10 +532,8 @@ class FormHelperTest extends TestCase
     /**
      * Test ensuring template variables work in template files loaded
      * during control().
-     *
-     * @return void
      */
-    public function testControlTemplatesFromFile()
+    public function testControlTemplatesFromFile(): void
     {
         $result = $this->Form->control('title', [
             'templates' => 'test_templates',
@@ -600,10 +555,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test using template vars in inputSubmit and submitContainer template.
-     *
-     * @return void
      */
-    public function testSubmitTemplateVars()
+    public function testSubmitTemplateVars(): void
     {
         $this->Form->setTemplates([
             'inputSubmit' => '<input custom="{{forinput}}" type="{{type}}"{{attrs}}/>',
@@ -628,9 +581,8 @@ class FormHelperTest extends TestCase
      * test the create() method
      *
      * @dataProvider requestTypeProvider
-     * @return void
      */
-    public function testCreateTypeOptions(string $type, string $method, string $override)
+    public function testCreateTypeOptions(string $type, string $method, string $override): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create(null, ['type' => $type]);
@@ -656,10 +608,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test using template vars in Create (formStart template)
-     *
-     * @return void
      */
-    public function testCreateTemplateVars()
+    public function testCreateTemplateVars(): void
     {
         $result = $this->Form->create($this->article, [
             'templates' => [
@@ -682,10 +632,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test opening a form for an update operation.
-     *
-     * @return void
      */
-    public function testCreateUpdateForm()
+    public function testCreateUpdateForm(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
@@ -711,10 +659,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test create() with automatic url generation
-     *
-     * @return void
      */
-    public function testCreateAutoUrl()
+    public function testCreateAutoUrl(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
@@ -788,10 +734,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test create() with no URL (no "action" attribute for <form> tag)
-     *
-     * @return void
      */
-    public function testCreateNoUrl()
+    public function testCreateNoUrl(): void
     {
         $result = $this->Form->create(null, ['url' => false]);
         $expected = [
@@ -805,10 +749,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test create() with a custom route
-     *
-     * @return void
      */
-    public function testCreateCustomRoute()
+    public function testCreateCustomRoute(): void
     {
         Router::connect('/login', ['controller' => 'Users', 'action' => 'login']);
         $encoding = strtolower(Configure::read('App.encoding'));
@@ -842,10 +784,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test automatic accept-charset overriding
-     *
-     * @return void
      */
-    public function testCreateWithAcceptCharset()
+    public function testCreateWithAcceptCharset(): void
     {
         $result = $this->Form->create(
             $this->article,
@@ -865,7 +805,7 @@ class FormHelperTest extends TestCase
     /**
      * Test base form URL when 'url' param is passed with multiple parameters (&)
      */
-    public function testCreateQueryStringRequest()
+    public function testCreateQueryStringRequest(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create($this->article, [
@@ -900,10 +840,8 @@ class FormHelperTest extends TestCase
     /**
      * test that create() doesn't cause errors by multiple id's being in the primary key
      * as could happen with multiple select or checkboxes.
-     *
-     * @return void
      */
-    public function testCreateWithMultipleIdInData()
+    public function testCreateWithMultipleIdInData(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
 
@@ -921,10 +859,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test that create() doesn't add in extra passed params.
-     *
-     * @return void
      */
-    public function testCreatePassedArgs()
+    public function testCreatePassedArgs(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $this->View->setRequest($this->View->getRequest()->withData('Article.id', 1));
@@ -948,10 +884,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test creating a get form, and get form inputs.
-     *
-     * @return void
      */
-    public function testGetFormCreate()
+    public function testGetFormCreate(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $result = $this->Form->create($this->article, ['type' => 'get']);
@@ -983,10 +917,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test get form, and inputs when the model param is false
-     *
-     * @return void
      */
-    public function testGetFormWithFalseModel()
+    public function testGetFormWithFalseModel(): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
         $this->View->setRequest($this->View->getRequest()->withParam('controller', 'ContactTest'));
@@ -1011,10 +943,8 @@ class FormHelperTest extends TestCase
      * testFormCreateWithSecurity method
      *
      * Test form->create() with security key.
-     *
-     * @return void
      */
-    public function testCreateWithSecurity()
+    public function testCreateWithSecurity(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'testKey'));
         $encoding = strtolower(Configure::read('App.encoding'));
@@ -1043,10 +973,8 @@ class FormHelperTest extends TestCase
      * testFormCreateGetNoSecurity method
      *
      * Test form->create() with no security key as its a get form
-     *
-     * @return void
      */
-    public function testCreateEndGetNoSecurity()
+    public function testCreateEndGetNoSecurity(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('csrfToken', 'testKey'));
         $article = new Article();
@@ -1062,10 +990,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests form hash generation with model-less data
-     *
-     * @return void
      */
-    public function testValidateHashNoModel()
+    public function testValidateHashNoModel(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1079,10 +1005,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests that hidden fields generated for checkboxes don't get locked
-     *
-     * @return void
      */
-    public function testNoCheckboxLocking()
+    public function testNoCheckboxLocking(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -1097,10 +1021,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityFields method
      *
      * Test generation of secure form hash generation.
-     *
-     * @return void
      */
-    public function testFormSecurityFields()
+    public function testFormSecurityFields(): void
     {
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
 
@@ -1145,10 +1067,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityFields method
      *
      * Test debug token is not generated if debug is false
-     *
-     * @return void
      */
-    public function testFormSecurityFieldsNoDebugMode()
+    public function testFormSecurityFieldsNoDebugMode(): void
     {
         Configure::write('debug', false);
         $fields = ['Model.password', 'Model.username', 'Model.valid' => '0'];
@@ -1181,10 +1101,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests correct generation of number fields for smallint
-     *
-     * @return void
      */
-    public function testTextFieldGenerationForSmallint()
+    public function testTextFieldGenerationForSmallint(): void
     {
         $this->article['schema'] = [
             'foo' => [
@@ -1203,10 +1121,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests correct generation of number fields for tinyint
-     *
-     * @return void
      */
-    public function testTextFieldGenerationForTinyint()
+    public function testTextFieldGenerationForTinyint(): void
     {
         $this->article['schema'] = [
             'foo' => [
@@ -1225,10 +1141,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests correct generation of number fields for double and float fields
-     *
-     * @return void
      */
-    public function testTextFieldGenerationForFloats()
+    public function testTextFieldGenerationForFloats(): void
     {
         $this->article['schema'] = [
             'foo' => [
@@ -1275,10 +1189,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests correct generation of number fields for integer fields
-     *
-     * @return void
      */
-    public function testTextFieldTypeNumberGenerationForIntegers()
+    public function testTextFieldTypeNumberGenerationForIntegers(): void
     {
         $this->getTableLocator()->get('Contacts', [
             'className' => ContactsTable::class,
@@ -1301,10 +1213,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests correct generation of file upload fields for binary fields
-     *
-     * @return void
      */
-    public function testFileUploadFieldTypeGenerationForBinaries()
+    public function testFileUploadFieldTypeGenerationForBinaries(): void
     {
         $table = $this->getTableLocator()->get('Contacts', [
             'className' => ContactsTable::class,
@@ -1336,10 +1246,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityMultipleFields method
      *
      * Test secure() with multiple row form. Ensure hash is correct.
-     *
-     * @return void
      */
-    public function testFormSecurityMultipleFields()
+    public function testFormSecurityMultipleFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -1400,10 +1308,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityMultipleSubmitButtons
      *
      * test form submit generation and ensure that _Token is only created on end()
-     *
-     * @return void
      */
-    public function testFormSecurityMultipleSubmitButtons()
+    public function testFormSecurityMultipleSubmitButtons(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1464,10 +1370,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test that buttons created with foo[bar] name attributes are unlocked correctly.
-     *
-     * @return void
      */
-    public function testSecurityButtonNestedNamed()
+    public function testSecurityButtonNestedNamed(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1479,10 +1383,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test that submit inputs created with foo[bar] name attributes are unlocked correctly.
-     *
-     * @return void
      */
-    public function testSecuritySubmitNestedNamed()
+    public function testSecuritySubmitNestedNamed(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1494,10 +1396,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test that the correct fields are unlocked for image submits with no names.
-     *
-     * @return void
      */
-    public function testSecuritySubmitImageNoName()
+    public function testSecuritySubmitImageNoName(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1516,10 +1416,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test that the correct fields are unlocked for image submits with names.
-     *
-     * @return void
      */
-    public function testSecuritySubmitImageName()
+    public function testSecuritySubmitImageName(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1539,10 +1437,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityMultipleControlFields method
      *
      * Test secure form creation with multiple row creation. Checks hidden, text, checkbox field types
-     *
-     * @return void
      */
-    public function testFormSecurityMultipleControlFields()
+    public function testFormSecurityMultipleControlFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -1618,10 +1514,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityArrayFields method
      *
      * Test form security with Model.field.0 style inputs.
-     *
-     * @return void
      */
-    public function testFormSecurityArrayFields()
+    public function testFormSecurityArrayFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -1639,10 +1533,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityMultipleControlDisabledFields method
      *
      * Test secure form generation with multiple records and disabled fields.
-     *
-     * @return void
      */
-    public function testFormSecurityMultipleControlDisabledFields()
+    public function testFormSecurityMultipleControlDisabledFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => ['first_name', 'address'],
@@ -1715,10 +1607,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityControlDisabledFields method
      *
      * Test single record form with disabled fields.
-     *
-     * @return void
      */
-    public function testFormSecurityControlUnlockedFields()
+    public function testFormSecurityControlUnlockedFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => ['first_name', 'address'],
@@ -1794,10 +1684,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityControlUnlockedFieldsDebugSecurityTrue method
      *
      * Test single record form with debugSecurity param.
-     *
-     * @return void
      */
-    public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue()
+    public function testFormSecurityControlUnlockedFieldsDebugSecurityTrue(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => ['first_name', 'address'],
@@ -1872,10 +1760,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityControlUnlockedFieldsDebugSecurityFalse method
      *
      * Debug is false, debugSecurity is true -> no debug
-     *
-     * @return void
      */
-    public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse()
+    public function testFormSecurityControlUnlockedFieldsDebugSecurityDebugFalse(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => ['first_name', 'address'],
@@ -1930,10 +1816,8 @@ class FormHelperTest extends TestCase
      * testFormSecurityControlUnlockedFieldsDebugSecurityFalse method
      *
      * Test single record form with debugSecurity param.
-     *
-     * @return void
      */
-    public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse()
+    public function testFormSecurityControlUnlockedFieldsDebugSecurityFalse(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => ['first_name', 'address'],
@@ -1989,10 +1873,8 @@ class FormHelperTest extends TestCase
      * testFormSecureWithCustomNameAttribute method
      *
      * Test securing inputs with custom name attributes.
-     *
-     * @return void
      */
-    public function testFormSecureWithCustomNameAttribute()
+    public function testFormSecureWithCustomNameAttribute(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2010,10 +1892,8 @@ class FormHelperTest extends TestCase
      * testFormSecuredControl method
      *
      * Test generation of entire secure form, assertions made on control() output.
-     *
-     * @return void
      */
-    public function testFormSecuredControl()
+    public function testFormSecuredControl(): void
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('formTokenData', [])
@@ -2189,10 +2069,8 @@ class FormHelperTest extends TestCase
      * testSecuredControlCustomName method
      *
      * Test secured inputs with custom names.
-     *
-     * @return void
      */
-    public function testSecuredControlCustomName()
+    public function testSecuredControlCustomName(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2222,10 +2100,8 @@ class FormHelperTest extends TestCase
      *
      * Test that a hidden field followed by a visible field
      * undoes the hidden field locking.
-     *
-     * @return void
      */
-    public function testSecuredControlDuplicate()
+    public function testSecuredControlDuplicate(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2250,10 +2126,8 @@ class FormHelperTest extends TestCase
      * testFormSecuredFileControl method
      *
      * Tests that the correct keys are added to the field hash index.
-     *
-     * @return void
      */
-    public function testFormSecuredFileControl()
+    public function testFormSecuredFileControl(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2268,10 +2142,8 @@ class FormHelperTest extends TestCase
      * testFormSecuredMultipleSelect method
      *
      * Test that multiple selects keys are added to field hash.
-     *
-     * @return void
      */
-    public function testFormSecuredMultipleSelect()
+    public function testFormSecuredMultipleSelect(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2290,10 +2162,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testFormSecuredRadio method
-     *
-     * @return void
      */
-    public function testFormSecuredRadio()
+    public function testFormSecuredRadio(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2324,10 +2194,8 @@ class FormHelperTest extends TestCase
      * testFormSecuredAndDisabledNotAssoc method
      *
      * Test that when disabled is in a list based attribute array it works.
-     *
-     * @return void
      */
-    public function testFormSecuredAndDisabledNotAssoc()
+    public function testFormSecuredAndDisabledNotAssoc(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2351,10 +2219,8 @@ class FormHelperTest extends TestCase
      *
      * Test that forms with disabled inputs + secured forms leave off the inputs from the form
      * hashing.
-     *
-     * @return void
      */
-    public function testFormSecuredAndDisabled()
+    public function testFormSecuredAndDisabled(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -2383,10 +2249,8 @@ class FormHelperTest extends TestCase
      * testUnlockFieldAddsToList method
      *
      * Test disableField.
-     *
-     * @return void
      */
-    public function testUnlockFieldAddsToList()
+    public function testUnlockFieldAddsToList(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => [],
@@ -2407,10 +2271,8 @@ class FormHelperTest extends TestCase
      * testUnlockFieldRemovingFromFields method
      *
      * Test unlockField removing from fields array.
-     *
-     * @return void
      */
-    public function testUnlockFieldRemovingFromFields()
+    public function testUnlockFieldRemovingFromFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'unlockedFields' => [],
@@ -2433,10 +2295,8 @@ class FormHelperTest extends TestCase
      * testResetUnlockFields method
      *
      * Test reset unlockFields, when create new form.
-     *
-     * @return void
      */
-    public function testResetUnlockFields()
+    public function testResetUnlockFields(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', [
             'key' => 'testKey',
@@ -2460,10 +2320,8 @@ class FormHelperTest extends TestCase
      * testSecuredFormUrlIgnoresHost method
      *
      * Test that only the path + query elements of a form's URL show up in their hash.
-     *
-     * @return void
      */
-    public function testSecuredFormUrlIgnoresHost()
+    public function testSecuredFormUrlIgnoresHost(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', ['key' => 'testKey']));
 
@@ -2491,10 +2349,8 @@ class FormHelperTest extends TestCase
      * testSecuredFormUrlHasHtmlAndIdentifier method
      *
      * Test that URL, HTML and identifier show up in their hashes.
-     *
-     * @return void
      */
-    public function testSecuredFormUrlHasHtmlAndIdentifier()
+    public function testSecuredFormUrlHasHtmlAndIdentifier(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
 
@@ -2531,10 +2387,8 @@ class FormHelperTest extends TestCase
      * testErrorMessageDisplay method
      *
      * Test error message display.
-     *
-     * @return void
      */
-    public function testErrorMessageDisplay()
+    public function testErrorMessageDisplay(): void
     {
         $this->article['errors'] = [
             'Article' => [
@@ -2636,10 +2490,8 @@ class FormHelperTest extends TestCase
      * testEmptyErrorValidation method
      *
      * Test validation errors, when validation message is an empty string.
-     *
-     * @return void
      */
-    public function testEmptyErrorValidation()
+    public function testEmptyErrorValidation(): void
     {
         $this->article['errors'] = [
             'Article' => ['title' => ''],
@@ -2668,10 +2520,8 @@ class FormHelperTest extends TestCase
      * testEmptyControlErrorValidation method
      *
      * Test validation errors, when calling control() overriding validation message by an empty string.
-     *
-     * @return void
      */
-    public function testEmptyControlErrorValidation()
+    public function testEmptyControlErrorValidation(): void
     {
         $this->article['errors'] = [
             'Article' => ['title' => 'error message'],
@@ -2700,10 +2550,8 @@ class FormHelperTest extends TestCase
      * testControlErrorMessage method
      *
      * Test validation errors, when calling control() overriding validation messages.
-     *
-     * @return void
      */
-    public function testControlErrorMessage()
+    public function testControlErrorMessage(): void
     {
         $this->article['errors'] = [
             'title' => ['error message'],
@@ -2763,10 +2611,8 @@ class FormHelperTest extends TestCase
      * testFormValidationAssociated method
      *
      * Tests displaying errors for nested entities.
-     *
-     * @return void
      */
-    public function testFormValidationAssociated()
+    public function testFormValidationAssociated(): void
     {
         $nested = new Entity(['foo' => 'bar']);
         $nested->setError('foo', ['not a valid bar']);
@@ -2781,10 +2627,8 @@ class FormHelperTest extends TestCase
      * testFormValidationAssociatedSecondLevel method
      *
      * Test form error display with associated model.
-     *
-     * @return void
      */
-    public function testFormValidationAssociatedSecondLevel()
+    public function testFormValidationAssociatedSecondLevel(): void
     {
         $inner = new Entity(['bar' => 'baz']);
         $nested = new Entity(['foo' => $inner]);
@@ -2799,10 +2643,8 @@ class FormHelperTest extends TestCase
      * testFormValidationMultiRecord method
      *
      * Test form error display with multiple records.
-     *
-     * @return void
      */
-    public function testFormValidationMultiRecord()
+    public function testFormValidationMultiRecord(): void
     {
         $one = new Entity();
         $two = new Entity();
@@ -2855,10 +2697,8 @@ class FormHelperTest extends TestCase
      * testControl method
      *
      * Test various incarnations of control().
-     *
-     * @return void
      */
-    public function testControl()
+    public function testControl(): void
     {
         $this->getTableLocator()->get('ValidateUsers', [
             'className' => ValidateUsersTable::class,
@@ -2902,10 +2742,8 @@ class FormHelperTest extends TestCase
      * testControlCustomization method
      *
      * Tests the input method and passing custom options.
-     *
-     * @return void
      */
-    public function testControlCustomization()
+    public function testControlCustomization(): void
     {
         $this->getTableLocator()->get('Contacts', [
             'className' => ContactsTable::class,
@@ -3121,10 +2959,8 @@ class FormHelperTest extends TestCase
      * testControlWithTemplateFile method
      *
      * Test that control() accepts a template file.
-     *
-     * @return void
      */
-    public function testControlWithTemplateFile()
+    public function testControlWithTemplateFile(): void
     {
         $result = $this->Form->control('field', [
             'templates' => 'htmlhelper_tags',
@@ -3145,10 +2981,8 @@ class FormHelperTest extends TestCase
      * testNestedControlsEndWithBrackets method
      *
      * Test that nested inputs end with brackets.
-     *
-     * @return void
      */
-    public function testNestedControlsEndWithBrackets()
+    public function testNestedControlsEndWithBrackets(): void
     {
         $result = $this->Form->text('nested.text[]');
         $expected = [
@@ -3171,10 +3005,8 @@ class FormHelperTest extends TestCase
      * testCreateIdPrefix method
      *
      * Test id prefix.
-     *
-     * @return void
      */
-    public function testCreateIdPrefix()
+    public function testCreateIdPrefix(): void
     {
         $this->Form->create(null, ['idPrefix' => 'prefix']);
 
@@ -3268,10 +3100,8 @@ class FormHelperTest extends TestCase
      * testControlZero method
      *
      * Test that inputs with 0 can be created.
-     *
-     * @return void
      */
-    public function testControlZero()
+    public function testControlZero(): void
     {
         $this->getTableLocator()->get('Contacts', [
             'className' => ContactsTable::class,
@@ -3291,10 +3121,8 @@ class FormHelperTest extends TestCase
      * testControlCheckbox method
      *
      * Test control() with checkbox creation.
-     *
-     * @return void
      */
-    public function testControlCheckbox()
+    public function testControlCheckbox(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->getSchema()->addColumn('active', ['type' => 'boolean', 'default' => null]);
@@ -3389,10 +3217,8 @@ class FormHelperTest extends TestCase
      * testControlHidden method
      *
      * Test that control() does not create wrapping div and label tag for hidden fields.
-     *
-     * @return void
      */
-    public function testControlHidden()
+    public function testControlHidden(): void
     {
         $this->getTableLocator()->get('ValidateUsers', [
             'className' => ValidateUsersTable::class,
@@ -3416,10 +3242,8 @@ class FormHelperTest extends TestCase
      * testControlDatetime method
      *
      * Test form->control() with datetime.
-     *
-     * @return void
      */
-    public function testControlDatetime()
+    public function testControlDatetime(): void
     {
         $result = $this->Form->control('prueba', [
             'type' => 'datetime',
@@ -3446,10 +3270,8 @@ class FormHelperTest extends TestCase
      * testControlDatetimeIdPrefix method
      *
      * Test form->control() with datetime with id prefix.
-     *
-     * @return void
      */
-    public function testControlDatetimeIdPrefix()
+    public function testControlDatetimeIdPrefix(): void
     {
         $this->Form->create(null, ['idPrefix' => 'prefix']);
 
@@ -3477,10 +3299,8 @@ class FormHelperTest extends TestCase
      * testControlDatetimeStep method
      *
      * Test form->control() with datetime with custom step size.
-     *
-     * @return void
      */
-    public function testControlDatetimeStep()
+    public function testControlDatetimeStep(): void
     {
         $result = $this->Form->control('prueba', [
             'type' => 'datetime',
@@ -3508,10 +3328,8 @@ class FormHelperTest extends TestCase
      * testControlCheckboxWithDisabledElements method
      *
      * Test generating checkboxes with disabled elements.
-     *
-     * @return void
      */
-    public function testControlCheckboxWithDisabledElements()
+    public function testControlCheckboxWithDisabledElements(): void
     {
         $options = [1 => 'One', 2 => 'Two', '3' => 'Three'];
         $result = $this->Form->control('Contact.multiple', [
@@ -3580,10 +3398,8 @@ class FormHelperTest extends TestCase
      * testControlWithLeadingInteger method
      *
      * Test input name with leading integer, ensure attributes are generated correctly.
-     *
-     * @return void
      */
-    public function testControlWithLeadingInteger()
+    public function testControlWithLeadingInteger(): void
     {
         $result = $this->Form->text('0.Node.title');
         $expected = [
@@ -3596,10 +3412,8 @@ class FormHelperTest extends TestCase
      * testControlSelectType method
      *
      * Test form->control() with select type inputs.
-     *
-     * @return void
      */
-    public function testControlSelectType()
+    public function testControlSelectType(): void
     {
         $result = $this->Form->control(
             'email',
@@ -3765,10 +3579,8 @@ class FormHelperTest extends TestCase
      * testControlWithNonStandardPrimaryKeyMakesHidden method
      *
      * Test that control() and a non standard primary key makes a hidden input by default.
-     *
-     * @return void
      */
-    public function testControlWithNonStandardPrimaryKeyMakesHidden()
+    public function testControlWithNonStandardPrimaryKeyMakesHidden(): void
     {
         $this->article['schema']['_constraints']['primary']['columns'] = ['title'];
         $this->Form->create($this->article);
@@ -3797,10 +3609,8 @@ class FormHelperTest extends TestCase
      * testControlOverridingMagicSelectType method
      *
      * Test that overriding the magic select type widget is possible.
-     *
-     * @return void
      */
-    public function testControlOverridingMagicSelectType()
+    public function testControlOverridingMagicSelectType(): void
     {
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.user_id', ['type' => 'text']);
@@ -3831,10 +3641,8 @@ class FormHelperTest extends TestCase
      * testControlMagicTypeDoesNotOverride method
      *
      * Test that inferred types do not override developer input.
-     *
-     * @return void
      */
-    public function testControlMagicTypeDoesNotOverride()
+    public function testControlMagicTypeDoesNotOverride(): void
     {
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.user', ['type' => 'checkbox']);
@@ -3900,10 +3708,8 @@ class FormHelperTest extends TestCase
      * testControlMagicSelectForTypeNumber method
      *
      * Test that magic control() selects are created for type=number.
-     *
-     * @return void
      */
-    public function testControlMagicSelectForTypeNumber()
+    public function testControlMagicSelectForTypeNumber(): void
     {
         $this->getTableLocator()->get('ValidateUsers', [
             'className' => ValidateUsersTable::class,
@@ -3937,10 +3743,8 @@ class FormHelperTest extends TestCase
      * testInvalidControlTypeOption method
      *
      * Test invalid 'input' type option to control() function.
-     *
-     * @return void
      */
-    public function testInvalidControlTypeOption()
+    public function testInvalidControlTypeOption(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid type \'input\' used for field \'text\'');
@@ -3951,10 +3755,8 @@ class FormHelperTest extends TestCase
      * testControlMagicSelectChangeToRadio method
      *
      * Test that magic control() selects can easily be converted into radio types without error.
-     *
-     * @return void
      */
-    public function testControlMagicSelectChangeToRadio()
+    public function testControlMagicSelectChangeToRadio(): void
     {
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $result = $this->Form->control('Model.user_id', ['type' => 'radio']);
@@ -3965,10 +3767,8 @@ class FormHelperTest extends TestCase
      * testFormControlSubmit method
      *
      * Test correct results for form::control() and type submit.
-     *
-     * @return void
      */
-    public function testFormControlSubmit()
+    public function testFormControlSubmit(): void
     {
         $result = $this->Form->control('Test Submit', ['type' => 'submit', 'class' => 'foobar']);
         $expected = [
@@ -3983,10 +3783,8 @@ class FormHelperTest extends TestCase
      * testFormControls method
      *
      * Test correct results from Form::controls().
-     *
-     * @return void
      */
-    public function testFormControlsLegendFieldset()
+    public function testFormControlsLegendFieldset(): void
     {
         $this->Form->create($this->article);
         $result = $this->Form->allControls([], ['legend' => 'The Legend']);
@@ -4060,10 +3858,8 @@ class FormHelperTest extends TestCase
      * testFormControls method
      *
      * Test the controls() method.
-     *
-     * @return void
      */
-    public function testFormControls()
+    public function testFormControls(): void
     {
         $this->Form->create($this->article);
         $result = $this->Form->allControls();
@@ -4142,10 +3938,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testFormControlsBlacklist method
-     *
-     * @return void
      */
-    public function testFormControlsBlacklist()
+    public function testFormControlsBlacklist(): void
     {
         $this->Form->create($this->article);
         $result = $this->Form->allControls([
@@ -4191,10 +3985,8 @@ class FormHelperTest extends TestCase
      * testSelectAsCheckbox method
      *
      * Test multi-select widget with checkbox formatting.
-     *
-     * @return void
      */
-    public function testSelectAsCheckbox()
+    public function testSelectAsCheckbox(): void
     {
         $result = $this->Form->select(
             'Model.multi_field',
@@ -4245,10 +4037,8 @@ class FormHelperTest extends TestCase
      * testLabel method
      *
      * Test label generation.
-     *
-     * @return void
      */
-    public function testLabel()
+    public function testLabel(): void
     {
         $result = $this->Form->label('Person.name');
         $expected = ['label' => ['for' => 'person-name'], 'Name', '/label'];
@@ -4287,10 +4077,8 @@ class FormHelperTest extends TestCase
      * testLabelContainControl method
      *
      * Test that label() can accept an input with the correct template vars.
-     *
-     * @return void
      */
-    public function testLabelContainControl()
+    public function testLabelContainControl(): void
     {
         $this->Form->setTemplates([
             'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
@@ -4311,10 +4099,8 @@ class FormHelperTest extends TestCase
      * testTextbox method
      *
      * Test textbox element generation.
-     *
-     * @return void
      */
-    public function testTextbox()
+    public function testTextbox(): void
     {
         $result = $this->Form->text('Model.field');
         $expected = ['input' => ['type' => 'text', 'name' => 'Model[field]']];
@@ -4333,10 +4119,8 @@ class FormHelperTest extends TestCase
      * testTextBoxDataAndError method
      *
      * Test that text() hooks up with request data and error fields.
-     *
-     * @return void
      */
-    public function testTextBoxDataAndError()
+    public function testTextBoxDataAndError(): void
     {
         $this->article['errors'] = [
             'Contact' => ['text' => 'wrong'],
@@ -4373,10 +4157,8 @@ class FormHelperTest extends TestCase
      * testDefaultValue method
      *
      * Test default value setting.
-     *
-     * @return void
      */
-    public function testTextDefaultValue()
+    public function testTextDefaultValue(): void
     {
         $this->View->setRequest($this->View->getRequest()->withData('Model.field', 'test'));
         $result = $this->Form->text('Model.field', ['default' => 'default value']);
@@ -4425,10 +4207,8 @@ class FormHelperTest extends TestCase
      * testError method
      *
      * Test field error generation.
-     *
-     * @return void
      */
-    public function testError()
+    public function testError(): void
     {
         $this->article['errors'] = [
             'Article' => ['field' => 'email'],
@@ -4464,10 +4244,8 @@ class FormHelperTest extends TestCase
      * testErrorRuleName method
      *
      * Test error translation can use rule names for translating.
-     *
-     * @return void
      */
-    public function testErrorRuleName()
+    public function testErrorRuleName(): void
     {
         $this->article['errors'] = [
             'Article' => [
@@ -4516,10 +4294,8 @@ class FormHelperTest extends TestCase
      * testErrorMessages method
      *
      * Test error with nested lists.
-     *
-     * @return void
      */
-    public function testErrorMessages()
+    public function testErrorMessages(): void
     {
         $this->article['errors'] = [
             'Article' => ['field' => 'email'],
@@ -4541,10 +4317,8 @@ class FormHelperTest extends TestCase
      * testErrorMultipleMessages method
      *
      * Test error() with multiple messages.
-     *
-     * @return void
      */
-    public function testErrorMultipleMessages()
+    public function testErrorMultipleMessages(): void
     {
         $this->article['errors'] = [
             'field' => ['notBlank', 'email', 'Something else'],
@@ -4571,10 +4345,8 @@ class FormHelperTest extends TestCase
      * testPassword method
      *
      * Test password element generation.
-     *
-     * @return void
      */
-    public function testPassword()
+    public function testPassword(): void
     {
         $this->article['errors'] = [
             'Contact' => [
@@ -4598,10 +4370,8 @@ class FormHelperTest extends TestCase
      * testRadio method
      *
      * Test radio element set generation.
-     *
-     * @return void
      */
-    public function testRadio()
+    public function testRadio(): void
     {
         $result = $this->Form->radio('Model.field', ['option A']);
         $expected = [
@@ -4687,10 +4457,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test radio with complex options and empty disabled data.
-     *
-     * @return void
      */
-    public function testRadioComplexDisabled()
+    public function testRadioComplexDisabled(): void
     {
         $options = [
             ['value' => 'r', 'text' => 'red'],
@@ -4720,10 +4488,8 @@ class FormHelperTest extends TestCase
      * testRadioDefaultValue method
      *
      * Test default value setting on radio() method.
-     *
-     * @return void
      */
-    public function testRadioDefaultValue()
+    public function testRadioDefaultValue(): void
     {
         $Articles = $this->getTableLocator()->get('Articles');
         $title = $Articles->getSchema()->getColumn('title');
@@ -4751,10 +4517,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test setting a hiddenField value on radio buttons.
-     *
-     * @return void
      */
-    public function testRadioHiddenFieldValue()
+    public function testRadioHiddenFieldValue(): void
     {
         $result = $this->Form->radio('title', ['option A'], ['hiddenField' => 'N']);
         $expected = [
@@ -4771,10 +4535,8 @@ class FormHelperTest extends TestCase
      * testControlRadio method
      *
      * Test that input works with radio types.
-     *
-     * @return void
      */
-    public function testControlRadio()
+    public function testControlRadio(): void
     {
         $result = $this->Form->control('test', [
             'type' => 'radio',
@@ -4846,10 +4608,8 @@ class FormHelperTest extends TestCase
      * testRadioNoLabel method
      *
      * Test that radio() works with label = false.
-     *
-     * @return void
      */
-    public function testRadioNoLabel()
+    public function testRadioNoLabel(): void
     {
         $result = $this->Form->radio('Model.field', ['A', 'B'], ['label' => false]);
         $expected = [
@@ -4864,10 +4624,8 @@ class FormHelperTest extends TestCase
      * testRadioControlInsideLabel method
      *
      * Test generating radio input inside label ala twitter bootstrap.
-     *
-     * @return void
      */
-    public function testRadioControlInsideLabel()
+    public function testRadioControlInsideLabel(): void
     {
         $this->Form->setTemplates([
             'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
@@ -4909,10 +4667,8 @@ class FormHelperTest extends TestCase
      * testRadioHiddenControlDisabling method
      *
      * Test disabling the hidden input for radio buttons.
-     *
-     * @return void
      */
-    public function testRadioHiddenControlDisabling()
+    public function testRadioHiddenControlDisabling(): void
     {
         $result = $this->Form->radio('Model.1.field', ['option A'], ['hiddenField' => false]);
         $expected = [
@@ -4928,10 +4684,8 @@ class FormHelperTest extends TestCase
      * testRadioOutOfRange method
      *
      * Test radio element set generation.
-     *
-     * @return void
      */
-    public function testRadioOutOfRange()
+    public function testRadioOutOfRange(): void
     {
         $result = $this->Form->radio('Model.field', ['v' => 'value'], ['value' => 'nope']);
         $expected = [
@@ -4948,10 +4702,8 @@ class FormHelperTest extends TestCase
      * testSelect method
      *
      * Test select element generation.
-     *
-     * @return void
      */
-    public function testSelect()
+    public function testSelect(): void
     {
         $result = $this->Form->select('Model.field', []);
         $expected = [
@@ -5048,10 +4800,8 @@ class FormHelperTest extends TestCase
      * testSelectEscapeHtml method
      *
      * Test that select() escapes HTML.
-     *
-     * @return void
      */
-    public function testSelectEscapeHtml()
+    public function testSelectEscapeHtml(): void
     {
         $result = $this->Form->select(
             'Model.field',
@@ -5092,10 +4842,8 @@ class FormHelperTest extends TestCase
      * testSelectRequired method
      *
      * Test select() with required and disabled attributes.
-     *
-     * @return void
      */
-    public function testSelectRequired()
+    public function testSelectRequired(): void
     {
         $this->article['required'] = [
             'user_id' => true,
@@ -5124,7 +4872,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testSelectEmptyWithRequiredFalse()
+    public function testSelectEmptyWithRequiredFalse(): void
     {
         $this->loadFixtures();
         $Articles = $this->getTableLocator()->get('Articles');
@@ -5150,10 +4898,8 @@ class FormHelperTest extends TestCase
      * testNestedSelect method
      *
      * Test select element generation with optgroups.
-     *
-     * @return void
      */
-    public function testNestedSelect()
+    public function testNestedSelect(): void
     {
         $result = $this->Form->select(
             'Model.field',
@@ -5190,10 +4936,8 @@ class FormHelperTest extends TestCase
      * testSelectMultiple method
      *
      * Test generation of multiple select elements.
-     *
-     * @return void
      */
-    public function testSelectMultiple()
+    public function testSelectMultiple(): void
     {
         $options = ['first', 'second', 'third'];
         $result = $this->Form->select(
@@ -5245,10 +4989,8 @@ class FormHelperTest extends TestCase
      * testCheckboxZeroValue method
      *
      * Test that a checkbox can have 0 for the value and 1 for the hidden input.
-     *
-     * @return void
      */
-    public function testCheckboxZeroValue()
+    public function testCheckboxZeroValue(): void
     {
         $result = $this->Form->control('User.get_spam', [
             'type' => 'checkbox',
@@ -5277,10 +5019,8 @@ class FormHelperTest extends TestCase
      * testHabtmSelectBox method
      *
      * Test generation of habtm select boxes.
-     *
-     * @return void
      */
-    public function testHabtmSelectBox()
+    public function testHabtmSelectBox(): void
     {
         $this->loadFixtures('Articles');
         $options = [
@@ -5390,10 +5130,8 @@ class FormHelperTest extends TestCase
      *
      * Tests that errors for belongsToMany select fields are being
      * picked up properly.
-     *
-     * @return void
      */
-    public function testErrorsForBelongsToManySelect()
+    public function testErrorsForBelongsToManySelect(): void
     {
         $this->loadFixtures();
 
@@ -5438,10 +5176,8 @@ class FormHelperTest extends TestCase
      * testSelectMultipleCheckboxes method
      *
      * Test generation of multi select elements in checkbox format.
-     *
-     * @return void
      */
-    public function testSelectMultipleCheckboxes()
+    public function testSelectMultipleCheckboxes(): void
     {
         $result = $this->Form->select(
             'Model.multi_field',
@@ -5566,10 +5302,8 @@ class FormHelperTest extends TestCase
      * testSelectMultipleCheckboxRequestData method
      *
      * Ensure that multiCheckbox reads from the request data.
-     *
-     * @return void
      */
-    public function testSelectMultipleCheckboxRequestData()
+    public function testSelectMultipleCheckboxRequestData(): void
     {
         $this->View->setRequest($this->View->getRequest()->withData('Model', ['tags' => [1]]));
         $result = $this->Form->select(
@@ -5608,10 +5342,8 @@ class FormHelperTest extends TestCase
      * testSelectMultipleCheckboxSecurity method
      *
      * Checks the security hash array generated for multiple-input checkbox elements.
-     *
-     * @return void
      */
-    public function testSelectMultipleCheckboxSecurity()
+    public function testSelectMultipleCheckboxSecurity(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -5635,10 +5367,8 @@ class FormHelperTest extends TestCase
      *
      * Multiple select elements should always be secured as they always participate
      * in the POST data.
-     *
-     * @return void
      */
-    public function testSelectMultipleSecureWithNoOptions()
+    public function testSelectMultipleSecureWithNoOptions(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -5657,10 +5387,8 @@ class FormHelperTest extends TestCase
      *
      * When a select box has no options it should not be added to the fields list
      * as it always fail post validation.
-     *
-     * @return void
      */
-    public function testSelectNoSecureWithNoOptions()
+    public function testSelectNoSecureWithNoOptions(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -5685,10 +5413,8 @@ class FormHelperTest extends TestCase
      * testControlMultipleCheckboxes method
      *
      * Test control() resulting in multi select elements being generated.
-     *
-     * @return void
      */
-    public function testControlMultipleCheckboxes()
+    public function testControlMultipleCheckboxes(): void
     {
         $result = $this->Form->control('Model.multi_field', [
             'options' => ['first', 'second', 'third'],
@@ -5759,10 +5485,8 @@ class FormHelperTest extends TestCase
      * testSelectHiddenFieldOmission method
      *
      * Test that select() with 'hiddenField' => false omits the hidden field.
-     *
-     * @return void
      */
-    public function testSelectHiddenFieldOmission()
+    public function testSelectHiddenFieldOmission(): void
     {
         $result = $this->Form->select(
             'Model.multi_field',
@@ -5776,10 +5500,8 @@ class FormHelperTest extends TestCase
      * testSelectCheckboxMultipleOverrideName method
      *
      * Test that select() with multiple = checkbox works with overriding name attribute.
-     *
-     * @return void
      */
-    public function testSelectCheckboxMultipleOverrideName()
+    public function testSelectCheckboxMultipleOverrideName(): void
     {
         $result = $this->Form->select('category', ['1', '2'], [
             'multiple' => 'checkbox',
@@ -5819,10 +5541,8 @@ class FormHelperTest extends TestCase
      * testControlMultiCheckbox method
      *
      * Test that control() works with multicheckbox.
-     *
-     * @return void
      */
-    public function testControlMultiCheckbox()
+    public function testControlMultiCheckbox(): void
     {
         $result = $this->Form->control('category', [
             'type' => 'multicheckbox',
@@ -5855,10 +5575,8 @@ class FormHelperTest extends TestCase
      * testCheckbox method
      *
      * Test generation of checkboxes.
-     *
-     * @return void
      */
-    public function testCheckbox()
+    public function testCheckbox(): void
     {
         $result = $this->Form->checkbox('Model.field');
         $expected = [
@@ -5887,10 +5605,8 @@ class FormHelperTest extends TestCase
      * testCheckboxDefaultValue method
      *
      * Test default value setting on checkbox() method.
-     *
-     * @return void
      */
-    public function testCheckboxDefaultValue()
+    public function testCheckboxDefaultValue(): void
     {
         $this->View->setRequest($this->View->getRequest()->withData('Model.field', false));
         $result = $this->Form->checkbox('Model.field', ['default' => true, 'hiddenField' => false]);
@@ -5931,10 +5647,8 @@ class FormHelperTest extends TestCase
      * testCheckboxCheckedAndError method
      *
      * Test checkbox being checked or having errors.
-     *
-     * @return void
      */
-    public function testCheckboxCheckedAndError()
+    public function testCheckboxCheckedAndError(): void
     {
         $this->article['errors'] = [
             'published' => true,
@@ -5970,10 +5684,8 @@ class FormHelperTest extends TestCase
      * testCheckboxCustomNameAttribute method
      *
      * Test checkbox() with a custom name attribute.
-     *
-     * @return void
      */
-    public function testCheckboxCustomNameAttribute()
+    public function testCheckboxCustomNameAttribute(): void
     {
         $result = $this->Form->checkbox('Test.test', ['name' => 'myField']);
         $expected = [
@@ -5988,10 +5700,8 @@ class FormHelperTest extends TestCase
      *
      * Test that the hidden input for checkboxes can be omitted or set to a
      * specific value.
-     *
-     * @return void
      */
-    public function testCheckboxHiddenField()
+    public function testCheckboxHiddenField(): void
     {
         $result = $this->Form->checkbox('UserForm.something', [
             'hiddenField' => false,
@@ -6026,10 +5736,8 @@ class FormHelperTest extends TestCase
      * testTime method
      *
      * Test the time type.
-     *
-     * @return void
      */
-    public function testTime()
+    public function testTime(): void
     {
         $result = $this->Form->time('start_time', [
             'value' => '2014-03-08 16:30:00',
@@ -6050,10 +5758,8 @@ class FormHelperTest extends TestCase
      * testDate method
      *
      * Test the date type.
-     *
-     * @return void
      */
-    public function testDate()
+    public function testDate(): void
     {
         $result = $this->Form->date('start_day', [
             'value' => '2014-03-08',
@@ -6076,10 +5782,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testDateTime method
-     *
-     * @return void
      */
-    public function testDateTime()
+    public function testDateTime(): void
     {
         $result = $this->Form->dateTime('date', ['default' => true]);
         $expected = [
@@ -6098,10 +5802,8 @@ class FormHelperTest extends TestCase
      * testDateTimeSecured method
      *
      * Test that datetime fields are added to protected fields list.
-     *
-     * @return void
      */
-    public function testDateTimeSecured()
+    public function testDateTimeSecured(): void
     {
         $this->View->setRequest(
             $this->View->getRequest()->withAttribute('formTokenData', ['unlockedFields' => []])
@@ -6124,10 +5826,8 @@ class FormHelperTest extends TestCase
      * testDateTimeSecuredDisabled method
      *
      * Test that datetime fields are added to protected fields list.
-     *
-     * @return void
      */
-    public function testDateTimeSecuredDisabled()
+    public function testDateTimeSecuredDisabled(): void
     {
         $this->View->setRequest(
             $this->View->getRequest()->withAttribute('formTokenData', ['unlockedFields' => []])
@@ -6150,10 +5850,8 @@ class FormHelperTest extends TestCase
      * testDatetimeWithDefault method
      *
      * Test that datetime() and default values work.
-     *
-     * @return void
      */
-    public function testDatetimeWithDefault()
+    public function testDatetimeWithDefault(): void
     {
         $result = $this->Form->dateTime('updated', ['value' => '2009-06-01 11:15:30']);
         $expected = [
@@ -6184,10 +5882,8 @@ class FormHelperTest extends TestCase
      * testMonth method
      *
      * Test generation of a month input.
-     *
-     * @return void
      */
-    public function testMonth()
+    public function testMonth(): void
     {
         $result = $this->Form->month('field', ['value' => '']);
         $expected = [
@@ -6233,10 +5929,8 @@ class FormHelperTest extends TestCase
      * testYear method
      *
      * Test generation of a year input.
-     *
-     * @return void
      */
-    public function testYear()
+    public function testYear(): void
     {
         $this->View->setRequest(
             $this->View->getRequest()->withData('published', '2006')
@@ -6325,10 +6019,8 @@ class FormHelperTest extends TestCase
      * testControlYearPreEpoch method
      *
      * Test minYear being prior to the unix epoch.
-     *
-     * @return void
      */
-    public function testControlYearPreEpoch()
+    public function testControlYearPreEpoch(): void
     {
         $start = date('Y') - 80;
         $end = date('Y') - 18;
@@ -6345,10 +6037,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test control() datetime & required attributes
-     *
-     * @return void
      */
-    public function testControlDatetimeRequired()
+    public function testControlDatetimeRequired(): void
     {
         $result = $this->Form->control('birthday', [
             'type' => 'date',
@@ -6362,10 +6052,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testYearAutoExpandRange method
-     *
-     * @return void
      */
-    public function testYearAutoExpandRange()
+    public function testYearAutoExpandRange(): void
     {
         $this->View->setRequest($this->View->getRequest()->withData('birthday', '1930'));
         $result = $this->Form->year('birthday');
@@ -6401,10 +6089,8 @@ class FormHelperTest extends TestCase
      * testControlLabelFalse method
      *
      * Test the label option being set to false.
-     *
-     * @return void
      */
-    public function testControlLabelFalse()
+    public function testControlLabelFalse(): void
     {
         $this->Form->create($this->article);
         $result = $this->Form->control('title', ['label' => false]);
@@ -6428,10 +6114,8 @@ class FormHelperTest extends TestCase
      * testTextArea method
      *
      * Test generation of a textarea input.
-     *
-     * @return void
      */
-    public function testTextArea()
+    public function testTextArea(): void
     {
         $this->View->setRequest($this->View->getRequest()->withData('field', 'some test data'));
         $result = $this->Form->textarea('field');
@@ -6485,10 +6169,8 @@ class FormHelperTest extends TestCase
      * testTextAreaWithStupidCharacters method
      *
      * Test text area with non-ascii characters.
-     *
-     * @return void
      */
-    public function testTextAreaWithStupidCharacters()
+    public function testTextAreaWithStupidCharacters(): void
     {
         $result = $this->Form->textarea('Post.content', [
             'value' => 'GREAT®',
@@ -6507,10 +6189,8 @@ class FormHelperTest extends TestCase
      * testTextAreaMaxLength method
      *
      * Test textareas maxlength read from schema.
-     *
-     * @return void
      */
-    public function testTextAreaMaxLength()
+    public function testTextAreaMaxLength(): void
     {
         $this->Form->create([
             'schema' => [
@@ -6546,10 +6226,8 @@ class FormHelperTest extends TestCase
      * testHiddenField method
      *
      * Test generation of a hidden input.
-     *
-     * @return void
      */
-    public function testHidden()
+    public function testHidden(): void
     {
         $this->article['errors'] = [
             'field' => true,
@@ -6570,10 +6248,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test hidden() with various boolean values.
-     *
-     * @return void
      */
-    public function testHiddenBooleanValues()
+    public function testHiddenBooleanValues(): void
     {
         $this->Form->create($this->article);
         $result = $this->Form->hidden('field', ['value' => null]);
@@ -6599,10 +6275,8 @@ class FormHelperTest extends TestCase
      * testFileUploadField method
      *
      * Test generation of a file upload input.
-     *
-     * @return void
      */
-    public function testFileUploadField()
+    public function testFileUploadField(): void
     {
         $expected = ['input' => ['type' => 'file', 'name' => 'Model[upload]']];
 
@@ -6627,10 +6301,8 @@ class FormHelperTest extends TestCase
      * testFileUploadOnOtherModel method
      *
      * Test File upload input on a model not used in create().
-     *
-     * @return void
      */
-    public function testFileUploadOnOtherModel()
+    public function testFileUploadOnOtherModel(): void
     {
         $this->Form->create($this->article, ['type' => 'file']);
         $result = $this->Form->file('ValidateProfile.city');
@@ -6644,10 +6316,8 @@ class FormHelperTest extends TestCase
      * testButton method
      *
      * Test generation of a form button.
-     *
-     * @return void
      */
-    public function testButton()
+    public function testButton(): void
     {
         $result = $this->Form->button('Hi');
         $expected = ['button' => ['type' => 'submit'], 'Hi', '/button'];
@@ -6680,10 +6350,8 @@ class FormHelperTest extends TestCase
      * testButtonUnlockedByDefault method
      *
      * Test that button() makes unlocked fields by default.
-     *
-     * @return void
      */
-    public function testButtonUnlockedByDefault()
+    public function testButtonUnlockedByDefault(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -6697,10 +6365,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test generation of a form button with confirm message.
-     *
-     * @return void
      */
-    public function testButtonWithConfirm()
+    public function testButtonWithConfirm(): void
     {
         $result = $this->Form->button('Hi', ['confirm' => 'Confirm me!']);
         $expected = ['button' => [
@@ -6721,10 +6387,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testPostButton method
-     *
-     * @return void
      */
-    public function testPostButton()
+    public function testPostButton(): void
     {
         $result = $this->Form->postButton('Hi', '/controller/action');
         $expected = [
@@ -6742,10 +6406,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testPostButtonMethodType method
-     *
-     * @return void
      */
-    public function testPostButtonMethodType()
+    public function testPostButtonMethodType(): void
     {
         $result = $this->Form->postButton('Hi', '/controller/action', ['method' => 'patch']);
         $expected = [
@@ -6763,10 +6425,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testPostButtonFormOptions method
-     *
-     * @return void
      */
-    public function testPostButtonFormOptions()
+    public function testPostButtonFormOptions(): void
     {
         $result = $this->Form->postButton('Hi', '/controller/action', ['form' => ['class' => 'inline']]);
         $expected = [
@@ -6783,10 +6443,8 @@ class FormHelperTest extends TestCase
      * testPostButtonNestedData method
      *
      * Test using postButton with N dimensional data.
-     *
-     * @return void
      */
-    public function testPostButtonNestedData()
+    public function testPostButtonNestedData(): void
     {
         $data = [
             'one' => [
@@ -6805,10 +6463,8 @@ class FormHelperTest extends TestCase
      * testSecurePostButton method
      *
      * Test that postButton adds _Token fields.
-     *
-     * @return void
      */
-    public function testSecurePostButton()
+    public function testSecurePostButton(): void
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('csrfToken', 'testkey')
@@ -6848,10 +6504,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testPostLink method
-     *
-     * @return void
      */
-    public function testPostLink()
+    public function testPostLink(): void
     {
         $result = $this->Form->postLink('Delete', '/posts/delete/1');
         $expected = [
@@ -6904,10 +6558,8 @@ class FormHelperTest extends TestCase
      * testPostLinkWithConfirm method
      *
      * Test the confirm option for postLink().
-     *
-     * @return void
      */
-    public function testPostLinkWithConfirm()
+    public function testPostLinkWithConfirm(): void
     {
         $result = $this->Form->postLink('Delete', '/posts/delete/1', ['confirm' => 'Confirm?']);
         $expected = [
@@ -6978,10 +6630,8 @@ class FormHelperTest extends TestCase
      * testPostLinkWithQuery method
      *
      * Test postLink() with query string args.
-     *
-     * @return void
      */
-    public function testPostLinkWithQuery()
+    public function testPostLinkWithQuery(): void
     {
         $result = $this->Form->postLink(
             'Delete',
@@ -7005,10 +6655,8 @@ class FormHelperTest extends TestCase
      * testPostLinkWithData method
      *
      * Test postLink with additional data.
-     *
-     * @return void
      */
-    public function testPostLinkWithData()
+    public function testPostLinkWithData(): void
     {
         $result = $this->Form->postLink('Delete', '/posts/delete', ['data' => ['id' => 1]]);
         $this->assertStringContainsString('<input type="hidden" name="id" value="1"', $result);
@@ -7028,10 +6676,8 @@ class FormHelperTest extends TestCase
      * testPostLinkSecurityHash method
      *
      * Test that security hashes for postLink include the url.
-     *
-     * @return void
      */
-    public function testPostLinkSecurityHash()
+    public function testPostLinkSecurityHash(): void
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
         $hash .= '%3Aid';
@@ -7081,10 +6727,8 @@ class FormHelperTest extends TestCase
      *
      * postLink() calls inside open forms should not modify the field list
      * for the form.
-     *
-     * @return void
      */
-    public function testPostLinkSecurityHashBlockMode()
+    public function testPostLinkSecurityHashBlockMode(): void
     {
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize([]) . session_id(), Security::getSalt());
         $hash .= '%3A';
@@ -7107,10 +6751,8 @@ class FormHelperTest extends TestCase
      * testPostLinkSecurityHashNoDebugMode method
      *
      * Test that security does not include debug token if debug is false.
-     *
-     * @return void
      */
-    public function testPostLinkSecurityHashNoDebugMode()
+    public function testPostLinkSecurityHashNoDebugMode(): void
     {
         Configure::write('debug', false);
         $hash = hash_hmac('sha1', '/posts/delete/1' . serialize(['id' => '1']) . session_id(), Security::getSalt());
@@ -7146,10 +6788,8 @@ class FormHelperTest extends TestCase
      * testPostLinkNestedData method
      *
      * Test using postLink with N dimensional data.
-     *
-     * @return void
      */
-    public function testPostLinkNestedData()
+    public function testPostLinkNestedData(): void
     {
         $data = [
             'one' => [
@@ -7168,10 +6808,8 @@ class FormHelperTest extends TestCase
      * testPostLinkAfterGetForm method
      *
      * Test creating postLinks after a GET form.
-     *
-     * @return void
      */
-    public function testPostLinkAfterGetForm()
+    public function testPostLinkAfterGetForm(): void
     {
         $this->View->setRequest($this->View->getRequest()
             ->withAttribute('csrfToken', 'testkey')
@@ -7214,10 +6852,8 @@ class FormHelperTest extends TestCase
      * testPostLinkFormBuffer method
      *
      * Test that postLink adds form tags to view block.
-     *
-     * @return void
      */
-    public function testPostLinkFormBuffer()
+    public function testPostLinkFormBuffer(): void
     {
         $result = $this->Form->postLink('Delete', '/posts/delete/1', ['block' => true]);
         $expected = [
@@ -7291,10 +6927,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testSubmitButton method
-     *
-     * @return void
      */
-    public function testSubmitButton()
+    public function testSubmitButton(): void
     {
         $result = $this->Form->submit('');
         $expected = [
@@ -7341,10 +6975,8 @@ class FormHelperTest extends TestCase
      * testSubmitImage method
      *
      * Test image submit types.
-     *
-     * @return void
      */
-    public function testSubmitImage()
+    public function testSubmitImage(): void
     {
         $result = $this->Form->submit('http://example.com/cake.power.gif');
         $expected = [
@@ -7384,10 +7016,8 @@ class FormHelperTest extends TestCase
      *
      * Submit buttons should be unlocked by default as there could be multiples, and only one will
      * be submitted at a time.
-     *
-     * @return void
      */
-    public function testSubmitUnlockedByDefault()
+    public function testSubmitUnlockedByDefault(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
@@ -7402,10 +7032,8 @@ class FormHelperTest extends TestCase
      * testSubmitImageTimestamp method
      *
      * Test submit image with timestamps.
-     *
-     * @return void
      */
-    public function testSubmitImageTimestamp()
+    public function testSubmitImageTimestamp(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -7422,10 +7050,8 @@ class FormHelperTest extends TestCase
      * testDateTimeWithGetForms method
      *
      * Test that datetime() works with GET style forms.
-     *
-     * @return void
      */
-    public function testDateTimeWithGetForms()
+    public function testDateTimeWithGetForms(): void
     {
         $this->Form->create($this->article, ['type' => 'get']);
         $result = $this->Form->datetime('created');
@@ -7472,10 +7098,9 @@ class FormHelperTest extends TestCase
      *
      * Test that datetime() works with datetimefractional.
      *
-     * @return void
      * @dataProvider fractionalTypeProvider
      */
-    public function testDateTimeWithFractional(string $type)
+    public function testDateTimeWithFractional(string $type): void
     {
         $this->Form->create([
             'schema' => [
@@ -7502,10 +7127,9 @@ class FormHelperTest extends TestCase
      *
      * Test that control() works with datetimefractional.
      *
-     * @return void
      * @dataProvider fractionalTypeProvider
      */
-    public function testControlWithFractional(string $type)
+    public function testControlWithFractional(string $type): void
     {
         $this->Form->create([
             'schema' => [
@@ -7535,10 +7159,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testForMagicControlNonExistentNotValidated method
-     *
-     * @return void
      */
-    public function testForMagicControlNonExistentNotValidated()
+    public function testForMagicControlNonExistentNotValidated(): void
     {
         $this->Form->create($this->article);
         $this->Form->setTemplates(['inputContainer' => '{{content}}']);
@@ -7587,10 +7209,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testFormMagicControlLabel method
-     *
-     * @return void
      */
-    public function testFormMagicControlLabel()
+    public function testFormMagicControlLabel(): void
     {
         $this->getTableLocator()->get('Contacts', [
             'className' => ContactsTable::class,
@@ -7675,10 +7295,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testFormEnd method
-     *
-     * @return void
      */
-    public function testFormEnd()
+    public function testFormEnd(): void
     {
         $this->assertSame('</form>', $this->Form->end());
     }
@@ -7687,10 +7305,8 @@ class FormHelperTest extends TestCase
      * testMultiRecordForm method
      *
      * Test the generation of fields for a multi record form.
-     *
-     * @return void
      */
-    public function testMultiRecordForm()
+    public function testMultiRecordForm(): void
     {
         $this->loadFixtures('Articles', 'Comments');
         $articles = $this->getTableLocator()->get('Articles');
@@ -7790,10 +7406,8 @@ class FormHelperTest extends TestCase
      * testHtml5Controls method
      *
      * Test that some html5 inputs + FormHelper::__call() work.
-     *
-     * @return void
      */
-    public function testHtml5Controls()
+    public function testHtml5Controls(): void
     {
         $result = $this->Form->email('User.email');
         $expected = [
@@ -7824,10 +7438,8 @@ class FormHelperTest extends TestCase
      * testHtml5ControlWithControl method
      *
      * Test accessing html5 inputs through control().
-     *
-     * @return void
      */
-    public function testHtml5ControlWithControl()
+    public function testHtml5ControlWithControl(): void
     {
         $this->Form->create();
         $this->Form->setTemplates(['inputContainer' => '{{content}}']);
@@ -7846,10 +7458,8 @@ class FormHelperTest extends TestCase
      * testHtml5ControlException method
      *
      * Test errors when field name is missing.
-     *
-     * @return void
      */
-    public function testHtml5ControlException()
+    public function testHtml5ControlException(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->Form->email();
@@ -7857,10 +7467,8 @@ class FormHelperTest extends TestCase
 
     /**
      * tests fields that are required use custom validation messages
-     *
-     * @return void
      */
-    public function testHtml5ErrorMessage()
+    public function testHtml5ErrorMessage(): void
     {
         $this->Form->setConfig('autoSetCustomValidity', true);
 
@@ -7938,10 +7546,8 @@ class FormHelperTest extends TestCase
 
     /**
      * tests that custom validation messages are in templateVars
-     *
-     * @return void
      */
-    public function testHtml5ErrorMessageInTemplateVars()
+    public function testHtml5ErrorMessageInTemplateVars(): void
     {
         $validator = (new \Cake\Validation\Validator())
             ->notEmptyString('email', 'Custom error "message" & entities')
@@ -8024,10 +7630,8 @@ class FormHelperTest extends TestCase
      * testRequiredAttribute method
      *
      * Tests that formhelper sets required attributes.
-     *
-     * @return void
      */
-    public function testRequiredAttribute()
+    public function testRequiredAttribute(): void
     {
         $this->article['required'] = [
             'title' => true,
@@ -8080,10 +7684,8 @@ class FormHelperTest extends TestCase
      * testControlsNotNested method
      *
      * Tests that it is possible to put inputs outside of the label.
-     *
-     * @return void
      */
-    public function testControlsNotNested()
+    public function testControlsNotNested(): void
     {
         $this->Form->setTemplates([
             'nestingLabel' => '{{hidden}}{{input}}<label{{attrs}}>{{text}}</label>',
@@ -8158,10 +7760,8 @@ class FormHelperTest extends TestCase
      * testControlContainerTemplates method
      *
      * Test that *Container templates are used by input.
-     *
-     * @return void
      */
-    public function testControlContainerTemplates()
+    public function testControlContainerTemplates(): void
     {
         $this->Form->setTemplates([
             'checkboxContainer' => '<div class="check">{{content}}</div>',
@@ -8205,10 +7805,8 @@ class FormHelperTest extends TestCase
      * testFormGroupTemplates method
      *
      * Test that *Container templates are used by input.
-     *
-     * @return void
      */
-    public function testFormGroupTemplates()
+    public function testFormGroupTemplates(): void
     {
         $this->Form->setTemplates([
             'radioFormGroup' => '<div class="radio">{{label}}{{input}}</div>',
@@ -8227,10 +7825,8 @@ class FormHelperTest extends TestCase
      * testResetTemplates method
      *
      * Test resetting templates.
-     *
-     * @return void
      */
-    public function testResetTemplates()
+    public function testResetTemplates(): void
     {
         $this->Form->setTemplates(['input' => '<input/>']);
         $this->assertSame('<input/>', $this->Form->templater()->get('input'));
@@ -8243,10 +7839,8 @@ class FormHelperTest extends TestCase
      * testContext method
      *
      * Test the context method.
-     *
-     * @return void
      */
-    public function testContext()
+    public function testContext(): void
     {
         $result = $this->Form->context();
         $this->assertInstanceOf('Cake\View\Form\ContextInterface', $result);
@@ -8258,10 +7852,8 @@ class FormHelperTest extends TestCase
 
     /**
      * testAutoDomId method
-     *
-     * @return void
      */
-    public function testAutoDomId()
+    public function testAutoDomId(): void
     {
         $result = $this->Form->text('field', ['id' => true]);
         $expected = [
@@ -8317,10 +7909,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test the basic setters and getters for value sources
-     *
-     * @return void
      */
-    public function testFormValueSourcesSettersGetters()
+    public function testFormValueSourcesSettersGetters(): void
     {
         $this->View->setRequest($this->View->getRequest()
             ->withData('id', '1')
@@ -8354,7 +7944,7 @@ class FormHelperTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function testValueSourcesValidation()
+    public function testValueSourcesValidation(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value source(s): invalid, foo. Valid values are: context, data, query');
@@ -8364,10 +7954,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Tests the different input rendering values based on sources values switching
-     *
-     * @return void
      */
-    public function testFormValueSourcesSingleSwitchRendering()
+    public function testFormValueSourcesSingleSwitchRendering(): void
     {
         $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
@@ -8421,10 +8009,8 @@ class FormHelperTest extends TestCase
     /**
      * Tests the different input rendering values based on sources values switching while supplying
      * an entity (base context) and multiple sources (such as data, query)
-     *
-     * @return void
      */
-    public function testFormValueSourcesListSwitchRendering()
+    public function testFormValueSourcesListSwitchRendering(): void
     {
         $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
@@ -8467,10 +8053,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test the different form input renderings based on values sources switchings through form options
-     *
-     * @return void
      */
-    public function testFormValueSourcesSwitchViaOptionsRendering()
+    public function testFormValueSourcesSwitchViaOptionsRendering(): void
     {
         $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
@@ -8524,10 +8108,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test the different form input renderings based on values sources switchings through form options
-     *
-     * @return void
      */
-    public function testFormValueSourcesSwitchViaOptionsAndSetterRendering()
+    public function testFormValueSourcesSwitchViaOptionsAndSetterRendering(): void
     {
         $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
@@ -8562,10 +8144,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test the different form values sources resetting through From::end();
-     *
-     * @return void
      */
-    public function testFormValueSourcesResetViaEnd()
+    public function testFormValueSourcesResetViaEnd(): void
     {
         $expected = ['data', 'context'];
         $result = $this->Form->getValueSources();
@@ -8588,10 +8168,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test sources values defaults handling
-     *
-     * @return void
      */
-    public function testFormValueSourcesDefaults()
+    public function testFormValueSourcesDefaults(): void
     {
         $this->View->setRequest(
             $this->View->getRequest()->withQueryParams(['password' => 'open Sesame'])
@@ -8619,10 +8197,8 @@ class FormHelperTest extends TestCase
 
     /**
      * Test sources values schema defaults handling
-     *
-     * @return void
      */
-    public function testSourcesValueDoesntExistPassThrough()
+    public function testSourcesValueDoesntExistPassThrough(): void
     {
         $this->View->setRequest($this->View->getRequest()->withQueryParams(['category' => 'sesame-cookies']));
 
@@ -8643,10 +8219,8 @@ class FormHelperTest extends TestCase
      * testNestedLabelInput method
      *
      * Test the `nestedInput` parameter
-     *
-     * @return void
      */
-    public function testNestedLabelInput()
+    public function testNestedLabelInput(): void
     {
         $result = $this->Form->control('foo', ['nestedInput' => true]);
         $expected = [
@@ -8668,10 +8242,8 @@ class FormHelperTest extends TestCase
      * Tests to make sure `labelOptions` is rendered correctly by MultiCheckboxWidget and RadioWidget
      *
      * This test makes sure `false` excludes the label from the render
-     *
-     * @return void
      */
-    public function testControlLabelManipulationDisableLabels()
+    public function testControlLabelManipulationDisableLabels(): void
     {
         $result = $this->Form->control('test', [
             'type' => 'radio',
@@ -8724,10 +8296,8 @@ class FormHelperTest extends TestCase
      * added to the class if checked.
      *
      * Also checks to make sure any custom attributes are rendered correctly
-     *
-     * @return void
      */
-    public function testControlLabelManipulationRadios()
+    public function testControlLabelManipulationRadios(): void
     {
         $result = $this->Form->control('test', [
             'type' => 'radio',
@@ -8834,10 +8404,8 @@ class FormHelperTest extends TestCase
      * added to the class if checked.
      *
      * Also checks to make sure any custom attributes are rendered correctly
-     *
-     * @return void
      */
-    public function testControlLabelManipulationCheckboxes()
+    public function testControlLabelManipulationCheckboxes(): void
     {
         $result = $this->Form->control('checkbox1', [
             'label' => 'My checkboxes',
@@ -8946,10 +8514,8 @@ class FormHelperTest extends TestCase
      * testControlMaxLengthArrayContext method
      *
      * Test control() with maxlength attribute in Array Context.
-     *
-     * @return void
      */
-    public function testControlMaxLengthArrayContext()
+    public function testControlMaxLengthArrayContext(): void
     {
         $this->article['schema'] = [
             'title' => ['length' => 10],
@@ -8981,10 +8547,8 @@ class FormHelperTest extends TestCase
      * testControlMaxLengthEntityContext method
      *
      * Test control() with maxlength attribute in Entity Context.
-     *
-     * @return void
      */
-    public function testControlMaxLengthEntityContext()
+    public function testControlMaxLengthEntityContext(): void
     {
         $this->article['schema']['title']['length'] = 45;
 
@@ -9099,10 +8663,8 @@ class FormHelperTest extends TestCase
      * testControlMinMaxLengthEntityContext method
      *
      * Test control() with maxlength attribute in Entity Context sets the minimum val.
-     *
-     * @return void
      */
-    public function testControlMinMaxLengthEntityContext()
+    public function testControlMinMaxLengthEntityContext(): void
     {
         $validator = new Validator();
         $validator->maxLength('title', 10);
@@ -9143,10 +8705,8 @@ class FormHelperTest extends TestCase
      * testControlMaxLengthFormContext method
      *
      * Test control() with maxlength attribute in Form Context.
-     *
-     * @return void
      */
-    public function testControlMaxLengthFormContext()
+    public function testControlMaxLengthFormContext(): void
     {
         $validator = new Validator();
         $validator->maxLength('title', 10);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -63,8 +63,6 @@ class HtmlHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -86,15 +84,13 @@ class HtmlHelperTest extends TestCase
         static::setAppNamespace();
         Configure::write('Asset.timestamp', false);
 
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks(DashedRoute::class);
         });
     }
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -105,10 +101,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testLink method
-     *
-     * @return void
      */
-    public function testLink()
+    public function testLink(): void
     {
         Router::reload();
         Router::connect('/{controller}', ['action' => 'index']);
@@ -337,9 +331,6 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    /**
-     * @return void
-     */
     public function testLinkFromPath(): void
     {
         $result = $this->Html->linkFromPath('Index', 'Articles::index');
@@ -353,10 +344,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testImageTag method
-     *
-     * @return void
      */
-    public function testImageTag()
+    public function testImageTag(): void
     {
         Router::connect('/:controller', ['action' => 'index']);
         Router::connect('/:controller/:action/*');
@@ -405,10 +394,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Ensure that data URIs don't get base paths set.
-     *
-     * @return void
      */
-    public function testImageDataUriBaseDir()
+    public function testImageDataUriBaseDir(): void
     {
         $request = $this->View->getRequest()
             ->withAttribute('base', 'subdir')
@@ -430,10 +417,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test image() with query strings.
-     *
-     * @return void
      */
-    public function testImageQueryString()
+    public function testImageQueryString(): void
     {
         $result = $this->Html->image('test.gif?one=two&three=four');
         $expected = ['img' => ['src' => 'img/test.gif?one=two&amp;three=four', 'alt' => '']];
@@ -442,10 +427,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test that image works with pathPrefix.
-     *
-     * @return void
      */
-    public function testImagePathPrefix()
+    public function testImagePathPrefix(): void
     {
         $result = $this->Html->image('test.gif', ['pathPrefix' => '/my/custom/path/']);
         $expected = ['img' => ['src' => '/my/custom/path/test.gif', 'alt' => '']];
@@ -469,10 +452,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test that image() works with fullBase and a webroot not equal to /
-     *
-     * @return void
      */
-    public function testImageWithFullBase()
+    public function testImageWithFullBase(): void
     {
         $result = $this->Html->image('test.gif', ['fullBase' => true]);
         $here = $this->Html->Url->build('/', ['fullBase' => true]);
@@ -496,10 +477,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test image() with Asset.timestamp
-     *
-     * @return void
      */
-    public function testImageWithTimestampping()
+    public function testImageWithTimestampping(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -527,10 +506,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Tests creation of an image tag using a theme and asset timestamping
-     *
-     * @return void
      */
-    public function testImageTagWithTheme()
+    public function testImageTagWithTheme(): void
     {
         $this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
 
@@ -570,10 +547,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test theme assets in main webroot path
-     *
-     * @return void
      */
-    public function testThemeAssetsInMainWebrootPath()
+    public function testThemeAssetsInMainWebrootPath(): void
     {
         Configure::write('App.wwwRoot', TEST_APP . 'webroot/');
 
@@ -594,10 +569,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testStyle method
-     *
-     * @return void
      */
-    public function testStyle()
+    public function testStyle(): void
     {
         $result = $this->Html->style(['display' => 'none', 'margin' => '10px']);
         $this->assertSame('display:none; margin:10px;', $result);
@@ -608,10 +581,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testCssLink method
-     *
-     * @return void
      */
-    public function testCssLink()
+    public function testCssLink(): void
     {
         $result = $this->Html->css('screen');
         $expected = [
@@ -688,10 +659,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test that css() includes CSP nonces if available.
-     *
-     * @return void
      */
-    public function testCssWithCspNonce()
+    public function testCssWithCspNonce(): void
     {
         $nonce = 'r@nd0mV4lue';
         $request = $this->View->getRequest()->withAttribute('cspStyleNonce', $nonce);
@@ -706,10 +675,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test css() with once option.
-     *
-     * @return void
      */
-    public function testCssLinkOnce()
+    public function testCssLinkOnce(): void
     {
         $result = $this->Html->css('screen', ['once' => true]);
         $expected = [
@@ -730,10 +697,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testCssWithFullBase method
-     *
-     * @return void
      */
-    public function testCssWithFullBase()
+    public function testCssWithFullBase(): void
     {
         Configure::write('Asset.filter.css', false);
         $here = $this->Html->Url->build('/', ['fullBase' => true]);
@@ -747,10 +712,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testPluginCssLink method
-     *
-     * @return void
      */
-    public function testPluginCssLink()
+    public function testPluginCssLink(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -786,10 +749,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test use of css() and timestamping
-     *
-     * @return void
      */
-    public function testCssTimestamping()
+    public function testCssTimestamping(): void
     {
         Configure::write('debug', true);
         Configure::write('Asset.timestamp', true);
@@ -829,10 +790,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test use of css() and timestamping with plugin syntax
-     *
-     * @return void
      */
-    public function testPluginCssTimestamping()
+    public function testPluginCssTimestamping(): void
     {
         $this->loadPlugins(['TestPlugin', 'Company/TestPluginThree']);
 
@@ -880,10 +839,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Resource names must be treated differently for css() and script()
-     *
-     * @return void
      */
-    public function testBufferedCssAndScriptWithIdenticalResourceName()
+    public function testBufferedCssAndScriptWithIdenticalResourceName(): void
     {
         $this->View->expects($this->exactly(2))
             ->method('append')
@@ -897,10 +854,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test timestamp enforcement for script tags.
-     *
-     * @return void
      */
-    public function testScriptTimestamping()
+    public function testScriptTimestamping(): void
     {
         $this->skipIf(!is_writable(WWW_ROOT . 'js'), 'webroot/js is not Writable, timestamp testing has been skipped.');
         Configure::write('debug', true);
@@ -922,10 +877,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test timestamp enforcement for script tags with plugin syntax.
-     *
-     * @return void
      */
-    public function testPluginScriptTimestamping()
+    public function testPluginScriptTimestamping(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -955,10 +908,8 @@ class HtmlHelperTest extends TestCase
     /**
      * test that scripts added with uses() are only ever included once.
      * test script tag generation
-     *
-     * @return void
      */
-    public function testScript()
+    public function testScript(): void
     {
         $result = $this->Html->script('foo');
         $expected = [
@@ -1057,10 +1008,8 @@ class HtmlHelperTest extends TestCase
     /**
      * Test that content-security-policy nonces are applied if the request attribute
      * is present.
-     *
-     * @return void
      */
-    public function testScriptCspNonce()
+    public function testScriptCspNonce(): void
     {
         $nonce = 'r@ndomV4lue';
         $request = $this->View->getRequest()
@@ -1077,10 +1026,8 @@ class HtmlHelperTest extends TestCase
     /**
      * test that plugin scripts added with uses() are only ever included once.
      * test script tag generation with plugin syntax
-     *
-     * @return void
      */
-    public function testPluginScript()
+    public function testPluginScript(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -1143,10 +1090,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test that script() works with blocks.
-     *
-     * @return void
      */
-    public function testScriptWithBlocks()
+    public function testScriptWithBlocks(): void
     {
         $this->View->expects($this->exactly(2))
             ->method('append')
@@ -1164,10 +1109,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testScriptWithFullBase method
-     *
-     * @return void
      */
-    public function testScriptWithFullBase()
+    public function testScriptWithFullBase(): void
     {
         $here = $this->Html->Url->build('/', ['fullBase' => true]);
 
@@ -1189,10 +1132,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test a script file in the webroot/theme dir.
-     *
-     * @return void
      */
-    public function testScriptInTheme()
+    public function testScriptInTheme(): void
     {
         $this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
 
@@ -1215,10 +1156,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test Script block generation
-     *
-     * @return void
      */
-    public function testScriptBlock()
+    public function testScriptBlock(): void
     {
         $result = $this->Html->scriptBlock('window.foo = 2;');
         $expected = [
@@ -1268,10 +1207,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Ensure that scriptBlock() uses CSP nonces.
-     *
-     * @return void
      */
-    public function testScriptBlockCspNonce()
+    public function testScriptBlockCspNonce(): void
     {
         $nonce = 'r@ndomV4lue';
         $request = $this->View->getRequest()
@@ -1289,10 +1226,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * test script tag output buffering when using scriptStart() and scriptEnd();
-     *
-     * @return void
      */
-    public function testScriptStartAndScriptEnd()
+    public function testScriptStartAndScriptEnd(): void
     {
         $this->Html->scriptStart();
         echo 'this is some javascript';
@@ -1319,10 +1254,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testCharsetTag method
-     *
-     * @return void
      */
-    public function testCharsetTag()
+    public function testCharsetTag(): void
     {
         Configure::write('App.encoding', null);
         $result = $this->Html->charset();
@@ -1341,10 +1274,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testNestedList method
-     *
-     * @return void
      */
-    public function testNestedList()
+    public function testNestedList(): void
     {
         $list = [
             'Item 1',
@@ -1555,10 +1486,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testMeta method
-     *
-     * @return void
      */
-    public function testMeta()
+    public function testMeta(): void
     {
         Router::connect('/:controller', ['action' => 'index']);
 
@@ -1643,7 +1572,7 @@ class HtmlHelperTest extends TestCase
      * @param string $expectedUrl
      * @dataProvider dataMetaLinksProvider
      */
-    public function testMetaLinks($type, array $url, $expectedUrl)
+    public function testMetaLinks($type, array $url, $expectedUrl): void
     {
         $result = $this->Html->meta($type, $url);
         $expected = ['link' => ['href' => $expectedUrl, 'rel' => $type]];
@@ -1652,10 +1581,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test generating favicon's with meta()
-     *
-     * @return void
      */
-    public function testMetaIcon()
+    public function testMetaIcon(): void
     {
         $result = $this->Html->meta('icon', 'favicon.ico');
         $expected = [
@@ -1719,10 +1646,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test generating favicon's with meta() with theme
-     *
-     * @return void
      */
-    public function testMetaIconWithTheme()
+    public function testMetaIconWithTheme(): void
     {
         $this->Html->Url->getView()->setTheme('TestTheme');
 
@@ -1752,10 +1677,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Test the inline and block options for meta()
-     *
-     * @return void
      */
-    public function testMetaWithBlocks()
+    public function testMetaWithBlocks(): void
     {
         $this->View->expects($this->exactly(2))
             ->method('append')
@@ -1774,7 +1697,7 @@ class HtmlHelperTest extends TestCase
     /**
      * Test meta() with custom tag and block argument
      */
-    public function testMetaCustomWithBlock()
+    public function testMetaCustomWithBlock(): void
     {
         $this->View->expects($this->exactly(2))
             ->method('append')
@@ -1791,10 +1714,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testTableHeaders method
-     *
-     * @return void
      */
-    public function testTableHeaders()
+    public function testTableHeaders(): void
     {
         $result = $this->Html->tableHeaders(['ID', 'Name', 'Date']);
         $expected = ['<tr', '<th', 'ID', '/th', '<th', 'Name', '/th', '<th', 'Date', '/th', '/tr'];
@@ -1833,10 +1754,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testTableCells method
-     *
-     * @return void
      */
-    public function testTableCells()
+    public function testTableCells(): void
     {
         $tr = [
             'td content 1',
@@ -1942,10 +1861,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testTag method
-     *
-     * @return void
      */
-    public function testTag()
+    public function testTag(): void
     {
         $result = $this->Html->tag('div', 'text');
         $this->assertHtml(['<div', 'text', '/div'], $result);
@@ -1957,10 +1874,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testDiv method
-     *
-     * @return void
      */
-    public function testDiv()
+    public function testDiv(): void
     {
         $result = $this->Html->div('class-name');
         $expected = ['div' => ['class' => 'class-name']];
@@ -1983,10 +1898,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testPara method
-     *
-     * @return void
      */
-    public function testPara()
+    public function testPara(): void
     {
         $result = $this->Html->para('class-name', null);
         $expected = ['p' => ['class' => 'class-name']];
@@ -2019,10 +1932,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * testMedia method
-     *
-     * @return void
      */
-    public function testMedia()
+    public function testMedia(): void
     {
         $result = $this->Html->media('video.webm');
         $expected = ['video' => ['src' => 'files/video.webm'], '/video'];
@@ -2087,10 +1998,8 @@ class HtmlHelperTest extends TestCase
 
     /**
      * Tests that CSS and Javascript files of the same name don't conflict with the 'once' test
-     *
-     * @return void
      */
-    public function testCssAndScriptWithSameName()
+    public function testCssAndScriptWithSameName(): void
     {
         $result = $this->Html->css('foo');
         $expected = [

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -41,8 +41,6 @@ class NumberHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -55,8 +53,6 @@ class NumberHelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -88,9 +84,8 @@ class NumberHelperTest extends TestCase
      * test CakeNumber class methods are called correctly
      *
      * @dataProvider methodProvider
-     * @return void
      */
-    public function testNumberHelperProxyMethodCalls(string $method)
+    public function testNumberHelperProxyMethodCalls(string $method): void
     {
         $number = $this->getMockBuilder(NumberMock::class)
             ->addMethods([$method])
@@ -109,9 +104,8 @@ class NumberHelperTest extends TestCase
      * corresponding method of Number class.
      *
      * @dataProvider methodProvider
-     * @return void
      */
-    public function testParameterCountMatch(string $method)
+    public function testParameterCountMatch(string $method): void
     {
         $numberMethod = new ReflectionMethod(Number::class, $method);
         $helperMethod = new ReflectionMethod(NumberHelper::class, $method);
@@ -121,10 +115,8 @@ class NumberHelperTest extends TestCase
 
     /**
      * test engine override
-     *
-     * @return void
      */
-    public function testEngineOverride()
+    public function testEngineOverride(): void
     {
         $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestAppEngine']);
         $this->assertInstanceOf(TestAppEngine::class, $Number->engine());

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -47,8 +47,6 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -89,8 +87,6 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -102,10 +98,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test the templates method.
-     *
-     * @return void
      */
-    public function testTemplates()
+    public function testTemplates(): void
     {
         $result = $this->Paginator->setTemplates([
             'test' => 'val',
@@ -125,10 +119,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testHasPrevious method
-     *
-     * @return void
      */
-    public function testHasPrevious()
+    public function testHasPrevious(): void
     {
         $this->assertFalse($this->Paginator->hasPrev());
         $this->setPagingParams(['Article' => [
@@ -139,10 +131,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testHasNext method
-     *
-     * @return void
      */
-    public function testHasNext()
+    public function testHasNext(): void
     {
         $this->assertTrue($this->Paginator->hasNext());
         $this->setPagingParams(['Article' => [
@@ -153,10 +143,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testSortLinks method
-     *
-     * @return void
      */
-    public function testSortLinks()
+    public function testSortLinks(): void
     {
         $request = new ServerRequest([
             'url' => '/accounts/',
@@ -321,7 +309,7 @@ class PaginatorHelperTest extends TestCase
     /**
      * test sort() with escape option
      */
-    public function testSortEscape()
+    public function testSortEscape(): void
     {
         $result = $this->Paginator->sort('title', 'TestTitle >');
         $expected = [
@@ -345,10 +333,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test that sort() works with virtual field order options.
-     *
-     * @return void
      */
-    public function testSortLinkWithVirtualField()
+    public function testSortLinkWithVirtualField(): void
     {
         $request = new ServerRequest([
             'url' => '/accounts/',
@@ -408,10 +394,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testSortLinksUsingDirectionOption method
-     *
-     * @return void
      */
-    public function testSortLinksUsingDirectionOption()
+    public function testSortLinksUsingDirectionOption(): void
     {
         $request = new ServerRequest([
             'url' => '/accounts/',
@@ -444,10 +428,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testSortLinksUsingDotNotation method
-     *
-     * @return void
      */
-    public function testSortLinksUsingDotNotation()
+    public function testSortLinksUsingDotNotation(): void
     {
         $request = new ServerRequest([
             'url' => '/accounts/',
@@ -518,10 +500,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test multiple pagination sort links
-     *
-     * @return void
      */
-    public function testSortLinksMultiplePagination()
+    public function testSortLinksMultiplePagination(): void
     {
         $request = new ServerRequest([
             'url' => '/accounts/',
@@ -578,10 +558,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test creating paging links for missing models.
-     *
-     * @return void
      */
-    public function testPagingLinksMissingModel()
+    public function testPagingLinksMissingModel(): void
     {
         $result = $this->Paginator->sort('title', 'Title', ['model' => 'Missing']);
         $expected = [
@@ -614,10 +592,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testSortKey method
-     *
-     * @return void
      */
-    public function testSortKey()
+    public function testSortKey(): void
     {
         $result = $this->Paginator->sortKey('Article', ['sort' => 'Article.title']);
         $this->assertSame('Article.title', $result);
@@ -629,10 +605,8 @@ class PaginatorHelperTest extends TestCase
     /**
      * Test that sortKey falls back to the default sorting options set
      * in the $params which are the default pagination options.
-     *
-     * @return void
      */
-    public function testSortKeyFallbackToParams()
+    public function testSortKeyFallbackToParams(): void
     {
         $this->setPagingParams([
             'Article' => [
@@ -660,10 +634,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testSortDir method
-     *
-     * @return void
      */
-    public function testSortDir()
+    public function testSortDir(): void
     {
         $result = $this->Paginator->sortDir();
         $expected = 'asc';
@@ -723,10 +695,8 @@ class PaginatorHelperTest extends TestCase
     /**
      * Test that sortDir falls back to the default sorting options set
      * in the $params which are the default pagination options.
-     *
-     * @return void
      */
-    public function testSortDirFallbackToParams()
+    public function testSortDirFallbackToParams(): void
     {
         $this->setPagingParams([
             'Article' => [
@@ -757,10 +727,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testSortAdminLinks method
-     *
-     * @return void
      */
-    public function testSortAdminLinks()
+    public function testSortAdminLinks(): void
     {
         Router::reload();
         Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
@@ -811,10 +779,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test that generated URLs work without sort defined within the request
-     *
-     * @return void
      */
-    public function testDefaultSortAndNoSort()
+    public function testDefaultSortAndNoSort(): void
     {
         $request = new ServerRequest([
             'url' => '/articles/index',
@@ -847,10 +813,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testUrlGeneration method
-     *
-     * @return void
      */
-    public function testUrlGeneration()
+    public function testUrlGeneration(): void
     {
         $result = $this->Paginator->sort('controller');
         $expected = [
@@ -912,7 +876,7 @@ class PaginatorHelperTest extends TestCase
      * @param string $expected
      * @dataProvider urlGenerationResetsToPage1Provider
      */
-    public function testUrlGenerationResetsToPage1($field, $options, $expected)
+    public function testUrlGenerationResetsToPage1($field, $options, $expected): void
     {
         $this->setPagingParams([
             'Article' => [
@@ -961,10 +925,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test URL generation with prefix routes
-     *
-     * @return void
      */
-    public function testGenerateUrlWithPrefixes()
+    public function testGenerateUrlWithPrefixes(): void
     {
         Router::reload();
         Router::connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
@@ -1038,10 +1000,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test URL generation can leave prefix routes
-     *
-     * @return void
      */
-    public function testGenerateUrlWithPrefixesLeavePrefix()
+    public function testGenerateUrlWithPrefixesLeavePrefix(): void
     {
         Router::reload();
         Router::connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
@@ -1079,10 +1039,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test generateUrl with multiple pagination
-     *
-     * @return void
      */
-    public function testGenerateUrlMultiplePagination()
+    public function testGenerateUrlMultiplePagination(): void
     {
         $request = new ServerRequest([
             'url' => '/Posts/index',
@@ -1146,10 +1104,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test generateUrl with multiple pagination and query string values
-     *
-     * @return void
      */
-    public function testGenerateUrlMultiplePaginationQueryStringData()
+    public function testGenerateUrlMultiplePaginationQueryStringData(): void
     {
         $request = new ServerRequest([
             'url' => '/Posts/index',
@@ -1187,10 +1143,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testOptions method
-     *
-     * @return void
      */
-    public function testOptions()
+    public function testOptions(): void
     {
         $this->Paginator->options = [];
         $this->View->setRequest($this->View->getRequest()->withAttribute('params', []));
@@ -1231,10 +1185,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testPassedArgsMergingWithUrlOptions method
-     *
-     * @return void
      */
-    public function testPassedArgsMergingWithUrlOptions()
+    public function testPassedArgsMergingWithUrlOptions(): void
     {
         $request = new ServerRequest([
             'url' => '/articles/',
@@ -1290,10 +1242,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test that generated URLs don't include sort and direction parameters
-     *
-     * @return void
      */
-    public function testDefaultSortRemovedFromUrl()
+    public function testDefaultSortRemovedFromUrl(): void
     {
         $request = new ServerRequest([
             'url' => '/Articles/',
@@ -1324,10 +1274,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Tests that generated default order URL doesn't include sort and direction parameters.
-     *
-     * @return void
      */
-    public function testDefaultSortRemovedFromUrlWithAliases()
+    public function testDefaultSortRemovedFromUrlWithAliases(): void
     {
         $request = new ServerRequest([
             'params' => ['controller' => 'Articles', 'action' => 'index', 'plugin' => null],
@@ -1357,10 +1305,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test the prev() method.
-     *
-     * @return void
      */
-    public function testPrev()
+    public function testPrev(): void
     {
         $this->setPagingParams([
             'Client' => [
@@ -1424,10 +1370,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test that prev() and the shared implementation underneath picks up from options
-     *
-     * @return void
      */
-    public function testPrevWithOptions()
+    public function testPrevWithOptions(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -1450,10 +1394,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the next() method.
-     *
-     * @return void
      */
-    public function testNext()
+    public function testNext(): void
     {
         $result = $this->Paginator->next('Next >>');
         $expected = [
@@ -1490,10 +1432,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test next() with disabled links
-     *
-     * @return void
      */
-    public function testNextDisabled()
+    public function testNextDisabled(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -1531,10 +1471,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test next() with a model argument.
-     *
-     * @return void
      */
-    public function testNextAndPrevNonDefaultModel()
+    public function testNextAndPrevNonDefaultModel(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -1593,10 +1531,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testNumbers method
-     *
-     * @return void
      */
-    public function testNumbers()
+    public function testNumbers(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
@@ -1877,10 +1813,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test for URLs with paging params as route placeholders instead of query string params.
-     *
-     * @return void
      */
-    public function testRoutePlaceholder()
+    public function testRoutePlaceholder(): void
     {
         Router::reload();
         Router::connect('/{controller}/{action}/{page}');
@@ -1936,10 +1870,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testNumbersPages method
-     *
-     * @return void
      */
-    public function testNumbersMulti()
+    public function testNumbersMulti(): void
     {
         $expected = [
             1 => '*1 2 3 4 5 6 7 ',
@@ -2126,7 +2058,7 @@ class PaginatorHelperTest extends TestCase
      * @param array $options Options for PaginatorHelper::numbers
      * @return string[]
      */
-    protected function getNumbersForMultiplePages($pagesToCheck, $pageCount, $options = [])
+    protected function getNumbersForMultiplePages($pagesToCheck, $pageCount, $options = []): array
     {
         $options['templates'] = [
             'first' => '<{{text}} ',
@@ -2157,10 +2089,8 @@ class PaginatorHelperTest extends TestCase
      * Test that numbers() lets you overwrite templates.
      *
      * The templates file has no li elements.
-     *
-     * @return void
      */
-    public function testNumbersTemplates()
+    public function testNumbersTemplates(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2195,10 +2125,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test modulus option for numbers()
-     *
-     * @return void
      */
-    public function testNumbersModulus()
+    public function testNumbersModulus(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2382,10 +2310,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test modulus option for numbers()
-     *
-     * @return void
      */
-    public function testNumbersModulusMulti()
+    public function testNumbersModulusMulti(): void
     {
         $expected = [
             1 => '*1 2 3 4 ',
@@ -2457,10 +2383,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Tests that disabling modulus displays all page links.
-     *
-     * @return void
      */
-    public function testModulusDisabled()
+    public function testModulusDisabled(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2487,10 +2411,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test that numbers() with url options.
-     *
-     * @return void
      */
-    public function testNumbersWithUrlOptions()
+    public function testNumbersWithUrlOptions(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2545,10 +2467,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test numbers() with routing parameters.
-     *
-     * @return void
      */
-    public function testNumbersRouting()
+    public function testNumbersRouting(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2578,10 +2498,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test that numbers() works with the non default model.
-     *
-     * @return void
      */
-    public function testNumbersNonDefaultModel()
+    public function testNumbersNonDefaultModel(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2612,10 +2530,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test first() and last() with tag options
-     *
-     * @return void
      */
-    public function testFirstAndLastTag()
+    public function testFirstAndLastTag(): void
     {
         $this->setPagingParams(['Article' => [
             'page' => 2,
@@ -2674,10 +2590,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test that on the last page you don't get a link ot the last page.
-     *
-     * @return void
      */
-    public function testLastNoOutput()
+    public function testLastNoOutput(): void
     {
         $this->setPagingParams(['Article' => [
             'page' => 15,
@@ -2691,10 +2605,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test first() with a the model parameter.
-     *
-     * @return void
      */
-    public function testFirstNonDefaultModel()
+    public function testFirstNonDefaultModel(): void
     {
         $this->setPagingParams([
             'Article' => ['page' => 1],
@@ -2724,10 +2636,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test first() on the first page.
-     *
-     * @return void
      */
-    public function testFirstEmpty()
+    public function testFirstEmpty(): void
     {
         $this->View->setRequest($this->View->getRequest()->withParam('paging.Article.page', 1));
 
@@ -2738,10 +2648,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test first() and options()
-     *
-     * @return void
      */
-    public function testFirstFullBaseUrl()
+    public function testFirstFullBaseUrl(): void
     {
         $this->setPagingParams(['Article' => [
             'page' => 3,
@@ -2766,10 +2674,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test first() on the fence-post
-     *
-     * @return void
      */
-    public function testFirstBoundaries()
+    public function testFirstBoundaries(): void
     {
         $this->setPagingParams(['Article' => ['page' => 3]]);
         $result = $this->Paginator->first();
@@ -2802,10 +2708,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test params() method
-     *
-     * @return void
      */
-    public function testParams()
+    public function testParams(): void
     {
         $result = $this->Paginator->params();
         $this->assertArrayHasKey('page', $result);
@@ -2817,10 +2721,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test param() method
-     *
-     * @return void
      */
-    public function testParam()
+    public function testParam(): void
     {
         $result = $this->Paginator->param('count');
         $this->assertSame(62, $result);
@@ -2831,10 +2733,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test last() method
-     *
-     * @return void
      */
-    public function testLast()
+    public function testLast(): void
     {
         $result = $this->Paginator->last();
         $expected = [
@@ -2885,10 +2785,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the options for last()
-     *
-     * @return void
      */
-    public function testLastOptions()
+    public function testLastOptions(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -2936,10 +2834,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test last() with a the model parameter.
-     *
-     * @return void
      */
-    public function testLastNonDefaultModel()
+    public function testLastNonDefaultModel(): void
     {
         $this->setPagingParams([
             'Article' => ['page' => 7],
@@ -2969,10 +2865,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testCounter method
-     *
-     * @return void
      */
-    public function testCounter()
+    public function testCounter(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -3012,10 +2906,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Tests that numbers are formatted according to the locale when using counter()
-     *
-     * @return void
      */
-    public function testCounterBigNumbers()
+    public function testCounterBigNumbers(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Client' => [
@@ -3051,10 +2943,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testHasPage method
-     *
-     * @return void
      */
-    public function testHasPage()
+    public function testHasPage(): void
     {
         $result = $this->Paginator->hasPage(15, 'Article');
         $this->assertFalse($result);
@@ -3071,10 +2961,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * testNextLinkUsingDotNotation method
-     *
-     * @return void
      */
-    public function testNextLinkUsingDotNotation()
+    public function testNextLinkUsingDotNotation(): void
     {
         $request = new ServerRequest([
             'url' => '/Accounts/index',
@@ -3117,10 +3005,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the current() method
-     *
-     * @return void
      */
-    public function testCurrent()
+    public function testCurrent(): void
     {
         $result = $this->Paginator->current();
         $params = $this->View->getRequest()->getAttribute('paging');
@@ -3132,10 +3018,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the total() method
-     *
-     * @return void
      */
-    public function testTotal()
+    public function testTotal(): void
     {
         $result = $this->Paginator->total();
         $params = $this->View->getRequest()->getAttribute('paging');
@@ -3147,10 +3031,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the defaultModel() method
-     *
-     * @return void
      */
-    public function testNoDefaultModel()
+    public function testNoDefaultModel(): void
     {
         $this->View->setRequest(new ServerRequest());
         $this->assertNull($this->Paginator->defaultModel());
@@ -3164,10 +3046,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the numbers() method when there is only one page
-     *
-     * @return void
      */
-    public function testWithOnePage()
+    public function testWithOnePage(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
@@ -3186,10 +3066,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the numbers() method when there is only one page
-     *
-     * @return void
      */
-    public function testWithZeroPages()
+    public function testWithZeroPages(): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
@@ -3266,7 +3144,7 @@ class PaginatorHelperTest extends TestCase
      * @param string $expected
      * @dataProvider dataMetaProvider
      */
-    public function testMeta($page, $prevPage, $nextPage, $pageCount, $options, $expected)
+    public function testMeta($page, $prevPage, $nextPage, $pageCount, $options, $expected): void
     {
         $this->View->setRequest($this->View->getRequest()->withAttribute('paging', [
             'Article' => [
@@ -3292,10 +3170,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the limitControl() method
-     *
-     * @return void
      */
-    public function testLimitControl()
+    public function testLimitControl(): void
     {
         $out = $this->Paginator->limitControl([1 => 1]);
         $expected = [
@@ -3383,10 +3259,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * test the limitControl() method with defaults and query
-     *
-     * @return void
      */
-    public function testLimitControlQuery()
+    public function testLimitControlQuery(): void
     {
         $out = $this->Paginator->limitControl([], 50);
         $expected = [
@@ -3438,10 +3312,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test using paging params set by SimplePaginator which doesn't do count query.
-     *
-     * @return void
      */
-    public function testMethodsWhenThereIsNoPageCount()
+    public function testMethodsWhenThereIsNoPageCount(): void
     {
         $request = new ServerRequest([
             'url' => '/',
@@ -3491,7 +3363,7 @@ class PaginatorHelperTest extends TestCase
     /**
      * @param mixed $params
      */
-    protected function setPagingParams($params, bool $merge = true)
+    protected function setPagingParams($params, bool $merge = true): void
     {
         if ($merge) {
             $params = Hash::merge($this->View->getRequest()->getAttribute('paging'), $params);
@@ -3501,10 +3373,8 @@ class PaginatorHelperTest extends TestCase
 
     /**
      * Test that generates a URL that keeps the passed parameters
-     *
-     * @return void
      */
-    public function testPaginationWithPassedParams()
+    public function testPaginationWithPassedParams(): void
     {
         $request = new ServerRequest([
             'url' => '/articles/index/whatever/3',

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -42,8 +42,6 @@ class TextHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -57,8 +55,6 @@ class TextHelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -69,10 +65,8 @@ class TextHelperTest extends TestCase
 
     /**
      * test String class methods are called correctly
-     *
-     * @return void
      */
-    public function testTextHelperProxyMethodCalls()
+    public function testTextHelperProxyMethodCalls(): void
     {
         $methods = [
             'stripLinks', 'toList',
@@ -129,10 +123,8 @@ class TextHelperTest extends TestCase
 
     /**
      * test engine override
-     *
-     * @return void
      */
-    public function testEngineOverride()
+    public function testEngineOverride(): void
     {
         $Text = new TextHelperTestObject($this->View, ['engine' => 'TestAppEngine']);
         $this->assertInstanceOf(TestAppEngine::class, $Text->engine());
@@ -145,10 +137,8 @@ class TextHelperTest extends TestCase
 
     /**
      * testAutoLink method
-     *
-     * @return void
      */
-    public function testAutoLink()
+    public function testAutoLink(): void
     {
         $text = 'The AWWWARD show happened today';
         $result = $this->Text->autoLink($text);
@@ -212,10 +202,8 @@ class TextHelperTest extends TestCase
 
     /**
      * Test mixing URLs and Email addresses in one confusing string.
-     *
-     * @return void
      */
-    public function testAutoLinkMixed()
+    public function testAutoLinkMixed(): void
     {
         $text = 'Text with a url/email http://example.com/store?email=mark@example.com and email.';
         $expected = 'Text with a url/email <a href="http://example.com/store?email=mark@example.com">' .
@@ -226,10 +214,8 @@ class TextHelperTest extends TestCase
 
     /**
      * test autoLink() and options.
-     *
-     * @return void
      */
-    public function testAutoLinkOptions()
+    public function testAutoLinkOptions(): void
     {
         $text = 'This is a test text with URL http://www.cakephp.org';
         $expected = 'This is a test text with URL <a href="http://www.cakephp.org" class="link">http://www.cakephp.org</a>';
@@ -244,10 +230,8 @@ class TextHelperTest extends TestCase
 
     /**
      * Test escaping for autoLink
-     *
-     * @return void
      */
-    public function testAutoLinkEscape()
+    public function testAutoLinkEscape(): void
     {
         $text = 'This is a <b>test</b> text with URL http://www.cakephp.org';
         $expected = 'This is a &lt;b&gt;test&lt;/b&gt; text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>';
@@ -390,9 +374,8 @@ class TextHelperTest extends TestCase
      * testAutoLinkUrls method
      *
      * @dataProvider autoLinkProvider
-     * @return void
      */
-    public function testAutoLinkUrls(string $text, string $expected)
+    public function testAutoLinkUrls(string $text, string $expected): void
     {
         $result = $this->Text->autoLinkUrls($text);
         $this->assertEquals($expected, $result);
@@ -400,10 +383,8 @@ class TextHelperTest extends TestCase
 
     /**
      * Test the options for autoLinkUrls
-     *
-     * @return void
      */
-    public function testAutoLinkUrlsOptions()
+    public function testAutoLinkUrlsOptions(): void
     {
         $text = 'Text with a partial www.cakephp.org URL';
         $expected = 'Text with a partial <a href="http://www.cakephp.org" \s*class="link">www.cakephp.org</a> URL';
@@ -418,10 +399,8 @@ class TextHelperTest extends TestCase
 
     /**
      * Test autoLinkUrls with the escape option.
-     *
-     * @return void
      */
-    public function testAutoLinkUrlsEscape()
+    public function testAutoLinkUrlsEscape(): void
     {
         $text = 'Text with a partial <a href="http://www.example.com">http://www.example.com</a> link';
         $expected = 'Text with a partial <a href="http://www.example.com">http://www.example.com</a> link';
@@ -471,10 +450,8 @@ class TextHelperTest extends TestCase
 
     /**
      * Test autoLinkUrls with query strings.
-     *
-     * @return void
      */
-    public function testAutoLinkUrlsQueryString()
+    public function testAutoLinkUrlsQueryString(): void
     {
         $text = 'Text with a partial http://www.cakephp.org?product_id=123&foo=bar link';
         $expected = 'Text with a partial <a href="http://www.cakephp.org?product_id=123&amp;foo=bar">http://www.cakephp.org?product_id=123&amp;foo=bar</a> link';
@@ -556,9 +533,8 @@ class TextHelperTest extends TestCase
      * @param string $text The text to link
      * @param string $expected The expected results.
      * @dataProvider autoLinkEmailProvider
-     * @return void
      */
-    public function testAutoLinkEmails(string $text, string $expected, array $attrs = [])
+    public function testAutoLinkEmails(string $text, string $expected, array $attrs = []): void
     {
         $result = $this->Text->autoLinkEmails($text, $attrs);
         $this->assertSame($expected, $result);
@@ -566,10 +542,8 @@ class TextHelperTest extends TestCase
 
     /**
      * test invalid email addresses.
-     *
-     * @return void
      */
-    public function testAutoLinkEmailInvalid()
+    public function testAutoLinkEmailInvalid(): void
     {
         $result = $this->Text->autoLinkEmails('this is a myaddress@gmx-de test');
         $expected = 'this is a myaddress@gmx-de test';
@@ -578,10 +552,8 @@ class TextHelperTest extends TestCase
 
     /**
      * testAutoParagraph method
-     *
-     * @return void
      */
-    public function testAutoParagraph()
+    public function testAutoParagraph(): void
     {
         $text = 'This is a test text';
         $expected = <<<TEXT
@@ -641,10 +613,9 @@ TEXT;
      * @param string $string String
      * @param array $options Options
      * @param String $expected Expected string
-     * @return void
      * @dataProvider slugInputProvider
      */
-    public function testSlug($string, $options, $expected)
+    public function testSlug($string, $options, $expected): void
     {
         $result = $this->Text->slug($string, $options);
         $this->assertSame($expected, $result);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -44,8 +44,6 @@ class TimeHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -58,8 +56,6 @@ class TimeHelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -70,10 +66,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * Test element wrapping in timeAgoInWords
-     *
-     * @return void
      */
-    public function testTimeAgoInWords()
+    public function testTimeAgoInWords(): void
     {
         $Time = new TimeHelper($this->View);
         $timestamp = strtotime('+8 years, +4 months +2 weeks +3 days');
@@ -127,10 +121,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * Test output timezone with timeAgoInWords
-     *
-     * @return void
      */
-    public function testTimeAgoInWordsOutputTimezone()
+    public function testTimeAgoInWordsOutputTimezone(): void
     {
         $Time = new TimeHelper($this->View, ['outputTimezone' => 'America/Vancouver']);
         $timestamp = new Time('+8 years, +4 months +2 weeks +3 days');
@@ -154,10 +146,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testToQuarter method
-     *
-     * @return void
      */
-    public function testToQuarter()
+    public function testToQuarter(): void
     {
         $this->assertSame(4, $this->Time->toQuarter('2007-12-25'));
         $this->assertEquals(['2007-10-01', '2007-12-31'], $this->Time->toQuarter('2007-12-25', true));
@@ -165,10 +155,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testNice method
-     *
-     * @return void
      */
-    public function testNice()
+    public function testNice(): void
     {
         $time = '2014-04-20 20:00';
         $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $this->Time->nice($time));
@@ -179,10 +167,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * test nice with outputTimezone
-     *
-     * @return void
      */
-    public function testNiceOutputTimezone()
+    public function testNiceOutputTimezone(): void
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $time = '2014-04-20 20:00';
@@ -191,20 +177,16 @@ class TimeHelperTest extends TestCase
 
     /**
      * testToUnix method
-     *
-     * @return void
      */
-    public function testToUnix()
+    public function testToUnix(): void
     {
         $this->assertSame('1397980800', $this->Time->toUnix('2014-04-20 08:00:00'));
     }
 
     /**
      * testToAtom method
-     *
-     * @return void
      */
-    public function testToAtom()
+    public function testToAtom(): void
     {
         $dateTime = new \DateTime();
         $this->assertSame($dateTime->format($dateTime::ATOM), $this->Time->toAtom($dateTime->getTimestamp()));
@@ -212,10 +194,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testToAtom method
-     *
-     * @return void
      */
-    public function testToAtomOutputTimezone()
+    public function testToAtomOutputTimezone(): void
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $dateTime = new Time();
@@ -226,10 +206,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testToRss method
-     *
-     * @return void
      */
-    public function testToRss()
+    public function testToRss(): void
     {
         $date = '2012-08-12 12:12:45';
         $time = strtotime($date);
@@ -246,10 +224,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * test toRss with outputTimezone
-     *
-     * @return void
      */
-    public function testToRssOutputTimezone()
+    public function testToRssOutputTimezone(): void
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $dateTime = new Time();
@@ -261,20 +237,16 @@ class TimeHelperTest extends TestCase
 
     /**
      * testOfGmt method
-     *
-     * @return void
      */
-    public function testGmt()
+    public function testGmt(): void
     {
         $this->assertSame('1397980800', $this->Time->gmt('2014-04-20 08:00:00'));
     }
 
     /**
      * testIsToday method
-     *
-     * @return void
      */
-    public function testIsToday()
+    public function testIsToday(): void
     {
         $result = $this->Time->isToday('+1 day');
         $this->assertFalse($result);
@@ -291,10 +263,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testIsFuture method
-     *
-     * @return void
      */
-    public function testIsFuture()
+    public function testIsFuture(): void
     {
         $this->assertTrue($this->Time->isFuture('+1 month'));
         $this->assertTrue($this->Time->isFuture('+1 days'));
@@ -309,10 +279,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testIsPast method
-     *
-     * @return void
      */
-    public function testIsPast()
+    public function testIsPast(): void
     {
         $this->assertFalse($this->Time->isPast('+1 month'));
         $this->assertFalse($this->Time->isPast('+1 days'));
@@ -327,10 +295,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testIsThisWeek method
-     *
-     * @return void
      */
-    public function testIsThisWeek()
+    public function testIsThisWeek(): void
     {
         // A map of days which goes from -1 day of week to +1 day of week
         $map = [
@@ -349,10 +315,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testIsThisMonth method
-     *
-     * @return void
      */
-    public function testIsThisMonth()
+    public function testIsThisMonth(): void
     {
         $result = $this->Time->isThisMonth('+0 day');
         $this->assertTrue($result);
@@ -366,10 +330,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testIsThisYear method
-     *
-     * @return void
      */
-    public function testIsThisYear()
+    public function testIsThisYear(): void
     {
         $result = $this->Time->isThisYear('+0 day');
         $this->assertTrue($result);
@@ -379,10 +341,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testWasYesterday method
-     *
-     * @return void
      */
-    public function testWasYesterday()
+    public function testWasYesterday(): void
     {
         $result = $this->Time->wasYesterday('+1 day');
         $this->assertFalse($result);
@@ -400,10 +360,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testIsTomorrow method
-     *
-     * @return void
      */
-    public function testIsTomorrow()
+    public function testIsTomorrow(): void
     {
         $result = $this->Time->isTomorrow('+1 day');
         $this->assertTrue($result);
@@ -417,10 +375,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testWasWithinLast method
-     *
-     * @return void
      */
-    public function testWasWithinLast()
+    public function testWasWithinLast(): void
     {
         $this->assertTrue($this->Time->wasWithinLast('1 day', '-1 day'));
         $this->assertTrue($this->Time->wasWithinLast('1 week', '-1 week'));
@@ -460,10 +416,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * testisWithinNext method
-     *
-     * @return void
      */
-    public function testIsWithinNext()
+    public function testIsWithinNext(): void
     {
         $this->assertFalse($this->Time->isWithinNext('1 day', '-1 day'));
         $this->assertFalse($this->Time->isWithinNext('1 week', '-1 week'));
@@ -506,10 +460,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * test formatting dates taking in account preferred i18n locale file
-     *
-     * @return void
      */
-    public function testFormat()
+    public function testFormat(): void
     {
         $time = strtotime('Thu Jan 14 13:59:28 2010');
 
@@ -535,10 +487,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * test format with outputTimezone
-     *
-     * @return void
      */
-    public function testFormatOutputTimezone()
+    public function testFormatOutputTimezone(): void
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
 
@@ -555,10 +505,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * test i18nFormat with outputTimezone
-     *
-     * @return void
      */
-    public function testI18nFormatOutputTimezone()
+    public function testI18nFormatOutputTimezone(): void
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
 
@@ -570,10 +518,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * Test format() with a string.
-     *
-     * @return void
      */
-    public function testFormatString()
+    public function testFormatString(): void
     {
         $time = '2010-01-14 13:59:28';
         $result = $this->Time->format($time);
@@ -585,10 +531,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * Test format() with a Time instance.
-     *
-     * @return void
      */
-    public function testFormatTimeInstance()
+    public function testFormatTimeInstance(): void
     {
         $time = new Time('2010-01-14 13:59:28', 'America/New_York');
         $result = $this->Time->format($time, 'HH:mm', null, 'America/New_York');
@@ -605,9 +549,8 @@ class TimeHelperTest extends TestCase
      *
      * @param string $expected
      * @param string $result
-     * @return void
      */
-    public function assertTimeFormat($expected, $result)
+    public function assertTimeFormat($expected, $result): void
     {
         $this->assertSame(
             str_replace([',', '(', ')', ' at', ' à'], '', $expected),
@@ -617,10 +560,8 @@ class TimeHelperTest extends TestCase
 
     /**
      * Test formatting in case the $time parameter is not set
-     *
-     * @return void
      */
-    public function testNullDateFormat()
+    public function testNullDateFormat(): void
     {
         $result = $this->Time->format(null);
         $this->assertFalse($result);

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -44,8 +44,6 @@ class UrlHelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -60,15 +58,13 @@ class UrlHelperTest extends TestCase
 
         static::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
-        Router::scope('/', function (RouteBuilder $routes) {
+        Router::scope('/', function (RouteBuilder $routes): void {
             $routes->fallbacks(DashedRoute::class);
         });
     }
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -80,10 +76,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Ensure HTML escaping of URL params. So link addresses are valid and not exploited
-     *
-     * @return void
      */
-    public function testBuildUrlConversion()
+    public function testBuildUrlConversion(): void
     {
         Router::connect('/:controller/:action/*');
 
@@ -120,10 +114,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * ensure that build factors in base paths.
-     *
-     * @return void
      */
-    public function testBuildBasePath()
+    public function testBuildBasePath(): void
     {
         Router::connect('/:controller/:action/*');
         $request = new ServerRequest([
@@ -145,10 +137,7 @@ class UrlHelperTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testBuildUrlConversionUnescaped()
+    public function testBuildUrlConversionUnescaped(): void
     {
         $result = $this->Helper->build('/controller/action/1?one=1&two=2', ['escape' => false]);
         $this->assertSame('/controller/action/1?one=1&two=2', $result);
@@ -165,9 +154,6 @@ class UrlHelperTest extends TestCase
         $this->assertSame('/posts/view?k=v&1=2&param=%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524', $result);
     }
 
-    /**
-     * @return void
-     */
     public function testBuildFromPath(): void
     {
         $result = $this->Helper->buildFromPath('Articles::index');
@@ -181,10 +167,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test assetTimestamp application
-     *
-     * @return void
      */
-    public function testAssetTimestamp()
+    public function testAssetTimestamp(): void
     {
         Configure::write('Foo.bar', 'test');
         Configure::write('Asset.timestamp', false);
@@ -222,10 +206,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test assetUrl application
-     *
-     * @return void
      */
-    public function testAssetUrl()
+    public function testAssetUrl(): void
     {
         $this->Helper->webroot = '';
         $result = $this->Helper->assetUrl('js/post.js', ['fullBase' => true]);
@@ -255,10 +237,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test assetUrl and data uris
-     *
-     * @return void
      */
-    public function testAssetUrlDataUri()
+    public function testAssetUrlDataUri(): void
     {
         $request = $this->View->getRequest()
             ->withAttribute('base', 'subdir')
@@ -279,10 +259,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test assetUrl with no rewriting.
-     *
-     * @return void
      */
-    public function testAssetUrlNoRewrite()
+    public function testAssetUrlNoRewrite(): void
     {
         $request = Router::getRequest()
             ->withAttribute('base', '/cake_dev/index.php')
@@ -297,10 +275,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test assetUrl with plugins.
-     *
-     * @return void
      */
-    public function testAssetUrlPlugin()
+    public function testAssetUrlPlugin(): void
     {
         $this->Helper->webroot = '';
         $this->loadPlugins(['TestPlugin']);
@@ -316,10 +292,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Tests assetUrl() with full base URL.
-     *
-     * @return void
      */
-    public function testAssetUrlFullBase()
+    public function testAssetUrlFullBase(): void
     {
         $result = $this->Helper->assetUrl('img/foo.jpg', ['fullBase' => true]);
         $this->assertSame(Router::fullBaseUrl() . '/img/foo.jpg', $result);
@@ -330,10 +304,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test assetUrl and Asset.timestamp = force
-     *
-     * @return void
      */
-    public function testAssetUrlTimestampForce()
+    public function testAssetUrlTimestampForce(): void
     {
         $this->Helper->webroot = '';
         Configure::write('Asset.timestamp', 'force');
@@ -344,10 +316,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test assetTimestamp with timestamp option overriding `Asset.timestamp` in Configure.
-     *
-     * @return void
      */
-    public function testAssetTimestampConfigureOverride()
+    public function testAssetTimestampConfigureOverride(): void
     {
         $this->Helper->webroot = '';
         Configure::write('Asset.timestamp', 'force');
@@ -359,10 +329,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test assetTimestamp with plugins and themes
-     *
-     * @return void
      */
-    public function testAssetTimestampPluginsAndThemes()
+    public function testAssetTimestampPluginsAndThemes(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $this->loadPlugins(['TestPlugin']);
@@ -382,10 +350,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test script()
-     *
-     * @return void
      */
-    public function testScript()
+    public function testScript(): void
     {
         $this->Helper->webroot = '';
         $result = $this->Helper->script(
@@ -397,10 +363,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test script and Asset.timestamp = force
-     *
-     * @return void
      */
-    public function testScriptTimestampForce()
+    public function testScriptTimestampForce(): void
     {
         $this->Helper->webroot = '';
         Configure::write('Asset.timestamp', 'force');
@@ -411,10 +375,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test script with timestamp option overriding `Asset.timestamp` in Configure
-     *
-     * @return void
      */
-    public function testScriptTimestampConfigureOverride()
+    public function testScriptTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -425,10 +387,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test image()
-     *
-     * @return void
      */
-    public function testImage()
+    public function testImage(): void
     {
         $result = $this->Helper->image('foo.jpg');
         $this->assertSame('img/foo.jpg', $result);
@@ -454,10 +414,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test image with `Asset.timestamp` = force
-     *
-     * @return void
      */
-    public function testImageTimestampForce()
+    public function testImageTimestampForce(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -467,10 +425,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test image with timestamp option overriding `Asset.timestamp` in Configure
-     *
-     * @return void
      */
-    public function testImageTimestampConfigureOverride()
+    public function testImageTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -481,10 +437,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * test css
-     *
-     * @return void
      */
-    public function testCss()
+    public function testCss(): void
     {
         $result = $this->Helper->css('style');
         $this->assertSame('css/style.css', $result);
@@ -492,10 +446,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test css with `Asset.timestamp` = force
-     *
-     * @return void
      */
-    public function testCssTimestampForce()
+    public function testCssTimestampForce(): void
     {
         Configure::write('Asset.timestamp', 'force');
 
@@ -505,10 +457,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test image with timestamp option overriding `Asset.timestamp` in Configure
-     *
-     * @return void
      */
-    public function testCssTimestampConfigureOverride()
+    public function testCssTimestampConfigureOverride(): void
     {
         Configure::write('Asset.timestamp', 'force');
         $timestamp = false;
@@ -519,10 +469,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test generating paths with webroot().
-     *
-     * @return void
      */
-    public function testWebrootPaths()
+    public function testWebrootPaths(): void
     {
         $request = $this->View->getRequest()->withAttribute('webroot', '/');
         $this->View->setRequest(
@@ -567,10 +515,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test plugin based assets will NOT use the plugin name
-     *
-     * @return void
      */
-    public function testPluginAssetsPrependImageBaseUrl()
+    public function testPluginAssetsPrependImageBaseUrl(): void
     {
         $cdnPrefix = 'https://cdn.example.com/';
         $imageBaseUrl = Configure::read('App.imageBaseUrl');
@@ -594,10 +540,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test if an app Asset class is being loaded
-     *
-     * @return void
      */
-    public function testAppAssetPresent()
+    public function testAppAssetPresent(): void
     {
         $Url = new UrlHelper($this->View, ['assetUrlClassName' => Asset::class]);
         $Url->webroot = '';
@@ -617,10 +561,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * Test if UrlHelper fails to load with wrong asset URL class name
-     *
-     * @return void
      */
-    public function testAppAssetPresentWrong()
+    public function testAppAssetPresentWrong(): void
     {
         $this->expectException(CakeException::class);
         new UrlHelper($this->View, ['assetUrlClassName' => 'InexistentClass']);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -46,8 +46,6 @@ class HelperRegistryTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -59,8 +57,6 @@ class HelperRegistryTest extends TestCase
 
     /**
      * tearDown
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -71,10 +67,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test loading helpers.
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $result = $this->Helpers->load('Html');
         $this->assertInstanceOf(HtmlHelper::class, $result);
@@ -86,10 +80,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test lazy loading of helpers
-     *
-     * @return void
      */
-    public function testLazyLoad()
+    public function testLazyLoad(): void
     {
         $result = $this->Helpers->Html;
         $this->assertInstanceOf(HtmlHelper::class, $result);
@@ -105,10 +97,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test lazy loading of helpers
-     *
-     * @return void
      */
-    public function testLazyLoadException()
+    public function testLazyLoadException(): void
     {
         $this->expectException(\Cake\View\Exception\MissingHelperException::class);
         $this->Helpers->NotAHelper;
@@ -116,10 +106,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Test that loading helpers subscribes to events.
-     *
-     * @return void
      */
-    public function testLoadSubscribeEvents()
+    public function testLoadSubscribeEvents(): void
     {
         $this->Helpers->load('Html', ['className' => HtmlAliasHelper::class]);
         $result = $this->Events->listeners('View.afterRender');
@@ -128,10 +116,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Tests loading as an alias
-     *
-     * @return void
      */
-    public function testLoadWithAlias()
+    public function testLoadWithAlias(): void
     {
         $result = $this->Helpers->load('Html', ['className' => HtmlAliasHelper::class]);
         $this->assertInstanceOf(HtmlAliasHelper::class, $result);
@@ -146,10 +132,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Test loading helpers with aliases and plugins.
-     *
-     * @return void
      */
-    public function testLoadWithAliasAndPlugin()
+    public function testLoadWithAliasAndPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $result = $this->Helpers->load('SomeOther', ['className' => 'TestPlugin.OtherHelper']);
@@ -162,10 +146,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test that the enabled setting disables the helper.
-     *
-     * @return void
      */
-    public function testLoadWithEnabledFalse()
+    public function testLoadWithEnabledFalse(): void
     {
         $result = $this->Helpers->load('Html', ['enabled' => false]);
         $this->assertInstanceOf(HtmlHelper::class, $result);
@@ -176,10 +158,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test missinghelper exception
-     *
-     * @return void
      */
-    public function testLoadMissingHelper()
+    public function testLoadMissingHelper(): void
     {
         $this->expectException(\Cake\View\Exception\MissingHelperException::class);
         $this->Helpers->load('ThisHelperShouldAlwaysBeMissing');
@@ -187,10 +167,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test loading a plugin helper.
-     *
-     * @return void
      */
-    public function testLoadPluginHelper()
+    public function testLoadPluginHelper(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -201,10 +179,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * test loading helpers with dotted aliases
-     *
-     * @return void
      */
-    public function testLoadPluginHelperDottedAlias()
+    public function testLoadPluginHelperDottedAlias(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -227,10 +203,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Test reset.
-     *
-     * @return void
      */
-    public function testReset()
+    public function testReset(): void
     {
         static::setAppNamespace();
 
@@ -250,10 +224,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Test unloading.
-     *
-     * @return void
      */
-    public function testUnload()
+    public function testUnload(): void
     {
         static::setAppNamespace();
 
@@ -271,10 +243,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Test that unloading a none existing helper triggers an error.
-     *
-     * @return void
      */
-    public function testUnloadUnknown()
+    public function testUnloadUnknown(): void
     {
         $this->expectException(\Cake\View\Exception\MissingHelperException::class);
         $this->expectExceptionMessage('Helper class FooHelper could not be found.');
@@ -285,10 +255,8 @@ class HelperRegistryTest extends TestCase
      * Loading a helper with no config should "just work"
      *
      * The addToAssertionCount call is to record that no exception was thrown
-     *
-     * @return void
      */
-    public function testLoadMultipleTimesNoConfig()
+    public function testLoadMultipleTimesNoConfig(): void
     {
         $this->Helpers->load('Html');
         $this->Helpers->load('Html');
@@ -300,10 +268,8 @@ class HelperRegistryTest extends TestCase
      * config should "just work"
      *
      * The addToAssertionCount call is to record that no exception was thrown
-     *
-     * @return void
      */
-    public function testLoadMultipleTimesAlreadyConfigured()
+    public function testLoadMultipleTimesAlreadyConfigured(): void
     {
         $this->Helpers->load('Html', ['same' => 'stuff']);
         $this->Helpers->load('Html');
@@ -313,10 +279,8 @@ class HelperRegistryTest extends TestCase
     /**
      * Loading a helper overriding defaults to default value
      * should "just work"
-     *
-     * @return void
      */
-    public function testLoadMultipleTimesDefaultConfigValuesWorks()
+    public function testLoadMultipleTimesDefaultConfigValuesWorks(): void
     {
         $this->Helpers->load('Number', ['engine' => 'Cake\I18n\Number']);
         $this->Helpers->load('Number');
@@ -325,10 +289,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Loading a helper with different config, should throw an exception
-     *
-     * @return void
      */
-    public function testLoadMultipleTimesDifferentConfigured()
+    public function testLoadMultipleTimesDifferentConfigured(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The "Html" alias has already been loaded');
@@ -338,10 +300,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Loading a helper with different config, should throw an exception
-     *
-     * @return void
      */
-    public function testLoadMultipleTimesDifferentConfigValues()
+    public function testLoadMultipleTimesDifferentConfigValues(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The "Html" alias has already been loaded');
@@ -351,10 +311,8 @@ class HelperRegistryTest extends TestCase
 
     /**
      * Test ObjectRegistry normalizeArray
-     *
-     * @return void
      */
-    public function testArrayIsNormalized()
+    public function testArrayIsNormalized(): void
     {
         $config = [
             'SomeHelper',
@@ -390,10 +348,8 @@ class HelperRegistryTest extends TestCase
     /**
      * Test that calling normalizeArray multiple times does
      * not nest the configuration.
-     *
-     * @return void
      */
-    public function testArrayIsNormalizedAfterMultipleCalls()
+    public function testArrayIsNormalizedAfterMultipleCalls(): void
     {
         $config = [
             'SomeHelper' => [

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -36,8 +36,6 @@ class HelperTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -49,8 +47,6 @@ class HelperTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -63,10 +59,8 @@ class HelperTest extends TestCase
 
     /**
      * Test settings merging
-     *
-     * @return void
      */
-    public function testSettingsMerging()
+    public function testSettingsMerging(): void
     {
         $Helper = new TestHelper($this->View, [
             'key3' => 'val3',
@@ -82,10 +76,8 @@ class HelperTest extends TestCase
 
     /**
      * test lazy loading helpers is seamless
-     *
-     * @return void
      */
-    public function testLazyLoadingHelpers()
+    public function testLazyLoadingHelpers(): void
     {
         $this->loadPlugins(['TestPlugin']);
 
@@ -96,10 +88,8 @@ class HelperTest extends TestCase
 
     /**
      * test that a helpers Helper is not 'attached' to the collection
-     *
-     * @return void
      */
-    public function testThatHelperHelpersAreNotAttached()
+    public function testThatHelperHelpersAreNotAttached(): void
     {
         $events = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $this->View->setEventManager($events);
@@ -113,10 +103,8 @@ class HelperTest extends TestCase
 
     /**
      * test that the lazy loader doesn't duplicate objects on each access.
-     *
-     * @return void
      */
-    public function testLazyLoadingUsesReferences()
+    public function testLazyLoadingUsesReferences(): void
     {
         $Helper = new TestHelper($this->View);
         $resultA = $Helper->Html;
@@ -128,10 +116,8 @@ class HelperTest extends TestCase
 
     /**
      * test getting view instance
-     *
-     * @return void
      */
-    public function testGetView()
+    public function testGetView(): void
     {
         $Helper = new TestHelper($this->View);
         $this->assertSame($this->View, $Helper->getView());
@@ -139,10 +125,8 @@ class HelperTest extends TestCase
 
     /**
      * Tests __debugInfo
-     *
-     * @return void
      */
-    public function testDebugInfo()
+    public function testDebugInfo(): void
     {
         $Helper = new TestHelper($this->View);
 
@@ -164,10 +148,8 @@ class HelperTest extends TestCase
 
     /**
      * Test addClass() with 'class' => array
-     *
-     * @return void
      */
-    public function testAddClassArray()
+    public function testAddClassArray(): void
     {
         $helper = new TestHelper($this->View);
         $input = ['class' => ['element1', 'element2']];
@@ -182,10 +164,8 @@ class HelperTest extends TestCase
 
     /**
      * Test addClass() with 'class' => string
-     *
-     * @return void
      */
-    public function testAddClassString()
+    public function testAddClassString(): void
     {
         $helper = new TestHelper($this->View);
 
@@ -197,10 +177,8 @@ class HelperTest extends TestCase
 
     /**
      * Test addClass() with no class element
-     *
-     * @return void
      */
-    public function testAddClassEmpty()
+    public function testAddClassEmpty(): void
     {
         $helper = new TestHelper($this->View);
 

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -216,15 +216,14 @@ class JsonViewTest extends TestCase
      * @param int|false|null $jsonOptions
      * @param string $expected
      * @dataProvider renderWithoutViewProvider
-     * @return void
      */
-    public function testRenderWithoutView($data, $serialize, $jsonOptions, $expected)
+    public function testRenderWithoutView($data, $serialize, $jsonOptions, $expected): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
         $Controller = new Controller($Request, $Response);
 
-        $this->deprecated(function () use ($Controller, $data, $serialize, $jsonOptions, $expected) {
+        $this->deprecated(function () use ($Controller, $data, $serialize, $jsonOptions, $expected): void {
             $Controller->set($data);
             $Controller->set('_serialize', $serialize);
             $Controller->set('_jsonOptions', $jsonOptions);
@@ -249,10 +248,8 @@ class JsonViewTest extends TestCase
 
     /**
      * Test that rendering with _serialize does not load helpers.
-     *
-     * @return void
      */
-    public function testRenderSerializeNoHelpers()
+    public function testRenderSerializeNoHelpers(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -272,10 +269,8 @@ class JsonViewTest extends TestCase
 
     /**
      * testJsonpResponse method
-     *
-     * @return void
      */
-    public function testJsonpResponse()
+    public function testJsonpResponse(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -310,10 +305,8 @@ class JsonViewTest extends TestCase
 
     /**
      * Test render with a View file specified.
-     *
-     * @return void
      */
-    public function testRenderWithView()
+    public function testRenderWithView(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -340,7 +333,7 @@ class JsonViewTest extends TestCase
         $this->assertSame('application/json', $View->getResponse()->getType());
     }
 
-    public function testSerializationFailureException()
+    public function testSerializationFailureException(): void
     {
         $this->expectException(SerializationFailureException::class);
         $this->expectExceptionMessage('Serialization of View data failed.');

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -28,8 +28,6 @@ class StringTemplateTest extends TestCase
 
     /**
      * setUp
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -39,10 +37,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test adding templates through the constructor.
-     *
-     * @return void
      */
-    public function testConstructorAdd()
+    public function testConstructorAdd(): void
     {
         $templates = [
             'link' => '<a href="{{url}}">{{text}}</a>',
@@ -53,10 +49,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * test adding templates.
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $templates = [
             'link' => '<a href="{{url}}">{{text}}</a>',
@@ -73,10 +67,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test remove.
-     *
-     * @return void
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $templates = [
             'link' => '<a href="{{url}}">{{text}}</a>',
@@ -88,10 +80,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test formatting strings.
-     *
-     * @return void
      */
-    public function testFormat()
+    public function testFormat(): void
     {
         $templates = [
             'link' => '<a href="{{url}}">{{text}}</a>',
@@ -121,10 +111,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test formatting strings with URL encoding
-     *
-     * @return void
      */
-    public function testFormatUrlEncoding()
+    public function testFormatUrlEncoding(): void
     {
         $templates = [
             'test' => '<img src="/img/foo%20bar.jpg">{{text}}',
@@ -137,10 +125,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Formatting array data should not trigger errors.
-     *
-     * @return void
      */
-    public function testFormatArrayData()
+    public function testFormatArrayData(): void
     {
         $templates = [
             'link' => '<a href="{{url}}">{{text}}</a>',
@@ -162,10 +148,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test formatting a missing template.
-     *
-     * @return void
      */
-    public function testFormatMissingTemplate()
+    public function testFormatMissingTemplate(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot find template named \'missing\'');
@@ -178,10 +162,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test loading templates files in the app.
-     *
-     * @return void
      */
-    public function testLoad()
+    public function testLoad(): void
     {
         $this->template->remove('attribute');
         $this->template->remove('compactAttribute');
@@ -192,10 +174,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test loading templates files from a plugin
-     *
-     * @return void
      */
-    public function testLoadPlugin()
+    public function testLoadPlugin(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $this->template->load('TestPlugin.test_templates');
@@ -206,7 +186,7 @@ class StringTemplateTest extends TestCase
     /**
      * Test that loading nonexistent templates causes errors.
      */
-    public function testLoadErrorNoFile()
+    public function testLoadErrorNoFile(): void
     {
         $this->expectException(\Cake\Core\Exception\CakeException::class);
         $this->expectExceptionMessage('Could not load configuration file');
@@ -215,10 +195,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test formatting compact attributes.
-     *
-     * @return void
      */
-    public function testFormatAttributesCompact()
+    public function testFormatAttributesCompact(): void
     {
         $attrs = ['disabled' => true, 'selected' => 1, 'checked' => '1', 'multiple' => 'multiple'];
         $result = $this->template->formatAttributes($attrs);
@@ -237,10 +215,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test formatting normal attributes.
-     *
-     * @return void
      */
-    public function testFormatAttributes()
+    public function testFormatAttributes(): void
     {
         $attrs = ['name' => 'bruce', 'data-hero' => '<batman>', 'spellcheck' => 'true'];
         $result = $this->template->formatAttributes($attrs);
@@ -282,10 +258,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test formatting array attributes.
-     *
-     * @return void
      */
-    public function testFormatAttributesArray()
+    public function testFormatAttributesArray(): void
     {
         $attrs = ['name' => ['bruce', 'wayne']];
         $result = $this->template->formatAttributes($attrs);
@@ -297,10 +271,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * test push/pop templates.
-     *
-     * @return void
      */
-    public function testPushPopTemplates()
+    public function testPushPopTemplates(): void
     {
         $this->template->add(['name' => '{{name}} is my name']);
         $this->template->push();
@@ -319,10 +291,8 @@ class StringTemplateTest extends TestCase
      * Test addClass method newClass parameter
      *
      * Tests null, string, array and false for `input`
-     *
-     * @return void
      */
-    public function testAddClassMethodNewClass()
+    public function testAddClassMethodNewClass(): void
     {
         $result = $this->template->addClass([], 'new_class');
         $this->assertEquals($result, ['class' => ['new_class']]);
@@ -344,10 +314,8 @@ class StringTemplateTest extends TestCase
      * Test addClass method input (currentClass) parameter
      *
      * Tests null, string, array, false and object
-     *
-     * @return void
      */
-    public function testAddClassMethodCurrentClass()
+    public function testAddClassMethodCurrentClass(): void
     {
         $result = $this->template->addClass(['class' => ['current']], 'new_class');
         $this->assertEquals($result, ['class' => ['current', 'new_class']]);
@@ -367,10 +335,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test addClass method string parameter, it should fallback to string
-     *
-     * @return void
      */
-    public function testAddClassMethodFallbackToString()
+    public function testAddClassMethodFallbackToString(): void
     {
         $result = $this->template->addClass('current', 'new_class');
         $this->assertEquals($result, ['class' => ['current', 'new_class']]);
@@ -378,10 +344,8 @@ class StringTemplateTest extends TestCase
 
     /**
      * Test addClass method to make sure the returned array is unique
-     *
-     * @return void
      */
-    public function testAddClassMethodUnique()
+    public function testAddClassMethodUnique(): void
     {
         $result = $this->template->addClass(['class' => ['new_class']], 'new_class');
         $this->assertEquals($result, ['class' => ['new_class']]);
@@ -391,10 +355,8 @@ class StringTemplateTest extends TestCase
      * Test addClass method useIndex param
      *
      * Tests for useIndex being the default, 'my_class' and false
-     *
-     * @return void
      */
-    public function testAddClassMethodUseIndex()
+    public function testAddClassMethodUseIndex(): void
     {
         $result = $this->template->addClass(
             [

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -32,8 +32,6 @@ class StringTemplateTraitTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class StringTemplateTraitTest extends TestCase
 
     /**
      * testInitStringTemplates
-     *
-     * @return void
      */
-    public function testInitStringTemplates()
+    public function testInitStringTemplates(): void
     {
         $templates = [
             'text' => '<p>{{text}}</p>',
@@ -64,10 +60,8 @@ class StringTemplateTraitTest extends TestCase
 
     /**
      * test settings['templates']
-     *
-     * @return void
      */
-    public function testInitStringTemplatesArrayForm()
+    public function testInitStringTemplatesArrayForm(): void
     {
         $this->Template->setConfig(
             'templates.text',
@@ -85,10 +79,8 @@ class StringTemplateTraitTest extends TestCase
 
     /**
      * testFormatStringTemplate
-     *
-     * @return void
      */
-    public function testFormatStringTemplate()
+    public function testFormatStringTemplate(): void
     {
         $templates = [
             'text' => '<p>{{text}}</p>',
@@ -105,10 +97,8 @@ class StringTemplateTraitTest extends TestCase
 
     /**
      * testGetTemplater
-     *
-     * @return void
      */
-    public function testGetTemplater()
+    public function testGetTemplater(): void
     {
         $templates = [
             'text' => '<p>{{text}}</p>',

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -27,7 +27,7 @@ use Cake\View\ViewBuilder;
  */
 class ViewBuilderTest extends TestCase
 {
-    public function testSetVar()
+    public function testSetVar(): void
     {
         $builder = new ViewBuilder();
 
@@ -35,7 +35,7 @@ class ViewBuilderTest extends TestCase
         $this->assertSame('value', $builder->getVar('testing'));
     }
 
-    public function testSetVars()
+    public function testSetVars(): void
     {
         $builder = new ViewBuilder();
 
@@ -58,7 +58,7 @@ class ViewBuilderTest extends TestCase
         );
     }
 
-    public function testHasVar()
+    public function testHasVar(): void
     {
         $builder = new ViewBuilder();
 
@@ -120,9 +120,8 @@ class ViewBuilderTest extends TestCase
      * Test string property accessor/mutator methods.
      *
      * @dataProvider stringPropertyProvider
-     * @return void
      */
-    public function testStringProperties(string $property, string $value)
+    public function testStringProperties(string $property, string $value): void
     {
         $get = 'get' . ucfirst($property);
         $set = 'set' . ucfirst($property);
@@ -137,9 +136,8 @@ class ViewBuilderTest extends TestCase
      * Test string property accessor/mutator methods.
      *
      * @dataProvider boolPropertyProvider
-     * @return void
      */
-    public function testBoolProperties(string $property, bool $default, bool $value)
+    public function testBoolProperties(string $property, bool $default, bool $value): void
     {
         $set = 'enable' . ucfirst($property);
         $get = 'is' . ucfirst($property) . 'Enabled';
@@ -154,9 +152,8 @@ class ViewBuilderTest extends TestCase
      * Test array property accessor/mutator methods.
      *
      * @dataProvider arrayPropertyProvider
-     * @return void
      */
-    public function testArrayProperties(string $property, array $value)
+    public function testArrayProperties(string $property, array $value): void
     {
         $get = 'get' . ucfirst($property);
         $set = 'set' . ucfirst($property);
@@ -171,9 +168,8 @@ class ViewBuilderTest extends TestCase
      * Test array property accessor/mutator methods.
      *
      * @dataProvider arrayPropertyProvider
-     * @return void
      */
-    public function testArrayPropertyMerge(string $property, array $value)
+    public function testArrayPropertyMerge(string $property, array $value): void
     {
         $get = 'get' . ucfirst($property);
         $set = 'set' . ucfirst($property);
@@ -190,10 +186,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test building with all the options.
-     *
-     * @return void
      */
-    public function testBuildComplete()
+    public function testBuildComplete(): void
     {
         $request = new ServerRequest();
         $response = new Response();
@@ -235,10 +229,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * Test that the default is AppView.
-     *
-     * @return void
      */
-    public function testBuildAppViewMissing()
+    public function testBuildAppViewMissing(): void
     {
         static::setAppNamespace('Nope');
         $builder = new ViewBuilder();
@@ -248,10 +240,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * Test that the default is AppView.
-     *
-     * @return void
      */
-    public function testBuildAppViewPresent()
+    public function testBuildAppViewPresent(): void
     {
         static::setAppNamespace();
         $builder = new ViewBuilder();
@@ -261,10 +251,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test missing view class
-     *
-     * @return void
      */
-    public function testBuildMissingViewClass()
+    public function testBuildMissingViewClass(): void
     {
         $this->expectException(\Cake\View\Exception\MissingViewException::class);
         $this->expectExceptionMessage('View class "Foo" is missing.');
@@ -275,10 +263,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * testJsonSerialize()
-     *
-     * @return void
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $builder = new ViewBuilder();
 
@@ -305,10 +291,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * testCreateFromArray()
-     *
-     * @return void
      */
-    public function testCreateFromArray()
+    public function testCreateFromArray(): void
     {
         $builder = new ViewBuilder();
 
@@ -331,10 +315,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test setOptions() with 1 string param, merge true
-     *
-     * @return void
      */
-    public function testSetOptionsOne()
+    public function testSetOptionsOne(): void
     {
         $builder = new ViewBuilder();
         $this->assertSame($builder, $builder->setOptions(['newOption']));
@@ -343,10 +325,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test setOptions() with 2 strings in array, merge true.
-     *
-     * @return void
      */
-    public function testSetOptionsMultiple()
+    public function testSetOptionsMultiple(): void
     {
         $builder = new ViewBuilder();
         $builder->setOptions(['oldOption'], false);
@@ -362,10 +342,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test empty params reads _viewOptions.
-     *
-     * @return void
      */
-    public function testReadingViewOptions()
+    public function testReadingViewOptions(): void
     {
         $builder = new ViewBuilder();
         $builder->setOptions(['one', 'two', 'three'], false);
@@ -375,10 +353,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test setting $merge `false` overrides correct options.
-     *
-     * @return void
      */
-    public function testMergeFalseViewOptions()
+    public function testMergeFalseViewOptions(): void
     {
         $builder = new ViewBuilder();
         $builder->setOptions(['one', 'two', 'three'], false);
@@ -390,10 +366,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * test _viewOptions is undefined and $opts is null, an empty array is returned.
-     *
-     * @return void
      */
-    public function testUndefinedValidViewOptions()
+    public function testUndefinedValidViewOptions(): void
     {
         $builder = new ViewBuilder();
         $builder->setOptions([], false);
@@ -402,10 +376,7 @@ class ViewBuilderTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    /**
-     * @return void
-     */
-    public function testOptionSetGet()
+    public function testOptionSetGet(): void
     {
         $builder = new ViewBuilder();
         $result = $builder->setOption('foo', 'bar');
@@ -418,10 +389,7 @@ class ViewBuilderTest extends TestCase
         $this->assertNull($builder->getOption('nonexistent'));
     }
 
-    /**
-     * @return void
-     */
-    public function testDisableAutoLayout()
+    public function testDisableAutoLayout(): void
     {
         $builder = new ViewBuilder();
         $this->assertTrue($builder->isAutoLayoutEnabled());
@@ -430,10 +398,7 @@ class ViewBuilderTest extends TestCase
         $this->assertFalse($builder->isAutoLayoutEnabled());
     }
 
-    /**
-     * @return void
-     */
-    public function testAddHelperChained()
+    public function testAddHelperChained(): void
     {
         $builder = new ViewBuilder();
         $builder->addHelper('Form')
@@ -449,10 +414,7 @@ class ViewBuilderTest extends TestCase
         $this->assertSame($expected, $helpers);
     }
 
-    /**
-     * @return void
-     */
-    public function testAddHelperOptions()
+    public function testAddHelperOptions(): void
     {
         $builder = new ViewBuilder();
         $builder->addHelper('Form')

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -64,8 +64,6 @@ class ViewTest extends TestCase
 
     /**
      * setUp method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -91,8 +89,6 @@ class ViewTest extends TestCase
 
     /**
      * tearDown method
-     *
-     * @return void
      */
     public function tearDown(): void
     {
@@ -108,10 +104,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getTemplateFileName method
-     *
-     * @return void
      */
-    public function testGetTemplate()
+    public function testGetTemplate(): void
     {
         $viewOptions = [
             'plugin' => null,
@@ -153,10 +147,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getLayoutFileName method on plugin
-     *
-     * @return void
      */
-    public function testPluginGetTemplate()
+    public function testPluginGetTemplate(): void
     {
         $viewOptions = [
             'plugin' => 'TestPlugin',
@@ -179,10 +171,8 @@ class ViewTest extends TestCase
     /**
      * Test that plugin files with absolute file paths are scoped
      * to the plugin and do now allow any file path.
-     *
-     * @return void
      */
-    public function testPluginGetTemplateAbsoluteFail()
+    public function testPluginGetTemplateAbsoluteFail(): void
     {
         $this->expectException(\Cake\View\Exception\MissingTemplateException::class);
         $viewOptions = [
@@ -201,10 +191,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getTemplateFileName method on plugin
-     *
-     * @return void
      */
-    public function testPluginThemedGetTemplate()
+    public function testPluginThemedGetTemplate(): void
     {
         $viewOptions = [
             'plugin' => 'TestPlugin',
@@ -232,10 +220,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that plugin/$plugin_name is only appended to the paths it should be.
-     *
-     * @return void
      */
-    public function testPathPluginGeneration()
+    public function testPathPluginGeneration(): void
     {
         $viewOptions = [
             'plugin' => 'TestPlugin',
@@ -262,10 +248,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that themed plugin paths are generated correctly.
-     *
-     * @return void
      */
-    public function testPathThemedPluginGeneration()
+    public function testPathThemedPluginGeneration(): void
     {
         $viewOptions = [
             'plugin' => 'TestPlugin',
@@ -292,10 +276,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that multiple paths can be used in App.paths.templates.
-     *
-     * @return void
      */
-    public function testMultipleAppPaths()
+    public function testMultipleAppPaths(): void
     {
         $viewOptions = [
             'plugin' => 'TestPlugin',
@@ -328,10 +310,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that CamelCase'd plugins still find their view files.
-     *
-     * @return void
      */
-    public function testCamelCasePluginGetTemplate()
+    public function testCamelCasePluginGetTemplate(): void
     {
         $viewOptions = [
             'plugin' => 'TestPlugin',
@@ -355,10 +335,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getTemplateFileName method
-     *
-     * @return void
      */
-    public function testGetViewFileNames()
+    public function testGetViewFileNames(): void
     {
         $viewOptions = [
             'plugin' => null,
@@ -396,10 +374,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that getTemplateFileName() protects against malicious directory traversal.
-     *
-     * @return void
      */
-    public function testGetViewFileNameDirectoryTraversal()
+    public function testGetViewFileNameDirectoryTraversal(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $viewOptions = [
@@ -415,10 +391,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getTemplateFileName doesn't re-apply existing subdirectories
-     *
-     * @return void
      */
-    public function testGetViewFileNameSubDir()
+    public function testGetViewFileNameSubDir(): void
     {
         $viewOptions = [
             'plugin' => null,
@@ -440,10 +414,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getTemplateFileName applies subdirectories on equal length names
-     *
-     * @return void
      */
-    public function testGetViewFileNameSubDirLength()
+    public function testGetViewFileNameSubDirLength(): void
     {
         $viewOptions = [
             'plugin' => null,
@@ -461,10 +433,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getting layout filenames
-     *
-     * @return void
      */
-    public function testGetLayoutFileName()
+    public function testGetLayoutFileName(): void
     {
         $viewOptions = [
             'plugin' => null,
@@ -492,10 +462,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getting layout filenames for plugins.
-     *
-     * @return void
      */
-    public function testGetLayoutFileNamePlugin()
+    public function testGetLayoutFileNamePlugin(): void
     {
         $viewOptions = [
             'plugin' => null,
@@ -520,10 +488,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getting layout filenames for prefix
-     *
-     * @return void
      */
-    public function testGetLayoutFileNamePrefix()
+    public function testGetLayoutFileNamePrefix(): void
     {
         $View = new TestView();
 
@@ -560,10 +526,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that getLayoutFileName() protects against malicious directory traversal.
-     *
-     * @return void
      */
-    public function testGetLayoutFileNameDirectoryTraversal()
+    public function testGetLayoutFileNameDirectoryTraversal(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $viewOptions = [
@@ -579,10 +543,8 @@ class ViewTest extends TestCase
 
     /**
      * Test for missing views
-     *
-     * @return void
      */
-    public function testMissingTemplate()
+    public function testMissingTemplate(): void
     {
         $this->expectException(\Cake\View\Exception\MissingTemplateException::class);
         $this->expectExceptionMessage('Template file `does_not_exist.php` could not be found');
@@ -602,10 +564,8 @@ class ViewTest extends TestCase
 
     /**
      * Test for missing layouts
-     *
-     * @return void
      */
-    public function testMissingLayout()
+    public function testMissingLayout(): void
     {
         $this->expectException(\Cake\View\Exception\MissingLayoutException::class);
         $this->expectExceptionMessage('Layout file `whatever.php` could not be found');
@@ -623,20 +583,16 @@ class ViewTest extends TestCase
 
     /**
      * Test viewVars method
-     *
-     * @return void
      */
-    public function testViewVars()
+    public function testViewVars(): void
     {
         $this->assertEquals(['testData', 'test2', 'test3'], $this->View->getVars());
     }
 
     /**
      * Test elementExists method
-     *
-     * @return void
      */
-    public function testElementExists()
+    public function testElementExists(): void
     {
         $result = $this->View->elementExists('test_element');
         $this->assertTrue($result);
@@ -657,10 +613,8 @@ class ViewTest extends TestCase
 
     /**
      * Test element method
-     *
-     * @return void
      */
-    public function testElement()
+    public function testElement(): void
     {
         $result = $this->View->element('test_element');
         $this->assertSame('this is the test element', $result);
@@ -678,10 +632,8 @@ class ViewTest extends TestCase
 
     /**
      * Test element method with a prefix
-     *
-     * @return void
      */
-    public function testPrefixElement()
+    public function testPrefixElement(): void
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
         $result = $this->View->element('prefix_element');
@@ -704,10 +656,8 @@ class ViewTest extends TestCase
 
     /**
      * Test loading missing view element
-     *
-     * @return void
      */
-    public function testElementMissing()
+    public function testElementMissing(): void
     {
         $this->expectException(\Cake\View\Exception\MissingElementException::class);
         $this->expectExceptionMessage('Element file `nonexistent_element.php` could not be found');
@@ -717,10 +667,8 @@ class ViewTest extends TestCase
 
     /**
      * Test loading nonexistent plugin view element
-     *
-     * @return void
      */
-    public function testElementMissingPluginElement()
+    public function testElementMissingPluginElement(): void
     {
         $this->expectException(\Cake\View\Exception\MissingElementException::class);
         $this->expectExceptionMessage('Element file `TestPlugin.nope.php` could not be found');
@@ -730,13 +678,11 @@ class ViewTest extends TestCase
 
     /**
      * Test that elements can have callbacks
-     *
-     * @return void
      */
-    public function testElementCallbacks()
+    public function testElementCallbacks(): void
     {
         $count = 0;
-        $callback = function (EventInterface $event, $file) use (&$count) {
+        $callback = function (EventInterface $event, $file) use (&$count): void {
             $count++;
         };
         $events = $this->View->getEventManager();
@@ -749,10 +695,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that additional element viewVars don't get overwritten with helpers.
-     *
-     * @return void
      */
-    public function testElementParamsDontOverwriteHelpers()
+    public function testElementParamsDontOverwriteHelpers(): void
     {
         $Controller = new ViewPostsController();
 
@@ -767,10 +711,8 @@ class ViewTest extends TestCase
 
     /**
      * Test elementCacheHelperNoCache method
-     *
-     * @return void
      */
-    public function testElementCacheHelperNoCache()
+    public function testElementCacheHelperNoCache(): void
     {
         $Controller = new ViewPostsController();
         $View = $Controller->createView();
@@ -780,10 +722,8 @@ class ViewTest extends TestCase
 
     /**
      * Test elementCache method
-     *
-     * @return void
      */
-    public function testElementCache()
+    public function testElementCache(): void
     {
         Cache::drop('test_view');
         Cache::setConfig('test_view', [
@@ -835,10 +775,8 @@ class ViewTest extends TestCase
 
     /**
      * Test elementCache method with namespaces and subfolder
-     *
-     * @return void
      */
-    public function testElementCacheSubfolder()
+    public function testElementCacheSubfolder(): void
     {
         Cache::drop('test_view');
         Cache::setConfig('test_view', [
@@ -862,10 +800,8 @@ class ViewTest extends TestCase
 
     /**
      * Test element events
-     *
-     * @return void
      */
-    public function testViewEvent()
+    public function testViewEvent(): void
     {
         $View = $this->PostsController->createView();
         $View->setTemplatePath($this->PostsController->getName());
@@ -888,10 +824,8 @@ class ViewTest extends TestCase
 
     /**
      * Test loading helper using loadHelper().
-     *
-     * @return void
      */
-    public function testLoadHelper()
+    public function testLoadHelper(): void
     {
         $View = new View();
 
@@ -904,10 +838,8 @@ class ViewTest extends TestCase
 
     /**
      * Test loading helper when duplicate.
-     *
-     * @return void
      */
-    public function testLoadHelperDuplicate()
+    public function testLoadHelperDuplicate(): void
     {
         $View = new View();
 
@@ -922,10 +854,8 @@ class ViewTest extends TestCase
 
     /**
      * Test loadHelpers method
-     *
-     * @return void
      */
-    public function testLoadHelpers()
+    public function testLoadHelpers(): void
     {
         $View = new View(null, null, null, [
             'helpers' => ['Html' => ['foo' => 'bar'], 'Form' => ['foo' => 'baz']],
@@ -946,10 +876,8 @@ class ViewTest extends TestCase
 
     /**
      * Test lazy loading helpers
-     *
-     * @return void
      */
-    public function testLazyLoadHelpers()
+    public function testLazyLoadHelpers(): void
     {
         $View = new View();
 
@@ -959,10 +887,8 @@ class ViewTest extends TestCase
 
     /**
      * Test manipulating class properties in initialize()
-     *
-     * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $View = new TestView();
         $config = $View->Html->getConfig();
@@ -971,10 +897,8 @@ class ViewTest extends TestCase
 
     /**
      * Test the correct triggering of helper callbacks
-     *
-     * @return void
      */
-    public function testHelperCallbackTriggering()
+    public function testHelperCallbackTriggering(): void
     {
         $View = $this->PostsController->createView();
         $View->setTemplatePath($this->PostsController->getName());
@@ -1016,10 +940,8 @@ class ViewTest extends TestCase
 
     /**
      * Test beforeLayout method
-     *
-     * @return void
      */
-    public function testBeforeLayout()
+    public function testBeforeLayout(): void
     {
         $this->PostsController->viewBuilder()->setHelpers([
             'TestBeforeAfter' => ['className' => TestBeforeAfterHelper::class],
@@ -1033,10 +955,8 @@ class ViewTest extends TestCase
 
     /**
      * Test afterLayout method
-     *
-     * @return void
      */
-    public function testAfterLayout()
+    public function testAfterLayout(): void
     {
         $this->PostsController->viewBuilder()->setHelpers([
             'TestBeforeAfter' => ['className' => TestBeforeAfterHelper::class],
@@ -1055,10 +975,8 @@ class ViewTest extends TestCase
 
     /**
      * Test renderLoadHelper method
-     *
-     * @return void
      */
-    public function testRenderLoadHelper()
+    public function testRenderLoadHelper(): void
     {
         $this->PostsController->viewBuilder()->setHelpers(['Form', 'Number']);
         $View = $this->PostsController->createView(TestView::class);
@@ -1087,10 +1005,8 @@ class ViewTest extends TestCase
 
     /**
      * Test render method
-     *
-     * @return void
      */
-    public function testRender()
+    public function testRender(): void
     {
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
@@ -1116,10 +1032,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that View::$view works
-     *
-     * @return void
      */
-    public function testRenderUsingViewProperty()
+    public function testRenderUsingViewProperty(): void
     {
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
@@ -1133,10 +1047,8 @@ class ViewTest extends TestCase
     /**
      * Test that layout set from view file takes precedence over layout set
      * as argument to render().
-     *
-     * @return void
      */
-    public function testRenderUsingLayoutArgument()
+    public function testRenderUsingLayoutArgument(): void
     {
         $error = new \PDOException();
         $error->queryString = 'this is sql string';
@@ -1154,10 +1066,8 @@ class ViewTest extends TestCase
 
     /**
      * Test renderLayout()
-     *
-     * @return void
      */
-    public function testRenderLayout()
+    public function testRenderLayout(): void
     {
         $View = $this->PostsController->createView(TestView::class);
         $result = $View->renderLayout('', 'ajax2');
@@ -1168,10 +1078,8 @@ class ViewTest extends TestCase
     /**
      * Test render()ing a file in a subdir from a custom viewPath
      * in a plugin.
-     *
-     * @return void
      */
-    public function testGetTemplateFileNameSubdirWithPluginAndViewPath()
+    public function testGetTemplateFileNameSubdirWithPluginAndViewPath(): void
     {
         $this->PostsController->setPlugin('TestPlugin');
         $this->PostsController->setName('Posts');
@@ -1185,7 +1093,7 @@ class ViewTest extends TestCase
         $this->assertPathEquals($expected, $result);
     }
 
-    public function testGetTemplateException()
+    public function testGetTemplateException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Template name not provided');
@@ -1196,10 +1104,8 @@ class ViewTest extends TestCase
     /**
      * Test that view vars can replace the local helper variables
      * and not overwrite the $this->Helper references
-     *
-     * @return void
      */
-    public function testViewVarOverwritingLocalHelperVar()
+    public function testViewVarOverwritingLocalHelperVar(): void
     {
         $Controller = new ViewPostsController();
         $Controller->set('html', 'I am some test html');
@@ -1213,10 +1119,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getTemplateFileName method
-     *
-     * @return void
      */
-    public function testViewFileName()
+    public function testViewFileName(): void
     {
         /** @var \TestApp\View\TestView $View */
         $View = $this->PostsController->createView(TestView::class);
@@ -1241,10 +1145,8 @@ class ViewTest extends TestCase
 
     /**
      * Test creating a block with capturing output.
-     *
-     * @return void
      */
-    public function testBlockCaptureOverwrite()
+    public function testBlockCaptureOverwrite(): void
     {
         $result = $this->View->start('test');
         $this->assertSame($this->View, $result);
@@ -1263,10 +1165,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that blocks can be fetched inside a block with the same name
-     *
-     * @return void
      */
-    public function testBlockExtend()
+    public function testBlockExtend(): void
     {
         $this->View->start('test');
         echo 'Block content';
@@ -1283,10 +1183,8 @@ class ViewTest extends TestCase
 
     /**
      * Test creating a block with capturing output.
-     *
-     * @return void
      */
-    public function testBlockCapture()
+    public function testBlockCapture(): void
     {
         $this->View->start('test');
         echo 'Block content';
@@ -1298,10 +1196,8 @@ class ViewTest extends TestCase
 
     /**
      * Test appending to a block with capturing output.
-     *
-     * @return void
      */
-    public function testBlockAppendCapture()
+    public function testBlockAppendCapture(): void
     {
         $this->View->start('test');
         echo 'Content ';
@@ -1319,10 +1215,8 @@ class ViewTest extends TestCase
 
     /**
      * Test setting a block's content.
-     *
-     * @return void
      */
-    public function testBlockSet()
+    public function testBlockSet(): void
     {
         $result = $this->View->assign('test', 'Block content');
         $this->assertSame($this->View, $result);
@@ -1333,10 +1227,8 @@ class ViewTest extends TestCase
 
     /**
      * Test resetting a block's content.
-     *
-     * @return void
      */
-    public function testBlockReset()
+    public function testBlockReset(): void
     {
         $this->View->assign('test', '');
         $result = $this->View->fetch('test', 'This should not be returned');
@@ -1345,10 +1237,8 @@ class ViewTest extends TestCase
 
     /**
      * Test resetting a block's content with reset.
-     *
-     * @return void
      */
-    public function testBlockResetFunc()
+    public function testBlockResetFunc(): void
     {
         $this->View->assign('test', 'Block content');
         $result = $this->View->fetch('test', 'This should not be returned');
@@ -1363,10 +1253,8 @@ class ViewTest extends TestCase
 
     /**
      * Test checking a block's existence.
-     *
-     * @return void
      */
-    public function testBlockExist()
+    public function testBlockExist(): void
     {
         $this->assertFalse($this->View->exists('test'));
         $this->View->assign('test', 'Block content');
@@ -1375,10 +1263,8 @@ class ViewTest extends TestCase
 
     /**
      * Test setting a block's content to null
-     *
-     * @return void
      */
-    public function testBlockSetNull()
+    public function testBlockSetNull(): void
     {
         $this->View->assign('testWithNull', null);
         $result = $this->View->fetch('testWithNull');
@@ -1387,10 +1273,8 @@ class ViewTest extends TestCase
 
     /**
      * Test setting a block's content to an object with __toString magic method
-     *
-     * @return void
      */
-    public function testBlockSetObjectWithToString()
+    public function testBlockSetObjectWithToString(): void
     {
         $objectWithToString = new TestObjectWithToString();
         $this->View->assign('testWithObjectWithToString', $objectWithToString);
@@ -1400,10 +1284,8 @@ class ViewTest extends TestCase
 
     /**
      * Test setting a block's content to an object without __toString magic method
-     *
-     * @return void
      */
-    public function testBlockSetObjectWithoutToString()
+    public function testBlockSetObjectWithoutToString(): void
     {
         $this->checkException(
             'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
@@ -1415,10 +1297,8 @@ class ViewTest extends TestCase
 
     /**
      * Test setting a block's content to a decimal
-     *
-     * @return void
      */
-    public function testBlockSetDecimal()
+    public function testBlockSetDecimal(): void
     {
         $this->View->assign('testWithDecimal', 1.23456789);
         $result = $this->View->fetch('testWithDecimal');
@@ -1443,10 +1323,9 @@ class ViewTest extends TestCase
      * Test appending to a block with append.
      *
      * @param mixed $value Value
-     * @return void
      * @dataProvider blockValueProvider
      */
-    public function testBlockAppend($value)
+    public function testBlockAppend($value): void
     {
         $this->View->assign('testBlock', 'Block');
         $this->View->append('testBlock', $value);
@@ -1457,10 +1336,8 @@ class ViewTest extends TestCase
 
     /**
      * Test appending an object without __toString magic method to a block with append.
-     *
-     * @return void
      */
-    public function testBlockAppendObjectWithoutToString()
+    public function testBlockAppendObjectWithoutToString(): void
     {
         $this->checkException(
             'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
@@ -1475,10 +1352,9 @@ class ViewTest extends TestCase
      * Test prepending to a block with prepend.
      *
      * @param mixed $value Value
-     * @return void
      * @dataProvider blockValueProvider
      */
-    public function testBlockPrepend($value)
+    public function testBlockPrepend($value): void
     {
         $this->View->assign('test', 'Block');
         $result = $this->View->prepend('test', $value);
@@ -1490,10 +1366,8 @@ class ViewTest extends TestCase
 
     /**
      * Test prepending an object without __toString magic method to a block with prepend.
-     *
-     * @return void
      */
-    public function testBlockPrependObjectWithoutToString()
+    public function testBlockPrependObjectWithoutToString(): void
     {
         $this->checkException(
             'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
@@ -1506,10 +1380,8 @@ class ViewTest extends TestCase
 
     /**
      * You should be able to append to undefined blocks.
-     *
-     * @return void
      */
-    public function testBlockAppendUndefined()
+    public function testBlockAppendUndefined(): void
     {
         $result = $this->View->append('test', 'Unknown');
         $this->assertSame($this->View, $result);
@@ -1520,10 +1392,8 @@ class ViewTest extends TestCase
 
     /**
      * You should be able to prepend to undefined blocks.
-     *
-     * @return void
      */
-    public function testBlockPrependUndefined()
+    public function testBlockPrependUndefined(): void
     {
         $this->View->prepend('test', 'Unknown');
         $result = $this->View->fetch('test');
@@ -1532,10 +1402,8 @@ class ViewTest extends TestCase
 
     /**
      * Test getting block names
-     *
-     * @return void
      */
-    public function testBlocks()
+    public function testBlocks(): void
     {
         $this->View->append('test', 'one');
         $this->View->assign('test1', 'one');
@@ -1545,10 +1413,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that blocks can be nested.
-     *
-     * @return void
      */
-    public function testNestedBlocks()
+    public function testNestedBlocks(): void
     {
         $this->View->start('first');
         echo 'In first ';
@@ -1564,10 +1430,8 @@ class ViewTest extends TestCase
 
     /**
      * Test that starting the same block twice throws an exception
-     *
-     * @return void
      */
-    public function testStartBlocksTwice()
+    public function testStartBlocksTwice(): void
     {
         try {
             $this->View->start('first');
@@ -1582,10 +1446,8 @@ class ViewTest extends TestCase
     /**
      * Test that an exception gets thrown when you leave a block open at the end
      * of a view.
-     *
-     * @return void
      */
-    public function testExceptionOnOpenBlock()
+    public function testExceptionOnOpenBlock(): void
     {
         try {
             $this->View->render('open_block');
@@ -1598,10 +1460,8 @@ class ViewTest extends TestCase
 
     /**
      * Test nested extended views.
-     *
-     * @return void
      */
-    public function testExtendNested()
+    public function testExtendNested(): void
     {
         $content = $this->View->render('nested_extends', false);
         $expected = <<<TEXT
@@ -1615,10 +1475,8 @@ TEXT;
 
     /**
      * Make sure that extending the current view with itself causes an exception
-     *
-     * @return void
      */
-    public function testExtendSelf()
+    public function testExtendSelf(): void
     {
         try {
             $this->View->render('extend_self', false);
@@ -1630,10 +1488,8 @@ TEXT;
 
     /**
      * Make sure that extending in a loop causes an exception
-     *
-     * @return void
      */
-    public function testExtendLoop()
+    public function testExtendLoop(): void
     {
         try {
             $this->View->render('extend_loop', false);
@@ -1645,10 +1501,8 @@ TEXT;
 
     /**
      * Test extend() in an element and a view.
-     *
-     * @return void
      */
-    public function testExtendElement()
+    public function testExtendElement(): void
     {
         $content = $this->View->render('extend_element', false);
         $expected = <<<TEXT
@@ -1663,10 +1517,8 @@ TEXT;
 
     /**
      * Test extend() in an element and a view.
-     *
-     * @return void
      */
-    public function testExtendPrefixElement()
+    public function testExtendPrefixElement(): void
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
         $content = $this->View->render('extend_element', false);
@@ -1682,10 +1534,8 @@ TEXT;
 
     /**
      * Extending an element which doesn't exist should throw a missing view exception
-     *
-     * @return void
      */
-    public function testExtendMissingElement()
+    public function testExtendMissingElement(): void
     {
         try {
             $this->View->render('extend_missing_element', false);
@@ -1697,10 +1547,8 @@ TEXT;
 
     /**
      * Test extend() preceded by an element()
-     *
-     * @return void
      */
-    public function testExtendWithElementBeforeExtend()
+    public function testExtendWithElementBeforeExtend(): void
     {
         $result = $this->View->render('extend_with_element', false);
         $expected = <<<TEXT
@@ -1713,10 +1561,8 @@ TEXT;
 
     /**
      * Test extend() preceded by an element()
-     *
-     * @return void
      */
-    public function testExtendWithPrefixElementBeforeExtend()
+    public function testExtendWithPrefixElementBeforeExtend(): void
     {
         $this->View->setRequest($this->View->getRequest()->withParam('prefix', 'Admin'));
         $this->View->disableAutoLayout();
@@ -1732,10 +1578,8 @@ TEXT;
     /**
      * Tests that the buffers that are opened when evaluating a template
      * are being closed in case an exception happens.
-     *
-     * @return void
      */
-    public function testBuffersOpenedDuringTemplateEvaluationAreBeingClosed()
+    public function testBuffersOpenedDuringTemplateEvaluationAreBeingClosed(): void
     {
         $bufferLevel = ob_get_level();
 
@@ -1753,10 +1597,8 @@ TEXT;
     /**
      * Tests that the buffers that are opened during block caching are
      * being closed in case an exception happens.
-     *
-     * @return void
      */
-    public function testBuffersOpenedDuringBlockCachingAreBeingClosed()
+    public function testBuffersOpenedDuringBlockCachingAreBeingClosed(): void
     {
         Cache::drop('test_view');
         Cache::setConfig('test_view', [
@@ -1771,7 +1613,7 @@ TEXT;
 
         $e = null;
         try {
-            $this->View->cache(function () {
+            $this->View->cache(function (): void {
                 ob_start();
 
                 throw new \Exception('Exception with open buffers');
@@ -1792,10 +1634,8 @@ TEXT;
 
     /**
      * Test memory leaks that existed in _paths at one point.
-     *
-     * @return void
      */
-    public function testMemoryLeakInPaths()
+    public function testMemoryLeakInPaths(): void
     {
         $this->skipIf((bool)env('CODECOVERAGE'), 'Running coverage this causes this tests to fail sometimes.');
         $this->ThemeController->setName('Posts');
@@ -1816,10 +1656,8 @@ TEXT;
 
     /**
      * Tests that a view block uses default value when not assigned and uses assigned value when it is
-     *
-     * @return void
      */
-    public function testBlockDefaultValue()
+    public function testBlockDefaultValue(): void
     {
         $default = 'Default';
         $result = $this->View->fetch('title', $default);
@@ -1833,10 +1671,8 @@ TEXT;
 
     /**
      * Tests that a view variable uses default value when not assigned and uses assigned value when it is
-     *
-     * @return void
      */
-    public function testViewVarDefaultValue()
+    public function testViewVarDefaultValue(): void
     {
         $default = 'Default';
         $result = $this->View->get('title', $default);
@@ -1850,10 +1686,8 @@ TEXT;
 
     /**
      * Test the helpers() method.
-     *
-     * @return void
      */
-    public function testHelpers()
+    public function testHelpers(): void
     {
         $this->assertInstanceOf('Cake\View\HelperRegistry', $this->View->helpers());
 
@@ -1863,10 +1697,8 @@ TEXT;
 
     /**
      * Test getTemplatePath() and setTemplatePath().
-     *
-     * @return void
      */
-    public function testGetSetTemplatePath()
+    public function testGetSetTemplatePath(): void
     {
         $result = $this->View->setTemplatePath('foo');
         $this->assertSame($this->View, $result);
@@ -1877,10 +1709,8 @@ TEXT;
 
     /**
      * Test getLayoutPath() and setLayoutPath().
-     *
-     * @return void
      */
-    public function testGetSetLayoutPath()
+    public function testGetSetLayoutPath(): void
     {
         $result = $this->View->setLayoutPath('foo');
         $this->assertSame($this->View, $result);
@@ -1891,10 +1721,8 @@ TEXT;
 
     /**
      * Test isAutoLayoutEnabled() and enableAutoLayout().
-     *
-     * @return void
      */
-    public function testAutoLayout()
+    public function testAutoLayout(): void
     {
         $result = $this->View->enableAutoLayout(false);
         $this->assertSame($this->View, $result);
@@ -1909,10 +1737,8 @@ TEXT;
 
     /**
      * testDisableAutoLayout
-     *
-     * @return void
      */
-    public function testDisableAutoLayout()
+    public function testDisableAutoLayout(): void
     {
         $this->assertTrue($this->View->isAutoLayoutEnabled());
 
@@ -1925,10 +1751,8 @@ TEXT;
 
     /**
      * Test getTheme() and setTheme().
-     *
-     * @return void
      */
-    public function testGetSetTheme()
+    public function testGetSetTheme(): void
     {
         $result = $this->View->setTheme('foo');
         $this->assertSame($this->View, $result);
@@ -1939,10 +1763,8 @@ TEXT;
 
     /**
      * Test getTemplate() and setTemplate().
-     *
-     * @return void
      */
-    public function testGetSetTemplate()
+    public function testGetSetTemplate(): void
     {
         $result = $this->View->setTemplate('foo');
         $this->assertSame($this->View, $result);
@@ -1953,10 +1775,8 @@ TEXT;
 
     /**
      * Test setLayout() and getLayout().
-     *
-     * @return void
      */
-    public function testGetSetLayout()
+    public function testGetSetLayout(): void
     {
         $result = $this->View->setLayout('foo');
         $this->assertSame($this->View, $result);
@@ -1967,10 +1787,8 @@ TEXT;
 
     /**
      * Test getName() and getPlugin().
-     *
-     * @return void
      */
-    public function testGetNamePlugin()
+    public function testGetNamePlugin(): void
     {
         $this->assertSame('Posts', $this->View->getName());
         $this->assertNull($this->View->getPlugin());
@@ -1979,7 +1797,7 @@ TEXT;
         $this->assertSame('TestPlugin', $this->View->getPlugin());
     }
 
-    protected function checkException(string $message)
+    protected function checkException(string $message): void
     {
         if (version_compare(PHP_VERSION, '7.4', '>=')) {
             $this->expectException(\Error::class);

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -30,8 +30,6 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -42,10 +40,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * Test set() with one param.
-     *
-     * @return void
      */
-    public function testSetOneParam()
+    public function testSetOneParam(): void
     {
         $data = ['test' => 'val', 'foo' => 'bar'];
         $this->subject->set($data);
@@ -58,10 +54,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * test set() with 2 params
-     *
-     * @return void
      */
-    public function testSetTwoParam()
+    public function testSetTwoParam(): void
     {
         $this->subject->set('testing', 'value');
         $this->assertEquals(['testing' => 'value'], $this->subject->viewBuilder()->getVars());
@@ -69,10 +63,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * test chainable set()
-     *
-     * @return void
      */
-    public function testSetChained()
+    public function testSetChained(): void
     {
         $result = $this->subject->set('testing', 'value')
             ->set('foo', 'bar');
@@ -82,10 +74,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * test set() with 2 params in combine mode
-     *
-     * @return void
      */
-    public function testSetTwoParamCombined()
+    public function testSetTwoParamCombined(): void
     {
         $keys = ['one', 'key'];
         $vals = ['two', 'val'];
@@ -97,10 +87,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * test that createView() updates viewVars of View instance on each call.
-     *
-     * @return void
      */
-    public function testUptoDateViewVars()
+    public function testUptoDateViewVars(): void
     {
         $expected = ['one' => 'one'];
         $this->subject->set($expected);
@@ -113,10 +101,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * test that parameters beats viewBuilder() and viewClass
-     *
-     * @return void
      */
-    public function testCreateViewParameter()
+    public function testCreateViewParameter(): void
     {
         $this->subject->viewBuilder()->setClassName('View');
         $view = $this->subject->createView('Xml');
@@ -125,10 +111,8 @@ class ViewVarsTraitTest extends TestCase
 
     /**
      * test createView() throws exception if view class cannot be found
-     *
-     * @return void
      */
-    public function testCreateViewException()
+    public function testCreateViewException(): void
     {
         $this->expectException(\Cake\View\Exception\MissingViewException::class);
         $this->expectExceptionMessage('View class "Foo" is missing.');

--- a/tests/TestCase/View/Widget/BasicWidgetTest.php
+++ b/tests/TestCase/View/Widget/BasicWidgetTest.php
@@ -38,10 +38,8 @@ class BasicWidgetTest extends TestCase
 
     /**
      * Test render in a simple case.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $text = new BasicWidget($this->templates);
         $result = $text->render(['name' => 'my_input'], $this->context);
@@ -53,10 +51,8 @@ class BasicWidgetTest extends TestCase
 
     /**
      * Test render with custom type
-     *
-     * @return void
      */
-    public function testRenderType()
+    public function testRenderType(): void
     {
         $text = new BasicWidget($this->templates);
         $data = [
@@ -72,10 +68,8 @@ class BasicWidgetTest extends TestCase
 
     /**
      * Test render with a value
-     *
-     * @return void
      */
-    public function testRenderWithValue()
+    public function testRenderWithValue(): void
     {
         $text = new BasicWidget($this->templates);
         $data = [
@@ -96,10 +90,8 @@ class BasicWidgetTest extends TestCase
 
     /**
      * Test render with additional attributes.
-     *
-     * @return void
      */
-    public function testRenderAttributes()
+    public function testRenderAttributes(): void
     {
         $text = new BasicWidget($this->templates);
         $data = [
@@ -122,10 +114,8 @@ class BasicWidgetTest extends TestCase
 
     /**
      * Test render with template params.
-     *
-     * @return void
      */
-    public function testRenderTemplateParams()
+    public function testRenderTemplateParams(): void
     {
         $text = new BasicWidget(new StringTemplate([
             'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}><span>{{help}}</span>',

--- a/tests/TestCase/View/Widget/ButtonWidgetTest.php
+++ b/tests/TestCase/View/Widget/ButtonWidgetTest.php
@@ -38,10 +38,8 @@ class ButtonWidgetTest extends TestCase
 
     /**
      * Test render in a simple case.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $button = new ButtonWidget($this->templates);
         $result = $button->render(['name' => 'my_input'], $this->context);
@@ -54,10 +52,8 @@ class ButtonWidgetTest extends TestCase
 
     /**
      * Test render with custom type
-     *
-     * @return void
      */
-    public function testRenderType()
+    public function testRenderType(): void
     {
         $button = new ButtonWidget($this->templates);
         $data = [
@@ -76,10 +72,8 @@ class ButtonWidgetTest extends TestCase
 
     /**
      * Test render with a text
-     *
-     * @return void
      */
-    public function testRenderWithText()
+    public function testRenderWithText(): void
     {
         $button = new ButtonWidget($this->templates);
         $data = [
@@ -106,10 +100,8 @@ class ButtonWidgetTest extends TestCase
 
     /**
      * Test render with additional attributes.
-     *
-     * @return void
      */
-    public function testRenderAttributes()
+    public function testRenderAttributes(): void
     {
         $button = new ButtonWidget($this->templates);
         $data = [
@@ -134,10 +126,8 @@ class ButtonWidgetTest extends TestCase
 
     /**
      * Ensure templateVars option is hooked up.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'button' => '<button {{attrs}} custom="{{custom}}">{{text}}</button>',

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -28,8 +28,6 @@ class CheckboxWidgetTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class CheckboxWidgetTest extends TestCase
 
     /**
      * Test rendering simple checkboxes.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $checkbox = new CheckboxWidget($this->templates);
         $data = [
@@ -79,10 +75,8 @@ class CheckboxWidgetTest extends TestCase
 
     /**
      * Test rendering disabled checkboxes.
-     *
-     * @return void
      */
-    public function testRenderDisabled()
+    public function testRenderDisabled(): void
     {
         $checkbox = new CheckboxWidget($this->templates);
         $data = [
@@ -103,10 +97,8 @@ class CheckboxWidgetTest extends TestCase
 
     /**
      * Test rendering checked checkboxes.
-     *
-     * @return void
      */
-    public function testRenderChecked()
+    public function testRenderChecked(): void
     {
         $checkbox = new CheckboxWidget($this->templates);
         $data = [
@@ -173,9 +165,8 @@ class CheckboxWidgetTest extends TestCase
      *
      * @dataProvider checkedProvider
      * @param mixed $checked
-     * @return void
      */
-    public function testRenderCheckedValue($checked)
+    public function testRenderCheckedValue($checked): void
     {
         $checkbox = new CheckboxWidget($this->templates);
         $data = [
@@ -216,9 +207,8 @@ class CheckboxWidgetTest extends TestCase
      *
      * @dataProvider uncheckedProvider
      * @param mixed $checked
-     * @return void
      */
-    public function testRenderUnCheckedValue($checked)
+    public function testRenderUnCheckedValue($checked): void
     {
         $checkbox = new CheckboxWidget($this->templates);
         $data = [
@@ -240,10 +230,8 @@ class CheckboxWidgetTest extends TestCase
 
     /**
      * Ensure templateVars option is hooked up.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'checkbox' => '<input type="checkbox" custom="{{custom}}" name="{{name}}" value="{{value}}"{{attrs}}>',
@@ -271,10 +259,8 @@ class CheckboxWidgetTest extends TestCase
      * testRenderCustomAttributes method
      *
      * Test render with custom attributes.
-     *
-     * @return void
      */
-    public function testRenderCustomAttributes()
+    public function testRenderCustomAttributes(): void
     {
         $checkbox = new CheckboxWidget($this->templates);
 

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -28,7 +28,6 @@ class DateTimeWidgetTest extends TestCase
 {
     /**
      * @setUp
-     * @return void
      */
     public function setUp(): void
     {
@@ -63,9 +62,8 @@ class DateTimeWidgetTest extends TestCase
      *
      * @dataProvider invalidSelectedValuesProvider
      * @param mixed $selected
-     * @return void
      */
-    public function testRenderInvalid($selected)
+    public function testRenderInvalid($selected): void
     {
         $result = $this->DateTime->render(['val' => $selected, 'type' => 'month'], $this->context);
         $now = new \DateTime();
@@ -97,9 +95,8 @@ class DateTimeWidgetTest extends TestCase
      *
      * @dataProvider selectedValuesProvider
      * @param mixed $selected
-     * @return void
      */
-    public function testRenderValid($selected)
+    public function testRenderValid($selected): void
     {
         $result = $this->DateTime->render(['val' => $selected], $this->context);
         $expected = [
@@ -115,10 +112,8 @@ class DateTimeWidgetTest extends TestCase
 
     /**
      * testTimezoneOption
-     *
-     * @return void
      */
-    public function testTimezoneOption()
+    public function testTimezoneOption(): void
     {
         $result = $this->DateTime->render([
             'val' => '2019-02-03 10:00:00',
@@ -135,7 +130,7 @@ class DateTimeWidgetTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testUnsettingStep()
+    public function testUnsettingStep(): void
     {
         $result = $this->DateTime->render([
             'val' => '2019-02-03 10:11:12',
@@ -164,7 +159,7 @@ class DateTimeWidgetTest extends TestCase
         $this->assertHtml($expected, $result);
     }
 
-    public function testDatetimeFormat()
+    public function testDatetimeFormat(): void
     {
         $result = $this->DateTime->render([
             'val' => '2019-02-03 10:11:12',
@@ -227,10 +222,8 @@ class DateTimeWidgetTest extends TestCase
 
     /**
      * Test rendering with templateVars
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $templates = [
             'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}><span>{{help}}</span>',
@@ -246,10 +239,8 @@ class DateTimeWidgetTest extends TestCase
 
     /**
      * testRenderInvalidTypeException
-     *
-     * @return void
      */
-    public function testRenderInvalidTypeException()
+    public function testRenderInvalidTypeException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid type `foo` for input tag, expected datetime-local, date, time, month or week');
@@ -258,10 +249,8 @@ class DateTimeWidgetTest extends TestCase
 
     /**
      * Test that secureFields omits removed selects
-     *
-     * @return void
      */
-    public function testSecureFields()
+    public function testSecureFields(): void
     {
         $data = [
             'name' => 'date',

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -29,8 +29,6 @@ class FileWidgetTest extends TestCase
 {
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -44,10 +42,8 @@ class FileWidgetTest extends TestCase
 
     /**
      * Test render in a simple case.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $input = new FileWidget($this->templates);
         $result = $input->render(['name' => 'image'], $this->context);
@@ -59,10 +55,8 @@ class FileWidgetTest extends TestCase
 
     /**
      * Test render with a value
-     *
-     * @return void
      */
-    public function testRenderAttributes()
+    public function testRenderAttributes(): void
     {
         $input = new FileWidget($this->templates);
         $data = ['name' => 'image', 'required' => true, 'val' => 'nope'];
@@ -75,10 +69,8 @@ class FileWidgetTest extends TestCase
 
     /**
      * Ensure templateVars option is hooked up.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'file' => '<input custom="{{custom}}" type="file" name="{{name}}"{{attrs}}>',
@@ -102,10 +94,8 @@ class FileWidgetTest extends TestCase
 
     /**
      * Test secureFields
-     *
-     * @return void
      */
-    public function testSecureFields()
+    public function testSecureFields(): void
     {
         $input = new FileWidget($this->templates);
         $data = ['name' => 'image', 'required' => true, 'val' => 'nope'];

--- a/tests/TestCase/View/Widget/LabelWidgetTest.php
+++ b/tests/TestCase/View/Widget/LabelWidgetTest.php
@@ -28,8 +28,6 @@ class LabelWidgetTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class LabelWidgetTest extends TestCase
 
     /**
      * test render
-     *
-     * @return void
      */
-    public function testRender()
+    public function testRender(): void
     {
         $label = new LabelWidget($this->templates);
         $data = [
@@ -63,10 +59,8 @@ class LabelWidgetTest extends TestCase
 
     /**
      * test render escape
-     *
-     * @return void
      */
-    public function testRenderEscape()
+    public function testRenderEscape(): void
     {
         $label = new LabelWidget($this->templates);
         $data = [
@@ -85,10 +79,8 @@ class LabelWidgetTest extends TestCase
 
     /**
      * test render escape
-     *
-     * @return void
      */
-    public function testRenderAttributes()
+    public function testRenderAttributes(): void
     {
         $label = new LabelWidget($this->templates);
         $data = [
@@ -108,10 +100,8 @@ class LabelWidgetTest extends TestCase
 
     /**
      * Ensure templateVars option is hooked up.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'label' => '<label custom="{{custom}}" {{attrs}}>{{text}}</label>',

--- a/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxWidgetTest.php
@@ -30,8 +30,6 @@ class MultiCheckboxWidgetTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,10 +49,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render simple option sets.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -95,10 +91,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render complex and additional attributes.
-     *
-     * @return void
      */
-    public function testRenderComplex()
+    public function testRenderComplex(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -145,10 +139,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render escpaing options.
-     *
-     * @return void
      */
-    public function testRenderEscaping()
+    public function testRenderEscaping(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -177,10 +169,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render selected checkboxes.
-     *
-     * @return void
      */
-    public function testRenderSelected()
+    public function testRenderSelected(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -232,10 +222,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render disabled checkboxes.
-     *
-     * @return void
      */
-    public function testRenderDisabled()
+    public function testRenderDisabled(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -322,10 +310,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render templateVars
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $templates = [
             'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}" data-var="{{inputVar}}" {{attrs}}>',
@@ -376,10 +362,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test label = false with checkboxWrapper option.
-     *
-     * @return void
      */
-    public function testNoLabelWithCheckboxWrapperOption()
+    public function testNoLabelWithCheckboxWrapperOption(): void
     {
         $data = [
             'label' => false,
@@ -447,10 +431,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test rendering without input nesting inspite of using NestingLabelWidget
-     *
-     * @return void
      */
-    public function testRenderNestingLabelWidgetWithoutInputNesting()
+    public function testRenderNestingLabelWidgetWithoutInputNesting(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -483,10 +465,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render with groupings.
-     *
-     * @return void
      */
-    public function testRenderGrouped()
+    public function testRenderGrouped(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -538,10 +518,8 @@ class MultiCheckboxWidgetTest extends TestCase
 
     /**
      * Test render with partial groupings.
-     *
-     * @return void
      */
-    public function testRenderPartialGrouped()
+    public function testRenderPartialGrouped(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -603,10 +581,8 @@ class MultiCheckboxWidgetTest extends TestCase
      * testRenderCustomAttributes method
      *
      * Test render with custom attributes
-     *
-     * @return void
      */
-    public function testRenderCustomAttributes()
+    public function testRenderCustomAttributes(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -657,10 +633,8 @@ class MultiCheckboxWidgetTest extends TestCase
      *
      * Test that the id passed is actually used
      * Issue: https://github.com/cakephp/cakephp/issues/13342
-     *
-     * @return void
      */
-    public function testRenderExplicitId()
+    public function testRenderExplicitId(): void
     {
         $label = new LabelWidget($this->templates);
         $input = new MultiCheckboxWidget($this->templates, $label);
@@ -723,10 +697,8 @@ class MultiCheckboxWidgetTest extends TestCase
      *
      * Test that the custom selected class is passed to label
      * Issue: https://github.com/cakephp/cakephp/issues/11249
-     *
-     * @return void
      */
-    public function testRenderSelectedClass()
+    public function testRenderSelectedClass(): void
     {
         $this->templates->add(['selectedClass' => 'active']);
 

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -30,8 +30,6 @@ class RadioWidgetTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -48,10 +46,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering basic radio buttons without nested inputs
-     *
-     * @return void
      */
-    public function testRenderSimpleNotNested()
+    public function testRenderSimpleNotNested(): void
     {
         $this->templates->add([
             'nestingLabel' => '<label{{attrs}}>{{text}}</label>',
@@ -112,10 +108,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering basic radio buttons.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -157,10 +151,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering the activeClass template var
-     *
-     * @return void
      */
-    public function testRenderSimpleActiveTemplateVar()
+    public function testRenderSimpleActiveTemplateVar(): void
     {
         $this->templates->add([
             'nestingLabel' => '<label class="{{activeClass}}"{{attrs}}>{{text}}</label>',
@@ -200,10 +192,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering inputs with the complex option form.
-     *
-     * @return void
      */
-    public function testRenderComplex()
+    public function testRenderComplex(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -241,10 +231,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering inputs with label options
-     *
-     * @return void
      */
-    public function testRenderComplexLabelAttributes()
+    public function testRenderComplexLabelAttributes(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -281,10 +269,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test that id suffixes are generated to not collide
-     *
-     * @return void
      */
-    public function testRenderIdSuffixGeneration()
+    public function testRenderIdSuffixGeneration(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -318,10 +304,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering checks the right option with booleanish values.
-     *
-     * @return void
      */
-    public function testRenderBooleanishValues()
+    public function testRenderBooleanishValues(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -394,10 +378,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test that render() works with the required attribute.
-     *
-     * @return void
      */
-    public function testRenderRequiredAndFormAttribute()
+    public function testRenderRequiredAndFormAttribute(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -425,10 +407,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering the empty option.
-     *
-     * @return void
      */
-    public function testRenderEmptyOption()
+    public function testRenderEmptyOption(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -487,10 +467,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering the input inside the label.
-     *
-     * @return void
      */
-    public function testRenderInputInsideLabel()
+    public function testRenderInputInsideLabel(): void
     {
         $this->templates->add([
             'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
@@ -519,10 +497,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * test render() and selected inputs.
-     *
-     * @return void
      */
-    public function testRenderSelected()
+    public function testRenderSelected(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -571,10 +547,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering with disable inputs
-     *
-     * @return void
      */
-    public function testRenderDisabled()
+    public function testRenderDisabled(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -644,10 +618,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Test rendering with label options.
-     *
-     * @return void
      */
-    public function testRenderLabelOptions()
+    public function testRenderLabelOptions(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -715,10 +687,8 @@ class RadioWidgetTest extends TestCase
     /**
      * Ensure that the input + label are composed with
      * a template.
-     *
-     * @return void
      */
-    public function testRenderContainerTemplate()
+    public function testRenderContainerTemplate(): void
     {
         $this->templates->add([
             'radioWrapper' => '<div class="radio">{{input}}{{label}}</div>',
@@ -746,10 +716,8 @@ class RadioWidgetTest extends TestCase
 
     /**
      * Ensure that template vars work.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'radioWrapper' => '<div class="radio" data-var="{{wrapperVar}}">{{label}}</div>',
@@ -779,10 +747,8 @@ class RadioWidgetTest extends TestCase
      * testRenderCustomAttributes method
      *
      * Test render with custom attributes.
-     *
-     * @return void
      */
-    public function testRenderCustomAttributes()
+    public function testRenderCustomAttributes(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $radio = new RadioWidget($this->templates, $label);
@@ -829,10 +795,8 @@ class RadioWidgetTest extends TestCase
      *
      * Test that the id passed is actually used
      * Issue: https://github.com/cakephp/cakephp/issues/13342
-     *
-     * @return void
      */
-    public function testRenderExplicitId()
+    public function testRenderExplicitId(): void
     {
         $label = new NestingLabelWidget($this->templates);
         $input = new RadioWidget($this->templates, $label);
@@ -887,10 +851,8 @@ class RadioWidgetTest extends TestCase
      *
      * Test that the custom selected class is passed to label
      * Issue: https://github.com/cakephp/cakephp/issues/11249
-     *
-     * @return void
      */
-    public function testRenderSelectedClass()
+    public function testRenderSelectedClass(): void
     {
         $this->templates->add(['selectedClass' => 'active']);
 

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -29,8 +29,6 @@ class SelectBoxWidgetTest extends TestCase
 {
     /**
      * setup method.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -47,10 +45,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test render no options
-     *
-     * @return void
      */
-    public function testRenderNoOptions()
+    public function testRenderNoOptions(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -68,10 +64,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test simple rendering
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -91,10 +85,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * Test render boolean options
-     *
-     * @return void
      */
-    public function testRenderBoolean()
+    public function testRenderBoolean(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -113,10 +105,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test simple iterator rendering
-     *
-     * @return void
      */
-    public function testRenderSimpleIterator()
+    public function testRenderSimpleIterator(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $options = new \ArrayObject(['a' => 'Albatross', 'b' => 'Budgie']);
@@ -138,10 +128,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test simple iterator rendering with empty option
-     *
-     * @return void
      */
-    public function testRenderSimpleIteratorWithEmpty()
+    public function testRenderSimpleIteratorWithEmpty(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $options = new Collection(['a' => 'Albatross', 'b' => 'Budgie']);
@@ -163,10 +151,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test complex option rendering
-     *
-     * @return void
      */
-    public function testRenderComplex()
+    public function testRenderComplex(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -193,10 +179,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with a selected value
-     *
-     * @return void
      */
-    public function testRenderSelected()
+    public function testRenderSelected(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -236,10 +220,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test complex option rendering with a selected value
-     *
-     * @return void
      */
-    public function testRenderComplexSelected()
+    public function testRenderComplexSelected(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -267,10 +249,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering a multi select
-     *
-     * @return void
      */
-    public function testRenderMultipleSelect()
+    public function testRenderMultipleSelect(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -295,10 +275,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering multi select & selected values
-     *
-     * @return void
      */
-    public function testRenderMultipleSelected()
+    public function testRenderMultipleSelected(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -331,10 +309,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with option groups
-     *
-     * @return void
      */
-    public function testRenderOptionGroups()
+    public function testRenderOptionGroups(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -378,10 +354,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with numeric option group keys
-     *
-     * @return void
      */
-    public function testRenderOptionGroupsIntegerKeys()
+    public function testRenderOptionGroupsIntegerKeys(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -420,10 +394,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with option groups and escaping
-     *
-     * @return void
      */
-    public function testRenderOptionGroupsEscape()
+    public function testRenderOptionGroupsEscape(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -466,10 +438,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with option groups
-     *
-     * @return void
      */
-    public function testRenderOptionGroupsWithAttributes()
+    public function testRenderOptionGroupsWithAttributes(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -505,10 +475,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with option groups with traversable nodes
-     *
-     * @return void
      */
-    public function testRenderOptionGroupsTraversable()
+    public function testRenderOptionGroupsTraversable(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $mammals = new \ArrayObject(['beaver' => 'Beaver', 'elk' => 'Elk']);
@@ -550,10 +518,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering option groups and selected values
-     *
-     * @return void
      */
-    public function testRenderOptionGroupsSelectedAndDisabled()
+    public function testRenderOptionGroupsSelectedAndDisabled(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -592,10 +558,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering a totally disabled element
-     *
-     * @return void
      */
-    public function testRenderDisabled()
+    public function testRenderDisabled(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -636,10 +600,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering a disabled element
-     *
-     * @return void
      */
-    public function testRenderDisabledMultiple()
+    public function testRenderDisabledMultiple(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -673,10 +635,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test complex option rendering with a disabled element
-     *
-     * @return void
      */
-    public function testRenderComplexDisabled()
+    public function testRenderComplexDisabled(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -704,10 +664,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test rendering with an empty value
-     *
-     * @return void
      */
-    public function testRenderEmptyOption()
+    public function testRenderEmptyOption(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -763,10 +721,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * Test rendering with disabling escaping.
-     *
-     * @return void
      */
-    public function testRenderEscapingOption()
+    public function testRenderEscapingOption(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -817,10 +773,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * test render with null options
-     *
-     * @return void
      */
-    public function testRenderNullOptions()
+    public function testRenderNullOptions(): void
     {
         $select = new SelectBoxWidget($this->templates);
         $data = [
@@ -856,10 +810,8 @@ class SelectBoxWidgetTest extends TestCase
 
     /**
      * Ensure templateVars option is hooked up.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'select' => '<select custom="{{custom}}" name="{{name}}"{{attrs}}>{{content}}</select>',

--- a/tests/TestCase/View/Widget/TextareaWidgetTest.php
+++ b/tests/TestCase/View/Widget/TextareaWidgetTest.php
@@ -28,8 +28,6 @@ class TextareaWidgetTest extends TestCase
 {
     /**
      * setup
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -43,10 +41,8 @@ class TextareaWidgetTest extends TestCase
 
     /**
      * Test render in a simple case.
-     *
-     * @return void
      */
-    public function testRenderSimple()
+    public function testRenderSimple(): void
     {
         $input = new TextareaWidget($this->templates);
         $result = $input->render(['name' => 'comment'], $this->context);
@@ -59,10 +55,8 @@ class TextareaWidgetTest extends TestCase
 
     /**
      * Test render with a value
-     *
-     * @return void
      */
-    public function testRenderWithValue()
+    public function testRenderWithValue(): void
     {
         $input = new TextareaWidget($this->templates);
         $data = ['name' => 'comment', 'data-foo' => '<val>', 'val' => 'some <html>'];
@@ -86,10 +80,8 @@ class TextareaWidgetTest extends TestCase
 
     /**
      * Ensure templateVars option is hooked up.
-     *
-     * @return void
      */
-    public function testRenderTemplateVars()
+    public function testRenderTemplateVars(): void
     {
         $this->templates->add([
             'textarea' => '<textarea custom="{{custom}}" name="{{name}}"{{attrs}}>{{value}}</textarea>',

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -39,8 +39,6 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * setup method
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -51,10 +49,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test adding new widgets.
-     *
-     * @return void
      */
-    public function testAddInConstructor()
+    public function testAddInConstructor(): void
     {
         $widgets = [
             'text' => ['Cake\View\Widget\BasicWidget'],
@@ -70,10 +66,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test that view instance is properly passed to widget constructor.
-     *
-     * @return void
      */
-    public function testGeneratingWidgetUsingViewInstance()
+    public function testGeneratingWidgetUsingViewInstance(): void
     {
         $inputs = new WidgetLocator(
             $this->templates,
@@ -88,10 +82,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test loading widgets files in the app.
-     *
-     * @return void
      */
-    public function testAddWidgetsFromConfigInConstructor()
+    public function testAddWidgetsFromConfigInConstructor(): void
     {
         $widgets = [
             'text' => ['Cake\View\Widget\BasicWidget'],
@@ -103,10 +95,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test loading templates files from a plugin
-     *
-     * @return void
      */
-    public function testAddPluginWidgetsFromConfigInConstructor()
+    public function testAddPluginWidgetsFromConfigInConstructor(): void
     {
         $this->loadPlugins(['TestPlugin']);
         $widgets = [
@@ -120,10 +110,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test adding new widgets.
-     *
-     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add([
@@ -142,10 +130,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test adding an instance of an invalid type.
-     *
-     * @return void
      */
-    public function testAddInvalidType()
+    public function testAddInvalidType(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
@@ -159,10 +145,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test getting registered widgets.
-     *
-     * @return void
      */
-    public function testGet()
+    public function testGet(): void
     {
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add([
@@ -175,10 +159,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test getting fallback widgets.
-     *
-     * @return void
      */
-    public function testGetFallback()
+    public function testGetFallback(): void
     {
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add([
@@ -193,10 +175,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test getting errors
-     *
-     * @return void
      */
-    public function testGetNoFallbackError()
+    public function testGetNoFallbackError(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unknown widget `foo`');
@@ -207,10 +187,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test getting resolve dependency
-     *
-     * @return void
      */
-    public function testGetResolveDependency()
+    public function testGetResolveDependency(): void
     {
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->clear();
@@ -224,10 +202,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test getting resolve dependency missing class
-     *
-     * @return void
      */
-    public function testGetResolveDependencyMissingClass()
+    public function testGetResolveDependencyMissingClass(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to locate widget class "TestApp\View\DerpWidget"');
@@ -238,10 +214,8 @@ class WidgetLocatorTest extends TestCase
 
     /**
      * Test getting resolve dependency missing dependency
-     *
-     * @return void
      */
-    public function testGetResolveDependencyMissingDependency()
+    public function testGetResolveDependencyMissingDependency(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unknown widget `label`');

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -40,10 +40,8 @@ class XmlViewTest extends TestCase
 
     /**
      * testRenderWithoutView method
-     *
-     * @return void
      */
-    public function testRenderWithoutView()
+    public function testRenderWithoutView(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -93,10 +91,8 @@ class XmlViewTest extends TestCase
 
     /**
      * Test that rendering with _serialize does not load helpers
-     *
-     * @return void
      */
-    public function testRenderSerializeNoHelpers()
+    public function testRenderSerializeNoHelpers(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -114,10 +110,8 @@ class XmlViewTest extends TestCase
 
     /**
      * Test that rendering with _serialize respects XML options.
-     *
-     * @return void
      */
-    public function testRenderSerializeWithOptions()
+    public function testRenderSerializeWithOptions(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -152,10 +146,8 @@ class XmlViewTest extends TestCase
 
     /**
      * Test that rendering with _serialize can work with string setting.
-     *
-     * @return void
      */
-    public function testRenderSerializeWithString()
+    public function testRenderSerializeWithString(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -192,10 +184,8 @@ class XmlViewTest extends TestCase
 
     /**
      * Test render with an array in _serialize
-     *
-     * @return void
      */
-    public function testRenderWithoutViewMultiple()
+    public function testRenderWithoutViewMultiple(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -226,10 +216,8 @@ class XmlViewTest extends TestCase
 
     /**
      * Test render with an array in _serialize and alias
-     *
-     * @return void
      */
-    public function testRenderWithoutViewMultipleAndAlias()
+    public function testRenderWithoutViewMultipleAndAlias(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -260,10 +248,8 @@ class XmlViewTest extends TestCase
 
     /**
      * test rendering with _serialize true
-     *
-     * @return void
      */
-    public function testRenderWithSerializeTrue()
+    public function testRenderWithSerializeTrue(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -295,10 +281,8 @@ class XmlViewTest extends TestCase
 
     /**
      * testRenderWithView method
-     *
-     * @return void
      */
-    public function testRenderWithView()
+    public function testRenderWithView(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();
@@ -332,7 +316,7 @@ class XmlViewTest extends TestCase
         $this->assertInstanceOf('Cake\View\HelperRegistry', $View->helpers());
     }
 
-    public function testSerializingResultSet()
+    public function testSerializingResultSet(): void
     {
         $Request = new ServerRequest();
         $Response = new Response();

--- a/tests/test_app/Plugin/Company/TestPluginFive/src/Utility/Hello.php
+++ b/tests/test_app/Plugin/Company/TestPluginFive/src/Utility/Hello.php
@@ -19,10 +19,8 @@ class Hello
 {
     /**
      * foo method
-     *
-     * @return string
      */
-    public function foo()
+    public function foo(): string
     {
         return 'bar';
     }

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/OvensController.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Controller/OvensController.php
@@ -7,7 +7,7 @@ use Cake\Controller\Controller;
 
 class OvensController extends Controller
 {
-    public function index()
+    public function index(): void
     {
         $this->autoRender = false;
     }

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Utility/Hello.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Utility/Hello.php
@@ -19,10 +19,8 @@ class Hello
 {
     /**
      * foo method
-     *
-     * @return string
      */
-    public function foo()
+    public function foo(): string
     {
         return 'bar';
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/TestsController.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/TestsController.php
@@ -22,7 +22,7 @@ namespace TestPlugin\Controller;
 
 class TestsController extends TestPluginAppController
 {
-    public function index()
+    public function index(): void
     {
         $this->set('test_value', 'It is a variable');
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Datasource/TestSource.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Datasource/TestSource.php
@@ -25,7 +25,7 @@ class TestSource
      *
      * @return array
      */
-    public function config()
+    public function config(): array
     {
         return $this->_config;
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Model/Behavior/PersisterOneBehavior.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Model/Behavior/PersisterOneBehavior.php
@@ -19,7 +19,7 @@ use Cake\ORM\Behavior;
 
 class PersisterOneBehavior extends Behavior
 {
-    public function persist()
+    public function persist(): void
     {
     }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Plugin.php
@@ -23,7 +23,7 @@ class Plugin extends BasePlugin
 {
     public function events(EventManagerInterface $events): EventManagerInterface
     {
-        $events->on('TestPlugin.load', function () {
+        $events->on('TestPlugin.load', function (): void {
         });
 
         return $events;

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/ExampleShell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/ExampleShell.php
@@ -26,10 +26,8 @@ class ExampleShell extends Shell
 {
     /**
      * main method
-     *
-     * @return void
      */
-    public function main()
+    public function main(): void
     {
         $this->out('This is the main method called from TestPlugin.ExampleShell');
     }

--- a/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Shell/SampleShell.php
@@ -26,20 +26,16 @@ class SampleShell extends Shell
 {
     /**
      * main method
-     *
-     * @return void
      */
-    public function main()
+    public function main(): void
     {
         $this->out('This is the main method called from SampleShell');
     }
 
     /**
      * example method
-     *
-     * @return void
      */
-    public function example()
+    public function example(): void
     {
         $this->out('This is the example method called from TestPlugin.SampleShell');
     }

--- a/tests/test_app/Plugin/TestPlugin/src/View/Cell/Admin/MenuCell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Cell/Admin/MenuCell.php
@@ -22,10 +22,8 @@ class MenuCell extends \Cake\View\Cell
 {
     /**
      * Default cell action.
-     *
-     * @return void
      */
-    public function display()
+    public function display(): void
     {
     }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/View/Cell/DummyCell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Cell/DummyCell.php
@@ -22,10 +22,8 @@ class DummyCell extends \Cake\View\Cell
 {
     /**
      * Default cell action.
-     *
-     * @return void
      */
-    public function display()
+    public function display(): void
     {
     }
 
@@ -33,9 +31,8 @@ class DummyCell extends \Cake\View\Cell
      * Simple echo.
      *
      * @param string $msg
-     * @return void
      */
-    public function echoThis($msg)
+    public function echoThis($msg): void
     {
         $this->set('msg', $msg);
     }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/ExampleShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/ExampleShell.php
@@ -26,20 +26,16 @@ class ExampleShell extends Shell
 {
     /**
      * main method
-     *
-     * @return void
      */
-    public function main()
+    public function main(): void
     {
         $this->out('This is the main method called from TestPluginTwo.ExampleShell');
     }
 
     /**
      * say_hello method
-     *
-     * @return void
      */
-    public function say_hello()
+    public function say_hello(): void
     {
         $this->out('Hello from the TestPluginTwo.ExampleShell');
     }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/UniqueShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/UniqueShell.php
@@ -26,10 +26,8 @@ class UniqueShell extends Shell
 {
     /**
      * main method
-     *
-     * @return void
      */
-    public function main()
+    public function main(): void
     {
         $this->out('This is the main method called from TestPluginTwo.UniqueShell');
     }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Shell/WelcomeShell.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Shell/WelcomeShell.php
@@ -26,10 +26,8 @@ class WelcomeShell extends Shell
 {
     /**
      * say_hello method
-     *
-     * @return void
      */
-    public function say_hello()
+    public function say_hello(): void
     {
         $this->out('This is the say_hello method called from TestPluginTwo.WelcomeShell');
     }

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -32,9 +32,6 @@ use TestApp\Command\FormatSpecifierCommand;
 
 class Application extends BaseApplication
 {
-    /**
-     * @return void
-     */
     public function bootstrap(): void
     {
         parent::bootstrap();
@@ -47,9 +44,6 @@ class Application extends BaseApplication
         }
     }
 
-    /**
-     * @return \Cake\Console\CommandCollection
-     */
     public function console(CommandCollection $commands): CommandCollection
     {
         return $commands
@@ -58,9 +52,6 @@ class Application extends BaseApplication
             ->addMany($commands->autoDiscover());
     }
 
-    /**
-     * @return \Cake\Http\MiddlewareQueue
-     */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         $middlewareQueue->add(function ($request, $handler) {
@@ -74,12 +65,10 @@ class Application extends BaseApplication
 
     /**
      * Routes hook, used for testing with RoutingMiddleware.
-     *
-     * @return void
      */
     public function routes(RouteBuilder $routes): void
     {
-        $routes->scope('/app', function (RouteBuilder $routes) {
+        $routes->scope('/app', function (RouteBuilder $routes): void {
             $routes->connect('/articles', ['controller' => 'Articles']);
             $routes->connect('/articles/{action}/*', ['controller' => 'Articles']);
 
@@ -99,7 +88,6 @@ class Application extends BaseApplication
      * Container register hook
      *
      * @param \Cake\Core\ContainerInterface $container The container to update
-     * @return void
      */
     public function services(ContainerInterface $container): void
     {

--- a/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
@@ -34,17 +34,12 @@ class ApplicationWithDefaultRoutes extends BaseApplication
      * Bootstrap hook.
      *
      * Nerfed as this is for IntegrationTestCase testing.
-     *
-     * @return void
      */
     public function bootstrap(): void
     {
         // Do nothing.
     }
 
-    /**
-     * @return \Cake\Http\MiddlewareQueue
-     */
     public function middleware(MiddlewareQueue $middlewareQueueQueue): MiddlewareQueue
     {
         $middlewareQueueQueue->add(new RoutingMiddleware($this));

--- a/tests/test_app/TestApp/ApplicationWithExceptionsInMiddleware.php
+++ b/tests/test_app/TestApp/ApplicationWithExceptionsInMiddleware.php
@@ -31,8 +31,6 @@ class ApplicationWithExceptionsInMiddleware extends BaseApplication
      * Bootstrap hook.
      *
      * Nerfed as this is for IntegrationTestCase testing.
-     *
-     * @return void
      */
     public function bootstrap(): void
     {

--- a/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithPluginRoutes.php
@@ -23,18 +23,12 @@ use Cake\Routing\RouteBuilder;
 
 class ApplicationWithPluginRoutes extends BaseApplication
 {
-    /**
-     * @return void
-     */
     public function bootstrap(): void
     {
         parent::bootstrap();
         $this->addPlugin('TestPlugin');
     }
 
-    /**
-     * @return \Cake\Http\MiddlewareQueue
-     */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
         $middlewareQueue->add(new RoutingMiddleware($this));
@@ -44,12 +38,10 @@ class ApplicationWithPluginRoutes extends BaseApplication
 
     /**
      * Routes hook, used for testing with RoutingMiddleware.
-     *
-     * @return void
      */
     public function routes(RouteBuilder $routes): void
     {
-        $routes->scope('/app', function (RouteBuilder $routes) {
+        $routes->scope('/app', function (RouteBuilder $routes): void {
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
         $routes->loadPlugin('TestPlugin');

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -43,14 +43,14 @@ class TestAuthenticate extends BaseAuthenticate
     /**
      * @return array
      */
-    public function authenticate(ServerRequest $request, Response $response)
+    public function authenticate(ServerRequest $request, Response $response): array
     {
         return ['id' => 1, 'username' => 'admad'];
     }
 
     /**
      * @param array $user
-     * @return array
+     * @return array|void
      */
     public function afterIdentify(EventInterface $event, array $user)
     {
@@ -65,7 +65,7 @@ class TestAuthenticate extends BaseAuthenticate
     /**
      * @param array $user
      */
-    public function logout(EventInterface $event, array $user)
+    public function logout(EventInterface $event, array $user): void
     {
         $this->callStack[] = __FUNCTION__;
     }

--- a/tests/test_app/TestApp/Config/ReadOnlyTestInstanceConfig.php
+++ b/tests/test_app/TestApp/Config/ReadOnlyTestInstanceConfig.php
@@ -30,7 +30,6 @@ class ReadOnlyTestInstanceConfig
      * @throws \Exception
      * @param array|string $key
      * @param mixed $value
-     * @return void
      */
     protected function _configWrite($key, $value): void
     {

--- a/tests/test_app/TestApp/Datasource/FakeConnection.php
+++ b/tests/test_app/TestApp/Datasource/FakeConnection.php
@@ -22,17 +22,15 @@ class FakeConnection
      *
      * @return array
      */
-    public function config()
+    public function config(): array
     {
         return $this->_config;
     }
 
     /**
      * Returns the set name
-     *
-     * @return string
      */
-    public function configName()
+    public function configName(): string
     {
         if (empty($this->_config['name'])) {
             return '';

--- a/tests/test_app/TestApp/Error/MyCustomExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/MyCustomExceptionRenderer.php
@@ -9,19 +9,16 @@ class MyCustomExceptionRenderer extends ExceptionRenderer
 {
     /**
      * @param \Cake\Controller\Controller $controller
-     * @return void
      */
-    public function setController($controller)
+    public function setController($controller): void
     {
         $this->controller = $controller;
     }
 
     /**
      * custom error message type.
-     *
-     * @return string
      */
-    public function missingWidgetThing()
+    public function missingWidgetThing(): string
     {
         return 'widget thing is missing';
     }

--- a/tests/test_app/TestApp/Error/TestErrorHandler.php
+++ b/tests/test_app/TestApp/Error/TestErrorHandler.php
@@ -21,7 +21,6 @@ class TestErrorHandler extends ErrorHandler
      * Stub sending responses
      *
      * @param \Cake\Http\Response $response
-     * @return void
      */
     protected function _sendResponse($response): void
     {

--- a/tests/test_app/TestApp/Http/EventApplication.php
+++ b/tests/test_app/TestApp/Http/EventApplication.php
@@ -24,7 +24,7 @@ class EventApplication extends BaseApplication
 {
     public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
-        $eventManager->on('My.event', function () {
+        $eventManager->on('My.event', function (): void {
         });
 
         return $eventManager;

--- a/tests/test_app/TestApp/Http/MiddlewareApplication.php
+++ b/tests/test_app/TestApp/Http/MiddlewareApplication.php
@@ -13,7 +13,6 @@ class MiddlewareApplication extends BaseApplication
 {
     /**
      * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware stack to set in your App Class
-     * @return \Cake\Http\MiddlewareQueue
      */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
@@ -39,7 +38,6 @@ class MiddlewareApplication extends BaseApplication
 
     /**
      * @param \Psr\Http\Message\ServerRequestInterface $request The request
-     * @return \Psr\Http\Message\ResponseInterface
      */
     public function handle(ServerRequestInterface $req): ResponseInterface
     {

--- a/tests/test_app/TestApp/Http/Session/TestWebSession.php
+++ b/tests/test_app/TestApp/Http/Session/TestWebSession.php
@@ -10,9 +10,6 @@ use Cake\Http\Session;
  */
 class TestWebSession extends Session
 {
-    /**
-     * @return bool
-     */
     protected function _hasSession(): bool
     {
         $isCLI = $this->_isCLI;

--- a/tests/test_app/TestApp/Log/Engine/TestAppLog.php
+++ b/tests/test_app/TestApp/Log/Engine/TestAppLog.php
@@ -34,9 +34,8 @@ class TestAppLog extends BaseLog
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->passedScope = $context;
     }

--- a/tests/test_app/TestApp/Log/Engine/TestBaseLog.php
+++ b/tests/test_app/TestApp/Log/Engine/TestBaseLog.php
@@ -23,9 +23,8 @@ class TestBaseLog extends BaseLog
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->message = $this->_format($message, $context);
     }

--- a/tests/test_app/TestApp/Mailer/TestMessage.php
+++ b/tests/test_app/TestApp/Mailer/TestMessage.php
@@ -15,37 +15,31 @@ class TestMessage extends Message
      *
      * @return array
      */
-    public function fmtAddress(array $address)
+    public function fmtAddress(array $address): array
     {
         return parent::formatAddress($address);
     }
 
     /**
      * Get the boundary attribute
-     *
-     * @return string
      */
-    public function getBoundary()
+    public function getBoundary(): ?string
     {
         return $this->boundary;
     }
 
     /**
      * Encode to protected method
-     *
-     * @return string
      */
-    public function encode(string $text)
+    public function encode(string $text): string
     {
         return parent::encodeForHeader($text);
     }
 
     /**
      * Decode to protected method
-     *
-     * @return string
      */
-    public function decode(string $text)
+    public function decode(string $text): string
     {
         return parent::decodeForHeader($text);
     }
@@ -55,7 +49,7 @@ class TestMessage extends Message
      *
      * @return array
      */
-    public function doWrap(string $text, int $length = Message::LINE_LENGTH_MUST)
+    public function doWrap(string $text, int $length = Message::LINE_LENGTH_MUST): array
     {
         return $this->wrap($text, $length);
     }

--- a/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
+++ b/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
@@ -13,18 +13,14 @@ class SmtpTestTransport extends SmtpTransport
 {
     /**
      * Helper to change the socket
-     *
-     * @return void
      */
-    public function setSocket(Socket $socket)
+    public function setSocket(Socket $socket): void
     {
         $this->_socket = $socket;
     }
 
     /**
      * Disabled the socket change
-     *
-     * @return void
      */
     protected function _generateSocket(): void
     {

--- a/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
@@ -32,11 +32,11 @@ class DuplicateBehavior extends Behavior
         ],
     ];
 
-    public function findChildren()
+    public function findChildren(): void
     {
     }
 
-    public function slugify()
+    public function slugify(): void
     {
     }
 }

--- a/tests/test_app/TestApp/Model/Behavior/Test2Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test2Behavior.php
@@ -19,21 +19,21 @@ class Test2Behavior extends Behavior
     /**
      * Test for event bindings.
      */
-    public function beforeFind()
+    public function beforeFind(): void
     {
     }
 
     /**
      * Test finder
      */
-    public function findFoo()
+    public function findFoo(): void
     {
     }
 
     /**
      * Test method
      */
-    public function doSomething()
+    public function doSomething(): void
     {
     }
 }

--- a/tests/test_app/TestApp/Model/Behavior/Test3Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test3Behavior.php
@@ -10,21 +10,21 @@ class Test3Behavior extends Behavior
     /**
      * Test for event bindings.
      */
-    public function beforeFind()
+    public function beforeFind(): void
     {
     }
 
     /**
      * Test finder
      */
-    public function findFoo()
+    public function findFoo(): void
     {
     }
 
     /**
      * Test method
      */
-    public function doSomething()
+    public function doSomething(): void
     {
     }
 
@@ -69,7 +69,7 @@ class Test3Behavior extends Behavior
      *
      * @return array
      */
-    public function testReflectionCache()
+    public function testReflectionCache(): array
     {
         return $this->_reflectionCache();
     }

--- a/tests/test_app/TestApp/Model/Behavior/TestBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/TestBehavior.php
@@ -10,42 +10,42 @@ class TestBehavior extends Behavior
     /**
      * Test for event bindings.
      */
-    public function beforeFind()
+    public function beforeFind(): void
     {
     }
 
     /**
      * Test for event bindings.
      */
-    public function beforeRules()
+    public function beforeRules(): void
     {
     }
 
     /**
      * Test for event bindings.
      */
-    public function afterRules()
+    public function afterRules(): void
     {
     }
 
     /**
      * Test for event bindings.
      */
-    public function buildRules()
+    public function buildRules(): void
     {
     }
 
     /**
      * Test for event bindings.
      */
-    public function afterSaveCommit()
+    public function afterSaveCommit(): void
     {
     }
 
     /**
      * Test for event bindings.
      */
-    public function afterDeleteCommit()
+    public function afterDeleteCommit(): void
     {
     }
 }

--- a/tests/test_app/TestApp/Model/Entity/Article.php
+++ b/tests/test_app/TestApp/Model/Entity/Article.php
@@ -12,10 +12,8 @@ class Article extends Entity
 {
     /**
      * Testing stub method.
-     *
-     * @return bool
      */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return true;
     }

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Table;
 
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 
 /**
@@ -33,9 +34,8 @@ class ArticlesTable extends Table
      *
      * @param \Cake\ORM\Query $query The query
      * @param array $options The options
-     * @return \Cake\ORM\Query
      */
-    public function findPublished($query, array $options = [])
+    public function findPublished($query, array $options = []): Query
     {
         $query = $query->where([$this->aliasField('published') => 'Y']);
 
@@ -48,28 +48,22 @@ class ArticlesTable extends Table
 
     /**
      * Example public method
-     *
-     * @return void
      */
-    public function doSomething()
+    public function doSomething(): void
     {
     }
 
     /**
      * Example Secondary public method
-     *
-     * @return void
      */
-    public function doSomethingElse()
+    public function doSomethingElse(): void
     {
     }
 
     /**
      * Example protected method
-     *
-     * @return void
      */
-    protected function _innerMethod()
+    protected function _innerMethod(): void
     {
     }
 }

--- a/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthUsersTable.php
@@ -30,7 +30,7 @@ class AuthUsersTable extends Table
      * @param array $options The options to find with
      * @return \Cake\ORM\Query The query builder
      */
-    public function findAuth(Query $query, array $options)
+    public function findAuth(Query $query, array $options): Query
     {
         $query->select(['id', 'username', 'password']);
         if (!empty($options['return_created'])) {
@@ -47,7 +47,7 @@ class AuthUsersTable extends Table
      * @param array $options The options to find with
      * @return \Cake\ORM\Query The query builder
      */
-    public function findUsername(Query $query, array $options)
+    public function findUsername(Query $query, array $options): Query
     {
         if (empty($options['username'])) {
             throw new CakeException(__('Username not defined'));

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -41,9 +41,8 @@ class AuthorsTable extends Table
      *
      * @param \Cake\ORM\Query $query The query
      * @param array $options The options
-     * @return \Cake\ORM\Query
      */
-    public function findFormatted(Query $query, array $options = [])
+    public function findFormatted(Query $query, array $options = []): Query
     {
         return $query->formatResults(function ($results) {
             return $results->map(function ($author) {

--- a/tests/test_app/TestApp/Model/Table/ContactsTable.php
+++ b/tests/test_app/TestApp/Model/Table/ContactsTable.php
@@ -29,7 +29,6 @@ class ContactsTable extends Table
      * Initializes the schema
      *
      * @param array $config
-     * @return void
      */
     public function initialize(array $config): void
     {

--- a/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
+++ b/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
@@ -15,7 +15,6 @@ class GreedyCommentsTable extends Table
      * initialize hook
      *
      * @param array $config Config data.
-     * @return void
      */
     public function initialize(array $config): void
     {
@@ -28,7 +27,6 @@ class GreedyCommentsTable extends Table
      *
      * @param string $type Find type
      * @param array $options find options
-     * @return \Cake\ORM\Query
      */
     public function find(string $type = 'all', $options = []): Query
     {

--- a/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
@@ -25,8 +25,6 @@ class PaginatorPostsTable extends Table
 {
     /**
      * initialize method
-     *
-     * @return void
      */
     public function initialize(array $config): void
     {
@@ -59,8 +57,6 @@ class PaginatorPostsTable extends Table
 
     /**
      * Custom finder, used with fixture data to ensure Paginator is sending options
-     *
-     * @return \Cake\ORM\Query
      */
     public function findAuthor(Query $query, array $options = []): Query
     {

--- a/tests/test_app/TestApp/Model/Table/PublishedPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PublishedPostsTable.php
@@ -25,10 +25,7 @@ use Cake\ORM\Table;
  */
 class PublishedPostsTable extends Table
 {
-    /**
-     * @return \Cake\Database\Query
-     */
-    public function findPublished(Query $query, array $options)
+    public function findPublished(Query $query, array $options): Query
     {
         return $query->where(['published' => true]);
     }

--- a/tests/test_app/TestApp/Model/Table/SecondaryPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/SecondaryPostsTable.php
@@ -18,9 +18,6 @@ use Cake\ORM\Table;
 
 class SecondaryPostsTable extends Table
 {
-    /**
-     * @return string
-     */
     public static function defaultConnectionName(): string
     {
         return 'secondary';

--- a/tests/test_app/TestApp/Model/Table/TestTable.php
+++ b/tests/test_app/TestApp/Model/Table/TestTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Model\Table;
 
-use Cake\Datasource\QueryInterface;
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 
 /**
@@ -13,17 +13,13 @@ class TestTable extends Table
 {
     /**
      * @param array $config
-     * @return void
      */
     public function initialize(array $config): void
     {
         $this->setSchema(['id' => ['type' => 'integer']]);
     }
 
-    /**
-     * @return \Cake\Datasource\QueryInterface
-     */
-    public function findPublished(QueryInterface $query)
+    public function findPublished(Query $query): Query
     {
         return $query->applyOptions(['this' => 'worked']);
     }

--- a/tests/test_app/TestApp/Model/Table/ValidateUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/ValidateUsersTable.php
@@ -30,7 +30,6 @@ class ValidateUsersTable extends Table
      * Initializes the schema
      *
      * @param array $config
-     * @return void
      */
     public function initialize(array $config): void
     {

--- a/tests/test_app/TestApp/Routing/Route/ProtectedRoute.php
+++ b/tests/test_app/TestApp/Routing/Route/ProtectedRoute.php
@@ -14,7 +14,7 @@ class ProtectedRoute extends Route
      * @param string $url
      * @return array
      */
-    public function parseExtension($url)
+    public function parseExtension($url): array
     {
         return $this->_parseExtension($url);
     }

--- a/tests/test_app/TestApp/Shell/I18mShell.php
+++ b/tests/test_app/TestApp/Shell/I18mShell.php
@@ -26,10 +26,8 @@ class I18mShell extends Shell
 {
     /**
      * main method
-     *
-     * @return void
      */
-    public function main()
+    public function main(): void
     {
         $this->out('This is the main method called from I18mShell');
     }

--- a/tests/test_app/TestApp/Shell/IntegrationShell.php
+++ b/tests/test_app/TestApp/Shell/IntegrationShell.php
@@ -27,8 +27,6 @@ class IntegrationShell extends Shell
 {
     /**
      * Option parser
-     *
-     * @return ConsoleOptionParser
      */
     public function getOptionParser(): ConsoleOptionParser
     {
@@ -53,10 +51,8 @@ class IntegrationShell extends Shell
 
     /**
      * Bridge of Death question
-     *
-     * @return void
      */
-    public function bridge()
+    public function bridge(): void
     {
         $name = $this->in('What is your name');
 
@@ -77,10 +73,8 @@ class IntegrationShell extends Shell
 
     /**
      * A sub command that requires an argument and has an option
-     *
-     * @return void
      */
-    public function argsAndOptions()
+    public function argsAndOptions(): void
     {
         $this->out('arg: ' . $this->args[0]);
         $this->out('opt: ' . $this->param('opt'));
@@ -89,7 +83,7 @@ class IntegrationShell extends Shell
     /**
      * @throws \Cake\Console\Exception\StopException
      */
-    public function abortShell()
+    public function abortShell(): void
     {
         $this->abort('Shell aborted');
     }

--- a/tests/test_app/TestApp/Shell/SampleShell.php
+++ b/tests/test_app/TestApp/Shell/SampleShell.php
@@ -31,25 +31,21 @@ class SampleShell extends Shell
 
     /**
      * main method
-     *
-     * @return void
      */
-    public function main()
+    public function main(): void
     {
         $this->out('This is the main method called from SampleShell');
     }
 
     /**
      * derp method
-     *
-     * @return void
      */
-    public function derp()
+    public function derp(): void
     {
         $this->out('This is the example method called from TestPlugin.SampleShell');
     }
 
-    public function withAbort()
+    public function withAbort(): void
     {
         $this->abort('Bad things');
     }

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -62,7 +62,7 @@ class ShellTestShell extends Shell
         $this->stopped = $status;
     }
 
-    protected function _secret()
+    protected function _secret(): void
     {
     }
 

--- a/tests/test_app/TestApp/Shell/TestingDispatchShell.php
+++ b/tests/test_app/TestApp/Shell/TestingDispatchShell.php
@@ -41,35 +41,35 @@ class TestingDispatchShell extends Shell
         return 1;
     }
 
-    public function testTask()
+    public function testTask(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
         $this->dispatchShell('testing_dispatch dispatch_test_task');
     }
 
-    public function testTaskDispatchArray()
+    public function testTaskDispatchArray(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
         $this->dispatchShell('testing_dispatch', 'dispatch_test_task');
     }
 
-    public function testTaskDispatchCommandString()
+    public function testTaskDispatchCommandString(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
         $this->dispatchShell(['command' => 'testing_dispatch dispatch_test_task']);
     }
 
-    public function testTaskDispatchCommandArray()
+    public function testTaskDispatchCommandArray(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
         $this->dispatchShell(['command' => ['testing_dispatch', 'dispatch_test_task']]);
     }
 
-    public function testTaskDispatchWithParam()
+    public function testTaskDispatchWithParam(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
@@ -81,7 +81,7 @@ class TestingDispatchShell extends Shell
         ]);
     }
 
-    public function testTaskDispatchWithMultipleParams()
+    public function testTaskDispatchWithMultipleParams(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
@@ -94,7 +94,7 @@ class TestingDispatchShell extends Shell
         ]);
     }
 
-    public function testTaskDispatchWithRequestedOff()
+    public function testTaskDispatchWithRequestedOff(): void
     {
         $this->out('I am a test task, I dispatch another Shell');
         TestCase::setAppNamespace();
@@ -106,17 +106,17 @@ class TestingDispatchShell extends Shell
         ]);
     }
 
-    public function dispatchTestTask()
+    public function dispatchTestTask(): void
     {
         $this->out('I am a dispatched Shell');
     }
 
-    public function dispatchTestTaskParam()
+    public function dispatchTestTaskParam(): void
     {
         $this->out('I am a dispatched Shell. My param `foo` has the value `' . $this->param('foo') . '`');
     }
 
-    public function dispatchTestTaskParams()
+    public function dispatchTestTaskParams(): void
     {
         $this->out('I am a dispatched Shell. My param `foo` has the value `' . $this->param('foo') . '`');
         $this->out('My param `fooz` has the value `' . $this->param('fooz') . '`');

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -12,9 +12,6 @@ class Stub
 {
     use ModelAwareTrait;
 
-    /**
-     * @return void
-     */
     public function setProps(string $name): void
     {
         $this->_setModelClass($name);

--- a/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
+++ b/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
@@ -27,10 +27,8 @@ class CustomTestEventListenerInterface extends EventTestListener implements Even
 
     /**
      * Test function to be used in event dispatching
-     *
-     * @return void
      */
-    public function thirdListenerFunction()
+    public function thirdListenerFunction(): void
     {
         $this->callList[] = __FUNCTION__;
     }

--- a/tests/test_app/TestApp/TestCase/Event/EventTestListener.php
+++ b/tests/test_app/TestApp/TestCase/Event/EventTestListener.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace TestApp\TestCase\Event;
 
+use Cake\Event\EventInterface;
+
 /**
  * Mock class used to test event dispatching
  */
@@ -13,9 +15,9 @@ class EventTestListener
     /**
      * Test function to be used in event dispatching
      *
-     * @return void
+     * @return bool|void
      */
-    public function listenerFunction()
+    public function listenerFunction(EventInterface $event)
     {
         $this->callList[] = __FUNCTION__;
     }
@@ -23,9 +25,9 @@ class EventTestListener
     /**
      * Test function to be used in event dispatching
      *
-     * @return void
+     * @return bool|void
      */
-    public function secondListenerFunction()
+    public function secondListenerFunction(EventInterface $event)
     {
         $this->callList[] = __FUNCTION__;
     }
@@ -33,10 +35,9 @@ class EventTestListener
     /**
      * Auxiliary function to help in stopPropagation testing
      *
-     * @param \Cake\Event\EventInterface $event
-     * @return void
+     * @return bool|void
      */
-    public function stopListener($event)
+    public function stopListener(EventInterface $event)
     {
         $event->stopPropagation();
     }

--- a/tests/test_app/TestApp/Utility/Base.php
+++ b/tests/test_app/TestApp/Utility/Base.php
@@ -18,10 +18,9 @@ class Base
     /**
      * @param string[] $properties An array of properties and the merge strategy for them.
      * @param array $options The options to use when merging properties.
-     * @return void
      */
-    public function mergeVars($properties, $options = [])
+    public function mergeVars($properties, $options = []): void
     {
-        return $this->_mergeVars($properties, $options);
+        $this->_mergeVars($properties, $options);
     }
 }

--- a/tests/test_app/TestApp/Utility/ThrowsDebugInfo.php
+++ b/tests/test_app/TestApp/Utility/ThrowsDebugInfo.php
@@ -7,6 +7,9 @@ use Exception;
 
 class ThrowsDebugInfo
 {
+    /**
+     * @inheritDoc
+     */
     public function __debugInfo()
     {
         throw new Exception('from __debugInfo');

--- a/tests/test_app/TestApp/Validation/CustomProvider.php
+++ b/tests/test_app/TestApp/Validation/CustomProvider.php
@@ -21,9 +21,8 @@ class CustomProvider
     /**
      * @param mixed $value
      * @param mixed $context
-     * @return bool
      */
-    public function validate($value, $context)
+    public function validate($value, $context): bool
     {
         return is_bool($value);
     }

--- a/tests/test_app/TestApp/View/Cell/Admin/MenuCell.php
+++ b/tests/test_app/TestApp/View/Cell/Admin/MenuCell.php
@@ -22,10 +22,8 @@ class MenuCell extends \Cake\View\Cell
 {
     /**
      * Default cell action.
-     *
-     * @return void
      */
-    public function display()
+    public function display(): void
     {
     }
 }

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -36,19 +36,15 @@ class ArticlesCell extends \Cake\View\Cell
 
     /**
      * Default cell action.
-     *
-     * @return void
      */
-    public function display()
+    public function display(): void
     {
     }
 
     /**
      * Renders articles in teaser view mode.
-     *
-     * @return void
      */
-    public function teaserList()
+    public function teaserList(): void
     {
         $this->set('articles', [
             ['title' => 'Lorem ipsum', 'body' => 'dolorem sit amet'],
@@ -61,10 +57,8 @@ class ArticlesCell extends \Cake\View\Cell
     /**
      * Renders a view using a different template than the action name
      * The template is set using the ViewBuilder bound to the Cell
-     *
-     * @return void
      */
-    public function customTemplateViewBuilder()
+    public function customTemplateViewBuilder(): void
     {
         $this->counter++;
         $this->viewBuilder()->setTemplate('alternate_teaser_list');
@@ -73,20 +67,16 @@ class ArticlesCell extends \Cake\View\Cell
     /**
      * Renders a template in a custom templatePath
      * The template is set using the ViewBuilder bound to the Cell
-     *
-     * @return void
      */
-    public function customTemplatePath()
+    public function customTemplatePath(): void
     {
         $this->viewBuilder()->setTemplatePath(static::TEMPLATE_FOLDER . '/Articles/Subdir');
     }
 
     /**
      * Simple echo.
-     *
-     * @return void
      */
-    public function doEcho(string $msg1, string $msg2)
+    public function doEcho(string $msg1, string $msg2): void
     {
         $this->set('msg', $msg1 . $msg2);
     }

--- a/tests/test_app/TestApp/View/Cell/CelloCell.php
+++ b/tests/test_app/TestApp/View/Cell/CelloCell.php
@@ -22,7 +22,7 @@ use Cake\View\Cell;
  */
 class CelloCell extends Cell
 {
-    public function display()
+    public function display(): void
     {
     }
 }

--- a/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
+++ b/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
@@ -26,9 +26,8 @@ class EventListenerTestHelper extends Helper
      *
      * @param \Cake\Event\EventInterface $event The event instance.
      * @param string $viewFile The view file being rendered.
-     * @return void
      */
-    public function beforeRender(EventInterface $event, string $viewFile)
+    public function beforeRender(EventInterface $event, string $viewFile): void
     {
         $this->config('options.foo', 'bar');
     }

--- a/tests/test_app/TestApp/View/Helper/HtmlAliasHelper.php
+++ b/tests/test_app/TestApp/View/Helper/HtmlAliasHelper.php
@@ -11,10 +11,7 @@ use Cake\View\Helper;
  */
 class HtmlAliasHelper extends Helper
 {
-    /**
-     * @return void
-     */
-    public function afterRender(EventInterface $event, string $viewFile)
+    public function afterRender(EventInterface $event, string $viewFile): void
     {
     }
 }

--- a/tests/test_app/TestApp/View/Helper/NumberHelperTestObject.php
+++ b/tests/test_app/TestApp/View/Helper/NumberHelperTestObject.php
@@ -11,7 +11,7 @@ use TestApp\Utility\NumberMock;
  */
 class NumberHelperTestObject extends NumberHelper
 {
-    public function attach(NumberMock $cakeNumber)
+    public function attach(NumberMock $cakeNumber): void
     {
         $this->_engine = $cakeNumber;
     }

--- a/tests/test_app/TestApp/View/Helper/TestBeforeAfterHelper.php
+++ b/tests/test_app/TestApp/View/Helper/TestBeforeAfterHelper.php
@@ -19,9 +19,8 @@ class TestBeforeAfterHelper extends Helper
      * beforeLayout method
      *
      * @param string $viewFile View file name.
-     * @return void
      */
-    public function beforeLayout(EventInterface $event, string $viewFile)
+    public function beforeLayout(EventInterface $event, string $viewFile): void
     {
         $this->property = 'Valuation';
     }
@@ -30,9 +29,8 @@ class TestBeforeAfterHelper extends Helper
      * afterLayout method
      *
      * @param string $layoutFile Layout file name.
-     * @return void
      */
-    public function afterLayout(EventInterface $event, string $layoutFile)
+    public function afterLayout(EventInterface $event, string $layoutFile): void
     {
         $this->_View->append('content', 'modified in the afterlife');
     }

--- a/tests/test_app/TestApp/View/Helper/TextHelperTestObject.php
+++ b/tests/test_app/TestApp/View/Helper/TextHelperTestObject.php
@@ -8,7 +8,7 @@ use TestApp\Utility\TextMock;
 
 class TextHelperTestObject extends TextHelper
 {
-    public function attach(TextMock $string)
+    public function attach(TextMock $string): void
     {
         $this->_engine = $string;
     }

--- a/tests/test_app/TestApp/View/Object/TestObjectWithToString.php
+++ b/tests/test_app/TestApp/View/Object/TestObjectWithToString.php
@@ -12,10 +12,8 @@ class TestObjectWithToString
 {
     /**
      * Return string value.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return "I'm ObjectWithToString";
     }

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -48,9 +48,8 @@ class TestView extends AppView
      * Setter for extension.
      *
      * @param string $ext The extension
-     * @return void
      */
-    public function ext(string $ext)
+    public function ext(string $ext): void
     {
         $this->_ext = $ext;
     }

--- a/tests/test_app/TestApp/View/TestViewEventListenerInterface.php
+++ b/tests/test_app/TestApp/View/TestViewEventListenerInterface.php
@@ -44,9 +44,8 @@ class TestViewEventListenerInterface implements EventListenerInterface
      * beforeRender method
      *
      * @param \Cake\Event\EventInterface $event the event being sent
-     * @return void
      */
-    public function beforeRender(EventInterface $event)
+    public function beforeRender(EventInterface $event): void
     {
         $this->beforeRenderViewType = $event->getSubject()->getCurrentType();
     }
@@ -55,9 +54,8 @@ class TestViewEventListenerInterface implements EventListenerInterface
      * afterRender method
      *
      * @param \Cake\Event\EventInterface $event the event being sent
-     * @return void
      */
-    public function afterRender(EventInterface $event)
+    public function afterRender(EventInterface $event): void
     {
         $this->afterRenderViewType = $event->getSubject()->getCurrentType();
     }

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -17,7 +17,7 @@ use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 
 Router::extensions('json');
-Router::scope('/', function (RouteBuilder $routes) {
+Router::scope('/', function (RouteBuilder $routes): void {
     $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
     $routes->connect(
         '/some_alias',


### PR DESCRIPTION
This was auto-fixed with CS by re-enabling missing native type and useless annotation sniffs. Hopefully reduces the noise when we do this with 8.0 types in cake 5.

I couldn't do this in src/ since it might change interfaces we can't change.

I reverted anything in Controllers/ to avoid the awkward action return types. I also fixed any fully qualified return types (and filed a bug with slevomat).
