### PR TITLE
Call parent constructor of Constraint

### DIFF
--- a/src/TestSuite/Constraint/Response/ResponseBase.php
+++ b/src/TestSuite/Constraint/Response/ResponseBase.php
@@ -43,6 +43,7 @@ abstract class ResponseBase extends Constraint
         }
 
         $this->response = $response;
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
Good morning,

For example when you use `assertContentType` and it fails, you'll get the error `Call to a member function export() on null` in the file `vendor/phpunit/phpunit/src/Framework/Constraint/Constraint.php` in the function `failureDescription`. This is because the constructor is not called and the exporter property is not set. By calling the Constraint constructor in the ResponseBase, this issue is resolved.

If further changes are needed, please let me know. 

Cheers,

Frank
