### PR TITLE
cake 5: Add use statements for all fully qualified classes

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -21,6 +21,7 @@ use Cake\Mailer\Message;
 use Cake\Network\Exception\SocketException;
 use Cake\Network\Socket;
 use Exception;
+use RuntimeException;
 
 /**
  * Send mail using SMTP protocol
@@ -539,7 +540,7 @@ class SmtpTransport extends AbstractTransport
     protected function _socket(): Socket
     {
         if ($this->_socket === null) {
-            throw new \RuntimeException('Socket is null, but must be set.');
+            throw new RuntimeException('Socket is null, but must be set.');
         }
 
         return $this->_socket;

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -16,13 +16,14 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Locator;
 
+use Cake\Datasource\Locator\LocatorInterface as BaseLocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Table;
 
 /**
  * Registries for Table objects should implement this interface.
  */
-interface LocatorInterface extends \Cake\Datasource\Locator\LocatorInterface
+interface LocatorInterface extends BaseLocatorInterface
 {
     /**
      * Returns configuration for an alias or the full configuration array for

--- a/tests/TestCase/BasicsTest.php
+++ b/tests/TestCase/BasicsTest.php
@@ -23,6 +23,7 @@ use Cake\Error\Debugger;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
+use stdClass;
 
 require_once CAKE . 'basics.php';
 
@@ -199,7 +200,7 @@ class BasicsTest extends TestCase
         $this->assertFalse($result['foo']);
         $this->assertTrue($result['bar']);
 
-        $obj = new \stdClass();
+        $obj = new stdClass();
         $result = h($obj);
         $this->assertSame('(object)stdClass', $result);
 

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Cache;
 
+use BadMethodCallException;
 use Cake\Cache\Cache;
 use Cake\Cache\CacheRegistry;
 use Cake\Cache\Engine\FileEngine;
@@ -23,6 +24,7 @@ use Cake\Cache\Engine\NullEngine;
 use Cake\Cache\InvalidArgumentException;
 use Cake\TestSuite\TestCase;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
+use stdClass;
 
 /**
  * CacheTest class
@@ -386,7 +388,7 @@ class CacheTest extends TestCase
         $config = ['engine' => 'Imaginary'];
         Cache::setConfig('test', $config);
 
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         Cache::pool('test');
     }
@@ -396,11 +398,11 @@ class CacheTest extends TestCase
      */
     public function testConfigInvalidObject(): void
     {
-        $this->getMockBuilder(\stdClass::class)
+        $this->getMockBuilder(stdClass::class)
             ->setMockClassName('RubbishEngine')
             ->getMock();
 
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         Cache::setConfig('test', [
             'engine' => '\RubbishEngine',
@@ -414,7 +416,7 @@ class CacheTest extends TestCase
     {
         Cache::setConfig('tests', ['engine' => 'File', 'path' => CACHE]);
 
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         Cache::setConfig('tests', ['engine' => 'Apc']);
     }

--- a/tests/TestCase/Cache/Engine/ArrayEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ArrayEngineTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Cache\Engine;
 
+use ArrayObject;
 use Cake\Cache\Cache;
 use Cake\Cache\Engine\ArrayEngine;
 use Cake\Cache\InvalidArgumentException;
@@ -262,7 +263,7 @@ class ArrayEngineTest extends TestCase
      */
     public function testWriteManyTraversable(): void
     {
-        $data = new \ArrayObject([
+        $data = new ArrayObject([
             'a' => 1,
             'b' => 'foo',
         ]);

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -120,7 +120,7 @@ class MemcachedEngineTest extends TestCase
             'compress' => false,
         ]);
 
-        $this->assertFalse($Memcached->getOption(\Memcached::OPT_COMPRESSION));
+        $this->assertFalse($Memcached->getOption(Memcached::OPT_COMPRESSION));
 
         $MemcachedCompressed = new MemcachedEngine();
         $MemcachedCompressed->init([
@@ -129,7 +129,7 @@ class MemcachedEngineTest extends TestCase
             'compress' => true,
         ]);
 
-        $this->assertTrue($MemcachedCompressed->getOption(\Memcached::OPT_COMPRESSION));
+        $this->assertTrue($MemcachedCompressed->getOption(Memcached::OPT_COMPRESSION));
     }
 
     /**
@@ -153,7 +153,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testInvalidSerializerSetting(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid_serializer is not a valid serializer engine for Memcached');
         $Memcached = new MemcachedEngine();
         $config = [
@@ -266,7 +266,7 @@ class MemcachedEngineTest extends TestCase
             'serialize' => 'json',
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Memcached extension is not compiled with json support');
         $Memcached->init($config);
     }
@@ -293,7 +293,7 @@ class MemcachedEngineTest extends TestCase
             'serialize' => 'msgpack',
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Memcached extension is not compiled with msgpack support');
         $Memcached->init($config);
     }
@@ -316,7 +316,7 @@ class MemcachedEngineTest extends TestCase
             'serialize' => 'igbinary',
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Memcached extension is not compiled with igbinary support');
         $Memcached->init($config);
     }
@@ -327,7 +327,7 @@ class MemcachedEngineTest extends TestCase
      */
     public function testSaslAuthException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Memcached extension is not build with SASL support');
         $this->skipIf(
             method_exists(Memcached::class, 'setSaslAuthData'),
@@ -341,7 +341,7 @@ class MemcachedEngineTest extends TestCase
             'username' => 'test',
             'password' => 'password',
         ];
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Memcached extension is not built with SASL support');
         $MemcachedEngine->init($config);
     }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -19,11 +19,15 @@ namespace Cake\Test\TestCase\Collection;
 use ArrayIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
+use Cake\Collection\Iterator\BufferedIterator;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use DateInterval;
 use DatePeriod;
+use DateTime;
 use Generator;
 use InvalidArgumentException;
+use LogicException;
 use NoRewindIterator;
 use stdClass;
 use TestApp\Collection\CountableIterator;
@@ -199,7 +203,7 @@ class CollectionTest extends TestCase
      */
     public function testIteratorIsWrapped(): void
     {
-        $items = new \ArrayObject([1, 2, 3]);
+        $items = new ArrayObject([1, 2, 3]);
         $collection = new Collection($items);
         $this->assertEquals(iterator_to_array($items), iterator_to_array($collection));
     }
@@ -988,9 +992,9 @@ class CollectionTest extends TestCase
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $result = $collection->take(3, 1)->toList();
         $expected = [
-            new \DateTime('2017-01-02'),
-            new \DateTime('2017-01-03'),
-            new \DateTime('2017-01-04'),
+            new DateTime('2017-01-02'),
+            new DateTime('2017-01-03'),
+            new DateTime('2017-01-04'),
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1178,7 +1182,7 @@ class CollectionTest extends TestCase
             ['myField' => '2'],
             ['myField' => '3'],
         ];
-        $buffered = (new \Cake\Collection\Collection($data))->buffered();
+        $buffered = (new Collection($data))->buffered();
         // Check going forwards
         $this->assertNotEmpty($buffered->firstMatch(['myField' => '1']));
         $this->assertNotEmpty($buffered->firstMatch(['myField' => '2']));
@@ -1893,8 +1897,8 @@ class CollectionTest extends TestCase
      */
     public function testIsEmptyDoesNotConsume(): void
     {
-        $array = new \ArrayIterator([1, 2, 3]);
-        $inner = new \Cake\Collection\Iterator\BufferedIterator($array);
+        $array = new ArrayIterator([1, 2, 3]);
+        $inner = new BufferedIterator($array);
         $collection = new Collection($inner);
         $this->assertFalse($collection->isEmpty());
         $this->assertCount(3, $collection->toArray());
@@ -1969,9 +1973,9 @@ class CollectionTest extends TestCase
         $collection = new Collection($this->datePeriod('2017-01-01', '2017-01-07'));
         $result = $collection->skip(3)->toList();
         $expected = [
-            new \DateTime('2017-01-04'),
-            new \DateTime('2017-01-05'),
-            new \DateTime('2017-01-06'),
+            new DateTime('2017-01-04'),
+            new DateTime('2017-01-05'),
+            new DateTime('2017-01-06'),
         ];
         $this->assertEquals($expected, $result);
     }
@@ -2122,7 +2126,7 @@ class CollectionTest extends TestCase
     public function testLastNtWithNegative($data): void
     {
         $collection = new Collection($data);
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The takeLast method requires a number greater than 0.');
         $collection->takeLast(-1)->toArray();
     }
@@ -2475,7 +2479,7 @@ class CollectionTest extends TestCase
      */
     public function testCartesianProductMultidimensionalArray(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $collection = new Collection([
             [
                 'names' => [
@@ -2517,7 +2521,7 @@ class CollectionTest extends TestCase
      */
     public function testTransposeUnEvenLengthShouldThrowException(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $collection = new Collection([
             ['Products', '2012', '2013', '2014'],
             ['Product A', '200', '100', '50'],
@@ -2549,7 +2553,7 @@ class CollectionTest extends TestCase
      */
     protected function datePeriod($start, $end): DatePeriod
     {
-        return new \DatePeriod(new \DateTime($start), new \DateInterval('P1D'), new \DateTime($end));
+        return new DatePeriod(new DateTime($start), new DateInterval('P1D'), new DateTime($end));
     }
 
     /**

--- a/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/FilterIteratorTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Iterator\FilterIterator;
 use Cake\TestSuite\TestCase;
 
@@ -29,7 +30,7 @@ class FilterIteratorTest extends TestCase
      */
     public function testFilter(): void
     {
-        $items = new \ArrayIterator([1, 2, 3]);
+        $items = new ArrayIterator([1, 2, 3]);
         $callable = function ($value, $key, $itemArg) use ($items) {
             $this->assertSame($items, $itemArg);
             $this->assertContains($value, $items);

--- a/tests/TestCase/Collection/Iterator/MapReduceTest.php
+++ b/tests/TestCase/Collection/Iterator/MapReduceTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Collection\Iterator;
 use ArrayIterator;
 use Cake\Collection\Iterator\MapReduce;
 use Cake\TestSuite\TestCase;
+use LogicException;
 
 /**
  * Tests MapReduce class
@@ -87,7 +88,7 @@ class MapReduceTest extends TestCase
      */
     public function testReducerRequired(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $data = ['a' => ['one', 'two'], 'b' => ['three', 'four']];
         $mapper = function ($row, $key, $mr): void {
             foreach ($row as $number) {

--- a/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/ReplaceIteratorTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Collection\Iterator;
 
+use ArrayIterator;
 use Cake\Collection\Iterator\ReplaceIterator;
 use Cake\TestSuite\TestCase;
 
@@ -29,7 +30,7 @@ class ReplaceIteratorTest extends TestCase
      */
     public function testReplace(): void
     {
-        $items = new \ArrayIterator([1, 2, 3]);
+        $items = new ArrayIterator([1, 2, 3]);
         $callable = function ($value, $key, $itemsArg) use ($items) {
             $this->assertSame($items, $itemsArg);
             $this->assertContains($value, $items);

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -19,6 +19,12 @@ namespace Cake\Test\TestCase\Collection\Iterator;
 use ArrayObject;
 use Cake\Collection\Iterator\SortIterator;
 use Cake\TestSuite\TestCase;
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+use const SORT_ASC;
+use const SORT_DESC;
+use const SORT_NUMERIC;
 
 /**
  * SortIterator Test
@@ -75,7 +81,7 @@ class SortIteratorTest extends TestCase
         $callback = function ($a) {
             return $a['foo'];
         };
-        $sorted = new SortIterator($items, $callback, \SORT_DESC, \SORT_NUMERIC);
+        $sorted = new SortIterator($items, $callback, SORT_DESC, SORT_NUMERIC);
         $expected = [
             ['foo' => 13, 'bar' => 'a'],
             ['foo' => 10, 'bar' => 'a'],
@@ -84,7 +90,7 @@ class SortIteratorTest extends TestCase
         ];
         $this->assertEquals($expected, $sorted->toList());
 
-        $sorted = new SortIterator($items, $callback, \SORT_ASC, \SORT_NUMERIC);
+        $sorted = new SortIterator($items, $callback, SORT_ASC, SORT_NUMERIC);
         $expected = [
             ['foo' => 1, 'bar' => 'a'],
             ['foo' => 2, 'bar' => 'a'],
@@ -186,34 +192,34 @@ class SortIteratorTest extends TestCase
     public function testSortDateTime(): void
     {
         $items = new ArrayObject([
-            new \DateTime('2014-07-21'),
-            new \DateTime('2015-06-30'),
-            new \DateTimeImmutable('2013-08-12'),
+            new DateTime('2014-07-21'),
+            new DateTime('2015-06-30'),
+            new DateTimeImmutable('2013-08-12'),
         ]);
 
         $callback = function ($a) {
-            return $a->add(new \DateInterval('P1Y'));
+            return $a->add(new DateInterval('P1Y'));
         };
         $sorted = new SortIterator($items, $callback);
         $expected = [
-            new \DateTime('2016-06-30'),
-            new \DateTime('2015-07-21'),
-            new \DateTimeImmutable('2013-08-12'),
+            new DateTime('2016-06-30'),
+            new DateTime('2015-07-21'),
+            new DateTimeImmutable('2013-08-12'),
 
         ];
         $this->assertEquals($expected, $sorted->toList());
 
         $items = new ArrayObject([
-            new \DateTime('2014-07-21'),
-            new \DateTime('2015-06-30'),
-            new \DateTimeImmutable('2013-08-12'),
+            new DateTime('2014-07-21'),
+            new DateTime('2015-06-30'),
+            new DateTimeImmutable('2013-08-12'),
         ]);
 
         $sorted = new SortIterator($items, $callback, SORT_ASC);
         $expected = [
-            new \DateTimeImmutable('2013-08-12'),
-            new \DateTime('2015-07-21'),
-            new \DateTime('2016-06-30'),
+            new DateTimeImmutable('2013-08-12'),
+            new DateTime('2015-07-21'),
+            new DateTime('2016-06-30'),
         ];
         $this->assertEquals($expected, $sorted->toList());
     }

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -24,6 +24,7 @@ use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Filesystem;
+use SplFileInfo;
 
 /**
  * PluginAssetsCommandsTest class
@@ -151,7 +152,7 @@ class PluginAssetsCommandsTest extends TestCase
         $this->exec('plugin assets symlink TestPlugin');
 
         $path = $this->wwwRoot . 'test_plugin';
-        $link = new \SplFileInfo($path);
+        $link = new SplFileInfo($path);
         $this->assertFileExists($path . DS . 'root.js');
 
         $path = $this->wwwRoot . 'company' . DS . 'test_plugin_three';
@@ -189,7 +190,7 @@ class PluginAssetsCommandsTest extends TestCase
         $pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'webroot';
 
         $path = $this->wwwRoot . 'test_plugin';
-        $dir = new \SplFileInfo($path);
+        $dir = new SplFileInfo($path);
         $this->assertTrue($dir->isDir());
         $this->assertFileExists($path . DS . 'root.js');
 

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -56,7 +56,7 @@ class CommandCollectionTest extends TestCase
      */
     public function testConstructorInvalidClass(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'nope\'. It is not a subclass of Cake\Console\CommandInterface');
         new CommandCollection([
             'nope' => stdClass::class,
@@ -147,7 +147,7 @@ class CommandCollectionTest extends TestCase
      */
     public function testInvalidCommandClassName(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot use \'Cake\TestSuite\TestCase\' for command \'routes\'. It is not a subclass of Cake\Console\CommandInterface');
         $collection = new CommandCollection();
         $collection->add('routes', TestCase::class);

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -29,6 +29,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DemoCommand;
 use TestApp\Command\DependencyCommand;
@@ -104,7 +105,7 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunMissingRootCommand(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot run any commands. No arguments received.');
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
+use Cake\Console\Exception\MissingHelperException;
 use Cake\Console\HelperRegistry;
 use Cake\TestSuite\TestCase;
 use TestApp\Command\Helper\CommandHelper;
@@ -94,7 +95,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadMissingHelper(): void
     {
-        $this->expectException(\Cake\Console\Exception\MissingHelperException::class);
+        $this->expectException(MissingHelperException::class);
         $this->helpers->load('ThisTaskShouldAlwaysBeMissing');
     }
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -29,6 +29,7 @@ use Cake\Http\ServerRequest;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use stdClass;
 use TestApp\Datasource\CustomPaginator;
 
@@ -112,7 +113,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testInvalidPaginatorOption(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Paginator must be an instance of Cake\Datasource\Paginator');
         new PaginatorComponent($this->registry, [
             'paginator' => new stdClass(),
@@ -769,7 +770,7 @@ class PaginatorComponentTest extends TestCase
      */
     public function testOutOfVeryBigPageNumberGetsClamped(): void
     {
-        $this->expectException(\Cake\Http\Exception\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
         $this->loadFixtures('Posts');
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams([
             'page' => '3000000000000000000000000',

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -20,6 +20,7 @@ use Cake\Controller\Component\RequestHandlerComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Event\Event;
+use Cake\Event\EventInterface;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -574,7 +575,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testRenderAsCalledTwice(): void
     {
-        $this->Controller->getEventManager()->on('Controller.beforeRender', function (\Cake\Event\EventInterface $e) {
+        $this->Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
         $this->Controller->render();

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -20,6 +20,7 @@ use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\Component\RequestHandlerComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
+use Cake\Controller\Exception\MissingComponentException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -117,7 +118,7 @@ class ComponentRegistryTest extends TestCase
      */
     public function testLoadMissingComponent(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingComponentException::class);
+        $this->expectException(MissingComponentException::class);
         $this->Components->load('ThisComponentShouldAlwaysBeMissing');
     }
 
@@ -209,7 +210,7 @@ class ComponentRegistryTest extends TestCase
      */
     public function testUnloadUnknown(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingComponentException::class);
+        $this->expectException(MissingComponentException::class);
         $this->expectExceptionMessage('Component class FooComponent could not be found.');
         $this->Components->unload('Foo');
     }

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -18,9 +18,11 @@ namespace Cake\Test\TestCase\Controller;
 use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
+use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 use TestApp\Controller\Component\AppleComponent;
 use TestApp\Controller\Component\BananaComponent;
 use TestApp\Controller\Component\ConfiguredComponent;
@@ -106,7 +108,7 @@ class ComponentTest extends TestCase
      */
     public function testDuplicateComponentInitialize(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The "Banana" alias has already been loaded. The `property` key');
         $Collection = new ComponentRegistry();
         $Collection->load('Banana', ['property' => ['closure' => function (): void {
@@ -192,7 +194,7 @@ class ComponentTest extends TestCase
      */
     public function testLazyLoadingDoesNotExists(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingComponentException::class);
+        $this->expectException(MissingComponentException::class);
         $this->expectExceptionMessage('Component class YouHaveNoBananasComponent could not be found.');
         $Component = new ConfiguredComponent(new ComponentRegistry(), [], ['YouHaveNoBananas']);
         $bananas = $Component->YouHaveNoBananas;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Controller;
 
 use Cake\Controller\Controller;
+use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventInterface;
@@ -26,11 +27,16 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Uri;
 use ReflectionFunction;
-use TestApp\Controller\Admin\PostsController;
+use RuntimeException;
+use TestApp\Controller\Admin\PostsController as AdminPostsController;
 use TestApp\Controller\ArticlesController;
+use TestApp\Controller\PagesController;
+use TestApp\Controller\PostsController;
 use TestApp\Controller\TestController;
 use TestApp\Model\Table\ArticlesTable;
+use TestPlugin\Controller\Admin\CommentsController;
 use TestPlugin\Controller\TestPluginController;
+use UnexpectedValueException;
 
 /**
  * ControllerTest class
@@ -167,16 +173,16 @@ class ControllerTest extends TestCase
 
         $request = new ServerRequest();
         $response = new Response();
-        $controller = new \TestApp\Controller\PostsController($request, $response);
+        $controller = new PostsController($request, $response);
         $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
-        $controller = new \TestApp\Controller\Admin\PostsController($request, $response);
+        $controller = new AdminPostsController($request, $response);
         $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
         $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
         $request = $request->withParam('plugin', 'TestPlugin');
-        $controller = new \TestPlugin\Controller\Admin\CommentsController($request, $response);
+        $controller = new CommentsController($request, $response);
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->loadModel());
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->Comments);
     }
@@ -545,7 +551,7 @@ class ControllerTest extends TestCase
      */
     public function testGetActionMissingAction(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
+        $this->expectException(MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::missing() could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/missing',
@@ -562,7 +568,7 @@ class ControllerTest extends TestCase
      */
     public function testGetActionPrivate(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
+        $this->expectException(MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::private_m() could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/private_m/',
@@ -579,7 +585,7 @@ class ControllerTest extends TestCase
      */
     public function testGetActionProtected(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
+        $this->expectException(MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::protected_m() could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/protected_m/',
@@ -596,7 +602,7 @@ class ControllerTest extends TestCase
      */
     public function testGetActionBaseMethods(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
+        $this->expectException(MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::redirect() could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/redirect/',
@@ -613,7 +619,7 @@ class ControllerTest extends TestCase
      */
     public function testGetActionMethodCasing(): void
     {
-        $this->expectException(\Cake\Controller\Exception\MissingActionException::class);
+        $this->expectException(MissingActionException::class);
         $this->expectExceptionMessage('Action TestController::RETURNER() could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/RETURNER/',
@@ -693,7 +699,7 @@ class ControllerTest extends TestCase
      */
     public function testInvokeActionException(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage(
             'Controller actions can only return ResponseInterface instance or null. '
                 . 'Got string instead.'
@@ -723,7 +729,7 @@ class ControllerTest extends TestCase
             'params' => ['prefix' => 'Admin'],
         ]);
         $response = new Response();
-        $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
+        $Controller = new AdminPostsController($request, $response);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
@@ -732,7 +738,7 @@ class ControllerTest extends TestCase
 
         $request = $request->withParam('prefix', 'admin/super');
         $response = new Response();
-        $Controller = new \TestApp\Controller\Admin\PostsController($request, $response);
+        $Controller = new AdminPostsController($request, $response);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
@@ -745,7 +751,7 @@ class ControllerTest extends TestCase
                 'prefix' => false,
             ],
         ]);
-        $Controller = new \TestApp\Controller\PagesController($request, $response);
+        $Controller = new PagesController($request, $response);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
@@ -817,7 +823,7 @@ class ControllerTest extends TestCase
         try {
             $controller->loadComponent('Paginator', ['bad' => 'settings']);
             $this->fail('No exception');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString('The "Paginator" alias has already been loaded', $e->getMessage());
         }
     }
@@ -841,7 +847,7 @@ class ControllerTest extends TestCase
      */
     public function testBeforeRenderViewVariables(): void
     {
-        $controller = new PostsController();
+        $controller = new AdminPostsController();
 
         $controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
             /** @var \Cake\Controller\Controller $controller */
@@ -886,7 +892,7 @@ class ControllerTest extends TestCase
      */
     public function testName(): void
     {
-        $controller = new PostsController();
+        $controller = new AdminPostsController();
         $this->assertSame('Posts', $controller->getName());
 
         $this->assertSame($controller, $controller->setName('Articles'));
@@ -898,7 +904,7 @@ class ControllerTest extends TestCase
      */
     public function testPlugin(): void
     {
-        $controller = new PostsController();
+        $controller = new AdminPostsController();
         $this->assertNull($controller->getPlugin());
 
         $this->assertSame($controller, $controller->setPlugin('Articles'));
@@ -910,7 +916,7 @@ class ControllerTest extends TestCase
      */
     public function testRequest(): void
     {
-        $controller = new PostsController();
+        $controller = new AdminPostsController();
         $this->assertInstanceOf(ServerRequest::class, $controller->getRequest());
 
         $request = new ServerRequest([
@@ -934,7 +940,7 @@ class ControllerTest extends TestCase
      */
     public function testResponse(): void
     {
-        $controller = new PostsController();
+        $controller = new AdminPostsController();
         $this->assertInstanceOf(Response::class, $controller->getResponse());
 
         $response = new Response();
@@ -947,7 +953,7 @@ class ControllerTest extends TestCase
      */
     public function testAutoRender(): void
     {
-        $controller = new PostsController();
+        $controller = new AdminPostsController();
         $this->assertTrue($controller->isAutoRenderEnabled());
 
         $this->assertSame($controller, $controller->disableAutoRender());

--- a/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/IniConfigTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Core\Configure\Engine;
 
 use Cake\Core\Configure\Engine\IniConfig;
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -151,7 +152,7 @@ class IniConfigTest extends TestCase
      */
     public function testReadWithExistentFileWithoutExtension(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new IniConfig($this->path);
         $engine->read('no_ini_extension');
     }
@@ -161,7 +162,7 @@ class IniConfigTest extends TestCase
      */
     public function testReadWithNonExistentFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new IniConfig($this->path);
         $engine->read('fake_values');
     }
@@ -181,7 +182,7 @@ class IniConfigTest extends TestCase
      */
     public function testReadWithDots(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new IniConfig($this->path);
         $engine->read('../empty');
     }

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Core\Configure\Engine;
 
 use Cake\Core\Configure\Engine\JsonConfig;
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -74,7 +75,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithExistentFileWithoutExtension(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new JsonConfig($this->path);
         $engine->read('no_json_extension');
     }
@@ -84,7 +85,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithNonExistentFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new JsonConfig($this->path);
         $engine->read('fake_values');
     }
@@ -94,7 +95,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadEmptyFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('config file "empty.json"');
         $engine = new JsonConfig($this->path);
         $config = $engine->read('empty');
@@ -105,7 +106,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithInvalidJson(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Error parsing JSON string fetched from config file "invalid.json"');
         $engine = new JsonConfig($this->path);
         $engine->read('invalid');
@@ -116,7 +117,7 @@ class JsonConfigTest extends TestCase
      */
     public function testReadWithDots(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new JsonConfig($this->path);
         $engine->read('../empty');
     }

--- a/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/PhpConfigTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Core\Configure\Engine;
 
 use Cake\Core\Configure\Engine\PhpConfig;
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -74,7 +75,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadWithExistentFileWithoutExtension(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('no_php_extension');
     }
@@ -84,7 +85,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadWithNonExistentFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('fake_values');
     }
@@ -94,7 +95,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadEmptyFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('empty');
     }
@@ -104,7 +105,7 @@ class PhpConfigTest extends TestCase
      */
     public function testReadWithDots(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $engine = new PhpConfig($this->path);
         $engine->read('../empty');
     }

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -19,7 +19,10 @@ namespace Cake\Test\TestCase\Core;
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
+use Exception;
+use RuntimeException;
 
 /**
  * ConfigureTest
@@ -79,7 +82,7 @@ class ConfigureTest extends TestCase
      */
     public function testReadOrFailThrowingException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
         Configure::readOrFail('This.Key.Does.Not.exist');
     }
@@ -250,7 +253,7 @@ class ConfigureTest extends TestCase
      */
     public function testLoadExceptionOnNonExistentFile(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         Configure::config('test', new PhpConfig());
         Configure::load('nonexistent_configuration_file', 'test');
     }
@@ -260,7 +263,7 @@ class ConfigureTest extends TestCase
      */
     public function testLoadExceptionOnNonExistentEngine(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         Configure::load('nonexistent_configuration_file', 'nonexistent_configuration_engine');
     }
 
@@ -271,7 +274,7 @@ class ConfigureTest extends TestCase
     {
         try {
             Configure::load('nonexistent_configuration_file');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->assertTrue(Configure::isConfigured('default'));
             $this->assertFalse(Configure::isConfigured('nonexistent_configuration_file'));
         }
@@ -483,7 +486,7 @@ class ConfigureTest extends TestCase
 
     public function testDumpNoAdapter(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         Configure::dump(TMP . 'test.php', 'does_not_exist');
     }
 
@@ -571,7 +574,7 @@ class ConfigureTest extends TestCase
      */
     public function testConsumeOrFailThrowingException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
         Configure::consumeOrFail('This.Key.Does.Not.exist');
     }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Core;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
+use stdClass;
 
 /**
  * Test cases for functions in Core\functions.php
@@ -71,7 +72,7 @@ class FunctionsTest extends TestCase
             [null, null],
             [1, 1],
             [1.1, 1.1],
-            [new \stdClass(), '(object)stdClass'],
+            [new stdClass(), '(object)stdClass'],
             [new Response(), ''],
             [['clean', '"clean-me'], ['clean', '&quot;clean-me']],
         ];

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Core;
 
 use Cake\TestSuite\TestCase;
+use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 use TestApp\Config\ReadOnlyTestInstanceConfig;
@@ -397,7 +398,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testReadOnlyConfig(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('This Instance is readonly');
         $object = new ReadOnlyTestInstanceConfig();
 
@@ -505,7 +506,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testDeleteClobber(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Cannot unset a.nested.value.whoops');
         $this->object->setConfig('a.nested.value.whoops', null);
     }

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -23,6 +23,7 @@ use Cake\Core\PluginInterface;
 use Cake\TestSuite\TestCase;
 use Company\TestPluginThree\Plugin as TestPluginThree;
 use InvalidArgumentException;
+use ParentPlugin\Plugin;
 use TestPlugin\Plugin as TestPlugin;
 
 /**
@@ -95,7 +96,7 @@ class PluginCollectionTest extends TestCase
     {
         $plugins = new PluginCollection();
         $plugin = $plugins->get('ParentPlugin');
-        $this->assertInstanceOf(\ParentPlugin\Plugin::class, $plugin);
+        $this->assertInstanceOf(Plugin::class, $plugin);
     }
 
     public function testGetInvalid(): void
@@ -111,14 +112,14 @@ class PluginCollectionTest extends TestCase
         $plugins = new PluginCollection();
 
         $plugin = $plugins->create('ParentPlugin');
-        $this->assertInstanceOf(\ParentPlugin\Plugin::class, $plugin);
+        $this->assertInstanceOf(Plugin::class, $plugin);
 
         $plugin = $plugins->create('ParentPlugin', ['name' => 'Granpa']);
-        $this->assertInstanceOf(\ParentPlugin\Plugin::class, $plugin);
+        $this->assertInstanceOf(Plugin::class, $plugin);
         $this->assertSame('Granpa', $plugin->getName());
 
-        $plugin = $plugins->create(\ParentPlugin\Plugin::class);
-        $this->assertInstanceOf(\ParentPlugin\Plugin::class, $plugin);
+        $plugin = $plugins->create(Plugin::class);
+        $this->assertInstanceOf(Plugin::class, $plugin);
 
         $plugin = $plugins->create('TestTheme');
         $this->assertInstanceOf(BasePlugin::class, $plugin);

--- a/tests/TestCase/Core/Retry/CommandRetryTest.php
+++ b/tests/TestCase/Core/Retry/CommandRetryTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Core\Retry;
 use Cake\Core\Retry\CommandRetry;
 use Cake\TestSuite\TestCase;
 use Exception;
+use TestApp\Database\Retry\TestRetryStrategy;
 
 /**
  * Tests for the CommandRetry class
@@ -39,7 +40,7 @@ class CommandRetryTest extends TestCase
             return $count;
         };
 
-        $strategy = new \TestApp\Database\Retry\TestRetryStrategy(true);
+        $strategy = new TestRetryStrategy(true);
         $retry = new CommandRetry($strategy, 2);
         $this->assertSame(2, $retry->run($action));
     }
@@ -59,7 +60,7 @@ class CommandRetryTest extends TestCase
             return $count;
         };
 
-        $strategy = new \TestApp\Database\Retry\TestRetryStrategy(true);
+        $strategy = new TestRetryStrategy(true);
         $retry = new CommandRetry($strategy, 1);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('this is failing');
@@ -75,7 +76,7 @@ class CommandRetryTest extends TestCase
             throw new Exception('this is failing');
         };
 
-        $strategy = new \TestApp\Database\Retry\TestRetryStrategy(false);
+        $strategy = new TestRetryStrategy(false);
         $retry = new CommandRetry($strategy, 2);
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('this is failing');

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -236,7 +236,7 @@ class SqlserverTest extends TestCase
      */
     public function testConnectionPersistentTrueException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Config setting "persistent" cannot be set to true, as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT');
         $this->skipIf($this->missingExtension, 'pdo_sqlsrv is not installed.');
         $config = [

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -24,6 +24,7 @@ use Cake\Database\QueryCompiler;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
+use Exception;
 use PDO;
 use PDOStatement;
 
@@ -56,7 +57,7 @@ class DriverTest extends TestCase
         $arg = ['login' => 'Bear'];
         try {
             $this->getMockForAbstractClass(Driver::class, [$arg]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->assertStringContainsString(
                 'Please pass "username" instead of "login" for connecting to the database',
                 $e->getMessage()

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Log\LoggedQuery;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
+use Exception;
 
 /**
  * Tests LoggedQuery class
@@ -167,7 +168,7 @@ class LoggedQueryTest extends TestCase
         $query->query = 'SELECT a FROM b where a = :p1';
         $query->params = ['p1' => '$2y$10$dUAIj'];
         $query->numRows = 4;
-        $query->error = new \Exception('You fail!');
+        $query->error = new Exception('You fail!');
 
         $expected = json_encode([
             'query' => $query->query,

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -22,6 +22,7 @@ use Cake\Database\Log\QueryLogger;
 use Cake\Database\StatementInterface;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use DateTime;
 use LogicException;
 
 /**
@@ -95,7 +96,7 @@ class LoggingStatementTest extends TestCase
         $inner->method('rowCount')->will($this->returnValue(4));
         $inner->method('execute')->will($this->returnValue(true));
 
-        $date = new \DateTime('2013-01-01');
+        $date = new DateTime('2013-01-01');
         $inner->expects($this->atLeast(2))
               ->method('bindValue')
               ->withConsecutive(['a', 1], ['b', $date]);
@@ -109,7 +110,7 @@ class LoggingStatementTest extends TestCase
         $st->execute();
         $st->fetchAll();
 
-        $st->bindValue('b', new \DateTime('2014-01-01'), 'date');
+        $st->bindValue('b', new DateTime('2014-01-01'), 'date');
         $st->execute();
         $st->fetchAll();
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -34,6 +34,7 @@ use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use ReflectionProperty;
@@ -288,7 +289,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:45:23');
+        $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
         $result = $query
             ->select(['title', 'comment' => 'c.comment'])
@@ -329,7 +330,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:45:23');
+        $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
         $result = $query
             ->select(['title', 'name' => 'c.comment'])
@@ -347,7 +348,7 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:45:23');
+        $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
         $result = $query
             ->select(['title', 'name' => 'c.comment'])
@@ -378,7 +379,7 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:45:23');
+        $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
         $statement = $query
             ->select(['title', 'name' => 'c.comment'])
@@ -396,11 +397,11 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
-            $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite,
+            $this->connection->getDriver() instanceof Sqlite,
             'SQLite does not support RIGHT joins'
         );
         $query = new Query($this->connection);
-        $time = new \DateTime('2007-03-18 10:45:23');
+        $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
         $result = $query
             ->select(['title', 'name' => 'c.comment'])
@@ -428,7 +429,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->innerJoin(['c' => 'comments'], function ($exp, $q) use ($query, $types) {
                 $this->assertSame($q, $query);
-                $exp->add(['created <' => new \DateTime('2007-03-18 10:45:23')], $types);
+                $exp->add(['created <' => new DateTime('2007-03-18 10:45:23')], $types);
 
                 return $exp;
             })
@@ -450,7 +451,7 @@ class QueryTest extends TestCase
             ->from('authors')
             ->innerJoin('comments', function ($exp, $q) use ($query, $types) {
                 $this->assertSame($q, $query);
-                $exp->add(['created' => new \DateTime('2007-03-18 10:47:23')], $types);
+                $exp->add(['created' => new DateTime('2007-03-18 10:47:23')], $types);
 
                 return $exp;
             })
@@ -651,7 +652,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+            ->where(['created' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
             ->execute();
         $this->assertCount(1, $result);
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
@@ -661,7 +662,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(['created >' => new \DateTime('2007-03-18 10:46:00')], ['created' => 'datetime'])
+            ->where(['created >' => new DateTime('2007-03-18 10:46:00')], ['created' => 'datetime'])
             ->execute();
         $this->assertCount(5, $result);
         $this->assertEquals(['id' => 2], $result->fetch('assoc'));
@@ -674,8 +675,8 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(
                 [
-                    'created >' => new \DateTime('2007-03-18 10:40:00'),
-                    'created <' => new \DateTime('2007-03-18 10:46:00'),
+                    'created >' => new DateTime('2007-03-18 10:40:00'),
+                    'created <' => new DateTime('2007-03-18 10:46:00'),
                 ],
                 ['created' => 'datetime']
             )
@@ -691,7 +692,7 @@ class QueryTest extends TestCase
             ->where(
                 [
                     'id' => '3',
-                    'created <' => new \DateTime('2013-01-01 12:00'),
+                    'created <' => new DateTime('2013-01-01 12:00'),
                 ],
                 ['created' => 'datetime', 'id' => 'integer']
             )
@@ -707,7 +708,7 @@ class QueryTest extends TestCase
             ->where(
                 [
                     'id' => '1',
-                    'created <' => new \DateTime('2013-01-01 12:00'),
+                    'created <' => new DateTime('2013-01-01 12:00'),
                 ],
                 ['created' => 'datetime', 'id' => 'integer']
             )
@@ -851,7 +852,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+            ->where(['created' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
             ->andWhere(['id' => 1])
             ->execute();
         $this->assertCount(1, $result);
@@ -862,7 +863,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->where(['created' => new \DateTime('2007-03-18 10:50:55')], ['created' => 'datetime'])
+            ->where(['created' => new DateTime('2007-03-18 10:50:55')], ['created' => 'datetime'])
             ->andWhere(['id' => 2])
             ->execute();
         $this->assertCount(0, $result);
@@ -879,7 +880,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->andWhere(['created' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
+            ->andWhere(['created' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
             ->andWhere(['id' => 1])
             ->execute();
         $this->assertCount(1, $result);
@@ -913,7 +914,7 @@ class QueryTest extends TestCase
             ->where(function ($exp) {
                 return $exp
                     ->eq('id', 1)
-                    ->eq('created', new \DateTime('2007-03-18 10:45:23'), 'datetime');
+                    ->eq('created', new DateTime('2007-03-18 10:45:23'), 'datetime');
             })
             ->execute();
         $this->assertCount(1, $result);
@@ -927,7 +928,7 @@ class QueryTest extends TestCase
             ->where(function ($exp) {
                 return $exp
                     ->eq('id', 1)
-                    ->eq('created', new \DateTime('2021-12-30 15:00'), 'datetime');
+                    ->eq('created', new DateTime('2021-12-30 15:00'), 'datetime');
             })
             ->execute();
         $this->assertCount(0, $result);
@@ -973,7 +974,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['id' => '1'])
             ->andWhere(function ($exp) {
-                return $exp->eq('created', new \DateTime('2007-03-18 10:45:23'), 'datetime');
+                return $exp->eq('created', new DateTime('2007-03-18 10:45:23'), 'datetime');
             })
             ->execute();
         $this->assertCount(1, $result);
@@ -986,7 +987,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['id' => '1'])
             ->andWhere(function ($exp) {
-                return $exp->eq('created', new \DateTime('2022-12-21 12:00'), 'datetime');
+                return $exp->eq('created', new DateTime('2022-12-21 12:00'), 'datetime');
             })
             ->execute();
         $this->assertCount(0, $result);
@@ -1163,7 +1164,7 @@ class QueryTest extends TestCase
             ->where(function ($exp) {
                 return $exp->in(
                     'created',
-                    [new \DateTime('2007-03-18 10:45:23'), new \DateTime('2007-03-18 10:47:23')],
+                    [new DateTime('2007-03-18 10:45:23'), new DateTime('2007-03-18 10:47:23')],
                     'datetime'
                 );
             })
@@ -1180,7 +1181,7 @@ class QueryTest extends TestCase
             ->where(function ($exp) {
                 return $exp->notIn(
                     'created',
-                    [new \DateTime('2007-03-18 10:45:23'), new \DateTime('2007-03-18 10:47:23')],
+                    [new DateTime('2007-03-18 10:45:23'), new DateTime('2007-03-18 10:47:23')],
                     'datetime'
                 );
             })
@@ -1373,8 +1374,8 @@ class QueryTest extends TestCase
             ->select(['id'])
             ->from('comments')
             ->where(function ($exp) {
-                $from = new \DateTime('2007-03-18 10:51:00');
-                $to = new \DateTime('2007-03-18 10:54:00');
+                $from = new DateTime('2007-03-18 10:51:00');
+                $to = new DateTime('2007-03-18 10:54:00');
 
                 return $exp->between('created', $from, $to, 'datetime');
             })
@@ -1540,7 +1541,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(function ($exp) {
                 return $exp->not(
-                    $exp->and(['id' => 2, 'created' => new \DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
+                    $exp->and(['id' => 2, 'created' => new DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
                 );
             })
             ->execute();
@@ -1555,7 +1556,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(function ($exp) {
                 return $exp->not(
-                    $exp->and(['id' => 2, 'created' => new \DateTime('2012-12-21 12:00')], ['created' => 'datetime'])
+                    $exp->and(['id' => 2, 'created' => new DateTime('2012-12-21 12:00')], ['created' => 'datetime'])
                 );
             })
             ->execute();
@@ -2454,7 +2455,7 @@ class QueryTest extends TestCase
         $subquery = (new Query($this->connection))
             ->select(['id', 'comment'])
             ->from('comments')
-            ->where(['created >' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime']);
+            ->where(['created >' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime']);
         $result = $query
             ->select(['say' => 'comment'])
             ->from(['b' => $subquery])
@@ -2500,7 +2501,7 @@ class QueryTest extends TestCase
         $subquery = (new Query($this->connection))
             ->select(['id'])
             ->from('comments')
-            ->where(['created >' => new \DateTime('2007-03-18 10:45:23')], ['created' => 'datetime']);
+            ->where(['created >' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime']);
         $result = $query
             ->select(['name'])
             ->from(['authors'])
@@ -2632,8 +2633,8 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
-            ($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite ||
-            $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver),
+            ($this->connection->getDriver() instanceof Sqlite ||
+            $this->connection->getDriver() instanceof Sqlserver),
             'Driver does not support ORDER BY in UNIONed queries.'
         );
         $union = (new Query($this->connection))
@@ -2806,7 +2807,7 @@ class QueryTest extends TestCase
      */
     public function testDeleteRemovingAliasesCanBreakJoins(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.');
         $query = new Query($this->connection);
 
@@ -3013,7 +3014,7 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
-        $date = new \DateTime();
+        $date = new DateTime();
         $query->update('comments')
             ->set(['comment' => 'mark', 'created' => $date], ['created' => 'date'])
             ->where(['id' => 1]);
@@ -3042,7 +3043,7 @@ class QueryTest extends TestCase
     {
         $this->loadFixtures('Comments');
         $query = new Query($this->connection);
-        $date = new \DateTime();
+        $date = new DateTime();
         $query->update('comments')
             ->set(function ($exp) use ($date) {
                 return $exp
@@ -3110,7 +3111,7 @@ class QueryTest extends TestCase
      */
     public function testUpdateRemovingAliasesCanBreakJoins(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.');
         $query = new Query($this->connection);
 
@@ -3207,7 +3208,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof Sqlserver) {
             $this->assertCount(1, $result, '1 row should be inserted');
         }
 
@@ -3269,7 +3270,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof Sqlserver) {
             $this->assertCount(1, $result, '1 row should be inserted');
         }
 
@@ -3305,7 +3306,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof Sqlserver) {
             $this->assertCount(2, $result, '2 rows should be inserted');
         }
 
@@ -3361,7 +3362,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof Sqlserver) {
             $this->assertCount(1, $result);
         }
 
@@ -3423,7 +3424,7 @@ class QueryTest extends TestCase
         $result->closeCursor();
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof Sqlserver) {
             $this->assertCount(1, $result);
         }
 
@@ -3453,7 +3454,7 @@ class QueryTest extends TestCase
         $result = $query->execute();
         $result->closeCursor();
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
-        if (!$this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver) {
+        if (!$this->connection->getDriver() instanceof Sqlserver) {
             $this->assertCount(1, $result);
         }
 
@@ -3554,7 +3555,7 @@ class QueryTest extends TestCase
 
         $this->assertWithinRange(
             date('U'),
-            (new \DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
+            (new DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
             5
         );
 
@@ -3564,7 +3565,7 @@ class QueryTest extends TestCase
             ->execute();
         $this->assertWithinRange(
             date('U'),
-            (new \DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
+            (new DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
             5
         );
 
@@ -3707,7 +3708,7 @@ class QueryTest extends TestCase
 
         $results = $query->select(['id', 'comment'])
             ->from('comments')
-            ->where(['created >=' => new \DateTime('2007-03-18 10:55:00')])
+            ->where(['created >=' => new DateTime('2007-03-18 10:55:00')])
             ->execute();
         $expected = [['id' => '6', 'comment' => 'Second Comment for Second Article']];
         $this->assertEquals($expected, $results->fetchAll('assoc'));
@@ -3715,7 +3716,7 @@ class QueryTest extends TestCase
         // Now test default can be overridden
         $types = ['created' => 'date'];
         $results = $query
-            ->where(['created >=' => new \DateTime('2007-03-18 10:50:00')], $types, true)
+            ->where(['created >=' => new DateTime('2007-03-18 10:50:00')], $types, true)
             ->execute();
         $this->assertCount(6, $results, 'All 6 rows should match.');
     }
@@ -3730,8 +3731,8 @@ class QueryTest extends TestCase
         $results = $query->select(['id', 'comment'])
             ->from('comments')
             ->where(['created BETWEEN :foo AND :bar'])
-            ->bind(':foo', new \DateTime('2007-03-18 10:50:00'), 'datetime')
-            ->bind(':bar', new \DateTime('2007-03-18 10:52:00'), 'datetime')
+            ->bind(':foo', new DateTime('2007-03-18 10:50:00'), 'datetime')
+            ->bind(':bar', new DateTime('2007-03-18 10:52:00'), 'datetime')
             ->execute();
         $expected = [['id' => '4', 'comment' => 'Fourth Comment for First Article']];
         $this->assertEquals($expected, $results->fetchAll('assoc'));
@@ -4111,7 +4112,7 @@ class QueryTest extends TestCase
      */
     public function testIsNullInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expression `name` is missing operator (IS, IS NOT) with `null` value.');
 
         $this->loadFixtures('Authors');
@@ -4128,7 +4129,7 @@ class QueryTest extends TestCase
      */
     public function testIsNotNullInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->loadFixtures('Authors');
         (new Query($this->connection))
@@ -4224,7 +4225,7 @@ class QueryTest extends TestCase
             );
 
         // Postgres requires the case statement to be cast to a integer
-        if ($this->connection->getDriver() instanceof \Cake\Database\Driver\Postgres) {
+        if ($this->connection->getDriver() instanceof Postgres) {
             $publishedCase = $query->func()->cast($publishedCase, 'integer');
             $notPublishedCase = $query->func()->cast($notPublishedCase, 'integer');
         }
@@ -4455,8 +4456,8 @@ class QueryTest extends TestCase
             ->from('comments')
             ->setDefaultTypes(['created' => 'datetime'])
             ->where(function ($expr) {
-                $from = new \DateTime('2007-03-18 10:45:00');
-                $to = new \DateTime('2007-03-18 10:48:00');
+                $from = new DateTime('2007-03-18 10:45:00');
+                $to = new DateTime('2007-03-18 10:48:00');
 
                 return $expr->between('created', $from, $to);
             });
@@ -4660,7 +4661,7 @@ class QueryTest extends TestCase
      */
     public function testClauseUndefined(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The \'nope\' clause is not defined. Valid clauses are: delete, update');
         $query = new Query($this->connection);
         $this->assertEmpty($query->clause('where'));

--- a/tests/TestCase/Database/QueryTests/AggregatesQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/AggregatesQueryTests.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\QueryTests;
 
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -56,8 +58,8 @@ class AggregatesQueryTests extends TestCase
      */
     public function testFilters(): void
     {
-        $skip = !($this->connection->getDriver() instanceof \Cake\Database\Driver\Postgres);
-        if ($this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlite) {
+        $skip = !($this->connection->getDriver() instanceof Postgres);
+        if ($this->connection->getDriver() instanceof Sqlite) {
             $skip = version_compare($this->connection->getDriver()->version(), '3.30.0', '<');
         }
         $this->skipif($skip);

--- a/tests/TestCase/Database/QueryTests/WindowQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTests.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\QueryTests;
 
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\Query;
@@ -56,8 +59,8 @@ class WindowQueryTests extends TestCase
 
         $driver = $this->connection->getDriver();
         if (
-            $driver instanceof \Cake\Database\Driver\Mysql ||
-            $driver instanceof \Cake\Database\Driver\Sqlite
+            $driver instanceof Mysql ||
+            $driver instanceof Sqlite
         ) {
             $this->skipTests = !$this->connection->getDriver()->supportsWindowFunctions();
         } else {
@@ -145,7 +148,7 @@ class WindowQueryTests extends TestCase
     {
         $skip = $this->skipTests;
         if (!$skip) {
-            $skip = $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver;
+            $skip = $this->connection->getDriver() instanceof Sqlserver;
         }
         $this->skipIf($skip);
 
@@ -167,8 +170,8 @@ class WindowQueryTests extends TestCase
         $skip = $this->skipTests;
         if (!$skip) {
             $driver = $this->connection->getDriver();
-            $skip = $driver instanceof \Cake\Database\Driver\Sqlserver;
-            if ($driver instanceof \Cake\Database\Driver\Sqlite) {
+            $skip = $driver instanceof Sqlserver;
+            if ($driver instanceof Sqlite) {
                 $skip = version_compare($driver->version(), '3.28.0', '<');
             }
         }

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Cache\Cache;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
@@ -67,7 +68,7 @@ class CollectionTest extends TestCase
      */
     public function testDescribeIncorrectTable(): void
     {
-        $this->expectException(\Cake\Database\Exception\DatabaseException::class);
+        $this->expectException(DatabaseException::class);
         $schema = new Collection($this->connection);
         $this->assertNull($schema->describe('derp'));
     }

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Driver\Postgres;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
@@ -369,7 +370,7 @@ class TableSchemaTest extends TestCase
      */
     public function testAddConstraintError(array $props): void
     {
-        $this->expectException(\Cake\Database\Exception\DatabaseException::class);
+        $this->expectException(DatabaseException::class);
         $table = new TableSchema('articles');
         $table->addColumn('author_id', 'integer');
         $table->addConstraint('author_idx', $props);
@@ -420,7 +421,7 @@ class TableSchemaTest extends TestCase
      */
     public function testAddIndexError(array $props): void
     {
-        $this->expectException(\Cake\Database\Exception\DatabaseException::class);
+        $this->expectException(DatabaseException::class);
         $table = new TableSchema('articles');
         $table->addColumn('author_id', 'integer');
         $table->addIndex('author_idx', $props);
@@ -598,7 +599,7 @@ class TableSchemaTest extends TestCase
      */
     public function testAddConstraintForeignKeyBadData(array $data): void
     {
-        $this->expectException(\Cake\Database\Exception\DatabaseException::class);
+        $this->expectException(DatabaseException::class);
         $table = new TableSchema('articles');
         $table->addColumn('author_id', 'integer')
             ->addConstraint('author_id_idx', $data);

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -66,7 +67,7 @@ class BinaryTypeTest extends TestCase
      */
     public function testToPHPFailure(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to convert array into binary.');
         $this->type->toPHP([], $this->driver);
     }

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Type;
 
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDO;
 
 /**
@@ -64,7 +65,7 @@ class BoolTypeTest extends TestCase
      */
     public function testToDatabaseInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->type->toDatabase([1, 2], $this->driver);
     }
 
@@ -73,7 +74,7 @@ class BoolTypeTest extends TestCase
      */
     public function testToDatabaseInvalidArray(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->type->toDatabase([1, 2, 3], $this->driver);
     }
 

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -20,7 +20,9 @@ use Cake\Database\Driver;
 use Cake\Database\Type\DecimalType;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDO;
+use RuntimeException;
 
 /**
  * Test for the Decimal type.
@@ -143,7 +145,7 @@ class DecimalTypeTest extends TestCase
      */
     public function testToDatabaseInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->type->toDatabase(['3', '4'], $this->driver);
     }
 
@@ -152,7 +154,7 @@ class DecimalTypeTest extends TestCase
      */
     public function testToDatabaseInvalid2(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->type->toDatabase('some data', $this->driver);
     }
 
@@ -235,7 +237,7 @@ class DecimalTypeTest extends TestCase
      */
     public function testUseLocaleParsingInvalid(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         DecimalType::$numberClass = 'stdClass';
         $this->type->useLocaleParser();
     }

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Type\FloatType;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use PDO;
+use RuntimeException;
 
 /**
  * Test for the Float type.
@@ -186,7 +187,7 @@ class FloatTypeTest extends TestCase
      */
     public function testUseLocaleParsingInvalid(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         FloatType::$numberClass = 'stdClass';
         $this->type->useLocaleParser();
     }

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Type;
 
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDO;
 
 /**
@@ -95,7 +96,7 @@ class IntegerTypeTest extends TestCase
      */
     public function testInvalidManyToPHP(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $values = [
             'a' => null,
             'b' => '2.3',
@@ -154,7 +155,7 @@ class IntegerTypeTest extends TestCase
      */
     public function testToDatabaseInvalid($value): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->type->toDatabase($value, $this->driver);
     }
 

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\Type;
 use Cake\Database\Type\JsonType;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDO;
 
 /**
@@ -95,7 +96,7 @@ class JsonTypeTest extends TestCase
      */
     public function testToDatabaseInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $value = fopen(__FILE__, 'r');
         $this->type->toDatabase($value, $this->driver);
     }

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDO;
 
 /**
@@ -77,7 +78,7 @@ class StringTypeTest extends TestCase
      */
     public function testToDatabaseInvalidArray(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->type->toDatabase([1, 2, 3], $this->driver);
     }
 

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database;
 use Cake\Database\TypeFactory;
 use Cake\Database\TypeInterface;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDO;
 use TestApp\Database\Type\BarType;
 use TestApp\Database\Type\FooType;
@@ -89,7 +90,7 @@ class TypeFactoryTest extends TestCase
      */
     public function testBuildUnknownType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         TypeFactory::build('foo');
     }
 

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -13,8 +13,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Datasource;
 
+use BadMethodCallException;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\Exception\MissingDatasourceConfigException;
+use Cake\Datasource\Exception\MissingDatasourceException;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use TestApp\Datasource\FakeConnection;
 
 /**
@@ -71,7 +76,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testConfigInvalidOptions(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\MissingDatasourceException::class);
+        $this->expectException(MissingDatasourceException::class);
         ConnectionManager::setConfig('test_variant', [
             'className' => 'Herp\Derp',
         ]);
@@ -83,7 +88,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testConfigDuplicateConfig(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot reconfigure existing key "test_variant"');
         $settings = [
             'className' => FakeConnection::class,
@@ -98,7 +103,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testGetFailOnMissingConfig(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The datasource configuration "test_variant" was not found.');
         ConnectionManager::get('test_variant');
     }
@@ -122,7 +127,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testGetNoAlias(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The datasource configuration "other_name" was not found.');
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');
@@ -198,7 +203,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testAliasError(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\MissingDatasourceConfigException::class);
+        $this->expectException(MissingDatasourceConfigException::class);
         $this->assertNotContains('test_kaboom', ConnectionManager::configured());
         ConnectionManager::alias('test_kaboom', 'other_name');
     }
@@ -390,7 +395,7 @@ class ConnectionManagerTest extends TestCase
      */
     public function testParseDsnInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The DSN string \'bagof:nope\' could not be parsed.');
         $result = ConnectionManager::parseDsn('bagof:nope');
     }

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -18,6 +18,8 @@ namespace Cake\Test\TestCase\Datasource;
 use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\Locator\LocatorInterface;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use stdClass;
 
 /**
  * FactoryLocatorTest test case
@@ -38,7 +40,7 @@ class FactoryLocatorTest extends TestCase
      */
     public function testGetNonExistent(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
         FactoryLocator::get('Test');
     }
@@ -49,7 +51,7 @@ class FactoryLocatorTest extends TestCase
     public function testAdd(): void
     {
         FactoryLocator::add('Test', function ($name) {
-            $mock = new \stdClass();
+            $mock = new stdClass();
             $mock->name = $name;
 
             return $mock;
@@ -66,7 +68,7 @@ class FactoryLocatorTest extends TestCase
      */
     public function testDrop(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
         FactoryLocator::drop('Test');
 

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -15,12 +15,15 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Datasource;
 
+use Cake\Datasource\Exception\MissingModelException;
 use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\Locator\LocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
+use stdClass;
 use TestApp\Model\Table\PaginatorPostsTable;
 use TestApp\Stub\Stub;
+use UnexpectedValueException;
 
 /**
  * ModelAwareTrait test case
@@ -68,7 +71,7 @@ class ModelAwareTraitTest extends TestCase
      */
     public function testLoadModelException(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Default modelClass is empty');
 
         $stub = new Stub();
@@ -141,7 +144,7 @@ class ModelAwareTraitTest extends TestCase
         $stub->setProps('Articles');
 
         FactoryLocator::add('Test', function ($name) {
-            $mock = new \stdClass();
+            $mock = new stdClass();
             $mock->name = $name;
 
             return $mock;
@@ -155,7 +158,7 @@ class ModelAwareTraitTest extends TestCase
      */
     public function testMissingModelException(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\MissingModelException::class);
+        $this->expectException(MissingModelException::class);
         $this->expectExceptionMessage('Model class "Magic" of type "Test" could not be found.');
         $stub = new Stub();
 

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -766,7 +766,7 @@ trait PaginatorTestTrait
      */
     public function testOutOfVeryBigPageNumberGetsClamped(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\PageOutOfBoundsException::class);
+        $this->expectException(PageOutOfBoundsException::class);
         $this->loadFixtures('Posts');
         $params = [
             'page' => '3000000000000000000000000',

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Datasource;
 use Cake\Cache\Cache;
 use Cake\Datasource\QueryCacher;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 use stdClass;
 
 /**
@@ -74,7 +75,7 @@ class QueryCacherTest extends TestCase
      */
     public function testFetchFunctionKeyNoString(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cache key functions must return a string. Got false.');
         $this->engine->set('my_key', 'A winner');
         $query = new stdClass();

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Datasource;
 
+use ArrayIterator;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\TestSuite\TestCase;
 
@@ -29,7 +30,7 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testDecorateSimpleIterator(): void
     {
-        $data = new \ArrayIterator([1, 2, 3]);
+        $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
         $this->assertEquals([1, 2, 3], iterator_to_array($decorator));
     }
@@ -39,7 +40,7 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testToArray(): void
     {
-        $data = new \ArrayIterator([1, 2, 3]);
+        $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
         $this->assertEquals([1, 2, 3], $decorator->toArray());
     }
@@ -49,7 +50,7 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testToJson(): void
     {
-        $data = new \ArrayIterator([1, 2, 3]);
+        $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
         $this->assertEquals(json_encode([1, 2, 3]), json_encode($decorator));
     }
@@ -59,7 +60,7 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testSerialization(): void
     {
-        $data = new \ArrayIterator([1, 2, 3]);
+        $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
         $serialized = serialize($decorator);
         $this->assertEquals([1, 2, 3], unserialize($serialized)->toArray());
@@ -70,7 +71,7 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testFirst(): void
     {
-        $data = new \ArrayIterator([1, 2, 3]);
+        $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
 
         $this->assertSame(1, $decorator->first());
@@ -82,7 +83,7 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testCount(): void
     {
-        $data = new \ArrayIterator([1, 2, 3]);
+        $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
 
         $this->assertSame(3, $decorator->count());

--- a/tests/TestCase/Error/ConsoleErrorHandlerTest.php
+++ b/tests/TestCase/Error/ConsoleErrorHandlerTest.php
@@ -21,6 +21,7 @@ use Cake\Controller\Exception\MissingActionException;
 use Cake\Log\Log;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * ConsoleErrorHandler Test case.
@@ -111,7 +112,7 @@ class ConsoleErrorHandlerTest extends TestCase
      */
     public function testNonCakeExceptions(): void
     {
-        $exception = new \InvalidArgumentException('Too many parameters.');
+        $exception = new InvalidArgumentException('Too many parameters.');
 
         $this->Error->expects($this->once())
             ->method('_stop')

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -28,6 +28,8 @@ use Cake\Error\Debugger;
 use Cake\Form\Form;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use MyClass;
 use RuntimeException;
 use SplFixedArray;
 use stdClass;
@@ -150,7 +152,7 @@ class DebuggerTest extends TestCase
      */
     public function testSetOutputAsException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Debugger::setOutputFormat('Invalid junk');
     }
 
@@ -398,7 +400,7 @@ TEXT;
         // This is gross but was simpler than adding a fixture file.
         // phpcs:ignore
         eval('class MyClass { private string $field; }');
-        $obj = new \MyClass();
+        $obj = new MyClass();
         $out = Debugger::exportVar($obj);
         $this->assertTextContains('field => [uninitialized]', $out);
     }

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -27,7 +27,9 @@ use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Exception;
 use RuntimeException;
+use stdClass;
 use TestApp\Error\TestErrorHandler;
 
 /**
@@ -103,7 +105,7 @@ class ErrorHandlerTest extends TestCase
         $this->expectExceptionMessage('The \'TotallyInvalid\' renderer class could not be found');
 
         $errorHandler = new ErrorHandler(['exceptionRenderer' => 'TotallyInvalid']);
-        $errorHandler->getRenderer(new \Exception('Something bad'));
+        $errorHandler->getRenderer(new Exception('Something bad'));
     }
 
     /**
@@ -477,7 +479,7 @@ class ErrorHandlerTest extends TestCase
      */
     public function testGetLoggerInvalid(): void
     {
-        $errorHandler = new TestErrorHandler(['errorLogger' => \stdClass::class]);
+        $errorHandler = new TestErrorHandler(['errorLogger' => stdClass::class]);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot create logger');
         $errorHandler->getLogger();

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -41,11 +41,14 @@ use Cake\View\Exception\MissingHelperException;
 use Cake\View\Exception\MissingLayoutException;
 use Cake\View\Exception\MissingTemplateException;
 use Exception;
+use OutOfBoundsException;
+use PDOException;
 use RuntimeException;
 use TestApp\Controller\Admin\ErrorController;
 use TestApp\Error\Exception\MissingWidgetThing;
 use TestApp\Error\Exception\MissingWidgetThingException;
 use TestApp\Error\MyCustomExceptionRenderer;
+use TestApp\Error\TestAppsExceptionRenderer;
 
 class ExceptionRendererTest extends TestCase
 {
@@ -238,7 +241,7 @@ class ExceptionRendererTest extends TestCase
     {
         static::setAppNamespace();
         $exception = new NotFoundException();
-        $renderer = new \TestApp\Error\TestAppsExceptionRenderer($exception);
+        $renderer = new TestAppsExceptionRenderer($exception);
 
         $result = $renderer->render();
         $this->assertStringContainsString('<b>peeled</b>', (string)$result->getBody());
@@ -263,7 +266,7 @@ class ExceptionRendererTest extends TestCase
      */
     public function testUnknownExceptionTypeWithNoCodeIsA500(): void
     {
-        $exception = new \OutOfBoundsException('foul ball.');
+        $exception = new OutOfBoundsException('foul ball.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
         $result = $ExceptionRenderer->render();
 
@@ -278,7 +281,7 @@ class ExceptionRendererTest extends TestCase
     {
         Configure::write('debug', false);
 
-        $exception = new \OutOfBoundsException('foul ball.');
+        $exception = new OutOfBoundsException('foul ball.');
         $ExceptionRenderer = new ExceptionRenderer($exception);
 
         $response = $ExceptionRenderer->render();
@@ -896,7 +899,7 @@ class ExceptionRendererTest extends TestCase
      */
     public function testPDOException(): void
     {
-        $exception = new \PDOException('There was an error in the SQL query');
+        $exception = new PDOException('There was an error in the SQL query');
         $exception->queryString = 'SELECT * from poo_query < 5 and :seven';
         $exception->params = ['seven' => 7];
         $ExceptionRenderer = new ExceptionRenderer($exception);

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -17,11 +17,14 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Error\Middleware;
 
 use Cake\Core\Configure;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Error\ErrorHandler;
 use Cake\Error\ExceptionRendererInterface;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\Exception\MissingControllerException;
+use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Exception\RedirectException;
+use Cake\Http\Exception\ServiceUnavailableException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\Log\Log;
@@ -115,7 +118,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware();
         $handler = new TestRequestHandler(function (): void {
-            throw new \Cake\Http\Exception\NotFoundException('whoops');
+            throw new NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf('Cake\Http\Response', $result);
@@ -177,7 +180,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
         $middleware = new ErrorHandlerMiddleware();
         $handler = new TestRequestHandler(function (): void {
-            throw new \Cake\Http\Exception\NotFoundException('whoops');
+            throw new NotFoundException('whoops');
         });
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf('Cake\Http\Response', $result);
@@ -210,7 +213,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
         $handler = new TestRequestHandler(function (): void {
-            throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
+            throw new NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
         $this->assertSame(404, $result->getStatusCode());
@@ -240,8 +243,8 @@ class ErrorHandlerMiddlewareTest extends TestCase
         ]);
         $middleware = new ErrorHandlerMiddleware(['log' => true, 'trace' => true]);
         $handler = new TestRequestHandler(function ($req): void {
-            $previous = new \Cake\Datasource\Exception\RecordNotFoundException('Previous logged');
-            throw new \Cake\Http\Exception\NotFoundException('Kaboom!', null, $previous);
+            $previous = new RecordNotFoundException('Previous logged');
+            throw new NotFoundException('Kaboom!', null, $previous);
         });
         $result = $middleware->process($request, $handler);
         $this->assertSame(404, $result->getStatusCode());
@@ -274,7 +277,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'skipLog' => ['Cake\Http\Exception\NotFoundException'],
         ]);
         $handler = new TestRequestHandler(function (): void {
-            throw new \Cake\Http\Exception\NotFoundException('Kaboom!');
+            throw new NotFoundException('Kaboom!');
         });
         $result = $middleware->process($request, $handler);
         $this->assertSame(404, $result->getStatusCode());
@@ -327,7 +330,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'exceptionRenderer' => $factory,
         ]));
         $handler = new TestRequestHandler(function (): void {
-            throw new \Cake\Http\Exception\ServiceUnavailableException('whoops');
+            throw new ServiceUnavailableException('whoops');
         });
         $response = $middleware->process($request, $handler);
         $this->assertSame(500, $response->getStatusCode());

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -21,6 +21,7 @@ use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * Tests the Cake\Event\Event class functionality
@@ -94,7 +95,7 @@ class ConditionDecoratorTest extends TestCase
      */
     public function testCallableRuntimeException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cake\Event\Decorator\ConditionDecorator the `if` condition is not a callable!');
         $callable = function (EventInterface $event) {
             return 'success';

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -15,10 +15,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http\Client\Adapter;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Client\Adapter\Stream;
+use Cake\Http\Client\Exception\NetworkException;
 use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
+use Exception;
 use TestApp\Http\Client\Adapter\CakeStreamWrapper;
 
 /**
@@ -60,7 +63,7 @@ class StreamTest extends TestCase
 
         try {
             $responses = $stream->send($request, []);
-        } catch (\Cake\Core\Exception\CakeException $e) {
+        } catch (CakeException $e) {
             $this->markTestSkipped('Could not connect to localhost, skipping');
         }
         $this->assertInstanceOf(Response::class, $responses[0]);
@@ -95,7 +98,7 @@ class StreamTest extends TestCase
 
         try {
             $stream->send($request, []);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
 
         $newHandler = set_error_handler(function (): void {
@@ -365,7 +368,7 @@ class StreamTest extends TestCase
 
         $stream = new Stream();
 
-        $this->expectException(\Cake\Http\Client\Exception\NetworkException::class);
+        $this->expectException(NetworkException::class);
         $this->expectExceptionMessage('Connection timed out http://dummy/?sleep');
 
         $stream->send($request, $options);

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http\Client\Auth;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Client\Auth\Oauth;
 use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;
@@ -62,7 +63,7 @@ shqoyFXJvizZzje7HaTQv/eJTuA6rUOzu/sAv/eBx2YAPkA8oa3qUw==
 
     public function testExceptionUnknownSigningMethod(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $auth = new Oauth();
         $creds = [
             'consumerSecret' => 'it is secret',

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Client;
 use Cake\Http\Client\Adapter\Stream;
 use Cake\Http\Client\Exception\MissingResponseException;
@@ -24,6 +25,7 @@ use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Laminas\Diactoros\Request as LaminasRequest;
 
 /**
  * HTTP client test.
@@ -401,7 +403,7 @@ class ClientTest extends TestCase
      */
     public function testInvalidAuthenticationType(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $mock = $this->getMockBuilder(Stream::class)
             ->onlyMethods(['send'])
             ->getMock();
@@ -588,7 +590,7 @@ class ClientTest extends TestCase
      */
     public function testExceptionOnUnknownType(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $mock = $this->getMockBuilder(Stream::class)
             ->onlyMethods(['send'])
             ->getMock();
@@ -665,7 +667,7 @@ class ClientTest extends TestCase
      */
     public function testAddCookieWithoutDomain(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cookie must have a domain and a path set.');
         $client = new Client();
         $cookie = new Cookie('foo', '', null, '/', '');
@@ -681,7 +683,7 @@ class ClientTest extends TestCase
      */
     public function testAddCookieWithoutPath(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cookie must have a domain and a path set.');
         $client = new Client();
         $cookie = new Cookie('foo', '', null, '', 'example.com');
@@ -836,7 +838,7 @@ class ClientTest extends TestCase
             ->will($this->returnValue([$response]));
 
         $http = new Client(['adapter' => $mock]);
-        $request = new \Laminas\Diactoros\Request(
+        $request = new LaminasRequest(
             'http://cakephp.org/test.html',
             Request::METHOD_GET,
             'php://temp',

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -170,7 +170,7 @@ class CookieCollectionTest extends TestCase
      */
     public function testConstructorWithInvalidCookieObjects(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected `Cake\Http\Cookie\CookieCollection[]` as $cookies but instead got `array` at index 1');
         $array = [
             new Cookie('one', 'one'),

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -19,6 +19,7 @@ use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
 use Cake\TestSuite\TestCase;
 use DateTimeInterface;
+use InvalidArgumentException;
 
 /**
  * HTTP cookies test.
@@ -49,7 +50,7 @@ class CookieTest extends TestCase
      */
     public function testValidateNameInvalidChars(string $name): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('contains invalid characters.');
         new Cookie($name, 'value');
     }
@@ -59,7 +60,7 @@ class CookieTest extends TestCase
      */
     public function testValidateNameEmptyName(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The cookie name cannot be empty.');
         new Cookie('', '');
     }
@@ -154,7 +155,7 @@ class CookieTest extends TestCase
      */
     public function testWithSameSiteException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
 
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
@@ -458,7 +459,7 @@ class CookieTest extends TestCase
 
     public function testInvalidExpiresForDefaults(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid type `array` for expire');
 
         Cookie::setDefaults(['expires' => ['ompalompa']]);
@@ -467,7 +468,7 @@ class CookieTest extends TestCase
 
     public function testInvalidSameSiteForDefaults(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
 
         Cookie::setDefaults(['samesite' => 'ompalompa']);

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -360,7 +360,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
      */
     public function testInvalidTokenNonStringCookies(): void
     {
-        $this->expectException(\Cake\Http\Exception\InvalidCsrfTokenException::class);
+        $this->expectException(InvalidCsrfTokenException::class);
         $request = new ServerRequest([
             'environment' => [
                 'REQUEST_METHOD' => 'POST',

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Http\Middleware;
 use Cake\Http\Middleware\SecurityHeadersMiddleware;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use Laminas\Diactoros\Response;
 use TestApp\Http\TestRequestHandler;
 
@@ -66,7 +67,7 @@ class SecurityHeadersMiddlewareTest extends TestCase
      */
     public function testInvalidArgumentExceptionForsetXFrameOptionsUrl(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The 2nd arg $url can not be empty when `allow-from` is used');
         $middleware = new SecurityHeadersMiddleware();
         $middleware->setXFrameOptions('allow-from');
@@ -78,7 +79,7 @@ class SecurityHeadersMiddlewareTest extends TestCase
      */
     public function testCheckValues(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid arg `INVALID-VALUE!`, use one of these: all, none, master-only, by-content-type, by-ftp-filename');
         $middleware = new SecurityHeadersMiddleware();
         $middleware->setCrossDomainPolicy('INVALID-VALUE!');

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -18,6 +18,8 @@ namespace Cake\Test\TestCase\Http;
 
 use Cake\Http\MiddlewareQueue;
 use Cake\TestSuite\TestCase;
+use LogicException;
+use OutOfBoundsException;
 use TestApp\Middleware\DumbMiddleware;
 use TestApp\Middleware\SampleMiddleware;
 
@@ -71,7 +73,7 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testGetException(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('Invalid current position (0)');
 
         $queue = new MiddlewareQueue();
@@ -295,7 +297,7 @@ class MiddlewareQueueTest extends TestCase
      */
     public function testInsertBeforeInvalid(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('No middleware matching \'InvalidClassName\' could be found.');
         $one = function (): void {
         };

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -27,6 +27,10 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
+use DateTimeImmutable;
+use DateTimeZone;
+use InvalidArgumentException;
 use Laminas\Diactoros\Stream;
 
 /**
@@ -196,7 +200,7 @@ class ResponseTest extends TestCase
      */
     public function testWithTypeInvalidType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"beans" is an invalid content type');
         $response = new Response();
         $response->withType('beans');
@@ -427,19 +431,19 @@ class ResponseTest extends TestCase
     public function testWithExpires(): void
     {
         $response = new Response();
-        $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
+        $now = new NativeDateTime('now', new DateTimeZone('America/Los_Angeles'));
 
         $new = $response->withExpires($now);
         $this->assertFalse($response->hasHeader('Expires'));
 
-        $now->setTimeZone(new \DateTimeZone('UTC'));
+        $now->setTimeZone(new DateTimeZone('UTC'));
         $this->assertSame($now->format(DATE_RFC7231), $new->getHeaderLine('Expires'));
 
         $now = time();
         $new = $response->withExpires($now);
         $this->assertSame(gmdate(DATE_RFC7231), $new->getHeaderLine('Expires'));
 
-        $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
+        $time = new NativeDateTime('+1 day', new DateTimeZone('UTC'));
         $new = $response->withExpires('+1 day');
         $this->assertSame($time->format(DATE_RFC7231), $new->getHeaderLine('Expires'));
     }
@@ -450,22 +454,22 @@ class ResponseTest extends TestCase
     public function testWithModified(): void
     {
         $response = new Response();
-        $now = new \DateTime('now', new \DateTimeZone('America/Los_Angeles'));
+        $now = new NativeDateTime('now', new DateTimeZone('America/Los_Angeles'));
         $new = $response->withModified($now);
         $this->assertFalse($response->hasHeader('Last-Modified'));
 
-        $now->setTimeZone(new \DateTimeZone('UTC'));
+        $now->setTimeZone(new DateTimeZone('UTC'));
         $this->assertSame($now->format(DATE_RFC7231), $new->getHeaderLine('Last-Modified'));
 
         $now = time();
         $new = $response->withModified($now);
         $this->assertSame(gmdate(DATE_RFC7231, $now), $new->getHeaderLine('Last-Modified'));
 
-        $now = new \DateTimeImmutable();
+        $now = new DateTimeImmutable();
         $new = $response->withModified($now);
         $this->assertSame(gmdate(DATE_RFC7231, $now->getTimestamp()), $new->getHeaderLine('Last-Modified'));
 
-        $time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
+        $time = new NativeDateTime('+1 day', new DateTimeZone('UTC'));
         $new = $response->withModified('+1 day');
         $this->assertSame($time->format(DATE_RFC7231), $new->getHeaderLine('Last-Modified'));
     }
@@ -775,7 +779,7 @@ class ResponseTest extends TestCase
      */
     public function testWithDuplicateCookie(): void
     {
-        $expiry = new \DateTimeImmutable('+24 hours');
+        $expiry = new DateTimeImmutable('+24 hours');
 
         $response = new Response();
         $cookie = new Cookie(
@@ -845,7 +849,7 @@ class ResponseTest extends TestCase
                 'path' => '/custompath/',
                 'secure' => true,
                 'httponly' => true,
-                'expires' => new \DateTimeImmutable('+14 days'),
+                'expires' => new DateTimeImmutable('+14 days'),
             ],
         ];
 
@@ -990,7 +994,7 @@ class ResponseTest extends TestCase
      */
     public function testWithFileNotFound(): void
     {
-        $this->expectException(\Cake\Http\Exception\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('The requested file /some/missing/folder/file.jpg was not found');
 
         $response = new Response();
@@ -1004,7 +1008,7 @@ class ResponseTest extends TestCase
     {
         Configure::write('debug', 0);
 
-        $this->expectException(\Cake\Http\Exception\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('The requested file was not found');
         $response = new Response();
         $response->withFile('/some/missing/folder/file.jpg');
@@ -1362,7 +1366,7 @@ class ResponseTest extends TestCase
      */
     public function testWithStatusInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid status code: 1001. Use a valid HTTP status code in range 1xx - 5xx.');
         $response = new Response();
         $response->withStatus(1001);

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -98,7 +98,7 @@ class RunnerTest extends TestCase
      */
     public function testRunExceptionInMiddleware(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('A bad thing');
         $this->queue->add($this->ok)->add($this->fail);
         $req = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
+use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieCollection;
@@ -24,6 +25,7 @@ use Cake\Http\FlashMessage;
 use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
 
@@ -302,7 +304,7 @@ class ServerRequestTest extends TestCase
      */
     public function testWithUploadedFilesInvalidFile(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid file at \'avatar\'');
         $request = new ServerRequest();
         $request->withUploadedFiles(['avatar' => 'not a file']);
@@ -313,7 +315,7 @@ class ServerRequestTest extends TestCase
      */
     public function testWithUploadedFilesInvalidFileNested(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid file at \'user.avatar\'');
         $request = new ServerRequest();
         $request->withUploadedFiles(['user' => ['avatar' => 'not a file']]);
@@ -547,7 +549,7 @@ class ServerRequestTest extends TestCase
      */
     public function testWithMethodInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported HTTP method "no good" provided');
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'delete'],
@@ -587,7 +589,7 @@ class ServerRequestTest extends TestCase
      */
     public function testWithProtocolVersionInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported protocol version \'no good\' provided');
         $request = new ServerRequest();
         $request->withProtocolVersion('no good');
@@ -694,7 +696,7 @@ class ServerRequestTest extends TestCase
      */
     public function testMagicCallExceptionOnUnknownMethod(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $request = new ServerRequest();
         $request->IamABanana();
     }
@@ -1879,7 +1881,7 @@ class ServerRequestTest extends TestCase
      */
     public function testWithoutAttributesDenyEmulatedProperties(string $prop): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $request = new ServerRequest([]);
         $request->withoutAttribute($prop);
     }

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -27,7 +27,8 @@ use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use Laminas\Diactoros\Response;
+use Laminas\Diactoros\Response as LaminasResponse;
+use Laminas\Diactoros\ServerRequest as LaminasServerRequest;
 use TestApp\Http\MiddlewareApplication;
 
 require_once __DIR__ . '/server_mocks.php';
@@ -216,7 +217,7 @@ class ServerTest extends TestCase
      */
     public function testRunDoesNotCloseSessionIfServerRequestNotUsed(): void
     {
-        $request = new \Laminas\Diactoros\ServerRequest();
+        $request = new LaminasServerRequest();
 
         $app = new MiddlewareApplication($this->config);
         $server = new Server($app);
@@ -261,7 +262,7 @@ class ServerTest extends TestCase
     public function testEmitCallbackStream(): void
     {
         $GLOBALS['mockedHeadersSent'] = false;
-        $response = new Response('php://memory', 200, ['x-testing' => 'source header']);
+        $response = new LaminasResponse('php://memory', 200, ['x-testing' => 'source header']);
         $response = $response->withBody(new CallbackStream(function (): void {
             echo 'body content';
         }));

--- a/tests/TestCase/Http/Session/CacheSessionTest.php
+++ b/tests/TestCase/Http/Session/CacheSessionTest.php
@@ -21,6 +21,7 @@ namespace Cake\Test\TestCase\Http\Session;
 use Cake\Cache\Cache;
 use Cake\Http\Session\CacheSession;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * CacheSessionTest
@@ -97,7 +98,7 @@ class CacheSessionTest extends TestCase
      */
     public function testMissingConfig(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The cache configuration name to use is required');
         new CacheSession(['foo' => 'bar']);
     }

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\I18n;
 use Cake\I18n\Date;
 use Cake\TestSuite\TestCase;
 use DateTimeZone;
+use IntlDateFormatter;
 
 /**
  * DateTest class
@@ -72,7 +73,7 @@ class DateTest extends TestCase
         $expected = '1/14/10';
         $this->assertSame($expected, $result);
 
-        $format = [\IntlDateFormatter::NONE, \IntlDateFormatter::SHORT];
+        $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
         $result = $time->i18nFormat($format);
         $expected = '12:00 AM';
         $this->assertSame($expected, $result);
@@ -82,16 +83,16 @@ class DateTest extends TestCase
         $this->assertSame($expected, $result);
 
         Date::setDefaultLocale('fr-FR');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $result = str_replace(' à', '', $result);
         $expected = 'jeudi 14 janvier 2010 00:00:00';
         $this->assertStringStartsWith($expected, $result);
 
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'es-ES');
+        $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'es-ES');
         $this->assertStringContainsString('14 de enero de 2010', $result, 'Default locale should not be used');
 
         $time = new Date('2014-01-01T00:00:00Z');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'en-US');
+        $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'en-US');
         $expected = 'Wednesday, January 1, 2014 at 12:00:00 AM';
         $this->assertStringStartsWith($expected, $result);
     }

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -20,6 +20,8 @@ use Cake\Chronos\Chronos;
 use Cake\I18n\DateTime;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
+use DateTimeZone;
 use IntlDateFormatter;
 
 /**
@@ -68,7 +70,7 @@ class DateTimeTest extends TestCase
         $subject = new DateTime($mut);
         $this->assertSame($time, $subject->format('Y-m-d H:i:s.u'), 'time construction');
 
-        $mut = new \DateTime($time, new \DateTimeZone('America/Chicago'));
+        $mut = new NativeDateTime($time, new DateTimeZone('America/Chicago'));
         $subject = new DateTime($mut);
         $this->assertSame($time, $subject->format('Y-m-d H:i:s.u'), 'time construction');
     }
@@ -387,24 +389,24 @@ class DateTimeTest extends TestCase
         $this->assertTimeFormat($expected, $result);
 
         // Test using a time-specific format
-        $format = [\IntlDateFormatter::NONE, \IntlDateFormatter::SHORT];
+        $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
         $result = $time->i18nFormat($format);
         $expected = '1:59 PM';
         $this->assertTimeFormat($expected, $result);
 
         // Test using a specific format, timezone and locale
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL, null, 'es-ES');
+        $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'es-ES');
         $expected = 'jueves, 14 de enero de 2010, 13:59:28 (GMT)';
         $this->assertTimeFormat($expected, $result);
 
         // Test with custom default locale
         DateTime::setDefaultLocale('fr-FR');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $expected = 'jeudi 14 janvier 2010 13:59:28 UTC';
         $this->assertTimeFormat($expected, $result);
 
         // Test with a non-gregorian calendar in locale
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL, 'Asia/Tokyo', 'ja-JP@calendar=japanese');
+        $result = $time->i18nFormat(IntlDateFormatter::FULL, 'Asia/Tokyo', 'ja-JP@calendar=japanese');
         $expected = '平成22年1月14日木曜日 22時59分28秒 日本標準時';
         $this->assertTimeFormat($expected, $result);
     }
@@ -436,22 +438,22 @@ class DateTimeTest extends TestCase
     public function testI18nFormatWithOffsetTimezone(): void
     {
         $time = new DateTime('2014-01-01T00:00:00+00');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00:00+09');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00:00-01:30');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00Z');
-        $result = $time->i18nFormat(\IntlDateFormatter::FULL);
+        $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
     }
@@ -491,11 +493,11 @@ class DateTimeTest extends TestCase
         $this->assertArrayHasKey('America/Argentina/Buenos_Aires', $return);
         $this->assertArrayHasKey('Pacific/Tahiti', $return);
 
-        $return = DateTime::listTimezones(\DateTimeZone::ASIA);
+        $return = DateTime::listTimezones(DateTimeZone::ASIA);
         $this->assertTrue(isset($return['Asia']['Asia/Bangkok']));
         $this->assertArrayNotHasKey('Pacific', $return);
 
-        $return = DateTime::listTimezones(\DateTimeZone::PER_COUNTRY, 'US', false);
+        $return = DateTime::listTimezones(DateTimeZone::PER_COUNTRY, 'US', false);
         $this->assertArrayHasKey('Pacific/Honolulu', $return);
         $this->assertArrayNotHasKey('Asia/Bangkok', $return);
     }
@@ -507,7 +509,7 @@ class DateTimeTest extends TestCase
     {
         $time = new DateTime('2014-04-20 22:10');
         DateTime::setDefaultLocale('fr-FR');
-        DateTime::setToStringFormat(\IntlDateFormatter::FULL);
+        DateTime::setToStringFormat(IntlDateFormatter::FULL);
         $this->assertTimeFormat('dimanche 20 avril 2014 22:10:00 UTC', (string)$time);
     }
 
@@ -821,7 +823,7 @@ class DateTimeTest extends TestCase
         DateTime::setDefaultLocale('fr-FR');
         $result = DateTime::parseDate('12/03/2015');
         $this->assertSame('2015-03-12', $result->format('Y-m-d'));
-        $this->assertEquals(new \DateTimeZone('Europe/Paris'), $result->tz);
+        $this->assertEquals(new DateTimeZone('Europe/Paris'), $result->tz);
     }
 
     /**

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\I18n\Formatter;
 
 use Cake\I18n\Formatter\IcuFormatter;
 use Cake\TestSuite\TestCase;
+use Exception;
 
 /**
  * IcuFormatter tests
@@ -82,7 +83,7 @@ class IcuFormatterTest extends TestCase
      */
     public function testBadMessageFormat(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $formatter = new IcuFormatter();
         $formatter->format('en_US', '{crazy format', ['some', 'vars']);

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -21,6 +21,7 @@ namespace Cake\Test\TestCase\I18n;
 use Cake\I18n\I18n;
 use Cake\I18n\Number;
 use Cake\TestSuite\TestCase;
+use NumberFormatter;
 
 /**
  * NumberTest class
@@ -566,7 +567,7 @@ class NumberTest extends TestCase
         $result = $this->Number->currency(150000, 'USD', ['locale' => 'en_US']);
         $this->assertSame('$150,000.00', $result);
 
-        Number::config('en_US', \NumberFormatter::CURRENCY, [
+        Number::config('en_US', NumberFormatter::CURRENCY, [
             'pattern' => '¤ #,##,##0',
         ]);
 

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -15,9 +15,12 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Log;
 
+use BadMethodCallException;
 use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * LogTest class
@@ -70,7 +73,7 @@ class LogTest extends TestCase
      */
     public function testImportingLoggerFailure(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         Log::setConfig('fail', []);
         Log::engine('fail');
     }
@@ -105,7 +108,7 @@ class LogTest extends TestCase
     {
         Log::setConfig('fail', ['engine' => '\stdClass']);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         Log::engine('fail');
     }
@@ -134,7 +137,7 @@ class LogTest extends TestCase
      */
     public function testInvalidLevel(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Log::setConfig('myengine', ['engine' => 'File']);
         Log::write('invalid', 'This will not be logged');
     }
@@ -209,7 +212,7 @@ class LogTest extends TestCase
      */
     public function testConfigErrorOnReconfigure(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         Log::setConfig('tests', ['engine' => 'File', 'path' => TMP]);
         Log::setConfig('tests', ['engine' => 'Apc']);
     }

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Mailer;
 
+use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Log\Log;
@@ -25,7 +26,10 @@ use Cake\Mailer\Transport\DebugTransport;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingTemplateException;
+use DateTime;
+use InvalidArgumentException;
 use RuntimeException;
+use stdClass;
 use TestApp\Mailer\TestMailer;
 
 class MailerTest extends TestCase
@@ -96,7 +100,7 @@ class MailerTest extends TestCase
      */
     public function testTransportInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "Invalid" transport configuration does not exist');
         $this->mailer->setTransport('Invalid');
     }
@@ -107,7 +111,7 @@ class MailerTest extends TestCase
     public function testTransportInstanceInvalid(): void
     {
         $this->expectException(CakeException::class);
-        $this->mailer->setTransport(new \stdClass());
+        $this->mailer->setTransport(new stdClass());
     }
 
     /**
@@ -115,7 +119,7 @@ class MailerTest extends TestCase
      */
     public function testTransportTypeInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The value passed for the "$name" argument must be either a string, or an object, integer given.');
         $this->mailer->setTransport(123);
     }
@@ -155,7 +159,7 @@ class MailerTest extends TestCase
      */
     public function testConfigErrorOnDuplicate(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $settings = [
             'to' => 'mark@example.com',
             'from' => 'noreply@example.com',
@@ -281,7 +285,7 @@ class MailerTest extends TestCase
      */
     public function testProfileInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown email configuration "derp".');
         $mailer = new Mailer();
         $mailer->setProfile('derp');
@@ -472,7 +476,7 @@ class MailerTest extends TestCase
      */
     public function testSendWithoutTransport(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
             'Transport was not defined. You must set on using setTransport() or set `transport` option in your mailer profile.'
         );
@@ -933,7 +937,7 @@ class MailerTest extends TestCase
         $this->mailer->setViewVars(['time' => $timestamp]);
 
         $result = $this->mailer->send();
-        $dateTime = new \DateTime();
+        $dateTime = new DateTime();
         $dateTime->setTimestamp($timestamp);
         $this->assertStringContainsString('Right now: ' . $dateTime->format($dateTime::ATOM), $result['message']);
 

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Mailer\Message;
 use Cake\Mailer\Transport\DebugTransport;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use TestApp\Mailer\TestMessage;
 
@@ -358,7 +359,7 @@ HTML;
         $this->assertSame($expected, $this->message->getFrom());
         $this->assertSame($this->message, $result);
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $result = $this->message->setFrom(['cake@cakephp.org' => 'CakePHP', 'fail@cakephp.org' => 'From can only be one address']);
     }
 
@@ -486,7 +487,7 @@ HTML;
      */
     public function testInvalidEmail($value): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->message->setTo($value);
     }
 
@@ -498,7 +499,7 @@ HTML;
      */
     public function testInvalidEmailAdd($value): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->message->addTo($value);
     }
 
@@ -568,7 +569,7 @@ HTML;
      */
     public function testUnsetEmailPattern(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
         $email = new Message();
         $this->assertSame(Message::EMAIL_PATTERN, $email->getEmailPattern());
@@ -585,7 +586,7 @@ HTML;
      */
     public function testEmptyTo(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The email set for "to" is empty.');
         $email = new Message();
         $email->setTo('');
@@ -783,7 +784,7 @@ HTML;
      */
     public function testMessageIdInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->message->setMessageId('my-email@localhost');
     }
 
@@ -908,7 +909,7 @@ HTML;
             'license' => ['file' => CORE_PATH . 'LICENSE', 'mimetype' => 'text/plain'],
         ];
         $this->assertSame($expected, $this->message->getAttachments());
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->message->setAttachments([['nofile' => CAKE . 'basics.php', 'mimetype' => 'text/plain']]);
     }
 
@@ -932,7 +933,7 @@ HTML;
 
     public function testSetAttachmentInvalidFile(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'File must be a filepath or UploadedFileInterface instance. Found `boolean` instead.'
         );
@@ -982,7 +983,7 @@ HTML;
         $result = $this->message->getEmailFormat();
         $this->assertSame('html', $result);
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->message->setEmailFormat('invalid');
     }
 
@@ -1182,7 +1183,7 @@ HTML;
         $this->assertSame($expected, $this->message->getContentTransferEncoding());
 
         //Test wrong encoding
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->message->setTransferEncoding('invalid');
     }
 

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -149,7 +149,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testConnectEhloNoTlsOnRequiredTlsServer(): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         $this->expectExceptionMessage('SMTP authentication method not allowed, check if SMTP server requires TLS.');
         $this->SmtpTransport->setConfig(['tls' => false] + $this->credentials);
 
@@ -268,7 +268,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testAuthNotRecognized(): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         $this->expectExceptionMessage('AUTH command not recognized or not implemented, SMTP server may not require authentication.');
 
         $this->socket->expects($this->exactly(2))
@@ -293,7 +293,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testAuthNotImplemented(): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         $this->expectExceptionMessage('AUTH command not recognized or not implemented, SMTP server may not require authentication.');
 
         $this->socket->expects($this->exactly(2))
@@ -317,7 +317,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testAuthBadSequence(): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         $this->expectExceptionMessage('SMTP Error: 503 5.5.1 Already authenticated');
 
         $this->socket->expects($this->exactly(2))

--- a/tests/TestCase/Mailer/TransportFactoryTest.php
+++ b/tests/TestCase/Mailer/TransportFactoryTest.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Mailer;
 
+use BadMethodCallException;
 use Cake\Mailer\Transport\DebugTransport;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * TransportFactory Test class
@@ -60,7 +62,7 @@ class TransportFactoryTest extends TestCase
      */
     public function testGetMissingClassName(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Transport config "debug" is invalid, the required `className` option is missing');
 
         TransportFactory::drop('debug');
@@ -113,7 +115,7 @@ class TransportFactoryTest extends TestCase
      */
     public function testSetConfigErrorOnDuplicate(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $settings = [
             'className' => 'Debug',
             'log' => true,

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Network;
 use Cake\Network\Exception\SocketException;
 use Cake\Network\Socket;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * SocketTest class
@@ -143,7 +144,7 @@ class SocketTest extends TestCase
      */
     public function testInvalidConnection(array $data): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         $this->Socket->setConfig($data);
         $this->Socket->connect();
     }
@@ -353,7 +354,7 @@ class SocketTest extends TestCase
      */
     public function testEnableCryptoBadMode(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         // testing wrong encryption mode
         $this->_connectSocketToSslTls();
         $this->Socket->enableCrypto('doesntExistMode', 'server');
@@ -376,7 +377,7 @@ class SocketTest extends TestCase
      */
     public function testEnableCryptoExceptionEnableTwice(): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         // testing on tls server
         $this->_connectSocketToSslTls();
         $this->Socket->enableCrypto('tls', 'client');
@@ -388,7 +389,7 @@ class SocketTest extends TestCase
      */
     public function testEnableCryptoExceptionDisableTwice(): void
     {
-        $this->expectException(\Cake\Network\Exception\SocketException::class);
+        $this->expectException(SocketException::class);
         $this->_connectSocketToSslTls();
         $this->Socket->enableCrypto('tls', 'client', false);
     }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -32,6 +32,7 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Tests BelongsToMany class
@@ -137,7 +138,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testStrategyFailure(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid strategy "join" was provided');
         $assoc = new BelongsToMany('Test');
         $assoc->setStrategy(BelongsToMany::STRATEGY_JOIN);
@@ -313,7 +314,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testSaveStrategyInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid save strategy "depsert"');
         new BelongsToMany('Test', ['saveStrategy' => 'depsert']);
     }
@@ -461,7 +462,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testLinkWithNotPersistedSource(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Source entity needs to be persisted before links can be created or removed');
         $config = [
             'sourceTable' => $this->article,
@@ -479,7 +480,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testLinkWithNotPersistedTarget(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot link entities that have not been persisted yet');
         $config = [
             'sourceTable' => $this->article,
@@ -660,7 +661,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testUnlinkWithNotPersistedSource(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Source entity needs to be persisted before links can be created or removed');
         $config = [
             'sourceTable' => $this->article,
@@ -678,7 +679,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testUnlinkWithNotPersistedTarget(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot link entities that have not been persisted');
         $config = [
             'sourceTable' => $this->article,
@@ -753,7 +754,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testReplaceWithMissingPrimaryKey(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not find primary key value for source entity');
         $config = [
             'sourceTable' => $this->article,
@@ -1295,7 +1296,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testEagerLoadingRequiresPrimaryKey(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The "tags" table does not define a primary key');
         $table = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -26,6 +26,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Tests BelongsTo class
@@ -234,7 +235,7 @@ class BelongsToTest extends TestCase
      */
     public function testAttachToMultiPrimaryKeyMismatch(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"');
         $this->company->setPrimaryKey(['id', 'tenant_id']);
         $query = $this->client->query();

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -160,7 +160,7 @@ class HasManyTest extends TestCase
      */
     public function testStrategyFailure(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid strategy "join" was provided');
         $assoc = new HasMany('Test');
         $assoc->setStrategy(HasMany::STRATEGY_JOIN);
@@ -298,7 +298,7 @@ class HasManyTest extends TestCase
      */
     public function testEagerLoaderFieldsException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('You are required to select the "Articles.author_id"');
         $config = [
             'sourceTable' => $this->author,
@@ -790,7 +790,7 @@ class HasManyTest extends TestCase
      */
     public function testSaveAssociatedNotEmptyNotIterable(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Could not save comments, it cannot be traversed');
         $articles = $this->getTableLocator()->get('Articles');
         $association = $articles->hasMany('Comments', [
@@ -973,7 +973,7 @@ class HasManyTest extends TestCase
      */
     public function testInvalidSaveStrategy(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $articles = $this->getTableLocator()->get('Articles');
 
         $association = $articles->hasMany('Comments');

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -16,12 +16,14 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
+use ArrayObject;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * Tests HasOne class
@@ -170,7 +172,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToMultiPrimaryKeyMismatch(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join', 'select'])
@@ -275,7 +277,7 @@ class HasOneTest extends TestCase
             'targetTable' => $this->profile,
         ];
         $this->listenerCalled = false;
-        $opts = new \ArrayObject(['something' => 'more']);
+        $opts = new ArrayObject(['something' => 'more']);
         $this->profile->getEventManager()->on(
             'Model.beforeFind',
             function ($event, $query, $options, $primary) use ($opts): void {

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -400,7 +400,7 @@ class AssociationCollectionTest extends TestCase
      */
     public function testErrorOnUnknownAlias(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot save Profiles, it is not associated to Users');
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->onlyMethods(['save'])

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * Tests the features related to proxying methods from the Association
@@ -53,7 +54,7 @@ class AssociationProxyTest extends TestCase
      */
     public function testGetBadAssociation(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('You have not defined');
         $articles = $this->getTableLocator()->get('articles');
         $articles->posts;

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -20,6 +20,8 @@ use Cake\Core\Configure;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use RuntimeException;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 
@@ -97,7 +99,7 @@ class AssociationTest extends TestCase
      */
     public function testSetNameAfterTarget(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Association name "Bar" does not match target table alias');
         $this->association->getTarget();
         $this->association->setName('Bar');
@@ -142,7 +144,7 @@ class AssociationTest extends TestCase
      */
     public function testSetClassNameAfterTarget(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The class name "' . AuthorsTable::class . '" doesn\'t match the target table class name of');
         $this->association->getTarget();
         $this->association->setClassName(AuthorsTable::class);
@@ -153,7 +155,7 @@ class AssociationTest extends TestCase
      */
     public function testSetClassNameWithShortSyntaxAfterTarget(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The class name "Authors" doesn\'t match the target table class name of');
         $this->association->getTarget();
         $this->association->setClassName('Authors');
@@ -208,7 +210,7 @@ class AssociationTest extends TestCase
      */
     public function testInvalidTableFetchedFromRegistry(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->getTableLocator()->get('Test');
 
         $config = [
@@ -475,7 +477,7 @@ class AssociationTest extends TestCase
      */
     public function testInvalidStrategy(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->association->setStrategy('anotherThing');
     }
 

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -22,7 +22,9 @@ use Cake\ORM\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
 use RuntimeException;
+use UnexpectedValueException;
 
 /**
  * Behavior test case
@@ -92,7 +94,7 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $event = new Event('Model.beforeSave');
@@ -113,11 +115,11 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $event = new Event('Model.beforeSave');
-        $existingValue = new \DateTime('2011-11-11');
+        $existingValue = new NativeDateTime('2011-11-11');
         $entity = new Entity(['name' => 'Foo', 'created' => $existingValue]);
 
         $return = $this->Behavior->handleEvent($event, $entity);
@@ -134,7 +136,7 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $event = new Event('Model.beforeSave');
@@ -155,7 +157,7 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $event = new Event('Model.beforeSave');
@@ -177,11 +179,11 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $event = new Event('Model.beforeSave');
-        $existingValue = new \DateTime('2011-11-11');
+        $existingValue = new NativeDateTime('2011-11-11');
         $entity = new Entity(['name' => 'Foo', 'modified' => $existingValue]);
         $entity->clean();
         $entity->setNew(false);
@@ -200,7 +202,7 @@ class TimestampBehaviorTest extends TestCase
         $table = $this->getTable();
         $table->getSchema()->removeColumn('created')->removeColumn('modified');
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $event = new Event('Model.beforeSave');
@@ -259,7 +261,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testInvalidEventConfig(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid');
         $table = $this->getTable();
         $settings = ['events' => ['Model.beforeSave' => ['created' => 'fat fingers']]];
@@ -333,7 +335,7 @@ class TimestampBehaviorTest extends TestCase
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
 
-        $ts = new \DateTime();
+        $ts = new NativeDateTime();
         $this->Behavior->timestamp($ts);
         $return = $this->Behavior->timestamp();
 
@@ -351,7 +353,7 @@ class TimestampBehaviorTest extends TestCase
     {
         $table = $this->getTable();
         $this->Behavior = new TimestampBehavior($table);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $entity = new Entity(['username' => 'timestamp test']);
@@ -380,7 +382,7 @@ class TimestampBehaviorTest extends TestCase
         ];
 
         $this->Behavior = new TimestampBehavior($table, $config);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $entity = new Entity(['username' => 'timestamp test']);
@@ -398,7 +400,7 @@ class TimestampBehaviorTest extends TestCase
         $table = $this->getTable();
         $settings = ['events' => ['Something.special' => ['date_specialed' => 'always']]];
         $this->Behavior = new TimestampBehavior($table, $settings);
-        $ts = new \DateTime('2000-01-01');
+        $ts = new NativeDateTime('2000-01-01');
         $this->Behavior->timestamp($ts);
 
         $entity = new Entity(['username' => 'timestamp test']);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -24,6 +24,7 @@ use Cake\ORM\Behavior\Translate\EavStrategy;
 use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
 use Cake\ORM\Behavior\TranslateBehavior;
 use Cake\Utility\Hash;
+use Cake\Validation\Validator;
 use TestApp\Model\Entity\TranslateArticle;
 use TestApp\Model\Entity\TranslateBakedArticle;
 
@@ -854,7 +855,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
             'fields' => ['title'],
-            'validator' => (new \Cake\Validation\Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),
+            'validator' => (new Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),
         ]);
         $table->setEntityClass(TranslateArticle::class);
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -1389,7 +1389,7 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', [
             'fields' => ['title'],
-            'validator' => (new \Cake\Validation\Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),
+            'validator' => (new Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),
         ]);
         $table->setEntityClass(TranslateArticle::class);
 
@@ -1436,7 +1436,7 @@ class TranslateBehaviorTest extends TestCase
         $table = $this->getTableLocator()->get('Sections');
         $table->addBehavior('Translate', [
             'fields' => ['title'],
-            'validator' => (new \Cake\Validation\Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),
+            'validator' => (new Validator())->add('title', 'notBlank', ['rule' => 'notBlank']),
         ]);
 
         $data = [

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * Translate behavior test case
@@ -239,7 +241,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testFindChildrenException(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
+        $this->expectException(RecordNotFoundException::class);
         $table = $this->getTableLocator()->get('MenuLinkTrees');
         $table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
         $query = $table->find('children', ['for' => 500]);
@@ -859,7 +861,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testReParentSelf(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot set a node\'s parent as itself');
         $entity = $this->table->get(1);
         $entity->parent_id = $entity->id;
@@ -871,7 +873,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testReParentSelfNewEntity(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot set a node\'s parent as itself');
         $entity = $this->table->newEntity(['name' => 'root']);
         $entity->id = 1;
@@ -1086,7 +1088,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testReparentCycle(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot use node "5" as parent for entity "2"');
         $table = $this->table;
         $entity = $table->get(2);

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -16,10 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use BadMethodCallException;
 use Cake\ORM\BehaviorRegistry;
+use Cake\ORM\Exception\MissingBehaviorException;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use LogicException;
 
 /**
  * Test case for BehaviorRegistry.
@@ -138,7 +141,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testLoadMissingClass(): void
     {
-        $this->expectException(\Cake\ORM\Exception\MissingBehaviorException::class);
+        $this->expectException(MissingBehaviorException::class);
         $this->Behaviors->load('DoesNotExist');
     }
 
@@ -147,7 +150,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testLoadDuplicateMethodError(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->load('Duplicate');
@@ -175,7 +178,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testLoadDuplicateFinderError(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"');
         $this->Behaviors->load('Tree');
         $this->Behaviors->load('Duplicate');
@@ -264,7 +267,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testCallError(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call "nope"');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->call('nope');
@@ -300,7 +303,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testCallFinderError(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call finder "nope"');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->callFinder('nope');
@@ -311,7 +314,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testUnloadBehaviorThenCall(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call "slugify" it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
@@ -324,7 +327,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testUnloadBehaviorThenCallFinder(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call finder "noslug" it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
@@ -364,7 +367,7 @@ class BehaviorRegistryTest extends TestCase
      */
     public function testUnloadUnknown(): void
     {
-        $this->expectException(\Cake\ORM\Exception\MissingBehaviorException::class);
+        $this->expectException(MissingBehaviorException::class);
         $this->expectExceptionMessage('Behavior class FooBehavior could not be found.');
         $this->Behaviors->unload('Foo');
     }

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -19,12 +19,14 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\ResultSetDecorator;
 use Cake\ORM\Entity;
 use Cake\ORM\Marshaller;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use PDO;
+use RuntimeException;
 use TestApp\Model\Entity\OpenArticleEntity;
 
 /**
@@ -106,7 +108,7 @@ class CompositeKeysTest extends TestCase
      */
     public function testSaveNewErrorCompositeKeyNoIncrement(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing');
         $articles = $this->getTableLocator()->get('SiteArticles');
         $article = $articles->newEntity(['site_id' => 1, 'author_id' => 1, 'title' => 'testing']);
@@ -421,7 +423,7 @@ class CompositeKeysTest extends TestCase
      */
     public function testSaveNewEntityMissingKey(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing. Got (5, ), expecting (id, site_id)');
         $entity = new Entity([
             'id' => 5,
@@ -571,7 +573,7 @@ class CompositeKeysTest extends TestCase
             ->setConstructorArgs([$table->getConnection(), $table])
             ->getMock();
 
-        $items = new \Cake\Datasource\ResultSetDecorator([
+        $items = new ResultSetDecorator([
             ['id' => 1, 'name' => 'a', 'site_id' => 1, 'parent_id' => null],
             ['id' => 2, 'name' => 'a', 'site_id' => 2, 'parent_id' => null],
             ['id' => 3, 'name' => 'a', 'site_id' => 1, 'parent_id' => 1],

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -18,6 +18,8 @@ namespace Cake\Test\TestCase\ORM;
 
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use stdClass;
 use TestApp\Model\Entity\Extending;
 use TestApp\Model\Entity\NonExtending;
 
@@ -1477,7 +1479,7 @@ class EntityTest extends TestCase
      */
     public function testEmptyProperties(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $entity = new Entity();
         $entity->get('');
     }
@@ -1571,7 +1573,7 @@ class EntityTest extends TestCase
         $entity = new Entity([
             'array' => ['foo' => 'bar'],
             'emptyArray' => [],
-            'object' => new \stdClass(),
+            'object' => new stdClass(),
             'string' => 'string',
             'stringZero' => '0',
             'emptyString' => '',
@@ -1603,7 +1605,7 @@ class EntityTest extends TestCase
         $entity = new Entity([
             'array' => ['foo' => 'bar'],
             'emptyArray' => [],
-            'object' => new \stdClass(),
+            'object' => new stdClass(),
             'string' => 'string',
             'stringZero' => '0',
             'emptyString' => '',

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
+use RuntimeException;
 use TestApp\Infrastructure\Table\AddressesTable;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\MyUsersTable;
@@ -102,7 +103,7 @@ class TableLocatorTest extends TestCase
         $users = $this->_locator->get('Users');
         $this->assertNotEmpty($users);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('You cannot configure "Users", it has already been constructed.');
 
         $this->_locator->setConfig('Users', ['table' => 'my_users']);
@@ -276,7 +277,7 @@ class TableLocatorTest extends TestCase
         $users = $this->_locator->get('Users');
         $this->assertNotEmpty($users);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('You cannot configure "Users", it already exists in the registry.');
 
         $this->_locator->get('Users', ['table' => 'my_users']);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -23,6 +23,8 @@ use Cake\ORM\Entity;
 use Cake\ORM\Marshaller;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
+use InvalidArgumentException;
+use RuntimeException;
 use TestApp\Model\Entity\OpenArticleEntity;
 use TestApp\Model\Entity\OpenTag;
 use TestApp\Model\Entity\ProtectedArticle;
@@ -282,7 +284,7 @@ class MarshallerTest extends TestCase
      */
     public function testOneInvalidAssociation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot marshal data for "Derp" association. It is not associated with "Articles".');
         $data = [
             'title' => 'My title',
@@ -1116,7 +1118,7 @@ class MarshallerTest extends TestCase
      */
     public function testManyInvalidAssociation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $data = [
             [
                 'comment' => 'First post',
@@ -1354,7 +1356,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeInvalidAssociation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot marshal data for "Derp" association. It is not associated with "Articles".');
         $data = [
             'title' => 'My title',
@@ -2752,7 +2754,7 @@ class MarshallerTest extends TestCase
      */
     public function testValidateInvalidType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $data = ['title' => 'foo'];
         $marshaller = new Marshaller($this->articles);
         $marshaller->one($data, [
@@ -3300,7 +3302,7 @@ class MarshallerTest extends TestCase
      */
     public function testInvalidTypesWhenLoadingAssociatedByIds(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
 
         $data = [
@@ -3320,7 +3322,7 @@ class MarshallerTest extends TestCase
      */
     public function testInvalidTypesWhenLoadingAssociatedByCompositeIds(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
 
         $data = [

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -16,13 +16,18 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Contains regression test for the Query builder
@@ -148,7 +153,7 @@ class QueryRegressionTest extends TestCase
             'finder' => 'list',
         ]);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('"_joinData" is missing from the belongsToMany results');
         $table->find()->contain('Tags')->toArray();
     }
@@ -621,7 +626,7 @@ class QueryRegressionTest extends TestCase
         $tags = $this->getTableLocator()->get('Tags');
 
         $this->skipIf(
-            $tags->getConnection()->getDriver() instanceof \Cake\Database\Driver\Sqlserver,
+            $tags->getConnection()->getDriver() instanceof Sqlserver,
             'SQL server is temporarily weird in this test, will investigate later'
         );
         $tags = $this->getTableLocator()->get('Tags');
@@ -960,7 +965,7 @@ class QueryRegressionTest extends TestCase
      */
     public function testQueryNotFatalError(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->loadFixtures('Comments');
         $comments = $this->getTableLocator()->get('Comments');
         $comments->find()->contain('Deprs')->all();
@@ -1234,7 +1239,7 @@ class QueryRegressionTest extends TestCase
         ]);
         $query = $table->find()
             ->contain(['Tags' => function ($q) {
-                return $q->where(['SpecialTags.highlighted_time >' => new \Cake\I18n\DateTime('2014-06-01 00:00:00')]);
+                return $q->where(['SpecialTags.highlighted_time >' => new DateTime('2014-06-01 00:00:00')]);
             }])
             ->where(['Articles.id' => 2]);
 
@@ -1257,7 +1262,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->contain('Comments')
             ->where([
-                'Comments.updated >' => new \DateTime('2007-03-18 10:55:00'),
+                'Comments.updated >' => new NativeDateTime('2007-03-18 10:55:00'),
             ]);
 
         $result = $query->first();
@@ -1284,7 +1289,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->contain('Comments.Articles.Authors')
             ->where([
-                'Authors.created >' => new \DateTime('2007-03-17 01:16:00'),
+                'Authors.created >' => new NativeDateTime('2007-03-17 01:16:00'),
             ]);
 
         $result = $query->first();
@@ -1311,7 +1316,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->matching('Comments')
             ->where([
-                'Comments.updated >' => new \DateTime('2007-03-18 10:55:00'),
+                'Comments.updated >' => new NativeDateTime('2007-03-18 10:55:00'),
             ]);
 
         $result = $query->first();
@@ -1321,7 +1326,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->matching('Comments.Articles.Authors')
             ->where([
-                'Authors.created >' => new \DateTime('2007-03-17 01:16:00'),
+                'Authors.created >' => new NativeDateTime('2007-03-17 01:16:00'),
             ]);
 
         $result = $query->first();
@@ -1343,7 +1348,7 @@ class QueryRegressionTest extends TestCase
                 return $q ->where(['ArticlesTags.tag_id !=' => 3 ]);
             })
             ->where([
-                'Tags.created <' => new \DateTime('2016-01-02 00:00:00'),
+                'Tags.created <' => new NativeDateTime('2016-01-02 00:00:00'),
             ]);
 
         $result = $query->first();
@@ -1371,7 +1376,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->innerJoinWith('Comments')
             ->where([
-                'Comments.updated >' => new \DateTime('2007-03-18 10:55:00'),
+                'Comments.updated >' => new NativeDateTime('2007-03-18 10:55:00'),
             ]);
 
         $result = $query->first();
@@ -1381,7 +1386,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->innerJoinWith('Comments.Articles.Authors')
             ->where([
-                'Authors.created >' => new \DateTime('2007-03-17 01:16:00'),
+                'Authors.created >' => new NativeDateTime('2007-03-17 01:16:00'),
             ]);
 
         $result = $query->first();
@@ -1408,7 +1413,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->leftJoinWith('Comments')
             ->where([
-                'Comments.updated >' => new \DateTime('2007-03-18 10:55:00'),
+                'Comments.updated >' => new NativeDateTime('2007-03-18 10:55:00'),
             ]);
 
         $result = $query->first();
@@ -1418,7 +1423,7 @@ class QueryRegressionTest extends TestCase
         $query = $table->find()
             ->leftJoinWith('Comments.Articles.Authors')
             ->where([
-                'Authors.created >' => new \DateTime('2007-03-17 01:16:00'),
+                'Authors.created >' => new NativeDateTime('2007-03-17 01:16:00'),
             ]);
 
         $result = $query->first();
@@ -1610,7 +1615,7 @@ class QueryRegressionTest extends TestCase
 
         $tags->getTarget()->getEventManager()->on('Model.beforeFind', function ($e, $query) {
             return $query->formatResults(function ($results) {
-                return $results->map(function (\Cake\ORM\Entity $tag) {
+                return $results->map(function (Entity $tag) {
                     $tag->name .= ' - visited';
 
                     return $tag;

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Cache\Engine\FileEngine;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
@@ -33,6 +34,7 @@ use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use ReflectionProperty;
 use RuntimeException;
 
@@ -1798,7 +1800,7 @@ class QueryTest extends TestCase
      */
     public function testCacheErrorOnNonSelect(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
         $query->insert(['test']);
@@ -1866,7 +1868,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = new Query($this->connection, $table);
-        $cacher = new \Cake\Cache\Engine\FileEngine();
+        $cacher = new FileEngine();
         $cacher->init();
 
         $query
@@ -1957,7 +1959,7 @@ class QueryTest extends TestCase
      */
     public function testContainWithQueryBuilderHasManyError(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('Articles');
         $query = new Query($this->connection, $table);
@@ -3425,7 +3427,7 @@ class QueryTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $results->toList());
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The `Tags` association is not defined on `Articles`.');
         $table
             ->find()

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -25,6 +25,9 @@ use Cake\ORM\Query;
 use Cake\ORM\Rule\LinkConstraint;
 use Cake\ORM\RulesChecker;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use RuntimeException;
+use stdClass;
 
 /**
  * Tests the LinkConstraint rule.
@@ -84,7 +87,7 @@ class LinkConstraintTest extends TestCase
      */
     public function invalidConstructorArgumentOneDataProvider(): array
     {
-        return [[null, 'null'], [1, 'int'], [[], 'array'], [new \stdClass(), 'stdClass']];
+        return [[null, 'null'], [1, 'int'], [[], 'array'], [new stdClass(), 'stdClass']];
     }
 
     /**
@@ -92,7 +95,7 @@ class LinkConstraintTest extends TestCase
      */
     public function testInvalidConstructorArgumentTwo(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument 2 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::STATUS_*` constants.');
 
         new LinkConstraint('Association', 'invalid');
@@ -103,7 +106,7 @@ class LinkConstraintTest extends TestCase
      */
     public function testNonExistentAssociation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The `NonExistent` association is not defined on `Articles`.');
 
         $Articles = $this->getTableLocator()->get('Articles');
@@ -122,7 +125,7 @@ class LinkConstraintTest extends TestCase
      */
     public function testMissingPrimaryKeyValues(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'LinkConstraint rule on `Articles` requires all primary key values for building the counting ' .
             'conditions, expected values for `(id, nonexistent)`, got `(1, )`.'
@@ -150,7 +153,7 @@ class LinkConstraintTest extends TestCase
      */
     public function testNonMatchingKeyFields(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'The number of fields is expected to match the number of values, got 0 field(s) and 1 value(s).'
         );
@@ -185,7 +188,7 @@ class LinkConstraintTest extends TestCase
     {
         return [
             [['repository' => null]],
-            [['repository' => new \stdClass()]],
+            [['repository' => new stdClass()]],
             [[]],
         ];
     }
@@ -198,7 +201,7 @@ class LinkConstraintTest extends TestCase
      */
     public function testInvalidRepository($options): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Argument 2 is expected to have a `repository` key that holds an instance of `\Cake\ORM\Table`');
 
         $Articles = $this->getMockForModel('Articles', ['buildRules'], ['table' => 'articles']);

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use ArrayObject;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
@@ -25,6 +26,9 @@ use Cake\ORM\Entity;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use Closure;
+use RuntimeException;
+use stdClass;
 
 /**
  * Tests the integration between the ORM and the domain checker
@@ -572,7 +576,7 @@ class RulesCheckerIntegrationTest extends TestCase
      */
     public function testExistsInInvalidAssociation(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('ExistsIn rule for \'author_id\' is invalid. \'NotValid\' is not associated with \'Cake\ORM\Table\'.');
         $entity = new Entity([
             'title' => 'An Article',
@@ -680,7 +684,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $table->getEventManager()->on(
             'Model.beforeRules',
-            function (EventInterface $event, EntityInterface $entity, \ArrayObject $options, $operation) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation) {
                 $this->assertEquals(
                     [
                         'atomic' => true,
@@ -719,7 +723,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $table->getEventManager()->on(
             'Model.afterRules',
-            function (EventInterface $event, EntityInterface $entity, \ArrayObject $options, $result, $operation) {
+            function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $result, $operation) {
                 $this->assertEquals(
                     [
                         'atomic' => true,
@@ -1317,7 +1321,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $entity->tags = null;
         $this->assertFalse($table->save($entity));
 
-        $entity->tags = new \stdClass();
+        $entity->tags = new stdClass();
         $this->assertFalse($table->save($entity));
 
         $entity->tags = 'string';
@@ -1733,7 +1737,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
 
-        \Closure::bind(
+        Closure::bind(
             function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },
@@ -1778,7 +1782,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
 
-        \Closure::bind(
+        Closure::bind(
             function () use ($rulesChecker): void {
                 $rulesChecker->{'_useI18n'} = false;
             },

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -20,6 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\ORM\SaveOptionsBuilder;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 /**
  * SaveOptionsBuilder test case.
@@ -97,7 +98,7 @@ class SaveOptionsBuilderTest extends TestCase
                 'Comments.DoesNotExist'
             );
             $this->fail('No \RuntimeException throw for invalid association!');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
         }
 
         $expected = [

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\ORM\Exception\RolledbackTransactionException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 
@@ -41,7 +42,7 @@ class TableRegressionTest extends TestCase
      */
     public function testAfterSaveRollbackTransaction(): void
     {
-        $this->expectException(\Cake\ORM\Exception\RolledbackTransactionException::class);
+        $this->expectException(RolledbackTransactionException::class);
         $table = $this->getTableLocator()->get('Authors');
         $table->getEventManager()->on(
             'Model.afterSave',

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -17,7 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
+use BadMethodCallException;
 use Cake\Collection\Collection;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Schema\TableSchema;
@@ -25,6 +27,8 @@ use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Exception\InvalidPrimaryKeyException;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\I18n\DateTime;
@@ -34,6 +38,8 @@ use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\AssociationCollection;
 use Cake\ORM\Entity;
+use Cake\ORM\Exception\MissingBehaviorException;
+use Cake\ORM\Exception\MissingEntityException;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -42,9 +48,12 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use Cake\Validation\Validator;
+use Exception;
 use InvalidArgumentException;
+use PDOException;
 use RuntimeException;
 use TestApp\Model\Entity\ProtectedEntity;
+use TestApp\Model\Entity\Tag;
 use TestApp\Model\Entity\VirtualUser;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\UsersTable;
@@ -1517,7 +1526,7 @@ class TableTest extends TestCase
      */
     public function testTableClassNonExistent(): void
     {
-        $this->expectException(\Cake\ORM\Exception\MissingEntityException::class);
+        $this->expectException(MissingEntityException::class);
         $this->expectExceptionMessage('Entity class FooUser could not be found.');
         $table = new Table();
         $table->setEntityClass('FooUser');
@@ -1529,7 +1538,7 @@ class TableTest extends TestCase
      */
     public function testTableClassConventionForAPP(): void
     {
-        $table = new \TestApp\Model\Table\ArticlesTable();
+        $table = new ArticlesTable();
         $this->assertSame('TestApp\Model\Entity\Article', $table->getEntityClass());
     }
 
@@ -1550,7 +1559,7 @@ class TableTest extends TestCase
      */
     public function testReciprocalBelongsToLoading(): void
     {
-        $table = new \TestApp\Model\Table\ArticlesTable([
+        $table = new ArticlesTable([
             'connection' => $this->connection,
         ]);
         $result = $table->find('all')->contain(['Authors'])->first();
@@ -1563,7 +1572,7 @@ class TableTest extends TestCase
      */
     public function testReciprocalHasManyLoading(): void
     {
-        $table = new \TestApp\Model\Table\ArticlesTable([
+        $table = new ArticlesTable([
             'connection' => $this->connection,
         ]);
         $result = $table->find('all')->contain(['Authors' => ['articles']])->first();
@@ -1579,7 +1588,7 @@ class TableTest extends TestCase
      */
     public function testReciprocalBelongsToMany(): void
     {
-        $table = new \TestApp\Model\Table\ArticlesTable([
+        $table = new ArticlesTable([
             'connection' => $this->connection,
         ]);
         $result = $table->find('all')->contain(['Tags'])->first();
@@ -1595,7 +1604,7 @@ class TableTest extends TestCase
      */
     public function testFindCleanEntities(): void
     {
-        $table = new \TestApp\Model\Table\ArticlesTable([
+        $table = new ArticlesTable([
             'connection' => $this->connection,
         ]);
         $results = $table->find('all')->contain(['Tags', 'Authors'])->toArray();
@@ -1621,7 +1630,7 @@ class TableTest extends TestCase
      */
     public function testFindPersistedEntities(): void
     {
-        $table = new \TestApp\Model\Table\ArticlesTable([
+        $table = new ArticlesTable([
             'connection' => $this->connection,
         ]);
         $results = $table->find('all')->contain(['Tags', 'Authors'])->toArray();
@@ -1677,7 +1686,7 @@ class TableTest extends TestCase
         try {
             $table->addBehavior('Sluggable', ['thing' => 'thing']);
             $this->fail('No exception raised');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString('The "Sluggable" alias has already been loaded', $e->getMessage());
         }
     }
@@ -1769,7 +1778,7 @@ class TableTest extends TestCase
      */
     public function testAddBehaviorMissing(): void
     {
-        $this->expectException(\Cake\ORM\Exception\MissingBehaviorException::class);
+        $this->expectException(MissingBehaviorException::class);
         $table = $this->getTableLocator()->get('article');
         $this->assertNull($table->addBehavior('NopeNotThere'));
     }
@@ -2310,7 +2319,7 @@ class TableTest extends TestCase
      */
     public function testSaveNewErrorOnNoPrimaryKey(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot insert row in "users" table, it has no primary key');
         $entity = new Entity(['username' => 'superuser']);
         $table = $this->getTableLocator()->get('users', [
@@ -2363,7 +2372,7 @@ class TableTest extends TestCase
      */
     public function testAtomicSaveRollback(): void
     {
-        $this->expectException(\PDOException::class);
+        $this->expectException(PDOException::class);
         $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->onlyMethods(['begin', 'rollback'])
             ->setConstructorArgs([ConnectionManager::getConfig('test')])
@@ -2387,7 +2396,7 @@ class TableTest extends TestCase
         $connection->expects($this->once())->method('begin');
         $connection->expects($this->once())->method('rollback');
         $query->expects($this->once())->method('execute')
-            ->will($this->throwException(new \PDOException()));
+            ->will($this->throwException(new PDOException()));
 
         $data = new Entity([
             'username' => 'superuser',
@@ -2664,7 +2673,7 @@ class TableTest extends TestCase
      */
     public function testUpdateNoPrimaryButOtherKeys(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['query'])
@@ -2763,11 +2772,11 @@ class TableTest extends TestCase
 
         $table->getEventManager()->on('Model.beforeSave', function (EventInterface $event, EntityInterface $entity): void {
             if ($entity->name === 'jose') {
-                throw new \Exception('Oh noes');
+                throw new Exception('Oh noes');
             }
         });
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         try {
             $table->saveMany($entities);
@@ -3061,7 +3070,7 @@ class TableTest extends TestCase
     public function testDeleteCallbacks(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
-        $options = new \ArrayObject(['atomic' => true, 'checkRules' => false, '_primary' => true]);
+        $options = new ArrayObject(['atomic' => true, 'checkRules' => false, '_primary' => true]);
 
         $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
 
@@ -3101,7 +3110,7 @@ class TableTest extends TestCase
         $table = $this->getTableLocator()->get('users');
 
         $data = $table->get(1);
-        $options = new \ArrayObject(['atomic' => false, 'checkRules' => false]);
+        $options = new ArrayObject(['atomic' => false, 'checkRules' => false]);
 
         $called = false;
         $listener = function ($e, $entity, $options) use ($data, &$called): void {
@@ -3157,7 +3166,7 @@ class TableTest extends TestCase
     public function testDeleteBeforeDeleteAbort(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
-        $options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
+        $options = new ArrayObject(['atomic' => true, 'cascade' => true]);
 
         $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->any())
@@ -3180,7 +3189,7 @@ class TableTest extends TestCase
     public function testDeleteBeforeDeleteReturnResult(): void
     {
         $entity = new Entity(['id' => 1, 'name' => 'mark']);
-        $options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
+        $options = new ArrayObject(['atomic' => true, 'cascade' => true]);
 
         $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->any())
@@ -3314,7 +3323,7 @@ class TableTest extends TestCase
         $table->expects($this->once())
             ->method('validationBad');
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
             'The %s::validationBad() validation method must return an instance of Cake\Validation\Validator.',
             get_class($table)
@@ -3328,7 +3337,7 @@ class TableTest extends TestCase
      */
     public function testValidatorWithMissingMethod(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The Cake\ORM\Table::validationMissing() validation method does not exists.');
         $table = new Table();
         $table->getValidator('missing');
@@ -3340,7 +3349,7 @@ class TableTest extends TestCase
     public function testValidatorSetter(): void
     {
         $table = new Table();
-        $validator = new \Cake\Validation\Validator();
+        $validator = new Validator();
         $table->setValidator('other', $validator);
         $this->assertSame($validator, $table->getValidator('other'));
         $this->assertSame($table, $validator->getProvider('table'));
@@ -3355,7 +3364,7 @@ class TableTest extends TestCase
         $this->assertTrue($table->hasValidator('default'));
         $this->assertFalse($table->hasValidator('other'));
 
-        $validator = new \Cake\Validation\Validator();
+        $validator = new Validator();
         $table->setValidator('other', $validator);
         $this->assertTrue($table->hasValidator('other'));
     }
@@ -3419,7 +3428,7 @@ class TableTest extends TestCase
      */
     public function testMagicFindError(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Not enough arguments for magic finder. Got 0 required 1');
         $table = $this->getTableLocator()->get('Users');
 
@@ -3431,7 +3440,7 @@ class TableTest extends TestCase
      */
     public function testMagicFindErrorMissingField(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Not enough arguments for magic finder. Got 1 required 2');
         $table = $this->getTableLocator()->get('Users');
 
@@ -3443,7 +3452,7 @@ class TableTest extends TestCase
      */
     public function testMagicFindErrorMixOfOperators(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot mix "and" & "or" in a magic finder. Use find() instead.');
         $table = $this->getTableLocator()->get('Users');
 
@@ -3981,7 +3990,7 @@ class TableTest extends TestCase
         $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $tags = $article->tags;
         $this->assertNotEmpty($tags);
-        $tags[] = new \TestApp\Model\Entity\Tag(['name' => 'Something New']);
+        $tags[] = new Tag(['name' => 'Something New']);
         $article->tags = $tags;
         $this->assertSame($article, $table->save($article));
         $tags = $article->tags;
@@ -4091,7 +4100,7 @@ class TableTest extends TestCase
                 ->setFinder('list')
                 ->setProperty('authors')
                 ->setJoinType('inner');
-        } catch (\BadMethodCallException $e) {
+        } catch (BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
         $this->assertSame('articles', $articles->getTable());
@@ -4117,7 +4126,7 @@ class TableTest extends TestCase
                 ->setStrategy('select')
                 ->setProperty('authors')
                 ->setJoinType('inner');
-        } catch (\BadMethodCallException $e) {
+        } catch (BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
         $this->assertSame('authors', $authors->getTable());
@@ -4145,7 +4154,7 @@ class TableTest extends TestCase
                 ->setSaveStrategy('replace')
                 ->setProperty('authors')
                 ->setJoinType('inner');
-        } catch (\BadMethodCallException $e) {
+        } catch (BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
         $this->assertSame('authors', $authors->getTable());
@@ -4173,7 +4182,7 @@ class TableTest extends TestCase
                 ->setSaveStrategy('append')
                 ->setThrough('author_articles')
                 ->setJoinType('inner');
-        } catch (\BadMethodCallException $e) {
+        } catch (BadMethodCallException $e) {
             $this->fail('Method chaining should be ok');
         }
         $this->assertSame('authors', $authors->getTable());
@@ -4194,12 +4203,12 @@ class TableTest extends TestCase
             'id' => 1,
         ], $options);
 
-        $newTag = new \TestApp\Model\Entity\Tag([
+        $newTag = new Tag([
             'name' => 'Foo',
             'description' => 'Foo desc',
             'created' => null,
         ], $source);
-        $tags[] = new \TestApp\Model\Entity\Tag([
+        $tags[] = new Tag([
             'id' => 3,
         ], $options + $source);
         $tags[] = $newTag;
@@ -4720,8 +4729,8 @@ class TableTest extends TestCase
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
+        $tags[] = new Tag(['id' => 1], $options);
+        $tags[] = new Tag(['id' => 2], $options);
 
         $table->getAssociation('Tags')->unlink($article, $tags);
         $left = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
@@ -4740,8 +4749,8 @@ class TableTest extends TestCase
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
+        $tags[] = new Tag(['id' => 1], $options);
+        $tags[] = new Tag(['id' => 2], $options);
 
         $tags[1]->_joinData = new Entity([
             'article_id' => 1,
@@ -4764,9 +4773,9 @@ class TableTest extends TestCase
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['name' => 'foo']);
+        $tags[] = new Tag(['id' => 2], $options);
+        $tags[] = new Tag(['id' => 3], $options);
+        $tags[] = new Tag(['name' => 'foo']);
 
         $table->getAssociation('Tags')->replaceLinks($article, $tags);
         $this->assertSame(2, $article->tags[0]->id);
@@ -4812,14 +4821,14 @@ class TableTest extends TestCase
         $options = ['markNew' => false];
 
         $article = new Entity(['id' => 1], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag([
+        $tags[] = new Tag([
             'id' => 2,
             '_joinData' => new Entity([
                 'article_id' => 1,
                 'tag_id' => 2,
             ]),
         ], $options);
-        $tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
+        $tags[] = new Tag(['id' => 3], $options);
 
         $table->getAssociation('Tags')->replaceLinks($article, $tags);
         $this->assertSame($tags, $article->tags);
@@ -5403,7 +5412,7 @@ class TableTest extends TestCase
      */
     public function testGetNotFoundException(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\RecordNotFoundException::class);
+        $this->expectException(RecordNotFoundException::class);
         $this->expectExceptionMessage('Record not found in table "articles"');
         $table = new Table([
             'name' => 'Articles',
@@ -5418,7 +5427,7 @@ class TableTest extends TestCase
      */
     public function testGetExceptionOnNoData(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\InvalidPrimaryKeyException::class);
+        $this->expectException(InvalidPrimaryKeyException::class);
         $this->expectExceptionMessage('Record not found in table "articles" with primary key [NULL]');
         $table = new Table([
             'name' => 'Articles',
@@ -5433,7 +5442,7 @@ class TableTest extends TestCase
      */
     public function testGetExceptionOnTooMuchData(): void
     {
-        $this->expectException(\Cake\Datasource\Exception\InvalidPrimaryKeyException::class);
+        $this->expectException(InvalidPrimaryKeyException::class);
         $this->expectExceptionMessage('Record not found in table "articles" with primary key [1, \'two\']');
         $table = new Table([
             'name' => 'Articles',
@@ -6299,7 +6308,7 @@ class TableTest extends TestCase
      */
     public function testSaveOrFail(): void
     {
-        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
+        $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure.');
 
         $entity = new Entity([
@@ -6315,7 +6324,7 @@ class TableTest extends TestCase
      */
     public function testSaveOrFailErrorDisplay(): void
     {
-        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
+        $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure. Found the following errors (field.0: "Some message", multiple.one: "One", multiple.two: "Two")');
 
         $entity = new Entity([
@@ -6333,7 +6342,7 @@ class TableTest extends TestCase
      */
     public function testSaveOrFailNestedError(): void
     {
-        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
+        $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity save failure. Found the following errors (articles.0.title.0: "Bad value")');
 
         $entity = new Entity([
@@ -6362,7 +6371,7 @@ class TableTest extends TestCase
 
         try {
             $table->saveOrFail($entity);
-        } catch (\Cake\ORM\Exception\PersistenceFailedException $e) {
+        } catch (PersistenceFailedException $e) {
             $this->assertSame($entity, $e->getEntity());
         }
     }
@@ -6372,7 +6381,7 @@ class TableTest extends TestCase
      */
     public function testDeleteOrFail(): void
     {
-        $this->expectException(\Cake\ORM\Exception\PersistenceFailedException::class);
+        $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage('Entity delete failure.');
         $entity = new Entity([
             'id' => 999,
@@ -6394,7 +6403,7 @@ class TableTest extends TestCase
 
         try {
             $table->deleteOrFail($entity);
-        } catch (\Cake\ORM\Exception\PersistenceFailedException $e) {
+        } catch (PersistenceFailedException $e) {
             $this->assertSame($entity, $e->getEntity());
         }
     }
@@ -6415,7 +6424,7 @@ class TableTest extends TestCase
     public function skipIfSqlServer(): void
     {
         $this->skipIf(
-            $this->connection->getDriver() instanceof \Cake\Database\Driver\Sqlserver,
+            $this->connection->getDriver() instanceof Sqlserver,
             'SQLServer does not support the requirements of this test.'
         );
     }

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -21,6 +21,7 @@ use Cake\Cache\InvalidArgumentException as CacheInvalidArgumentException;
 use Cake\Core\Configure;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Http\ServerRequestFactory;
+use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Middleware\RoutingMiddleware;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
@@ -204,7 +205,7 @@ class RoutingMiddlewareTest extends TestCase
      */
     public function testMissingRouteNotCaught(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/missing']);
         $middleware = new RoutingMiddleware($this->app());
         $middleware->process($request, new TestRequestHandler());

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -21,6 +21,7 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use TestApp\Routing\Route\ProtectedRoute;
 
 /**
@@ -52,7 +53,7 @@ class RouteTest extends TestCase
 
     public function testConstructionWithInvalidMethod(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index', '_method' => 'nope']);
     }
@@ -1640,7 +1641,7 @@ class RouteTest extends TestCase
      */
     public function testSetMethodsInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
         $route = new Route('/books/reviews', ['controller' => 'Reviews', 'action' => 'index']);
         $route->setMethods(['nope']);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Routing;
 
+use BadMethodCallException;
+use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\Route\RedirectRoute;
@@ -25,6 +27,7 @@ use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * RouteBuilder test case
@@ -352,7 +355,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testConnectConflictingParameters(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('You cannot define routes that conflict with the scope.');
         $routes = new RouteBuilder($this->collection, '/admin', ['plugin' => 'TestPlugin']);
         $routes->connect('/', ['plugin' => 'TestPlugin2', 'controller' => 'Dashboard', 'action' => 'view']);
@@ -880,7 +883,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testScopeException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Need a valid callable to connect routes. Got `null` instead.');
 
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
@@ -961,7 +964,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testMiddlewareGroupOverlap(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot add middleware group \'test\'. A middleware by this name has already been registered.');
         $func = function (): void {
         };
@@ -975,7 +978,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testApplyMiddlewareInvalidName(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot apply \'bad\' middleware or middleware group. Use registerMiddleware() to register middleware');
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->applyMiddleware('bad');
@@ -1134,7 +1137,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testLoadPluginBadPlugin(): void
     {
-        $this->expectException(\Cake\Core\Exception\MissingPluginException::class);
+        $this->expectException(MissingPluginException::class);
         $routes = new RouteBuilder($this->collection, '/');
         $routes->loadPlugin('Nope');
     }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -17,11 +17,13 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Routing;
 
 use Cake\Http\ServerRequest;
+use Cake\Routing\Exception\DuplicateNamedRouteException;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 class RouteCollectionTest extends TestCase
 {
@@ -44,7 +46,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testParseMissingRoute(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "/" could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
@@ -59,7 +61,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testParseMissingRouteMethod(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $this->expectExceptionMessage('A "POST" route matching "/b" could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles', '_method' => ['GET']]);
@@ -241,7 +243,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testParseRequestMissingRoute(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "/" could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
@@ -324,7 +326,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testParseRequestCheckHostConditionFail(string $host): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "/fallback" could not be found');
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect(
@@ -432,7 +434,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testMatchError(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $this->expectExceptionMessage('A route matching "array (');
         $context = [
             '_base' => '/',
@@ -495,7 +497,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testMatchNamedError(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $this->expectExceptionMessage('A named route was found for `fail`, but matching failed');
         $context = [
             '_base' => '/',
@@ -513,7 +515,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testMatchNamedMissingError(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         $context = [
             '_base' => '/',
             '_scheme' => 'http',
@@ -613,7 +615,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testAddingDuplicateNamedRoutes(): void
     {
-        $this->expectException(\Cake\Routing\Exception\DuplicateNamedRouteException::class);
+        $this->expectException(DuplicateNamedRouteException::class);
         $one = new Route('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
         $two = new Route('/', ['controller' => 'Dashboards', 'action' => 'display']);
         $this->collection->add($one, ['_name' => 'test']);
@@ -698,7 +700,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testMiddlewareGroupUnregisteredMiddleware(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot add \'bad\' middleware to group \'group\'. It has not been registered.');
         $this->collection->middlewareGroup('group', ['bad']);
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -19,11 +19,14 @@ namespace Cake\Test\TestCase\Routing;
 use Cake\Core\Configure;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
+use Cake\Routing\Exception\DuplicateNamedRouteException;
+use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -993,7 +996,7 @@ class RouterTest extends TestCase
      */
     public function testNamedRouteException(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         Router::connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
@@ -1007,7 +1010,7 @@ class RouterTest extends TestCase
      */
     public function testDuplicateNamedRouteException(): void
     {
-        $this->expectException(\Cake\Routing\Exception\DuplicateNamedRouteException::class);
+        $this->expectException(DuplicateNamedRouteException::class);
         Router::connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
@@ -1566,7 +1569,7 @@ class RouterTest extends TestCase
      */
     public function testParseError(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
         Router::parseRequest($this->makeRequest('/nope', 'GET'));
     }
@@ -1958,14 +1961,14 @@ class RouterTest extends TestCase
         try {
             Router::url(['controller' => '0', 'action' => '1', 'test']);
             $this->fail('No exception raised');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->assertTrue(true, 'Exception was raised');
         }
 
         try {
             Router::url(['prefix' => '1', 'controller' => '0', 'action' => '1', 'test']);
             $this->fail('No exception raised');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->assertTrue(true, 'Exception was raised');
         }
     }
@@ -2084,7 +2087,7 @@ class RouterTest extends TestCase
      */
     public function testParsingWithPatternOnAction(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         Router::connect(
             '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
@@ -2215,7 +2218,7 @@ class RouterTest extends TestCase
      */
     public function testUrlPatternOnAction(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         Router::connect(
             '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
@@ -2395,7 +2398,7 @@ class RouterTest extends TestCase
      */
     public function testRegexRouteMatchUrl(): void
     {
-        $this->expectException(\Cake\Routing\Exception\MissingRouteException::class);
+        $this->expectException(MissingRouteException::class);
         Router::connect('/{locale}/{controller}/{action}/*', [], ['locale' => 'dan|eng']);
 
         $request = new ServerRequest([
@@ -2461,7 +2464,7 @@ class RouterTest extends TestCase
      */
     public function testCustomRouteException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Router::connect('/{controller}', [], ['routeClass' => 'Object']);
     }
 

--- a/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
@@ -8,6 +8,7 @@ use Cake\Event\EventList;
 use Cake\Event\EventManager;
 use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
 use stdClass;
 
 /**
@@ -61,7 +62,7 @@ class EventFiredWithTest extends TestCase
      */
     public function testMatchesInvalid(): void
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->expectException(AssertionFailedError::class);
         $manager = EventManager::instance();
         $manager->setEventList(new EventList());
         $manager->trackEvents(true);

--- a/tests/TestCase/TestSuite/Fixture/SchemaCleanerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaCleanerTest.php
@@ -19,6 +19,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaCleaner;
 use Cake\TestSuite\TestCase;
+use Throwable;
 
 class SchemaCleanerTest extends TestCase
 {
@@ -33,7 +34,7 @@ class SchemaCleanerTest extends TestCase
         $exceptionThrown = false;
         try {
             $connection->delete($table);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $exceptionThrown = true;
         } finally {
             $this->assertTrue($exceptionThrown);

--- a/tests/TestCase/TestSuite/Fixture/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaManagerTest.php
@@ -20,6 +20,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\SchemaCleaner;
 use Cake\TestSuite\Fixture\SchemaManager;
 use Cake\TestSuite\TestCase;
+use RuntimeException;
 
 class SchemaManagerTest extends TestCase
 {
@@ -76,7 +77,7 @@ class SchemaManagerTest extends TestCase
 
     public function testCreateFromNonExistentFile(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         SchemaManager::create('test', 'foo');
     }
 
@@ -86,7 +87,7 @@ class SchemaManagerTest extends TestCase
         $tmpFile = tempnam(sys_get_temp_dir(), 'SchemaManagerTest');
         file_put_contents($tmpFile, $query);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         SchemaManager::create('test', $tmpFile, false, false);
     }
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -32,6 +32,8 @@ use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Laminas\Diactoros\UploadedFile;
+use LogicException;
+use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
 use stdClass;
 
@@ -356,7 +358,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testConfigApplication(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Cannot load `TestApp\MissingApp` for use in integration');
         $this->configApplication('TestApp\MissingApp', []);
         $this->get('/request_action/test_request_action');
@@ -1372,7 +1374,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testDisableErrorHandlerMiddleware(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
         $this->expectExceptionMessage('oh no!');
         $this->disableErrorHandlerMiddleware();
         $this->get('/posts/throw_exception');

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -43,7 +43,7 @@ class TestCaseTest extends TestCase
      */
     public function testEventFiredMisconfiguredEventList(): void
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->expectException(AssertionFailedError::class);
         $manager = EventManager::instance();
         $this->assertEventFired('my.event', $manager);
     }
@@ -53,7 +53,7 @@ class TestCaseTest extends TestCase
      */
     public function testEventFiredWithMisconfiguredEventList(): void
     {
-        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+        $this->expectException(AssertionFailedError::class);
         $manager = EventManager::instance();
         $this->assertEventFiredWith('my.event', 'some', 'data', $manager);
     }

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\TestSuite;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
@@ -136,7 +137,7 @@ class TestFixtureTest extends TestCase
      */
     public function testInitNoImportNoFieldsException(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`: the table does not exist.');
         $fixture = new LettersFixture();
         $fixture->init();

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -21,6 +21,8 @@ use Cake\I18n\DateTime;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * HashTest
@@ -2234,7 +2236,7 @@ class HashTest extends TestCase
      */
     public function testCombineErrorMissingValue(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $data = [
             ['User' => ['id' => 1, 'name' => 'mark']],
             ['User' => ['name' => 'jose']],
@@ -2247,7 +2249,7 @@ class HashTest extends TestCase
      */
     public function testCombineErrorMissingKey(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $data = [
             ['User' => ['id' => 1, 'name' => 'mark']],
             ['User' => ['id' => 2]],
@@ -2973,7 +2975,7 @@ class HashTest extends TestCase
      */
     public function testNestInvalid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $input = [
             [
                 'ParentCategory' => [

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Utility;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Crypto\OpenSsl;
 use Cake\Utility\Security;
+use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -139,7 +140,7 @@ class SecurityTest extends TestCase
      */
     public function testEncryptInvalidKey(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.');
         $txt = 'The quick brown fox jumped over the lazy dog.';
         $key = 'this is too short';
@@ -165,7 +166,7 @@ class SecurityTest extends TestCase
      */
     public function testDecryptInvalidKey(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.');
         $txt = 'The quick brown fox jumped over the lazy dog.';
         $key = 'this is too short';
@@ -177,7 +178,7 @@ class SecurityTest extends TestCase
      */
     public function testDecryptInvalidData(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The data to decrypt cannot be empty.');
         $txt = '';
         $key = 'This is a key that is long enough to be ok.';

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -18,6 +18,9 @@ namespace Cake\Test\TestCase\Utility;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
+use InvalidArgumentException;
+use ReflectionMethod;
+use Transliterator;
 
 /**
  * TextTest class
@@ -1545,7 +1548,7 @@ HTML;
      */
     public function testParseFileSizeException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         Text::parseFileSize('bogus', false);
     }
 
@@ -1584,12 +1587,12 @@ HTML;
     {
         $this->assertNull(Text::getTransliterator());
 
-        $transliterator = \Transliterator::createFromRules('
+        $transliterator = Transliterator::createFromRules('
             $nonletter = [:^Letter:];
             $nonletter → \'*\';
             ::Latin-ASCII;
         ');
-        $this->assertInstanceOf(\Transliterator::class, $transliterator);
+        $this->assertInstanceOf(Transliterator::class, $transliterator);
         Text::setTransliterator($transliterator);
         $this->assertSame($transliterator, Text::getTransliterator());
     }
@@ -1606,7 +1609,7 @@ HTML;
         Text::setTransliteratorId($expected);
         $this->assertSame($expected, Text::getTransliteratorId());
 
-        $this->assertInstanceOf(\Transliterator::class, Text::getTransliterator());
+        $this->assertInstanceOf(Transliterator::class, Text::getTransliterator());
         $this->assertSame($expected, Text::getTransliterator()->id);
 
         Text::setTransliteratorId($defaultTransliteratorId);
@@ -1821,7 +1824,7 @@ HTML;
      */
     public function testStrlen(): void
     {
-        $method = new \ReflectionMethod('Cake\Utility\Text', '_strlen');
+        $method = new ReflectionMethod('Cake\Utility\Text', '_strlen');
         $method->setAccessible(true);
         $strlen = function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
@@ -1845,7 +1848,7 @@ HTML;
      */
     public function testSubstr(): void
     {
-        $method = new \ReflectionMethod('Cake\Utility\Text', '_substr');
+        $method = new ReflectionMethod('Cake\Utility\Text', '_substr');
         $method->setAccessible(true);
         $substr = function () use ($method) {
             return $method->invokeArgs(null, func_get_args());

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -22,6 +22,11 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Exception\XmlException;
 use Cake\Utility\Xml;
+use DateTime;
+use DOMDocument;
+use Exception;
+use RuntimeException;
+use SimpleXMLElement;
 use TypeError;
 
 /**
@@ -57,7 +62,7 @@ class XmlTest extends TestCase
         } catch (XmlException $exception) {
             $cause = $exception->getPrevious();
             $this->assertNotNull($cause);
-            $this->assertInstanceOf(\Exception::class, $cause);
+            $this->assertInstanceOf(Exception::class, $cause);
         }
     }
 
@@ -68,7 +73,7 @@ class XmlTest extends TestCase
     {
         $xml = '<tag>value</tag>';
         $obj = Xml::build($xml);
-        $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
+        $this->assertInstanceOf(SimpleXMLElement::class, $obj);
         $this->assertSame('tag', (string)$obj->getName());
         $this->assertSame('value', (string)$obj);
 
@@ -76,7 +81,7 @@ class XmlTest extends TestCase
         $this->assertEquals($obj, Xml::build($xml));
 
         $obj = Xml::build($xml, ['return' => 'domdocument']);
-        $this->assertInstanceOf(\DOMDocument::class, $obj);
+        $this->assertInstanceOf(DOMDocument::class, $obj);
         $this->assertSame('tag', $obj->firstChild->nodeName);
         $this->assertSame('value', $obj->firstChild->nodeValue);
 
@@ -127,7 +132,7 @@ class XmlTest extends TestCase
      */
     public function testBuildFromFileWhenDisabled(): void
     {
-        $this->expectException(\Cake\Utility\Exception\XmlException::class);
+        $this->expectException(XmlException::class);
         $xml = CORE_TESTS . 'Fixture/sample.xml';
         $obj = Xml::build($xml, ['readFile' => false]);
     }
@@ -190,7 +195,7 @@ class XmlTest extends TestCase
      */
     public function testBuildInvalidData($value): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         Xml::build($value);
     }
 
@@ -199,7 +204,7 @@ class XmlTest extends TestCase
      */
     public function testBuildInvalidDataSimpleXml(): void
     {
-        $this->expectException(\Cake\Utility\Exception\XmlException::class);
+        $this->expectException(XmlException::class);
         $input = '<derp';
         Xml::build($input, ['return' => 'simplexml']);
     }
@@ -212,7 +217,7 @@ class XmlTest extends TestCase
         try {
             Xml::build('<tag>');
             $this->fail('No exception');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->assertTrue(true, 'An exception was raised');
         }
     }
@@ -296,7 +301,7 @@ close to 5 million globally.
             ],
         ];
         $obj = Xml::fromArray($xml, ['format' => 'attributes']);
-        $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
+        $this->assertInstanceOf(SimpleXMLElement::class, $obj);
         $this->assertSame('tags', $obj->getName());
         $this->assertSame(2, count($obj));
         $xmlText = <<<XML
@@ -309,7 +314,7 @@ XML;
         $this->assertXmlStringEqualsXmlString($xmlText, $obj->asXML());
 
         $obj = Xml::fromArray($xml);
-        $this->assertInstanceOf(\SimpleXMLElement::class, $obj);
+        $this->assertInstanceOf(SimpleXMLElement::class, $obj);
         $this->assertSame('tags', $obj->getName());
         $this->assertSame(2, count($obj));
         $xmlText = <<<XML
@@ -600,7 +605,7 @@ XML;
                     ],
                 ],
             ]],
-            [new \DateTime()],
+            [new DateTime()],
         ];
     }
 
@@ -612,7 +617,7 @@ XML;
      */
     public function testFromArrayFail($value): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         Xml::fromArray($value);
     }
 

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
 use Cake\Validation\ValidationRule;
+use InvalidArgumentException;
 
 /**
  * ValidationRuleTest
@@ -90,7 +91,7 @@ class ValidationRuleTest extends TestCase
      */
     public function testCustomMethodMissingError(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to call method "totallyMissing" in "default" provider for field "test"');
         $def = ['rule' => ['totallyMissing']];
         $data = 'some data';

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -21,8 +21,12 @@ use Cake\Core\Configure;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
+use DateTime;
+use DateTimeImmutable;
+use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Locale;
+use RuntimeException;
 use stdClass;
 
 require_once __DIR__ . '/stubs.php';
@@ -948,13 +952,13 @@ class ValidationTest extends TestCase
      */
     public function testDateTimeObject(): void
     {
-        $dateTime = new \DateTime();
+        $dateTime = new DateTime();
         $this->assertTrue(Validation::date($dateTime));
         $this->assertTrue(Validation::time($dateTime));
         $this->assertTrue(Validation::dateTime($dateTime));
         $this->assertTrue(Validation::localizedTime($dateTime));
 
-        $dateTime = new \DateTimeImmutable();
+        $dateTime = new DateTimeImmutable();
         $this->assertTrue(Validation::date($dateTime));
         $this->assertTrue(Validation::time($dateTime));
         $this->assertTrue(Validation::dateTime($dateTime));
@@ -2553,7 +2557,7 @@ class ValidationTest extends TestCase
      */
     public function testMimeTypeFalse(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $image = CORE_TESTS . 'invalid-file.png';
         Validation::mimeType($image, ['image/gif']);
     }
@@ -2875,7 +2879,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::isInteger('2.5'));
         $this->assertFalse(Validation::isInteger(2.5));
         $this->assertFalse(Validation::isInteger([]));
-        $this->assertFalse(Validation::isInteger(new \stdClass()));
+        $this->assertFalse(Validation::isInteger(new stdClass()));
         $this->assertFalse(Validation::isInteger('2 bears'));
         $this->assertFalse(Validation::isInteger(true));
         $this->assertFalse(Validation::isInteger(false));
@@ -2892,7 +2896,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::ascii([]));
         $this->assertFalse(Validation::ascii(1001));
         $this->assertFalse(Validation::ascii(3.14));
-        $this->assertFalse(Validation::ascii(new \stdClass()));
+        $this->assertFalse(Validation::ascii(new stdClass()));
 
         // Latin-1 supplement
         $this->assertFalse(Validation::ascii('some' . "\xc2\x82" . 'value'));
@@ -2913,7 +2917,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::utf8([]));
         $this->assertFalse(Validation::utf8(1001));
         $this->assertFalse(Validation::utf8(3.14));
-        $this->assertFalse(Validation::utf8(new \stdClass()));
+        $this->assertFalse(Validation::utf8(new stdClass()));
         $this->assertTrue(Validation::utf8('1 big blue bus.'));
         $this->assertTrue(Validation::utf8(',.<>[]{;/?\)()'));
 
@@ -2939,7 +2943,7 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::utf8([], ['extended' => true]));
         $this->assertFalse(Validation::utf8(1001, ['extended' => true]));
         $this->assertFalse(Validation::utf8(3.14, ['extended' => true]));
-        $this->assertFalse(Validation::utf8(new \stdClass(), ['extended' => true]));
+        $this->assertFalse(Validation::utf8(new stdClass(), ['extended' => true]));
         $this->assertTrue(Validation::utf8('1 big blue bus.', ['extended' => true]));
         $this->assertTrue(Validation::utf8(',.<>[]{;/?\)()', ['extended' => true]));
 
@@ -2983,7 +2987,7 @@ class ValidationTest extends TestCase
      */
     public function testImageSizeInvalidArgumentException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->assertTrue(Validation::imageSize([], []));
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -17,12 +17,14 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
+use Cake\Validation\RulesProvider;
 use Cake\Validation\Validation;
 use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
+use stdClass;
 
 /**
  * Tests Validator class
@@ -1487,16 +1489,16 @@ class ValidatorTest extends TestCase
     public function testProvider(): void
     {
         $validator = new Validator();
-        $object = new \stdClass();
+        $object = new stdClass();
         $this->assertSame($validator, $validator->setProvider('foo', $object));
         $this->assertSame($object, $validator->getProvider('foo'));
         $this->assertNull($validator->getProvider('bar'));
 
-        $another = new \stdClass();
+        $another = new stdClass();
         $this->assertSame($validator, $validator->setProvider('bar', $another));
         $this->assertSame($another, $validator->getProvider('bar'));
 
-        $this->assertEquals(new \Cake\Validation\RulesProvider(), $validator->getProvider('default'));
+        $this->assertEquals(new RulesProvider(), $validator->getProvider('default'));
     }
 
     /**
@@ -1538,7 +1540,7 @@ class ValidatorTest extends TestCase
             ->will($this->returnCallback(function ($data, $context) use ($thing) {
                 $this->assertSame('bar', $data);
                 $expected = [
-                    'default' => new \Cake\Validation\RulesProvider(),
+                    'default' => new RulesProvider(),
                     'thing' => $thing,
                 ];
                 $expected = [
@@ -1584,7 +1586,7 @@ class ValidatorTest extends TestCase
                 $this->assertSame('and', $a);
                 $this->assertSame('awesome', $b);
                 $expected = [
-                    'default' => new \Cake\Validation\RulesProvider(),
+                    'default' => new RulesProvider(),
                     'thing' => $thing,
                 ];
                 $expected = [
@@ -1924,7 +1926,7 @@ class ValidatorTest extends TestCase
      */
     public function testLengthBetweenFailure(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $validator = new Validator();
         $validator->lengthBetween('username', [7]);
     }
@@ -2249,7 +2251,7 @@ class ValidatorTest extends TestCase
      */
     public function testRangeFailure(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $validator = new Validator();
         $validator->range('username', [1]);
     }

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -16,11 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View;
 
+use BadMethodCallException;
 use Cake\Cache\Cache;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Cell;
+use Cake\View\Exception\MissingCellException;
 use Cake\View\Exception\MissingCellTemplateException;
 use Cake\View\Exception\MissingTemplateException;
 use Cake\View\View;
@@ -282,7 +284,7 @@ class CellTest extends TestCase
      */
     public function testNonExistentCell(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingCellException::class);
+        $this->expectException(MissingCellException::class);
         $cell = $this->View->cell('TestPlugin.Void::echoThis', ['arg1' => 'v1']);
         $cell = $this->View->cell('Void::echoThis', ['arg1' => 'v1', 'arg2' => 'v2']);
     }
@@ -292,7 +294,7 @@ class CellTest extends TestCase
      */
     public function testCellMissingMethod(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Class TestApp\View\Cell\ArticlesCell does not have a "nope" method.');
         $cell = $this->View->cell('Articles::nope');
         $cell->render();

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\View\Form;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\ContextFactory;
+use RuntimeException;
 
 /**
  * ContextFactory test case.
@@ -27,7 +28,7 @@ class ContextFactoryTest extends TestCase
 {
     public function testGetException(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'No context provider found for value of type `bool`.'
             . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.'

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -23,6 +23,8 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
+use RuntimeException;
+use stdClass;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\ArticlesTag;
 use TestApp\Model\Entity\Tag;
@@ -140,9 +142,9 @@ class EntityContextTest extends TestCase
      */
     public function testInvalidTable(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find table class for current entity');
-        $row = new \stdClass();
+        $row = new stdClass();
         $context = new EntityContext([
             'entity' => $row,
         ]);
@@ -153,7 +155,7 @@ class EntityContextTest extends TestCase
      */
     public function testDefaultEntityError(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to find table class for current entity');
         $context = new EntityContext([
             'entity' => new Entity(),

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -21,6 +21,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\BreadcrumbsHelper;
 use Cake\View\View;
+use LogicException;
 
 class BreadcrumbsHelperTest extends TestCase
 {
@@ -266,7 +267,7 @@ class BreadcrumbsHelperTest extends TestCase
      */
     public function testInsertAtIndexOutOfBounds(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
         $this->breadcrumbs
             ->add('Home', '/', ['class' => 'first'])
             ->insertAt(2, 'Insert At Again', ['controller' => 'Insert', 'action' => 'at_again']);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Helper;
 
+use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Form\Form;
 use Cake\Http\ServerRequest;
 use Cake\I18n\Date;
@@ -32,7 +34,9 @@ use Cake\View\Form\EntityContext;
 use Cake\View\Helper\FormHelper;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
+use InvalidArgumentException;
 use ReflectionProperty;
+use RuntimeException;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
@@ -335,7 +339,7 @@ class FormHelperTest extends TestCase
         $entity = new Article();
         $collection = new Collection([$entity]);
         $emptyCollection = new Collection([]);
-        $arrayObject = new \ArrayObject([]);
+        $arrayObject = new ArrayObject([]);
         $data = [
             'schema' => [
                 'title' => ['type' => 'string'],
@@ -3454,7 +3458,7 @@ class FormHelperTest extends TestCase
 
         $result = $this->Form->control('email', [
             'type' => 'select',
-            'options' => new \ArrayObject(['First', 'Second']),
+            'options' => new ArrayObject(['First', 'Second']),
             'empty' => true,
         ]);
         $this->assertHtml($expected, $result);
@@ -3735,7 +3739,7 @@ class FormHelperTest extends TestCase
      */
     public function testInvalidControlTypeOption(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid type \'input\' used for field \'text\'');
         $this->Form->control('text', ['type' => 'input']);
     }
@@ -7483,7 +7487,7 @@ class FormHelperTest extends TestCase
      */
     public function testHtml5ControlException(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->Form->email();
     }
 
@@ -7494,7 +7498,7 @@ class FormHelperTest extends TestCase
     {
         $this->Form->setConfig('autoSetCustomValidity', true);
 
-        $validator = (new \Cake\Validation\Validator())
+        $validator = (new Validator())
             ->notEmptyString('email', 'Custom error message')
             ->requirePresence('password')
             ->alphaNumeric('password')
@@ -7571,7 +7575,7 @@ class FormHelperTest extends TestCase
      */
     public function testHtml5ErrorMessageInTemplateVars(): void
     {
-        $validator = (new \Cake\Validation\Validator())
+        $validator = (new Validator())
             ->notEmptyString('email', 'Custom error "message" & entities')
             ->requirePresence('password')
             ->alphaNumeric('password')
@@ -7968,7 +7972,7 @@ class FormHelperTest extends TestCase
 
     public function testValueSourcesValidation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid value source(s): invalid, foo. Valid values are: context, data, query');
 
         $this->Form->setValueSources(['query', 'data', 'invalid', 'context', 'foo']);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -21,6 +21,9 @@ use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\TimeHelper;
 use Cake\View\View;
+use DateTime as NativeDateTime;
+use DateTimeZone;
+use IntlDateFormatter;
 
 /**
  * TimeHelperTest class
@@ -188,7 +191,7 @@ class TimeHelperTest extends TestCase
      */
     public function testToAtom(): void
     {
-        $dateTime = new \DateTime();
+        $dateTime = new NativeDateTime();
         $this->assertSame($dateTime->format($dateTime::ATOM), $this->Time->toAtom($dateTime->getTimestamp()));
     }
 
@@ -215,8 +218,8 @@ class TimeHelperTest extends TestCase
 
         $timezones = ['Europe/London', 'Europe/Brussels', 'UTC', 'America/Denver', 'America/Caracas', 'Asia/Kathmandu'];
         foreach ($timezones as $timezone) {
-            $yourTimezone = new \DateTimeZone($timezone);
-            $yourTime = new \DateTime($date, $yourTimezone);
+            $yourTimezone = new DateTimeZone($timezone);
+            $yourTime = new NativeDateTime($date, $yourTimezone);
             $time = $yourTime->format('U');
             $this->assertSame($yourTime->format('r'), $this->Time->toRss($time, $timezone), "Failed on $timezone");
         }
@@ -469,7 +472,7 @@ class TimeHelperTest extends TestCase
         $expected = '1/14/10, 1:59 PM';
         $this->assertTimeFormat($expected, $result);
 
-        $result = $this->Time->format($time, \IntlDateFormatter::FULL);
+        $result = $this->Time->format($time, IntlDateFormatter::FULL);
         $expected = 'Thursday, January 14, 2010 at 1:59:28 PM';
         $this->assertStringStartsWith($expected, $result);
 
@@ -480,7 +483,7 @@ class TimeHelperTest extends TestCase
         I18n::setLocale('fr_FR');
         DateTime::setDefaultLocale('fr_FR');
         $time = new DateTime('Thu Jan 14 13:59:28 2010');
-        $result = $this->Time->format($time, \IntlDateFormatter::FULL);
+        $result = $this->Time->format($time, IntlDateFormatter::FULL);
         $this->assertStringContainsString('jeudi 14 janvier 2010', $result);
         $this->assertStringContainsString('13:59:28', $result);
     }
@@ -511,7 +514,7 @@ class TimeHelperTest extends TestCase
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
-        $result = $this->Time->i18nFormat($time, [\IntlDateFormatter::SHORT, \IntlDateFormatter::FULL]);
+        $result = $this->Time->i18nFormat($time, [IntlDateFormatter::SHORT, IntlDateFormatter::FULL]);
         $expected = '1/14/10, 12:59:28 AM';
         $this->assertStringStartsWith($expected, $result);
     }
@@ -535,11 +538,11 @@ class TimeHelperTest extends TestCase
     public function testFormatTimeInstance(): void
     {
         $this->deprecated(function () {
-            $time = new \Cake\I18n\DateTime('2010-01-14 13:59:28', 'America/New_York');
+            $time = new DateTime('2010-01-14 13:59:28', 'America/New_York');
             $result = $this->Time->format($time, 'HH:mm', false, 'America/New_York');
             $this->assertTimeFormat('13:59', $result);
 
-            $time = new \Cake\I18n\DateTime('2010-01-14 13:59:28', 'UTC');
+            $time = new DateTime('2010-01-14 13:59:28', 'UTC');
             $result = $this->Time->format($time, 'HH:mm', false, 'America/New_York');
             $this->assertTimeFormat('08:59', $result);
         });
@@ -569,7 +572,7 @@ class TimeHelperTest extends TestCase
         $this->assertFalse($result);
 
         $fallback = 'Date invalid or not set';
-        $result = $this->Time->format(null, \IntlDateFormatter::FULL, $fallback);
+        $result = $this->Time->format(null, IntlDateFormatter::FULL, $fallback);
         $this->assertSame($fallback, $result);
     }
 }

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -17,10 +17,12 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View;
 
 use Cake\TestSuite\TestCase;
+use Cake\View\Exception\MissingHelperException;
 use Cake\View\Helper\FormHelper;
 use Cake\View\Helper\HtmlHelper;
 use Cake\View\HelperRegistry;
 use Cake\View\View;
+use RuntimeException;
 use TestApp\View\Helper\HtmlAliasHelper;
 use TestPlugin\View\Helper\OtherHelperHelper;
 
@@ -100,7 +102,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLazyLoadException(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingHelperException::class);
+        $this->expectException(MissingHelperException::class);
         $this->Helpers->NotAHelper;
     }
 
@@ -161,7 +163,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadMissingHelper(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingHelperException::class);
+        $this->expectException(MissingHelperException::class);
         $this->Helpers->load('ThisHelperShouldAlwaysBeMissing');
     }
 
@@ -246,7 +248,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testUnloadUnknown(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingHelperException::class);
+        $this->expectException(MissingHelperException::class);
         $this->expectExceptionMessage('Helper class FooHelper could not be found.');
         $this->Helpers->unload('Foo');
     }
@@ -292,7 +294,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadMultipleTimesDifferentConfigured(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The "Html" alias has already been loaded');
         $this->Helpers->load('Html');
         $this->Helpers->load('Html', ['same' => 'stuff']);
@@ -303,7 +305,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadMultipleTimesDifferentConfigValues(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The "Html" alias has already been loaded');
         $this->Helpers->load('Html', ['key' => 'value']);
         $this->Helpers->load('Html', ['key' => 'new value']);

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -16,8 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
+use RuntimeException;
+use stdClass;
 
 class StringTemplateTest extends TestCase
 {
@@ -151,7 +154,7 @@ class StringTemplateTest extends TestCase
      */
     public function testFormatMissingTemplate(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot find template named \'missing\'');
         $templates = [
             'text' => '{{text}}',
@@ -188,7 +191,7 @@ class StringTemplateTest extends TestCase
      */
     public function testLoadErrorNoFile(): void
     {
-        $this->expectException(\Cake\Core\Exception\CakeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Could not load configuration file');
         $this->template->load('no_such_file');
     }
@@ -329,7 +332,7 @@ class StringTemplateTest extends TestCase
         $result = $this->template->addClass(false, 'new_class');
         $this->assertEquals($result, ['class' => ['new_class']]);
 
-        $result = $this->template->addClass(new \stdClass(), 'new_class');
+        $result = $this->template->addClass(new stdClass(), 'new_class');
         $this->assertEquals($result, ['class' => ['new_class']]);
     }
 

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -20,6 +20,7 @@ use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Exception\MissingViewException;
 use Cake\View\ViewBuilder;
 
 /**
@@ -252,7 +253,7 @@ class ViewBuilderTest extends TestCase
      */
     public function testBuildMissingViewClass(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingViewException::class);
+        $this->expectException(MissingViewException::class);
         $this->expectExceptionMessage('View class "Foo" is missing.');
         $builder = new ViewBuilder();
         $builder->setClassName('Foo');

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -20,12 +20,21 @@ use Cake\Cache\Cache;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Plugin;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use Cake\View\Exception\MissingElementException;
+use Cake\View\Exception\MissingLayoutException;
+use Cake\View\Exception\MissingTemplateException;
 use Cake\View\View;
+use Error;
+use Exception;
+use InvalidArgumentException;
+use LogicException;
+use PDOException;
 use RuntimeException;
 use TestApp\Controller\ThemePostsController;
 use TestApp\Controller\ViewPostsController;
@@ -174,7 +183,7 @@ class ViewTest extends TestCase
      */
     public function testPluginGetTemplateAbsoluteFail(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingTemplateException::class);
+        $this->expectException(MissingTemplateException::class);
         $viewOptions = [
             'plugin' => null,
             'name' => 'Pages',
@@ -377,7 +386,7 @@ class ViewTest extends TestCase
      */
     public function testGetViewFileNameDirectoryTraversal(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $viewOptions = [
             'plugin' => null,
             'name' => 'Pages',
@@ -529,7 +538,7 @@ class ViewTest extends TestCase
      */
     public function testGetLayoutFileNameDirectoryTraversal(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $viewOptions = [
             'plugin' => null,
             'name' => 'Pages',
@@ -546,7 +555,7 @@ class ViewTest extends TestCase
      */
     public function testMissingTemplate(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingTemplateException::class);
+        $this->expectException(MissingTemplateException::class);
         $this->expectExceptionMessage('Template file `does_not_exist.php` could not be found');
         $this->expectExceptionMessage('The following paths were searched');
         $this->expectExceptionMessage('- `' . ROOT . DS . 'templates' . DS . 'does_not_exist.php`');
@@ -567,7 +576,7 @@ class ViewTest extends TestCase
      */
     public function testMissingLayout(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingLayoutException::class);
+        $this->expectException(MissingLayoutException::class);
         $this->expectExceptionMessage('Layout file `whatever.php` could not be found');
         $this->expectExceptionMessage('The following paths were searched');
         $this->expectExceptionMessage('- `' . ROOT . DS . 'templates' . DS . 'layout' . DS . 'whatever.php`');
@@ -659,7 +668,7 @@ class ViewTest extends TestCase
      */
     public function testElementMissing(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingElementException::class);
+        $this->expectException(MissingElementException::class);
         $this->expectExceptionMessage('Element file `nonexistent_element.php` could not be found');
 
         $this->View->element('nonexistent_element');
@@ -670,7 +679,7 @@ class ViewTest extends TestCase
      */
     public function testElementMissingPluginElement(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingElementException::class);
+        $this->expectException(MissingElementException::class);
         $this->expectExceptionMessage('Element file `TestPlugin.nope.php` could not be found');
         $this->expectExceptionMessage(implode(DS, ['test_app', 'templates', 'plugin', 'TestPlugin', 'element', 'nope.php']));
         $this->expectExceptionMessage(implode(DS, ['test_app', 'Plugin', 'TestPlugin', 'templates', 'element', 'nope.php']));
@@ -849,7 +858,7 @@ class ViewTest extends TestCase
         try {
             $View->loadHelper('Html', ['test' => 'value']);
             $this->fail('No exception');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString('The "Html" alias has already been loaded', $e->getMessage());
         }
     }
@@ -1052,7 +1061,7 @@ class ViewTest extends TestCase
      */
     public function testRenderUsingLayoutArgument(): void
     {
-        $error = new \PDOException();
+        $error = new PDOException();
         $error->queryString = 'this is sql string';
         $message = 'it works';
         $trace = $error->getTrace();
@@ -1439,7 +1448,7 @@ class ViewTest extends TestCase
             $this->View->start('first');
             $this->View->start('first');
             $this->fail('No exception');
-        } catch (\Cake\Core\Exception\CakeException $e) {
+        } catch (CakeException $e) {
             ob_end_clean();
             $this->assertTrue(true);
         }
@@ -1454,7 +1463,7 @@ class ViewTest extends TestCase
         try {
             $this->View->render('open_block');
             $this->fail('No exception');
-        } catch (\LogicException $e) {
+        } catch (LogicException $e) {
             ob_end_clean();
             $this->assertStringContainsString('The "no_close" block was left open', $e->getMessage());
         }
@@ -1483,7 +1492,7 @@ TEXT;
         try {
             $this->View->render('extend_self', false);
             $this->fail('No exception');
-        } catch (\LogicException $e) {
+        } catch (LogicException $e) {
             $this->assertStringContainsString('cannot have templates extend themselves', $e->getMessage());
         }
     }
@@ -1496,7 +1505,7 @@ TEXT;
         try {
             $this->View->render('extend_loop', false);
             $this->fail('No exception');
-        } catch (\LogicException $e) {
+        } catch (LogicException $e) {
             $this->assertStringContainsString('cannot have templates extend in a loop', $e->getMessage());
         }
     }
@@ -1542,7 +1551,7 @@ TEXT;
         try {
             $this->View->render('extend_missing_element', false);
             $this->fail('No exception');
-        } catch (\LogicException $e) {
+        } catch (LogicException $e) {
             $this->assertStringContainsString('element', $e->getMessage());
         }
     }
@@ -1588,7 +1597,7 @@ TEXT;
         $e = null;
         try {
             $this->View->element('exception_with_open_buffers');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
 
         $this->assertNotNull($e);
@@ -1618,12 +1627,12 @@ TEXT;
             $this->View->cache(function (): void {
                 ob_start();
 
-                throw new \Exception('Exception with open buffers');
+                throw new Exception('Exception with open buffers');
             }, [
                 'key' => __FUNCTION__,
                 'config' => 'test_view',
             ]);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
 
         Cache::clear('test_view');
@@ -1801,7 +1810,7 @@ TEXT;
 
     protected function checkException(string $message): void
     {
-        $this->expectException(\Error::class);
+        $this->expectException(Error::class);
         $this->expectExceptionMessage($message);
     }
 }

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\View;
 
 use Cake\Controller\Controller;
 use Cake\TestSuite\TestCase;
+use Cake\View\Exception\MissingViewException;
 
 /**
  * ViewVarsTrait test case
@@ -114,7 +115,7 @@ class ViewVarsTraitTest extends TestCase
      */
     public function testCreateViewException(): void
     {
-        $this->expectException(\Cake\View\Exception\MissingViewException::class);
+        $this->expectException(MissingViewException::class);
         $this->expectExceptionMessage('View class "Foo" is missing.');
         $this->subject->createView('Foo');
     }

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\DateTimeWidget;
+use DateTime;
 
 /**
  * DateTimeWidget test case
@@ -44,7 +45,7 @@ class DateTimeWidgetTest extends TestCase
      */
     public static function selectedValuesProvider(): array
     {
-        $date = new \DateTime('2014-01-20 12:30:45');
+        $date = new DateTime('2014-01-20 12:30:45');
 
         return [
             'DateTime' => [$date],
@@ -208,7 +209,7 @@ class DateTimeWidgetTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid type `foo` for input tag, expected datetime-local, date, time, month or week');
-        $result = $this->DateTime->render(['type' => 'foo', 'val' => new \DateTime()], $this->context);
+        $result = $this->DateTime->render(['type' => 'foo', 'val' => new DateTime()], $this->context);
     }
 
     /**

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
+use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\NullContext;
@@ -109,7 +110,7 @@ class SelectBoxWidgetTest extends TestCase
     public function testRenderSimpleIterator(): void
     {
         $select = new SelectBoxWidget($this->templates);
-        $options = new \ArrayObject(['a' => 'Albatross', 'b' => 'Budgie']);
+        $options = new ArrayObject(['a' => 'Albatross', 'b' => 'Budgie']);
         $data = [
             'name' => 'Birds[name]',
             'options' => $options,
@@ -479,7 +480,7 @@ class SelectBoxWidgetTest extends TestCase
     public function testRenderOptionGroupsTraversable(): void
     {
         $select = new SelectBoxWidget($this->templates);
-        $mammals = new \ArrayObject(['beaver' => 'Beaver', 'elk' => 'Elk']);
+        $mammals = new ArrayObject(['beaver' => 'Beaver', 'elk' => 'Elk']);
         $data = [
             'name' => 'Birds[name]',
             'options' => [

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -20,6 +20,8 @@ use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
+use RuntimeException;
+use stdClass;
 use TestApp\View\Widget\TestUsingViewWidget;
 
 /**
@@ -133,13 +135,13 @@ class WidgetLocatorTest extends TestCase
      */
     public function testAddInvalidType(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'Widget objects must implement `Cake\View\Widget\WidgetInterface`. Got `stdClass` instance instead.'
         );
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add([
-            'text' => new \stdClass(),
+            'text' => new stdClass(),
         ]);
     }
 
@@ -178,7 +180,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testGetNoFallbackError(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unknown widget `foo`');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->clear();
@@ -205,7 +207,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testGetResolveDependencyMissingClass(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to locate widget class "TestApp\View\DerpWidget"');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add(['test' => ['TestApp\View\DerpWidget']]);
@@ -217,7 +219,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testGetResolveDependencyMissingDependency(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unknown widget `label`');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->clear();

--- a/tests/test_app/Plugin/TestPlugin/src/View/Cell/Admin/MenuCell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Cell/Admin/MenuCell.php
@@ -15,10 +15,12 @@ declare(strict_types=1);
  */
 namespace TestPlugin\View\Cell\Admin;
 
+use Cake\View\Cell;
+
 /**
  * TestPlugin Admin Menu Cell
  */
-class MenuCell extends \Cake\View\Cell
+class MenuCell extends Cell
 {
     /**
      * Default cell action.

--- a/tests/test_app/Plugin/TestPlugin/src/View/Cell/DummyCell.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Cell/DummyCell.php
@@ -15,10 +15,12 @@ declare(strict_types=1);
  */
 namespace TestPlugin\View\Cell;
 
+use Cake\View\Cell;
+
 /**
  * DummyCell class
  */
-class DummyCell extends \Cake\View\Cell
+class DummyCell extends Cell
 {
     /**
      * Default cell action.

--- a/tests/test_app/TestApp/Collection/CountableIterator.php
+++ b/tests/test_app/TestApp/Collection/CountableIterator.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace TestApp\Collection;
 
-class CountableIterator extends \IteratorIterator implements \Countable
+use Countable;
+use IteratorIterator;
+
+class CountableIterator extends IteratorIterator implements Countable
 {
     /**
      * @param mixed $items

--- a/tests/test_app/TestApp/Collection/TestCollection.php
+++ b/tests/test_app/TestApp/Collection/TestCollection.php
@@ -3,10 +3,14 @@ declare(strict_types=1);
 
 namespace TestApp\Collection;
 
+use ArrayIterator;
 use Cake\Collection\CollectionInterface;
 use Cake\Collection\CollectionTrait;
+use InvalidArgumentException;
+use IteratorIterator;
+use Traversable;
 
-class TestCollection extends \IteratorIterator implements CollectionInterface
+class TestCollection extends IteratorIterator implements CollectionInterface
 {
     use CollectionTrait;
 
@@ -17,12 +21,12 @@ class TestCollection extends \IteratorIterator implements CollectionInterface
     public function __construct(iterable $items)
     {
         if (is_array($items)) {
-            $items = new \ArrayIterator($items);
+            $items = new ArrayIterator($items);
         }
 
-        if (!($items instanceof \Traversable)) {
+        if (!($items instanceof Traversable)) {
             $msg = 'Only an array or \Traversable is allowed for Collection';
-            throw new \InvalidArgumentException($msg);
+            throw new InvalidArgumentException($msg);
         }
 
         parent::__construct($items);

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -18,6 +18,7 @@ namespace TestApp\Controller;
 
 use Cake\Event\EventInterface;
 use Cake\Http\Cookie\Cookie;
+use OutOfBoundsException;
 
 /**
  * PostsController class
@@ -198,6 +199,6 @@ class PostsController extends AppController
     public function throw_exception()
     {
         $this->Flash->error('Error 1');
-        throw new \OutOfBoundsException('oh no!');
+        throw new OutOfBoundsException('oh no!');
     }
 }

--- a/tests/test_app/TestApp/Controller/TestsAppsController.php
+++ b/tests/test_app/TestApp/Controller/TestsAppsController.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
  */
 namespace TestApp\Controller;
 
+use RuntimeException;
+
 class TestsAppsController extends AppController
 {
     public function index()
@@ -73,6 +75,6 @@ class TestsAppsController extends AppController
 
     public function throw_exception()
     {
-        throw new \RuntimeException('Foo');
+        throw new RuntimeException('Foo');
     }
 }

--- a/tests/test_app/TestApp/Database/Type/ColumnSchemaAwareType.php
+++ b/tests/test_app/TestApp/Database/Type/ColumnSchemaAwareType.php
@@ -11,6 +11,7 @@ use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\Type\BaseType;
 use Cake\Database\Type\ColumnSchemaAwareInterface;
 use Cake\Database\Type\ExpressionTypeInterface;
+use InvalidArgumentException;
 use TestApp\Database\ColumnSchemaAwareTypeValueObject;
 
 class ColumnSchemaAwareType extends BaseType implements ExpressionTypeInterface, ColumnSchemaAwareInterface
@@ -59,7 +60,7 @@ class ColumnSchemaAwareType extends BaseType implements ExpressionTypeInterface,
             );
         }
 
-        throw new \InvalidArgumentException(sprintf(
+        throw new InvalidArgumentException(sprintf(
             'The `$value` argument must be an instance of `\%s`, or a string, `%s` given.',
             ColumnSchemaAwareTypeValueObject::class,
             get_debug_type($value)

--- a/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/TestAppsExceptionRenderer.php
@@ -8,6 +8,7 @@ use Cake\Error\ExceptionRenderer;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
+use Exception;
 use TestApp\Controller\TestAppsErrorController;
 
 class TestAppsExceptionRenderer extends ExceptionRenderer
@@ -25,7 +26,7 @@ class TestAppsExceptionRenderer extends ExceptionRenderer
         try {
             $controller = new TestAppsErrorController($request, $response);
             $controller->viewBuilder()->setLayout('banana');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $controller = new Controller($request, $response);
             $controller->viewBuilder()->setTemplatePath('Error');
         }

--- a/tests/test_app/TestApp/Http/Client/Adapter/CakeStreamWrapper.php
+++ b/tests/test_app/TestApp/Http/Client/Adapter/CakeStreamWrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace TestApp\Http\Client\Adapter;
 
 use ArrayAccess;
+use Exception;
 use ReturnTypeWillChange;
 
 class CakeStreamWrapper implements ArrayAccess
@@ -21,7 +22,7 @@ class CakeStreamWrapper implements ArrayAccess
     public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
         if ($path === 'http://throw_exception/') {
-            throw new \Exception();
+            throw new Exception();
         }
 
         $query = parse_url($path, PHP_URL_QUERY);

--- a/tests/test_app/TestApp/View/Cell/Admin/MenuCell.php
+++ b/tests/test_app/TestApp/View/Cell/Admin/MenuCell.php
@@ -15,10 +15,12 @@ declare(strict_types=1);
  */
 namespace TestApp\View\Cell\Admin;
 
+use Cake\View\Cell;
+
 /**
  * Admin Menu Cell
  */
-class MenuCell extends \Cake\View\Cell
+class MenuCell extends Cell
 {
     /**
      * Default cell action.

--- a/tests/test_app/TestApp/View/Cell/ArticlesCell.php
+++ b/tests/test_app/TestApp/View/Cell/ArticlesCell.php
@@ -15,10 +15,12 @@ declare(strict_types=1);
  */
 namespace TestApp\View\Cell;
 
+use Cake\View\Cell;
+
 /**
  * TagCloudCell class
  */
-class ArticlesCell extends \Cake\View\Cell
+class ArticlesCell extends Cell
 {
     /**
      * valid cell options.


### PR DESCRIPTION
This is almost entirely test cases. This cleans up the use statements with the new phpcs sniff.

Instead of allowing fully qualified names when there are conflicts, I added aliases in those places. They are mostly `\DateTime`.
