### PR TITLE
Configure::load() now throws an exception when config engine does not exist 

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -329,9 +329,13 @@ class Configure
     {
         $engine = static::_getEngine($config);
         if (!$engine) {
-            throw new CakeException(sprintf(
-                'Config %s engine not found when attempting to load %s.', $config, $key
-            ));
+            throw new CakeException(
+                sprintf(
+                    'Config %s engine not found when attempting to load %s.',
+                    $config,
+                    $key
+                )
+            );
         }
 
         $values = $engine->read($key);

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -321,15 +321,19 @@ class Configure
      * @param string $key name of configuration resource to load.
      * @param string $config Name of the configured engine to use to read the resource identified by $key.
      * @param bool $merge if config files should be merged instead of simply overridden
-     * @return bool False if file not found, true if load successful.
+     * @return bool True if load successful.
+     * @throws \Cake\Core\Exception\CakeException if the $config engine is not found
      * @link https://book.cakephp.org/4/en/development/configuration.html#reading-and-writing-configuration-files
      */
     public static function load(string $key, string $config = 'default', bool $merge = true): bool
     {
         $engine = static::_getEngine($config);
         if (!$engine) {
-            return false;
+            throw new CakeException(sprintf(
+                'Config %s engine not found when attempting to load %s.', $config, $key
+            ));
         }
+
         $values = $engine->read($key);
 
         if ($merge) {

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -260,6 +260,15 @@ class ConfigureTest extends TestCase
     }
 
     /**
+     * test load() with invalid config engine
+     */
+    public function testLoadExceptionOnNonExistentEngine(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        Configure::load('nonexistent_configuration_file', 'nonexistent_configuration_engine');
+    }
+
+    /**
      * test load method for default config creation
      */
     public function testLoadDefaultConfig(): void


### PR DESCRIPTION
Alters `Configure::load()` to throw an exception if the `$config` engine does not exist. A test is added so there is coverage for this now.

See discussion in #15675