### PR TITLE
Move TestApp fixtures into correct namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
             "Cake\\PHPStan\\": "tests/PHPStan/",
             "Cake\\Test\\": "tests/",
             "TestApp\\": "tests/test_app/TestApp/",
+            "TestApp\\Test\\": "tests/test_app/TestApp/tests/",
             "TestPlugin\\": "tests/test_app/Plugin/TestPlugin/src/",
             "TestPlugin\\Test\\": "tests/test_app/Plugin/TestPlugin/tests/",
             "TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src/",

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -23,10 +23,10 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Exception;
-use TestApp\Fixture\ArticlesFixture;
-use TestApp\Fixture\ImportsFixture;
-use TestApp\Fixture\LettersFixture;
-use TestApp\Fixture\StringsTestsFixture;
+use TestApp\Test\Fixture\ArticlesFixture;
+use TestApp\Test\Fixture\ImportsFixture;
+use TestApp\Test\Fixture\LettersFixture;
+use TestApp\Test\Fixture\StringsTestsFixture;
 
 /**
  * Test case for TestFixture

--- a/tests/test_app/TestApp/tests/Fixture/ArticlesFixture.php
+++ b/tests/test_app/TestApp/tests/Fixture/ArticlesFixture.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace TestApp\Fixture;
+namespace TestApp\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/test_app/TestApp/tests/Fixture/ImportsFixture.php
+++ b/tests/test_app/TestApp/tests/Fixture/ImportsFixture.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace TestApp\Fixture;
+namespace TestApp\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/test_app/TestApp/tests/Fixture/LettersFixture.php
+++ b/tests/test_app/TestApp/tests/Fixture/LettersFixture.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace TestApp\Fixture;
+namespace TestApp\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/test_app/TestApp/tests/Fixture/StringsTestsFixture.php
+++ b/tests/test_app/TestApp/tests/Fixture/StringsTestsFixture.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace TestApp\Fixture;
+namespace TestApp\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 


### PR DESCRIPTION
These don't exist in a valid namespace and can't be loaded.