### PR TITLE
Resolves out-of-date/inaccurate doc blocks for Configure::load

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -321,7 +321,8 @@ class Configure
      * @param string $key name of configuration resource to load.
      * @param string $config Name of the configured engine to use to read the resource identified by $key.
      * @param bool $merge if config files should be merged instead of simply overridden
-     * @return bool False if file not found, true if load successful.
+     * @return bool False if engine not found, true if load successful.
+     * @throws \Cake\Core\Exception\CakeException if file not found
      * @link https://book.cakephp.org/4/en/development/configuration.html#reading-and-writing-configuration-files
      */
     public static function load(string $key, string $config = 'default', bool $merge = true): bool


### PR DESCRIPTION
A boolean false is returned only if the engine is not found. When a file is not found a CakeException is raised.

\Cake\Core\Exception\CakeException:

```php
Configure::load('i_dont_exist_config', 'default');
```

Returns `false`:

```php
Configure::load('i_do_exist_config', 'but_this_engine_does_not');
```

While this resolves the doc blocks, I am not exactly sure if this is how this should work :-/ I think it should be the other way around or better yet have both throw exceptions...