### PR TITLE
Clean up resetting default locale in tests

### DIFF
--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -43,11 +43,6 @@ class DecimalTypeTest extends TestCase
     protected $numberClass;
 
     /**
-     * @var string
-     */
-    protected $localeString;
-
-    /**
      * Setup
      */
     public function setUp(): void
@@ -55,10 +50,7 @@ class DecimalTypeTest extends TestCase
         parent::setUp();
         $this->type = new DecimalType();
         $this->driver = $this->getMockBuilder(Driver::class)->getMock();
-        $this->localeString = I18n::getLocale();
         $this->numberClass = DecimalType::$numberClass;
-
-        I18n::setLocale($this->localeString);
     }
 
     /**
@@ -67,7 +59,7 @@ class DecimalTypeTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        I18n::setLocale($this->localeString);
+        I18n::setLocale(I18n::getDefaultLocale());
         DecimalType::$numberClass = $this->numberClass;
     }
 

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -42,11 +42,6 @@ class FloatTypeTest extends TestCase
     protected $numberClass;
 
     /**
-     * @var string
-     */
-    protected $localeString;
-
-    /**
      * Setup
      */
     public function setUp(): void
@@ -54,10 +49,7 @@ class FloatTypeTest extends TestCase
         parent::setUp();
         $this->type = new FloatType();
         $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
-        $this->localeString = I18n::getLocale();
         $this->numberClass = FloatType::$numberClass;
-
-        I18n::setLocale($this->localeString);
     }
 
     /**
@@ -66,7 +58,7 @@ class FloatTypeTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        I18n::setLocale($this->localeString);
+        I18n::setLocale(I18n::getDefaultLocale());
         FloatType::$numberClass = $this->numberClass;
     }
 

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -39,11 +39,6 @@ class TimeTypeTest extends TestCase
     protected $driver;
 
     /**
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * Setup
      */
     public function setUp(): void
@@ -51,7 +46,6 @@ class TimeTypeTest extends TestCase
         parent::setUp();
         $this->type = new TimeType();
         $this->driver = $this->getMockBuilder('Cake\Database\Driver')->getMock();
