### PR TITLE
Return a `Closure` from `routes.php` files.

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -18,6 +18,7 @@ namespace Cake\Core;
 use Cake\Console\CommandCollection;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
+use Closure;
 use InvalidArgumentException;
 use ReflectionClass;
 
@@ -258,7 +259,10 @@ class BasePlugin implements PluginInterface
     {
         $path = $this->getConfigPath() . 'routes.php';
         if (is_file($path)) {
-            require $path;
+            $return = require $path;
+            if ($return instanceof Closure) {
+                $return($routes);
+            }
         }
     }
 

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -34,6 +34,7 @@ use Cake\Event\EventManagerInterface;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
+use Closure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -194,7 +195,10 @@ abstract class BaseApplication implements
     {
         // Only load routes if the router is empty
         if (!Router::routes()) {
-            require $this->configDir . 'routes.php';
+            $return = require $this->configDir . 'routes.php';
+            if ($return instanceof Closure) {
+                $return($routes);
+            }
         }
     }
 

--- a/tests/test_app/Plugin/TestPlugin/config/routes.php
+++ b/tests/test_app/Plugin/TestPlugin/config/routes.php
@@ -1,13 +1,14 @@
 <?php
 
 use Cake\Core\Configure;
+use Cake\Routing\RouteBuilder;
 
 Configure::write('PluginTest.test_plugin.routes', 'loaded plugin routes');
 
-if (isset($routes)) {
+return function (RouteBuilder $routes) {
     $routes->get(
         '/test_plugin',
         ['controller' => 'TestPlugin', 'plugin' => 'TestPlugin', 'action' => 'index'],
         'test_plugin:index'
     );
-}
+};

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -15,18 +15,20 @@
 
 use Cake\Routing\RouteBuilder;
 
-$routes->setExtensions('json');
-$routes->scope('/', function (RouteBuilder $routes): void {
-    $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
-    $routes->connect(
-        '/some_alias',
-        [
-            'controller' => 'tests_apps',
-            'action' => 'some_method'],
-        [
-            '_name' => 'some_alias',
-            'routeClass' => 'InflectedRoute',
-        ]
-    );
-    $routes->fallbacks();
-});
+return function (RouteBuilder $routes) {
+    $routes->setExtensions('json');
+    $routes->scope('/', function (RouteBuilder $routes): void {
+        $routes->connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+        $routes->connect(
+            '/some_alias',
+            [
+                'controller' => 'tests_apps',
+                'action' => 'some_method'],
+            [
+                '_name' => 'some_alias',
+                'routeClass' => 'InflectedRoute',
+            ]
+        );
+        $routes->fallbacks();
+    });
+};

--- a/tests/test_app/invalid_routes/routes.php
+++ b/tests/test_app/invalid_routes/routes.php
@@ -1,10 +1,14 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Routing\RouteBuilder;
+
 /*
  * Test routes file with routes that trigger a missing route class error.
  * Application requests should have InvalidArgument error rendered.
  */
 
-$routes->setRouteClass('DoesNotExist');
-$routes->get('/', ['controller' => 'Pages']);
+return function (RouteBuilder $routes) {
+    $routes->setRouteClass('DoesNotExist');
+    $routes->get('/', ['controller' => 'Pages']);
+};


### PR DESCRIPTION
This is cleaner than including the file within a method's context and making `$routes`
variable magically available.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
