### PR TITLE
Rename phpunit fixture extension

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
     </testsuites>
 
     <extensions>
-        <extension class="Cake\TestSuite\FixtureSchemaExtension" />
+        <extension class="Cake\TestSuite\Fixture\PHPUnitExtension"/>
     </extensions>
 
     <!-- Prevent coverage reports from looking in tests, vendors, config folders -->

--- a/src/TestSuite/Fixture/PHPUnitExtension.php
+++ b/src/TestSuite/Fixture/PHPUnitExtension.php
@@ -14,19 +14,17 @@ declare(strict_types=1);
  * @since         4.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\TestSuite;
+namespace Cake\TestSuite\Fixture;
 
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
-use Cake\TestSuite\Fixture\FixtureDataManager;
-use Cake\TestSuite\Fixture\FixtureLoader;
 use PHPUnit\Runner\BeforeFirstTestHook;
 
 /**
  * PHPUnit extension to integrate CakePHP's data-only fixtures.
  */
-class FixtureSchemaExtension implements BeforeFirstTestHook
+class PHPUnitExtension implements BeforeFirstTestHook
 {
     /**
      * Constructor. Set the record only fixture manager as the singleton.

--- a/tests/TestCase/TestSuite/Fixture/PHPUnitExtensionTest.php
+++ b/tests/TestCase/TestSuite/Fixture/PHPUnitExtensionTest.php
@@ -19,10 +19,10 @@ namespace Cake\Test\TestCase\TestSuite;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
-use Cake\TestSuite\FixtureSchemaExtension;
+use Cake\TestSuite\Fixture\PHPUnitExtension;
 use Cake\TestSuite\TestCase;
 
-class FixtureSchemaExtensionTest extends TestCase
+class PHPUnitExtensionTest extends TestCase
 {
     /**
      * Test connection aliasing during construction.
@@ -36,7 +36,7 @@ class FixtureSchemaExtensionTest extends TestCase
             'database' => TMP . 'fixture_schema.sqlite',
         ]);
         $this->assertNotContains('fixture_schema', ConnectionManager::configured());
-        $extension = new FixtureSchemaExtension();
+        $extension = new PHPUnitExtension();
 
         $this->assertContains('test_fixture_schema', ConnectionManager::configured());
         $this->assertSame(


### PR DESCRIPTION
@markstory It feels like this belongs in the Fixture namespace. Renamed to PhpUnitExtension so it's clear what the use case is in the future.
