### PR TITLE
Deprecate non assoc options usage.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2262,6 +2262,7 @@ class FormHelper extends Helper
 
         $disabledIndex = array_search('disabled', $options, true);
         if (is_int($disabledIndex)) {
+            deprecationWarning('Using non-associative options is deprecated, use `\'disabled\' => true` instead.');
             unset($options[$disabledIndex]);
             $options['disabled'] = true;
         }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2198,12 +2198,14 @@ class FormHelperTest extends TestCase
         $this->View->setRequest($this->View->getRequest()->withAttribute('formTokenData', []));
         $this->Form->create();
 
-        $this->Form->select('Model.select', [1, 2], ['disabled']);
-        $this->Form->checkbox('Model.checkbox', ['disabled']);
-        $this->Form->text('Model.text', ['disabled']);
-        $this->Form->textarea('Model.textarea', ['disabled']);
-        $this->Form->password('Model.password', ['disabled']);
-        $this->Form->radio('Model.radio', [1, 2], ['disabled']);
+        $this->deprecated(function () {
+            $this->Form->select('Model.select', [1, 2], ['disabled']);
+            $this->Form->checkbox('Model.checkbox', ['disabled']);
+            $this->Form->text('Model.text', ['disabled']);
+            $this->Form->textarea('Model.textarea', ['disabled']);
+            $this->Form->password('Model.password', ['disabled']);
+            $this->Form->radio('Model.radio', [1, 2], ['disabled']);
+        });
 
         $expected = [
             'Model.radio' => '',


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/15806

Will simplify the documentation for this method to just `array<string, mixed>` in 5.0