### PR TITLE
cake 5: Add native type hints for Console

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -778,7 +778,7 @@ class I18nExtractCommand extends Command
      * @param int $count Count
      * @return void
      */
-    protected function _markerError($io, string $file, int $line, string $marker, int $count): void
+    protected function _markerError(ConsoleIo $io, string $file, int $line, string $marker, int $count): void
     {
         if (strpos($this->_file, CAKE_CORE_INCLUDE_PATH) === false) {
             $this->_countMarkerError++;
@@ -863,7 +863,7 @@ class I18nExtractCommand extends Command
      * @param string $path Path to folder
      * @return bool true if it exists and is writable, false otherwise
      */
-    protected function _isPathUsable($path): bool
+    protected function _isPathUsable(string $path): bool
     {
         if (!is_dir($path)) {
             mkdir($path, 0770, true);

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -140,9 +140,9 @@ class Arguments
      * Get an option's value or null
      *
      * @param string $name The name of the option to check.
-     * @return string|int|bool|null The option value or null.
+     * @return string|bool|null The option value or null.
      */
-    public function getOption(string $name)
+    public function getOption(string $name): string|bool|null
     {
         return $this->options[$name] ?? null;
     }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -251,7 +251,7 @@ abstract class BaseCommand implements CommandInterface
      * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.
      * @return int|null The exit code or null for success of the command.
      */
-    public function executeCommand($command, array $args = [], ?ConsoleIo $io = null): ?int
+    public function executeCommand(CommandInterface|string $command, array $args = [], ?ConsoleIo $io = null): ?int
     {
         if (is_string($command)) {
             if (!class_exists($command)) {

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -130,7 +130,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * @throws \InvalidArgumentException when unknown commands are fetched.
      * @psalm-return \Cake\Console\CommandInterface|class-string
      */
-    public function get(string $name)
+    public function get(string $name): CommandInterface|string
     {
         if (!$this->has($name)) {
             throw new InvalidArgumentException("The $name is not a known command name.");

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -63,7 +63,7 @@ class ConsoleInputArgument
      * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
      * @param array<string> $choices Valid choices for this option.
      */
-    public function __construct($name, $help = '', $required = false, $choices = [])
+    public function __construct(array|string $name, string $help = '', bool $required = false, array $choices = [])
     {
         if (is_array($name) && isset($name['name'])) {
             foreach ($name as $key => $value) {

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -90,7 +90,7 @@ class ConsoleInputOption
      * @param string $short The short alias for this option
      * @param string $help The help text for this option
      * @param bool $isBoolean Whether this option is a boolean option. Boolean options don't consume extra tokens
-     * @param string|bool|null $default The default value for this option.
+     * @param mixed $default The default value for this option.
      * @param array<string> $choices Valid choices for this option.
      * @param bool $multiple Whether this option can accept multiple value definition.
      * @param bool $required Whether this option is required or not.
@@ -205,7 +205,7 @@ class ConsoleInputOption
      *
      * @return string|bool|null
      */
-    public function defaultValue()
+    public function defaultValue(): string|bool|null
     {
         return $this->_default;
     }
@@ -247,7 +247,7 @@ class ConsoleInputOption
      * @return true
      * @throws \Cake\Console\Exception\ConsoleException
      */
-    public function validChoice($value): bool
+    public function validChoice(string|bool $value): bool
     {
         if (empty($this->_choices)) {
             return true;

--- a/src/Console/ConsoleInputSubcommand.php
+++ b/src/Console/ConsoleInputSubcommand.php
@@ -58,7 +58,7 @@ class ConsoleInputSubcommand
      * @param \Cake\Console\ConsoleOptionParser|array|null $parser A parser for this subcommand.
      *   Either a ConsoleOptionParser, or an array that can be used with ConsoleOptionParser::buildFromArray().
      */
-    public function __construct($name, $help = '', $parser = null)
+    public function __construct(array|string $name, string $help = '', ConsoleOptionParser|array|null $parser = null)
     {
         if (is_array($name)) {
             $data = $name + ['name' => null, 'help' => '', 'parser' => null];

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -160,7 +160,7 @@ class ConsoleIo
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if current level is less than ConsoleIo::VERBOSE
      */
-    public function verbose($message, int $newlines = 1): ?int
+    public function verbose(array|string $message, int $newlines = 1): ?int
     {
         return $this->out($message, $newlines, self::VERBOSE);
     }
@@ -173,7 +173,7 @@ class ConsoleIo
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if current level is less than ConsoleIo::QUIET
      */
-    public function quiet($message, int $newlines = 1): ?int
+    public function quiet(array|string $message, int $newlines = 1): ?int
     {
         return $this->out($message, $newlines, self::QUIET);
     }
@@ -195,7 +195,7 @@ class ConsoleIo
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if provided $level is greater than current level.
      */
-    public function out($message = '', int $newlines = 1, int $level = self::NORMAL): ?int
+    public function out(array|string $message = '', int $newlines = 1, int $level = self::NORMAL): ?int
     {
         if ($level <= $this->_level) {
             $this->_lastWritten = $this->_out->write($message, $newlines);
@@ -216,7 +216,7 @@ class ConsoleIo
      *   or null if provided $level is greater than current level.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::out
      */
-    public function info($message, int $newlines = 1, int $level = self::NORMAL): ?int
+    public function info(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
         $messageType = 'info';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -234,7 +234,7 @@ class ConsoleIo
      *   or null if provided $level is greater than current level.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::out
      */
-    public function comment($message, int $newlines = 1, int $level = self::NORMAL): ?int
+    public function comment(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
         $messageType = 'comment';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -250,7 +250,7 @@ class ConsoleIo
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::err
      */
-    public function warning($message, int $newlines = 1): int
+    public function warning(array|string $message, int $newlines = 1): int
     {
         $messageType = 'warning';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -266,7 +266,7 @@ class ConsoleIo
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::err
      */
-    public function error($message, int $newlines = 1): int
+    public function error(array|string $message, int $newlines = 1): int
     {
         $messageType = 'error';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -284,7 +284,7 @@ class ConsoleIo
      *   or null if provided $level is greater than current level.
      * @see https://book.cakephp.org/4/en/console-and-shells.html#ConsoleIo::out
      */
-    public function success($message, int $newlines = 1, int $level = self::NORMAL): ?int
+    public function success(array|string $message, int $newlines = 1, int $level = self::NORMAL): ?int
     {
         $messageType = 'success';
         $message = $this->wrapMessageWithType($messageType, $message);
@@ -300,7 +300,7 @@ class ConsoleIo
      * @return void
      * @throws \Cake\Console\Exception\StopException
      */
-    public function abort($message, $code = CommandInterface::CODE_ERROR): void
+    public function abort(string $message, int $code = CommandInterface::CODE_ERROR): void
     {
         $this->error($message);
 
@@ -314,7 +314,7 @@ class ConsoleIo
      * @param array<string>|string $message The message to wrap.
      * @return array<string>|string The message wrapped with the given message type.
      */
-    protected function wrapMessageWithType(string $messageType, $message)
+    protected function wrapMessageWithType(string $messageType, array|string $message): array|string
     {
         if (is_array($message)) {
             foreach ($message as $k => $v) {
@@ -341,7 +341,7 @@ class ConsoleIo
      *    length of the last message output.
      * @return void
      */
-    public function overwrite($message, int $newlines = 1, ?int $size = null): void
+    public function overwrite(array|string $message, int $newlines = 1, ?int $size = null): void
     {
         $size = $size ?: $this->_lastWritten;
 
@@ -375,7 +375,7 @@ class ConsoleIo
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      */
-    public function err($message = '', int $newlines = 1): int
+    public function err(array|string $message = '', int $newlines = 1): int
     {
         return $this->_err->write($message, $newlines);
     }
@@ -473,7 +473,7 @@ class ConsoleIo
      * @param string|null $default Default input value.
      * @return string Either the default value, or the user-provided input.
      */
-    public function askChoice(string $prompt, $options, ?string $default = null): string
+    public function askChoice(string $prompt, array|string $options, ?string $default = null): string
     {
         if (is_string($options)) {
             if (strpos($options, ',')) {
@@ -546,7 +546,7 @@ class ConsoleIo
      *   QUIET disables notice, info and debug logs.
      * @return void
      */
-    public function setLoggers($enable): void
+    public function setLoggers(int|bool $enable): void
     {
         Log::drop('stdout');
         Log::drop('stderr');

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -188,7 +188,7 @@ class ConsoleOptionParser
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
      * @return static
      */
-    public static function create(string $command, bool $defaultOptions = true)
+    public static function create(string $command, bool $defaultOptions = true): static
     {
         return new static($command, $defaultOptions);
     }
@@ -216,7 +216,7 @@ class ConsoleOptionParser
      * @param bool $defaultOptions Whether you want the verbose and quiet options set.
      * @return static
      */
-    public static function buildFromArray(array $spec, bool $defaultOptions = true)
+    public static function buildFromArray(array $spec, bool $defaultOptions = true): static
     {
         $parser = new static($spec['command'], $defaultOptions);
         if (!empty($spec['arguments'])) {
@@ -263,7 +263,7 @@ class ConsoleOptionParser
      * @param \Cake\Console\ConsoleOptionParser|array $spec ConsoleOptionParser or spec to merge with.
      * @return $this
      */
-    public function merge($spec)
+    public function merge(ConsoleOptionParser|array $spec)
     {
         if ($spec instanceof ConsoleOptionParser) {
             $spec = $spec->toArray();
@@ -317,7 +317,7 @@ class ConsoleOptionParser
      *   text will be imploded with "\n".
      * @return $this
      */
-    public function setDescription($text)
+    public function setDescription(array|string $text)
     {
         if (is_array($text)) {
             $text = implode("\n", $text);
@@ -345,7 +345,7 @@ class ConsoleOptionParser
      *   be imploded with "\n".
      * @return $this
      */
-    public function setEpilog($text)
+    public function setEpilog(array|string $text)
     {
         if (is_array($text)) {
             $text = implode("\n", $text);
@@ -412,7 +412,7 @@ class ConsoleOptionParser
      * @param array $options An array of parameters that define the behavior of the option
      * @return $this
      */
-    public function addOption($name, array $options = [])
+    public function addOption(ConsoleInputOption|string $name, array $options = [])
     {
         if ($name instanceof ConsoleInputOption) {
             $option = $name;
@@ -480,7 +480,7 @@ class ConsoleOptionParser
      * @param array $params Parameters for the argument, see above.
      * @return $this
      */
-    public function addArgument($name, array $params = [])
+    public function addArgument(ConsoleInputArgument|string $name, array $params = [])
     {
         if ($name instanceof ConsoleInputArgument) {
             $arg = $name;
@@ -570,7 +570,7 @@ class ConsoleOptionParser
      * @param array $options Array of params, see above.
      * @return $this
      */
-    public function addSubcommand($name, array $options = [])
+    public function addSubcommand(ConsoleInputSubcommand|string $name, array $options = [])
     {
         if ($name instanceof ConsoleInputSubcommand) {
             $command = $name;
@@ -631,7 +631,7 @@ class ConsoleOptionParser
      *
      * @return array<\Cake\Console\ConsoleInputArgument>
      */
-    public function arguments()
+    public function arguments(): array
     {
         return $this->_args;
     }
@@ -641,7 +641,7 @@ class ConsoleOptionParser
      *
      * @return array<string>
      */
-    public function argumentNames()
+    public function argumentNames(): array
     {
         $out = [];
         foreach ($this->_args as $arg) {
@@ -656,7 +656,7 @@ class ConsoleOptionParser
      *
      * @return array<\Cake\Console\ConsoleInputOption>
      */
-    public function options()
+    public function options(): array
     {
         return $this->_options;
     }
@@ -666,7 +666,7 @@ class ConsoleOptionParser
      *
      * @return array<\Cake\Console\ConsoleInputSubcommand>
      */
-    public function subcommands()
+    public function subcommands(): array
     {
         return $this->_subcommands;
     }

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -194,7 +194,7 @@ class ConsoleOutput
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to output.
      */
-    public function write($message, int $newlines = 1): int
+    public function write(array|string $message, int $newlines = 1): int
     {
         if (is_array($message)) {
             $message = implode(static::LF, $message);

--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -90,7 +90,7 @@ class MissingOptionException extends ConsoleException
      * @param array<string> $haystack Suggestions to look through.
      * @return string The best match
      */
-    protected function findClosestItem($needle, $haystack): ?string
+    protected function findClosestItem(string $needle, array $haystack): ?string
     {
         $bestGuess = null;
         foreach ($haystack as $item) {

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -211,7 +211,7 @@ class HelpFormatter
      * @param bool $string Return the SimpleXml object or a string. Defaults to true.
      * @return \SimpleXMLElement|string See $string
      */
-    public function xml(bool $string = true)
+    public function xml(bool $string = true): SimpleXMLElement|string
     {
         $parser = $this->_parser;
         $xml = new SimpleXMLElement('<shell></shell>');

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -141,14 +141,14 @@ class ArgumentsTest extends TestCase
         $options = [
             'verbose' => true,
             'off' => false,
-            'zero' => 0,
+            'zero' => '0',
             'empty' => '',
         ];
         $args = new Arguments([], $options, []);
         $this->assertTrue($args->getOption('verbose'));
         $this->assertFalse($args->getOption('off'));
         $this->assertSame('', $args->getOption('empty'));
-        $this->assertSame(0, $args->getOption('zero'));
+        $this->assertSame('0', $args->getOption('zero'));
         $this->assertNull($args->getOption('undef'));
     }
 }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -313,18 +313,6 @@ class CommandTest extends TestCase
     }
 
     /**
-     * test executeCommand with an invalid instance
-     */
-    public function testExecuteCommandInstanceInvalid(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Command 'stdClass' is not a subclass");
-
-        $command = new Command();
-        $command->executeCommand(new \stdClass(), [], $this->getMockIo(new ConsoleOutput()));
-    }
-
-    /**
      * Test that noninteractive commands use defaults where applicable.
      */
     public function testExecuteCommandNonInteractive(): void

--- a/tests/test_app/TestApp/Command/AbortCommand.php
+++ b/tests/test_app/TestApp/Command/AbortCommand.php
@@ -9,7 +9,7 @@ use Cake\Console\ConsoleIo;
 
 class AbortCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->error('Command aborted');
         $this->abort(127);

--- a/tests/test_app/TestApp/Command/BridgeCommand.php
+++ b/tests/test_app/TestApp/Command/BridgeCommand.php
@@ -9,9 +9,6 @@ use Cake\Console\ConsoleIo;
 
 class BridgeCommand extends Command
 {
-    /**
-     * @inheritDoc
-     */
     public function execute(Arguments $args, ConsoleIo $io)
     {
         $name = $io->ask('What is your name');

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -9,7 +9,7 @@ use Cake\Console\ConsoleIo;
 
 class DemoCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->quiet('Quiet!');
         $io->out('Demo Command!');

--- a/tests/test_app/TestApp/Command/DependencyCommand.php
+++ b/tests/test_app/TestApp/Command/DependencyCommand.php
@@ -18,7 +18,7 @@ class DependencyCommand extends Command
         $this->inject = $inject;
     }
 
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->out('Dependency Command');
         $io->out('constructor inject: ' . json_encode($this->inject));

--- a/tests/test_app/TestApp/Command/FormatSpecifierCommand.php
+++ b/tests/test_app/TestApp/Command/FormatSpecifierCommand.php
@@ -9,7 +9,7 @@ use Cake\Console\ConsoleIo;
 
 class FormatSpecifierCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io): void
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->out('Be careful! %s is a format specifier!');
     }

--- a/tests/test_app/TestApp/Command/IntegrationCommand.php
+++ b/tests/test_app/TestApp/Command/IntegrationCommand.php
@@ -10,7 +10,7 @@ use Cake\Console\ConsoleOptionParser;
 
 class IntegrationCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io): void
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         $io->out('arg: ' . $args->getArgument('arg'));
         $io->out('opt: ' . $args->getOption('opt'));

--- a/tests/test_app/TestApp/Command/NonInteractiveCommand.php
+++ b/tests/test_app/TestApp/Command/NonInteractiveCommand.php
@@ -9,7 +9,7 @@ use Cake\Console\ConsoleIo;
 
 class NonInteractiveCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io)
     {
         $result = $io->ask('What?', 'Default!');
         $io->quiet('Result: ' . $result);


### PR DESCRIPTION
Did not add return type for `BaseCommand::execute()` to allow implicit null return. Otherwise, we have to enforce returning something.

@markstory 