### PR TITLE
Use hash_equals in BlowfishPasswordHasher to mitigate timing attacks

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
@@ -45,9 +45,8 @@ class BlowfishPasswordHasher extends AbstractPasswordHasher {
 		if (function_exists('hash_equals')) {
 			// Use hash_equals to mitigate timing attacks
 			return hash_equals($hashedPassword, Security::hash($password, 'blowfish', $hashedPassword));
-		} else {
-			return $hashedPassword === Security::hash($password, 'blowfish', $hashedPassword);
 		}
+		return $hashedPassword === Security::hash($password, 'blowfish', $hashedPassword);
 	}
 
 }

--- a/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
@@ -42,7 +42,12 @@ class BlowfishPasswordHasher extends AbstractPasswordHasher {
  * @return bool True if hashes match else false.
  */
 	public function check($password, $hashedPassword) {
-		return $hashedPassword === Security::hash($password, 'blowfish', $hashedPassword);
+		if (function_exists('hash_equals')) {
+			// Use hash_equals to mitigate timing attacks
+			return hash_equals($hashedPassword, Security::hash($password, 'blowfish', $hashedPassword));
+		} else {
+			return $hashedPassword === Security::hash($password, 'blowfish', $hashedPassword);
+		}
 	}
 
 }


### PR DESCRIPTION
hash_equals is available since PHP 5.6, but CakePHP 2.x still supports PHP 5.3, so we have to first check if this function exists and fallback to `===` otherwise.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
