### PR TITLE
Fix var, param and return tag type hint format

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -155,7 +155,7 @@ class ConsoleIo
     /**
      * Output at the verbose level.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if current level is less than ConsoleIo::VERBOSE
@@ -168,7 +168,7 @@ class ConsoleIo
     /**
      * Output at all levels.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if current level is less than ConsoleIo::QUIET
@@ -189,7 +189,7 @@ class ConsoleIo
      * present in most shells. Using ConsoleIo::QUIET for a message means it will always display.
      * While using ConsoleIo::VERBOSE means it will only display when verbose output is toggled.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -209,7 +209,7 @@ class ConsoleIo
     /**
      * Convenience method for out() that wraps message between <info /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -227,7 +227,7 @@ class ConsoleIo
     /**
      * Convenience method for out() that wraps message between <comment /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -245,7 +245,7 @@ class ConsoleIo
     /**
      * Convenience method for err() that wraps message between <warning /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::err
@@ -261,7 +261,7 @@ class ConsoleIo
     /**
      * Convenience method for err() that wraps message between <error /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::err
@@ -277,7 +277,7 @@ class ConsoleIo
     /**
      * Convenience method for out() that wraps message between <success /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -311,8 +311,8 @@ class ConsoleIo
      * Wraps a message with a given message type, e.g. <warning>
      *
      * @param string $messageType The message type, e.g. "warning".
-     * @param string|string[] $message The message to wrap.
-     * @return string|string[] The message wrapped with the given message type.
+     * @param array<string>|string $message The message to wrap.
+     * @return array<string>|string The message wrapped with the given message type.
      */
     protected function wrapMessageWithType(string $messageType, $message)
     {
@@ -371,7 +371,7 @@ class ConsoleIo
      * Outputs a single or multiple error messages to stderr. If no parameters
      * are passed outputs just a newline.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      */

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -190,7 +190,7 @@ class ConsoleOutput
      * Outputs a single or multiple messages to stdout or stderr. If no parameters
      * are passed, outputs just a newline.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to output.
      */

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -661,7 +661,7 @@ class Shell
     /**
      * Output at the verbose level.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|null The number of bytes returned from writing to stdout.
      */
@@ -673,7 +673,7 @@ class Shell
     /**
      * Output at all levels.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|null The number of bytes returned from writing to stdout.
      */
@@ -693,7 +693,7 @@ class Shell
      * present in most shells. Using Shell::QUIET for a message means it will always display.
      * While using Shell::VERBOSE means it will only display when verbose output is toggled.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout.
@@ -708,7 +708,7 @@ class Shell
      * Outputs a single or multiple error messages to stderr. If no parameters
      * are passed outputs just a newline.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      */
@@ -720,7 +720,7 @@ class Shell
     /**
      * Convenience method for out() that wraps message between <info /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout.
@@ -734,7 +734,7 @@ class Shell
     /**
      * Convenience method for err() that wraps message between <warning /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#Shell::err
@@ -747,7 +747,7 @@ class Shell
     /**
      * Convenience method for out() that wraps message between <success /> tag
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout.

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -203,7 +203,7 @@ class ShellDispatcher
      * Built-in extra parameter is :
      *
      * - `requested` : if used, will prevent the Shell welcome message to be displayed
-     * @return bool|int|null
+     * @return int|bool|null
      * @throws \Cake\Console\Exception\MissingShellMethodException
      */
     protected function _dispatch(array $extra = [])

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -578,7 +578,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * $this->Auth->allow();
      * ```
      *
-     * @param string|string[]|null $actions Controller action name or array of actions
+     * @param array<string>|string|null $actions Controller action name or array of actions
      * @return void
      * @link https://book.cakephp.org/4/en/controllers/components/authentication.html#making-actions-public
      */
@@ -608,7 +608,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
      * ```
      * to remove all items from the allowed list
      *
-     * @param string|string[]|null $actions Controller action name or array of actions
+     * @param array<string>|string|null $actions Controller action name or array of actions
      * @return void
      * @see \Cake\Controller\Component\AuthComponent::allow()
      * @link https://book.cakephp.org/4/en/controllers/components/authentication.html#making-actions-require-authorization

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -139,7 +139,7 @@ class SecurityComponent extends Component
     /**
      * Sets the actions that require a request that is SSL-secured, or empty for all actions
      *
-     * @param string|string[]|null $actions Actions list
+     * @param array<string>|string|null $actions Actions list
      * @return void
      */
     public function requireSecure($actions = null): void

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -553,7 +553,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Register middleware for the controller.
      *
-     * @param \Closure|\Psr\Http\Server\MiddlewareInterface|string $middleware Middleware.
+     * @param \Psr\Http\Server\MiddlewareInterface|\Closure|string $middleware Middleware.
      * @param array $options Valid options:
      *  - `only`: (array|string) Only run the middleware for specified actions.
      *  - `except`: (array|string) Run the middleware for all actions except the specified ones.
@@ -819,7 +819,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *
      * This method will also make the PaginatorHelper available in the view.
      *
-     * @param \Cake\ORM\Table|string|\Cake\ORM\Query|null $object Table to paginate
+     * @param \Cake\ORM\Table|\Cake\ORM\Query|string|null $object Table to paginate
      * (e.g: Table instance, 'TableName' or a Query object)
      * @param array $settings The settings/configuration used for pagination.
      * @return \Cake\ORM\ResultSet|\Cake\Datasource\ResultSetInterface Query results

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -189,11 +189,11 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * This method should construct and do any other initialization logic
      * required.
      *
-     * @param string|object $class The class to build.
+     * @param object|string $class The class to build.
      * @param string $alias The alias of the object.
      * @param array $config The Configuration settings for construction
      * @return object
-     * @psalm-param string|TObject $class
+     * @psalm-param TObject|string $class
      * @psalm-return TObject
      */
     abstract protected function _create($class, string $alias, array $config);

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -68,7 +68,7 @@ trait StaticConfigTrait
      * ```
      *
      * @param array|string $key The name of the configuration, or an array of multiple configs.
-     * @param array|object|null $config An array of name => configuration data for adapter.
+     * @param object|array|null $config An array of name => configuration data for adapter.
      * @throws \BadMethodCallException When trying to modify an existing config.
      * @throws \LogicException When trying to store an invalid structured config array.
      * @return void

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -41,7 +41,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      * Adds conditions to the FILTER clause. The conditions are the same format as
      * `Query::where()`.
      *
-     * @param \Cake\Database\ExpressionInterface|array|string|\Closure $conditions The conditions to filter on.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The conditions to filter on.
      * @param array $types associative array of type names used to bind values to query
      * @return $this
      * @see \Cake\Database\Query::where()

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -81,7 +81,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
             'to' => $this->_to,
         ];
 
-        /** @var string|\Cake\Database\ExpressionInterface $field */
+        /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
         if ($field instanceof ExpressionInterface) {
             $field = $field->sql($binder);

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -47,7 +47,7 @@ class CaseExpression implements ExpressionInterface
     /**
      * The `ELSE` value for the case statement. If null then no `ELSE` will be included.
      *
-     * @var string|\Cake\Database\ExpressionInterface|array|null
+     * @var \Cake\Database\ExpressionInterface|array|string|null
      */
     protected $_elseValue;
 

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -65,7 +65,7 @@ class CommonTableExpression implements ExpressionInterface
      * Constructor.
      *
      * @param string $name The CTE name.
-     * @param \Closure|\Cake\Database\ExpressionInterface $query CTE query
+     * @param \Cake\Database\ExpressionInterface|\Closure $query CTE query
      */
     public function __construct(string $name = '', $query = null)
     {
@@ -94,7 +94,7 @@ class CommonTableExpression implements ExpressionInterface
     /**
      * Sets the query for this CTE.
      *
-     * @param \Closure|\Cake\Database\ExpressionInterface $query CTE query
+     * @param \Cake\Database\ExpressionInterface|\Closure $query CTE query
      * @return $this
      */
     public function query($query)
@@ -115,7 +115,7 @@ class CommonTableExpression implements ExpressionInterface
     /**
      * Adds one or more fields (arguments) to the CTE.
      *
-     * @param \Cake\Database\Expression\IdentifierExpression|\Cake\Database\Expression\IdentifierExpression[]|string|string[] $fields Field names
+     * @param \Cake\Database\Expression\IdentifierExpression|array<\Cake\Database\Expression\IdentifierExpression>|array<string>|string $fields Field names
      * @return $this
      */
     public function field($fields)

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -139,7 +139,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        /** @var string|\Cake\Database\ExpressionInterface $field */
+        /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
 
         if ($field instanceof ExpressionInterface) {

--- a/src/Database/Expression/FieldTrait.php
+++ b/src/Database/Expression/FieldTrait.php
@@ -24,7 +24,7 @@ trait FieldTrait
     /**
      * The field name or expression to be used in the left hand side of the operator
      *
-     * @var array|string|\Cake\Database\ExpressionInterface
+     * @var \Cake\Database\ExpressionInterface|array|string
      */
     protected $_field;
 

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -52,7 +52,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        /** @var string|\Cake\Database\ExpressionInterface $field */
+        /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
         if ($field instanceof Query) {
             $field = sprintf('(%s)', $field->sql($binder));

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -430,7 +430,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
      *
-     * @param \Closure|array|string|\Cake\Database\ExpressionInterface $conditions to be joined with AND
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with AND
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
@@ -448,7 +448,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "OR"
      *
-     * @param \Closure|array|string|\Cake\Database\ExpressionInterface $conditions to be joined with OR
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with OR
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
@@ -468,7 +468,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "AND"
      *
-     * @param \Closure|array|string|\Cake\Database\ExpressionInterface $conditions to be joined with AND
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with AND
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
@@ -485,7 +485,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new QueryExpression object containing all the conditions passed
      * and set up the conjunction to be "OR"
      *
-     * @param \Closure|array|string|\Cake\Database\ExpressionInterface $conditions to be joined with OR
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with OR
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
@@ -506,7 +506,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * "NOT ( (condition1) AND (conditions2) )" conjunction depends on the one
      * currently configured for this object.
      *
-     * @param \Closure|\Cake\Database\ExpressionInterface|array|string $conditions to be added and negated
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be added and negated
      * @param array $types associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return $this

--- a/src/Database/Expression/WindowInterface.php
+++ b/src/Database/Expression/WindowInterface.php
@@ -49,7 +49,7 @@ interface WindowInterface
     /**
      * Adds one or more partition expressions to the window.
      *
-     * @param \Closure|(\Cake\Database\ExpressionInterface|string)[]|\Cake\Database\ExpressionInterface|string $partitions Partition expressions
+     * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $partitions Partition expressions
      * @return $this
      */
     public function partition($partitions);
@@ -57,7 +57,7 @@ interface WindowInterface
     /**
      * Adds one or more order clauses to the window.
      *
-     * @param \Closure|(\Cake\Database\ExpressionInterface|string)[]|\Cake\Database\ExpressionInterface|string $fields Order expressions
+     * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $fields Order expressions
      * @return $this
      */
     public function order($fields);

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -46,7 +46,7 @@ class FieldTypeConverter
      * at the moment this object is created. Used so that the types list
      * is not fetched on each single row of the results.
      *
-     * @var \Cake\Database\TypeInterface[]|\Cake\Database\Type\BatchCastingInterface[]
+     * @var array<\Cake\Database\TypeInterface>|array<\Cake\Database\Type\BatchCastingInterface>
      */
     protected $types;
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -412,7 +412,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * });
      * ```
      *
-     * @param \Closure|\Cake\Database\Expression\CommonTableExpression $cte The CTE to add.
+     * @param \Cake\Database\Expression\CommonTableExpression|\Closure $cte The CTE to add.
      * @param bool $overwrite Whether to reset the list of CTEs.
      * @return $this
      */
@@ -469,7 +469,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * fields you should also call `Cake\ORM\Query::enableAutoFields()` to select the default fields
      * from the table.
      *
-     * @param \Cake\Database\ExpressionInterface|array|callable|string $fields fields to be added to the list.
+     * @param \Cake\Database\ExpressionInterface|callable|array|string $fields fields to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
@@ -790,7 +790,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * See `join()` for further details on conditions and types.
      *
-     * @param string|string[] $table The table to join with
+     * @param array<string>|string $table The table to join with
      * @param \Cake\Database\ExpressionInterface|array|string $conditions The conditions
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
@@ -812,7 +812,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * The arguments of this method are identical to the `leftJoin()` shorthand, please refer
      * to that methods description for further details.
      *
-     * @param string|string[] $table The table to join with
+     * @param array<string>|string $table The table to join with
      * @param \Cake\Database\ExpressionInterface|array|string $conditions The conditions
      * to use for joining.
      * @param array $types a list of types associated to the conditions used for converting
@@ -851,7 +851,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Returns an array that can be passed to the join method describing a single join clause
      *
-     * @param string|string[] $table The table to join with
+     * @param array<string>|string $table The table to join with
      * @param \Cake\Database\ExpressionInterface|array|string $conditions The conditions
      * to use for joining.
      * @param string $type the join type to use
@@ -993,7 +993,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If you use string conditions make sure that your values are correctly quoted.
      * The safest thing you can do is to never use string conditions.
      *
-     * @param \Cake\Database\ExpressionInterface|array|string|\Closure|null $conditions The conditions to filter on.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The conditions to filter on.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\TypeFactory
@@ -1196,7 +1196,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * `WHERE (title = 'Foo') AND (author_id = 1 OR author_id = 2)`
      *
-     * @param \Cake\Database\ExpressionInterface|array|string|\Closure $conditions The conditions to add with AND.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The conditions to add with AND.
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::where()
      * @see \Cake\Database\TypeFactory
@@ -1266,7 +1266,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If you need to set complex expressions as order conditions, you
      * should use `orderAsc()` or `orderDesc()`.
      *
-     * @param \Cake\Database\ExpressionInterface|array|\Closure|string $fields fields to be added to the list
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
      * @return $this
      */
@@ -1406,7 +1406,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Having fields are not suitable for use with user supplied data as they are
      * not sanitized by the query builder.
      *
-     * @param \Cake\Database\ExpressionInterface|array|string|\Closure|null $conditions The having conditions.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The having conditions.
      * @param array $types associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Query::where()
@@ -1431,7 +1431,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Having fields are not suitable for use with user supplied data as they are
      * not sanitized by the query builder.
      *
-     * @param \Cake\Database\ExpressionInterface|array|string|\Closure $conditions The AND conditions for HAVING.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The AND conditions for HAVING.
      * @param array $types associative array of type names used to bind values to query
      * @see \Cake\Database\Query::andWhere()
      * @return $this
@@ -2052,7 +2052,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     /**
      * Query parts traversal method used by traverseExpressions()
      *
-     * @param \Cake\Database\ExpressionInterface|\Cake\Database\ExpressionInterface[] $expression Query expression or
+     * @param \Cake\Database\ExpressionInterface|array<\Cake\Database\ExpressionInterface> $expression Query expression or
      *   array of expressions.
      * @param \Closure $callback The callback to be executed for each ExpressionInterface
      *   found inside this query.
@@ -2294,7 +2294,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Helper function used to build conditions by composing QueryExpression objects.
      *
      * @param string $part Name of the query part to append the new part to
-     * @param \Cake\Database\ExpressionInterface|array|string|\Closure|null $append Expression or builder function to append.
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $append Expression or builder function to append.
      *   to append.
      * @param string $conjunction type of conjunction to be used to operate part
      * @param array $types associative array of type names used to bind values to query

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -193,7 +193,7 @@ class BufferedStatement implements Iterator, StatementInterface
     /**
      * {@inheritDoc}
      *
-     * @param int|string $type The type to fetch.
+     * @param string|int $type The type to fetch.
      * @return array|false
      */
     public function fetch($type = self::FETCH_TYPE_NUM)

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -144,7 +144,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
     /**
      * Returns the error code for the last error that occurred when executing this statement.
      *
-     * @return int|string
+     * @return string|int
      */
     public function errorCode()
     {

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -94,7 +94,7 @@ interface StatementInterface
     /**
      * Returns the error code for the last error that occurred when executing this statement
      *
-     * @return int|string
+     * @return string|int
      */
     public function errorCode();
 

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -35,7 +35,7 @@ class BinaryType extends BaseType
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
-     * @return string|resource
+     * @return resource|string
      */
     public function toDatabase($value, DriverInterface $driver)
     {

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -36,7 +36,7 @@ class BinaryUuidType extends BaseType
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
-     * @return string|resource|null
+     * @return resource|string|null
      */
     public function toDatabase($value, DriverInterface $driver)
     {

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -140,7 +140,7 @@ class TypeFactory
      * Get mapped class name for given type or map array.
      *
      * @param string|null $type Type name to get mapped class for or null to get map array.
-     * @return string[]|string|null Configured class name for given $type or map array.
+     * @return array<string>|string|null Configured class name for given $type or map array.
      */
     public static function getMap(?string $type = null)
     {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -218,7 +218,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * Returns whether this entity contains a field named $field
      * regardless of if it is empty.
      *
-     * @param string|string[] $field The field to check.
+     * @param array<string>|string $field The field to check.
      * @return bool
      */
     public function has($field): bool;
@@ -226,7 +226,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
     /**
      * Removes a field or list of fields from this entity
      *
-     * @param string|string[] $field The field to unset.
+     * @param array<string>|string $field The field to unset.
      * @return $this
      */
     public function unset($field);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -355,7 +355,7 @@ trait EntityTrait
      * When checking multiple fields. All fields must not be null
      * in order for true to be returned.
      *
-     * @param string|string[] $field The field or fields to check.
+     * @param array<string>|string $field The field or fields to check.
      * @return bool
      */
     public function has($field): bool
@@ -435,7 +435,7 @@ trait EntityTrait
      * $entity->unset(['name', 'last_name']);
      * ```
      *
-     * @param string|string[] $field The field to unset.
+     * @param array<string>|string $field The field to unset.
      * @return $this
      */
     public function unset($field)
@@ -452,7 +452,7 @@ trait EntityTrait
      * Removes a field or list of fields from this entity
      *
      * @deprecated 4.0.0 Use {@link unset()} instead. Will be removed in 5.0.
-     * @param string|string[] $field The field to unset.
+     * @param array<string>|string $field The field to unset.
      * @return $this
      */
     public function unsetProperty($field)

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -431,7 +431,7 @@ class Paginator implements PaginatorInterface
      * Shim method for reading the deprecated sortWhitelist or sortableFields options.
      *
      * @param array $config The configuration data to coalesce and emit warnings on.
-     * @return string[]|null
+     * @return array<string>|null
      */
     protected function getSortableFields(array $config): ?array
     {

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -35,14 +35,14 @@ class QueryCacher
     /**
      * The key or function to generate a key.
      *
-     * @var string|\Closure
+     * @var \Closure|string
      */
     protected $_key;
 
     /**
      * Config for cache engine.
      *
-     * @var string|\Psr\SimpleCache\CacheInterface
+     * @var \Psr\SimpleCache\CacheInterface|string
      */
     protected $_config;
 

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -242,7 +242,7 @@ interface QueryInterface
      * If you need to set complex expressions as order conditions, you
      * should use `orderAsc()` or `orderDesc()`.
      *
-     * @param \Cake\Database\ExpressionInterface|array|\Closure|string $fields fields to be added to the list
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
      * @return $this
      */

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -242,7 +242,7 @@ interface RepositoryInterface
      * $article = $this->Articles->patchEntities($articles, $this->request->getData());
      * ```
      *
-     * @param \Cake\Datasource\EntityInterface[]|\Traversable $entities the entities that will get the
+     * @param \Traversable|array<\Cake\Datasource\EntityInterface> $entities the entities that will get the
      * data merged in
      * @param array $data list of arrays to be merged into the entities
      * @param array $options A list of options for the objects hydration.

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -292,7 +292,7 @@ abstract class BaseErrorHandler
     /**
      * Log an error.
      *
-     * @param int|string $level The level name of the log.
+     * @param string|int $level The level name of the log.
      * @param array $data Array of error data.
      * @return bool
      */

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -338,7 +338,7 @@ class Debugger
      * as well as export the variable using exportVar. By default the log is written to the debug log.
      *
      * @param mixed $var Variable or content to log.
-     * @param int|string $level Type of log to use. Defaults to 'debug'.
+     * @param string|int $level Type of log to use. Defaults to 'debug'.
      * @param int $maxDepth The depth to output to. Defaults to 3.
      * @return void
      */

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -163,7 +163,7 @@ class Event implements EventInterface
      * Access the event data/payload.
      *
      * @param string|null $key The data payload element to return, or null to return all data.
-     * @return array|mixed|null The data payload if $key is null, or the data value for the given $key.
+     * @return mixed|array|null The data payload if $key is null, or the data value for the given $key.
      *   If the $key does not exist a null value is returned.
      */
     public function getData(?string $key = null)

--- a/src/Event/EventInterface.php
+++ b/src/Event/EventInterface.php
@@ -70,7 +70,7 @@ interface EventInterface
      * Accesses the event data/payload.
      *
      * @param string|null $key The data payload element to return, or null to return all data.
-     * @return array|mixed|null The data payload if $key is null, or the data value for the given $key.
+     * @return mixed|array|null The data payload if $key is null, or the data value for the given $key.
      *   If the $key does not exist a null value is returned.
      */
     public function getData(?string $key = null);

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -104,7 +104,7 @@ class CorsBuilder
      * Accepts a string or an array of domains that have CORS enabled.
      * You can use `*.example.com` wildcards to accept subdomains, or `*` to allow all domains
      *
-     * @param string|string[] $domains The allowed domains
+     * @param array<string>|string $domains The allowed domains
      * @return $this
      */
     public function allowOrigin($domains)
@@ -202,7 +202,7 @@ class CorsBuilder
     /**
      * Define the max-age preflight OPTIONS requests are valid for.
      *
-     * @param int|string $age The max-age for OPTIONS requests in seconds
+     * @param string|int $age The max-age for OPTIONS requests in seconds
      * @return $this
      */
     public function maxAge($age)

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -40,7 +40,7 @@ class HttpException extends CakeException
      * Set a single HTTP response header.
      *
      * @param string $header Header name
-     * @param string|string[]|null $value Header value
+     * @param array<string>|string|null $value Header value
      * @return void
      */
     public function setHeader(string $header, $value = null): void

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -429,7 +429,7 @@ class Response implements ResponseInterface
     /**
      * Stream target or resource object.
      *
-     * @var string|resource
+     * @var resource|string
      */
     protected $_streamTarget = 'php://memory';
 
@@ -811,8 +811,8 @@ class Response implements ResponseInterface
     /**
      * Create a new instance with the headers to enable client caching.
      *
-     * @param int|string $since a valid time since the response text has not been modified
-     * @param int|string $time a valid time for cache expiry
+     * @param string|int $since a valid time since the response text has not been modified
+     * @param string|int $time a valid time for cache expiry
      * @return static
      */
     public function withCache($since, $time = '+1 day')
@@ -1142,7 +1142,7 @@ class Response implements ResponseInterface
     /**
      * Create a new response with the Content-Length header set.
      *
-     * @param int|string $bytes Number of bytes
+     * @param string|int $bytes Number of bytes
      * @return static
      */
     public function withLength($bytes)

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -55,7 +55,7 @@ class ServerRequest implements ServerRequestInterface
      * In PUT/PATCH/DELETE requests this property will contain the form-urlencoded
      * data.
      *
-     * @var array|object|null
+     * @var object|array|null
      */
     protected $data = [];
 
@@ -475,7 +475,7 @@ class ServerRequest implements ServerRequestInterface
      * defined with Cake\Http\ServerRequest::addDetector(). Any detector can be called
      * as `is($type)` or `is$Type()`.
      *
-     * @param string|string[] $type The type of request you want to check. If an array
+     * @param array<string>|string $type The type of request you want to check. If an array
      *   this method will return true if the request matches any type.
      * @param mixed ...$args List of arguments
      * @return bool Whether or not the request is the type you are checking.
@@ -1392,7 +1392,7 @@ class ServerRequest implements ServerRequestInterface
      * post data. For other content types, it may be the deserialized request
      * body.
      *
-     * @return array|object|null The deserialized body parameters, if any.
+     * @return object|array|null The deserialized body parameters, if any.
      *     These will typically be an array.
      */
     public function getParsedBody()
@@ -1403,7 +1403,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * Update the parsed body and get a new instance.
      *
-     * @param array|object|null $data The deserialized body data. This will
+     * @param object|array|null $data The deserialized body data. This will
      *     typically be in an array or object.
      * @return static
      */

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -40,7 +40,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\DateFormatTrait::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
@@ -56,7 +56,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]|\Closure
+     * @var \Closure|array<int>|string|int
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = 'yyyy-MM-dd';
@@ -65,7 +65,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\Date::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\Date::$wordEnd`
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\DateFormatTrait::parseDate()
      */
     public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
@@ -81,7 +81,7 @@ class Date extends MutableDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\DateFormatTrait::nice()
      */
     public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE];

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -171,7 +171,7 @@ trait DateFormatTrait
      * You can control the default locale used through `Time::setDefaultLocale()`.
      * If empty, the default will be taken from the `intl.default_locale` ini config.
      *
-     * @param string|int|int[]|null $format Format string.
+     * @param array<int>|string|int|null $format Format string.
      * @param \DateTimeZone|string|null $timezone Timezone string or DateTimeZone object
      * in which the date will be displayed. The timezone stored for this object will not
      * be changed.
@@ -203,7 +203,7 @@ trait DateFormatTrait
      * Implements what IntlDateFormatter::formatObject() is in PHP 5.5+
      *
      * @param \DateTime|\DateTimeImmutable $date Date.
-     * @param string|int|int[] $format Format.
+     * @param array<int>|string|int $format Format.
      * @param string|null $locale The locale name in which the date should be displayed.
      * @return string
      */
@@ -294,7 +294,7 @@ trait DateFormatTrait
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @param string|int|int[] $format Format.
+     * @param array<int>|string|int $format Format.
      * @return void
      */
     public static function setToStringFormat($format): void
@@ -333,7 +333,7 @@ trait DateFormatTrait
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|int|int[]|null $format Any format accepted by IntlDateFormatter.
+     * @param array<int>|string|int|null $format Any format accepted by IntlDateFormatter.
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      * @return static|null
      */

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -42,7 +42,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\DateFormatTrait::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, -1];
@@ -58,7 +58,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]|\Closure
+     * @var \Closure|array<int>|string|int
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = 'yyyy-MM-dd';
@@ -67,7 +67,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\Date::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\Date::$wordEnd`
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\DateFormatTrait::parseDate()
      */
     public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
@@ -83,7 +83,7 @@ class FrozenDate extends ChronosDate implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\DateFormatTrait::nice()
      */
     public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE];

--- a/src/I18n/FrozenTime.php
+++ b/src/I18n/FrozenTime.php
@@ -43,7 +43,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\FrozenTime::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::SHORT];
@@ -59,7 +59,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]|\Closure
+     * @var \Closure|array<int>|string|int
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH':'mm':'ssxxx";
@@ -75,7 +75,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\FrozenTime::nice()
      */
     public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT];
