### PR TITLE
Remove redundant code.

### DIFF
--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\View;
 
 use Cake\Core\Configure;
-use RuntimeException;
 
 /**
  * A view class that is used for JSON responses.
@@ -140,21 +139,13 @@ class JsonView extends SerializedView
         } elseif ($jsonOptions === false) {
             $jsonOptions = 0;
         }
+        $jsonOptions |= JSON_THROW_ON_ERROR;
 
         if (Configure::read('debug')) {
             $jsonOptions |= JSON_PRETTY_PRINT;
         }
 
-        if (defined('JSON_THROW_ON_ERROR')) {
-            $jsonOptions |= JSON_THROW_ON_ERROR;
-        }
-
-        $return = json_encode($data, $jsonOptions);
-        if ($return === false) {
-            throw new RuntimeException(json_last_error_msg(), json_last_error());
-        }
-
-        return $return;
+        return json_encode($data, $jsonOptions);
     }
 
     /**


### PR DESCRIPTION
JSON_THROW_ON_ERROR is available since PHP 7.3.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
