### PR TITLE
Remove checks for defunct controller properties.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -216,20 +216,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $this->initialize();
 
-        if (isset($this->components)) {
-            triggerWarning(
-                'Support for loading components using $components property is removed. ' .
-                'Use $this->loadComponent() instead in initialize().'
-            );
-        }
-
-        if (isset($this->helpers)) {
-            triggerWarning(
-                'Support for loading helpers using $helpers property is removed. ' .
-                'Use $this->viewBuilder()->setHelpers() instead.'
-            );
-        }
-
         $this->getEventManager()->on($this);
     }
 
@@ -326,36 +312,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         );
 
         return null;
-    }
-
-    /**
-     * Magic setter for removed properties.
-     *
-     * @param string $name Property name.
-     * @param mixed $value Value to set.
-     * @return void
-     */
-    public function __set(string $name, $value): void
-    {
-        if ($name === 'components') {
-            triggerWarning(
-                'Support for loading components using $components property is removed. ' .
-                'Use $this->loadComponent() instead in initialize().'
-            );
-
-            return;
-        }
-
-        if ($name === 'helpers') {
-            triggerWarning(
-                'Support for loading helpers using $helpers property is removed. ' .
-                'Use $this->viewBuilder()->setHelpers() instead.'
-            );
-
-            return;
-        }
-
-        $this->{$name} = $value;
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -79,17 +79,7 @@ class ControllerTest extends TestCase
     public function testTableAutoload(): void
     {
         $request = new ServerRequest(['url' => 'controller/posts/index']);
-        $Controller = new Controller($request, new Response());
-        $Controller->modelClass = 'SiteArticles';
-
-        $this->assertFalse(isset($Controller->Articles));
-        $this->assertInstanceOf(
-            'Cake\ORM\Table',
-            $Controller->SiteArticles
-        );
-        unset($Controller->SiteArticles);
-
-        $Controller->modelClass = 'Articles';
+        $Controller = new Controller($request, new Response(), 'Articles');
 
         $this->assertFalse(isset($Controller->SiteArticles));
         $this->assertInstanceOf(
@@ -550,8 +540,7 @@ class ControllerTest extends TestCase
         ]);
         $response = new Response();
 
-        $Controller = new Controller($request, $response);
-        $Controller->modelClass = 'Posts';
+        $Controller = new Controller($request, $response, 'Posts');
         $results = $Controller->paginate();
 
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
@@ -783,32 +772,6 @@ class ControllerTest extends TestCase
 
         $result = $controller->components();
         $this->assertSame($result, $controller->components());
-    }
-
-    /**
-     * Test the components property errors
-     */
-    public function testComponentsPropertyError(): void
-    {
-        $this->expectWarning();
-        $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
-
-        $controller = new TestController($request, $response);
-        $controller->components = ['Flash'];
-    }
-
-    /**
-     * Test the helpers property errors
-     */
-    public function testHelpersPropertyError(): void
-    {
-        $this->expectWarning();
-        $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
-
-        $controller = new TestController($request, $response);
-        $controller->helpers = ['Flash'];
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -678,7 +678,7 @@ class ExceptionRendererTest extends TestCase
         $controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->onlyMethods(['beforeRender'])
             ->getMock();
-        $controller->request = new ServerRequest();
+        $controller->setRequest(new ServerRequest());
         $controller->expects($this->any())
             ->method('beforeRender')
             ->will($this->throwException($exception));
@@ -760,7 +760,7 @@ class ExceptionRendererTest extends TestCase
             ->onlyMethods(['render'])
             ->getMock();
         $controller->setPlugin('TestPlugin');
-        $controller->request = new ServerRequest();
+        $controller->setRequest(new ServerRequest());
 
         $exception = new MissingPluginException(['plugin' => 'TestPlugin']);
         $controller->expects($this->once())
@@ -790,7 +790,6 @@ class ExceptionRendererTest extends TestCase
             ->onlyMethods(['render'])
             ->getMock();
         $controller->setPlugin('TestPlugin');
-        $controller->request = new ServerRequest();
 
         $exception = new MissingPluginException(['plugin' => 'TestPluginTwo']);
         $controller->expects($this->once())


### PR DESCRIPTION
The Controller::__set() method was allowing to set even protected properties
from outside the Controller class scope :(

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
