### PR TITLE
Move PHPUnit bootstrap condition to schema loader

### DIFF
--- a/src/TestSuite/Fixture/SchemaGenerator.php
+++ b/src/TestSuite/Fixture/SchemaGenerator.php
@@ -23,6 +23,10 @@ use RuntimeException;
 /**
  * Create database schema from the provided metadata file.
  *
+ * This class is only intended for use by CakePHP's testsuite
+ * as we need to test against many database platforms and can't
+ * leverage migrations, or other dependencies to manage schema.
+ *
  * @internal
  */
 class SchemaGenerator
@@ -66,8 +70,7 @@ class SchemaGenerator
      */
     public function reload(?array $tables = null): void
     {
-        // Don't reload schema when we are in a separate process
-        // state.
+        // Don't reload schema when we are in a separate process state.
         if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
             return;
         }

--- a/src/TestSuite/Fixture/SchemaGenerator.php
+++ b/src/TestSuite/Fixture/SchemaGenerator.php
@@ -66,6 +66,11 @@ class SchemaGenerator
      */
     public function reload(?array $tables = null): void
     {
+        // Don't reload schema when we are in a separate process
+        // state.
+        if (isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
+            return;
+        }
         $cleaner = new SchemaCleaner();
         $cleaner->dropTables($this->connection, $tables);
 

--- a/src/TestSuite/Fixture/SchemaManager.php
+++ b/src/TestSuite/Fixture/SchemaManager.php
@@ -19,7 +19,15 @@ use Cake\Console\ConsoleIo;
 use Cake\Datasource\ConnectionManager;
 
 /**
- * This class will create the schema of the test DB
+ * Create test database schema from one or more SQL dump files.
+ *
+ * This class can be useful to create test database schema when
+ * your schema is managed by tools external to your CakePHP
+ * application.
+ *
+ * It is not well suited for applications/plugins that need to
+ * support multiple database platforms. You should use migrations
+ * for that instead.
  */
 class SchemaManager
 {
@@ -42,6 +50,9 @@ class SchemaManager
     /**
      * Import the schema from a file, or an array of files.
      *
+     * This function will drop all tables in the database and then
+     * load the provided schema file(s).
+     *
      * @param string $connectionName Connection
      * @param array<string>|string $file File to dump
      * @param bool|null $verbose Set to true to display messages
@@ -58,7 +69,8 @@ class SchemaManager
     ): void {
         $files = (array)$file;
 
-        if (empty($files)) {
+        // Don't create schema if we are in a phpunit separate process test method.
+        if (empty($files) || isset($GLOBALS['__PHPUNIT_BOOTSTRAP'])) {
             return;
         }
 

--- a/tests/TestCase/TestSuite/Fixture/SchemaGeneratorTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaGeneratorTest.php
@@ -25,6 +25,24 @@ use Cake\TestSuite\TestCase;
 class SchemaGeneratorTest extends TestCase
 {
     /**
+     * @var bool|null
+     */
+    protected $restore;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
+        unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $this->restore;
+    }
+
+    /**
      * test reload on a table subset.
      */
     public function testReload(): void

--- a/tests/TestCase/TestSuite/Fixture/SchemaManagerTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaManagerTest.php
@@ -23,6 +23,24 @@ use Cake\TestSuite\TestCase;
 
 class SchemaManagerTest extends TestCase
 {
+    /**
+     * @var bool|null
+     */
+    protected $restore;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->restore = $GLOBALS['__PHPUNIT_BOOTSTRAP'];
+        unset($GLOBALS['__PHPUNIT_BOOTSTRAP']);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $this->restore;
+    }
+
     public function testCreateFromOneFile(): void
     {
         $connection = ConnectionManager::get('test');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -135,8 +135,6 @@ ini_set('session.gc_divisor', '1');
 // has been written to.
 session_id('cli');
 
-// Create test database schema as long as we are not in an isolated process test.
-if (!isset($GLOBALS['__PHPUNIT_BOOTSTRAP']) && env('FIXTURE_SCHEMA_METADATA')) {
-    $schema = new SchemaGenerator(env('FIXTURE_SCHEMA_METADATA'), 'test');
-    $schema->reload();
-}
+// Create test database schema
+$schema = new SchemaGenerator(env('FIXTURE_SCHEMA_METADATA'), 'test');
+$schema->reload();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -136,5 +136,5 @@ ini_set('session.gc_divisor', '1');
 session_id('cli');
 
 // Create test database schema
-$schema = new SchemaGenerator(env('FIXTURE_SCHEMA_METADATA'), 'test');
+$schema = new SchemaGenerator(env('FIXTURE_SCHEMA_METADATA', ''), 'test');
 $schema->reload();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -136,5 +136,7 @@ ini_set('session.gc_divisor', '1');
 session_id('cli');
 
 // Create test database schema
-$schema = new SchemaGenerator(env('FIXTURE_SCHEMA_METADATA', ''), 'test');
-$schema->reload();
+if (env('FIXTURE_SCHEMA_METADATA')) {
+    $schema = new SchemaGenerator(env('FIXTURE_SCHEMA_METADATA'), 'test');
+    $schema->reload();
+}


### PR DESCRIPTION
Having this check in the schema loader lets the user-facing API be simpler to operate and have one fewer gotcha.

