### PR TITLE
cake 5: Add native type hints for Http

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -267,7 +267,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
-			count: 1
+			count: 3
 			path: src/Http/Cookie/Cookie.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -102,6 +102,18 @@
       <code>$this-&gt;headers</code>
     </PropertyTypeCoercion>
   </file>
+  <file src="src/Http/Cookie/Cookie.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;value</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>string</code>
+    </InvalidReturnType>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>setTimezone</code>
+      <code>setTimezone</code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="src/Http/Response.php">
     <PropertyTypeCoercion occurrences="2">
       <code>$this-&gt;headerNames</code>

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -28,6 +28,7 @@ use Cake\Core\HttpApplicationInterface;
 use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Core\PluginCollection;
+use Cake\Core\PluginInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
@@ -143,7 +144,7 @@ abstract class BaseApplication implements
      * @param array $config The configuration data for the plugin if using a string for $name
      * @return $this
      */
-    public function addOptionalPlugin($name, array $config = [])
+    public function addOptionalPlugin(PluginInterface|string $name, array $config = [])
     {
         try {
             $this->addPlugin($name, $config);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -212,7 +212,7 @@ class Client implements ClientInterface
      * @return static
      * @throws \InvalidArgumentException
      */
-    public static function createFromUrl(string $url)
+    public static function createFromUrl(string $url): static
     {
         $parts = parse_url($url);
 
@@ -275,7 +275,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function get(string $url, $data = [], array $options = []): Response
+    public function get(string $url, array|string $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $body = null;
@@ -301,7 +301,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function post(string $url, $data = [], array $options = []): Response
+    public function post(string $url, mixed $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
@@ -317,7 +317,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function put(string $url, $data = [], array $options = []): Response
+    public function put(string $url, mixed $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
@@ -333,7 +333,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function patch(string $url, $data = [], array $options = []): Response
+    public function patch(string $url, mixed $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
@@ -349,7 +349,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function options(string $url, $data = [], array $options = []): Response
+    public function options(string $url, mixed $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
@@ -365,7 +365,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function trace(string $url, $data = [], array $options = []): Response
+    public function trace(string $url, mixed $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
@@ -381,7 +381,7 @@ class Client implements ClientInterface
      * @param array $options Additional options for the request.
      * @return \Cake\Http\Client\Response
      */
-    public function delete(string $url, $data = [], array $options = []): Response
+    public function delete(string $url, mixed $data = [], array $options = []): Response
     {
         $options = $this->_mergeOptions($options);
         $url = $this->buildUrl($url, [], $options);
@@ -414,7 +414,7 @@ class Client implements ClientInterface
      * @param array $options The options to use. Contains auth, proxy, etc.
      * @return \Cake\Http\Client\Response
      */
-    protected function _doRequest(string $method, string $url, $data, $options): Response
+    protected function _doRequest(string $method, string $url, mixed $data, array $options): Response
     {
         $request = $this->_createRequest(
             $method,
@@ -514,7 +514,7 @@ class Client implements ClientInterface
      * @param array $options The config options stored with Client::config()
      * @return string A complete url with scheme, port, host, and path.
      */
-    public function buildUrl(string $url, $query = [], array $options = []): string
+    public function buildUrl(string $url, array|string $query = [], array $options = []): string
     {
         if (empty($options) && empty($query)) {
             return $url;
@@ -566,7 +566,7 @@ class Client implements ClientInterface
      * @param array $options The options to use. Contains auth, proxy, etc.
      * @return \Cake\Http\Client\Request
      */
-    protected function _createRequest(string $method, string $url, $data, $options): Request
+    protected function _createRequest(string $method, string $url, mixed $data, array $options): Request
     {
         $headers = (array)($options['headers'] ?? []);
         if (isset($options['type'])) {
@@ -672,7 +672,7 @@ class Client implements ClientInterface
      * @return object Authentication strategy instance.
      * @throws \Cake\Core\Exception\CakeException when an invalid strategy is chosen.
      */
-    protected function _createAuth(array $auth, array $options)
+    protected function _createAuth(array $auth, array $options): object
     {
         if (empty($auth['type'])) {
             $auth['type'] = 'basic';

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -23,6 +23,7 @@ use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\Http\Exception\HttpException;
 use Composer\CaBundle\CaBundle;
+use CurlHandle;
 use Psr\Http\Message\RequestInterface;
 
 /**
@@ -195,7 +196,7 @@ class Curl implements AdapterInterface
      * @param string $responseData string The response data from curl_exec
      * @return array<\Cake\Http\Client\Response>
      */
-    protected function createResponse($handle, $responseData): array
+    protected function createResponse(CurlHandle $handle, string $responseData): array
     {
         $headerSize = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
         $headers = trim(substr($responseData, 0, $headerSize));
@@ -211,7 +212,7 @@ class Curl implements AdapterInterface
      * @param \CurlHandle $ch Curl Resource handle
      * @return string|bool
      */
-    protected function exec($ch)
+    protected function exec(CurlHandle $ch): string|bool
     {
         return curl_exec($ch);
     }

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -96,7 +96,7 @@ class FormData implements Countable
      * @param mixed $value The value for the part.
      * @return $this
      */
-    public function add($name, $value = null)
+    public function add(FormDataPart|string $name, mixed $value = null)
     {
         if (is_string($name)) {
             if (is_array($value)) {
@@ -139,7 +139,7 @@ class FormData implements Countable
      * @param mixed $value Either a string filename, or a filehandle.
      * @return \Cake\Http\Client\FormDataPart
      */
-    public function addFile(string $name, $value): FormDataPart
+    public function addFile(string $name, mixed $value): FormDataPart
     {
         $this->_hasFile = true;
 
@@ -177,7 +177,7 @@ class FormData implements Countable
      * @param mixed $value The value to add.
      * @return void
      */
-    public function addRecursive(string $name, $value): void
+    public function addRecursive(string $name, mixed $value): void
     {
         foreach ($value as $key => $value) {
             $key = $name . '[' . $key . ']';

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -39,8 +39,12 @@ class Request extends Message implements RequestInterface
      * @param array $headers The HTTP headers to set.
      * @param array|string|null $data The request body to use.
      */
-    public function __construct(string $url = '', string $method = self::METHOD_GET, array $headers = [], $data = null)
-    {
+    public function __construct(
+        string $url = '',
+        string $method = self::METHOD_GET,
+        array $headers = [],
+        array|string|null $data = null
+    ) {
         $this->setMethod($method);
         $this->uri = $this->createUri($url);
         $headers += [
@@ -80,7 +84,7 @@ class Request extends Message implements RequestInterface
      * @param array|string $content The body for the request.
      * @return $this
      */
-    protected function setContent($content)
+    protected function setContent(array|string $content)
     {
         if (is_array($content)) {
             $formData = new FormData();

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -326,7 +326,7 @@ class Response extends Message implements ResponseInterface
      * @param string $name The name of the cookie value.
      * @return array|string|null Either the cookie's value or null when the cookie is undefined.
      */
-    public function getCookie(string $name)
+    public function getCookie(string $name): array|string|null
     {
         $this->buildCookieCollection();
 
@@ -401,7 +401,7 @@ class Response extends Message implements ResponseInterface
      *
      * @return mixed
      */
-    public function getJson()
+    public function getJson(): mixed
     {
         return $this->_getJson();
     }
@@ -411,7 +411,7 @@ class Response extends Message implements ResponseInterface
      *
      * @return mixed
      */
-    protected function _getJson()
+    protected function _getJson(): mixed
     {
         if ($this->_json) {
             return $this->_json;

--- a/src/Http/ControllerFactoryInterface.php
+++ b/src/Http/ControllerFactoryInterface.php
@@ -34,7 +34,7 @@ interface ControllerFactoryInterface
      * @throws \Cake\Http\Exception\MissingControllerException
      * @psalm-return TController
      */
-    public function create(ServerRequestInterface $request);
+    public function create(ServerRequestInterface $request): mixed;
 
     /**
      * Invoke a controller's action and wrapping methods.
@@ -43,5 +43,5 @@ interface ControllerFactoryInterface
      * @return \Psr\Http\Message\ResponseInterface The response
      * @psalm-param TController $controller
      */
-    public function invoke($controller): ResponseInterface;
+    public function invoke(mixed $controller): ResponseInterface;
 }

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -73,7 +73,7 @@ class Cookie implements CookieInterface
     /**
      * Expiration time
      *
-     * @var \DateTime|\DateTimeImmutable|null
+     * @var \DateTimeInterface|null
      */
     protected $expiresAt;
 
@@ -136,8 +136,8 @@ class Cookie implements CookieInterface
      *
      * @link http://php.net/manual/en/function.setcookie.php
      * @param string $name Cookie name
-     * @param array|string $value Value of the cookie
-     * @param \DateTime|\DateTimeImmutable|null $expiresAt Expiration time and date
+     * @param array|string|float|int|bool $value Value of the cookie
+     * @param \DateTimeInterface|null $expiresAt Expiration time and date
      * @param string|null $path Path
      * @param string|null $domain Domain
      * @param bool|null $secure Is secure
@@ -146,7 +146,7 @@ class Cookie implements CookieInterface
      */
     public function __construct(
         string $name,
-        $value = '',
+        array|string|float|int|bool $value = '',
         ?DateTimeInterface $expiresAt = null,
         ?string $path = null,
         ?string $domain = null,
@@ -210,12 +210,12 @@ class Cookie implements CookieInterface
      * Factory method to create Cookie instances.
      *
      * @param string $name Cookie name
-     * @param array|string $value Value of the cookie
+     * @param array|string|float|int|bool $value Value of the cookie
      * @param array $options Cookies options.
      * @return static
      * @see \Cake\Cookie\Cookie::setDefaults()
      */
-    public static function create(string $name, $value, array $options = [])
+    public static function create(string $name, array|string|float|int|bool $value, array $options = []): static
     {
         $options += static::$defaults;
         $options['expires'] = static::dateTimeInstance($options['expires']);
@@ -236,9 +236,9 @@ class Cookie implements CookieInterface
      * Converts non null expiry value into DateTimeInterface instance.
      *
      * @param mixed $expires Expiry value.
-     * @return \DateTime|\DatetimeImmutable|null
+     * @return \DateTimeInterface|null
      */
-    protected static function dateTimeInstance($expires): ?DateTimeInterface
+    protected static function dateTimeInstance(mixed $expires): ?DateTimeInterface
     {
         if ($expires === null) {
             return $expires;
@@ -275,7 +275,7 @@ class Cookie implements CookieInterface
      * @return static
      * @see \Cake\Cookie\Cookie::setDefaults()
      */
-    public static function createFromHeaderString(string $cookie, array $defaults = [])
+    public static function createFromHeaderString(string $cookie, array $defaults = []): static
     {
         if (strpos($cookie, '";"') !== false) {
             $cookie = str_replace('";"', '{__cookie_replace__}', $cookie);
@@ -367,7 +367,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withName(string $name)
+    public function withName(string $name): static
     {
         $this->validateName($name);
         $new = clone $this;
@@ -416,7 +416,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function getValue()
+    public function getValue(): array|string
     {
         return $this->value;
     }
@@ -424,7 +424,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function getScalarValue()
+    public function getScalarValue(): string
     {
         if ($this->isExpanded) {
             /** @psalm-suppress PossiblyInvalidArgument */
@@ -437,7 +437,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withValue($value)
+    public function withValue($value): static
     {
         $new = clone $this;
         $new->_setValue($value);
@@ -448,19 +448,19 @@ class Cookie implements CookieInterface
     /**
      * Setter for the value attribute.
      *
-     * @param array|string $value The value to store.
+     * @param array|string|float|int|bool $value The value to store.
      * @return void
      */
-    protected function _setValue($value): void
+    protected function _setValue(array|string|float|int|bool $value): void
     {
         $this->isExpanded = is_array($value);
-        $this->value = $value;
+        $this->value = is_array($value) ? $value : (string)$value;
     }
 
     /**
      * @inheritDoc
      */
-    public function withPath(string $path)
+    public function withPath(string $path): static
     {
         $new = clone $this;
         $new->path = $path;
@@ -479,7 +479,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withDomain(string $domain)
+    public function withDomain(string $domain): static
     {
         $new = clone $this;
         $new->domain = $domain;
@@ -506,7 +506,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withSecure(bool $secure)
+    public function withSecure(bool $secure): static
     {
         $new = clone $this;
         $new->secure = $secure;
@@ -517,7 +517,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withHttpOnly(bool $httpOnly)
+    public function withHttpOnly(bool $httpOnly): static
     {
         $new = clone $this;
         $new->httpOnly = $httpOnly;
@@ -536,7 +536,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withExpiry($dateTime)
+    public function withExpiry($dateTime): static
     {
         $new = clone $this;
         $new->expiresAt = $dateTime->setTimezone(new DateTimeZone('GMT'));
@@ -547,7 +547,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function getExpiry()
+    public function getExpiry(): DateTimeInterface|null
     {
         return $this->expiresAt;
     }
@@ -592,7 +592,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withNeverExpire()
+    public function withNeverExpire(): static
     {
         $new = clone $this;
         $new->expiresAt = new DateTimeImmutable('2038-01-01');
@@ -603,7 +603,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withExpired()
+    public function withExpired(): static
     {
         $new = clone $this;
         $new->expiresAt = new DateTimeImmutable('1970-01-01 00:00:01');
@@ -622,7 +622,7 @@ class Cookie implements CookieInterface
     /**
      * @inheritDoc
      */
-    public function withSameSite(?string $sameSite)
+    public function withSameSite(?string $sameSite): static
     {
         if ($sameSite !== null) {
             $this->validateSameSiteValue($sameSite);
@@ -641,7 +641,7 @@ class Cookie implements CookieInterface
      * @return void
      * @throws \InvalidArgumentException
      */
-    protected static function validateSameSiteValue(string $sameSite)
+    protected static function validateSameSiteValue(string $sameSite): void
     {
         if (!in_array($sameSite, CookieInterface::SAMESITE_VALUES, true)) {
             throw new InvalidArgumentException(
@@ -677,7 +677,7 @@ class Cookie implements CookieInterface
      * @param mixed $value Value to write
      * @return static
      */
-    public function withAddedValue(string $path, $value)
+    public function withAddedValue(string $path, mixed $value): static
     {
         $new = clone $this;
         if ($new->isExpanded === false) {
@@ -697,7 +697,7 @@ class Cookie implements CookieInterface
      * @param string $path Path to remove
      * @return static
      */
-    public function withoutAddedValue(string $path)
+    public function withoutAddedValue(string $path): static
     {
         $new = clone $this;
         if ($new->isExpanded === false) {
@@ -720,7 +720,7 @@ class Cookie implements CookieInterface
      * @param string $path Path to read the data from
      * @return mixed
      */
-    public function read(?string $path = null)
+    public function read(?string $path = null): mixed
     {
         if ($this->isExpanded === false) {
             /** @psalm-suppress PossiblyInvalidArgument */
@@ -794,7 +794,7 @@ class Cookie implements CookieInterface
      * @param string $string A string containing JSON encoded data, or a bare string.
      * @return array|string Map of key and values
      */
-    protected function _expand(string $string)
+    protected function _expand(string $string): array|string
     {
         $this->isExpanded = true;
         $first = substr($string, 0, 1);

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -62,7 +62,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param array $defaults The defaults attributes.
      * @return static
      */
-    public static function createFromHeader(array $header, array $defaults = [])
+    public static function createFromHeader(array $header, array $defaults = []): static
     {
         $cookies = [];
         foreach ($header as $value) {
@@ -82,7 +82,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param \Psr\Http\Message\ServerRequestInterface $request The request to extract cookie data from
      * @return static
      */
-    public static function createFromServerRequest(ServerRequestInterface $request)
+    public static function createFromServerRequest(ServerRequestInterface $request): static
     {
         $data = $request->getCookieParams();
         $cookies = [];
@@ -113,7 +113,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param \Cake\Http\Cookie\CookieInterface $cookie Cookie instance to add.
      * @return static
      */
-    public function add(CookieInterface $cookie)
+    public function add(CookieInterface $cookie): static
     {
         $new = clone $this;
         $new->cookies[$cookie->getId()] = $cookie;
@@ -171,7 +171,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param string $name The name of the cookie to remove.
      * @return static
      */
-    public function remove(string $name)
+    public function remove(string $name): static
     {
         $new = clone $this;
         $key = mb_strtolower($name);
@@ -306,7 +306,7 @@ class CookieCollection implements IteratorAggregate, Countable
      * @param \Psr\Http\Message\RequestInterface $request Request to get cookie context from.
      * @return static
      */
-    public function addFromResponse(ResponseInterface $response, RequestInterface $request)
+    public function addFromResponse(ResponseInterface $response, RequestInterface $request): static
     {
         $uri = $request->getUri();
         $host = $uri->getHost();

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Cookie;
 
+use DateTimeInterface;
+
 /**
  * Cookie Interface
  */
@@ -65,7 +67,7 @@ interface CookieInterface
      * @param string $name Name of the cookie
      * @return static
      */
-    public function withName(string $name);
+    public function withName(string $name): static;
 
     /**
      * Gets the cookie name
@@ -79,24 +81,24 @@ interface CookieInterface
      *
      * @return array|string
      */
-    public function getValue();
+    public function getValue(): array|string;
 
     /**
      * Gets the cookie value as scalar.
      *
      * This will collapse any complex data in the cookie with json_encode()
      *
-     * @return mixed
+     * @return string
      */
-    public function getScalarValue();
+    public function getScalarValue(): string;
 
     /**
      * Create a cookie with an updated value.
      *
-     * @param array|string $value Value of the cookie to set
+     * @param array|string|float|int|bool $value Value of the cookie to set
      * @return static
      */
-    public function withValue($value);
+    public function withValue(array|string|float|int|bool $value): static;
 
     /**
      * Get the id for a cookie
@@ -120,7 +122,7 @@ interface CookieInterface
      * @param string $path Sets the path
      * @return static
      */
-    public function withPath(string $path);
+    public function withPath(string $path): static;
 
     /**
      * Get the domain attribute.
@@ -135,14 +137,14 @@ interface CookieInterface
      * @param string $domain Domain to set
      * @return static
      */
-    public function withDomain(string $domain);
+    public function withDomain(string $domain): static;
 
     /**
      * Get the current expiry time
      *
-     * @return \DateTime|\DateTimeImmutable|null Timestamp of expiry or null
+     * @return \DateTimeInterface|null Timestamp of expiry or null
      */
-    public function getExpiry();
+    public function getExpiry(): DateTimeInterface|null;
 
     /**
      * Get the timestamp from the expiration time
@@ -161,17 +163,17 @@ interface CookieInterface
     /**
      * Create a cookie with an updated expiration date
      *
-     * @param \DateTime|\DateTimeImmutable $dateTime Date time object
+     * @param \DateTimeInterface $dateTime Date time object
      * @return static
      */
-    public function withExpiry($dateTime);
+    public function withExpiry(DateTimeInterface $dateTime): static;
 
     /**
      * Create a new cookie that will virtually never expire.
      *
      * @return static
      */
-    public function withNeverExpire();
+    public function withNeverExpire(): static;
 
     /**
      * Create a new cookie that will expire/delete the cookie from the browser.
@@ -180,17 +182,17 @@ interface CookieInterface
      *
      * @return static
      */
-    public function withExpired();
+    public function withExpired(): static;
 
     /**
      * Check if a cookie is expired when compared to $time
      *
      * Cookies without an expiration date always return false.
      *
-     * @param \DateTime|\DateTimeImmutable $time The time to test against. Defaults to 'now' in UTC.
+     * @param \DateTimeInterface $time The time to test against. Defaults to 'now' in UTC.
      * @return bool
      */
-    public function isExpired($time = null): bool;
+    public function isExpired(DateTimeInterface|null $time = null): bool;
 
     /**
      * Check if the cookie is HTTP only
@@ -205,7 +207,7 @@ interface CookieInterface
      * @param bool $httpOnly HTTP Only
      * @return static
      */
-    public function withHttpOnly(bool $httpOnly);
+    public function withHttpOnly(bool $httpOnly): static;
 
     /**
      * Check if the cookie is secure
@@ -220,7 +222,7 @@ interface CookieInterface
      * @param bool $secure Secure attribute value
      * @return static
      */
-    public function withSecure(bool $secure);
+    public function withSecure(bool $secure): static;
 
     /**
      * Get the SameSite attribute.
@@ -236,7 +238,7 @@ interface CookieInterface
      *   One of CookieInterface::SAMESITE_* constants.
      * @return static
      */
-    public function withSameSite(?string $sameSite);
+    public function withSameSite(?string $sameSite): static;
 
     /**
      * Get cookie options

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -107,7 +107,7 @@ class CorsBuilder
      * @param array<string>|string $domains The allowed domains
      * @return $this
      */
-    public function allowOrigin($domains)
+    public function allowOrigin(array|string $domains)
     {
         $allowed = $this->_normalizeDomains((array)$domains);
         foreach ($allowed as $domain) {
@@ -205,7 +205,7 @@ class CorsBuilder
      * @param string|int $age The max-age for OPTIONS requests in seconds
      * @return $this
      */
-    public function maxAge($age)
+    public function maxAge(string|int $age)
     {
         $this->_headers['Access-Control-Max-Age'] = $age;
 

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -43,7 +43,7 @@ class HttpException extends CakeException
      * @param array<string>|string|null $value Header value
      * @return void
      */
-    public function setHeader(string $header, $value = null): void
+    public function setHeader(string $header, array|string|null $value = null): void
     {
         $this->headers[$header] = $value;
     }

--- a/src/Http/FlashMessage.php
+++ b/src/Http/FlashMessage.php
@@ -80,7 +80,7 @@ class FlashMessage
      * @return void
      * @see FlashMessage::$_defaultConfig For default values for the options.
      */
-    public function set($message, array $options = []): void
+    public function set(string $message, array $options = []): void
     {
         $options += (array)$this->getConfig();
 

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -180,7 +180,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      * @param string $body The request body to decode
      * @return array|null
      */
-    protected function decodeJson(string $body)
+    protected function decodeJson(string $body): ?array
     {
         if ($body === '') {
             return [];

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -42,7 +42,7 @@ class CspMiddleware implements MiddlewareInterface
      * @param \ParagonIE\CSPBuilder\CSPBuilder|array $csp CSP object or config array
      * @throws \RuntimeException
      */
-    public function __construct($csp)
+    public function __construct(CSPBuilder|array $csp)
     {
         if (!class_exists(CSPBuilder::class)) {
             throw new RuntimeException('You must install paragonie/csp-builder to use CspMiddleware');

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -94,7 +94,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param \Psr\Http\Server\MiddlewareInterface|\Closure|array|string $middleware The middleware(s) to append.
      * @return $this
      */
-    public function add($middleware)
+    public function add(MiddlewareInterface|Closure|array|string $middleware)
     {
         if (is_array($middleware)) {
             $this->queue = array_merge($this->queue, $middleware);
@@ -113,7 +113,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return $this
      * @see MiddlewareQueue::add()
      */
-    public function push($middleware)
+    public function push(MiddlewareInterface|Closure|array|string $middleware)
     {
         return $this->add($middleware);
     }
@@ -124,7 +124,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param \Psr\Http\Server\MiddlewareInterface|\Closure|array|string $middleware The middleware(s) to prepend.
      * @return $this
      */
-    public function prepend($middleware)
+    public function prepend(MiddlewareInterface|Closure|array|string $middleware)
     {
         if (is_array($middleware)) {
             $this->queue = array_merge($middleware, $this->queue);
@@ -146,7 +146,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param \Psr\Http\Server\MiddlewareInterface|\Closure|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertAt(int $index, $middleware)
+    public function insertAt(int $index, MiddlewareInterface|Closure|string $middleware)
     {
         array_splice($this->queue, $index, 0, [$middleware]);
 
@@ -164,7 +164,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return $this
      * @throws \LogicException If middleware to insert before is not found.
      */
-    public function insertBefore(string $class, $middleware)
+    public function insertBefore(string $class, MiddlewareInterface|Closure|string $middleware)
     {
         $found = false;
         $i = 0;
@@ -197,7 +197,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @param \Psr\Http\Server\MiddlewareInterface|\Closure|string $middleware The middleware to insert.
      * @return $this
      */
-    public function insertAfter(string $class, $middleware)
+    public function insertAfter(string $class, MiddlewareInterface|Closure|string $middleware)
     {
         $found = false;
         $i = 0;
@@ -239,7 +239,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      * @return void
      * @see \SeekableIterator::seek()
      */
-    public function seek($position): void
+    public function seek(int $position): void
     {
         if (!isset($this->queue[$position])) {
             throw new OutOfBoundsException("Invalid seek position ($position)");

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -529,7 +529,7 @@ class Response implements ResponseInterface
      * @param string $url The location to redirect to.
      * @return static A new response with the Location header set.
      */
-    public function withLocation(string $url)
+    public function withLocation(string $url): static
     {
         $new = $this->withHeader('Location', $url);
         if ($new->_status === 200) {
@@ -677,7 +677,7 @@ class Response implements ResponseInterface
      * @param array|string $mimeType Definition of the mime type.
      * @return void
      */
-    public function setTypeMap(string $type, $mimeType): void
+    public function setTypeMap(string $type, array|string $mimeType): void
     {
         $this->_mimeTypes[$type] = $mimeType;
     }
@@ -706,7 +706,7 @@ class Response implements ResponseInterface
      * @param string $contentType Either a file extension which will be mapped to a mime-type or a concrete mime-type.
      * @return static
      */
-    public function withType(string $contentType)
+    public function withType(string $contentType): static
     {
         $mappedType = $this->resolveType($contentType);
         $new = clone $this;
@@ -743,7 +743,7 @@ class Response implements ResponseInterface
      * @param string $alias the content type alias to map
      * @return array|string|false String mapped mime type or false if $alias is not mapped
      */
-    public function getMimeType(string $alias)
+    public function getMimeType(string $alias): array|string|false
     {
         return $this->_mimeTypes[$alias] ?? false;
     }
@@ -756,7 +756,7 @@ class Response implements ResponseInterface
      * @param array|string $ctype Either a string content type to map, or an array of types.
      * @return array|string|null Aliases for the types provided.
      */
-    public function mapType($ctype)
+    public function mapType(array|string $ctype): array|string|null
     {
         if (is_array($ctype)) {
             return array_map([$this, 'mapType'], $ctype);
@@ -787,7 +787,7 @@ class Response implements ResponseInterface
      * @param string $charset Character set string.
      * @return static
      */
-    public function withCharset(string $charset)
+    public function withCharset(string $charset): static
     {
         $new = clone $this;
         $new->_charset = $charset;
@@ -801,7 +801,7 @@ class Response implements ResponseInterface
      *
      * @return static
      */
-    public function withDisabledCache()
+    public function withDisabledCache(): static
     {
         return $this->withHeader('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT')
             ->withHeader('Last-Modified', gmdate(DATE_RFC7231))
@@ -815,7 +815,7 @@ class Response implements ResponseInterface
      * @param string|int $time a valid time for cache expiry
      * @return static
      */
-    public function withCache($since, $time = '+1 day')
+    public function withCache(string|int $since, string|int $time = '+1 day'): static
     {
         if (!is_int($time)) {
             $time = strtotime($time);
@@ -841,7 +841,7 @@ class Response implements ResponseInterface
      * @param int|null $time time in seconds after which the response should no longer be considered fresh.
      * @return static
      */
-    public function withSharable(bool $public, ?int $time = null)
+    public function withSharable(bool $public, ?int $time = null): static
     {
         $new = clone $this;
         unset($new->_cacheDirectives['private'], $new->_cacheDirectives['public']);
@@ -866,7 +866,7 @@ class Response implements ResponseInterface
      * @param int $seconds The number of seconds for shared max-age
      * @return static
      */
-    public function withSharedMaxAge(int $seconds)
+    public function withSharedMaxAge(int $seconds): static
     {
         $new = clone $this;
         $new->_cacheDirectives['s-maxage'] = $seconds;
@@ -884,7 +884,7 @@ class Response implements ResponseInterface
      * @param int $seconds The seconds a cached response can be considered valid
      * @return static
      */
-    public function withMaxAge(int $seconds)
+    public function withMaxAge(int $seconds): static
     {
         $new = clone $this;
         $new->_cacheDirectives['max-age'] = $seconds;
@@ -904,7 +904,7 @@ class Response implements ResponseInterface
      * @param bool $enable If boolean sets or unsets the directive.
      * @return static
      */
-    public function withMustRevalidate(bool $enable)
+    public function withMustRevalidate(bool $enable): static
     {
         $new = clone $this;
         if ($enable) {
@@ -950,7 +950,7 @@ class Response implements ResponseInterface
      * @param \DateTimeInterface|string|int|null $time Valid time string or \DateTime instance.
      * @return static
      */
-    public function withExpires($time)
+    public function withExpires(DateTimeInterface|string|int|null $time): static
     {
         $date = $this->_getUTCDate($time);
 
@@ -973,7 +973,7 @@ class Response implements ResponseInterface
      * @param \DateTimeInterface|string|int $time Valid time string or \DateTime instance.
      * @return static
      */
-    public function withModified($time)
+    public function withModified(DateTimeInterface|string|int $time): static
     {
         $date = $this->_getUTCDate($time);
 
@@ -1017,7 +1017,7 @@ class Response implements ResponseInterface
      *
      * @return static
      */
-    public function withNotModified()
+    public function withNotModified(): static
     {
         $new = $this->withStatus(304);
         $new->_createStream();
@@ -1048,7 +1048,7 @@ class Response implements ResponseInterface
      *   containing the list for variances.
      * @return static
      */
-    public function withVary($cacheVariances)
+    public function withVary(array|string $cacheVariances): static
     {
         return $this->withHeader('Vary', (array)$cacheVariances);
     }
@@ -1074,7 +1074,7 @@ class Response implements ResponseInterface
      *   other with the same hash or not. Defaults to false
      * @return static
      */
-    public function withEtag(string $hash, bool $weak = false)
+    public function withEtag(string $hash, bool $weak = false): static
     {
         $hash = sprintf('%s"%s"', $weak ? 'W/' : '', $hash);
 
@@ -1088,7 +1088,7 @@ class Response implements ResponseInterface
      * @param \DateTimeInterface|string|int|null $time Valid time string or \DateTimeInterface instance.
      * @return \DateTimeInterface
      */
-    protected function _getUTCDate($time = null): DateTimeInterface
+    protected function _getUTCDate(DateTimeInterface|string|int|null $time = null): DateTimeInterface
     {
         if ($time instanceof DateTimeInterface) {
             $result = clone $time;
@@ -1134,7 +1134,7 @@ class Response implements ResponseInterface
      * @param string $filename The name of the file as the browser will download the response
      * @return static
      */
-    public function withDownload(string $filename)
+    public function withDownload(string $filename): static
     {
         return $this->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');
     }
@@ -1145,7 +1145,7 @@ class Response implements ResponseInterface
      * @param string|int $bytes Number of bytes
      * @return static
      */
-    public function withLength($bytes)
+    public function withLength(string|int $bytes): static
     {
         return $this->withHeader('Content-Length', (string)$bytes);
     }
@@ -1172,7 +1172,7 @@ class Response implements ResponseInterface
      * @return static
      * @since 3.6.0
      */
-    public function withAddedLink(string $url, array $options = [])
+    public function withAddedLink(string $url, array $options = []): static
     {
         $params = [];
         foreach ($options as $key => $option) {
@@ -1254,7 +1254,7 @@ class Response implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieInterface $cookie cookie object
      * @return static
      */
-    public function withCookie(CookieInterface $cookie)
+    public function withCookie(CookieInterface $cookie): static
     {
         $new = clone $this;
         $new->_cookies = $new->_cookies->add($cookie);
@@ -1275,7 +1275,7 @@ class Response implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieInterface $cookie cookie object
      * @return static
      */
-    public function withExpiredCookie(CookieInterface $cookie)
+    public function withExpiredCookie(CookieInterface $cookie): static
     {
         $cookie = $cookie->withExpired();
 
@@ -1338,7 +1338,7 @@ class Response implements ResponseInterface
      * @param \Cake\Http\Cookie\CookieCollection $cookieCollection Cookie collection to set.
      * @return static
      */
-    public function withCookieCollection(CookieCollection $cookieCollection)
+    public function withCookieCollection(CookieCollection $cookieCollection): static
     {
         $new = clone $this;
         $new->_cookies = $cookieCollection;
@@ -1410,7 +1410,7 @@ class Response implements ResponseInterface
      * @return static
      * @throws \Cake\Http\Exception\NotFoundException
      */
-    public function withFile(string $path, array $options = [])
+    public function withFile(string $path, array $options = []): static
     {
         $file = $this->validateFile($path);
         $options += [
@@ -1466,7 +1466,7 @@ class Response implements ResponseInterface
      * @param string $string The string to be sent
      * @return static
      */
-    public function withStringBody(?string $string)
+    public function withStringBody(?string $string): static
     {
         $new = clone $this;
         $new->_createStream();

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieInterface;
 use Laminas\Diactoros\RelativeStream;
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -225,7 +226,7 @@ class ResponseEmitter implements EmitterInterface
      * @param \Cake\Http\Cookie\CookieInterface|string $cookie Cookie.
      * @return bool
      */
-    protected function setCookie($cookie): bool
+    protected function setCookie(CookieInterface|string $cookie): bool
     {
         if (is_string($cookie)) {
             $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);
@@ -280,7 +281,7 @@ class ResponseEmitter implements EmitterInterface
      * @return array|false [unit, first, last, length]; returns false if no
      *     content range or an invalid content range is provided
      */
-    protected function parseContentRange(string $header)
+    protected function parseContentRange(string $header): array|false
     {
         if (preg_match('/(?P<unit>[\w]+)\s+(?P<first>\d+)-(?P<last>\d+)\/(?P<length>\d+|\*)/', $header, $matches)) {
             return [

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -456,7 +456,7 @@ class ServerRequest implements ServerRequestInterface
      * @return mixed
      * @throws \BadMethodCallException when an invalid method is called.
      */
-    public function __call(string $name, array $params)
+    public function __call(string $name, array $params): mixed
     {
         if (strpos($name, 'is') === 0) {
             $type = strtolower(substr($name, 2));
@@ -480,7 +480,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed ...$args List of arguments
      * @return bool Whether or not the request is the type you are checking.
      */
-    public function is($type, ...$args): bool
+    public function is(array|string $type, mixed ...$args): bool
     {
         if (is_array($type)) {
             foreach ($type as $_type) {
@@ -728,7 +728,7 @@ class ServerRequest implements ServerRequestInterface
      * @param callable|array $callable A callable or options array for the detector definition.
      * @return void
      */
-    public static function addDetector(string $name, $callable): void
+    public static function addDetector(string $name, callable|array $callable): void
     {
         $name = strtolower($name);
         if (is_callable($callable)) {
@@ -799,7 +799,7 @@ class ServerRequest implements ServerRequestInterface
      * @return bool Whether or not the header is defined.
      * @link http://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
-    public function hasHeader($name): bool
+    public function hasHeader($name)
     {
         $name = $this->normalizeHeaderName($name);
 
@@ -817,7 +817,7 @@ class ServerRequest implements ServerRequestInterface
      *   If the header doesn't exist, an empty array will be returned.
      * @link http://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
-    public function getHeader($name): array
+    public function getHeader($name)
     {
         $name = $this->normalizeHeaderName($name);
         if (isset($this->_environment[$name])) {
@@ -976,7 +976,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static A new instance with the updated query string data.
      * @link http://www.php-fig.org/psr/psr-7/ This method is part of the PSR-7 server request interface.
      */
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): static
     {
         $new = clone $this;
         $new->query = $query;
@@ -1090,7 +1090,7 @@ class ServerRequest implements ServerRequestInterface
      * @return array|bool Either an array of all the types the client accepts or a boolean if they accept the
      *   provided type.
      */
-    public function accepts(?string $type = null)
+    public function accepts(?string $type = null): array|bool
     {
         $raw = $this->parseAccept();
         $accept = [];
@@ -1132,7 +1132,7 @@ class ServerRequest implements ServerRequestInterface
      * @param string|null $language The language to test.
      * @return array|bool If a $language is provided, a boolean. Otherwise the array of accepted languages.
      */
-    public function acceptLanguage(?string $language = null)
+    public function acceptLanguage(?string $language = null): array|bool
     {
         $raw = $this->_parseAcceptWithQualifier($this->getHeaderLine('Accept-Language'));
         $accept = [];
@@ -1207,10 +1207,10 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string|null $name The name or dotted path to the query param or null to read all.
      * @param mixed $default The default value if the named parameter is not set, and $name is not null.
-     * @return array|string|null Query data.
+     * @return mixed Query data.
      * @see ServerRequest::getQueryParams()
      */
-    public function getQuery(?string $name = null, $default = null)
+    public function getQuery(?string $name = null, mixed $default = null): mixed
     {
         if ($name === null) {
             return $this->query;
@@ -1251,7 +1251,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed $default The default data.
      * @return mixed The value being read.
      */
-    public function getData(?string $name = null, $default = null)
+    public function getData(?string $name = null, mixed $default = null): mixed
     {
         if ($name === null) {
             return $this->data;
@@ -1271,7 +1271,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array|string|null $default The default value if the cookie is not set.
      * @return array|string|null Either the cookie value, or null if the value doesn't exist.
      */
-    public function getCookie(string $key, $default = null)
+    public function getCookie(string $key, array|string|null $default = null): array|string|null
     {
         return Hash::get($this->cookies, $key, $default);
     }
@@ -1303,7 +1303,7 @@ class ServerRequest implements ServerRequestInterface
      * @param \Cake\Http\Cookie\CookieCollection $cookies The cookie collection
      * @return static
      */
-    public function withCookieCollection(CookieCollection $cookies)
+    public function withCookieCollection(CookieCollection $cookies): static
     {
         $new = clone $this;
         $values = [];
@@ -1331,7 +1331,7 @@ class ServerRequest implements ServerRequestInterface
      * @param array $cookies The new cookie data to use.
      * @return static
      */
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): static
     {
         $new = clone $this;
         $new->cookies = $cookies;
@@ -1350,7 +1350,7 @@ class ServerRequest implements ServerRequestInterface
      * @return object|array|null The deserialized body parameters, if any.
      *     These will typically be an array.
      */
-    public function getParsedBody()
+    public function getParsedBody(): object|array|null
     {
         return $this->data;
     }
@@ -1441,7 +1441,7 @@ class ServerRequest implements ServerRequestInterface
      * @param string $value Value to set
      * @return static
      */
-    public function withEnv(string $key, string $value)
+    public function withEnv(string $key, string $value): static
     {
         $new = clone $this;
         $new->_environment[$key] = $value;
@@ -1467,7 +1467,7 @@ class ServerRequest implements ServerRequestInterface
      * @return true
      * @throws \Cake\Http\Exception\MethodNotAllowedException
      */
-    public function allowMethod($methods): bool
+    public function allowMethod(array|string $methods): bool
     {
         $methods = (array)$methods;
         foreach ($methods as $method) {
@@ -1493,7 +1493,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed $value The value to insert into the request data.
      * @return static
      */
-    public function withData(string $name, $value)
+    public function withData(string $name, mixed $value): static
     {
         $copy = clone $this;
 
@@ -1513,7 +1513,7 @@ class ServerRequest implements ServerRequestInterface
      * @param string $name The dot separated path to remove.
      * @return static
      */
-    public function withoutData(string $name)
+    public function withoutData(string $name): static
     {
         $copy = clone $this;
 
@@ -1534,7 +1534,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed $value The value to insert into the the request parameters.
      * @return static
      */
-    public function withParam(string $name, $value)
+    public function withParam(string $name, mixed $value): static
     {
         $copy = clone $this;
         $copy->params = Hash::insert($copy->params, $name, $value);
@@ -1549,7 +1549,7 @@ class ServerRequest implements ServerRequestInterface
      * @param mixed $default The default value if `$name` is not set. Default `null`.
      * @return mixed
      */
-    public function getParam(string $name, $default = null)
+    public function getParam(string $name, mixed $default = null): mixed
     {
         return Hash::get($this->params, $name, $default);
     }
@@ -1669,7 +1669,7 @@ class ServerRequest implements ServerRequestInterface
      * @return static
      * @throws \InvalidArgumentException when $files contains an invalid object.
      */
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): static
     {
         $this->validateUploadedFiles($uploadedFiles, '');
         $new = clone $this;
@@ -1716,7 +1716,7 @@ class ServerRequest implements ServerRequestInterface
      * @param \Psr\Http\Message\StreamInterface $body The new request body
      * @return static
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): static
     {
         $new = clone $this;
         $new->stream = $body;
@@ -1745,7 +1745,7 @@ class ServerRequest implements ServerRequestInterface
      * @param bool $preserveHost Whether or not the host should be retained.
      * @return static
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri($uri, $preserveHost = false)
     {
         $new = clone $this;
         $new->uri = $uri;

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -21,6 +21,7 @@ use Cake\Utility\Hash;
 use InvalidArgumentException;
 use RuntimeException;
 use SessionHandlerInterface;
+use const PHP_SESSION_ACTIVE;
 
 /**
  * This class is a wrapper for the native PHP session functions. It provides
@@ -92,7 +93,7 @@ class Session
      * @return static
      * @see \Cake\Http\Session::__construct()
      */
-    public static function create(array $sessionConfig = [])
+    public static function create(array $sessionConfig = []): static
     {
         if (isset($sessionConfig['defaults'])) {
             $defaults = static::_defaultConfig($sessionConfig['defaults']);
@@ -133,7 +134,7 @@ class Session
      * @param string $name Config name.
      * @return array|false
      */
-    protected static function _defaultConfig(string $name)
+    protected static function _defaultConfig(string $name): array|false
     {
         $tmp = defined('TMP') ? TMP : sys_get_temp_dir() . DIRECTORY_SEPARATOR;
         $defaults = [
@@ -255,8 +256,10 @@ class Session
      * @return \SessionHandlerInterface|null
      * @throws \InvalidArgumentException
      */
-    public function engine($class = null, array $options = []): ?SessionHandlerInterface
-    {
+    public function engine(
+        SessionHandlerInterface|string|null $class = null,
+        array $options = []
+    ): ?SessionHandlerInterface {
         if ($class === null) {
             return $this->_engine;
         }
@@ -289,7 +292,7 @@ class Session
      */
     protected function setEngine(SessionHandlerInterface $handler): SessionHandlerInterface
     {
-        if (!headers_sent() && session_status() !== \PHP_SESSION_ACTIVE) {
+        if (!headers_sent() && session_status() !== PHP_SESSION_ACTIVE) {
             session_set_save_handler($handler, false);
         }
 
@@ -312,7 +315,7 @@ class Session
      */
     public function options(array $options): void
     {
-        if (session_status() === \PHP_SESSION_ACTIVE || headers_sent()) {
+        if (session_status() === PHP_SESSION_ACTIVE || headers_sent()) {
             return;
         }
 
@@ -344,7 +347,7 @@ class Session
             return $this->_started = true;
         }
 
-        if (session_status() === \PHP_SESSION_ACTIVE) {
+        if (session_status() === PHP_SESSION_ACTIVE) {
             throw new RuntimeException('Session was already started');
         }
 
@@ -400,7 +403,7 @@ class Session
      */
     public function started(): bool
     {
-        return $this->_started || session_status() === \PHP_SESSION_ACTIVE;
+        return $this->_started || session_status() === PHP_SESSION_ACTIVE;
     }
 
     /**
@@ -434,7 +437,7 @@ class Session
      * @return mixed|null The value of the session variable, or default value if a session
      *   is not available, can't be started, or provided $name is not found in the session.
      */
-    public function read(?string $name = null, $default = null)
+    public function read(?string $name = null, mixed $default = null): mixed
     {
         if ($this->_hasSession() && !$this->started()) {
             $this->start();
@@ -458,7 +461,7 @@ class Session
      * @throws \RuntimeException
      * @return mixed|null
      */
-    public function readOrFail(string $name)
+    public function readOrFail(string $name): mixed
     {
         if (!$this->check($name)) {
             throw new RuntimeException(sprintf('Expected session key "%s" not found.', $name));
@@ -474,7 +477,7 @@ class Session
      * @return mixed|null The value of the session variable, null if session not available,
      *   session not started, or provided name not found in the session.
      */
-    public function consume(string $name)
+    public function consume(string $name): mixed
     {
         if (empty($name)) {
             return null;
@@ -494,7 +497,7 @@ class Session
      * @param mixed $value Value to write
      * @return void
      */
-    public function write($name, $value = null): void
+    public function write(array|string $name, mixed $value = null): void
     {
         if (!$this->started()) {
             $this->start();
@@ -581,7 +584,7 @@ class Session
             $this->start();
         }
 
-        if (!$this->_isCLI && session_status() === \PHP_SESSION_ACTIVE) {
+        if (!$this->_isCLI && session_status() === PHP_SESSION_ACTIVE) {
             session_destroy();
         }
 

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -59,7 +59,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $name The session name.
      * @return bool Success
      */
-    public function open($path, $name): bool
+    public function open(string $path, string $name): bool
     {
         return true;
     }
@@ -80,7 +80,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in cache.
      * @return string|false Session data or false if it does not exist.
      */
-    public function read($id): string|false
+    public function read(string $id): string|false
     {
         $value = Cache::read($id, $this->_options['config']);
 
@@ -98,7 +98,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $data The data to be saved.
      * @return bool True for successful write, false otherwise.
      */
-    public function write($id, $data): bool
+    public function write(string $id, string $data): bool
     {
         if (!$id) {
             return false;
@@ -113,7 +113,7 @@ class CacheSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in cache.
      * @return bool Always true.
      */
-    public function destroy($id): bool
+    public function destroy(string $id): bool
     {
         Cache::delete($id, $this->_options['config']);
 
@@ -126,7 +126,7 @@ class CacheSession implements SessionHandlerInterface
      * @param int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
      * @return int|false
      */
-    public function gc($maxlifetime): int|false
+    public function gc(int $maxlifetime): int|false
     {
         return 0;
     }

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -88,7 +88,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $name The session name.
      * @return bool Success
      */
-    public function open($path, $name): bool
+    public function open(string $path, string $name): bool
     {
         return true;
     }
@@ -109,7 +109,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in database.
      * @return string|false Session data or false if it does not exist.
      */
-    public function read($id): string|false
+    public function read(string $id): string|false
     {
         /** @var string $pkField */
         $pkField = $this->_table->getPrimaryKey();
@@ -138,7 +138,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $data The data to be saved.
      * @return bool True for successful write, false otherwise.
      */
-    public function write($id, $data): bool
+    public function write(string $id, string $data): bool
     {
         if (!$id) {
             return false;
@@ -161,7 +161,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param string $id ID that uniquely identifies session in database.
      * @return bool True for successful delete, false otherwise.
      */
-    public function destroy($id): bool
+    public function destroy(string $id): bool
     {
         /** @var string $pkField */
         $pkField = $this->_table->getPrimaryKey();
@@ -176,7 +176,7 @@ class DatabaseSession implements SessionHandlerInterface
      * @param int $maxlifetime Sessions that have not updated for the last maxlifetime seconds will be removed.
      * @return int|false The number of deleted sessions on success, or false on failure.
      */
-    public function gc($maxlifetime): int|false
+    public function gc(int $maxlifetime): int|false
     {
         return $this->_table->deleteAll(['expires <' => time()]);
     }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -759,14 +759,17 @@ class ResponseTest extends TestCase
         $this->assertNull($response->getCookie('testing'), 'withCookie does not mutate');
         $this->assertSame('abc123', $new->getCookie('testing')['value']);
 
+        $new = $response->withCookie(new Cookie('testing', 0.99));
+        $this->assertEquals(0.99, $new->getCookie('testing')['value']);
+
         $new = $response->withCookie(new Cookie('testing', 99));
-        $this->assertSame(99, $new->getCookie('testing')['value']);
+        $this->assertEquals(99, $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', false));
-        $this->assertFalse($new->getCookie('testing')['value']);
+        $this->assertEquals(false, $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', true));
-        $this->assertTrue($new->getCookie('testing')['value']);
+        $this->assertEquals(true, $new->getCookie('testing')['value']);
     }
 
     /**

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1558,7 +1558,7 @@ class ServerRequestTest extends TestCase
     public function testGetCookieCollection(): void
     {
         $cookies = [
-            'remember_me' => '1',
+            'remember_me' => 1,
             'color' => 'blue',
         ];
         $request = new ServerRequest(['cookies' => $cookies]);
@@ -1581,7 +1581,7 @@ class ServerRequestTest extends TestCase
         $this->assertNotSame($new, $request, 'Should clone');
 
         $this->assertSame(['bad' => 'goaway'], $request->getCookieParams());
-        $this->assertSame(['remember_me' => 1, 'color' => 'red'], $new->getCookieParams());
+        $this->assertSame(['remember_me' => '1', 'color' => 'red'], $new->getCookieParams());
         $cookies = $new->getCookieCollection();
         $this->assertCount(2, $cookies);
         $this->assertSame('red', $cookies->get('color')->getValue());

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -60,7 +60,7 @@ class CacheSessionTest extends TestCase
      */
     public function testOpen(): void
     {
-        $this->assertTrue($this->storage->open(null, null));
+        $this->assertTrue($this->storage->open('', ''));
     }
 
     /**

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -82,7 +82,7 @@ class DatabaseSessionTest extends TestCase
      */
     public function testOpen(): void
     {
-        $this->assertTrue($this->storage->open(null, null));
+        $this->assertTrue($this->storage->open('', ''));
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -638,7 +638,7 @@ class IntegrationTestTraitTest extends TestCase
         $this->post('/posts/index');
 
         $this->assertSession('An error message', 'Flash.flash.0.message');
-        $this->assertCookie(1, 'remember_me');
+        $this->assertCookie('1', 'remember_me');
         $this->assertCookieNotSet('user_id');
     }
 
@@ -651,7 +651,7 @@ class IntegrationTestTraitTest extends TestCase
 
         $this->assertSession('An error message', 'Flash.flash.0.message');
         $this->assertCookieNotSet('user_id');
-        $this->assertCookie(1, 'remember_me');
+        $this->assertCookie('1', 'remember_me');
     }
 
     /**


### PR DESCRIPTION
@markstory Please take a close look at the changes to Cookie. We expect `array|string` values but have been accepting other values due to implicit string conversion when writing the headers.