### PR TITLE
cake 5: Add native type hints for Core

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,3 +3,6 @@ linters:
   phpcs:
     standard: CakePHP4
     extensions: 'php'
+
+branches:
+    ignore: ['5.0']

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -156,8 +156,23 @@ parameters:
 			path: src/Core/ObjectRegistry.php
 
 		-
-			message: "#^PHPDoc tag @param for parameter \\$object with type TObject is not subtype of native type object\\.$#"
+			message: "#^PHPDoc tag @param for parameter \\$class with type string\\|TObject is not subtype of native type object\\|string\\.$#"
 			count: 1
+			path: src/Core/ObjectRegistry.php
+
+		-
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type object\\.$#"
+			count: 2
+			path: src/Core/ObjectRegistry.php
+
+		-
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type object\\|null\\.$#"
+			count: 1
+			path: src/Core/ObjectRegistry.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$object with type TObject is not subtype of native type object\\.$#"
+			count: 2
 			path: src/Core/ObjectRegistry.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@">
+  <file src="src/Cache/Engine/RedisEngine.php">
+    <UndefinedClass occurrences="2">
+      <code>$e</code>
+      <code>RedisException</code>
+    </UndefinedClass>
+  </file>
   <file src="src/Collection/CollectionTrait.php">
     <ArgumentTypeCoercion occurrences="2">
       <code>$iterator</code>
@@ -53,6 +59,11 @@
       <code>$request</code>
     </ArgumentTypeCoercion>
   </file>
+  <file src="src/Core/Retry/CommandRetry.php">
+    <InvalidReturnType occurrences="1">
+      <code>mixed</code>
+    </InvalidReturnType>
+  </file>
   <file src="src/Database/Driver.php">
     <InvalidScalarArgument occurrences="2">
       <code>$value</code>
@@ -68,6 +79,11 @@
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$_statement</code>
     </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="src/Datasource/ConnectionRegistry.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>object</code>
+    </LessSpecificImplementedReturnType>
   </file>
   <file src="src/Http/BaseApplication.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -70,7 +70,7 @@ class CacheRegistry extends ObjectRegistry
      * @return \Cake\Cache\CacheEngine The constructed CacheEngine class.
      * @throws \RuntimeException when an object doesn't implement the correct interface.
      */