@@ -84,7 +84,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\FrozenTime::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\FrozenTime::$wordEnd`
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\FrozenTime::timeAgoInWords()
      */
     public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
@@ -187,7 +187,7 @@ class FrozenTime extends Chronos implements I18nDateTimeInterface
     /**
      * Get list of timezone identifiers
      *
-     * @param int|string|null $filter A regex to filter identifier
+     * @param string|int|null $filter A regex to filter identifier
      *   Or one of DateTimeZone class constants
      * @param string|null $country A two-letter ISO 3166-1 compatible country code.
      *   This option is only used when $filter is set to DateTimeZone::PER_COUNTRY

--- a/src/I18n/I18nDateTimeInterface.php
+++ b/src/I18n/I18nDateTimeInterface.php
@@ -122,7 +122,7 @@ interface I18nDateTimeInterface extends ChronosInterface, JsonSerializable
     /**
      * Sets the default format used when type converting instances of this type to string
      *
-     * @param string|int|int[] $format Format.
+     * @param array<int>|string|int $format Format.
      * @return void
      */
     public static function setToStringFormat($format): void;
@@ -166,7 +166,7 @@ interface I18nDateTimeInterface extends ChronosInterface, JsonSerializable
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|int[]|null $format Any format accepted by IntlDateFormatter.
+     * @param array<int>|string|null $format Any format accepted by IntlDateFormatter.
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      * @return static|null
      * @throws \InvalidArgumentException If $format is a single int instead of array of constants

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -85,7 +85,7 @@ class Number
      *
      * - `locale`: The locale name to use for formatting the number, e.g. fr_FR
      *
-     * @param float|string $value A floating point number.
+     * @param string|float $value A floating point number.
      * @param int $precision The precision of the returned number.
      * @param array $options Additional options
      * @return string Formatted float.
@@ -101,7 +101,7 @@ class Number
     /**
      * Returns a formatted-for-humans file size.
      *
-     * @param int|string $size Size in bytes
+     * @param string|int $size Size in bytes
      * @return string Human readable size
      * @link https://book.cakephp.org/4/en/core-libraries/number.html#interacting-with-human-readable-values
      */
@@ -131,7 +131,7 @@ class Number
      * - `multiply`: Multiply the input value by 100 for decimal percentages.
      * - `locale`: The locale name to use for formatting the number, e.g. fr_FR
      *
-     * @param float|string $value A floating point number
+     * @param string|float $value A floating point number
      * @param int $precision The precision of the returned number
      * @param array $options Options
      * @return string Percentage string
@@ -159,7 +159,7 @@ class Number
      * - `before` - The string to place before whole numbers, e.g. '['
      * - `after` - The string to place after decimal numbers, e.g. ']'
      *
-     * @param float|string $value A floating point number.
+     * @param string|float $value A floating point number.
      * @param array $options An array with options.
      * @return string Formatted number
      */
@@ -202,7 +202,7 @@ class Number
      * - `before` - The string to place before whole numbers, e.g. '['
      * - `after` - The string to place after decimal numbers, e.g. ']'
      *
-     * @param float|string $value A floating point number
+     * @param string|float $value A floating point number
      * @param array $options Options list.
      * @return string formatted delta
      */
@@ -234,7 +234,7 @@ class Number
      * - `useIntlCode` - Whether or not to replace the currency symbol with the international
      *   currency code.
      *
-     * @param float|string $value Value to format.
+     * @param string|float $value Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array $options Options list.
      * @return string Number formatted as a currency.

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -186,8 +186,8 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
     /**
      * Calculate the data needed to format a relative difference string.
      *
-     * @param int|string $futureTime The timestamp from the future.
-     * @param int|string $pastTime The timestamp from the past.
+     * @param string|int $futureTime The timestamp from the future.
+     * @param string|int $pastTime The timestamp from the past.
      * @param bool $backwards Whether or not the difference was backwards.
      * @param array $options An array of options.
      * @return array An array of values.

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -41,7 +41,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_toStringFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::SHORT];
@@ -57,7 +57,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]|\Closure
+     * @var \Closure|array<int>|string|int
      * @see \Cake\I18n\Time::i18nFormat()
      */
     protected static $_jsonEncodeFormat = "yyyy-MM-dd'T'HH':'mm':'ssxxx";
@@ -73,7 +73,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * will be used for formatting the date part of the object and the second position
      * will be used to format the time part.
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\Time::nice()
      */
     public static $niceFormat = [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT];
@@ -82,7 +82,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * The format to use when formatting a time using `Cake\I18n\Time::timeAgoInWords()`
      * and the difference is more than `Cake\I18n\Time::$wordEnd`
      *
-     * @var string|int|int[]
+     * @var array<int>|string|int
      * @see \Cake\I18n\Time::timeAgoInWords()
      */
     public static $wordFormat = [IntlDateFormatter::SHORT, IntlDateFormatter::NONE];
@@ -188,7 +188,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
      * Returns the quarter
      *
      * @param bool $range Range.
-     * @return string[]|int 1, 2, 3, or 4 quarter of year, or array if $range true
+     * @return array<string>|int 1, 2, 3, or 4 quarter of year, or array if $range true
      */
     public function toQuarter(bool $range = false)
     {
@@ -267,7 +267,7 @@ class Time extends MutableDateTime implements I18nDateTimeInterface
     /**
      * Get list of timezone identifiers
      *
-     * @param int|string|null $filter A regex to filter identifier
+     * @param string|int|null $filter A regex to filter identifier
      *   Or one of DateTimeZone class constants
      * @param string|null $country A two-letter ISO 3166-1 compatible country code.
      *   This option is only used when $filter is set to DateTimeZone::PER_COUNTRY

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -340,7 +340,7 @@ class Log
      * then the logged message will be ignored and silently dropped. You can check if this has happened
      * by inspecting the return of write(). If false the message was not handled.
      *
-     * @param int|string $level The severity level of the message being written.
+     * @param string|int $level The severity level of the message being written.
      *    The value must be an integer or string matching a known level.
      * @param string $message Message content to log
      * @param array|string $context Additional data to be used for logging the message.

--- a/src/Log/LogTrait.php
+++ b/src/Log/LogTrait.php
@@ -28,7 +28,7 @@ trait LogTrait
      * for more information on writing to logs.
      *
      * @param string $message Log message.
-     * @param int|string $level Error level.
+     * @param string|int $level Error level.
      * @param array|string $context Additional log data relevant to this message.
      * @return bool Success of log write.
      */

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -106,14 +106,14 @@ abstract class Association
     /**
      * The field name in the owning side table that is used to match with the foreignKey
      *
-     * @var string|string[]|null
+     * @var array<string>|string|null
      */
     protected $_bindingKey;
 
     /**
      * The name of the field representing the foreign key to the table to load
      *
-     * @var string|string[]
+     * @var array<string>|string
      */
     protected $_foreignKey;
 
@@ -121,7 +121,7 @@ abstract class Association
      * A list of conditions to be always included when fetching records from
      * the target association
      *
-     * @var array|\Closure
+     * @var \Closure|array
      */
     protected $_conditions = [];
 
@@ -449,7 +449,7 @@ abstract class Association
      * Sets the name of the field representing the binding field with the target table.
      * When not manually specified the primary key of the owning side table is used.
      *
-     * @param string|string[] $key the table field or fields to be used to link both tables together
+     * @param array<string>|string $key the table field or fields to be used to link both tables together
      * @return $this
      */
     public function setBindingKey($key)
@@ -463,7 +463,7 @@ abstract class Association
      * Gets the name of the field representing the binding field with the target table.
      * When not manually specified the primary key of the owning side table is used.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getBindingKey()
     {
@@ -479,7 +479,7 @@ abstract class Association
     /**
      * Gets the name of the field representing the foreign key to the target table.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getForeignKey()
     {
@@ -489,7 +489,7 @@ abstract class Association
     /**
      * Sets the name of the field representing the foreign key to the target table.
      *
-     * @param string|string[] $key the key or keys to be used to link both tables together
+     * @param array<string>|string $key the key or keys to be used to link both tables together
      * @return $this
      */
     public function setForeignKey($key)

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -46,7 +46,7 @@ class BelongsTo extends Association
     /**
      * Gets the name of the field representing the foreign key to the target table.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getForeignKey()
     {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -107,14 +107,14 @@ class BelongsToMany extends Association
     /**
      * The name of the field representing the foreign key to the target table
      *
-     * @var string|string[]|null
+     * @var array<string>|string|null
      */
     protected $_targetForeignKey;
 
     /**
      * The table instance for the junction relation.
      *
-     * @var string|\Cake\ORM\Table
+     * @var \Cake\ORM\Table|string
      */
     protected $_through;
 
@@ -162,7 +162,7 @@ class BelongsToMany extends Association
     /**
      * Sets the name of the field representing the foreign key to the target table.
      *
-     * @param string|string[] $key the key to be used to link both tables together
+     * @param array<string>|string $key the key to be used to link both tables together
      * @return $this
      */
     public function setTargetForeignKey($key)
@@ -175,7 +175,7 @@ class BelongsToMany extends Association
     /**
      * Gets the name of the field representing the foreign key to the target table.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getTargetForeignKey()
     {
@@ -201,7 +201,7 @@ class BelongsToMany extends Association
     /**
      * Gets the name of the field representing the foreign key to the source table.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getForeignKey()
     {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -587,7 +587,7 @@ class HasMany extends Association
     /**
      * Gets the name of the field representing the foreign key to the source table.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getForeignKey()
     {

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -44,7 +44,7 @@ class HasOne extends Association
     /**
      * Gets the name of the field representing the foreign key to the target table.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getForeignKey()
     {

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -281,7 +281,7 @@ class SelectLoader
      * filtering needs to be done using a subquery.
      *
      * @param \Cake\ORM\Query $query Target table's query
-     * @param string|string[] $key the fields that should be used for filtering
+     * @param array<string>|string $key the fields that should be used for filtering
      * @param \Cake\ORM\Query $subquery The Subquery to use for filtering
      * @return \Cake\ORM\Query
      */
@@ -360,7 +360,7 @@ class SelectLoader
      * which the filter should be applied
      *
      * @param array $options The options for getting the link field.
-     * @return string|string[]
+     * @return array<string>|string
      * @throws \RuntimeException
      */
     protected function _linkField(array $options)

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -50,7 +50,7 @@ class SelectWithPivotLoader extends SelectLoader
     /**
      * Custom conditions for the junction association
      *
-     * @var array|string|\Cake\Database\ExpressionInterface|\Closure|null
+     * @var \Cake\Database\ExpressionInterface|\Closure|array|string|null
      */
     protected $junctionConditions;
 
@@ -142,7 +142,7 @@ class SelectWithPivotLoader extends SelectLoader
      * which the filter should be applied
      *
      * @param array $options the options to use for getting the link field.
-     * @return string|string[]
+     * @return array<string>|string
      */
     protected function _linkField(array $options)
     {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -42,7 +42,7 @@ class EagerLoader
      * Contains a nested array with the compiled containments tree
      * This is a normalized version of the user provided containments array.
      *
-     * @var \Cake\ORM\EagerLoadable[]|\Cake\ORM\EagerLoadable|null
+     * @var \Cake\ORM\EagerLoadable|array<\Cake\ORM\EagerLoadable>|null
      */
     protected $_normalized;
 

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -36,11 +36,11 @@ class LazyEagerLoader
      *
      * The properties for the associations to be loaded will be overwritten on each entity.
      *
-     * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[] $entities a single entity or list of entities
+     * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $entities a single entity or list of entities
      * @param array $contain A `contain()` compatible array.
      * @see \Cake\ORM\Query::contain()
      * @param \Cake\ORM\Table $source The table to use for fetching the top level entities
-     * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]
+     * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>
      */
     public function loadInto($entities, array $contain, Table $source)
     {
@@ -135,7 +135,7 @@ class LazyEagerLoader
      * Injects the results of the eager loader query into the original list of
      * entities.
      *
-     * @param \Cake\Datasource\EntityInterface[]|\Traversable $objects The original list of entities
+     * @param \Traversable|array<\Cake\Datasource\EntityInterface> $objects The original list of entities
      * @param \Cake\ORM\Query $results The loaded results
      * @param string[] $associations The top level associations that were loaded
      * @param \Cake\ORM\Table $source The table where the entities came from

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -300,7 +300,7 @@ class Marshaller
      * @param \Cake\ORM\Association $assoc The association to marshall
      * @param mixed $value The data to hydrate. If not an array, this method will return null.
      * @param array $options List of options.
-     * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
+     * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>|null
      */
     protected function _marshalAssociation(Association $assoc, $value, array $options)
     {
@@ -732,11 +732,11 @@ class Marshaller
     /**
      * Creates a new sub-marshaller and merges the associated data.
      *
-     * @param \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[] $original The original entity
+     * @param \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> $original The original entity
      * @param \Cake\ORM\Association $assoc The association to merge
      * @param mixed $value The array of data to hydrate. If not an array, this method will return null.
      * @param array $options List of options.
-     * @return \Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[]|null
+     * @return \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface>|null
      */
     protected function _mergeAssociation($original, Association $assoc, $value, array $options)
     {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -220,7 +220,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * all the fields in the schema of the table or the association will be added to
      * the select clause.
      *
-     * @param \Cake\Database\ExpressionInterface|array|callable|string|\Cake\ORM\Table|\Cake\ORM\Association $fields Fields
+     * @param \Cake\Database\ExpressionInterface|\Cake\ORM\Table|\Cake\ORM\Association|callable|array|string $fields Fields
      * to be added to the list.
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -51,7 +51,7 @@ class ResultSet implements ResultSetInterface
     /**
      * Last record fetched from the statement
      *
-     * @var array|object
+     * @var object|array
      */
     protected $_current;
 
@@ -103,7 +103,7 @@ class ResultSet implements ResultSetInterface
     /**
      * Results that have been fetched or hydrated into the results.
      *
-     * @var array|\SplFixedArray
+     * @var \SplFixedArray|array
      */
     protected $_results = [];
 
@@ -182,7 +182,7 @@ class ResultSet implements ResultSetInterface
      *
      * Part of Iterator interface.
      *
-     * @return array|object
+     * @return object|array
      */
     public function current()
     {
@@ -275,7 +275,7 @@ class ResultSet implements ResultSetInterface
      *
      * This method will also close the underlying statement cursor.
      *
-     * @return array|object|null
+     * @return object|array|null
      */
     public function first()
     {

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -89,7 +89,7 @@ class RulesChecker extends BaseRulesChecker
      * 'message' sets a custom error message.
      * Set 'allowNullableNulls' to true to accept composite foreign keys where one or more nullable columns are null.
      *
-     * @param string|string[] $field The field or list of fields to check for existence by
+     * @param array<string>|string $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table name where the fields existence will be checked.
      * @param array|string|null $message The error message to show in case the rule does not pass. Can

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -214,14 +214,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * The name of the field that represents the primary key in the table
      *
-     * @var string|string[]|null
+     * @var array<string>|string|null
      */
     protected $_primaryKey;
 
     /**
      * The name of the field that represents a human readable representation of a row
      *
-     * @var string|string[]|null
+     * @var array<string>|string|null
      */
     protected $_displayField;
 
@@ -632,7 +632,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the primary key field name.
      *
-     * @param string|string[] $key Sets a new name to be used as primary key
+     * @param array<string>|string $key Sets a new name to be used as primary key
      * @return $this
      */
     public function setPrimaryKey($key)
@@ -645,7 +645,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the primary key field name.
      *
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function getPrimaryKey()
     {
@@ -663,7 +663,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the display field.
      *
-     * @param string|string[] $field Name to be used as display field.
+     * @param array<string>|string $field Name to be used as display field.
      * @return $this
      */
     public function setDisplayField($field)
@@ -676,7 +676,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Returns the display field.
      *
-     * @return string|string[]|null
+     * @return array<string>|string|null
      */
     public function getDisplayField()
     {
@@ -1839,7 +1839,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * ```
      *
      * @param \Cake\Datasource\EntityInterface $entity the entity to be saved
