### PR TITLE
cake 5: Normalize passing  array to initialize() and documentation

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -128,7 +128,8 @@ class Component implements EventListenerInterface
      * Implement this method to avoid having to overwrite
      * the constructor and call parent.
      *
-     * @param array $config The configuration settings provided to this component.
+     * @param array $config The original config array passed to constructor.
+     *  It is not merged with defaults.
      * @return void
      */
     public function initialize(array $config): void

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -117,15 +117,16 @@ class BasePlugin implements PluginInterface
             }
         }
 
-        $this->initialize();
+        $this->initialize($options);
     }
 
     /**
      * Initialization hook called from constructor.
      *
+     * @param array $config The original config array passed to constructor.
      * @return void
      */
-    public function initialize(): void
+    public function initialize(array $config): void
     {
     }
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -173,7 +173,8 @@ class Behavior implements EventListenerInterface
      * Implement this method to avoid having to overwrite
      * the constructor and call parent.
      *
-     * @param array $config The configuration settings provided to this behavior.
+     * @param array $config The original config array passed to constructor.
+     *  It is not merged with defaults.
      * @return void
      */
     public function initialize(array $config): void

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -74,7 +74,8 @@ class TimestampBehavior extends Behavior
      * If events are specified - do *not* merge them with existing events,
      * overwrite the events to listen on
      *
-     * @param array $config The config for this behavior.
+     * @param array $config The original config array passed to constructor.
+     *  It is not merged with defaults.
      * @return void
      */
     public function initialize(array $config): void

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -117,10 +117,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     }
 
     /**
-     * Initialize hook
-     *
-     * @param array $config The config for this behavior.
-     * @return void
+     * @inheritDoc
      */
     public function initialize(array $config): void
     {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -357,7 +357,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *  }
      * ```
      *
-     * @param array $config Configuration options passed to the constructor
+     * @param array $config The original config array passed to constructor.
      * @return void
      */
     public function initialize(array $config): void

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -31,9 +31,9 @@ class AjaxView extends View
     /**
      * @inheritDoc
      */
-    public function initialize(): void
+    public function initialize(array $config): void
     {
-        parent::initialize();
+        parent::initialize($config);
         $this->setResponse($this->getResponse()->withType('ajax'));
     }
 }

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -136,7 +136,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
             $this->_cache = $cellOptions['cache'];
         }
 
-        $this->initialize();
+        $this->initialize($cellOptions);
     }
 
     /**
@@ -145,9 +145,11 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      * Implement this method to avoid having to overwrite
      * the constructor and calling parent::__construct().
      *
+     * @param array $config The original config array passed to constructor.
+     *  It is not merged with defaults.
      * @return void
      */
-    public function initialize(): void
+    public function initialize(array $config): void
     {
     }
 

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -199,7 +199,8 @@ class Helper implements EventListenerInterface
      *
      * Implement this method to avoid having to overwrite the constructor and call parent.
      *
-     * @param array $config The configuration settings provided to this helper.
+     * @param array $config The original config array passed to constructor.
+     *  It is not merged with defaults.
      * @return void
      */
     public function initialize(array $config): void

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -45,10 +45,7 @@ class UrlHelper extends Helper
     protected $_assetUrlClassName;
 
     /**
-     * Check proper configuration
-     *
-     * @param array $config The configuration settings provided to this helper.
-     * @return void
+     * @inheritDoc
      */
     public function initialize(array $config): void
     {

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -51,9 +51,9 @@ abstract class SerializedView extends View
     /**
      * @inheritDoc
      */
-    public function initialize(): void
+    public function initialize(array $config): void
     {
-        parent::initialize();
+        parent::initialize($config);
         $this->setResponse($this->getResponse()->withType($this->_responseType));
     }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -348,7 +348,7 @@ class View implements EventDispatcherInterface
         $this->request = $request;
         $this->response = $response ?: new Response();
         $this->Blocks = new $this->_viewBlockClass();
-        $this->initialize();
+        $this->initialize($viewOptions);
         $this->loadHelpers();
     }
 
@@ -360,9 +360,11 @@ class View implements EventDispatcherInterface
      * So this method allows you to manipulate them as required after view instance
      * is constructed.
      *
+     * @param array $config The original config array passed to constructor.
+     *  It is not merged with defaults.
      * @return void
      */
-    public function initialize(): void
+    public function initialize(array $config): void
     {
     }
 

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -5,7 +5,7 @@ namespace TestApp\View;
 
 class TestView extends AppView
 {
-    public function initialize(): void
+    public function initialize(array $config): void
     {
         $this->loadHelper('Html', ['mykey' => 'myval']);
     }


### PR DESCRIPTION
This just adds a `$config` parameter to `initialize()` functions that are called by constructors with config arrays.

Updated the docblock to read the exact same in all places and explain the config array is unmerged.
