### PR TITLE
Remove unneeded param of ViewBuilder::build().

### DIFF
--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -530,7 +530,6 @@ class ViewBuilder implements JsonSerializable
      * If className() is null, App\View\AppView will be used.
      * If that class does not exist, then Cake\View\View will be used.
      *
-     * @param array $vars The view variables/context to use.
      * @param \Cake\Http\ServerRequest|null $request The request to use.
      * @param \Cake\Http\Response|null $response The response to use.
      * @param \Cake\Event\EventManagerInterface|null $events The event manager to use.
@@ -538,7 +537,6 @@ class ViewBuilder implements JsonSerializable
      * @throws \Cake\View\Exception\MissingViewException
      */
     public function build(
-        array $vars = [],
         ?ServerRequest $request = null,
         ?Response $response = null,
         ?EventManagerInterface $events = null
@@ -555,12 +553,6 @@ class ViewBuilder implements JsonSerializable
             throw new MissingViewException(['class' => $this->_className]);
         }
 
-        if (!empty($vars)) {
-            deprecationWarning(
-                'The $vars argument is deprecated. Use the setVar()/setVars() methods instead.'
-            );
-        }
-
         $data = [
             'name' => $this->_name,
             'templatePath' => $this->_templatePath,
@@ -571,7 +563,7 @@ class ViewBuilder implements JsonSerializable
             'autoLayout' => $this->_autoLayout,
             'layoutPath' => $this->_layoutPath,
             'helpers' => $this->_helpers,
-            'viewVars' => $vars + $this->_vars,
+            'viewVars' => $this->_vars,
         ];
         $data += $this->_options;
 

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -69,7 +69,6 @@ trait ViewVarsTrait
 
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         return $builder->build(
-            [],
             $this->request ?? null,
             $this->response ?? null,
             $this instanceof EventDispatcherInterface ? $this->getEventManager() : null

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -189,44 +189,40 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildComplete(): void
     {
-        $this->deprecated(function () {
-            $request = new ServerRequest();
-            $response = new Response();
-            $events = new EventManager();
+        $request = new ServerRequest();
+        $response = new Response();
+        $events = new EventManager();
 
-            $builder = new ViewBuilder();
-            $builder->setName('Articles')
-                ->setClassName('Ajax')
-                ->setTemplate('edit')
-                ->setLayout('default')
-                ->setTemplatePath('Articles/')
-                ->setHelpers(['Form', 'Html'])
-                ->setLayoutPath('Admin/')
-                ->setTheme('TestTheme')
-                ->setPlugin('TestPlugin')
-                ->setVars(['foo' => 'bar', 'x' => 'old']);
-            $view = $builder->build(
-                ['one' => 'value', 'x' => 'new'],
-                $request,
-                $response,
-                $events
-            );
-            $this->assertInstanceOf('Cake\View\AjaxView', $view);
-            $this->assertSame('edit', $view->getTemplate());
-            $this->assertSame('default', $view->getLayout());
-            $this->assertSame('Articles/', $view->getTemplatePath());
-            $this->assertSame('Admin/', $view->getLayoutPath());
-            $this->assertSame('TestPlugin', $view->getPlugin());
-            $this->assertSame('TestTheme', $view->getTheme());
-            $this->assertSame($request, $view->getRequest());
-            $this->assertInstanceOf(Response::class, $view->getResponse());
-            $this->assertSame($events, $view->getEventManager());
-            $this->assertSame(['one', 'x', 'foo'], $view->getVars());
-            $this->assertSame('value', $view->get('one'));
-            $this->assertSame('bar', $view->get('foo'));
-            $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $view->Html);
-            $this->assertInstanceOf('Cake\View\Helper\FormHelper', $view->Form);
-        });
+        $builder = new ViewBuilder();
+        $builder->setName('Articles')
+            ->setClassName('Ajax')
+            ->setTemplate('edit')
+            ->setLayout('default')
+            ->setTemplatePath('Articles/')
+            ->setHelpers(['Form', 'Html'])
+            ->setLayoutPath('Admin/')
+            ->setTheme('TestTheme')
+            ->setPlugin('TestPlugin')
+            ->setVars(['foo' => 'bar', 'x' => 'old']);
+        $view = $builder->build(
+            $request,
+            $response,
+            $events
+        );
+        $this->assertInstanceOf('Cake\View\AjaxView', $view);
+        $this->assertSame('edit', $view->getTemplate());
+        $this->assertSame('default', $view->getLayout());
+        $this->assertSame('Articles/', $view->getTemplatePath());
+        $this->assertSame('Admin/', $view->getLayoutPath());
+        $this->assertSame('TestPlugin', $view->getPlugin());
+        $this->assertSame('TestTheme', $view->getTheme());
+        $this->assertSame($request, $view->getRequest());
+        $this->assertInstanceOf(Response::class, $view->getResponse());
+        $this->assertSame($events, $view->getEventManager());
+        $this->assertSame(['foo', 'x'], $view->getVars());
+        $this->assertSame('bar', $view->get('foo'));
+        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $view->Html);
+        $this->assertInstanceOf('Cake\View\Helper\FormHelper', $view->Form);
     }
 
     /**


### PR DESCRIPTION
View vars are set using the setVar()/setVars() methods.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
