### PR TITLE
Add deprecation warning for dropTables

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -323,11 +323,12 @@
     </DeprecatedClass>
   </file>
   <file src="src/TestSuite/TestCase.php">
-    <DeprecatedProperty occurrences="5">
+    <DeprecatedProperty occurrences="6">
       <code>$this-&gt;autoFixtures</code>
       <code>$this-&gt;autoFixtures</code>
       <code>$this-&gt;autoFixtures</code>
       <code>$this-&gt;autoFixtures</code>
+      <code>$this-&gt;dropTables</code>
       <code>$this-&gt;dropTables</code>
     </DeprecatedProperty>
   </file>

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -230,6 +230,9 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
         $this->fixtureManager = FixtureLoader::getInstance();
         if ($this->fixtureManager) {
+            if ($this->dropTables) {
+                deprecationWarning('`$dropTables` is deprecated and will be removed in 5.0.');
+            }
             $this->fixtureManager->setupTest($this);
         }
 


### PR DESCRIPTION
Unfortunately, `FixtureLoader::loadSingle()` defaults the `$dropTables` parameter to true. However, loadSingle() is really only used from TestCase which uses `TestCase::$dropTables` instead.

`FixtureDataManager` ignores `$dropTables` entirely.
