### PR TITLE
Skip fs test with vfsstream for php 8.1

### DIFF
--- a/tests/TestCase/Filesystem/FilesystemTest.php
+++ b/tests/TestCase/Filesystem/FilesystemTest.php
@@ -37,6 +37,8 @@ class FilesystemTest extends TestCase
     {
         parent::setUp();
 
+        $this->skipIf(version_compare(PHP_VERSION, '8.1.0-dev', '>='));
+
         $this->vfs = vfsStream::setup('root');
         $this->vfsPath = vfsStream::url('root');
 


### PR DESCRIPTION
These throw php fatal errors which block the rest of testing.