### PR TITLE
Switch ConnectionManager::alias() parameter names

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -150,20 +150,20 @@ class ConnectionManager
      * ConnectionManager::alias('test_things', 'things');
      * ```
      *
-     * @param string $alias The alias to add. Fetching $source will return $alias when loaded with get.
-     * @param string $source The connection to add an alias to.
+     * @param string $source The existing connection to alias.
+     * @param string $alias The alias name that resolves to `$source`.
      * @return void
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When aliasing a
      * connection that does not exist.
      */
-    public static function alias(string $alias, string $source): void
+    public static function alias(string $source, string $alias): void
     {
-        if (empty(static::$_config[$source]) && empty(static::$_config[$alias])) {
+        if (empty(static::$_config[$source])) {
             throw new MissingDatasourceConfigException(
-                sprintf('Cannot create alias of "%s" as it does not exist.', $alias)
+                sprintf('Cannot create alias of "%s" as it does not exist.', $source)
             );
         }
-        static::$_aliasMap[$source] = $alias;
+        static::$_aliasMap[$alias] = $source;
     }
 
     /**


### PR DESCRIPTION
I find this confusing every time. The alias should be the new name and the source should be the existing connection. This matches the name used by `dropAlias()`.

~Renamed $source to $target.~