### PR TITLE
Allow json_encode options in JsonType

### DIFF
--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -112,10 +112,10 @@ class JsonType extends BaseType implements BatchCastingInterface
      * Set json_encode options.
      *
      * @param  int $jsonOptions Options. Use JSON_* flags. Set `0` to reset.
-     * @return self
+     * @return $this
      * @see https://www.php.net/manual/en/function.json-encode.php
      */
-    public function setJsonOptions(int $jsonOptions): self
+    public function setJsonOptions(int $jsonOptions)
     {
         $this->_jsonOptions = $jsonOptions;
 

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -28,6 +28,11 @@ use PDO;
 class JsonType extends BaseType implements BatchCastingInterface
 {
     /**
+     * @var int
+     */
+    protected $_jsonOptions = 0;
+
+    /**
      * Convert a value data into a JSON string
      *
      * @param mixed $value The value to convert.
@@ -45,7 +50,7 @@ class JsonType extends BaseType implements BatchCastingInterface
             return null;
         }
 
-        return json_encode($value);
+        return json_encode($value, $this->_jsonOptions);
     }
 
     /**
@@ -101,5 +106,19 @@ class JsonType extends BaseType implements BatchCastingInterface
     public function marshal($value)
     {
         return $value;
+    }
+
+    /**
+     * Set json_encode options.
+     *
+     * @param  int|null $jsonOptions Options. Use JSON_* flags
+     * @return self
+     * @see https://www.php.net/manual/en/function.json-encode.php
+     */
+    public function setJsonOptions(int $jsonOptions): self
+    {
+        $this->_jsonOptions = $jsonOptions;
+
+        return $this;
     }
 }

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -30,7 +30,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * @var int
      */
-    protected $_jsonOptions = 0;
+    protected $_encodingOptions = 0;
 
     /**
      * Convert a value data into a JSON string
@@ -50,7 +50,7 @@ class JsonType extends BaseType implements BatchCastingInterface
             return null;
         }
 
-        return json_encode($value, $this->_jsonOptions);
+        return json_encode($value, $this->_encodingOptions);
     }
 
     /**
@@ -111,13 +111,13 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * Set json_encode options.
      *
-     * @param int $jsonOptions Options. Use JSON_* flags. Set `0` to reset.
+     * @param int $options Encoding flags. Use JSON_* flags. Set `0` to reset.
      * @return $this
      * @see https://www.php.net/manual/en/function.json-encode.php
      */
-    public function setJsonOptions(int $jsonOptions)
+    public function setEncodingOptions(int $options)
     {
-        $this->_jsonOptions = $jsonOptions;
+        $this->_encodingOptions = $options;
 
         return $this;
     }

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -111,7 +111,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * Set json_encode options.
      *
-     * @param  int $jsonOptions Options. Use JSON_* flags. Set `0` to reset.
+     * @param int $jsonOptions Options. Use JSON_* flags. Set `0` to reset.
      * @return $this
      * @see https://www.php.net/manual/en/function.json-encode.php
      */

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -111,7 +111,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * Set json_encode options.
      *
-     * @param  int|null $jsonOptions Options. Use JSON_* flags
+     * @param  int $jsonOptions Options. Use JSON_* flags. Set `0` to reset.
      * @return self
      * @see https://www.php.net/manual/en/function.json-encode.php
      */

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -136,15 +136,15 @@ class JsonTypeTest extends TestCase
     }
 
     /**
-     * Test instance options
+     * Test encoding options
      *
      * @return void
      */
-    public function testInstanceOptions()
+    public function testEncodingOptions()
     {
         // New instance to prevent others tests breaking
         $instance = new JsonType();
-        $instance->setJsonOptions(JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $instance->setEncodingOptions(JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         $result = $instance->toDatabase(['é', 'https://cakephp.org/'], $this->driver);
         $this->assertSame('["é","https://cakephp.org/"]', $result);

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
+use Cake\Database\Type\JsonType;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -132,5 +133,20 @@ class JsonTypeTest extends TestCase
     public function testToStatement()
     {
         $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
+    }
+
+    /**
+     * Test instance options
+     *
+     * @return void
+     */
+    public function testInstanceOptions()
+    {
+        // New instance to prevent others tests breaking
+        $instance = new JsonType();
+        $instance->setJsonOptions(JSON_UNESCAPED_UNICODE + JSON_UNESCAPED_SLASHES);
+
+        $result = $instance->toDatabase(['é', 'https://cakephp.org/'], $this->driver);
+        $this->assertSame('["é","https://cakephp.org/"]', $result);
     }
 }

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -144,7 +144,7 @@ class JsonTypeTest extends TestCase
     {
         // New instance to prevent others tests breaking
         $instance = new JsonType();
-        $instance->setJsonOptions(JSON_UNESCAPED_UNICODE + JSON_UNESCAPED_SLASHES);
+        $instance->setJsonOptions(JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         $result = $instance->toDatabase(['é', 'https://cakephp.org/'], $this->driver);
         $this->assertSame('["é","https://cakephp.org/"]', $result);


### PR DESCRIPTION
Add possibility to pass `json_encode()` options to database JsonType.
This can be useful in total UTF-8 context to prevent extra characters in database.

Changing the `options` in existing project don't break old data.

JsonType documentation : 
```
// Don't escape unicode and slashes
TypeFactory::build('json')->setEncodingOptions(JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
```