-     * @param \ArrayAccess|array|\Cake\ORM\SaveOptionsBuilder $options The options to use when saving.
+     * @param \Cake\ORM\SaveOptionsBuilder|\ArrayAccess|array $options The options to use when saving.
      * @return \Cake\Datasource\EntityInterface|false
      * @throws \Cake\ORM\Exception\RolledbackTransactionException If the transaction is aborted in the afterSave event.
      */
@@ -2173,9 +2173,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * any one of the records fails to save due to failed validation or database
      * error.
      *
-     * @param array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface $entities Entities to save.
-     * @param \ArrayAccess|array|\Cake\ORM\SaveOptionsBuilder $options Options used when calling Table::save() for each entity.
-     * @return array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface|false False on failure, entities list on success.
+     * @param \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> $entities Entities to save.
+     * @param \Cake\ORM\SaveOptionsBuilder|\ArrayAccess|array $options Options used when calling Table::save() for each entity.
+     * @return \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface>|false False on failure, entities list on success.
      * @throws \Exception
      */
     public function saveMany(iterable $entities, $options = [])
@@ -2194,9 +2194,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * any one of the records fails to save due to failed validation or database
      * error.
      *
-     * @param array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface $entities Entities to save.
+     * @param \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> $entities Entities to save.
      * @param \ArrayAccess|array $options Options used when calling Table::save() for each entity.
