### PR TITLE
Move fixture cleanup to teardown

### DIFF
--- a/src/TestSuite/Fixture/TruncationStrategy.php
+++ b/src/TestSuite/Fixture/TruncationStrategy.php
@@ -66,7 +66,7 @@ class TruncationStrategy implements ResetStrategyInterface
      *
      * @return void
      */
-    public function setupTest(): void
+    public function teardownTest(): void
     {
         $connections = ConnectionManager::configured();
         foreach ($connections as $connection) {
@@ -104,7 +104,7 @@ class TruncationStrategy implements ResetStrategyInterface
      *
      * @return void
      */
-    public function teardownTest(): void
+    public function setupTest(): void
     {
     }
 

--- a/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncationStrategyTest.php
@@ -30,7 +30,7 @@ class TruncationStrategyTest extends TestCase
     /**
      * Test that beforeTest truncates tables from the previous test
      */
-    public function testSetupSimple(): void
+    public function testTeardownSimple(): void
     {
         $articles = TableRegistry::get('Articles');
         $articlesTags = TableRegistry::get('ArticlesTags');
@@ -41,7 +41,7 @@ class TruncationStrategyTest extends TestCase
         $this->assertGreaterThan(0, $rowCount);
 
         $strategy = new TruncationStrategy($this->fixtureManager);
-        $strategy->setupTest();
+        $strategy->teardownTest();
 
         $rowCount = $articles->find()->count();
         $this->assertEquals(0, $rowCount);


### PR DESCRIPTION
Doing cleanup in setup causes problems for subsequent test runs as data from the previous test run is left behind in the database. Doing the cleanup in teardown attempts to ensure that the database is cleared at the end of the test.

This will work less well when tests are killed before a test run is complete as state will not be cleaned up. The old fixture system solved this by dropping tables at the beginning of a test run which can happenin the new fixture system depending on how schema is loaded.
