### PR TITLE
Remove use of deprecated autoFixtures setting

### DIFF
--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -46,13 +46,6 @@ class PaginatorComponentTest extends TestCase
     ];
 
     /**
-     * Don't load data for fixtures for all tests
-     *
-     * @var bool
-     */
-    public $autoFixtures = false;
-
-    /**
      * @var \Cake\Controller\Controller
      */
     protected $controller;
@@ -184,7 +177,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateCustomFinderOptions(): void
     {
-        $this->loadFixtures('Posts');
         $settings = [
             'PaginatorPosts' => [
                 'finder' => ['author' => ['author_id' => 1]],
@@ -211,8 +203,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testRequestParamsSetting(): void
     {
-        $this->loadFixtures('Posts');
-
         $settings = [
             'PaginatorPosts' => [
                 'limit' => 10,
@@ -257,7 +247,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateNestedEagerLoader(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'Authors', 'ArticlesTags', 'AuthorsTags');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Tags');
         $tags = $this->getTableLocator()->get('Tags');
@@ -703,8 +692,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testEmptyPaginationResult(): void
     {
-        $this->loadFixtures('Posts');
-
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $table->deleteAll('1=1');
 
@@ -733,7 +720,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testOutOfRangePageNumberGetsClamped(): void
     {
-        $this->loadFixtures('Posts');
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams(['page' => 3000]));
 
         $table = $this->getTableLocator()->get('PaginatorPosts');
@@ -760,7 +746,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testOutOfRangePageNumberStillProvidesPageCount(): void
     {
-        $this->loadFixtures('Posts');
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams([
             'limit' => 1,
             'page' => '4',
@@ -791,7 +776,6 @@ class PaginatorComponentTest extends TestCase
     public function testOutOfVeryBigPageNumberGetsClamped(): void
     {
         $this->expectException(NotFoundException::class);
-        $this->loadFixtures('Posts');
         $this->controller->setRequest($this->controller->getRequest()->withQueryParams([
             'page' => '3000000000000000000000000',
         ]));
@@ -1075,7 +1059,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateMaxLimit(): void
     {
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
 
         $settings = [
@@ -1103,7 +1086,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateCustomFind(): void
     {
-        $this->loadFixtures('Posts');
         $titleExtractor = function ($result) {
             $ids = [];
             foreach ($result as $record) {
@@ -1165,7 +1147,6 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
         $table->save(new Entity($data));
@@ -1265,7 +1246,7 @@ class PaginatorComponentTest extends TestCase
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') !== false, 'Test temporarily broken in SQLServer');
-        $this->loadFixtures('Posts');
+
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $query = $table->find()
             ->where(['PaginatorPosts.author_id BETWEEN :start AND :end'])

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -55,8 +55,6 @@ class QueryTest extends TestCase
         'core.MenuLinkTrees',
     ];
 
-    public $autoFixtures = false;
-
     public const ARTICLE_COUNT = 3;
     public const AUTHOR_COUNT = 4;
     public const COMMENT_COUNT = 6;
@@ -141,7 +139,6 @@ class QueryTest extends TestCase
      */
     public function testSelectFieldsFromTable(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query->select(['body', 'author_id'])->from('articles')->execute();
         $this->assertEquals(['body' => 'First Article Body', 'author_id' => 1], $result->fetch('assoc'));
@@ -168,7 +165,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAliasedFieldsFromTable(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query->select(['text' => 'comment', 'article_id'])->from('comments')->execute();
         $this->assertEquals(['text' => 'First Comment for First Article', 'article_id' => 1], $result->fetch('assoc'));
@@ -204,7 +200,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAliasedTables(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query->select(['text' => 'a.body', 'a.author_id'])
             ->from(['a' => 'articles'])->execute();
@@ -232,7 +227,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWithJoins(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title', 'name'])
@@ -264,7 +258,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWithJoinsConditions(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title', 'name'])
@@ -305,7 +298,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAliasedJoins(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title', 'name'])
@@ -346,7 +338,6 @@ class QueryTest extends TestCase
      */
     public function testSelectLeftJoin(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
         $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
@@ -377,7 +368,6 @@ class QueryTest extends TestCase
      */
     public function testSelectInnerJoin(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
         $time = new DateTime('2007-03-18 10:45:23');
         $types = ['created' => 'datetime'];
@@ -395,7 +385,6 @@ class QueryTest extends TestCase
      */
     public function testSelectRightJoin(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlite,
             'SQLite does not support RIGHT joins'
@@ -421,7 +410,6 @@ class QueryTest extends TestCase
      */
     public function testSelectJoinWithCallback(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
         $types = ['created' => 'datetime'];
         $result = $query
@@ -443,7 +431,6 @@ class QueryTest extends TestCase
      */
     public function testSelectJoinWithCallback2(): void
     {
-        $this->loadFixtures('Authors', 'Comments');
         $query = new Query($this->connection);
         $types = ['created' => 'datetime'];
         $result = $query
@@ -468,7 +455,6 @@ class QueryTest extends TestCase
      */
     public function testSelectSimpleWhere(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -493,7 +479,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorMoreThan(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['comment'])
@@ -510,7 +495,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorLessThan(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -527,7 +511,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorLessThanEqual(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -543,7 +526,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorMoreThanEqual(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -559,7 +541,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorNotEqual(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -576,7 +557,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorLike(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -593,7 +573,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorLikeExpansion(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -609,7 +588,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorNotLike(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -625,7 +603,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereUnary(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -647,7 +624,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereTypes(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -723,8 +699,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereNull(): void
     {
-        $this->loadFixtures('MenuLinkTrees');
-
         $query = new Query($this->connection);
         $result = $query
             ->select(['id', 'parent_id'])
@@ -758,8 +732,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereNotNull(): void
     {
-        $this->loadFixtures('MenuLinkTrees');
-
         $query = new Query($this->connection);
         $result = $query
             ->select(['id', 'parent_id'])
@@ -794,7 +766,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereArrayType(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -815,7 +786,6 @@ class QueryTest extends TestCase
     {
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Impossible to generate condition with empty list of values for field');
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -831,7 +801,6 @@ class QueryTest extends TestCase
     {
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('with empty list of values for field (SELECT 1)');
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -847,7 +816,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAndWhere(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -875,7 +843,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAndWhereNoPreviousCondition(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -894,7 +861,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereUsingClosure(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -940,7 +906,6 @@ class QueryTest extends TestCase
      */
     public function testTupleWithClosureExpression(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('comments')
@@ -967,7 +932,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAndWhereUsingClosure(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1000,7 +964,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereUsingExpressionInField(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1022,7 +985,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereOperatorMethods(): void
     {
-        $this->loadFixtures('Articles', 'Comments', 'Authors');
         $query = new Query($this->connection);
         $result = $query
             ->select(['title'])
@@ -1196,7 +1158,6 @@ class QueryTest extends TestCase
      */
     public function testInValueCast(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1261,7 +1222,6 @@ class QueryTest extends TestCase
      */
     public function testInValueCast2(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1287,7 +1247,6 @@ class QueryTest extends TestCase
      */
     public function testInClausePlaceholderGeneration(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('comments')
@@ -1343,7 +1302,6 @@ class QueryTest extends TestCase
      */
     public function testWhereWithBetween(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1368,7 +1326,6 @@ class QueryTest extends TestCase
      */
     public function testWhereWithBetweenComplex(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1396,7 +1353,6 @@ class QueryTest extends TestCase
      */
     public function testWhereWithBetweenWithExpressionField(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1423,7 +1379,6 @@ class QueryTest extends TestCase
      */
     public function testWhereWithBetweenWithExpressionParts(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1450,7 +1405,6 @@ class QueryTest extends TestCase
      */
     public function testSelectExpressionComposition(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1534,7 +1488,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereNot(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1570,7 +1523,6 @@ class QueryTest extends TestCase
      */
     public function testSelectWhereNot2(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1590,7 +1542,6 @@ class QueryTest extends TestCase
      */
     public function testWhereInArray(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1613,7 +1564,6 @@ class QueryTest extends TestCase
      */
     public function testWhereInArrayEmpty(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1635,7 +1585,6 @@ class QueryTest extends TestCase
      */
     public function testWhereNotInList(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1656,7 +1605,6 @@ class QueryTest extends TestCase
      */
     public function testWhereNotInListEmpty(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1678,7 +1626,6 @@ class QueryTest extends TestCase
      */
     public function testWhereNotInListOrNull(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1699,7 +1646,6 @@ class QueryTest extends TestCase
      */
     public function testWhereNotInListOrNullEmpty(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1721,7 +1667,6 @@ class QueryTest extends TestCase
      */
     public function testSelectOrderBy(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -1784,7 +1729,6 @@ class QueryTest extends TestCase
      */
     public function testSelectOrderByString(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1808,7 +1752,6 @@ class QueryTest extends TestCase
             'Use QueryExpression or numeric array instead.'
         );
 
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1887,7 +1830,6 @@ class QueryTest extends TestCase
      */
     public function testSelectOrderAsc(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -1951,7 +1893,6 @@ class QueryTest extends TestCase
      */
     public function testSelectOrderDesc(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id'])
             ->from('articles')
@@ -2015,7 +1956,6 @@ class QueryTest extends TestCase
      */
     public function testSelectGroup(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
@@ -2045,7 +1985,6 @@ class QueryTest extends TestCase
      */
     public function testSelectDistinct(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['author_id'])
@@ -2065,7 +2004,6 @@ class QueryTest extends TestCase
      */
     public function testSelectDistinctON(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['author_id'])
@@ -2153,7 +2091,6 @@ class QueryTest extends TestCase
      */
     public function testSelectHaving(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
@@ -2184,7 +2121,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAndHaving(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['total' => 'count(author_id)', 'author_id'])
@@ -2251,7 +2187,6 @@ class QueryTest extends TestCase
      */
     public function testSelectLimit(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query->select('id')->from('articles')->limit(1)->execute();
         $this->assertCount(1, $result);
@@ -2266,7 +2201,6 @@ class QueryTest extends TestCase
      */
     public function testSelectOffset(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $query = new Query($this->connection);
         $result = $query->select('id')->from('comments')
             ->limit(1)
@@ -2329,7 +2263,6 @@ class QueryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Pages must start at 1.');
 
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query->from('comments')->page(0);
     }
@@ -2339,7 +2272,6 @@ class QueryTest extends TestCase
      */
     public function testSelectPage(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query->select('id')->from('comments')
             ->limit(1)
@@ -2379,7 +2311,6 @@ class QueryTest extends TestCase
      */
     public function testSelectPageWithOrder(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query
             ->select([
@@ -2407,7 +2338,6 @@ class QueryTest extends TestCase
      */
     public function testSubqueryInSelect(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Comments');
         $query = new Query($this->connection);
         $subquery = (new Query($this->connection))
             ->select('name')
@@ -2450,7 +2380,6 @@ class QueryTest extends TestCase
      */
     public function testSuqueryInFrom(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $subquery = (new Query($this->connection))
             ->select(['id', 'comment'])
@@ -2477,7 +2406,6 @@ class QueryTest extends TestCase
      */
     public function testSubqueryInWhere(): void
     {
-        $this->loadFixtures('Authors', 'Comments');
         $query = new Query($this->connection);
         $subquery = (new Query($this->connection))
             ->select(['id'])
@@ -2521,7 +2449,6 @@ class QueryTest extends TestCase
      */
     public function testSubqueryExistsWhere(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $query = new Query($this->connection);
         $subQuery = (new Query($this->connection))
             ->select(['id'])
@@ -2564,7 +2491,6 @@ class QueryTest extends TestCase
      */
     public function testSubqueryInJoin(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $subquery = (new Query($this->connection))->select('*')->from('authors');
 
         $query = new Query($this->connection);
@@ -2592,7 +2518,6 @@ class QueryTest extends TestCase
      */
     public function testUnion(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Comments');
         $union = (new Query($this->connection))->select(['id', 'title'])->from(['a' => 'articles']);
         $query = new Query($this->connection);
         $result = $query->select(['id', 'comment'])
@@ -2631,7 +2556,6 @@ class QueryTest extends TestCase
      */
     public function testUnionOrderBy(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $this->skipIf(
             ($this->connection->getDriver() instanceof Sqlite ||
             $this->connection->getDriver() instanceof Sqlserver),
@@ -2659,7 +2583,6 @@ class QueryTest extends TestCase
      */
     public function testUnionAll(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Comments');
         $union = (new Query($this->connection))->select(['id', 'title'])->from(['a' => 'articles']);
         $query = new Query($this->connection);
         $result = $query->select(['id', 'comment'])
@@ -2689,7 +2612,6 @@ class QueryTest extends TestCase
      */
     public function testDecorateResults(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id', 'title'])
@@ -2743,7 +2665,6 @@ class QueryTest extends TestCase
      */
     public function testDeleteWithFrom(): void
     {
-        $this->loadFixtures('Authors');
         $query = new Query($this->connection);
 
         $query->delete()
@@ -2764,7 +2685,6 @@ class QueryTest extends TestCase
      */
     public function testDeleteWithAliasedFrom(): void
     {
-        $this->loadFixtures('Authors');
         $query = new Query($this->connection);
 
         $query->delete()
@@ -2785,7 +2705,6 @@ class QueryTest extends TestCase
      */
     public function testDeleteNoFrom(): void
     {
-        $this->loadFixtures('Authors');
         $query = new Query($this->connection);
 
         $query->delete('authors')
@@ -2865,7 +2784,6 @@ class QueryTest extends TestCase
      */
     public function testSelectAndDeleteOnSameQuery(): void
     {
-        $this->loadFixtures('Authors');
         $query = new Query($this->connection);
         $result = $query->select()
             ->delete('authors')
@@ -2881,7 +2799,6 @@ class QueryTest extends TestCase
      */
     public function testUpdateSimple(): void
     {
-        $this->loadFixtures('Authors');
         $query = new Query($this->connection);
         $query->update('authors')
             ->set('name', 'mark')
@@ -2910,7 +2827,6 @@ class QueryTest extends TestCase
      */
     public function testUpdateMultipleFields(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->update('articles')
             ->set('title', 'mark', 'string')
@@ -2935,7 +2851,6 @@ class QueryTest extends TestCase
      */
     public function testUpdateMultipleFieldsArray(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->update('articles')
             ->set([
@@ -2962,7 +2877,6 @@ class QueryTest extends TestCase
      */
     public function testUpdateWithExpression(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
 
         $expr = $query->newExpr()->equalFields('article_id', 'user_id');
@@ -2989,8 +2903,6 @@ class QueryTest extends TestCase
     public function testUpdateSubquery(): void
     {
         $this->skipIf($this->connection->getDriver() instanceof Mysql);
-
-        $this->loadFixtures('Comments');
 
         $subquery = new Query($this->connection);
         $subquery
@@ -3023,7 +2935,6 @@ class QueryTest extends TestCase
      */
     public function testUpdateArrayFields(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $date = new DateTime();
         $query->update('comments')
@@ -3052,7 +2963,6 @@ class QueryTest extends TestCase
      */
     public function testUpdateSetCallable(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $date = new DateTime();
         $query->update('comments')
@@ -3176,7 +3086,6 @@ class QueryTest extends TestCase
      */
     public function testInsertOverwritesValues(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert(['title', 'body'])
             ->insert(['title'])
@@ -3199,7 +3108,6 @@ class QueryTest extends TestCase
      */
     public function testInsertSimple(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert(['title', 'body'])
             ->into('articles')
@@ -3240,7 +3148,6 @@ class QueryTest extends TestCase
      */
     public function testInsertQuoteColumns(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert([123])
             ->into('articles')
@@ -3262,7 +3169,6 @@ class QueryTest extends TestCase
      */
     public function testInsertSparseRow(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert(['title', 'body'])
             ->into('articles')
@@ -3302,7 +3208,6 @@ class QueryTest extends TestCase
      */
     public function testInsertMultipleRowsSparse(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert(['title', 'body'])
             ->into('articles')
@@ -3345,7 +3250,6 @@ class QueryTest extends TestCase
      */
     public function testInsertFromSelect(): void
     {
-        $this->loadFixtures('Authors', 'Articles');
         $select = (new Query($this->connection))->select(['name', "'some text'", 99])
             ->from('authors')
             ->where(['id' => 1]);
@@ -3398,7 +3302,6 @@ class QueryTest extends TestCase
     public function testInsertFailureMixingTypesArrayFirst(): void
     {
         $this->expectException(DatabaseException::class);
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert(['name'])
             ->into('articles')
@@ -3412,7 +3315,6 @@ class QueryTest extends TestCase
     public function testInsertFailureMixingTypesQueryFirst(): void
     {
         $this->expectException(DatabaseException::class);
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->insert(['name'])
             ->into('articles')
@@ -3425,7 +3327,6 @@ class QueryTest extends TestCase
      */
     public function testInsertExpressionValues(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $query = new Query($this->connection);
         $query->insert(['title', 'author_id'])
             ->into('articles')
@@ -3519,7 +3420,6 @@ class QueryTest extends TestCase
      */
     public function testSQLFunctions(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $result = $query->select(
             function ($q) {
@@ -3710,7 +3610,6 @@ class QueryTest extends TestCase
      */
     public function testDefaultTypes(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $this->assertEquals([], $query->getDefaultTypes());
         $types = ['id' => 'integer', 'created' => 'datetime'];
@@ -3737,7 +3636,6 @@ class QueryTest extends TestCase
      */
     public function testBind(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $results = $query->select(['id', 'comment'])
             ->from('comments')
@@ -3763,7 +3661,6 @@ class QueryTest extends TestCase
      */
     public function testAppendSelect(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $sql = $query
             ->select(['id', 'title'])
@@ -4048,7 +3945,6 @@ class QueryTest extends TestCase
      */
     public function testIsNullWithExpressions(): void
     {
-        $this->loadFixtures('Authors');
         $query = new Query($this->connection);
         $subquery = (new Query($this->connection))
             ->select(['id'])
@@ -4100,7 +3996,6 @@ class QueryTest extends TestCase
      */
     public function testDirectIsNull(): void
     {
-        $this->loadFixtures('Authors');
         $sql = (new Query($this->connection))
             ->select(['name'])
             ->from(['authors'])
@@ -4126,7 +4021,6 @@ class QueryTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expression `name` is missing operator (IS, IS NOT) with `null` value.');
 
-        $this->loadFixtures('Authors');
         (new Query($this->connection))
             ->select(['name'])
             ->from(['authors'])
@@ -4142,7 +4036,6 @@ class QueryTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $this->loadFixtures('Authors');
         (new Query($this->connection))
             ->select(['name'])
             ->from(['authors'])
@@ -4156,7 +4049,6 @@ class QueryTest extends TestCase
      */
     public function testDirectIsNotNull(): void
     {
-        $this->loadFixtures('Authors');
         $sql = (new Query($this->connection))
             ->select(['name'])
             ->from(['authors'])
@@ -4178,8 +4070,6 @@ class QueryTest extends TestCase
      */
     public function testRowCountAndClose(): void
     {
-        $this->loadFixtures('Authors');
-
         $statementMock = $this->getMockBuilder(StatementInterface::class)
             ->onlyMethods(['rowCount', 'closeCursor'])
             ->getMockForAbstractClass();
@@ -4214,7 +4104,6 @@ class QueryTest extends TestCase
      */
     public function testSqlCaseStatement(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $publishedCase = $query
             ->newExpr()
@@ -4300,7 +4189,6 @@ class QueryTest extends TestCase
      */
     public function testUnbufferedQuery(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $result = $query->select(['body', 'author_id'])
             ->from('articles')
@@ -4334,7 +4222,6 @@ class QueryTest extends TestCase
      */
     public function testDeepClone(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id', 'title' => $query->func()->concat(['title' => 'literal', 'test'])])
             ->from('articles')
@@ -4384,7 +4271,6 @@ class QueryTest extends TestCase
     public function testSelectTypeConversion(): void
     {
         TypeFactory::set('custom_datetime', new BarType('custom_datetime'));
-        $this->loadFixtures('Comments');
 
         $query = new Query($this->connection);
         $query
@@ -4441,7 +4327,6 @@ class QueryTest extends TestCase
      */
     public function testRemoveJoin(): void
     {
-        $this->loadFixtures('Articles');
         $query = new Query($this->connection);
         $query->select(['id', 'title'])
             ->from('articles')
@@ -4461,7 +4346,6 @@ class QueryTest extends TestCase
      */
     public function testBetweenExpressionAndTypeMap(): void
     {
-        $this->loadFixtures('Comments');
         $query = new Query($this->connection);
         $query->select('id')
             ->from('comments')
@@ -4593,7 +4477,6 @@ class QueryTest extends TestCase
      */
     public function testCastResults(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
         $fields = [
             'user_id' => 'integer',
@@ -4616,7 +4499,6 @@ class QueryTest extends TestCase
      */
     public function testCastResultsDisable(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
         $typeMap = new TypeMap(['a' => 'datetime']);
         $results = $query
@@ -4725,7 +4607,6 @@ class QueryTest extends TestCase
      */
     public function testFetchAssoc(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
         $fields = [
             'id' => 'integer',
@@ -4755,7 +4636,6 @@ class QueryTest extends TestCase
      */
     public function testFetchAssocWithEmptyResult(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
 
         $results = $query
@@ -4774,7 +4654,6 @@ class QueryTest extends TestCase
      */
     public function testFetchObjects(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
         $stmt = $query->select([
                 'id',
@@ -4798,7 +4677,6 @@ class QueryTest extends TestCase
      */
     public function testFetchColumn(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
         $fields = [
             'integer',
@@ -4839,7 +4717,6 @@ class QueryTest extends TestCase
      */
     public function testFetchColumnReturnsFalse(): void
     {
-        $this->loadFixtures('Profiles');
         $query = new Query($this->connection);
         $fields = [
             'integer',
@@ -4871,7 +4748,6 @@ class QueryTest extends TestCase
         $this->autoQuote = true;
         $this->connection->getDriver()->enableAutoQuoting($this->autoQuote);
 
-        $this->loadFixtures('Articles');
         $connection = $this->connection;
 
         $query = new Query($connection);
@@ -4938,7 +4814,6 @@ class QueryTest extends TestCase
      */
     public function testReusingExpressions(): void
     {
-        $this->loadFixtures('Articles');
         $connection = $this->connection;
 
         $query = new Query($connection);
@@ -5075,7 +4950,6 @@ class QueryTest extends TestCase
      */
     public function testIdentifierCollation(): void
     {
-        $this->loadFixtures('Articles');
         $driver = $this->connection->getDriver();
         if ($driver instanceof Mysql) {
             if (version_compare($this->connection->getDriver()->version(), '5.7.0', '<')) {

--- a/tests/TestCase/Database/QueryTests/AggregatesQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/AggregatesQueryTests.php
@@ -30,8 +30,6 @@ class AggregatesQueryTests extends TestCase
         'core.Comments',
     ];
 
-    public $autoFixtures = false;
-
     /**
      * @var \Cake\Database\Connection
      */
@@ -63,7 +61,6 @@ class AggregatesQueryTests extends TestCase
             $skip = version_compare($this->connection->getDriver()->version(), '3.30.0', '<');
         }
         $this->skipif($skip);
-        $this->loadFixtures('Comments');
 
         $query = new Query($this->connection);
         $result = $query

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
@@ -36,11 +36,6 @@ class CommonTableExpressionQueryTests extends TestCase
     ];
 
     /**
-     * @inheritDoc
-     */
-    public $autoFixtures = false;
-
-    /**
      * @var \Cake\Database\Connection
      */
     protected $connection;
@@ -199,8 +194,6 @@ class CommonTableExpressionQueryTests extends TestCase
             '`WITH ... INSERT INTO` syntax is not supported in MySQL.'
         );
 
-        $this->loadFixtures('Articles');
-
         // test initial state
         $result = $this->connection->newQuery()
             ->select('*')
@@ -265,8 +258,6 @@ class CommonTableExpressionQueryTests extends TestCase
             '`INSERT INTO ... WITH` syntax is not supported in SQL Server.'
         );
 
-        $this->loadFixtures('Articles');
-
         $query = $this->connection->newQuery()
             ->insert(['title', 'body'])
             ->into('articles')
@@ -319,8 +310,6 @@ class CommonTableExpressionQueryTests extends TestCase
             $this->connection->getDriver() instanceof Mysql && $this->connection->getDriver()->isMariadb(),
             'MariaDB does not support CTEs in UPDATE query.'
         );
-
-        $this->loadFixtures('Articles');
 
         // test initial state
         $result = $this->connection->newQuery()
@@ -383,8 +372,6 @@ class CommonTableExpressionQueryTests extends TestCase
             $this->connection->getDriver() instanceof Mysql && $this->connection->getDriver()->isMariadb(),
             'MariaDB does not support CTEs in DELETE query.'
         );
-
-        $this->loadFixtures('Articles');
 
         // test initial state
         $result = $this->connection

--- a/tests/TestCase/Database/QueryTests/WindowQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTests.php
@@ -34,8 +34,6 @@ class WindowQueryTests extends TestCase
         'core.Comments',
     ];
 
-    public $autoFixtures = false;
-
     /**
      * @var \Cake\Database\Connection
      */
@@ -110,7 +108,6 @@ class WindowQueryTests extends TestCase
     public function testPartitions(): void
     {
         $this->skipIf($this->skipTests);
-        $this->loadFixtures('Comments');
 
         $query = new Query($this->connection);
         $result = $query
@@ -152,8 +149,6 @@ class WindowQueryTests extends TestCase
         }
         $this->skipIf($skip);
 
-        $this->loadFixtures('Comments');
-
         $query = new Query($this->connection);
         $result = $query
             ->select(['num_rows' => $query->func()->count('*')->over('window1')])
@@ -176,8 +171,6 @@ class WindowQueryTests extends TestCase
             }
         }
         $this->skipIf($skip);
-
-        $this->loadFixtures('Comments');
 
         $query = new Query($this->connection);
         $result = $query

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -34,18 +34,10 @@ class PaginatorTest extends TestCase
     ];
 
     /**
-     * Don't load data for fixtures for all tests
-     *
-     * @var bool
-     */
-    public $autoFixtures = false;
-
-    /**
      * test paginate() and custom find, to make sure the correct count is returned.
      */
     public function testPaginateCustomFind(): void
     {
-        $this->loadFixtures('Posts');
         $titleExtractor = function ($result) {
             $ids = [];
             foreach ($result as $record) {
@@ -107,7 +99,6 @@ class PaginatorTest extends TestCase
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
         $table->save(new Entity($data));
@@ -147,7 +138,6 @@ class PaginatorTest extends TestCase
             ],
         ];
 
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $table->updateAll(['published' => 'N'], ['id' => 2]);
 
@@ -171,7 +161,6 @@ class PaginatorTest extends TestCase
             ],
         ];
 
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
 
         $this->Paginator->paginate($table, [], $settings);

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -122,7 +122,6 @@ trait PaginatorTestTrait
      */
     public function testPaginateCustomFinderOptions(): void
     {
-        $this->loadFixtures('Posts');
         $settings = [
             'PaginatorPosts' => [
                 'finder' => ['author' => ['author_id' => 1]],
@@ -147,7 +146,6 @@ trait PaginatorTestTrait
      */
     public function testPaginateNestedEagerLoader(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'Authors', 'ArticlesTags', 'AuthorsTags');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Tags');
         $tags = $this->getTableLocator()->get('Tags');
@@ -763,7 +761,6 @@ trait PaginatorTestTrait
      */
     public function testOutOfRangePageNumberGetsClamped(): void
     {
-        $this->loadFixtures('Posts');
         $params['page'] = 3000;
 
         $table = $this->getTableLocator()->get('PaginatorPosts');
@@ -792,7 +789,6 @@ trait PaginatorTestTrait
     public function testOutOfVeryBigPageNumberGetsClamped(): void
     {
         $this->expectException(PageOutOfBoundsException::class);
-        $this->loadFixtures('Posts');
         $params = [
             'page' => '3000000000000000000000000',
         ];
@@ -1148,7 +1144,6 @@ trait PaginatorTestTrait
      */
     public function testPaginateMaxLimit(): void
     {
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
 
         $settings = [
@@ -1242,7 +1237,6 @@ trait PaginatorTestTrait
     {
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(strpos($config['driver'], 'Sqlserver') !== false, 'Test temporarily broken in SQLServer');
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $query = $table->find()
             ->where(['PaginatorPosts.author_id BETWEEN :start AND :end'])

--- a/tests/TestCase/Datasource/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/SimplePaginatorTest.php
@@ -36,7 +36,6 @@ class SimplePaginatorTest extends PaginatorTest
      */
     public function testPaginateCustomFind(): void
     {
-        $this->loadFixtures('Posts');
         $titleExtractor = function ($result) {
             $ids = [];
             foreach ($result as $record) {
@@ -98,7 +97,6 @@ class SimplePaginatorTest extends PaginatorTest
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
         $table->save(new Entity($data));
@@ -138,7 +136,6 @@ class SimplePaginatorTest extends PaginatorTest
             ],
         ];
 
-        $this->loadFixtures('Posts');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $table->updateAll(['published' => 'N'], ['id' => 2]);
 

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -33,15 +33,6 @@ use UnexpectedValueException;
 class TimestampBehaviorTest extends TestCase
 {
     /**
-     * autoFixtures
-     *
-     * Don't load fixtures for all tests
-     *
-     * @var bool
-     */
-    public $autoFixtures = false;
-
-    /**
      * fixtures
      *
      * @var array
@@ -430,8 +421,6 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testSaveTriggersInsert(): void
     {
-        $this->loadFixtures('Users');
-
         $table = $this->getTableLocator()->get('users');
         $table->addBehavior('Timestamp', [
             'events' => [

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -11,10 +11,8 @@ use TestApp\Database\Type\ColumnSchemaAwareType;
 class ColumnSchemaAwareTypeIntegrationTest extends TestCase
 {
     protected $fixtures = [
-        'core.ColumnSchemaAwareTypeValues',
+        //'core.ColumnSchemaAwareTypeValues',
     ];
-
-    public $autoFixtures = false;
 
     /**
      * @var \Cake\Database\TypeInterface|null
@@ -24,13 +22,12 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+        $this->markTestSkipped('This test requires non-auto-fixtures');
 
         $this->textType = TypeFactory::build('text');
         TypeFactory::map('text', ColumnSchemaAwareType::class);
         // For SQLServer.
         TypeFactory::map('nvarchar', ColumnSchemaAwareType::class);
-
-        $this->loadFixtures('ColumnSchemaAwareTypeValues');
     }
 
     public function tearDown(): void

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -53,14 +53,11 @@ class QueryRegressionTest extends TestCase
         'core.Users',
     ];
 
-    public $autoFixtures = false;
-
     /**
      * Test for https://github.com/cakephp/cakephp/issues/3087
      */
     public function testSelectTimestampColumn(): void
     {
-        $this->loadFixtures('Users');
         $table = $this->getTableLocator()->get('users');
         $user = $table->find()->where(['id' => 1])->first();
         $this->assertEquals(new FrozenTime('2007-03-17 01:16:23'), $user->created);
@@ -73,7 +70,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingFromEmptyResults(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('ArticlesTags');
         $results = $table->find()->where(['id >' => 100])->contain('ArticlesTags')->toArray();
@@ -85,7 +81,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingAliasedAssociationFields(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors', [
             'foreignKey' => 'author_id',
@@ -110,7 +105,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingMismatchingAliasInBelongsTo(): void
     {
-        $this->loadFixtures('Articles', 'Users');
         $table = $this->getTableLocator()->get('Articles');
         $users = $this->getTableLocator()->get('Users');
         $table->belongsTo('Authors', [
@@ -129,7 +123,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingMismatchingAliasInHasOne(): void
     {
-        $this->loadFixtures('Articles', 'Users');
         $articles = $this->getTableLocator()->get('Articles');
         $users = $this->getTableLocator()->get('Users');
         $users->hasOne('Posts', [
@@ -147,7 +140,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingBelongsToManyList(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'finder' => 'list',
@@ -164,7 +156,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadingNestedMatchingCalls(): void
     {
-        $this->loadFixtures('Articles', 'Authors', 'Tags', 'ArticlesTags', 'AuthorsTags');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
@@ -200,7 +191,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testDuplicateAttachableAliases(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags', 'Authors');
         $this->getTableLocator()->get('Stuff', ['table' => 'tags']);
         $this->getTableLocator()->get('Things', ['table' => 'articles_tags']);
 
@@ -236,7 +226,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testNullableTimeColumn(): void
     {
-        $this->loadFixtures('Users');
         $table = $this->getTableLocator()->get('users');
         $entity = $table->newEntity(['username' => 'derp', 'created' => null]);
         $this->assertSame($entity, $table->save($entity));
@@ -250,7 +239,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testCreateJointData(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Highlights', [
             'className' => 'TestApp\Model\Table\TagsTable',
@@ -281,7 +269,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testReciprocalBelongsToMany(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
 
@@ -301,7 +288,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testReciprocalBelongsToManyNoOverwrite(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
 
@@ -341,7 +327,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testBelongsToManyDeepSave($strategy): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'SpecialTags', 'Authors');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Highlights', [
             'className' => 'TestApp\Model\Table\TagsTable',
@@ -401,7 +386,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testSaveWithCallbacks(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors');
 
@@ -421,7 +405,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testSaveWithExpressionProperty(): void
     {
-        $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
         $article = $articles->newEmptyEntity();
         $article->title = new QueryExpression("SELECT 'jose'");
@@ -436,7 +419,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testBelongsToManyDeepSave2(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Highlights', [
             'className' => 'TestApp\Model\Table\TagsTable',
@@ -492,7 +474,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testPluginAssociationQueryGeneration(): void
     {
-        $this->loadFixtures('Articles', 'Comments', 'Authors');
         $this->loadPlugins(['TestPlugin']);
         $articles = $this->getTableLocator()->get('Articles');
         $articles->hasMany('TestPlugin.Comments');
@@ -523,7 +504,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testAssociationChainOrder(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags', 'Authors');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors');
         $articles->hasOne('ArticlesTags');
@@ -551,7 +531,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testAssociationSubQueryNoOffset(): void
     {
-        $this->loadFixtures('Articles', 'Translates');
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->setLocale('eng');
@@ -570,7 +549,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testDeepBelongsToManySubqueryStrategy(): void
     {
-        $this->loadFixtures('Authors', 'Tags', 'Articles', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('Articles');
         $table->Articles->belongsToMany('Tags', [
@@ -592,7 +570,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testDeepBelongsToManySubqueryStrategy2(): void
     {
-        $this->loadFixtures('Articles', 'Authors', 'Tags', 'Authors', 'AuthorsTags');
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('Articles');
         $table->Articles->belongsToMany('Tags', [
@@ -622,7 +599,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testDeepHasManyEitherStrategy(): void
     {
-        $this->loadFixtures('Tags', 'FeaturedTags', 'TagsTranslations');
         $tags = $this->getTableLocator()->get('Tags');
 
         $this->skipIf(
@@ -667,7 +643,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testCountWithContain(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors', ['joinType' => 'inner']);
         $count = $table
@@ -686,7 +661,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testCountWithBind(): void
     {
-        $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
         $query = $table
             ->find()
@@ -703,7 +677,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testCountWithInnerJoinContain(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors')->setJoinType('INNER');
 
@@ -729,7 +702,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testSubqueryBind(): void
     {
-        $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
         $sub = $table->find()
             ->select(['id'])
@@ -752,7 +724,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testContainNoEmptyAssociatedObjects(): void
     {
-        $this->loadFixtures('Comments', 'Users', 'Articles');
         $comments = $this->getTableLocator()->get('Comments');
         $comments->belongsTo('Users');
         $users = $this->getTableLocator()->get('Users');
@@ -782,7 +753,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testOrConditionsWithExpression(): void
     {
-        $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
         $query->where([
@@ -803,7 +773,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testCountWithUnionQuery(): void
     {
-        $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find()->where(['id' => 1]);
         $query2 = $table->find()->where(['id' => 2]);
@@ -816,7 +785,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testSelectNoFieldsOnPrimaryAlias(): void
     {
-        $this->loadFixtures('Articles', 'Users');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Users');
         $query = $table->find()
@@ -833,7 +801,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testAliasedAggregateFieldTypeConversionSafe(): void
     {
-        $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
 
         $driver = $articles->getConnection()->getDriver();
@@ -856,7 +823,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFirstOnResultSet(): void
     {
-        $this->loadFixtures('Articles');
         $results = $this->getTableLocator()->get('Articles')->find()->all();
         $this->assertSame(3, $results->count());
         $this->assertNotNull($results->first());
@@ -870,7 +836,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFindMatchingAndContain(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
         $article = $table->find()
@@ -890,7 +855,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFindMatchingAndContainWithSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Authors', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles', ['strategy' => 'subquery']);
         $table->articles->belongsToMany('tags');
@@ -911,7 +875,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFindMatchingOverwrite(): void
     {
-        $this->loadFixtures('Articles', 'Comments', 'Tags', 'ArticlesTags');
         $comments = $this->getTableLocator()->get('Comments');
         $comments->belongsTo('Articles');
 
@@ -940,7 +903,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFindMatchingOverwrite2(): void
     {
-        $this->loadFixtures('Articles', 'Comments', 'Tags', 'ArticlesTags', 'Authors');
         $comments = $this->getTableLocator()->get('Comments');
         $comments->belongsTo('Articles');
 
@@ -966,7 +928,6 @@ class QueryRegressionTest extends TestCase
     public function testQueryNotFatalError(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->loadFixtures('Comments');
         $comments = $this->getTableLocator()->get('Comments');
         $comments->find()->contain('Deprs')->all();
     }
@@ -979,7 +940,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFindMatchingWithContain(): void
     {
-        $this->loadFixtures('Articles', 'Comments', 'Users');
         $comments = $this->getTableLocator()->get('Comments');
         $comments->belongsTo('Articles');
         $comments->belongsTo('Users');
@@ -1005,7 +965,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testHasManyEagerLoadingUniqueKey(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('ArticlesTags');
         $table->belongsTo('Articles', [
             'strategy' => 'select',
@@ -1031,7 +990,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testContainWithNoFields(): void
     {
-        $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Comments');
         $table->belongsTo('Users');
         $results = $table->find()
@@ -1051,7 +1009,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testContainWithComputedField(): void
     {
-        $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Users');
         $table->hasMany('Comments');
 
@@ -1077,7 +1034,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testMatchingWithNoFields(): void
     {
-        $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Users');
         $table->hasMany('Comments');
         $results = $table->find()
@@ -1096,7 +1052,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testMatchingEmptyQuery(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags');
 
@@ -1120,7 +1075,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testSubqueryInSelectExpression(): void
     {
-        $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $ratio = $table->find()
             ->select(function ($query) use ($table) {
@@ -1147,7 +1101,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testContainInNestedClosure(): void
     {
-        $this->loadFixtures('Comments', 'Articles', 'Authors', 'Tags', 'AuthorsTags');
         $table = $this->getTableLocator()->get('Comments');
         $table->belongsTo('Articles');
         $table->Articles->belongsTo('Authors');
@@ -1167,7 +1120,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testTypemapInFunctions(): void
     {
-        $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $table->updateAll(['published' => null], ['1 = 1']);
         $query = $table->find();
@@ -1192,7 +1144,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testTypemapInFunctions2(): void
     {
-        $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $query = $table->find();
         $query->select([
@@ -1211,7 +1162,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testTypemapInFunctions3(): void
     {
-        $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $query = $table->find();
 
@@ -1230,7 +1180,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testBooleanConditionsInContain(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'SpecialTags');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
@@ -1254,7 +1203,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexTypesInJoinedWhere(): void
     {
-        $this->loadFixtures('Comments', 'Users');
         $table = $this->getTableLocator()->get('Users');
         $table->hasOne('Comments', [
             'foreignKey' => 'user_id',
@@ -1275,7 +1223,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexNestedTypesInJoinedWhere(): void
     {
-        $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
         $table->hasOne('Comments', [
             'foreignKey' => 'user_id',
@@ -1302,7 +1249,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexTypesInJoinedWhereWithMatching(): void
     {
-        $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
         $table->hasOne('Comments', [
             'foreignKey' => 'user_id',
@@ -1339,7 +1285,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexTypesInJoinedWhereWithNotMatching(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
         $Tags = $this->getTableLocator()->get('Tags');
         $Tags->belongsToMany('Articles');
 
@@ -1362,7 +1307,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexTypesInJoinedWhereWithInnerJoinWith(): void
     {
-        $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
         $table->hasOne('Comments', [
             'foreignKey' => 'user_id',
@@ -1399,7 +1343,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexTypesInJoinedWhereWithLeftJoinWith(): void
     {
-        $this->loadFixtures('Comments', 'Users', 'Articles');
         $table = $this->getTableLocator()->get('Users');
         $table->hasOne('Comments', [
             'foreignKey' => 'user_id',
@@ -1437,7 +1380,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testBelongsToManyJoinDataAssociation(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Tags', 'SpecialTags');
         $articles = $this->getTableLocator()->get('Articles');
 
         $tags = $this->getTableLocator()->get('Tags');
@@ -1468,7 +1410,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testDotNotationNotOverride(): void
     {
-        $this->loadFixtures('Comments', 'Articles', 'Tags', 'Authors', 'SpecialTags');
         $table = $this->getTableLocator()->get('Comments');
         $articles = $table->belongsTo('Articles');
         $specialTags = $articles->hasMany('SpecialTags');
@@ -1494,7 +1435,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testComplexOrderWithUnion(): void
     {
-        $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $query = $table->find();
         $inner = $table->find()
@@ -1520,7 +1460,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testEagerLoadOrderAndSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments', [
             'strategy' => 'subquery',
@@ -1541,7 +1480,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testCountWithComplexOrderBy(): void
     {
-        $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
         $query->orderDesc($query->newExpr()->addCase(
@@ -1572,7 +1510,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFunctionInWhereClause(): void
     {
-        $this->loadFixtures('Comments');
         $table = $this->getTableLocator()->get('Comments');
         $table->updateAll(['updated' => FrozenTime::now()->addDays(2)], ['id' => 6]);
         $query = $table->find();
@@ -1586,8 +1523,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testNotMatchingForBelongsToManyWithoutQueryBuilder(): void
     {
-        $this->loadFixtures('Articles', 'Tags', 'ArticlesTags');
-
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->belongsToMany('Tags');
 
@@ -1606,7 +1541,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFormatDeepDistantAssociationRecords2(): void
     {
-        $this->loadFixtures('Authors', 'Articles', 'Tags', 'ArticlesTags');
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
         $articles = $table->getAssociation('articles')->getTarget();
@@ -1642,7 +1576,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFunctionExpressionWithSubquery(): void
     {
-        $this->loadFixtures('Articles');
         $table = $this->getTableLocator()->get('Articles');
 
         $query = $table
@@ -1670,7 +1603,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testFunctionExpressionWithCorrelatedSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
 
@@ -1699,7 +1631,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testMultiArgumentFunctionExpressionWithSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
 
         $query = $table
@@ -1731,7 +1662,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testMultiArgumentFunctionExpressionWithCorrelatedSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
 
@@ -1766,7 +1696,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testTranspiledFunctionExpressionWithSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
 
@@ -1794,7 +1723,6 @@ class QueryRegressionTest extends TestCase
      */
     public function testTranspiledFunctionExpressionWithCorrelatedSubquery(): void
     {
-        $this->loadFixtures('Articles', 'Authors');
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo('Authors');
 

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -48,27 +48,12 @@ class LinkConstraintTest extends TestCase
     ];
 
     /**
-     * Do not load fixtures by default.
-     *
-     * @var bool
-     */
-    public $autoFixtures = false;
-
-    /**
      * Setup
      */
     public function setUp(): void
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
-
-        $this->loadFixtures(
-            'Articles',
-            'Comments',
-            'Attachments',
-            'Tags',
-            'ArticlesTags'
-        );
     }
 
     /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -57,13 +57,6 @@ class FormHelperTest extends TestCase
     protected $fixtures = ['core.Articles', 'core.Comments'];
 
     /**
-     * Do not load the fixtures by default
-     *
-     * @var bool
-     */
-    public $autoFixtures = false;
-
-    /**
      * @var array
      */
     protected $article = [];
@@ -378,7 +371,6 @@ class FormHelperTest extends TestCase
      */
     public function testCreateContextSelectionBuiltIn($data, string $class): void
     {
-        $this->loadFixtures('Articles');
         $this->Form->create($data);
         $this->assertInstanceOf($class, $this->Form->context());
     }
@@ -4911,7 +4903,6 @@ class FormHelperTest extends TestCase
 
     public function testSelectEmptyWithRequiredFalse(): void
     {
-        $this->loadFixtures();
         $Articles = $this->getTableLocator()->get('Articles');
         $validator = $Articles->getValidator('default');
         $validator->allowEmptyString('user_id');
@@ -5059,7 +5050,6 @@ class FormHelperTest extends TestCase
      */
     public function testHabtmSelectBox(): void
     {
-        $this->loadFixtures('Articles');
         $options = [
             1 => 'blue',
             2 => 'red',
@@ -5170,8 +5160,6 @@ class FormHelperTest extends TestCase
      */
     public function testErrorsForBelongsToManySelect(): void
     {
-        $this->loadFixtures();
-
         $spacecraft = [
             1 => 'Orion',
             2 => 'Helios',
@@ -7345,7 +7333,6 @@ class FormHelperTest extends TestCase
      */
     public function testMultiRecordForm(): void
     {
-        $this->loadFixtures('Articles', 'Comments');
         $articles = $this->getTableLocator()->get('Articles');
         $articles->hasMany('Comments');
 
@@ -7994,7 +7981,6 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesSingleSwitchRendering(): void
     {
-        $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
@@ -8049,7 +8035,6 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesListSwitchRendering(): void
     {
-        $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
@@ -8093,7 +8078,6 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesSwitchViaOptionsRendering(): void
     {
-        $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);
@@ -8148,7 +8132,6 @@ class FormHelperTest extends TestCase
      */
     public function testFormValueSourcesSwitchViaOptionsAndSetterRendering(): void
     {
-        $this->loadFixtures('Articles');
         $articles = $this->getTableLocator()->get('Articles');
         $article = new Article();
         $articles->patchEntity($article, ['id' => '3']);


### PR DESCRIPTION
This back-ports a fix from 5.0 for loading fixtures with foreign key dependencies. Only postgres needs to wrap disableConstraints() in a transaction.