### PR TITLE
Fix type specified for FunctionExpression not being respected.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1215,15 +1215,16 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $types = [];
 
         foreach ($select as $alias => $value) {
+            if ($value instanceof TypedResultInterface) {
+                $types[$alias] = $value->getReturnType();
+                continue;
+            }
             if (isset($typeMap[$alias])) {
                 $types[$alias] = $typeMap[$alias];
                 continue;
             }
             if (is_string($value) && isset($typeMap[$value])) {
                 $types[$alias] = $typeMap[$value];
-            }
-            if ($value instanceof TypedResultInterface) {
-                $types[$alias] = $value->getReturnType();
             }
         }
         $this->getSelectTypeMap()->addDefaults($types);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1199,6 +1199,29 @@ class QueryRegressionTest extends TestCase
     }
 
     /**
+     * Test that the type specified in function expressions takes priority over
+     * default types set for columns.
+     *
+     * @see https://github.com/cakephp/cakephp/issues/13049
+     * @return void
+     */
+    public function testTypemapInFunctions3(): void
+    {
+        $this->loadFixtures('Comments');
+        $table = $this->getTableLocator()->get('Comments');
+        $query = $table->find();
+
+        $result = $query->select(['id' => $query->func()->min('id')])
+            ->first();
+        $this->assertSame(1.0, $result['id']);
+
+        $query = $table->find();
+        $result = $query->select(['id' => $query->func()->min('id', ['boolean'])])
+            ->first();
+        $this->assertTrue($result['id']);
+    }
+
+    /**
      * Test that contain queries map types correctly.
      */
     public function testBooleanConditionsInContain(): void


### PR DESCRIPTION
Refs #13049.

While I think this is a bug I am being extra cautious here and targeting `4.next`. I can re-target it to `master` if it's generally considered a safe change. 