-        $this->locale = I18n::getLocale();
 
         Configure::write('Error.ignoredDeprecationPaths', [
             'src/Database/Type/DateTimeType.php',
@@ -66,7 +60,7 @@ class TimeTypeTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        I18n::setLocale($this->locale);
+        I18n::setLocale(I18n::getDefaultLocale());
     }
 
     /**
@@ -233,14 +227,10 @@ class TimeTypeTest extends TestCase
      */
     public function testMarshalWithLocaleParsing(): void
     {
-        $this->type->useLocaleParser();
-
         $expected = new Time('23:23:00');
-        $result = $this->type->marshal('11:23pm');
+        $result = $this->type->useLocaleParser()->marshal('11:23pm');
         $this->assertSame($expected->format('H:i'), $result->format('H:i'));
         $this->assertNull($this->type->marshal('derp:23'));
-
-        $this->type->useLocaleParser(false);
     }
 
     /**
@@ -248,17 +238,15 @@ class TimeTypeTest extends TestCase
      */
     public function testMarshalWithLocaleParsingDanishLocale(): void
     {
+        $original = setlocale(LC_COLLATE, '0');
         $updated = setlocale(LC_COLLATE, 'da_DK.utf8');
+        setlocale(LC_COLLATE, $original);
         $this->skipIf($updated === false, 'Could not set locale to da_DK.utf8, skipping test.');
-
-        $this->type->useLocaleParser();
 
         I18n::setLocale('da_DK');
         $expected = new Time('03:20:00');
-        $result = $this->type->marshal('03.20');
+        $result = $this->type->useLocaleParser()->marshal('03.20');
         $this->assertSame($expected->format('H:i'), $result->format('H:i'));
-
-        $this->type->useLocaleParser(false);
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -28,19 +28,11 @@ use DateTimeZone;
 class DateTest extends TestCase
 {
     /**
-     * Backup the locale property
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * setup
      */
     public function setUp(): void
     {
         parent::setUp();
-        $this->locale = Date::getDefaultLocale();
 
         Configure::write('Error.ignoredDeprecationPaths', [
             'src/I18n/DateFormatTrait.php',
@@ -54,8 +46,8 @@ class DateTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        Date::setDefaultLocale($this->locale);
-        FrozenDate::setDefaultLocale($this->locale);
+        Date::setDefaultLocale(null);
+        FrozenDate::setDefaultLocale(null);
         date_default_timezone_set('UTC');
     }
 

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -22,7 +22,6 @@ use Cake\I18n\Package;
 use Cake\I18n\Translator;
 use Cake\I18n\TranslatorRegistry;
 use Cake\TestSuite\TestCase;
-use Locale;
 
 /**
  * I18nTest class
@@ -30,19 +29,11 @@ use Locale;
 class I18nTest extends TestCase
 {
     /**
-     * Used to restore the internal locale after tests
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * Set Up
      */
     public function setUp(): void
     {
         parent::setUp();
-        $this->locale = Locale::getDefault() ?: I18n::DEFAULT_LOCALE;
     }
 
     /**
@@ -53,7 +44,7 @@ class I18nTest extends TestCase
         parent::tearDown();
         I18n::clear();
         I18n::setDefaultFormatter('default');
-        I18n::setLocale($this->locale);
+        I18n::setLocale(I18n::getDefaultLocale());
         $this->clearPlugins();
         Cache::clear('_cake_core_');
     }
@@ -63,10 +54,11 @@ class I18nTest extends TestCase
      */
     public function testDefaultLocale(): void
     {
+        $default = I18n::getDefaultLocale();
         $newLocale = 'de_DE';
         I18n::setLocale($newLocale);
         $this->assertSame($newLocale, I18n::getLocale());
-        $this->assertSame($this->locale, I18n::getDefaultLocale());
+        $this->assertSame($default, I18n::getDefaultLocale());
     }
 
     /**

--- a/tests/TestCase/I18n/NumberTest.php
+++ b/tests/TestCase/I18n/NumberTest.php
@@ -33,20 +33,12 @@ class NumberTest extends TestCase
     protected $Number;
 
     /**
-     * Backup the locale property
-     *
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * setUp method
      */
     public function setUp(): void
     {
         parent::setUp();
         $this->Number = new Number();
-        $this->locale = I18n::getLocale();
     }
 
     /**
@@ -56,7 +48,7 @@ class NumberTest extends TestCase
     {
         parent::tearDown();
         unset($this->Number);
-        I18n::setLocale($this->locale);
+        I18n::setLocale(I18n::getDefaultLocale());
         Number::setDefaultCurrency();
         Number::setDefaultCurrencyFormat();
     }

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -28,8 +28,6 @@ use Cake\TestSuite\TestCase;
  */
 class PoFileParserTest extends TestCase
 {
-    protected $locale;
-
     /**
      * Locale folder path
      *
@@ -43,7 +41,6 @@ class PoFileParserTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->locale = I18n::getLocale();
         $this->path = Configure::read('App.paths.locales.0');
     }
 
@@ -54,7 +51,7 @@ class PoFileParserTest extends TestCase
     {
         parent::tearDown();
         I18n::clear();
-        I18n::setLocale($this->locale);
+        I18n::setLocale(I18n::getDefaultLocale());
         Cache::clear('_cake_core_');
     }
 

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -36,9 +36,6 @@ class TimeTest extends TestCase
     {
         parent::setUp();
         $this->now = Time::getTestNow();
-        $this->locale = Time::getDefaultLocale();
-        Time::setDefaultLocale('en_US');
-        FrozenTime::setDefaultLocale('en_US');
 
         Configure::write('Error.ignoredDeprecationPaths', [
             'src/I18n/DateFormatTrait.php',
@@ -54,16 +51,16 @@ class TimeTest extends TestCase
     {
         parent::tearDown();
         Time::setTestNow($this->now);
-        Time::setDefaultLocale($this->locale);
+        Time::setDefaultLocale(null);
         Time::resetToStringFormat();
         Time::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssxxx");
 
-        FrozenTime::setDefaultLocale($this->locale);
+        FrozenTime::setDefaultLocale(null);
         FrozenTime::resetToStringFormat();
         FrozenTime::setJsonEncodeFormat("yyyy-MM-dd'T'HH':'mm':'ssxxx");
 
         date_default_timezone_set('UTC');
-        I18n::setLocale(I18n::DEFAULT_LOCALE);
+        I18n::setLocale(I18n::getDefaultLocale());
     }
 
     /**
@@ -468,18 +465,12 @@ class TimeTest extends TestCase
      */
     public function testI18nFormatUsingSystemLocale(): void
     {
-        // Unset default locale for the Time class to ensure system's locale is used.
-        Time::setDefaultLocale();
-        $locale = I18n::getLocale();
-
         $time = new Time(1556864870);
         I18n::setLocale('ar');
         $this->assertSame('٢٠١٩-٠٥-٠٣', $time->i18nFormat('yyyy-MM-dd'));
 
         I18n::setLocale('en');
         $this->assertSame('2019-05-03', $time->i18nFormat('yyyy-MM-dd'));
-
-        I18n::setLocale($locale);
     }
 
     /**

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -1719,8 +1719,7 @@ class HashTest extends TestCase
     public function testSortLocale(): void
     {
         // get the current locale
-        $oldLocale = setlocale(LC_COLLATE, '0');
-
+        $original = setlocale(LC_COLLATE, '0');
         $updated = setlocale(LC_COLLATE, 'de_DE.utf8');
         $this->skipIf($updated === false, 'Could not set locale to de_DE.utf8, skipping test.');
 
@@ -1738,10 +1737,9 @@ class HashTest extends TestCase
             ['Item' => ['entry' => 'Ostfriesland']],
             ['Item' => ['entry' => 'Übergabe']],
         ];
-        $this->assertSame($expected, $result);
 
-        // change to the original locale
-        setlocale(LC_COLLATE, $oldLocale);
+        setlocale(LC_COLLATE, $original);
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -35,11 +35,6 @@ class ValidationTest extends TestCase
     /**
      * @var string
      */
-    protected $locale;
-
-    /**
-     * @var string
-     */
     protected $_appEncoding;
 
     /**
@@ -49,8 +44,6 @@ class ValidationTest extends TestCase
     {
         parent::setUp();
         $this->_appEncoding = Configure::read('App.encoding');
-        $this->locale = Locale::getDefault();
-        Locale::setDefault('en_US');
     }
 
     /**
@@ -60,7 +53,7 @@ class ValidationTest extends TestCase
     {
         parent::tearDown();
         Configure::write('App.encoding', $this->_appEncoding);
-        Locale::setDefault($this->locale);
+        I18n::setLocale(I18n::getDefaultLocale());
     }
 
     /**
@@ -1645,8 +1638,6 @@ class ValidationTest extends TestCase
      */
     public function testLocalizedTime(): void
     {
-        $locale = I18n::getLocale();
-
         $this->assertFalse(Validation::localizedTime('', 'date'));
         $this->assertFalse(Validation::localizedTime('invalid', 'date'));
         $this->assertFalse(Validation::localizedTime(1, 'date'));
@@ -1675,8 +1666,6 @@ class ValidationTest extends TestCase
         $this->assertTrue(Validation::localizedTime('31 декабря 2006', 'date'));
 
         $this->assertFalse(Validation::localizedTime('December 31, 2006', 'date')); // non-Russian format
-
-        I18n::setLocale($locale);
     }
 
     /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -31,11 +31,6 @@ use Cake\View\View;
 class PaginatorHelperTest extends TestCase
 {
     /**
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * @var \Cake\View\View
      */
     protected $View;
@@ -81,8 +76,6 @@ class PaginatorHelperTest extends TestCase
         Router::connect('/{controller}/{action}/*');
         Router::connect('/{plugin}/{controller}/{action}/*');
         Router::setRequest($request);
-
-        $this->locale = I18n::getLocale();
     }
 
     /**
@@ -93,7 +86,7 @@ class PaginatorHelperTest extends TestCase
         parent::tearDown();
         unset($this->View, $this->Paginator);
 
-        I18n::setLocale($this->locale);
+        I18n::setLocale(I18n::getDefaultLocale());
     }
 
     /**

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -39,11 +39,6 @@ class TimeHelperTest extends TestCase
     protected $View;
 
     /**
-     * @var string
-     */
-    protected $locale;
-
-    /**
      * setUp method
      */
     public function setUp(): void
@@ -51,8 +46,6 @@ class TimeHelperTest extends TestCase
         parent::setUp();
         $this->View = new View();
         $this->Time = new TimeHelper($this->View);
-        Time::setDefaultLocale('en_US');
-        $this->locale = I18n::getLocale();
     }
 
     /**
@@ -61,8 +54,8 @@ class TimeHelperTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        Time::setDefaultLocale('en_US');
-        I18n::setLocale($this->locale);
+        Time::setDefaultLocale(null);
+        I18n::setLocale(I18n::getDefaultLocale());
     }
 
     /**


### PR DESCRIPTION
This will fix the danish TimeType test in 5.0 when merged.