### PR TITLE
cake 5: Add native type hints for Core properties

### DIFF
--- a/src/Console/Exception/ConsoleException.php
+++ b/src/Console/Exception/ConsoleException.php
@@ -29,5 +29,5 @@ class ConsoleException extends CakeException
      *
      * @var int
      */
-    protected $_defaultCode = CommandInterface::CODE_ERROR;
+    protected int $_defaultCode = CommandInterface::CODE_ERROR;
 }

--- a/src/Console/Exception/MissingHelperException.php
+++ b/src/Console/Exception/MissingHelperException.php
@@ -22,5 +22,5 @@ class MissingHelperException extends ConsoleException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Helper class %s could not be found.';
+    protected string $_messageTemplate = 'Helper class %s could not be found.';
 }

--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -25,5 +25,5 @@ class MissingActionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Action %s::%s() could not be found, or is not accessible.';
+    protected string $_messageTemplate = 'Action %s::%s() could not be found, or is not accessible.';
 }

--- a/src/Controller/Exception/MissingComponentException.php
+++ b/src/Controller/Exception/MissingComponentException.php
@@ -24,5 +24,5 @@ class MissingComponentException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Component class %s could not be found.';
+    protected string $_messageTemplate = 'Component class %s could not be found.';
 }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -34,70 +34,70 @@ class BasePlugin implements PluginInterface
      *
      * @var bool
      */
-    protected $bootstrapEnabled = true;
+    protected bool $bootstrapEnabled = true;
 
     /**
      * Console middleware
      *
      * @var bool
      */
-    protected $consoleEnabled = true;
+    protected bool $consoleEnabled = true;
 
     /**
      * Enable middleware
      *
      * @var bool
      */
-    protected $middlewareEnabled = true;
+    protected bool $middlewareEnabled = true;
 
     /**
      * Register container services
      *
      * @var bool
      */
-    protected $servicesEnabled = true;
+    protected bool $servicesEnabled = true;
 
     /**
      * Load routes or not
      *
      * @var bool
      */
-    protected $routesEnabled = true;
+    protected bool $routesEnabled = true;
 
     /**
      * The path to this plugin.
      *
-     * @var string
+     * @var string|null
      */
-    protected $path;
+    protected ?string $path = null;
 
     /**
      * The class path for this plugin.
      *
-     * @var string
+     * @var string|null
      */
-    protected $classPath;
+    protected ?string $classPath = null;
 
     /**
      * The config path for this plugin.
      *
-     * @var string
+     * @var string|null
      */
-    protected $configPath;
+    protected ?string $configPath = null;
 
     /**
      * The templates path for this plugin.
      *
-     * @var string
+     * @var string|null
      */
-    protected $templatePath;
+    protected ?string $templatePath = null;
 
     /**
      * The name of this plugin
      *
-     * @var string
+     * @var string|null
      */
