### PR TITLE
Start documenting the assoc arrays as per their string key.

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -20,6 +20,7 @@
 
     <issueHandlers>
         <RedundantConditionGivenDocblockType errorLevel="suppress"/>
+        <RedundantCastGivenDocblockType errorLevel="suppress"/>
         <DocblockTypeContradiction errorLevel="suppress"/>
         <MissingClosureParamType errorLevel="suppress"/>
         <MissingClosureReturnType errorLevel="suppress"/>

--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -256,7 +256,7 @@ abstract class BaseAuthenticate implements EventListenerInterface
      *   function should have signature like `logout(EventInterface $event, array $user)`
      *   where `$user` is the user about to be logged out.
      *
-     * @return array List of events this class listens to. Defaults to `[]`.
+     * @return array<string, mixed> List of events this class listens to. Defaults to `[]`.
      */
     public function implementedEvents(): array
     {

--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -104,7 +104,7 @@ class BasicAuthenticate extends BaseAuthenticate
      * Generate the login headers
      *
      * @param \Cake\Http\ServerRequest $request Request object.
-     * @return array<string> Headers for logging in.
+     * @return array<string, string> Headers for logging in.
      */
     public function loginHeaders(ServerRequest $request): array
     {

--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -219,7 +219,7 @@ class DigestAuthenticate extends BasicAuthenticate
      * Generate the login headers
      *
      * @param \Cake\Http\ServerRequest $request Request object.
-     * @return array<string> Headers for logging in.
+     * @return array<string, string> Headers for logging in.
      */
     public function loginHeaders(ServerRequest $request): array
     {

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -466,7 +466,7 @@ class Cache
     /**
      * Delete all keys from the cache from all configurations.
      *
-     * @return array<bool> Status code. For each configuration, it reports the status of the operation
+     * @return array<string, bool> Status code. For each configuration, it reports the status of the operation
      */
     public static function clearAll(): array
     {

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -116,7 +116,7 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -25,30 +25,30 @@ class Arguments
     /**
      * Positional argument name map
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $argNames;
 
     /**
      * Positional arguments.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $args;
 
     /**
      * Named options
      *
-     * @var array
+     * @var array<string, string|int|bool|null>
      */
     protected $options;
 
     /**
      * Constructor
      *
-     * @param array<string> $args Positional arguments
-     * @param array<string, mixed> $options Named arguments
-     * @param array<string> $argNames List of argument names. Order is expected to be
+     * @param array<int, string> $args Positional arguments
+     * @param array<string, string|int|bool|null> $options Named arguments
+     * @param array<int, string> $argNames List of argument names. Order is expected to be
      *  the same as $args.
      */
     public function __construct(array $args, array $options, array $argNames)
@@ -61,7 +61,7 @@ class Arguments
     /**
      * Get all positional arguments.
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     public function getArguments(): array
     {
@@ -129,7 +129,7 @@ class Arguments
     /**
      * Get an array of all the options
      *
-     * @return array
+     * @return array<string, string|int|bool|null>
      */
     public function getOptions(): array
     {

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -172,7 +172,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * the long name (`plugin.command`) will be returned.
      *
      * @param string $plugin The plugin to scan.
-     * @return array<string> Discovered plugin commands.
+     * @return array<string, string> Discovered plugin commands.
      */
     public function discoverPlugin(string $plugin): array
     {
@@ -186,7 +186,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * Resolve names based on existing commands
      *
      * @param array $input The results of a CommandScanner operation.
-     * @return array<string> A flat map of command names => class names.
+     * @return array<string, string> A flat map of command names => class names.
      */
     protected function resolveNames(array $input): array
     {
@@ -223,7 +223,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * Commands defined in the application will overwrite commands with
      * the same name provided by CakePHP.
      *
-     * @return array<string> An array of command names and their classes.
+     * @return array<string, string> An array of command names and their classes.
      */
     public function autoDiscover(): array
     {
@@ -232,7 +232,7 @@ class CommandCollection implements IteratorAggregate, Countable
         $core = $this->resolveNames($scanner->scanCore());
         $app = $this->resolveNames($scanner->scanApp());
 
-        return array_merge($core, $app);
+        return $app + $core;
     }
 
     /**

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -241,7 +241,7 @@ class ConsoleOptionParser
     /**
      * Returns an array representation of this parser.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -138,7 +138,7 @@ class ConsoleOutput
      * Styles that are available as tags in console output.
      * You can modify these styles with ConsoleOutput::styles()
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected static $_styles = [
         'emergency' => ['text' => 'red'],
@@ -158,7 +158,7 @@ class ConsoleOutput
      * Construct the output object.
      *
      * Checks for a pretty console environment. Ansicon and ConEmu allows
-     *  pretty consoles on windows, and is supported.
+     *  pretty consoles on Windows, and is supported.
      *
      * @param string $stream The identifier of the stream to write output to.
      */
@@ -312,7 +312,7 @@ class ConsoleOutput
     /**
      * Gets all the style definitions.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function styles(): array
     {

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -925,7 +925,7 @@ class Shell
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -161,7 +161,7 @@ class Component implements EventListenerInterface
      * Override this method if you need to add non-conventional event listeners.
      * Or if you want components to listen to non-standard events.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {
@@ -186,7 +186,7 @@ class Component implements EventListenerInterface
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -308,7 +308,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
     /**
      * Events supported by this component.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -118,7 +118,7 @@ class FormProtectionComponent extends Component
     /**
      * Events supported by this component.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -87,7 +87,7 @@ class PaginatorComponent extends Component
     /**
      * Events supported by this component.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -93,7 +93,7 @@ class RequestHandlerComponent extends Component
     /**
      * Events supported by this component.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -127,7 +127,7 @@ class SecurityComponent extends Component
     /**
      * Events supported by this component.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -605,7 +605,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Returns a list of all events that will fire in the controller during its lifecycle.
      * You can override this function to add your own listener callbacks
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -405,7 +405,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     /**
      * Debug friendly object properties.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -207,7 +207,7 @@ trait StaticConfigTrait
      * Note that querystring arguments are also parsed and set as values in the returned configuration.
      *
      * @param string $dsn The DSN string to convert to a configuration array
-     * @return array The configuration array to be stored after parsing the DSN
+     * @return array<string, mixed> The configuration array to be stored after parsing the DSN
      * @throws \InvalidArgumentException If not passed a string, or passed an invalid string
      */
     public static function parseDsn(string $dsn): array
@@ -303,7 +303,7 @@ REGEXP;
     /**
      * Updates the DSN class map for this class.
      *
-     * @param array<string> $map Additions/edits to the class map to apply.
+     * @param array<string, string> $map Additions/edits to the class map to apply.
      * @return void
      * @psalm-param array<string, class-string> $map
      */
@@ -315,7 +315,7 @@ REGEXP;
     /**
      * Returns the DSN class map for this class.
      *
-     * @return array<string>
+     * @return array<string, string>
      * @psalm-return array<string, class-string>
      */
     public static function getDsnClassMap(): array

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -936,7 +936,7 @@ class Connection implements ConnectionInterface
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -495,7 +495,7 @@ abstract class Driver implements DriverInterface
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -73,7 +73,8 @@ trait TupleComparisonTranslatorTrait
 
         $type = $expression->getType();
         if ($type) {
-            $typeMap = array_combine($fields, $type);
+            /** @var array<string, string> $typeMap */
+            $typeMap = array_combine($fields, $type) ?: [];
         } else {
             $typeMap = [];
         }

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -42,7 +42,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      * `Query::where()`.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The conditions to filter on.
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @return $this
      * @see \Cake\Database\Query::where()
      */

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -56,10 +56,10 @@ class CaseExpression implements ExpressionInterface
      *
      * @param \Cake\Database\ExpressionInterface|array $conditions The conditions to test. Must be a ExpressionInterface
      * instance, or an array of ExpressionInterface instances.
-     * @param \Cake\Database\ExpressionInterface|array $values associative array of values to be associated with the
+     * @param \Cake\Database\ExpressionInterface|array $values Associative array of values to be associated with the
      * conditions passed in $conditions. If there are more $values than $conditions,
      * the last $value is used as the `ELSE` value.
-     * @param array $types associative array of types to be associated with the values
+     * @param array<string, string> $types Associative array of types to be associated with the values
      * passed in $values
      */
     public function __construct($conditions = [], $values = [], $types = [])
@@ -82,8 +82,8 @@ class CaseExpression implements ExpressionInterface
      *
      * @param \Cake\Database\ExpressionInterface|array $conditions Must be a ExpressionInterface instance,
      *   or an array of ExpressionInterface instances.
-     * @param \Cake\Database\ExpressionInterface|array $values associative array of values of each condition
-     * @param array $types associative array of types to be associated with the values
+     * @param \Cake\Database\ExpressionInterface|array $values Associative array of values of each condition
+     * @param array<string, string> $types Associative array of types to be associated with the values
      * @return $this
      */
     public function add($conditions = [], $values = [], $types = [])
@@ -108,8 +108,8 @@ class CaseExpression implements ExpressionInterface
      * If no matching true value, then it is defaulted to '1'.
      *
      * @param array $conditions Array of ExpressionInterface instances.
-     * @param array $values associative array of values of each condition
-     * @param array $types associative array of types to be associated with the values
+     * @param array<string, mixed> $values Associative array of values of each condition
+     * @param array<string, string> $types Associative array of types to be associated with the values
      * @return void
      */
     protected function _addExpressions(array $conditions, array $values, array $types): void

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -109,7 +109,7 @@ class CaseExpression implements ExpressionInterface
      *
      * @param array $conditions Array of ExpressionInterface instances.
      * @param array<string, mixed> $values Associative array of values of each condition
-     * @param array<string, string> $types Associative array of types to be associated with the values
+     * @param array<string, string>|array<string> $types Associative array of types to be associated with the values
      * @return void
      */
     protected function _addExpressions(array $conditions, array $values, array $types): void

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -62,7 +62,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      * @param string $name the name of the function to be constructed
      * @param array $params list of arguments to be passed to the function
      * If associative the key would be used as argument when value is 'literal'
-     * @param array $types associative array of types to be associated with the
+     * @param array<string, string> $types Associative array of types to be associated with the
      * passed arguments
      * @param string $returnType The return type of this expression
      */
@@ -101,7 +101,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      *
      * @param array $conditions list of arguments to be passed to the function
      * If associative the key would be used as argument when value is 'literal'
-     * @param array $types associative array of types to be associated with the
+     * @param array<string, string> $types Associative array of types to be associated with the
      * passed arguments
      * @param bool $prepend Whether to prepend or append to the list of arguments
      * @see \Cake\Database\Expression\FunctionExpression::__construct() for more details.

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -62,7 +62,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      * @param string $name the name of the function to be constructed
      * @param array $params list of arguments to be passed to the function
      * If associative the key would be used as argument when value is 'literal'
-     * @param array<string, string> $types Associative array of types to be associated with the
+     * @param array<string, string>|array<string|null> $types Associative array of types to be associated with the
      * passed arguments
      * @param string $returnType The return type of this expression
      */

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -29,7 +29,7 @@ class OrderByExpression extends QueryExpression
      * Constructor
      *
      * @param \Cake\Database\ExpressionInterface|array|string $conditions The sort columns
-     * @param \Cake\Database\TypeMap|array $types The types for each column.
+     * @param \Cake\Database\TypeMap|array<string, string> $types The types for each column.
      * @param string $conjunction The glue used to join conditions together.
      */
     public function __construct($conditions = [], $types = [], $conjunction = '')

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -58,7 +58,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param \Cake\Database\ExpressionInterface|array|string $conditions Tree like array structure
      * containing all the conditions to be added or nested inside this expression object.
-     * @param \Cake\Database\TypeMap|array $types associative array of types to be associated with the values
+     * @param \Cake\Database\TypeMap|array<string, string> $types Associative array of types to be associated with the values
      * passed in $conditions.
      * @param string $conjunction the glue that will join all the string conditions at this
      * level of the expression tree. For example "AND", "OR", "XOR"...
@@ -111,7 +111,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * be added. When using an array and the key is 'OR' or 'AND' a new expression
      * object will be created with that conjunction and internal array value passed
      * as conditions.
-     * @param array $types associative array of fields pointing to the type of the
+     * @param array<string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @see \Cake\Database\Query::where() for examples on conditions
      * @return $this
@@ -333,10 +333,10 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param \Cake\Database\ExpressionInterface|array $conditions The conditions to test. Must be a ExpressionInterface
      * instance, or an array of ExpressionInterface instances.
-     * @param \Cake\Database\ExpressionInterface|array $values associative array of values to be associated with the
+     * @param \Cake\Database\ExpressionInterface|array $values Associative array of values to be associated with the
      * conditions passed in $conditions. If there are more $values than $conditions,
      * the last $value is used as the `ELSE` value.
-     * @param array $types associative array of types to be associated with the values
+     * @param array<string, string> $types Associative array of types to be associated with the values
      * passed in $values
      * @return $this
      */
@@ -431,7 +431,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * and set up the conjunction to be "AND"
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with AND
-     * @param array $types associative array of fields pointing to the type of the
+     * @param array<string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
      */
@@ -449,7 +449,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * and set up the conjunction to be "OR"
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with OR
-     * @param array $types associative array of fields pointing to the type of the
+     * @param array<string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
      */
@@ -469,7 +469,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * and set up the conjunction to be "AND"
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with AND
-     * @param array $types associative array of fields pointing to the type of the
+     * @param array<string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
      * @deprecated 4.0.0 Use {@link and()} instead.
@@ -486,7 +486,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * and set up the conjunction to be "OR"
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be joined with OR
-     * @param array $types associative array of fields pointing to the type of the
+     * @param array<string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return \Cake\Database\Expression\QueryExpression
      * @deprecated 4.0.0 Use {@link or()} instead.
@@ -507,7 +507,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * currently configured for this object.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions to be added and negated
-     * @param array $types associative array of fields pointing to the type of the
+     * @param array<string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @return $this
      */
@@ -667,7 +667,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * representation is wrapped around an adequate instance or of this class.
      *
      * @param array $conditions list of conditions to be stored in this object
-     * @param array $types list of types associated on fields referenced in $conditions
+     * @param array<string, string> $types list of types associated on fields referenced in $conditions
      * @return void
      */
     protected function _addConditions(array $conditions, array $types): void

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -58,7 +58,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @param \Cake\Database\ExpressionInterface|array|string $conditions Tree like array structure
      * containing all the conditions to be added or nested inside this expression object.
-     * @param \Cake\Database\TypeMap|array<string, string> $types Associative array of types to be associated with the values
+     * @param \Cake\Database\TypeMap|array $types Associative array of types to be associated with the values
      * passed in $conditions.
      * @param string $conjunction the glue that will join all the string conditions at this
      * level of the expression tree. For example "AND", "OR", "XOR"...

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -123,7 +123,7 @@ class LoggedQuery implements JsonSerializable
     /**
      * Get the logging context data for a query.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getContext(): array
     {
@@ -136,7 +136,7 @@ class LoggedQuery implements JsonSerializable
     /**
      * Returns data that will be serialized as JSON
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function jsonSerialize(): array
     {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -703,8 +703,8 @@ class Query implements ExpressionInterface, IteratorAggregate
      * $query->join(['something' => 'different_table'], [], true); // resets joins list
      * ```
      *
-     * @param array|string $tables list of tables to be joined in the query
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, mixed>|string $tables list of tables to be joined in the query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset joins with passed list or not
      * @see \Cake\Database\TypeFactory
      * @return $this
@@ -995,7 +995,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * The safest thing you can do is to never use string conditions.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The conditions to filter on.
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\TypeFactory
      * @see \Cake\Database\Expression\QueryExpression
@@ -1198,7 +1198,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * `WHERE (title = 'Foo') AND (author_id = 1 OR author_id = 2)`
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The conditions to add with AND.
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @see \Cake\Database\Query::where()
      * @see \Cake\Database\TypeFactory
      * @return $this
@@ -1408,7 +1408,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * not sanitized by the query builder.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The having conditions.
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @see \Cake\Database\Query::where()
      * @return $this
@@ -1433,7 +1433,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * not sanitized by the query builder.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $conditions The AND conditions for HAVING.
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @see \Cake\Database\Query::andWhere()
      * @return $this
      */
@@ -2299,7 +2299,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $append Expression or builder function to append.
      *   to append.
      * @param string $conjunction type of conjunction to be used to operate part
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @return void
      */
     protected function _conjugate(string $part, $append, $conjunction, array $types): void
@@ -2388,7 +2388,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -75,7 +75,7 @@ class PostgresSchemaDialect extends SchemaDialect
      *
      * @param string $column The column type + length
      * @throws \Cake\Database\Exception\DatabaseException when column cannot be parsed.
-     * @return array Array of column information.
+     * @return array<string, mixed> Array of column information.
      */
     protected function _convertColumn(string $column): array
     {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -782,7 +782,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * Returns an array of the table schema.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -27,7 +27,7 @@ class TypeMap
      * Used to avoid repetition when calling multiple functions inside this class that
      * may require a custom type for a specific field.
      *
-     * @var array<string>
+     * @var array<string, string>
      */
     protected $_defaults = [];
 
@@ -37,14 +37,14 @@ class TypeMap
      * Used to avoid repetition when calling multiple functions inside this class that
      * may require a custom type for a specific field.
      *
-     * @var array<string>
+     * @var array<string, string>
      */
     protected $_types = [];
 
     /**
      * Creates an instance with the given defaults
      *
-     * @param array<string> $defaults The defaults to use.
+     * @param array<string, string> $defaults The defaults to use.
      */
     public function __construct(array $defaults = [])
     {
@@ -69,7 +69,7 @@ class TypeMap
      * This method will replace all the existing default mappings with the ones provided.
      * To add into the mappings use `addDefaults()`.
      *
-     * @param array<string> $defaults Associative array where keys are field names and values
+     * @param array<string, string> $defaults Associative array where keys are field names and values
      * are the correspondent type.
      * @return $this
      */
@@ -83,7 +83,7 @@ class TypeMap
     /**
      * Returns the currently configured types.
      *
-     * @return array<string>
+     * @return array<string, string>
      */
     public function getDefaults(): array
     {
@@ -95,7 +95,7 @@ class TypeMap
      *
      * If a key already exists it will not be overwritten.
      *
-     * @param array<string> $types The additional types to add.
+     * @param array<string, string> $types The additional types to add.
      * @return void
      */
     public function addDefaults(array $types): void
@@ -114,7 +114,7 @@ class TypeMap
      *
      * This method will replace all the existing type maps with the ones provided.
      *
-     * @param array<string> $types Associative array where keys are field names and values
+     * @param array<string, string> $types Associative array where keys are field names and values
      * are the correspondent type.
      * @return $this
      */
@@ -128,7 +128,7 @@ class TypeMap
     /**
      * Gets a map of fields and their associated types for single-use.
      *
-     * @return array<string>
+     * @return array<string, string>
      */
     public function getTypes(): array
     {
@@ -151,7 +151,7 @@ class TypeMap
     /**
      * Returns an array of all types mapped types
      *
-     * @return array<string>
+     * @return array<string, string>
      */
     public function toArray(): array
     {

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -66,7 +66,7 @@ trait TypeMapTrait
      * To add a default without overwriting existing ones
      * use `getTypeMap()->addDefaults()`
      *
-     * @param array $types The array of types to set.
+     * @param array<string, string> $types The array of types to set.
      * @return $this
      * @see \Cake\Database\TypeMap::setDefaults()
      */
@@ -80,7 +80,7 @@ trait TypeMapTrait
     /**
      * Gets default types of current type map.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function getDefaultTypes(): array
     {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -185,7 +185,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
      * fields with their respective values
      * @param mixed $value The value to set to the field or an array if the
      * first argument is also an array, in which case will be treated as $options
-     * @param array<string, mixed> $options options to be used for setting the field. Allowed option
+     * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
      * keys are `setter` and `guard`
      * @return $this
      */

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -215,7 +215,7 @@ trait EntityTrait
      * fields with their respective values
      * @param mixed $value The value to set to the field or an array if the
      * first argument is also an array, in which case will be treated as $options
-     * @param array<string, mixed> $options options to be used for setting the field. Allowed option
+     * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
      * keys are `setter` and `guard`
      * @return $this
      * @throws \InvalidArgumentException
@@ -1235,7 +1235,7 @@ trait EntityTrait
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -397,7 +397,7 @@ interface QueryInterface
      * The safest thing you can do is to never use string conditions.
      *
      * @param \Closure|array|string|null $conditions The conditions to filter on.
-     * @param array $types associative array of type names used to bind values to query
+     * @param array<string, string> $types Associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not
      * @return $this
      */

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -457,7 +457,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Event/EventListenerInterface.php
+++ b/src/Event/EventListenerInterface.php
@@ -39,7 +39,7 @@ interface EventListenerInterface
      *  }
      * ```
      *
-     * @return array Associative array or event key names pointing to the function
+     * @return array<string, mixed> Associative array or event key names pointing to the function
      * that should be called in the object when the respective event is fired
      */
     public function implementedEvents(): array;

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -451,7 +451,7 @@ class EventManager implements EventManagerInterface
     /**
      * Debug friendly object properties.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -123,7 +123,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
      *
      * - Form.buildValidator => buildValidator
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {
@@ -344,7 +344,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
     /**
      * Get the printable version of a Form instance.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -578,7 +578,7 @@ class FormProtector
     /**
      * Return debug info
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -128,7 +128,7 @@ class Schema
     /**
      * Get the printable version of this object
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -648,7 +648,7 @@ class Client implements ClientInterface
      * or full mime-type.
      *
      * @param string $type short type alias or full mimetype.
-     * @return array<string> Headers to set on the request.
+     * @return array<string, string> Headers to set on the request.
      * @throws \Cake\Core\Exception\CakeException When an unknown type alias is used.
      * @psalm-return array{Accept: string, Content-Type: string}
      */

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1558,7 +1558,7 @@ class Response implements ResponseInterface
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -483,7 +483,7 @@ trait DateFormatTrait
     /**
      * Returns the data that should be displayed when debugging this object
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -606,7 +606,7 @@ class Mailer implements EventListenerInterface
     /**
      * Implemented events.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -273,7 +273,7 @@ class Behavior implements EventListenerInterface
      * Override this method if you need to add non-conventional event listeners.
      * Or if you want your behavior to listen to non-standard events.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -131,7 +131,7 @@ class TimestampBehavior extends Behavior
      *
      * The implemented events of this behavior depend on configuration
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -202,7 +202,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     /**
      * Gets the Model callbacks this behavior is interested in.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2974,7 +2974,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * - Model.beforeRules => beforeRules
      * - Model.afterRules => afterRules
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -463,7 +463,10 @@ class Xml
         $data = [];
 
         foreach ($namespaces as $namespace) {
-            /** @psalm-suppress PossiblyNullIterator */
+            /**
+             * @psalm-suppress PossiblyNullIterator
+             * @var string $key
+             */
             foreach ($xml->attributes($namespace, true) as $key => $value) {
                 if (!empty($namespace)) {
                     $key = $namespace . ':' . $key;

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2738,7 +2738,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Get the printable version of this object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -284,7 +284,7 @@ abstract class Cell implements EventDispatcherInterface
     /**
      * Debug info.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -170,7 +170,7 @@ class Helper implements EventListenerInterface
      * Override this method if you need to add non-conventional event listeners.
      * Or if you want helpers to listen to non-standard events.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {
@@ -208,7 +208,7 @@ class Helper implements EventListenerInterface
      * Returns an array that can be used to describe the internal state of this
      * object.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function __debugInfo(): array
     {

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -86,7 +86,7 @@ class FlashHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2466,7 +2466,7 @@ class FormHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1129,7 +1129,7 @@ class HtmlHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -236,7 +236,7 @@ class NumberHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1216,7 +1216,7 @@ class PaginatorHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -426,7 +426,7 @@ class TextHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -400,7 +400,7 @@ class TimeHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -250,7 +250,7 @@ class UrlHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -227,7 +227,7 @@ class StringTemplate
      * Format a template string with $data
      *
      * @param string $name The template name.
-     * @param array $data The data to insert.
+     * @param array<string, mixed> $data The data to insert.
      * @return string Formatted string
      * @throws \RuntimeException If template not found.
      */
@@ -276,8 +276,8 @@ class StringTemplate
      * these templates uses the `name` and `value` variables. You can modify these
      * templates to change how attributes are formatted.
      *
-     * @param array|null $options Array of options.
-     * @param array|null $exclude Array of options to be excluded, the options here will not be part of the return.
+     * @param array<string, mixed>|null $options Array of options.
+     * @param array<string>|null $exclude Array of options to be excluded, the options here will not be part of the return.
      * @return string Composed attributes.
      */
     public function formatAttributes(?array $options, ?array $exclude = null): string
@@ -340,7 +340,7 @@ class StringTemplate
      * Adds a class and returns a unique list either in array or space separated
      *
      * @param array|string $input The array or string to add the class to
-     * @param array|string $newClass the new class or classes to add
+     * @param array<string>|string $newClass the new class or classes to add
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
      * @return array<string>|string
      */

--- a/src/View/StringTemplateTrait.php
+++ b/src/View/StringTemplateTrait.php
@@ -61,7 +61,7 @@ trait StringTemplateTrait
      * Formats a template string with $data
      *
      * @param string $name The template name.
-     * @param array $data The data to insert.
+     * @param array<string, mixed> $data The data to insert.
      * @return string
      */
     public function formatTemplate(string $name, array $data): string

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -69,7 +69,7 @@ class BasicWidget implements WidgetInterface
      *
      * Any other keys provided in $data will be converted into HTML attributes.
      *
-     * @param array $data The data to build an input with.
+     * @param array<string, mixed> $data The data to build an input with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
@@ -113,7 +113,7 @@ class BasicWidget implements WidgetInterface
     /**
      * Merge default values with supplied data.
      *
-     * @param array $data Data array
+     * @param array<string, mixed> $data Data array
      * @param \Cake\View\Form\ContextInterface $context Context instance.
      * @return array Updated data array.
      */
@@ -131,7 +131,7 @@ class BasicWidget implements WidgetInterface
     /**
      * Set value for "required" attribute if applicable.
      *
-     * @param array $data Data array
+     * @param array<string, mixed> $data Data array
      * @param \Cake\View\Form\ContextInterface $context Context instance.
      * @param string $fieldName Field name.
      * @return array Updated data array.
@@ -157,7 +157,7 @@ class BasicWidget implements WidgetInterface
     /**
      * Set value for "maxlength" attribute if applicable.
      *
-     * @param array $data Data array
+     * @param array<string, mixed> $data Data array
      * @param \Cake\View\Form\ContextInterface $context Context instance.
      * @param string $fieldName Field name.
      * @return array Updated data array.
@@ -175,7 +175,7 @@ class BasicWidget implements WidgetInterface
     /**
      * Set value for "step" attribute if applicable.
      *
-     * @param array $data Data array
+     * @param array<string, mixed> $data Data array
      * @param \Cake\View\Form\ContextInterface $context Context instance.
      * @param string $fieldName Field name.
      * @return array Updated data array.

--- a/src/View/Widget/ButtonWidget.php
+++ b/src/View/Widget/ButtonWidget.php
@@ -58,7 +58,7 @@ class ButtonWidget implements WidgetInterface
      *
      * Any other keys provided in $data will be converted into HTML attributes.
      *
-     * @param array $data The data to build a button with.
+     * @param array<string, mixed> $data The data to build a button with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -52,7 +52,7 @@ class CheckboxWidget extends BasicWidget
      *
      * Any other attributes passed in will be treated as HTML attributes.
      *
-     * @param array $data The data to create a checkbox with.
+     * @param array<string, mixed> $data The data to create a checkbox with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string Generated HTML string.
      */
@@ -79,9 +79,9 @@ class CheckboxWidget extends BasicWidget
     }
 
     /**
-     * Check whether or not the checkbox should be checked.
+     * Checks whether the checkbox should be checked.
      *
-     * @param array $data Data to look at and determine checked state.
+     * @param array<string, mixed> $data Data to look at and determine checked state.
      * @return bool
      */
     protected function _isChecked(array $data): bool

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -101,7 +101,7 @@ class DateTimeWidget extends BasicWidget
      *
      * All other keys will be converted into HTML attributes.
      *
-     * @param array $data The data to build a file input with.
+     * @param array<string, mixed> $data The data to build a file input with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */
@@ -135,7 +135,7 @@ class DateTimeWidget extends BasicWidget
     /**
      * Set value for "step" attribute if applicable.
      *
-     * @param array $data Data array
+     * @param array<string, mixed> $data Data array
      * @param \Cake\View\Form\ContextInterface $context Context instance.
      * @param string $fieldName Field name.
      * @return array Updated data array.

--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -50,7 +50,7 @@ class FileWidget extends BasicWidget
      * Unlike other input objects the `val` property will be specifically
      * ignored.
      *
-     * @param array $data The data to build a file input with.
+     * @param array<string, mixed> $data The data to build a file input with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */

--- a/src/View/Widget/LabelWidget.php
+++ b/src/View/Widget/LabelWidget.php
@@ -67,7 +67,7 @@ class LabelWidget implements WidgetInterface
      *
      * All other attributes will be converted into HTML attributes.
      *
-     * @param array $data Data array.
+     * @param array<string, mixed> $data Data array.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -113,7 +113,7 @@ class MultiCheckboxWidget extends BasicWidget
      * This form **requires** that both the `value` and `text` keys be defined.
      * If either is not set options will not be generated correctly.
      *
-     * @param array $data The data to generate a checkbox set with.
+     * @param array<string, mixed> $data The data to generate a checkbox set with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
@@ -130,7 +130,7 @@ class MultiCheckboxWidget extends BasicWidget
     /**
      * Render the checkbox inputs.
      *
-     * @param array $data The data array defining the checkboxes.
+     * @param array<string, mixed> $data The data array defining the checkboxes.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return array<string> An array of rendered inputs.
      */

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -91,7 +91,7 @@ class RadioWidget extends BasicWidget
      *   on all generated radios.
      * - `idPrefix` Prefix for generated ID attributes.
      *
-     * @param array $data The data to build radio buttons with.
+     * @param array<string, mixed> $data The data to build radio buttons with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string
      */
@@ -146,7 +146,7 @@ class RadioWidget extends BasicWidget
      *
      * @param string|int $val The value of the radio input.
      * @param array|string $text The label text, or complex radio type.
-     * @param array $data Additional options for input generation.
+     * @param array<string, mixed> $data Additional options for input generation.
      * @param \Cake\View\Form\ContextInterface $context The form context
      * @return string
      */

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -112,7 +112,7 @@ class SelectBoxWidget extends BasicWidget
      * You are free to mix each of the forms in the same option set, and
      * nest complex types as required.
      *
-     * @param array $data Data to render with.
+     * @param array<string, mixed> $data Data to render with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string A generated select box.
      * @throws \RuntimeException when the name attribute is empty.
@@ -146,7 +146,7 @@ class SelectBoxWidget extends BasicWidget
     /**
      * Render the contents of the select element.
      *
-     * @param array $data The context for rendering a select.
+     * @param array<string, mixed> $data The context for rendering a select.
      * @return array
      */
     protected function _renderContent(array $data): array

--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -50,7 +50,7 @@ class TextareaWidget extends BasicWidget
      *
      * All other keys will be converted into HTML attributes.
      *
-     * @param array $data The data to build a textarea with.
+     * @param array<string, mixed> $data The data to build a textarea with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */

--- a/src/View/Widget/WidgetInterface.php
+++ b/src/View/Widget/WidgetInterface.php
@@ -26,7 +26,7 @@ interface WidgetInterface
     /**
      * Converts the $data into one or many HTML elements.
      *
-     * @param array $data The data to render.
+     * @param array<string, mixed> $data The data to render.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string Generated HTML for the widget element.
      */

--- a/src/View/Widget/YearWidget.php
+++ b/src/View/Widget/YearWidget.php
@@ -65,7 +65,7 @@ class YearWidget extends BasicWidget
     /**
      * Renders a year select box.
      *
-     * @param array $data Data to render with.
+     * @param array<string, mixed> $data Data to render with.
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string A generated select box.
      */

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -30,7 +30,7 @@ class TestAuthenticate extends BaseAuthenticate
     public $authenticationProvider;
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/tests/test_app/TestApp/Model/Behavior/Test3Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test3Behavior.php
@@ -41,7 +41,7 @@ class Test3Behavior extends Behavior
      *
      * This class does pretend to implement beforeFind
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
+++ b/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
@@ -11,7 +11,7 @@ use Cake\Event\EventListenerInterface;
 class CustomTestEventListenerInterface extends EventTestListener implements EventListenerInterface
 {
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
+++ b/tests/test_app/TestApp/View/Helper/EventListenerTestHelper.php
@@ -35,7 +35,7 @@ class EventListenerTestHelper extends Helper
     /**
      * Event listeners.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {

--- a/tests/test_app/TestApp/View/TestViewEventListenerInterface.php
+++ b/tests/test_app/TestApp/View/TestViewEventListenerInterface.php
@@ -30,7 +30,7 @@ class TestViewEventListenerInterface implements EventListenerInterface
     /**
      * implementedEvents method
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/15804#pullrequestreview-742943993

After all, assoc arrays are defined by their assoc key.

Quite the manual work
There are for example 360 options arrays left

I wonder if there is a bit more automated (tooling based way) for it.. :)