### PR TITLE
4.3 - Improve deprecations

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -309,6 +309,13 @@ if (!function_exists('deprecationWarning')) {
             );
         }
 
+        static $errors = [];
+        $checksum = md5($message);
+        if (isset($errors[$checksum])) {
+            return;
+        }
+        $errors[$checksum] = true;
+
         trigger_error($message, E_USER_DEPRECATED);
     }
 }

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -557,7 +557,7 @@ trait QueryTrait
                 'Calling result set method `%s()` directly on query instance is deprecated. ' .
                 'You must call `all()` to retrieve the results first.',
                 $method
-            ));
+            ), 2);
             $results = $this->all();
 
             return $results->$method(...$arguments);

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -97,10 +97,10 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabledDefaultFrame(): void
     {
         $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectDeprecationMessageMatches('/This is going away too - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function (): void {
-            deprecationWarning('This is going away');
+            deprecationWarning('This is going away too');
         });
     }
 
@@ -113,7 +113,7 @@ class FunctionsTest extends TestCase
 
         Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/*']);
         $this->withErrorReporting(E_ALL, function (): void {
-            deprecationWarning('This is going away');
+            deprecationWarning('This will be gone soon');
         });
     }
 
@@ -125,7 +125,7 @@ class FunctionsTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function (): void {
-            deprecationWarning('This is going away');
+            deprecationWarning('This is leaving');
         });
     }
 
@@ -135,10 +135,10 @@ class FunctionsTest extends TestCase
     public function testTriggerWarningEnabled(): void
     {
         $this->expectWarning();
-        $this->expectWarningMessageMatches('/This is going away - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectWarningMessageMatches('/This will be gone one day - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function (): void {
-            triggerWarning('This is going away');
+            triggerWarning('This will be gone one day');
             $this->assertTrue(true);
         });
     }
@@ -149,7 +149,7 @@ class FunctionsTest extends TestCase
     public function testTriggerWarningLevelDisabled(): void
     {
         $this->withErrorReporting(E_ALL ^ E_USER_WARNING, function (): void {
-            triggerWarning('This is going away');
+            triggerWarning('This was a mistake.');
             $this->assertTrue(true);
         });
     }


### PR DESCRIPTION
* Improve the deprecation in QueryTrait::_call() so it will point to application code. Having the message point to a line in ORM\Query is not helpful.
* Don't emit duplicate deprecations. When running tests is it common for the same code to be run multiple times. Instead of flooding output with duplicate content we can use md5 sums to prevent noise. This will consume some memory, but deprecations should only really be on in dev/ci so we should be relatively safe.