-    protected $name;
+    protected ?string $name = null;
 
     /**
      * Constructor
@@ -134,7 +134,7 @@ class BasePlugin implements PluginInterface
      */
     public function getName(): string
     {
-        if ($this->name) {
+        if ($this->name !== null) {
             return $this->name;
         }
         $parts = explode('\\', static::class);
@@ -149,7 +149,7 @@ class BasePlugin implements PluginInterface
      */
     public function getPath(): string
     {
-        if ($this->path) {
+        if ($this->path !== null) {
             return $this->path;
         }
         $reflection = new ReflectionClass($this);
@@ -169,7 +169,7 @@ class BasePlugin implements PluginInterface
      */
     public function getConfigPath(): string
     {
-        if ($this->configPath) {
+        if ($this->configPath !== null) {
             return $this->configPath;
         }
         $path = $this->getPath();
@@ -182,7 +182,7 @@ class BasePlugin implements PluginInterface
      */
     public function getClassPath(): string
     {
-        if ($this->classPath) {
+        if ($this->classPath !== null) {
             return $this->classPath;
         }
         $path = $this->getPath();
@@ -195,7 +195,7 @@ class BasePlugin implements PluginInterface
      */
     public function getTemplatePath(): string
     {
-        if ($this->templatePath) {
+        if ($this->templatePath !== null) {
             return $this->templatePath;
         }
         $path = $this->getPath();

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -39,7 +39,7 @@ class Configure
      *
      * @var array
      */
-    protected static $_values = [
+    protected static array $_values = [
         'debug' => false,
     ];
 
@@ -49,14 +49,14 @@ class Configure
      * @see \Cake\Core\Configure::load()
      * @var array<\Cake\Core\Configure\ConfigEngineInterface>
      */
-    protected static $_engines = [];
+    protected static array $_engines = [];
 
     /**
      * Flag to track whether or not ini_set exists.
      *
      * @var bool|null
      */
-    protected static $_hasIniSet;
+    protected static ?bool $_hasIniSet = null;
 
     /**
      * Used to store a dynamic variable in Configure.

--- a/src/Core/Configure/Engine/IniConfig.php
+++ b/src/Core/Configure/Engine/IniConfig.php
@@ -62,14 +62,14 @@ class IniConfig implements ConfigEngineInterface
      *
      * @var string
      */
-    protected $_extension = '.ini';
+    protected string $_extension = '.ini';
 
     /**
      * The section to read, if null all sections will be read.
      *
      * @var string|null
      */
-    protected $_section;
+    protected ?string $_section = null;
 
     /**
      * Build and construct a new ini file parser. The parser can be used to read

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -47,7 +47,7 @@ class JsonConfig implements ConfigEngineInterface
      *
      * @var string
      */
-    protected $_extension = '.json';
+    protected string $_extension = '.json';
 
     /**
      * Constructor for JSON Config file reading.

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -53,7 +53,7 @@ class PhpConfig implements ConfigEngineInterface
      *
      * @var string
      */
-    protected $_extension = '.php';
+    protected string $_extension = '.php';
 
     /**
      * Constructor for PHP Config file reading.

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -29,7 +29,7 @@ trait FileConfigTrait
      *
      * @var string
      */
-    protected $_path = '';
+    protected string $_path = '';
 
     /**
      * Get file path

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -30,21 +30,21 @@ class CakeException extends RuntimeException
      *
      * @var array
      */
-    protected $_attributes = [];
+    protected array $_attributes = [];
 
     /**
      * Template string that has attributes sprintf()'ed into it.
      *
      * @var string
      */
-    protected $_messageTemplate = '';
+    protected string $_messageTemplate = '';
 
     /**
      * Default exception code
      *
      * @var int
      */
-    protected $_defaultCode = 0;
+    protected int $_defaultCode = 0;
 
     /**
      * Constructor.

--- a/src/Core/Exception/MissingPluginException.php
+++ b/src/Core/Exception/MissingPluginException.php
@@ -22,5 +22,5 @@ class MissingPluginException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Plugin %s could not be found.';
+    protected string $_messageTemplate = 'Plugin %s could not be found.';
 }

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -32,14 +32,14 @@ trait InstanceConfigTrait
      *
      * @var array
      */
-    protected $_config = [];
+    protected array $_config = [];
 
     /**
      * Whether the config property has already been configured with defaults
      *
      * @var bool
      */
-    protected $_configInitialized = false;
+    protected bool $_configInitialized = false;
 
     /**
      * Sets the config.

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -49,7 +49,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @var array<object>
      * @psalm-var array<array-key, TObject>
      */
-    protected $_loaded = [];
+    protected array $_loaded = [];
 
     /**
      * Loads/constructs an object instance.

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -30,7 +30,7 @@ class Plugin
      *
      * @var \Cake\Core\PluginCollection|null
      */
-    protected static $plugins;
+    protected static ?PluginCollection $plugins = null;
 
     /**
      * Returns the filesystem path for a plugin

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -42,28 +42,28 @@ class PluginCollection implements Iterator, Countable
      *
      * @var array<\Cake\Core\PluginInterface>
      */
-    protected $plugins = [];
+    protected array $plugins = [];
 
     /**
      * Names of plugins
      *
      * @var array<string>
      */
-    protected $names = [];
+    protected array $names = [];
 
     /**
      * Iterator position stack.
      *
      * @var array<int>
      */
-    protected $positions = [];
+    protected array $positions = [];
 
     /**
      * Loop depth
      *
      * @var int
      */
-    protected $loopDepth = -1;
+    protected int $loopDepth = -1;
 
     /**
      * Constructor

--- a/src/Core/Retry/CommandRetry.php
+++ b/src/Core/Retry/CommandRetry.php
@@ -31,17 +31,17 @@ class CommandRetry
      *
      * @var \Cake\Core\Retry\RetryStrategyInterface
      */
-    protected $strategy;
+    protected RetryStrategyInterface $strategy;
 
     /**
      * @var int
      */
-    protected $maxRetries;
+    protected int $maxRetries;
 
     /**
      * @var int
      */
-    protected $numRetries;
+    protected int $numRetries;
 
     /**
      * Creates the CommandRetry object with the given strategy and retry count

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -39,7 +39,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
      * @var array<string>
      * @see ServiceProvider::provides()
      */
-    protected $provides = [];
+    protected array $provides = [];
 
     /**
      * Get the container.

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -34,7 +34,7 @@ trait StaticConfigTrait
      *
      * @var array
      */
-    protected static $_config = [];
+    protected static array $_config = [];
 
     /**
      * This method can be used to define configuration adapters for an application.

--- a/src/Database/Exception/MissingConnectionException.php
+++ b/src/Database/Exception/MissingConnectionException.php
@@ -26,5 +26,5 @@ class MissingConnectionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Connection to %s could not be established: %s';
+    protected string $_messageTemplate = 'Connection to %s could not be established: %s';
 }

--- a/src/Database/Exception/MissingDriverException.php
+++ b/src/Database/Exception/MissingDriverException.php
@@ -26,5 +26,5 @@ class MissingDriverException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Database driver %s could not be found.';
+    protected string $_messageTemplate = 'Database driver %s could not be found.';
 }

--- a/src/Database/Exception/MissingExtensionException.php
+++ b/src/Database/Exception/MissingExtensionException.php
@@ -27,5 +27,5 @@ class MissingExtensionException extends CakeException
      * @inheritDoc
      */
     // phpcs:ignore Generic.Files.LineLength
-    protected $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency';
+    protected string $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency';
 }

--- a/src/Datasource/Exception/MissingDatasourceConfigException.php
+++ b/src/Datasource/Exception/MissingDatasourceConfigException.php
@@ -24,5 +24,5 @@ class MissingDatasourceConfigException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'The datasource configuration "%s" was not found.';
+    protected string $_messageTemplate = 'The datasource configuration "%s" was not found.';
 }

--- a/src/Datasource/Exception/MissingDatasourceException.php
+++ b/src/Datasource/Exception/MissingDatasourceException.php
@@ -24,5 +24,5 @@ class MissingDatasourceException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Datasource class %s could not be found. %s';
+    protected string $_messageTemplate = 'Datasource class %s could not be found. %s';
 }

--- a/src/Datasource/Exception/MissingModelException.php
+++ b/src/Datasource/Exception/MissingModelException.php
@@ -26,5 +26,5 @@ class MissingModelException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Model class "%s" of type "%s" could not be found.';
+    protected string $_messageTemplate = 'Model class "%s" of type "%s" could not be found.';
 }

--- a/src/Datasource/Exception/PageOutOfBoundsException.php
+++ b/src/Datasource/Exception/PageOutOfBoundsException.php
@@ -24,5 +24,5 @@ class PageOutOfBoundsException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Page number %s could not be found.';
+    protected string $_messageTemplate = 'Page number %s could not be found.';
 }

--- a/src/Http/Exception/BadRequestException.php
+++ b/src/Http/Exception/BadRequestException.php
@@ -24,7 +24,7 @@ class BadRequestException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 400;
+    protected int $_defaultCode = 400;
 
     /**
      * Constructor

--- a/src/Http/Exception/ConflictException.php
+++ b/src/Http/Exception/ConflictException.php
@@ -24,7 +24,7 @@ class ConflictException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 409;
+    protected int $_defaultCode = 409;
 
     /**
      * Constructor

--- a/src/Http/Exception/ForbiddenException.php
+++ b/src/Http/Exception/ForbiddenException.php
@@ -24,7 +24,7 @@ class ForbiddenException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 403;
+    protected int $_defaultCode = 403;
 
     /**
      * Constructor

--- a/src/Http/Exception/GoneException.php
+++ b/src/Http/Exception/GoneException.php
@@ -24,7 +24,7 @@ class GoneException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 410;
+    protected int $_defaultCode = 410;
 
     /**
      * Constructor

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -29,7 +29,7 @@ class HttpException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 500;
+    protected int $_defaultCode = 500;
 
     /**
      * @var array

--- a/src/Http/Exception/InvalidCsrfTokenException.php
+++ b/src/Http/Exception/InvalidCsrfTokenException.php
@@ -24,7 +24,7 @@ class InvalidCsrfTokenException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 403;
+    protected int $_defaultCode = 403;
 
     /**
      * Constructor

--- a/src/Http/Exception/MethodNotAllowedException.php
+++ b/src/Http/Exception/MethodNotAllowedException.php
@@ -24,7 +24,7 @@ class MethodNotAllowedException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 405;
+    protected int $_defaultCode = 405;
 
     /**
      * Constructor

--- a/src/Http/Exception/MissingControllerException.php
+++ b/src/Http/Exception/MissingControllerException.php
@@ -25,10 +25,10 @@ class MissingControllerException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 404;
+    protected int $_defaultCode = 404;
 
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Controller class %s could not be found.';
+    protected string $_messageTemplate = 'Controller class %s could not be found.';
 }

--- a/src/Http/Exception/NotAcceptableException.php
+++ b/src/Http/Exception/NotAcceptableException.php
@@ -24,7 +24,7 @@ class NotAcceptableException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 406;
+    protected int $_defaultCode = 406;
 
     /**
      * Constructor

--- a/src/Http/Exception/NotFoundException.php
+++ b/src/Http/Exception/NotFoundException.php
@@ -24,7 +24,7 @@ class NotFoundException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 404;
+    protected int $_defaultCode = 404;
 
     /**
      * Constructor

--- a/src/Http/Exception/NotImplementedException.php
+++ b/src/Http/Exception/NotImplementedException.php
@@ -22,10 +22,10 @@ class NotImplementedException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = '%s is not implemented.';
+    protected string $_messageTemplate = '%s is not implemented.';
 
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 501;
+    protected int $_defaultCode = 501;
 }

--- a/src/Http/Exception/ServiceUnavailableException.php
+++ b/src/Http/Exception/ServiceUnavailableException.php
@@ -24,7 +24,7 @@ class ServiceUnavailableException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 503;
+    protected int $_defaultCode = 503;
 
     /**
      * Constructor

--- a/src/Http/Exception/UnauthorizedException.php
+++ b/src/Http/Exception/UnauthorizedException.php
@@ -24,7 +24,7 @@ class UnauthorizedException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 401;
+    protected int $_defaultCode = 401;
 
     /**
      * Constructor

--- a/src/Http/Exception/UnavailableForLegalReasonsException.php
+++ b/src/Http/Exception/UnavailableForLegalReasonsException.php
@@ -24,7 +24,7 @@ class UnavailableForLegalReasonsException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_defaultCode = 451;
+    protected int $_defaultCode = 451;
 
     /**
      * Constructor

--- a/src/Mailer/Exception/MissingActionException.php
+++ b/src/Mailer/Exception/MissingActionException.php
@@ -24,5 +24,5 @@ class MissingActionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Mail %s::%s() could not be found, or is not accessible.';
+    protected string $_messageTemplate = 'Mail %s::%s() could not be found, or is not accessible.';
 }

--- a/src/Mailer/Exception/MissingMailerException.php
+++ b/src/Mailer/Exception/MissingMailerException.php
@@ -26,5 +26,5 @@ class MissingMailerException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Mailer class "%s" could not be found.';
+    protected string $_messageTemplate = 'Mailer class "%s" could not be found.';
 }

--- a/src/ORM/Exception/MissingBehaviorException.php
+++ b/src/ORM/Exception/MissingBehaviorException.php
@@ -24,5 +24,5 @@ class MissingBehaviorException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Behavior class %s could not be found.';
+    protected string $_messageTemplate = 'Behavior class %s could not be found.';
 }

--- a/src/ORM/Exception/MissingEntityException.php
+++ b/src/ORM/Exception/MissingEntityException.php
@@ -28,5 +28,5 @@ class MissingEntityException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Entity class %s could not be found.';
+    protected string $_messageTemplate = 'Entity class %s could not be found.';
 }

--- a/src/ORM/Exception/MissingTableClassException.php
+++ b/src/ORM/Exception/MissingTableClassException.php
@@ -26,5 +26,5 @@ class MissingTableClassException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Table class %s could not be found.';
+    protected string $_messageTemplate = 'Table class %s could not be found.';
 }

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -34,7 +34,7 @@ class PersistenceFailedException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Entity %s failure.';
+    protected string $_messageTemplate = 'Entity %s failure.';
 
     /**
      * Constructor.

--- a/src/ORM/Exception/RolledbackTransactionException.php
+++ b/src/ORM/Exception/RolledbackTransactionException.php
@@ -24,6 +24,6 @@ class RolledbackTransactionException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'The afterSave event in "%s" is aborting the transaction'
+    protected string $_messageTemplate = 'The afterSave event in "%s" is aborting the transaction'
         . ' before the save process is done.';
 }

--- a/src/Routing/Exception/DuplicateNamedRouteException.php
+++ b/src/Routing/Exception/DuplicateNamedRouteException.php
@@ -25,7 +25,7 @@ class DuplicateNamedRouteException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'A route named "%s" has already been connected to "%s".';
+    protected string $_messageTemplate = 'A route named "%s" has already been connected to "%s".';
 
     /**
      * Constructor.

--- a/src/Routing/Exception/MissingDispatcherFilterException.php
+++ b/src/Routing/Exception/MissingDispatcherFilterException.php
@@ -24,5 +24,5 @@ class MissingDispatcherFilterException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Dispatcher filter %s could not be found.';
+    protected string $_messageTemplate = 'Dispatcher filter %s could not be found.';
 }

--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -26,14 +26,14 @@ class MissingRouteException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'A route matching "%s" could not be found.';
+    protected string $_messageTemplate = 'A route matching "%s" could not be found.';
 
     /**
      * Message template to use when the requested method is included.
      *
      * @var string
      */
-    protected $_messageTemplateWithMethod = 'A "%s" route matching "%s" could not be found.';
+    protected string $_messageTemplateWithMethod = 'A "%s" route matching "%s" could not be found.';
 
     /**
      * Constructor.

--- a/src/View/Exception/MissingCellException.php
+++ b/src/View/Exception/MissingCellException.php
@@ -26,5 +26,5 @@ class MissingCellException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Cell class %s is missing.';
+    protected string $_messageTemplate = 'Cell class %s is missing.';
 }

--- a/src/View/Exception/MissingHelperException.php
+++ b/src/View/Exception/MissingHelperException.php
@@ -24,5 +24,5 @@ class MissingHelperException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Helper class %s could not be found.';
+    protected string $_messageTemplate = 'Helper class %s could not be found.';
 }

--- a/src/View/Exception/MissingViewException.php
+++ b/src/View/Exception/MissingViewException.php
@@ -26,5 +26,5 @@ class MissingViewException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'View class "%s" is missing.';
+    protected string $_messageTemplate = 'View class "%s" is missing.';
 }

--- a/tests/test_app/TestApp/ServiceProvider/PersonServiceProvider.php
+++ b/tests/test_app/TestApp/ServiceProvider/PersonServiceProvider.php
@@ -8,7 +8,7 @@ use Cake\Core\ServiceProvider;
 
 class PersonServiceProvider extends ServiceProvider
 {
-    protected $provides = ['boot', 'sally'];
+    protected array $provides = ['boot', 'sally'];
 
     public function bootstrap(ContainerInterface $container): void
     {


### PR DESCRIPTION
For uninitialized properties, I use `isset()` instead of using a random initialization.

However, psalm will complain that it's not initialized in the constructor. Should we make all optional properties nullable? Should we just add that psalm warning to the global suppression list?