### PR TITLE
Use crlf in mail headers

### DIFF
--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -41,7 +41,7 @@ class MailTransport extends AbstractTransport
         $to = $message->getHeaders(['to'])['To'];
         $to = str_replace("\r\n", '', $to);
 
-        $eol = $this->getConfig('eol', PHP_EOL);
+        $eol = $this->getConfig('eol', "\r\n");
         $headers = $message->getHeadersString(
             [
                 'from',

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -41,7 +41,7 @@ class MailTransport extends AbstractTransport
         $to = $message->getHeaders(['to'])['To'];
         $to = str_replace("\r\n", '', $to);
 
-        $eol = $this->getConfig('eol', "\r\n");
+        $eol = $this->getConfig('eol', version_compare(PHP_VERSION, '8.0', '>=') ? "\r\n" : "\n");
         $headers = $message->getHeadersString(
             [
                 'from',

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -67,6 +67,8 @@ class MailTransportTest extends TestCase
      */
     public function testSendData()
     {
+        $eol = version_compare(PHP_VERSION, '8.0', '>=') ? "\r\n" : "\n";
+
         $message = new Message();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
@@ -88,24 +90,24 @@ class MailTransportTest extends TestCase
         $encoded = '=?UTF-8?B?Rm/DuCBCw6VyIELDqXogRm/DuCBCw6VyIELDqXogRm/DuCBCw6VyIELDqXog?=';
         $encoded .= ' =?UTF-8?B?Rm/DuCBCw6VyIELDqXo=?=';
 
-        $data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
-        $data .= "Reply-To: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>\r\n";
-        $data .= "Return-Path: CakePHP Return <pleasereply@cakephp.org>\r\n";
-        $data .= "Cc: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>\r\n";
-        $data .= "Bcc: phpnut@cakephp.org\r\n";
-        $data .= "X-Mailer: CakePHP Email\r\n";
-        $data .= 'Date: ' . $date . "\r\n";
-        $data .= 'X-add: ' . $encoded . "\r\n";
-        $data .= "Message-ID: <4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>\r\n";
-        $data .= "MIME-Version: 1.0\r\n";
-        $data .= "Content-Type: text/plain; charset=UTF-8\r\n";
+        $data = "From: CakePHP Test <noreply@cakephp.org>{$eol}";
+        $data .= "Reply-To: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>{$eol}";
+        $data .= "Return-Path: CakePHP Return <pleasereply@cakephp.org>{$eol}";
+        $data .= "Cc: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>{$eol}";
+        $data .= "Bcc: phpnut@cakephp.org{$eol}";
+        $data .= "X-Mailer: CakePHP Email{$eol}";
+        $data .= 'Date: ' . $date . $eol;
+        $data .= 'X-add: ' . $encoded . $eol;
+        $data .= "Message-ID: <4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>{$eol}";
+        $data .= "MIME-Version: 1.0{$eol}";
+        $data .= "Content-Type: text/plain; charset=UTF-8{$eol}";
         $data .= 'Content-Transfer-Encoding: 8bit';
 
         $this->MailTransport->expects($this->once())->method('_mail')
             ->with(
                 'CakePHP <cake@cakephp.org>',
                 $encoded,
-                implode("\r\n", ['First Line', 'Second Line', '.Third Line', '', '']),
+                implode($eol, ['First Line', 'Second Line', '.Third Line', '', '']),
                 $data,
                 '-f'
             );

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -88,24 +88,24 @@ class MailTransportTest extends TestCase
         $encoded = '=?UTF-8?B?Rm/DuCBCw6VyIELDqXogRm/DuCBCw6VyIELDqXogRm/DuCBCw6VyIELDqXog?=';
         $encoded .= ' =?UTF-8?B?Rm/DuCBCw6VyIELDqXo=?=';
 
-        $data = 'From: CakePHP Test <noreply@cakephp.org>' . PHP_EOL;
-        $data .= 'Reply-To: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>' . PHP_EOL;
-        $data .= 'Return-Path: CakePHP Return <pleasereply@cakephp.org>' . PHP_EOL;
-        $data .= 'Cc: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>' . PHP_EOL;
-        $data .= 'Bcc: phpnut@cakephp.org' . PHP_EOL;
-        $data .= 'X-Mailer: CakePHP Email' . PHP_EOL;
-        $data .= 'Date: ' . $date . PHP_EOL;
-        $data .= 'X-add: ' . $encoded . PHP_EOL;
-        $data .= 'Message-ID: <4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>' . PHP_EOL;
-        $data .= 'MIME-Version: 1.0' . PHP_EOL;
-        $data .= 'Content-Type: text/plain; charset=UTF-8' . PHP_EOL;
+        $data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
+        $data .= "Reply-To: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>\r\n";
+        $data .= "Return-Path: CakePHP Return <pleasereply@cakephp.org>\r\n";
+        $data .= "Cc: Mark Story <mark@cakephp.org>, Juan Basso <juan@cakephp.org>\r\n";
+        $data .= "Bcc: phpnut@cakephp.org\r\n";
+        $data .= "X-Mailer: CakePHP Email\r\n";
+        $data .= 'Date: ' . $date . "\r\n";
+        $data .= 'X-add: ' . $encoded . "\r\n";
+        $data .= "Message-ID: <4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>\r\n";
+        $data .= "MIME-Version: 1.0\r\n";
+        $data .= "Content-Type: text/plain; charset=UTF-8\r\n";
         $data .= 'Content-Transfer-Encoding: 8bit';
 
         $this->MailTransport->expects($this->once())->method('_mail')
             ->with(
                 'CakePHP <cake@cakephp.org>',
                 $encoded,
-                implode(PHP_EOL, ['First Line', 'Second Line', '.Third Line', '', '']),
+                implode("\r\n", ['First Line', 'Second Line', '.Third Line', '', '']),
                 $data,
                 '-f'
             );


### PR DESCRIPTION
Separate mail headers with \r\n to be compliant with RFC specs. This also fixes delivery issues in PHP 8. The content is also wrapped with CRLF for consistency. Testing this with a variety mail transfer agents is not something I'm able to do at this time.

Refs #15803