### PR TITLE
fix class name

### DIFF
--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -115,5 +115,5 @@ class CakeException extends RuntimeException
 }
 
 // phpcs:disable
-class_exists('Cake\Core\Exception\CakeException');
+class_exists('Cake\Core\Exception\Exception');
 // phpcs:enable


### PR DESCRIPTION
looks class name should be `Cake\Core\Exception\Exception`

see previous commit : https://github.com/cakephp/cakephp/commit/d43092a93821