-    protected function _create($class, string $alias, array $config): CacheEngine
+    protected function _create(object|string $class, string $alias, array $config): CacheEngine
     {
         if (is_object($class)) {
             $instance = $class;

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -92,14 +92,18 @@ class HelperRegistry extends ObjectRegistry
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
-     * @param string $class The classname to create.
+     * @param \Cake\Console\Helper|string $class The classname to create.
      * @param string $alias The alias of the helper.
      * @param array $config An array of settings to use for the helper.
      * @return \Cake\Console\Helper The constructed helper class.
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    protected function _create($class, string $alias, array $config): Helper
+    protected function _create(object|string $class, string $alias, array $config): Helper
     {
+        if (is_object($class)) {
+            return $class;
+        }
+
         /** @var \Cake\Console\Helper */
         return new $class($this->_io, $config);
     }

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -89,12 +89,12 @@ class FlashComponent extends Component
      * Proxy method to FlashMessage instance.
      *
      * @param array|string $key The key to set, or a complete array of configs.
-     * @param mixed|null $value The value to set.
+     * @param mixed $value The value to set.
      * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
      * @return $this
      * @throws \Cake\Core\Exception\CakeException When trying to set a key that is invalid.
      */
-    public function setConfig($key, $value = null, $merge = true)
+    public function setConfig(array|string $key, mixed $value = null, bool $merge = true)
     {
         $this->flash()->setConfig($key, $value, $merge);
 
@@ -108,7 +108,7 @@ class FlashComponent extends Component
      * @param mixed $default The return value when the key does not exist.
      * @return mixed Configuration data at the named key or null if the key does not exist.
      */
-    public function getConfig(?string $key = null, $default = null)
+    public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return $this->flash()->getConfig($key, $default);
     }
@@ -120,7 +120,7 @@ class FlashComponent extends Component
      * @return mixed Configuration data at the named key
      * @throws \InvalidArgumentException
      */
-    public function getConfigOrFail(string $key)
+    public function getConfigOrFail(string $key): mixed
     {
         return $this->flash()->getConfigOrFail($key);
     }
@@ -129,10 +129,10 @@ class FlashComponent extends Component
      * Proxy method to FlashMessage instance.
      *
      * @param array|string $key The key to set, or a complete array of configs.
-     * @param mixed|null $value The value to set.
+     * @param mixed $value The value to set.
      * @return $this
      */
-    public function configShallow($key, $value = null)
+    public function configShallow(array|string $key, mixed $value = null)
     {
         $this->flash()->configShallow($key, $value);
 

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -280,11 +280,11 @@ class PaginatorComponent extends Component
      * Proxy setting config options to Paginator.
      *
      * @param array|string $key The key to set, or a complete array of configs.
-     * @param mixed|null $value The value to set.
+     * @param mixed $value The value to set.
      * @param bool $merge Whether to recursively merge or overwrite existing config, defaults to true.
      * @return $this
      */
-    public function setConfig($key, $value = null, $merge = true)
+    public function setConfig(array|string $key, mixed $value = null, bool $merge = true)
     {
         $this->_paginator->setConfig($key, $value, $merge);
 
@@ -298,7 +298,7 @@ class PaginatorComponent extends Component
      * @param mixed $default The return value when the key does not exist.
      * @return mixed Config value being read.
      */
-    public function getConfig(?string $key = null, $default = null)
+    public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return $this->_paginator->getConfig($key, $default);
     }
@@ -307,10 +307,10 @@ class PaginatorComponent extends Component
      * Proxy setting config options to Paginator.
      *
      * @param array|string $key The key to set, or a complete array of configs.
-     * @param mixed|null $value The value to set.
+     * @param mixed $value The value to set.
      * @return $this
      */
-    public function configShallow($key, $value = null)
+    public function configShallow(array|string $key, mixed $value = null)
     {
         $this->_paginator->configShallow($key, null);
 

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -120,15 +120,19 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      * Enabled components will be registered with the event manager.
      *
-     * @param string $class The classname to create.
+     * @param \Cake\Controller\Component|string $class The classname to create.
      * @param string $alias The alias of the component.
      * @param array $config An array of config to use for the component.
      * @return \Cake\Controller\Component The constructed component class.
      * @psalm-suppress MoreSpecificImplementedParamType
      * @psalm-param class-string $class
      */
-    protected function _create($class, string $alias, array $config): Component
+    protected function _create(object|string $class, string $alias, array $config): Component
     {
+        if (is_object($class)) {
+            return $class;
+        }
+
         /** @var \Cake\Controller\Component $instance */
         $instance = new $class($this, $config);
         $enable = $config['enabled'] ?? true;

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -82,7 +82,7 @@ class Configure
      * @return void
      * @link https://book.cakephp.org/4/en/development/configuration.html#writing-configuration-data
      */
-    public static function write($config, $value = null): void
+    public static function write(array|string $config, mixed $value = null): void
     {
         if (!is_array($config)) {
             $config = [$config => $value];
@@ -117,7 +117,7 @@ class Configure
      * @return mixed Value stored in configure, or null.
      * @link https://book.cakephp.org/4/en/development/configuration.html#reading-configuration-data
      */
-    public static function read(?string $var = null, $default = null)
+    public static function read(?string $var = null, mixed $default = null): mixed
     {
         if ($var === null) {
             return static::$_values;
@@ -160,7 +160,7 @@ class Configure
      * @throws \RuntimeException if the requested configuration is not set.
      * @link https://book.cakephp.org/4/en/development/configuration.html#reading-configuration-data
      */
-    public static function readOrFail(string $var)
+    public static function readOrFail(string $var): mixed
     {
         if (!static::check($var)) {
             throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
@@ -200,7 +200,7 @@ class Configure
      * @throws \RuntimeException if the requested configuration is not set.
      * @since 3.6.0
      */
-    public static function consumeOrFail(string $var)
+    public static function consumeOrFail(string $var): mixed
     {
         if (!static::check($var)) {
             throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
@@ -216,9 +216,9 @@ class Configure
      * out of configure into the various other classes in CakePHP.
      *
      * @param string $var The key to read and remove.
-     * @return array|string|null
+     * @return mixed
      */
-    public static function consume(string $var)
+    public static function consume(string $var): mixed
     {
         if (strpos($var, '.') === false) {
             if (!isset(static::$_values[$var])) {

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -186,7 +186,7 @@ class IniConfig implements ConfigEngineInterface
      * @param mixed $value Value to export.
      * @return string String value for ini file.
      */
-    protected function _value($value): string
+    protected function _value(mixed $value): string
     {
         if ($value === null) {
             return 'null';

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -57,7 +57,7 @@ class CakeException extends RuntimeException
      * @param int|null $code The error code
      * @param \Throwable|null $previous the previous exception.
      */
-    public function __construct($message = '', ?int $code = null, ?Throwable $previous = null)
+    public function __construct(array|string $message = '', ?int $code = null, ?Throwable $previous = null)
     {
         if (is_array($message)) {
             $this->_attributes = $message;

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -70,7 +70,7 @@ trait InstanceConfigTrait
      * @return $this
      * @throws \Cake\Core\Exception\CakeException When trying to set a key that is invalid.
      */
-    public function setConfig($key, $value = null, $merge = true)
+    public function setConfig(array|string $key, mixed $value = null, bool $merge = true)
     {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;
@@ -115,7 +115,7 @@ trait InstanceConfigTrait
      * @param mixed $default The return value when the key does not exist.
      * @return mixed Configuration data at the named key or null if the key does not exist.
      */
-    public function getConfig(?string $key = null, $default = null)
+    public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;
@@ -136,7 +136,7 @@ trait InstanceConfigTrait
      * @return mixed Configuration data at the named key
      * @throws \InvalidArgumentException
      */
-    public function getConfigOrFail(string $key)
+    public function getConfigOrFail(string $key): mixed
     {
         $config = $this->getConfig($key);
         if ($config === null) {
@@ -172,7 +172,7 @@ trait InstanceConfigTrait
      * @param mixed|null $value The value to set.
      * @return $this
      */
-    public function configShallow($key, $value = null)
+    public function configShallow(array|string $key, mixed $value = null)
     {
         if (!$this->_configInitialized) {
             $this->_config = $this->_defaultConfig;
@@ -190,7 +190,7 @@ trait InstanceConfigTrait
      * @param string|null $key Key to read.
      * @return mixed
      */
-    protected function _configRead(?string $key)
+    protected function _configRead(?string $key): mixed
     {
         if ($key === null) {
             return $this->_config;
@@ -224,7 +224,7 @@ trait InstanceConfigTrait
      * @return void
      * @throws \Cake\Core\Exception\CakeException if attempting to clobber existing config
      */
-    protected function _configWrite($key, $value, $merge = false): void
+    protected function _configWrite(array|string $key, mixed $value, string|bool $merge = false): void
     {
         if (is_string($key) && $value === null) {
             $this->_configDelete($key);

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -73,11 +73,11 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      *
      * @param string $name The name/class of the object to load.
      * @param array $config Additional settings to use when loading the object.
-     * @return mixed
+     * @return object
      * @psalm-return TObject
      * @throws \Exception If the class cannot be found.
      */
-    public function load(string $name, array $config = [])
+    public function load(string $name, array $config = []): object
     {
         if (isset($config['className'])) {
             $objName = $name;
@@ -196,7 +196,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @psalm-param TObject|string $class
      * @psalm-return TObject
      */
-    abstract protected function _create($class, string $alias, array $config);
+    abstract protected function _create(object|string $class, string $alias, array $config): object;
 
     /**
      * Get the list of loaded objects.
@@ -227,7 +227,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @throws \RuntimeException If not loaded or found.
      * @psalm-return TObject
      */
-    public function get(string $name)
+    public function get(string $name): object
     {
         if (!isset($this->_loaded[$name])) {
             throw new RuntimeException(sprintf('Unknown object "%s"', $name));
@@ -243,7 +243,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @return object|null
      * @psalm-return TObject|null
      */
-    public function __get(string $name)
+    public function __get(string $name): ?object
     {
         return $this->_loaded[$name] ?? null;
     }
@@ -267,7 +267,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @psalm-param TObject $object
      * @return void
      */
-    public function __set(string $name, $object): void
+    public function __set(string $name, object $object): void
     {
         $this->set($name, $object);
     }

--- a/src/Core/PluginApplicationInterface.php
+++ b/src/Core/PluginApplicationInterface.php
@@ -40,7 +40,7 @@ interface PluginApplicationInterface extends EventDispatcherInterface
      * @param array $config The configuration data for the plugin if using a string for $name
      * @return $this
      */
-    public function addPlugin($name, array $config = []);
+    public function addPlugin(PluginInterface|string $name, array $config = []);
 
     /**
      * Run bootstrap logic for loaded plugins.

--- a/src/Core/Retry/CommandRetry.php
+++ b/src/Core/Retry/CommandRetry.php
@@ -60,9 +60,9 @@ class CommandRetry
      *
      * @param callable $action The callable action to execute with a retry strategy
      * @return mixed The return value of the passed action callable
-     * @throws \Exception
+     * @throws \Exception Throws exception from last failure
      */
-    public function run(callable $action)
+    public function run(callable $action): mixed
     {
         $this->numRetries = 0;
         while (true) {

--- a/src/Core/ServiceConfig.php
+++ b/src/Core/ServiceConfig.php
@@ -32,7 +32,7 @@ class ServiceConfig
      * @param mixed $default The default value to use if $path does not exist.
      * @return mixed The configuration data or $default value.
      */
-    public function get(string $path, $default = null)
+    public function get(string $path, mixed $default = null): mixed
     {
         return Configure::read($path, $default);
     }

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -93,7 +93,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->services($this->getContainer());
     }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -73,7 +73,7 @@ trait StaticConfigTrait
      * @throws \LogicException When trying to store an invalid structured config array.
      * @return void
      */
-    public static function setConfig($key, $config = null): void
+    public static function setConfig(array|string $key, object|array|null $config = null): void
     {
         if ($config === null) {
             if (!is_array($key)) {
@@ -115,7 +115,7 @@ trait StaticConfigTrait
      * @param string $key The name of the configuration.
      * @return mixed|null Configuration data at the named key or null if the key does not exist.
      */
-    public static function getConfig(string $key)
+    public static function getConfig(string $key): mixed
     {
         return static::$_config[$key] ?? null;
     }
@@ -129,7 +129,7 @@ trait StaticConfigTrait
      * @return mixed Configuration data at the named key.
      * @throws \InvalidArgumentException If value does not exist.
      */
-    public static function getConfigOrFail(string $key)
+    public static function getConfigOrFail(string $key): mixed
     {
         if (!isset(static::$_config[$key])) {
             throw new InvalidArgumentException(sprintf('Expected configuration `%s` not found.', $key));

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -38,7 +38,7 @@ if (!function_exists('h')) {
      * @return mixed Wrapped text.
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#h
      */
-    function h($text, bool $double = true, ?string $charset = null)
+    function h(mixed $text, bool $double = true, ?string $charset = null): mixed
     {
         if (is_string($text)) {
             //optimize for strings
@@ -138,7 +138,7 @@ if (!function_exists('pr')) {
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#pr
      * @see debug()
      */
-    function pr($var)
+    function pr(mixed $var): mixed
     {
         if (!Configure::read('debug')) {
             return $var;
@@ -166,7 +166,7 @@ if (!function_exists('pj')) {
      * @see pr()
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#pj
      */
-    function pj($var)
+    function pj(mixed $var): mixed
     {
         if (!Configure::read('debug')) {
             return $var;
@@ -192,7 +192,7 @@ if (!function_exists('env')) {
      * @return string|bool|null Environment variable setting.
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#env
      */
-    function env(string $key, $default = null)
+    function env(string $key, string|bool|null $default = null): string|bool|null
     {
         if ($key === 'HTTPS') {
             if (isset($_SERVER['HTTPS'])) {
@@ -320,7 +320,7 @@ if (!function_exists('getTypeName')) {
      * @param mixed $var Variable to check
      * @return string Returns the class name or variable type
      */
-    function getTypeName($var): string
+    function getTypeName(mixed $var): string
     {
         return is_object($var) ? get_class($var) : gettype($var);
     }

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -68,12 +68,12 @@ class ConnectionRegistry extends ObjectRegistry
      * If a callable is passed as first argument, The returned value of this
      * function will be the result of the callable.
      *
-     * @param \Cake\Datasource\ConnectionInterface|callable|string $class The classname or object to make.
+     * @param callable|object|string $class The classname or object to make.
      * @param string $alias The alias of the object.
      * @param array $config An array of settings to use for the datasource.
-     * @return \Cake\Datasource\ConnectionInterface A connection with the correct settings.
+     * @return object A connection with the correct settings.
      */
-    protected function _create($class, string $alias, array $config)
+    protected function _create(callable|object|string $class, string $alias, array $config): object
     {
         if (is_callable($class)) {
             return $class($alias);
@@ -85,7 +85,6 @@ class ConnectionRegistry extends ObjectRegistry
 
         unset($config['className']);
 
-        /** @var \Cake\Datasource\ConnectionInterface */
         return new $class($config);
     }
 

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -62,16 +62,16 @@ class LogEngineRegistry extends ObjectRegistry
      *
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      *
-     * @param \Psr\Log\LoggerInterface|string $class The classname or object to make.
+     * @param \Psr\Log\LoggerInterface|callable|string $class The classname or object to make.
      * @param string $alias The alias of the object.
      * @param array $config An array of settings to use for the logger.
      * @return \Psr\Log\LoggerInterface The constructed logger class.
      * @throws \RuntimeException when an object doesn't implement the correct interface.
      */
-    protected function _create($class, string $alias, array $config): LoggerInterface
+    protected function _create(callable|object|string $class, string $alias, array $config): LoggerInterface
     {
         if (is_callable($class)) {
-            $class = $class($alias);
+            return $class($alias);
         }
 
         if (is_object($class)) {

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -68,7 +68,7 @@ class TransportRegistry extends ObjectRegistry
      * @return \Cake\Mailer\AbstractTransport The constructed transport class.
      * @throws \RuntimeException when an object doesn't implement the correct interface.
      */
-    protected function _create($class, string $alias, array $config): AbstractTransport
+    protected function _create(object|string $class, string $alias, array $config): AbstractTransport
     {
         if (is_object($class)) {
             $instance = $class;

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -133,14 +133,18 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      * Enabled behaviors will be registered with the event manager.
      *
-     * @param string $class The classname that is missing.
+     * @param \Cake\ORM\Behavior|string $class The classname that is missing.
      * @param string $alias The alias of the object.
      * @param array $config An array of config to use for the behavior.
      * @return \Cake\ORM\Behavior The constructed behavior class.
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    protected function _create($class, string $alias, array $config): Behavior
+    protected function _create(object|string $class, string $alias, array $config): Behavior
     {
+        if (is_object($class)) {
+            return $class;
+        }
+
         /** @var \Cake\ORM\Behavior $instance */
         $instance = new $class($this->_table, $config);
         $enable = $config['enabled'] ?? true;

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -90,7 +90,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * @param string $name Name of property to read
      * @return \Cake\View\Helper|null
      */
-    public function __get(string $name)
+    public function __get(string $name): ?Helper
     {
         if (isset($this->_loaded[$name])) {
             return $this->_loaded[$name];
@@ -141,14 +141,18 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
      * Part of the template method for Cake\Core\ObjectRegistry::load()
      * Enabled helpers will be registered with the event manager.
      *
-     * @param string $class The class to create.
+     * @param \Cake\View\Helper|string $class The class to create.
      * @param string $alias The alias of the loaded helper.
      * @param array $config An array of settings to use for the helper.
      * @return \Cake\View\Helper The constructed helper class.
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    protected function _create($class, string $alias, array $config): Helper
+    protected function _create(object|string $class, string $alias, array $config): Helper
     {
+        if (is_object($class)) {
+            return $class;
+        }
+
         /** @var \Cake\View\Helper $instance */
         $instance = new $class($this->_View, $config);
 

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -72,10 +72,10 @@ class StaticConfigTraitTest extends TestCase
     public function testGetConfigOrFail(): void
     {
         $className = get_class($this->subject);
-        $className::setConfig('foo', 'bar');
+        $className::setConfig('foo', ['bar' => true]);
 
         $result = $className::getConfigOrFail('foo');
-        $this->assertSame('bar', $result);
+        $this->assertSame(['bar' => true], $result);
     }
 
     public function testGetConfigOrFailException(): void

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -755,7 +755,6 @@ class MailerTest extends TestCase
         $this->mailer->setFrom('cake@cakephp.org');
         $this->mailer->setTo(['you@cakephp.org' => 'You']);
         $this->mailer->setSubject('My title');
-        $this->mailer->setConfig(['empty']);
         $this->mailer->viewBuilder()
             ->setTemplate('default')
             ->setVar('content', 'message body.')


### PR DESCRIPTION
This pulls in just the src/Core files and dependent changes.

The key change is removing `callable` support from a few classes that extend ObjectRegistry and adding object support to a few.