### PR TITLE
Deprecate methods of Router for connecting routes.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -226,6 +226,12 @@
       <code>$request</code>
     </ArgumentTypeCoercion>
   </file>
+  <file src="src/Routing/Router.php">
+    <DeprecatedMethod occurrences="3">
+      <code>static::scope($path, $params, $callback)</code>
+      <code>static::scope($path, $params, $callback)</code>
+    </DeprecatedMethod>
+  </file>
   <file src="src/Shell/Task/CommandTask.php">
     <DeprecatedClass occurrences="1">
       <code>Shell</code>

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -206,9 +206,14 @@ class Router
      * @throws \Cake\Core\Exception\CakeException
      * @see \Cake\Routing\RouteBuilder::connect()
      * @see \Cake\Routing\Router::scope()
+     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::connect()` instead.
      */
     public static function connect($route, $defaults = [], $options = []): void
     {
+        deprecationWarning(
+            '`Router::connect()` is deprecated, use the non-static method `RouterBuilder::connect()` instead.'
+        );
+
         static::scope('/', function ($routes) use ($route, $defaults, $options): void {
             /** @var \Cake\Routing\RouteBuilder $routes */
             $routes->connect($route, $defaults, $options);
@@ -740,6 +745,7 @@ class Router
         if ($extensions === null) {
             return array_unique(array_merge(static::$_defaultExtensions, $collection->getExtensions()));
         }
+
         $extensions = (array)$extensions;
         if ($merge) {
             $extensions = array_unique(array_merge(static::$_defaultExtensions, $extensions));
@@ -810,9 +816,14 @@ class Router
      * @param callable|null $callback The callback to invoke with the scoped collection.
      * @throws \InvalidArgumentException When an invalid callable is provided.
      * @return void
+     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::scope()` instead.
      */
     public static function scope(string $path, $params = [], $callback = null): void
     {
+        deprecationWarning(
+            '`Router::scope()` is deprecated, use the non-static method `RouterBuilder::scope()` instead.'
+        );
+
         $options = [];
         if (is_array($params)) {
             $options = $params;
@@ -844,9 +855,14 @@ class Router
      *   If you have no parameters, this argument can be a callable.
      * @param callable|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
+     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::prefix()` instead.
      */
     public static function prefix(string $name, $params = [], $callback = null): void
     {
+        deprecationWarning(
+            '`Router::prefix()` is deprecated, use the non-static method `RouterBuilder::prefix()` instead.'
+        );
+
         if (!is_array($params)) {
             $callback = $params;
             $params = [];
@@ -876,9 +892,14 @@ class Router
      * @param callable|null $callback The callback to invoke that builds the plugin routes.
      *   Only required when $options is defined
      * @return void
+     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::plugin()` instead.
      */
     public static function plugin(string $name, $options = [], $callback = null): void
     {
+        deprecationWarning(
+            '`Router::plugin()` is deprecated, use the non-static method `RouterBuilder::plugin()` instead.'
+        );
+
         if (!is_array($options)) {
             $callback = $options;
             $options = [];

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -138,7 +138,7 @@ class RoutesCommandTest extends TestCase
      */
     public function testRouteListSorted(): void
     {
-        Router::connect(
+        Router::createRouteBuilder('/')->connect(
             new Route('/a/route/sorted', [], ['_name' => '_aRoute'])
         );
 

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -68,9 +68,7 @@ class AuthComponentTest extends TestCase
         Security::setSalt('YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
         static::setAppNamespace();
 
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks(InflectedRoute::class);
-        });
+        Router::createRouteBuilder('/')->fallbacks(InflectedRoute::class);
 
         $request = new ServerRequest([
             'url' => '/auth_test',
@@ -1073,12 +1071,12 @@ class AuthComponentTest extends TestCase
     {
         $event = new Event('Controller.startup', $this->Controller);
         Router::reload();
-        Router::prefix('admin', function (RouteBuilder $routes): void {
+        $builder = Router::createRouteBuilder('/');
+        $builder->prefix('admin', function (RouteBuilder $routes): void {
             $routes->fallbacks(InflectedRoute::class);
         });
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks(InflectedRoute::class);
-        });
+        $builder->fallbacks(InflectedRoute::class);
+
         $this->Controller->setRequest(new ServerRequest([
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
@@ -1142,12 +1140,11 @@ class AuthComponentTest extends TestCase
     {
         $event = new Event('Controller.startup', $this->Controller);
         Router::reload();
-        Router::prefix('admin', function (RouteBuilder $routes): void {
+        $builder = Router::createRouteBuilder('/');
+        $builder->prefix('admin', function (RouteBuilder $routes): void {
             $routes->fallbacks(InflectedRoute::class);
         });
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks(InflectedRoute::class);
-        });
+        $builder->fallbacks(InflectedRoute::class);
 
         $url = '/admin/auth_test/login';
         $request = new ServerRequest([

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -23,7 +23,6 @@ use Cake\Event\Event;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
-use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\AjaxView;
@@ -61,6 +60,11 @@ class RequestHandlerComponentTest extends TestCase
     protected $server = [];
 
     /**
+     * @var \Cake\Routing\RouteBuilder
+     */
+    protected $builder;
+
+    /**
      * setUp method
      */
     public function setUp(): void
@@ -82,10 +86,9 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler = $this->Controller->components()->load(RequestHandlerExtComponent::class);
         $this->request = $request;
 
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->setExtensions('json');
-            $routes->fallbacks('InflectedRoute');
-        });
+        $this->builder = Router::createRouteBuilder('/');
+        $this->builder->setExtensions('json');
+        $this->builder->fallbacks('InflectedRoute');
     }
 
     /**

--- a/tests/TestCase/Routing/AssetTest.php
+++ b/tests/TestCase/Routing/AssetTest.php
@@ -19,7 +19,6 @@ namespace Cake\Test\TestCase\Routing;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Asset;
-use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
@@ -28,6 +27,11 @@ use Cake\TestSuite\TestCase;
  */
 class AssetTest extends TestCase
 {
+    /**
+     * @var \Cake\Routing\RouteBuilder
+     */
+    protected $builder;
+
     /**
      * setUp method
      */
@@ -43,9 +47,8 @@ class AssetTest extends TestCase
 
         static::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks();
-        });
+        $this->builder = Router::createRouteBuilder('/');
+        $this->builder->fallbacks();
     }
 
     /**
@@ -101,7 +104,7 @@ class AssetTest extends TestCase
      */
     public function testAssetUrl(): void
     {
-        Router::connect('/{controller}/{action}/*');
+        $this->builder->connect('/{controller}/{action}/*');
 
         $result = Asset::url('js/post.js', ['fullBase' => true]);
         $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
@@ -249,7 +252,7 @@ class AssetTest extends TestCase
      */
     public function testScript(): void
     {
-        Router::connect('/{controller}/{action}/*');
+        $this->builder->connect('/{controller}/{action}/*');
 
         $result = Asset::scriptUrl('post.js', ['fullBase' => true]);
         $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -39,13 +39,20 @@ class RoutingMiddlewareTest extends TestCase
     protected $log = [];
 
     /**
+     * @var \Cake\Routing\RouteBuilder
+     */
+    protected $builder;
+
+    /**
      * Setup method
      */
     public function setUp(): void
     {
         parent::setUp();
+
         Router::reload();
-        Router::connect('/articles', ['controller' => 'Articles', 'action' => 'index']);
+        $this->builder = Router::createRouteBuilder('/');
+        $this->builder->connect('/articles', ['controller' => 'Articles', 'action' => 'index']);
         $this->log = [];
 
         Configure::write('App.base', '');
@@ -56,9 +63,7 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testRedirectResponse(): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->redirect('/testpath', '/pages');
-        });
+        $this->builder->redirect('/testpath', '/pages');
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
         $request = $request->withAttribute('base', '/subdir');
 
@@ -75,7 +80,7 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testRedirectResponseWithHeaders(): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
+        $this->builder->scope('/', function (RouteBuilder $routes): void {
             $routes->redirect('/testpath', '/pages');
         });
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/testpath']);
@@ -215,7 +220,7 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testFakedRequestMethodParsed(): void
     {
-        Router::connect('/articles-patch', [
+        $this->builder->connect('/articles-patch', [
             'controller' => 'Articles',
             'action' => 'index',
             '_method' => 'PATCH',
@@ -252,7 +257,7 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testInvokeScopedMiddleware(): void
     {
-        Router::scope('/api', function (RouteBuilder $routes): void {
+        $this->builder->scope('/api', function (RouteBuilder $routes): void {
             $routes->registerMiddleware('first', function ($request, $handler) {
                 $this->log[] = 'first';
 
@@ -293,25 +298,23 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testInvokeScopedMiddlewareReturnResponse(): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->registerMiddleware('first', function ($request, $handler) {
-                $this->log[] = 'first';
+        $this->builder->registerMiddleware('first', function ($request, $handler) {
+            $this->log[] = 'first';
 
-                return $handler->handle($request);
-            });
-            $routes->registerMiddleware('second', function ($request, $handler) {
-                $this->log[] = 'second';
+            return $handler->handle($request);
+        });
+        $this->builder->registerMiddleware('second', function ($request, $handler) {
+            $this->log[] = 'second';
 
-                return new Response();
-            });
+            return new Response();
+        });
 
-            $routes->applyMiddleware('first');
-            $routes->connect('/', ['controller' => 'Home']);
+        $this->builder->applyMiddleware('first');
+        $this->builder->connect('/', ['controller' => 'Home']);
 
-            $routes->scope('/api', function (RouteBuilder $routes): void {
-                $routes->applyMiddleware('second');
-                $routes->connect('/articles', ['controller' => 'Articles']);
-            });
+        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+            $routes->applyMiddleware('second');
+            $routes->connect('/articles', ['controller' => 'Articles']);
         });
 
         $request = ServerRequestFactory::fromGlobals([
@@ -332,25 +335,23 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testInvokeScopedMiddlewareReturnResponseMainScope(): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->registerMiddleware('first', function ($request, $handler) {
-                $this->log[] = 'first';
+        $this->builder->registerMiddleware('first', function ($request, $handler) {
+            $this->log[] = 'first';
 
-                return new Response();
-            });
-            $routes->registerMiddleware('second', function ($request, $handler) {
-                $this->log[] = 'second';
+            return new Response();
+        });
+        $this->builder->registerMiddleware('second', function ($request, $handler) {
+            $this->log[] = 'second';
 
-                return $handler->handle($request);
-            });
+            return $handler->handle($request);
+        });
 
-            $routes->applyMiddleware('first');
-            $routes->connect('/', ['controller' => 'Home']);
+        $this->builder->applyMiddleware('first');
+        $this->builder->connect('/', ['controller' => 'Home']);
 
-            $routes->scope('/api', function (RouteBuilder $routes): void {
-                $routes->applyMiddleware('second');
-                $routes->connect('/articles', ['controller' => 'Articles']);
-            });
+        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+            $routes->applyMiddleware('second');
+            $routes->connect('/articles', ['controller' => 'Articles']);
         });
 
         $request = ServerRequestFactory::fromGlobals([
@@ -376,27 +377,25 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testInvokeScopedMiddlewareIsolatedScopes(string $url, array $expected): void
     {
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->registerMiddleware('first', function ($request, $handler) {
-                $this->log[] = 'first';
+        $this->builder->registerMiddleware('first', function ($request, $handler) {
+            $this->log[] = 'first';
 
-                return $handler->handle($request);
-            });
-            $routes->registerMiddleware('second', function ($request, $handler) {
-                $this->log[] = 'second';
+            return $handler->handle($request);
+        });
+        $this->builder->registerMiddleware('second', function ($request, $handler) {
+            $this->log[] = 'second';
 
-                return $handler->handle($request);
-            });
+            return $handler->handle($request);
+        });
 
-            $routes->scope('/api', function (RouteBuilder $routes): void {
-                $routes->applyMiddleware('first');
-                $routes->connect('/ping', ['controller' => 'Pings']);
-            });
+        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+            $routes->applyMiddleware('first');
+            $routes->connect('/ping', ['controller' => 'Pings']);
+        });
 
-            $routes->scope('/api', function (RouteBuilder $routes): void {
-                $routes->applyMiddleware('second');
-                $routes->connect('/version', ['controller' => 'Version']);
-            });
+        $this->builder->scope('/api', function (RouteBuilder $routes): void {
+            $routes->applyMiddleware('second');
+            $routes->connect('/version', ['controller' => 'Version']);
         });
 
         $request = ServerRequestFactory::fromGlobals([

--- a/tests/TestCase/Routing/Route/RedirectRouteTest.php
+++ b/tests/TestCase/Routing/Route/RedirectRouteTest.php
@@ -28,6 +28,11 @@ use Cake\TestSuite\TestCase;
 class RedirectRouteTest extends TestCase
 {
     /**
+     * @var \Cake\Routing\RouteBuilder
+     */
+    protected $builder;
+
+    /**
      * setUp method
      */
     public function setUp(): void
@@ -35,8 +40,9 @@ class RedirectRouteTest extends TestCase
         parent::setUp();
         Router::reload();
 
-        Router::connect('/{controller}', ['action' => 'index']);
-        Router::connect('/{controller}/{action}/*');
+        $this->builder = Router::createRouteBuilder('/');
+        $this->builder->connect('/{controller}', ['action' => 'index']);
+        $this->builder->connect('/{controller}/{action}/*');
     }
 
     /**
@@ -204,7 +210,8 @@ class RedirectRouteTest extends TestCase
         $this->expectException(RedirectException::class);
         $this->expectExceptionMessage('http://localhost/nl/preferred_controllers');
         $this->expectExceptionCode(301);
-        Router::connect('/{lang}/preferred_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
+
+        $this->builder->connect('/{lang}/preferred_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route = new RedirectRoute('/{lang}/my_controllers', ['controller' => 'Tags', 'action' => 'add'], ['lang' => '(nl|en)', 'persist' => ['lang']]);
         $route->parse('/nl/my_controllers/');
     }

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -693,7 +693,8 @@ class RouteBuilderTest extends TestCase
      */
     public function testResourcesInScope(): void
     {
-        Router::scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
+        $builder = Router::createRouteBuilder('/');
+        $builder->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
         });

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -38,6 +38,11 @@ class RouterTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        Configure::write('Error.ignoredDeprecationPaths', [
+            'src/Routing/Router.php',
+            'tests/TestCase/Routing/RouterTest.php',
+        ]);
         Configure::write('Routing', ['prefixes' => []]);
         Router::reload();
     }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -51,6 +51,11 @@ class IntegrationTestTraitTest extends TestCase
     protected $key = 'abcdabcdabcdabcdabcdabcdabcdabcdabcd';
 
     /**
+     * @var \Cake\Routing\RouteBuilder
+     */
+    protected $builder;
+
+    /**
      * Setup method
      */
     public function setUp(): void
@@ -59,23 +64,23 @@ class IntegrationTestTraitTest extends TestCase
         static::setAppNamespace();
 
         Router::reload();
-        Router::extensions(['json']);
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->registerMiddleware('cookie', new EncryptedCookieMiddleware(['secrets'], $this->key));
-            $routes->applyMiddleware('cookie');
+        $this->builder = Router::createRouteBuilder('/');
+        $this->builder->setExtensions(['json']);
+        $this->builder->registerMiddleware('cookie', new EncryptedCookieMiddleware(['secrets'], $this->key));
+        $this->builder->applyMiddleware('cookie');
 
-            $routes->setRouteClass(InflectedRoute::class);
-            $routes->get('/get/{controller}/{action}', []);
-            $routes->head('/head/{controller}/{action}', []);
-            $routes->options('/options/{controller}/{action}', []);
-            $routes->connect('/{controller}/{action}/*', []);
-        });
-        Router::scope('/cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
+        $this->builder->setRouteClass(InflectedRoute::class);
+        $this->builder->get('/get/{controller}/{action}', []);
+        $this->builder->head('/head/{controller}/{action}', []);
+        $this->builder->options('/options/{controller}/{action}', []);
+        $this->builder->connect('/{controller}/{action}/*', []);
+
+        $this->builder->scope('/cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware());
             $routes->applyMiddleware('cookieCsrf');
             $routes->connect('/posts/{action}', ['controller' => 'Posts']);
         });
-        Router::scope('/session-csrf/', ['csrf' => 'session'], function (RouteBuilder $routes): void {
+        $this->builder->scope('/session-csrf/', ['csrf' => 'session'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('sessionCsrf', new SessionCsrfProtectionMiddleware());
             $routes->applyMiddleware('sessionCsrf');
             $routes->connect('/posts/{action}/', ['controller' => 'Posts']);
@@ -283,7 +288,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testExceptionsInMiddlewareJsonView(): void
     {
         Router::reload();
-        Router::connect('/json_response/api_get_data', [
+        $this->builder->connect('/json_response/api_get_data', [
             'controller' => 'JsonResponse',
             'action' => 'apiGetData',
         ]);
@@ -950,7 +955,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testPostSessionCsrfSuccessWithSetCookieName(): void
     {
-        Router::scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
+        $this->builder->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                 [
                     'cookieName' => 'customCsrfToken',
@@ -973,7 +978,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testPostSessionCsrfFailureWithSetCookieName(): void
     {
-        Router::scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
+        $this->builder->scope('/custom-cookie-csrf/', ['csrf' => 'cookie'], function (RouteBuilder $routes): void {
             $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                 [
                     'cookieName' => 'customCsrfToken',

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Helper;
 
-use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\BreadcrumbsHelper;
@@ -41,9 +40,7 @@ class BreadcrumbsHelperTest extends TestCase
         $this->breadcrumbs = new BreadcrumbsHelper($view);
 
         Router::reload();
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks();
-        });
+        Router::createRouteBuilder('/')->fallbacks();
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -127,8 +127,9 @@ class FormHelperTest extends TestCase
         ];
 
         Security::setSalt('foo!');
-        Router::connect('/{controller}', ['action' => 'index']);
-        Router::connect('/{controller}/{action}/*');
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/{controller}', ['action' => 'index']);
+        $builder->connect('/{controller}/{action}/*');
     }
 
     /**
@@ -752,7 +753,8 @@ class FormHelperTest extends TestCase
      */
     public function testCreateCustomRoute(): void
     {
-        Router::connect('/login', ['controller' => 'Users', 'action' => 'login']);
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/login', ['controller' => 'Users', 'action' => 'login']);
         $encoding = strtolower(Configure::read('App.encoding'));
 
         $this->View->setRequest($this->View->getRequest()
@@ -767,7 +769,7 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
-        Router::connect(
+        $builder->connect(
             '/new-article',
             ['controller' => 'Articles', 'action' => 'myAction'],
             ['_name' => 'my-route']

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -22,7 +22,6 @@ use Cake\Filesystem\Filesystem;
 use Cake\Http\ServerRequest;
 use Cake\I18n\FrozenDate;
 use Cake\Routing\Route\DashedRoute;
-use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\HtmlHelper;
@@ -84,9 +83,8 @@ class HtmlHelperTest extends TestCase
         static::setAppNamespace();
         Configure::write('Asset.timestamp', false);
 
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks(DashedRoute::class);
-        });
+        $builder = Router::createRouteBuilder('/');
+        $builder->fallbacks(DashedRoute::class);
     }
 
     /**
@@ -105,8 +103,9 @@ class HtmlHelperTest extends TestCase
     public function testLink(): void
     {
         Router::reload();
-        Router::connect('/{controller}', ['action' => 'index']);
-        Router::connect('/{controller}/{action}/*');
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/{controller}', ['action' => 'index']);
+        $builder->connect('/{controller}/{action}/*');
         Router::setRequest(new ServerRequest());
 
         $this->View->setRequest($this->View->getRequest()->withAttribute('webroot', ''));
@@ -347,8 +346,9 @@ class HtmlHelperTest extends TestCase
      */
     public function testImageTag(): void
     {
-        Router::connect('/:controller', ['action' => 'index']);
-        Router::connect('/:controller/:action/*');
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/:controller', ['action' => 'index']);
+        $builder->connect('/:controller/:action/*');
 
         $result = $this->Html->image('test.gif');
         $expected = ['img' => ['src' => 'img/test.gif', 'alt' => '']];
@@ -1489,7 +1489,7 @@ class HtmlHelperTest extends TestCase
      */
     public function testMeta(): void
     {
-        Router::connect('/:controller', ['action' => 'index']);
+        Router::createRouteBuilder('/')->connect('/:controller', ['action' => 'index']);
 
         $result = $this->Html->meta('this is an rss feed', ['controller' => 'Posts', '_ext' => 'rss']);
         $expected = ['link' => ['href' => 'preg:/.*\/posts\.rss/', 'type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => 'this is an rss feed']];

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -77,9 +77,10 @@ class PaginatorHelperTest extends TestCase
         $this->Paginator = new PaginatorHelper($this->View);
 
         Router::reload();
-        Router::connect('/', ['controller' => 'Articles', 'action' => 'index']);
-        Router::connect('/{controller}/{action}/*');
-        Router::connect('/{plugin}/{controller}/{action}/*');
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/', ['controller' => 'Articles', 'action' => 'index']);
+        $builder->connect('/{controller}/{action}/*');
+        $builder->connect('/{plugin}/{controller}/{action}/*');
         Router::setRequest($request);
 
         $this->locale = I18n::getLocale();
@@ -731,7 +732,7 @@ class PaginatorHelperTest extends TestCase
     public function testSortAdminLinks(): void
     {
         Router::reload();
-        Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
+        Router::createRouteBuilder('/')->connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
 
         $request = new ServerRequest([
             'url' => '/admin/users',
@@ -929,8 +930,9 @@ class PaginatorHelperTest extends TestCase
     public function testGenerateUrlWithPrefixes(): void
     {
         Router::reload();
-        Router::connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
-        Router::connect('/{controller}/{action}/*');
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
+        $builder->connect('/{controller}/{action}/*');
 
         $request = new ServerRequest([
             'url' => '/Posts/index',
@@ -1004,8 +1006,9 @@ class PaginatorHelperTest extends TestCase
     public function testGenerateUrlWithPrefixesLeavePrefix(): void
     {
         Router::reload();
-        Router::connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
-        Router::connect('/{controller}/{action}/*');
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect('/members/{controller}/{action}/*', ['prefix' => 'Members']);
+        $builder->connect('/{controller}/{action}/*');
 
         $request = new ServerRequest([
             'params' => [
@@ -1817,7 +1820,7 @@ class PaginatorHelperTest extends TestCase
     public function testRoutePlaceholder(): void
     {
         Router::reload();
-        Router::connect('/{controller}/{action}/{page}');
+        Router::createRouteBuilder('/')->connect('/{controller}/{action}/{page}');
         $request = $this->View
             ->getRequest()
             ->withAttribute('params', [
@@ -1855,7 +1858,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         Router::reload();
-        Router::connect('/{controller}/{action}/{sort}/{direction}');
+        Router::createRouteBuilder('/')->connect('/{controller}/{action}/{sort}/{direction}');
         Router::setRequest($request);
 
         $this->Paginator->options(['routePlaceholders' => ['sort', 'direction']]);

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -20,7 +20,6 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Route\DashedRoute;
-use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\UrlHelper;
@@ -43,6 +42,11 @@ class UrlHelperTest extends TestCase
     protected $View;
 
     /**
+     * @var \Cake\Routing\RouteBuilder
+     */
+    protected $builder;
+
+    /**
      * setUp method
      */
     public function setUp(): void
@@ -58,9 +62,8 @@ class UrlHelperTest extends TestCase
 
         static::setAppNamespace();
         $this->loadPlugins(['TestTheme']);
-        Router::scope('/', function (RouteBuilder $routes): void {
-            $routes->fallbacks(DashedRoute::class);
-        });
+        $this->builder = Router::createRouteBuilder('/');
+        $this->builder->fallbacks(DashedRoute::class);
     }
 
     /**
@@ -79,7 +82,7 @@ class UrlHelperTest extends TestCase
      */
     public function testBuildUrlConversion(): void
     {
-        Router::connect('/:controller/:action/*');
+        $this->builder->connect('/:controller/:action/*');
 
         $result = $this->Helper->build('/controller/action/1');
         $this->assertSame('/controller/action/1', $result);
@@ -117,7 +120,7 @@ class UrlHelperTest extends TestCase
      */
     public function testBuildBasePath(): void
     {
-        Router::connect('/:controller/:action/*');
+        $this->builder->connect('/:controller/:action/*');
         $request = new ServerRequest([
             'params' => [
                 'action' => 'index',

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -14,10 +14,9 @@
  */
 
 use Cake\Routing\RouteBuilder;
-use Cake\Routing\Router;
 
-Router::extensions('json');
-Router::scope('/', function (RouteBuilder $routes): void {
+$routes->setExtensions('json');
+$routes->scope('/', function (RouteBuilder $routes): void {
     $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
     $routes->connect(
         '/some_alias',


### PR DESCRIPTION
The RouteBuilder's instance methods should be used instead.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
