### PR TITLE
Adds an extra check before trying to set the session_id

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -529,7 +529,7 @@ class Session
      */
     public function id(?string $id = null): string
     {
-        if ($id !== null && !headers_sent()) {
+        if ($id !== null && !headers_sent() && session_id() == '') {
             session_id($id);
         }
 


### PR DESCRIPTION
In our tests we're seeing the following error pop up frequently:
```
Warning Error: session_id(): Cannot change session id when session is active
In [vendor/cakephp/cakephp/src/Http/Session.php, line 533]
```
This adds a simple check to ensure the session_id() is empty before trying to set it.