### PR TITLE
cake 5: ZipIterator::current() should return array

### DIFF
--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -95,7 +95,7 @@ class ZipIterator extends MultipleIterator implements CollectionInterface
             return parent::current();
         }
 
-        return call_user_func_array($this->_callback, parent::current());
+        return [call_user_func_array($this->_callback, parent::current())];
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1930,12 +1930,12 @@ class CollectionTest extends TestCase
         $zipped = $collection->zipWith([3, 4], function ($a, $b) {
             return $a * $b;
         });
-        $this->assertEquals([3, 8], $zipped->toList());
+        $this->assertEquals([[3], [8]], $zipped->toList());
 
         $zipped = $collection->zipWith([3, 4], [5, 6, 7], function (...$args) {
             return array_sum($args);
         });
-        $this->assertEquals([9, 12], $zipped->toList());
+        $this->assertEquals([[9], [12]], $zipped->toList());
     }
 
     /**


### PR DESCRIPTION
I was trying to fix the static analysis errors from merging, but I found there is an actual error.

`MultipleIterator::current()` has a return type of `array`. `ZipIterator::current()` does not return array when a callback is passed in.

This doesn't look great because zipWith() suggests reducing to a single value. However, the return type needs to be consistent.
