### PR TITLE
Remove redundant Fixture from strategy names

### DIFF
--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -25,7 +25,7 @@ use RuntimeException;
  *
  * Any test that calls Connection::rollback(true) will break this strategy.
  */
-class TransactionFixtureStrategy implements FixtureStrategyInterface
+class TransactionStrategy implements FixtureStrategyInterface
 {
     /**
      * @var \Cake\TestSuite\Fixture\FixtureHelper
@@ -64,7 +64,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
                     throw new RuntimeException(
                         "Could not enable save points for the `{$connection->configName()}` connection. " .
                             'Your database needs to support savepoints in order to use ' .
-                            'TransactionFixtureStrategy.'
+                            'TransactionStrategy.'
                     );
                 }
 

--- a/src/TestSuite/Fixture/TruncateStrategy.php
+++ b/src/TestSuite/Fixture/TruncateStrategy.php
@@ -19,7 +19,7 @@ namespace Cake\TestSuite\Fixture;
 /**
  * Fixture strategy that truncates all fixture ables at the end of test.
  */
-class TruncateFixtureStrategy implements FixtureStrategyInterface
+class TruncateStrategy implements FixtureStrategyInterface
 {
     /**
      * @var \Cake\TestSuite\Fixture\FixtureHelper

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -28,7 +28,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\Constraint\EventFired;
 use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\TestSuite\Fixture\FixtureStrategyInterface;
-use Cake\TestSuite\Fixture\TruncateFixtureStrategy;
+use Cake\TestSuite\Fixture\TruncateStrategy;
 use Cake\Utility\Inflector;
 use LogicException;
 use PHPUnit\Framework\Constraint\DirectoryExists;
@@ -297,7 +297,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getFixtureStrategy(): FixtureStrategyInterface
     {
-        return new TruncateFixtureStrategy();
+        return new TruncateStrategy();
     }
 
     /**

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Datasource\ConnectionManager;
-use Cake\TestSuite\Fixture\TruncateFixtureStrategy;
+use Cake\TestSuite\Fixture\TransactionStrategy;
 use Cake\TestSuite\TestCase;
 
-class TruncateFixtureStrategyTest extends TestCase
+class TransactionStrategyTest extends TestCase
 {
     protected $fixtures = ['core.Articles'];
 
@@ -38,7 +38,7 @@ class TruncateFixtureStrategyTest extends TestCase
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
-        $strategy = new TruncateFixtureStrategy();
+        $strategy = new TransactionStrategy();
         $strategy->setupTest(['core.Articles']);
         $rows = $connection->newQuery()->select('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());

--- a/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Datasource\ConnectionManager;
-use Cake\TestSuite\Fixture\TransactionFixtureStrategy;
+use Cake\TestSuite\Fixture\TruncateStrategy;
 use Cake\TestSuite\TestCase;
 
-class TransactionFixtureStrategyTest extends TestCase
+class TruncateStrategyTest extends TestCase
 {
     protected $fixtures = ['core.Articles'];
 
@@ -38,7 +38,7 @@ class TransactionFixtureStrategyTest extends TestCase
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
-        $strategy = new TransactionFixtureStrategy();
+        $strategy = new TruncateStrategy();
         $strategy->setupTest(['core.Articles']);
         $rows = $connection->newQuery()->select('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());


### PR DESCRIPTION
I think `Fixture` is redundant in this context in the Fixture namespace.