-     * @return array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface Entities list.
+     * @return \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> Entities list.
      * @throws \Exception
      * @throws \Cake\ORM\Exception\PersistenceFailedException If an entity couldn't be saved.
      */
@@ -2206,11 +2206,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * @param array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface $entities Entities to save.
-     * @param \ArrayAccess|array|\Cake\ORM\SaveOptionsBuilder $options Options used when calling Table::save() for each entity.
+     * @param \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> $entities Entities to save.
+     * @param \Cake\ORM\SaveOptionsBuilder|\ArrayAccess|array $options Options used when calling Table::save() for each entity.
      * @throws \Cake\ORM\Exception\PersistenceFailedException If an entity couldn't be saved.
      * @throws \Exception If an entity couldn't be saved.
-     * @return array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface Entities list.
+     * @return \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> Entities list.
      */
     protected function _saveMany(iterable $entities, $options = []): iterable
     {
@@ -2328,9 +2328,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * any one of the records fails to delete due to failed validation or database
      * error.
      *
-     * @param array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface $entities Entities to delete.
+     * @param \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> $entities Entities to delete.
      * @param \ArrayAccess|array $options Options used when calling Table::save() for each entity.
-     * @return array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface|false Entities list
+     * @return \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface>|false Entities list
      *   on success, false on failure.
      * @see \Cake\ORM\Table::delete() for options and events related to this method.
      */
@@ -2352,9 +2352,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * any one of the records fails to delete due to failed validation or database
      * error.
      *
-     * @param array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface $entities Entities to delete.
+     * @param \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> $entities Entities to delete.
      * @param \ArrayAccess|array $options Options used when calling Table::save() for each entity.
-     * @return array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface Entities list.
+     * @return \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> Entities list.
      * @throws \Cake\ORM\Exception\PersistenceFailedException
      * @see \Cake\ORM\Table::delete() for options and events related to this method.
      */
@@ -2370,7 +2370,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * @param array<\Cake\Datasource\EntityInterface>|\Cake\Datasource\ResultSetInterface $entities Entities to delete.
+     * @param \Cake\Datasource\ResultSetInterface|array<\Cake\Datasource\EntityInterface> $entities Entities to delete.
      * @param \ArrayAccess|array $options Options used.
      * @return \Cake\Datasource\EntityInterface|null
      */
@@ -2872,7 +2872,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * You can use the `Model.beforeMarshal` event to modify request data
      * before it is converted into entities.
      *
-     * @param array<\Cake\Datasource\EntityInterface>|\Traversable $entities the entities that will get the
+     * @param \Traversable|array<\Cake\Datasource\EntityInterface> $entities the entities that will get the
      * data merged in
      * @param array $data list of arrays to be merged into the entities
      * @param array $options A list of options for the objects hydration.

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -185,8 +185,8 @@ class Route
     /**
      * Normalize method names to upper case and validate that they are valid HTTP methods.
      *
-     * @param string|string[] $methods Methods.
-     * @return string|string[]
+     * @param array<string>|string $methods Methods.
+     * @return array<string>|string
      * @throws \InvalidArgumentException When methods are not in `VALID_METHODS` list.
      */
     protected function normalizeAndValidateMethods($methods)

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -174,7 +174,7 @@ class RouteBuilder
      * Future routes connected in through this builder will have the connected
      * extensions applied. However, setting extensions does not modify existing routes.
      *
-     * @param string|string[] $extensions The extensions to set.
+     * @param array<string>|string $extensions The extensions to set.
      * @return $this
      */
     public function setExtensions($extensions)
@@ -197,7 +197,7 @@ class RouteBuilder
     /**
      * Add additional extensions to what is already in current scope
      *
-     * @param string|string[] $extensions One or more extensions to add
+     * @param array<string>|string $extensions One or more extensions to add
      * @return $this
      */
     public function addExtensions($extensions)

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -729,7 +729,7 @@ class Router
      * A string or an array of valid extensions can be passed to this method.
      * If called without any parameters it will return current list of set extensions.
      *
-     * @param string[]|string|null $extensions List of extensions to be added.
+     * @param array<string>|string|null $extensions List of extensions to be added.
      * @param bool $merge Whether to merge with or override existing extensions.
      *   Defaults to `true`.
      * @return string[] Array of extensions Router is configured to parse.

--- a/src/TestSuite/Fixture/SchemaCleaner.php
+++ b/src/TestSuite/Fixture/SchemaCleaner.php
@@ -73,7 +73,7 @@ class SchemaCleaner
      * @param string $connectionName Name of the connection.
      * @param string $dialectMethod Method applied to the SQL dialect.
      * @param string $action Action displayed in the info message
-     * @param string[]|null $tables Tables to truncate (all if null)
+     * @param array<string>|null $tables Tables to truncate (all if null)
      * @return void
      * @throws \Exception
      */

--- a/src/TestSuite/Fixture/SchemaManager.php
+++ b/src/TestSuite/Fixture/SchemaManager.php
@@ -43,7 +43,7 @@ class SchemaManager
      * Import the schema from a file, or an array of files.
      *
      * @param string $connectionName Connection
-     * @param string|string[] $file File to dump
+     * @param array<string>|string $file File to dump
      * @param bool|null $verbose Set to true to display messages
      * @param bool|null $enableDropping Will drop all tables prior to creating the schema (true by default)
      * @return void

--- a/src/TestSuite/Stub/ConsoleOutput.php
+++ b/src/TestSuite/Stub/ConsoleOutput.php
@@ -43,7 +43,7 @@ class ConsoleOutput extends ConsoleOutputBase
     /**
      * Write output to the buffer.
      *
-     * @param string|string[] $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int
      */

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -92,7 +92,7 @@ trait CookieCryptTrait
     /**
      * Decrypts $value using public $type method in Security class
      *
-     * @param string[]|string $values Values to decrypt
+     * @param array<string>|string $values Values to decrypt
      * @param string|false $mode Encryption mode
      * @param string|null $key Used as the security salt if specified.
      * @return array|string Decrypted values

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -39,7 +39,7 @@ class Hash
      *
      * @param \ArrayAccess|array $data Array of data or object implementing
      *   \ArrayAccess interface to operate on.
-     * @param string|int|string[]|null $path The path being searched for. Either a dot
+     * @param array<string>|string|int|null $path The path being searched for. Either a dot
      *   separated string, or an array of path segments.
      * @param mixed $default The return value when the path does not exist
      * @throws \InvalidArgumentException
@@ -456,8 +456,8 @@ class Hash
      * following the path specified in `$groupPath`.
      *
      * @param array $data Array from where to extract keys and values
-     * @param string|string[]|null $keyPath A dot-separated string.
-     * @param string|string[]|null $valuePath A dot-separated string.
+     * @param array<string>|string|null $keyPath A dot-separated string.
+     * @param array<string>|string|null $valuePath A dot-separated string.
      * @param string|null $groupPath A dot-separated string.
      * @return array Combined array
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::combine
@@ -542,7 +542,7 @@ class Hash
      * @param array $data Source array from which to extract the data
      * @param string[] $paths An array containing one or more Hash::extract()-style key paths
      * @param string $format Format string into which values will be inserted, see sprintf()
-     * @return string[]|null An array of strings extracted from `$path` and formatted with `$format`
+     * @return array<string>|null An array of strings extracted from `$path` and formatted with `$format`
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::format
      * @see sprintf()
      * @see \Cake\Utility\Hash::extract()

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -97,7 +97,7 @@ class Xml
      *
      * If using array as input, you can pass `options` from Xml::fromArray.
      *
-     * @param array|string|object $input XML string, a path to a file, a URL or an array
+     * @param object|array|string $input XML string, a path to a file, a URL or an array
      * @param array $options The options to use
      * @return \SimpleXMLElement|\DOMDocument SimpleXMLElement or DOMDocument
      * @throws \Cake\Utility\Exception\XmlException
@@ -261,7 +261,7 @@ class Xml
      *
      * `<root><tag id="1" value="defect">description</tag></root>`
      *
-     * @param array|object $input Array with data or a collection instance.
+     * @param object|array $input Array with data or a collection instance.
      * @param array $options The options to use.
      * @return \SimpleXMLElement|\DOMDocument SimpleXMLElement or DOMDocument
      * @throws \Cake\Utility\Exception\XmlException

--- a/src/Validation/RulesProvider.php
+++ b/src/Validation/RulesProvider.php
@@ -29,7 +29,7 @@ class RulesProvider
     /**
      * The class/object to proxy.
      *
-     * @var string|object
+     * @var object|string
      */
     protected $_class;
 
@@ -43,9 +43,9 @@ class RulesProvider
     /**
      * Constructor, sets the default class to use for calling methods
      *
-     * @param string|object $class the default class to proxy
+     * @param object|string $class the default class to proxy
      * @throws \ReflectionException
-     * @psalm-param class-string|object $class
+     * @psalm-param object|class-string $class
      */
     public function __construct($class = Validation::class)
     {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -232,7 +232,7 @@ class Validation
      * Returns true if $check is in the proper credit card format.
      *
      * @param mixed $check credit card number to validate
-     * @param string|string[] $type 'all' may be passed as a string, defaults to fast which checks format of
+     * @param array<string>|string $type 'all' may be passed as a string, defaults to fast which checks format of
      *     most major credit cards if an array is used only the values of the array are checked.
      *    Example: ['amex', 'bankcard', 'maestro']
      * @param bool $deep set to true this will check the Luhn algorithm of the credit card.
@@ -695,7 +695,7 @@ class Validation
      *
      * The list of what is considered to be boolean values, may be set via $booleanValues.
      *
-     * @param bool|int|string $check Value to check.
+     * @param string|int|bool $check Value to check.
      * @param array $booleanValues List of valid boolean values, defaults to `[true, false, 0, 1, '0', '1']`.
      * @return bool Success.
      */
@@ -713,7 +713,7 @@ class Validation
      *
      * The list of what is considered to be truthy values, may be set via $truthyValues.
      *
-     * @param bool|int|string $check Value to check.
+     * @param string|int|bool $check Value to check.
      * @param array $truthyValues List of valid truthy values, defaults to `[true, 1, '1']`.
      * @return bool Success.
      */
@@ -731,7 +731,7 @@ class Validation
      *
      * The list of what is considered to be falsey values, may be set via $falseyValues.
      *
-     * @param bool|int|string $check Value to check.
+     * @param string|int|bool $check Value to check.
      * @param array $falseyValues List of valid falsey values, defaults to `[false, 0, '0']`.
      * @return bool Success.
      */
@@ -1302,7 +1302,7 @@ class Validation
      *
      * @param \Psr\Http\Message\UploadedFileInterface|array|string $check Value to check.
      * @param string $operator See `Validation::comparison()`.
-     * @param int|string $size Size in bytes or human readable string like '5MB'.
+     * @param string|int $size Size in bytes or human readable string like '5MB'.
      * @return bool Success
      */
     public static function fileSize($check, string $operator, $size): bool

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -38,21 +38,21 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Denotes whether the fieldname key must be present in data array
      *
-     * @var string|bool|callable
+     * @var callable|string|bool
      */
     protected $_validatePresent = false;
 
     /**
      * Denotes if a field is allowed to be empty
      *
-     * @var string|bool|callable
+     * @var callable|string|bool
      */
     protected $_allowEmpty = false;
 
     /**
      * Returns whether or not a field can be left out.
      *
-     * @return string|bool|callable
+     * @return callable|string|bool
      */
     public function isPresenceRequired()
     {
@@ -62,7 +62,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Sets whether a field is required to be present in data array.
      *
-     * @param string|bool|callable $validatePresent Valid values are true, false, 'create', 'update' or a callable.
+     * @param callable|string|bool $validatePresent Valid values are true, false, 'create', 'update' or a callable.
      * @return $this
      */
     public function requirePresence($validatePresent)
@@ -75,7 +75,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns whether or not a field can be left empty.
      *
-     * @return string|bool|callable
+     * @return callable|string|bool
      */
     public function isEmptyAllowed()
     {
@@ -85,7 +85,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Sets whether a field value is allowed to be empty.
      *
-     * @param string|bool|callable $allowEmpty Valid values are true, false,
+     * @param callable|string|bool $allowEmpty Valid values are true, false,
      * 'create', 'update' or a callable.
      * @return $this
      */

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -677,7 +677,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * setting takes precedence over group settings.
      *
      * @param array|string $field the name of the field or list of fields.
-     * @param string|bool|callable $mode Valid values are true, false, 'create', 'update'.
+     * @param callable|string|bool $mode Valid values are true, false, 'create', 'update'.
      *   If a callable is passed then the field will be required only when the callback
      *   returns true.
      * @param string|null $message The message to show if the field presence validation fails.
@@ -769,7 +769,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @deprecated 3.7.0 Use {@link allowEmptyString()}, {@link allowEmptyArray()}, {@link allowEmptyFile()},
      *   {@link allowEmptyDate()}, {@link allowEmptyTime()}, {@link allowEmptyDateTime()} or {@link allowEmptyFor()} instead.
      * @param array|string $field the name of the field or a list of fields
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      * Valid values are true (always), 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @param string|null $message The message to show if the field is not
@@ -867,7 +867,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string $field The name of the field.
      * @param int|null $flags A bitmask of EMPTY_* flags which specify what is empty.
      *   If no flags/bitmask is provided only `null` will be allowed as empty value.
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @param string|null $message The message to show if the field is not
@@ -894,7 +894,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @return $this
@@ -912,7 +912,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is empty.
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are false (never), 'create', 'update'. If a
      *   callable is passed then the field will be required to be not empty when
      *   the callback returns true.
@@ -935,7 +935,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @return $this
@@ -954,7 +954,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is empty.
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are false (never), 'create', 'update'. If a
      *   callable is passed then the field will be required to be not empty when
      *   the callback returns true.
@@ -977,7 +977,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      *   Valid values are true, 'create', 'update'. If a callable is passed then
      *   the field will allowed to be empty only when the callback returns true.
      * @return $this
@@ -996,7 +996,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is empty.
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are false (never), 'create', 'update'. If a
      *   callable is passed then the field will be required to be not empty when
      *   the callback returns true.
@@ -1019,7 +1019,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @return $this
@@ -1035,7 +1035,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is empty.
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are false (never), 'create', 'update'. If a
      *   callable is passed then the field will be required to be not empty when
      *   the callback returns true.
@@ -1060,7 +1060,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      * Valid values are true, false, 'create', 'update'. If a callable is passed then
      * the field will allowed to be empty only when the callback returns true.
      * @return $this
@@ -1079,7 +1079,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is empty.
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are false (never), 'create', 'update'. If a
      *   callable is passed then the field will be required to be not empty when
      *   the callback returns true.
@@ -1105,7 +1105,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is allowed to be empty
+     * @param callable|string|bool $when Indicates when the field is allowed to be empty
      *   Valid values are true, false, 'create', 'update'. If a callable is passed then
      *   the field will allowed to be empty only when the callback returns false.
      * @return $this
@@ -1124,7 +1124,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string $field The name of the field.
      * @param string|null $message The message to show if the field is empty.
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are false (never), 'create', 'update'. If a
      *   callable is passed then the field will be required to be not empty when
      *   the callback returns true.
@@ -1142,7 +1142,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Converts validator to fieldName => $settings array
      *
-     * @param int|string $fieldName name of field
+     * @param string|int $fieldName name of field
      * @param array $defaults default settings
      * @param array|string $settings settings from data
      * @return array[]
@@ -1226,7 +1226,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *   {@link notEmptyDate()}, {@link notEmptyTime()} or {@link notEmptyDateTime()} instead.
      * @param array|string $field the name of the field or list of fields
      * @param string|null $message The message to show if the field is not
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are true (always), 'create', 'update'. If a
      *   callable is passed then the field will allowed to be empty only when
      *   the callback returns false.
@@ -1268,11 +1268,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Invert a when clause for creating notEmpty rules
      *
-     * @param string|bool|callable $when Indicates when the field is not allowed
+     * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are true (always), 'create', 'update'. If a
      *   callable is passed then the field will allowed to be empty only when
      *   the callback returns false.
-     * @return string|bool|callable
+     * @return callable|string|bool
      */
     protected function invertWhenClause($when)
     {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -630,7 +630,7 @@ class EntityContext implements ContextInterface
     /**
      * Get the table instance from a property path
      *
-     * @param \Cake\Datasource\EntityInterface|string[]|string $parts Each one of the parts in a path for a field name
+     * @param \Cake\Datasource\EntityInterface|array<string>|string $parts Each one of the parts in a path for a field name
      * @param bool $fallback Whether or not to fallback to the last found table
      *  when a nonexistent field/property is being encountered.
      * @return \Cake\ORM\Table|null Table instance or null

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1461,7 +1461,7 @@ class FormHelper extends Helper
      *
      * @param string $fieldName Name of a field, like this "modelname.fieldname"
      * @param array $options Array of HTML attributes.
-     * @return string[]|string An HTML text input element.
+     * @return array<string>|string An HTML text input element.
      * @link https://book.cakephp.org/4/en/views/helpers/form.html#creating-checkboxes
      */
     public function checkbox(string $fieldName, array $options = [])
@@ -2512,7 +2512,7 @@ class FormHelper extends Helper
      * Order sets priority.
      *
      * @see FormHelper::$supportedValueSources for valid values.
-     * @param string|string[] $sources A string or a list of strings identifying a source.
+     * @param array<string>|string $sources A string or a list of strings identifying a source.
      * @return $this
      * @throws \InvalidArgumentException If sources list contains invalid value.
      */

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -367,7 +367,7 @@ class HtmlHelper extends Helper
      * `cspStyleNonce` attribute, that value will be applied as the `nonce` attribute on the
      * generated HTML.
      *
-     * @param string|string[] $path The name of a CSS style sheet or an array containing names of
+     * @param array<string>|string $path The name of a CSS style sheet or an array containing names of
      *   CSS stylesheets. If `$path` is prefixed with '/', the path will be relative to the webroot
      *   of your application. Otherwise, the path will be relative to your CSS path, usually webroot/css.
      * @param array $options Array of options and HTML arguments.
@@ -472,7 +472,7 @@ class HtmlHelper extends Helper
      * If the current request has a `cspScriptNonce` attribute, that value will
      * be inserted as a `nonce` attribute on the script tag.
      *
-     * @param string|string[] $url String or array of javascript files to include
+     * @param array<string>|string $url String or array of javascript files to include
      * @param array $options Array of options, and html attributes see above.
      * @return string|null String of `<script />` tags or null if block is specified in options
      *   or if $once is true and the file has been included before.

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -90,7 +90,7 @@ class NumberHelper extends Helper
     /**
      * Formats a number with a level of precision.
      *
-     * @param float|string $number A floating point number.
+     * @param string|float $number A floating point number.
      * @param int $precision The precision of the returned number.
      * @param array $options Additional options.
      * @return string Formatted float.
@@ -105,7 +105,7 @@ class NumberHelper extends Helper
     /**
      * Returns a formatted-for-humans file size.
      *
-     * @param int|string $size Size in bytes
+     * @param string|int $size Size in bytes
      * @return string Human readable size
      * @see \Cake\I18n\Number::toReadableSize()
      * @link https://book.cakephp.org/4/en/views/helpers/number.html#interacting-with-human-readable-values
@@ -122,7 +122,7 @@ class NumberHelper extends Helper
      *
      * - `multiply`: Multiply the input value by 100 for decimal percentages.
      *
-     * @param float|string $number A floating point number
+     * @param string|float $number A floating point number
      * @param int $precision The precision of the returned number
      * @param array $options Options
      * @return string Percentage string
@@ -146,7 +146,7 @@ class NumberHelper extends Helper
      * - `after` - The string to place after decimal numbers, e.g. ']'
      * - `escape` - Whether or not to escape html in resulting string
      *
-     * @param float|string $number A floating point number.
+     * @param string|float $number A floating point number.
      * @param array $options An array with options.
      * @return string Formatted number
      * @link https://book.cakephp.org/4/en/views/helpers/number.html#formatting-numbers
@@ -178,7 +178,7 @@ class NumberHelper extends Helper
      *   currency code.
      * - `escape` - Whether or not to escape html in resulting string
      *
-     * @param float|string $number Value to format.
+     * @param string|float $number Value to format.
      * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
      * @param array $options Options list.
      * @return string Number formatted as a currency.
@@ -203,7 +203,7 @@ class NumberHelper extends Helper
      * - `after` - The string to place after decimal numbers, e.g. ']'
      * - `escape` - Set to false to prevent escaping
      *
-     * @param float|string $value A floating point number
+     * @param string|float $value A floating point number
      * @param array $options Options list.
      * @return string formatted delta
      */

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -193,7 +193,7 @@ class TimeHelper extends Helper
      *
      * @param \DateTimeInterface|string|int $dateString UNIX timestamp, strtotime() valid string or DateTime object
      * @param bool $range if true returns a range in Y-m-d format
-     * @return string[]|int 1, 2, 3, or 4 quarter of year or array if $range true
+     * @return array<string>|int 1, 2, 3, or 4 quarter of year or array if $range true
      * @see \Cake\I18n\Time::toQuarter()
      */
     public function toQuarter($dateString, $range = false)
@@ -353,7 +353,7 @@ class TimeHelper extends Helper
      *
      * @param \DateTimeInterface|string|int|null $date UNIX timestamp, strtotime() valid string
      *   or DateTime object (or a date format string).
-     * @param int|string|null $format date format string (or a UNIX timestamp,
+     * @param string|int|null $format date format string (or a UNIX timestamp,
      *   strtotime() valid string or DateTime object).
      * @param string|false $invalid Default value to display on invalid dates
      * @param \DateTimeZone|string|null $timezone User's timezone string or DateTimeZone object

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -309,7 +309,7 @@ class StringTemplate
      * Works with minimized attributes that have the same value as their name such as 'disabled' and 'checked'
      *
      * @param string $key The name of the attribute to create
-     * @param string|string[] $value The value of the attribute to create.
+     * @param array<string>|string $value The value of the attribute to create.
      * @param bool $escape Define if the value must be escaped
      * @return string The composed attribute.
      */
@@ -342,7 +342,7 @@ class StringTemplate
      * @param array|string $input The array or string to add the class to
      * @param array|string $newClass the new class or classes to add
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
-     * @return string|string[]
+     * @return array<string>|string
      */
     public function addClass($input, $newClass, string $useIndex = 'class')
     {

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -235,7 +235,7 @@ class MultiCheckboxWidget extends BasicWidget
      * Helper method for deciding what options are selected.
      *
      * @param string $key The key to test.
-     * @param string[]|string|int|false|null $selected The selected values.
+     * @param array<string>|string|int|false|null $selected The selected values.
      * @return bool
      */
     protected function _isSelected(string $key, $selected): bool

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -304,7 +304,7 @@ class SelectBoxWidget extends BasicWidget
      * Helper method for deciding what options are selected.
      *
      * @param string $key The key to test.
-     * @param string[]|string|int|false|null $selected The selected values.
+     * @param array<string>|string|int|false|null $selected The selected values.
      * @return bool
      */
     protected function _isSelected(string $key, $selected): bool
@@ -326,7 +326,7 @@ class SelectBoxWidget extends BasicWidget
      * Helper method for deciding what options are disabled.
      *
      * @param string $key The key to test.
-     * @param string[]|null $disabled The disabled values.
+     * @param array<string>|null $disabled The disabled values.
      * @return bool
      */
     protected function _isDisabled(string $key, ?array $disabled): bool


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/15528

This orders the type hints in tags according to the above RFC.