### PR TITLE
Add a trait to make defining mock responses simpler

### DIFF
--- a/src/TestSuite/HttpClientTrait.php
+++ b/src/TestSuite/HttpClientTrait.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\TestSuite;
+
+use Cake\Http\Client;
+use Cake\Http\Client\Response;
+
+/**
+ * Define mock responses and have mocks automatically cleared.
+ */
+trait HttpClientTrait
+{
+    /**
+     * Resets mocked responses
+     *
+     * @after
+     * @return void
+     */
+    public function cleanupMockResponses(): void
+    {
+        Client::clearMockResponses();
+    }
+
+    /**
+     * Create a new response.
+     *
+     * @param int $code The response code to use. Defaults to 200
+     * @param array $headers A list of headers for the response. Example `Content-Type: application/json`
+     * @param string $body The body for the response.
+     * @return \Cake\Http\Client\Response
+     */
+    public function newResponse(int $code = 200, array $headers = [], string $body = ''): Response
+    {
+        $headers = array_merge(["HTTP/1.1 {$code}"], $headers);
+
+        return new Response($headers, $body);
+    }
+
+    /**
+     * Add a mock response for a POST request.
+     *
+     * @param string $url The URL to mock
+     * @param \Cake\Http\Client\Response $response The response for the mock.
+     * @param array $options Additional options. See Client::addMockResponse()
+     * @return void
+     */
+    public function mockClientPost(string $url, Response $response, array $options = []): void
+    {
+        Client::addMockResponse('POST', $url, $response, $options);
+    }
+
+    /**
+     * Add a mock response for a GET request.
+     *
+     * @param string $url The URL to mock
+     * @param \Cake\Http\Client\Response $response The response for the mock.
+     * @param array $options Additional options. See Client::addMockResponse()
+     * @return void
+     */
+    public function mockClientGet(string $url, Response $response, array $options = []): void
+    {
+        Client::addMockResponse('GET', $url, $response, $options);
+    }
+
+    /**
+     * Add a mock response for a PATCH request.
+     *
+     * @param string $url The URL to mock
+     * @param \Cake\Http\Client\Response $response The response for the mock.
+     * @param array $options Additional options. See Client::addMockResponse()
+     * @return void
+     */
+    public function mockClientPatch(string $url, Response $response, array $options = []): void
+    {
+        Client::addMockResponse('PATCH', $url, $response, $options);
+    }
+
+    /**
+     * Add a mock response for a PUT request.
+     *
+     * @param string $url The URL to mock
+     * @param \Cake\Http\Client\Response $response The response for the mock.
+     * @param array $options Additional options. See Client::addMockResponse()
+     * @return void
+     */
+    public function mockClientPut(string $url, Response $response, array $options = []): void
+    {
+        Client::addMockResponse('PUT', $url, $response, $options);
+    }
+
+    /**
+     * Add a mock response for a DELETE request.
+     *
+     * @param string $url The URL to mock
+     * @param \Cake\Http\Client\Response $response The response for the mock.
+     * @param array $options Additional options. See Client::addMockResponse()
+     * @return void
+     */
+    public function mockClientDelete(string $url, Response $response, array $options = []): void
+    {
+        Client::addMockResponse('DELETE', $url, $response, $options);
+    }
+}

--- a/src/TestSuite/HttpClientTrait.php
+++ b/src/TestSuite/HttpClientTrait.php
@@ -43,7 +43,7 @@ trait HttpClientTrait
      * @param string $body The body for the response.
      * @return \Cake\Http\Client\Response
      */
-    public function newResponse(int $code = 200, array $headers = [], string $body = ''): Response
+    public function newClientResponse(int $code = 200, array $headers = [], string $body = ''): Response
     {
         $headers = array_merge(["HTTP/1.1 {$code}"], $headers);
 

--- a/tests/TestCase/TestSuite/HttpClientTraitTest.php
+++ b/tests/TestCase/TestSuite/HttpClientTraitTest.php
@@ -27,7 +27,7 @@ class HttpClientTraitTest extends TestCase
     /**
      * Provider for http methods.
      *
-     * @return void
+     * @return array<array>
      */
     public static function methodProvider(): array
     {
@@ -48,7 +48,7 @@ class HttpClientTraitTest extends TestCase
         $traitMethod = "mockClient{$httpMethod}";
         $clientMethod = strtolower($httpMethod);
 
-        $response = $this->newResponse(200, ['Content-Type: application/json'], '{"ok":true}');
+        $response = $this->newClientResponse(200, ['Content-Type: application/json'], '{"ok":true}');
         $this->{$traitMethod}('http://example.com', $response);
 
         $client = new Client();

--- a/tests/TestCase/TestSuite/HttpClientTraitTest.php
+++ b/tests/TestCase/TestSuite/HttpClientTraitTest.php
@@ -46,13 +46,12 @@ class HttpClientTraitTest extends TestCase
     public function testRequestMethods(string $httpMethod)
     {
         $traitMethod = "mockClient{$httpMethod}";
-        $clientMethod = strtolower($httpMethod);
 
         $response = $this->newClientResponse(200, ['Content-Type: application/json'], '{"ok":true}');
         $this->{$traitMethod}('http://example.com', $response);
 
         $client = new Client();
-        $result = $client->{$clientMethod}('http://example.com');
+        $result = $client->{$httpMethod}('http://example.com');
         $this->assertSame($response, $result);
     }
 }

--- a/tests/TestCase/TestSuite/HttpClientTraitTest.php
+++ b/tests/TestCase/TestSuite/HttpClientTraitTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\TestSuite;
+
+use Cake\Http\Client;
+use Cake\TestSuite\HttpClientTrait;
+use Cake\TestSuite\TestCase;
+
+class HttpClientTraitTest extends TestCase
+{
+    use HttpClientTrait;
+
+    /**
+     * Provider for http methods.
+     *
+     * @return void
+     */
+    public static function methodProvider(): array
+    {
+        return [
+            ['Get'],
+            ['Post'],
+            ['Put'],
+            ['Patch'],
+            ['Delete'],
+        ];
+    }
+
+    /**
+     * @dataProvider methodProvider
+     * @param string $httpMethod Http Method name.
+     */
+    public function testRequestMethods($httpMethod)
+    {
+        $traitMethod = "mockClient{$httpMethod}";
+        $clientMethod = strtolower($httpMethod);
+
+        $response = $this->newResponse(200, ['Content-Type: application/json'], '{"ok":true}');
+        $this->{$traitMethod}('http://example.com', $response);
+
+        $client = new Client();
+        $result = $client->{$clientMethod}('http://example.com');
+        $this->assertSame($response, $result);
+    }
+}

--- a/tests/TestCase/TestSuite/HttpClientTraitTest.php
+++ b/tests/TestCase/TestSuite/HttpClientTraitTest.php
@@ -42,9 +42,8 @@ class HttpClientTraitTest extends TestCase
 
     /**
      * @dataProvider methodProvider
-     * @param string $httpMethod Http Method name.
      */
-    public function testRequestMethods($httpMethod)
+    public function testRequestMethods(string $httpMethod)
     {
         $traitMethod = "mockClient{$httpMethod}";
         $clientMethod = strtolower($httpMethod);


### PR DESCRIPTION
The trait automatically clears up mocks and makes possible to define mocks with no static class name references.
