### PR TITLE
Remove parenthesis around sql identifiers in comparison expressions

### DIFF
--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -146,7 +146,10 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             $field = $field->sql($binder);
         }
 
-        if ($this->_value instanceof ExpressionInterface) {
+        if ($this->_value instanceof IdentifierExpression) {
+            $template = '%s %s %s';
+            $value = $this->_value->sql($binder);
+        } elseif ($this->_value instanceof ExpressionInterface) {
             $template = '%s %s (%s)';
             $value = $this->_value->sql($binder);
         } else {
@@ -206,7 +209,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
     {
         $template = '%s ';
 
-        if ($this->_field instanceof ExpressionInterface) {
+        if ($this->_field instanceof ExpressionInterface && !$this->_field instanceof IdentifierExpression) {
             $template = '(%s) ';
         }
 

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -53,7 +53,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
     {
         $f = (new AggregateExpression('MyFunction'))->filter(['this' => new IdentifierExpression('that')]);
         $this->assertEqualsSql(
-            'MyFunction() FILTER (WHERE this = (that))',
+            'MyFunction() FILTER (WHERE this = that)',
             $f->sql(new ValueBinder())
         );
 
@@ -61,13 +61,13 @@ class AggregateExpressionTest extends FunctionExpressionTest
             return $q->add(['this2' => new IdentifierExpression('that2')]);
         });
         $this->assertEqualsSql(
-            'MyFunction() FILTER (WHERE (this = (that) AND this2 = (that2)))',
+            'MyFunction() FILTER (WHERE (this = that AND this2 = that2))',
             $f->sql(new ValueBinder())
         );
 
         $f->over();
         $this->assertEqualsSql(
-            'MyFunction() FILTER (WHERE (this = (that) AND this2 = (that2))) OVER ()',
+            'MyFunction() FILTER (WHERE (this = that AND this2 = that2)) OVER ()',
             $f->sql(new ValueBinder())
         );
     }

--- a/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
+++ b/tests/TestCase/Database/Expression/ComparisonExpressionTest.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Expression;
 
 use Cake\Database\Expression\ComparisonExpression;
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -25,6 +27,27 @@ use Cake\TestSuite\TestCase;
  */
 class ComparisonExpressionTest extends TestCase
 {
+    /**
+     * Test sql generation using IdentifierExpression
+     */
+    public function testIdentifiers(): void
+    {
+        $expr = new ComparisonExpression('field', new IdentifierExpression('other_field'));
+        $this->assertEqualsSql('field = other_field', $expr->sql(new ValueBinder()));
+
+        $expr = new ComparisonExpression(new IdentifierExpression('field'), new IdentifierExpression('other_field'));
+        $this->assertEqualsSql('field = other_field', $expr->sql(new ValueBinder()));
+
+        $expr = new ComparisonExpression(new IdentifierExpression('field'), new QueryExpression(['other_field']));
+        $this->assertEqualsSql('field = (other_field)', $expr->sql(new ValueBinder()));
+
+        $expr = new ComparisonExpression(new IdentifierExpression('field'), 'value');
+        $this->assertEqualsSql('field = :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new ComparisonExpression(new QueryExpression(['field']), new IdentifierExpression('other_field'));
+        $this->assertEqualsSql('field = other_field', $expr->sql(new ValueBinder()));
+    }
+
     /**
      * Tests that cloning Comparion instance clones it's value and field expressions.
      */

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2850,7 +2850,7 @@ class QueryTest extends TestCase
             'DELETE FROM <authors> WHERE \(' .
                 '<id> = :c0 OR \(<name>\) IS NULL OR \(<email>\) IS NOT NULL OR \(' .
                     '<name> not in \(:c1,:c2\) AND \(' .
-                        '\(<name>\) = :c3 OR <name> = :c4 OR \(SELECT <e>\.<name> WHERE <e>\.<name> = :c5\)' .
+                        '<name> = :c3 OR <name> = :c4 OR \(SELECT <e>\.<name> WHERE <e>\.<name> = :c5\)' .
                     '\)' .
                 '\)' .
             '\)',
@@ -2972,7 +2972,7 @@ class QueryTest extends TestCase
         $result = $query->sql();
 
         $this->assertQuotedQuery(
-            'UPDATE <comments> SET <article_id> = \(<user_id>\) WHERE <id> = :',
+            'UPDATE <comments> SET <article_id> = <user_id> WHERE <id> = :',
             $result,
             !$this->autoQuote
         );
@@ -3070,7 +3070,7 @@ class QueryTest extends TestCase
             'UPDATE <authors> SET <name> = :c0 WHERE \(' .
                 '<id> = :c1 OR \(<name>\) IS NULL OR \(<email>\) IS NOT NULL OR \(' .
                     '<name> not in \(:c2,:c3\) AND \(' .
-                        '\(<name>\) = :c4 OR <name> = :c5 OR \(SELECT <e>\.<name> WHERE <e>\.<name> = :c6\)' .
+                        '<name> = :c4 OR <name> = :c5 OR \(SELECT <e>\.<name> WHERE <e>\.<name> = :c6\)' .
                     '\)' .
                 '\)' .
             '\)',


### PR DESCRIPTION
This avoids wrapping sql identifiers in parenthesis which helps with self-references in UPDATE queries.

```sql
UPDATE table SET field = (SELECT field2 FROM table as t1 WHERE t1.field3 = table.field3)
```

This also generates SQL in the format you expect when using field name directly.