### PR TITLE
cake 5: Add native type hints for Database properties

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -49,7 +49,7 @@ class Connection implements ConnectionInterface
      *
      * @var array
      */
-    protected $_config;
+    protected array $_config;
 
     /**
      * Driver object, responsible for creating the real connection
@@ -57,21 +57,21 @@ class Connection implements ConnectionInterface
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * Contains how many nested transactions have been started.
      *
      * @var int
      */
-    protected $_transactionLevel = 0;
+    protected int $_transactionLevel = 0;
 
     /**
      * Whether a transaction is active in this connection.
      *
      * @var bool
      */
-    protected $_transactionStarted = false;
+    protected bool $_transactionStarted = false;
 
     /**
      * Whether this connection can and should use savepoints for nested
@@ -79,35 +79,35 @@ class Connection implements ConnectionInterface
      *
      * @var bool
      */
-    protected $_useSavePoints = false;
+    protected bool $_useSavePoints = false;
 
     /**
      * Whether to log queries generated during this connection.
      *
      * @var bool
      */
-    protected $_logQueries = false;
+    protected bool $_logQueries = false;
 
     /**
      * Logger object instance.
      *
      * @var \Psr\Log\LoggerInterface|null
      */
-    protected $_logger;
+    protected ?LoggerInterface $_logger = null;
 
     /**
      * Cacher object instance.
      *
      * @var \Psr\SimpleCache\CacheInterface|null
      */
-    protected $cacher;
+    protected ?CacheInterface $cacher = null;
 
     /**
      * The schema collection object
      *
      * @var \Cake\Database\Schema\CollectionInterface|null
      */
-    protected $_schemaCollection;
+    protected ?SchemaCollectionInterface $_schemaCollection = null;
 
     /**
      * NestedTransactionRollbackException object instance, will be stored if
@@ -115,7 +115,7 @@ class Connection implements ConnectionInterface
      *
      * @var \Cake\Database\Exception\NestedTransactionRollbackException|null
      */
-    protected $nestedTransactionRollbackException;
+    protected ?NestedTransactionRollbackException $nestedTransactionRollbackException = null;
 
     /**
      * Constructor.

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -56,7 +56,7 @@ abstract class Driver implements DriverInterface
      *
      * @var array
      */
-    protected $_config;
+    protected array $_config;
 
     /**
      * Base configuration that is merged into the user
@@ -64,7 +64,7 @@ abstract class Driver implements DriverInterface
      *
      * @var array
      */
-    protected $_baseConfig = [];
+    protected array $_baseConfig = [];
 
     /**
      * Indicates whether or not the driver is doing automatic identifier quoting
@@ -72,28 +72,28 @@ abstract class Driver implements DriverInterface
      *
      * @var bool
      */
-    protected $_autoQuoting = false;
+    protected bool $_autoQuoting = false;
 
     /**
      * Whether or not the server supports common table expressions.
      *
      * @var bool|null
      */
-    protected $supportsCTEs = null;
+    protected ?bool $supportsCTEs = null;
 
     /**
      * The server version
      *
      * @var string|null
      */
-    protected $_version;
+    protected ?string $_version = null;
 
     /**
      * The last number of connection retry attempts.
      *
      * @var int
      */
-    protected $connectRetries = 0;
+    protected int $connectRetries = 0;
 
     /**
      * Constructor

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -55,7 +55,7 @@ class Mysql extends Driver
      *
      * @var array
      */
-    protected $_baseConfig = [
+    protected array $_baseConfig = [
         'persistent' => true,
         'host' => 'localhost',
         'username' => 'root',
@@ -73,35 +73,35 @@ class Mysql extends Driver
      *
      * @var \Cake\Database\Schema\MysqlSchemaDialect|null
      */
-    protected $_schemaDialect;
+    protected ?MysqlSchemaDialect $_schemaDialect = null;
 
     /**
      * Whether or not the server supports native JSON
      *
      * @var bool|null
      */
-    protected $_supportsNativeJson;
+    protected ?bool $_supportsNativeJson = null;
 
     /**
      * Whether or not the connected server supports window functions.
      *
      * @var bool|null
      */
-    protected $_supportsWindowFunctions;
+    protected ?bool $_supportsWindowFunctions = null;
 
     /**
      * String used to start a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_startQuote = '`';
+    protected string $_startQuote = '`';
 
     /**
      * String used to end a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_endQuote = '`';
+    protected string $_endQuote = '`';
 
     /**
      * Server type.
@@ -111,14 +111,14 @@ class Mysql extends Driver
      *
      * @var string
      */
-    protected $serverType = self::SERVER_TYPE_MYSQL;
+    protected string $serverType = self::SERVER_TYPE_MYSQL;
 
     /**
      * Mapping of feature to db server version for feature availability checks.
      *
      * @var array
      */
-    protected $featuresToVersionMap = [
+    protected array $featuresToVersionMap = [
         'mysql' => [
             'json' => '5.7.0',
             'cte' => '8.0.0',

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -44,7 +44,7 @@ class Postgres extends Driver
      *
      * @var array
      */
-    protected $_baseConfig = [
+    protected array $_baseConfig = [
         'persistent' => true,
         'host' => 'localhost',
         'username' => 'root',
@@ -63,26 +63,26 @@ class Postgres extends Driver
      *
      * @var \Cake\Database\Schema\PostgresSchemaDialect|null
      */
-    protected $_schemaDialect;
+    protected ?PostgresSchemaDialect $_schemaDialect = null;
 
     /**
      * String used to start a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_startQuote = '"';
+    protected string $_startQuote = '"';
 
     /**
      * String used to end a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_endQuote = '"';
+    protected string $_endQuote = '"';
 
     /**
      * @inheritDoc
      */
-    protected $supportsCTEs = true;
+    protected ?bool $supportsCTEs = true;
 
     /**
      * Establishes a connection to the database server

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -45,7 +45,7 @@ class Sqlite extends Driver
      *
      * @var array
      */
-    protected $_baseConfig = [
+    protected array $_baseConfig = [
         'persistent' => false,
         'username' => null,
         'password' => null,
@@ -61,35 +61,35 @@ class Sqlite extends Driver
      *
      * @var \Cake\Database\Schema\SqliteSchemaDialect|null
      */
-    protected $_schemaDialect;
+    protected ?SqliteSchemaDialect $_schemaDialect = null;
 
     /**
      * Whether or not the connected server supports window functions.
      *
      * @var bool|null
      */
-    protected $_supportsWindowFunctions;
+    protected ?bool $_supportsWindowFunctions = null;
 
     /**
      * String used to start a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_startQuote = '"';
+    protected string $_startQuote = '"';
 
     /**
      * String used to end a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_endQuote = '"';
+    protected string $_endQuote = '"';
 
     /**
      * Mapping of date parts.
      *
      * @var array
      */
-    protected $_dateParts = [
+    protected array $_dateParts = [
         'day' => 'd',
         'hour' => 'H',
         'month' => 'm',

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -58,7 +58,7 @@ class Sqlserver extends Driver
      *
      * @var array
      */
-    protected $_baseConfig = [
+    protected array $_baseConfig = [
         'host' => 'localhost\SQLEXPRESS',
         'username' => '',
         'password' => '',
@@ -82,26 +82,26 @@ class Sqlserver extends Driver
      *
      * @var \Cake\Database\Schema\SqlserverSchemaDialect|null
      */
-    protected $_schemaDialect;
+    protected ?SqlserverSchemaDialect $_schemaDialect = null;
 
     /**
      * String used to start a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_startQuote = '[';
+    protected string $_startQuote = '[';
 
     /**
      * String used to end a database identifier quoting to make it safe
      *
      * @var string
      */
-    protected $_endQuote = ']';
+    protected string $_endQuote = ']';
 
     /**
      * @inheritDoc
      */
-    protected $supportsCTEs = true;
+    protected ?bool $supportsCTEs = true;
 
     /**
      * Establishes a connection to the database server.

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -29,14 +29,14 @@ use Closure;
 class AggregateExpression extends FunctionExpression implements WindowInterface
 {
     /**
-     * @var \Cake\Database\Expression\QueryExpression
+     * @var \Cake\Database\Expression\QueryExpression|null
      */
-    protected $filter;
+    protected ?QueryExpression $filter = null;
 
     /**
-     * @var \Cake\Database\Expression\WindowExpression
+     * @var \Cake\Database\Expression\WindowExpression|null
      */
-    protected $window;
+    protected ?WindowExpression $window = null;
 
     /**
      * Adds conditions to the FILTER clause. The conditions are the same format as
@@ -70,12 +70,10 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function over(?string $name = null)
     {
-        if ($this->window === null) {
-            $this->window = new WindowExpression();
-        }
+        $window = $this->getWindow();
         if ($name) {
             // Set name manually in case this was chained from FunctionsBuilder wrapper
-            $this->window->name($name);
+            $window->name($name);
         }
 
         return $this;
@@ -86,8 +84,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function partition($partitions)
     {
-        $this->over();
-        $this->window->partition($partitions);
+        $this->getWindow()->partition($partitions);
 
         return $this;
     }
@@ -97,8 +94,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function order($fields)
     {
-        $this->over();
-        $this->window->order($fields);
+        $this->getWindow()->order($fields);
 
         return $this;
     }
@@ -108,8 +104,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function range($start, $end = 0)
     {
-        $this->over();
-        $this->window->range($start, $end);
+        $this->getWindow()->range($start, $end);
 
         return $this;
     }
@@ -119,8 +114,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function rows(?int $start, ?int $end = 0)
     {
-        $this->over();
-        $this->window->rows($start, $end);
+        $this->getWindow()->rows($start, $end);
 
         return $this;
     }
@@ -130,8 +124,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function groups(?int $start, ?int $end = 0)
     {
-        $this->over();
-        $this->window->groups($start, $end);
+        $this->getWindow()->groups($start, $end);
 
         return $this;
     }
@@ -146,8 +139,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
         $endOffset,
         string $endDirection
     ) {
-        $this->over();
-        $this->window->frame($type, $startOffset, $startDirection, $endOffset, $endDirection);
+        $this->getWindow()->frame($type, $startOffset, $startDirection, $endOffset, $endDirection);
 
         return $this;
     }
@@ -157,8 +149,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function excludeCurrent()
     {
-        $this->over();
-        $this->window->excludeCurrent();
+        $this->getWindow()->excludeCurrent();
 
         return $this;
     }
@@ -168,8 +159,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function excludeGroup()
     {
-        $this->over();
-        $this->window->excludeGroup();
+        $this->getWindow()->excludeGroup();
 
         return $this;
     }
@@ -179,10 +169,23 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function excludeTies()
     {
-        $this->over();
-        $this->window->excludeTies();
+        $this->getWindow()->excludeTies();
 
         return $this;
+    }
+
+    /**
+     * Returns or creates WindowExpression for function.
+     *
+     * @return \Cake\Database\Expression\WindowExpression
+     */
+    protected function getWindow(): WindowExpression
+    {
+        if ($this->window === null) {
+            $this->window = new WindowExpression();
+        }
+
+        return $this->window;
     }
 
     /**

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -34,21 +34,21 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
      *
      * @var mixed
      */
-    protected $_from;
+    protected mixed $_from;
 
     /**
      * The second value in the expression
      *
      * @var mixed
      */
-    protected $_to;
+    protected mixed $_to;
 
     /**
      * The data type for the from and to arguments
      *
      * @var mixed
      */
-    protected $_type;
+    protected mixed $_type;
 
     /**
      * Constructor

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -34,7 +34,7 @@ class CaseExpression implements ExpressionInterface
      *
      * @var array
      */
-    protected $_conditions = [];
+    protected array $_conditions = [];
 
     /**
      * Values that are associated with the conditions in the $_conditions array.
@@ -42,14 +42,14 @@ class CaseExpression implements ExpressionInterface
      *
      * @var array
      */
-    protected $_values = [];
+    protected array $_values = [];
 
     /**
      * The `ELSE` value for the case statement. If null then no `ELSE` will be included.
      *
      * @var \Cake\Database\ExpressionInterface|array|string|null
      */
-    protected $_elseValue;
+    protected ExpressionInterface|array|string|null $_elseValue = null;
 
     /**
      * Constructs the case expression

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -31,35 +31,35 @@ class CommonTableExpression implements ExpressionInterface
      *
      * @var \Cake\Database\Expression\IdentifierExpression
      */
-    protected $name;
+    protected IdentifierExpression $name;
 
     /**
      * The field names to use for the CTE.
      *
      * @var array<\Cake\Database\Expression\IdentifierExpression>
      */
-    protected $fields = [];
+    protected array $fields = [];
 
     /**
      * The CTE query definition.
      *
      * @var \Cake\Database\ExpressionInterface|null
      */
-    protected $query;
+    protected ?ExpressionInterface $query = null;
 
     /**
      * Whether the CTE is materialized or not materialized.
      *
      * @var string|null
      */
-    protected $materialized = null;
+    protected ?string $materialized = null;
 
     /**
      * Whether the CTE is recursive.
      *
      * @var bool
      */
-    protected $recursive = false;
+    protected bool $recursive = false;
 
     /**
      * Constructor.

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -37,28 +37,28 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      *
      * @var mixed
      */
-    protected $_value;
+    protected mixed $_value;
 
     /**
      * The type to be used for casting the value to a database representation
      *
      * @var string|null
      */
-    protected $_type;
+    protected ?string $_type = null;
 
     /**
      * The operator used for comparing field and value
      *
      * @var string
      */
-    protected $_operator = '=';
+    protected string $_operator = '=';
 
     /**
      * Whether or not the value in this expression is a traversable
      *
      * @var bool
      */
-    protected $_isMultiple = false;
+    protected bool $_isMultiple = false;
 
     /**
      * A cached list of ExpressionInterface objects that were
@@ -66,7 +66,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      *
      * @var array<\Cake\Database\ExpressionInterface>
      */
-    protected $_valueExpressions = [];
+    protected array $_valueExpressions = [];
 
     /**
      * Constructor

--- a/src/Database/Expression/FieldTrait.php
+++ b/src/Database/Expression/FieldTrait.php
@@ -28,7 +28,7 @@ trait FieldTrait
      *
      * @var \Cake\Database\ExpressionInterface|array|string
      */
-    protected $_field;
+    protected ExpressionInterface|array|string $_field;
 
     /**
      * Sets the field name

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -39,7 +39,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
      *
      * @var string
      */
-    protected $_name;
+    protected string $_name;
 
     /**
      * Constructor. Takes a name for the function to be invoked and a list of params

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -35,12 +35,12 @@ class IdentifierExpression implements ExpressionInterface
      *
      * @var string
      */
-    protected $_identifier;
+    protected string $_identifier;
 
     /**
      * @var string|null
      */
-    protected $collation;
+    protected ?string $collation = null;
 
     /**
      * Constructor

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -33,7 +33,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
      *
      * @var string
      */
-    protected $_direction;
+    protected string $_direction;
 
     /**
      * Constructor

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -40,7 +40,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @var string
      */
-    protected $_conjunction;
+    protected string $_conjunction;
 
     /**
      * A list of strings or other expression objects that represent the "branches" of
@@ -48,7 +48,7 @@ class QueryExpression implements ExpressionInterface, Countable
      *
      * @var array
      */
-    protected $_conditions = [];
+    protected array $_conditions = [];
 
     /**
      * Constructor. A new expression object can be created without any params and

--- a/src/Database/Expression/StringExpression.php
+++ b/src/Database/Expression/StringExpression.php
@@ -28,12 +28,12 @@ class StringExpression implements ExpressionInterface
     /**
      * @var string
      */
-    protected $string;
+    protected string $string;
 
     /**
      * @var string
      */
-    protected $collation;
+    protected string $collation;
 
     /**
      * @param string $string String value

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -32,7 +32,7 @@ class TupleComparison extends ComparisonExpression
      * @var array<string|null>
      * @psalm-suppress NonInvariantDocblockPropertyType
      */
-    protected $_type;
+    protected array $types;
 
     /**
      * Constructor
@@ -49,7 +49,7 @@ class TupleComparison extends ComparisonExpression
         array $types = [],
         string $conjunction = '='
     ) {
-        $this->_type = $types;
+        $this->types = $types;
         $this->setField($fields);
         $this->setValue($values);
         $this->_operator = $conjunction;
@@ -62,7 +62,7 @@ class TupleComparison extends ComparisonExpression
      */
     public function getType(): array
     {
-        return $this->_type;
+        return $this->types;
     }
 
     /**
@@ -122,7 +122,7 @@ class TupleComparison extends ComparisonExpression
                 continue;
             }
 
-            $type = $this->_type;
+            $type = $this->types;
             $isMultiOperation = $this->isMulti();
             if (empty($type)) {
                 $type = null;

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -44,21 +44,21 @@ class UnaryExpression implements ExpressionInterface
      *
      * @var string
      */
-    protected $_operator;
+    protected string $_operator;
 
     /**
      * Holds the value which the unary expression operates
      *
      * @var mixed
      */
-    protected $_value;
+    protected mixed $_value;
 
     /**
      * Where to place the operator
      *
      * @var int
      */
-    protected $position;
+    protected int $position;
 
     /**
      * Constructor

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -41,21 +41,21 @@ class ValuesExpression implements ExpressionInterface
      *
      * @var array
      */
-    protected $_values = [];
+    protected array $_values = [];
 
     /**
      * List of columns to ensure are part of the insert.
      *
      * @var array
      */
-    protected $_columns = [];
+    protected array $_columns = [];
 
     /**
      * The Query object to use as a values expression
      *
      * @var \Cake\Database\Query|null
      */
-    protected $_query;
+    protected ?Query $_query = null;
 
     /**
      * Whether or not values have been casted to expressions
@@ -63,7 +63,7 @@ class ValuesExpression implements ExpressionInterface
      *
      * @var bool
      */
-    protected $_castedExpressions = false;
+    protected bool $_castedExpressions = false;
 
     /**
      * Constructor

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -28,27 +28,27 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     /**
      * @var \Cake\Database\Expression\IdentifierExpression
      */
-    protected $name;
+    protected IdentifierExpression $name;
 
     /**
      * @var array<\Cake\Database\ExpressionInterface>
      */
-    protected $partitions = [];
+    protected array $partitions = [];
 
     /**
      * @var \Cake\Database\Expression\OrderByExpression|null
      */
-    protected $order;
+    protected ?OrderByExpression $order = null;
 
     /**
      * @var array|null
      */
-    protected $frame;
+    protected ?array $frame = null;
 
     /**
      * @var string|null
      */
-    protected $exclusion;
+    protected ?string $exclusion = null;
 
     /**
      * @param string $name Window name

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -31,7 +31,7 @@ class FieldTypeConverter
      *
      * @var array<\Cake\Database\TypeInterface>
      */
-    protected $_typeMap;
+    protected array $_typeMap;
 
     /**
      * An array containing the name of the fields and the Type objects
@@ -39,7 +39,7 @@ class FieldTypeConverter
      *
      * @var array
      */
-    protected $batchingTypeMap;
+    protected array $batchingTypeMap;
 
     /**
      * An array containing all the types registered in the Type system
@@ -48,14 +48,14 @@ class FieldTypeConverter
      *
      * @var array<\Cake\Database\TypeInterface>|array<\Cake\Database\Type\BatchCastingInterface>
      */
-    protected $types;
+    protected array $types;
 
     /**
      * The driver object to be used in the type conversion
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * Builds the type map

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -30,16 +30,16 @@ class IdentifierQuoter
     /**
      * The driver instance used to do the identifier quoting
      *
-     * @var \Cake\Database\Driver
+     * @var \Cake\Database\DriverInterface
      */
-    protected Driver $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * Constructor
      *
-     * @param \Cake\Database\Driver $driver The driver instance used to do the identifier quoting
+     * @param \Cake\Database\DriverInterface $driver The driver instance used to do the identifier quoting
      */
-    public function __construct(Driver $driver)
+    public function __construct(DriverInterface $driver)
     {
         $this->_driver = $driver;
     }

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -32,7 +32,7 @@ class IdentifierQuoter
      *
      * @var \Cake\Database\Driver
      */
-    protected $_driver;
+    protected Driver $_driver;
 
     /**
      * Constructor

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Cake\Database\Log;
 
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\DriverInterface;
+use Exception;
 use JsonSerializable;
 use Stringable;
 
@@ -33,42 +35,42 @@ class LoggedQuery implements JsonSerializable, Stringable
      *
      * @var \Cake\Database\DriverInterface|null
      */
-    public $driver = null;
+    public ?DriverInterface $driver = null;
 
     /**
      * Query string that was executed
      *
      * @var string
      */
-    public $query = '';
+    public string $query = '';
 
     /**
      * Number of milliseconds this query took to complete
      *
      * @var float
      */
-    public $took = 0;
+    public float $took = 0;
 
     /**
      * Associative array with the params bound to the query string
      *
      * @var array
      */
-    public $params = [];
+    public array $params = [];
 
     /**
      * Number of rows affected or returned by the query execution
      *
      * @var int
      */
-    public $numRows = 0;
+    public int $numRows = 0;
 
     /**
      * The exception that was thrown by the execution of this query
      *
      * @var \Exception|null
      */
-    public $error;
+    public ?Exception $error = null;
 
     /**
      * Helper function used to replace query placeholders by the real

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -33,28 +33,28 @@ class LoggingStatement extends StatementDecorator
      *
      * @var \Psr\Log\LoggerInterface
      */
-    protected $_logger;
+    protected LoggerInterface $_logger;
 
     /**
      * Holds bound params
      *
      * @var array
      */
-    protected $_compiledParams = [];
+    protected array $_compiledParams = [];
 
     /**
      * Query execution start time.
      *
      * @var float
      */
-    protected $startTime = 0.0;
+    protected float $startTime = 0.0;
 
     /**
      * Logged query
      *
      * @var \Cake\Database\Log\LoggedQuery|null
      */
-    protected $loggedQuery;
+    protected ?LoggedQuery $loggedQuery = null;
 
     /**
      * Wrapper for the execute function to calculate time spent

--- a/src/Database/PostgresCompiler.php
+++ b/src/Database/PostgresCompiler.php
@@ -33,12 +33,12 @@ class PostgresCompiler extends QueryCompiler
      *
      * @var bool
      */
-    protected $_quotedSelectAliases = true;
+    protected bool $_quotedSelectAliases = true;
 
     /**
      * @inheritDoc
      */
-    protected $_templates = [
+    protected array $_templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
         'group' => ' GROUP BY %s',

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -62,21 +62,21 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var \Cake\Database\Connection
      */
-    protected $_connection;
+    protected Connection $_connection;
 
     /**
      * Type of this query (select, insert, update, delete).
      *
      * @var string
      */
-    protected $_type = 'select';
+    protected string $_type = 'select';
 
     /**
      * List of SQL parts that will be used to build this query.
      *
      * @var array
      */
-    protected $_parts = [
+    protected array $_parts = [
         'delete' => true,
         'update' => [],
         'set' => [],
@@ -104,7 +104,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var array<string>
      */
-    protected $_selectParts = [
+    protected array $_selectParts = [
         'with', 'select', 'from', 'join', 'where', 'group', 'having', 'order', 'limit',
         'offset', 'union', 'epilog',
     ];
@@ -114,21 +114,21 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var array<string>
      */
-    protected $_updateParts = ['with', 'update', 'set', 'where', 'epilog'];
+    protected array $_updateParts = ['with', 'update', 'set', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating a DELETE statement
      *
      * @var array<string>
      */
-    protected $_deleteParts = ['with', 'delete', 'modifier', 'from', 'where', 'epilog'];
+    protected array $_deleteParts = ['with', 'delete', 'modifier', 'from', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating an INSERT statement
      *
      * @var array<string>
      */
-    protected $_insertParts = ['with', 'insert', 'values', 'epilog'];
+    protected array $_insertParts = ['with', 'insert', 'values', 'epilog'];
 
     /**
      * Indicates whether internal state of this query was changed, this is used to
@@ -137,7 +137,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var bool
      */
-    protected $_dirty = false;
+    protected bool $_dirty = false;
 
     /**
      * A list of callback functions to be called to alter each row from resulting
@@ -146,14 +146,14 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var array<callable>
      */
-    protected $_resultDecorators = [];
+    protected array $_resultDecorators = [];
 
     /**
      * Statement object resulting from executing this query.
      *
      * @var \Cake\Database\StatementInterface|null
      */
-    protected $_iterator;
+    protected ?StatementInterface $_iterator = null;
 
     /**
      * The object responsible for generating query placeholders and temporarily store values
@@ -161,14 +161,14 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var \Cake\Database\ValueBinder|null
      */
-    protected $_valueBinder;
+    protected ?ValueBinder $_valueBinder = null;
 
     /**
      * Instance of functions builder object used for generating arbitrary SQL functions.
      *
      * @var \Cake\Database\FunctionsBuilder|null
      */
-    protected $_functionsBuilder;
+    protected ?FunctionsBuilder $_functionsBuilder = null;
 
     /**
      * Boolean for tracking whether or not buffered results
@@ -176,21 +176,21 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      *
      * @var bool
      */
-    protected $_useBufferedResults = true;
+    protected bool $_useBufferedResults = true;
 
     /**
      * The Type map for fields in the select clause
      *
      * @var \Cake\Database\TypeMap|null
      */
-    protected $_selectTypeMap;
+    protected ?TypeMap $_selectTypeMap = null;
 
     /**
      * Tracking flag to disable casting
      *
      * @var bool
      */
-    protected $typeCastEnabled = true;
+    protected bool $typeCastEnabled = true;
 
     /**
      * Constructor.

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -34,7 +34,7 @@ class QueryCompiler
      *
      * @var array
      */
-    protected $_templates = [
+    protected array $_templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
         'group' => ' GROUP BY %s ',
@@ -50,7 +50,7 @@ class QueryCompiler
      *
      * @var array
      */
-    protected $_selectParts = [
+    protected array $_selectParts = [
         'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
         'limit', 'offset', 'union', 'epilog',
     ];
@@ -60,21 +60,21 @@ class QueryCompiler
      *
      * @var array
      */
-    protected $_updateParts = ['with', 'update', 'set', 'where', 'epilog'];
+    protected array $_updateParts = ['with', 'update', 'set', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating a DELETE statement
      *
      * @var array
      */
-    protected $_deleteParts = ['with', 'delete', 'modifier', 'from', 'where', 'epilog'];
+    protected array $_deleteParts = ['with', 'delete', 'modifier', 'from', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating an INSERT statement
      *
      * @var array
      */
-    protected $_insertParts = ['with', 'insert', 'values', 'epilog'];
+    protected array $_insertParts = ['with', 'insert', 'values', 'epilog'];
 
     /**
      * Indicate whether or not this query dialect supports ordered unions.
@@ -83,14 +83,14 @@ class QueryCompiler
      *
      * @var bool
      */
-    protected $_orderedUnion = true;
+    protected bool $_orderedUnion = true;
 
     /**
      * Indicate whether aliases in SELECT clause need to be always quoted.
      *
      * @var bool
      */
-    protected $_quotedSelectAliases = false;
+    protected bool $_quotedSelectAliases = false;
 
     /**
      * Returns the SQL representation of the provided query after generating

--- a/src/Database/Retry/ErrorCodeWaitStrategy.php
+++ b/src/Database/Retry/ErrorCodeWaitStrategy.php
@@ -30,12 +30,12 @@ class ErrorCodeWaitStrategy implements RetryStrategyInterface
     /**
      * @var array<int>
      */
-    protected $errorCodes;
+    protected array $errorCodes;
 
     /**
      * @var int
      */
-    protected $retryInterval;
+    protected int $retryInterval;
 
     /**
      * @param array<int> $errorCodes DB-specific error codes that allow retrying

--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -35,7 +35,7 @@ class ReconnectStrategy implements RetryStrategyInterface
      *
      * @var array
      */
-    protected static $causes = [
+    protected static array $causes = [
         'gone away',
         'Lost connection',
         'Transaction() on null',
@@ -57,7 +57,7 @@ class ReconnectStrategy implements RetryStrategyInterface
      *
      * @var \Cake\Database\Connection
      */
-    protected $connection;
+    protected Connection $connection;
 
     /**
      * Creates the ReconnectStrategy object by storing a reference to the

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -28,21 +28,21 @@ class CachedCollection implements CollectionInterface
      *
      * @var \Psr\SimpleCache\CacheInterface
      */
-    protected $cacher;
+    protected CacheInterface $cacher;
 
     /**
      * The decorated schema collection
      *
      * @var \Cake\Database\Schema\CollectionInterface
      */
-    protected $collection;
+    protected CollectionInterface $collection;
 
     /**
      * The cache key prefix
      *
      * @var string
      */
-    protected $prefix;
+    protected string $prefix;
 
     /**
      * Constructor.

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -33,14 +33,14 @@ class Collection implements CollectionInterface
      *
      * @var \Cake\Database\Connection
      */
-    protected $_connection;
+    protected Connection $_connection;
 
     /**
      * Schema dialect instance.
      *
      * @var \Cake\Database\Schema\SchemaDialect
      */
-    protected $_dialect;
+    protected SchemaDialect $_dialect;
 
     /**
      * Constructor.

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -26,13 +26,6 @@ use Cake\Database\Exception\DatabaseException;
 class MysqlSchemaDialect extends SchemaDialect
 {
     /**
-     * The driver instance being used.
-     *
-     * @var \Cake\Database\Driver\Mysql
-     */
-    protected $_driver;
-
-    /**
      * @inheritDoc
      */
     public function listTablesSql(array $config): array
@@ -338,7 +331,10 @@ class MysqlSchemaDialect extends SchemaDialect
         }
 
         $out = $this->_driver->quoteIdentifier($name);
-        $nativeJson = $this->_driver->supportsNativeJson();
+
+        /** @var \Cake\Database\Driver\Mysql $driver */
+        $driver = $this->_driver;
+        $nativeJson = $driver->supportsNativeJson();
 
         $typeMap = [
             TableSchema::TYPE_TINYINTEGER => ' TINYINT',

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -34,7 +34,7 @@ abstract class SchemaDialect
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * Constructor

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -31,14 +31,14 @@ class SqliteSchemaDialect extends SchemaDialect
      *
      * @var array
      */
-    protected $_constraintsIdMap = [];
+    protected array $_constraintsIdMap = [];
 
     /**
      * Whether there is any table in this connection to SQLite containing sequences.
      *
      * @var bool
      */
-    protected $_hasSequences;
+    protected bool $_hasSequences;
 
     /**
      * Convert a column definition to the abstract types.

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -38,49 +38,49 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var string
      */
-    protected $_table;
+    protected string $_table;
 
     /**
      * Columns in the table.
      *
      * @var array
      */
-    protected $_columns = [];
+    protected array $_columns = [];
 
     /**
      * A map with columns to types
      *
      * @var array
      */
-    protected $_typeMap = [];
+    protected array $_typeMap = [];
 
     /**
      * Indexes in the table.
      *
      * @var array
      */
-    protected $_indexes = [];
+    protected array $_indexes = [];
 
     /**
      * Constraints in the table.
      *
      * @var array
      */
-    protected $_constraints = [];
+    protected array $_constraints = [];
 
     /**
      * Options for the table.
      *
      * @var array
      */
-    protected $_options = [];
+    protected array $_options = [];
 
     /**
      * Whether or not the table is temporary
      *
      * @var bool
      */
-    protected $_temporary = false;
+    protected bool $_temporary = false;
 
     /**
      * Column length when using a `tiny` column type
@@ -108,7 +108,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    public static $columnLengths = [
+    public static array $columnLengths = [
         'tiny' => self::LENGTH_TINY,
         'medium' => self::LENGTH_MEDIUM,
         'long' => self::LENGTH_LONG,
@@ -120,7 +120,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    protected static $_columnKeys = [
+    protected static array $_columnKeys = [
         'type' => null,
         'baseType' => null,
         'length' => null,
@@ -135,7 +135,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    protected static $_columnExtras = [
+    protected static array $_columnExtras = [
         'string' => [
             'collate' => null,
         ],
@@ -173,7 +173,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    protected static $_indexKeys = [
+    protected static array $_indexKeys = [
         'type' => null,
         'columns' => [],
         'length' => [],
@@ -187,7 +187,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    protected static $_validIndexTypes = [
+    protected static array $_validIndexTypes = [
         self::INDEX_INDEX,
         self::INDEX_FULLTEXT,
     ];
@@ -197,7 +197,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    protected static $_validConstraintTypes = [
+    protected static array $_validConstraintTypes = [
         self::CONSTRAINT_PRIMARY,
         self::CONSTRAINT_UNIQUE,
         self::CONSTRAINT_FOREIGN,
@@ -208,7 +208,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      *
      * @var array
      */
-    protected static $_validForeignKeyActions = [
+    protected static array $_validForeignKeyActions = [
         self::ACTION_CASCADE,
         self::ACTION_SET_NULL,
         self::ACTION_SET_DEFAULT,

--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -35,7 +35,7 @@ class SchemaCache
      *
      * @var \Cake\Database\Schema\CachedCollection
      */
-    protected $_schema;
+    protected CachedCollection $_schema;
 
     /**
      * Constructor

--- a/src/Database/SqliteCompiler.php
+++ b/src/Database/SqliteCompiler.php
@@ -29,5 +29,5 @@ class SqliteCompiler extends QueryCompiler
      *
      * @var bool
      */
-    protected $_orderedUnion = false;
+    protected bool $_orderedUnion = false;
 }

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -32,12 +32,12 @@ class SqlserverCompiler extends QueryCompiler
      *
      * @var bool
      */
-    protected $_orderedUnion = false;
+    protected bool $_orderedUnion = false;
 
     /**
      * @inheritDoc
      */
-    protected $_templates = [
+    protected array $_templates = [
         'delete' => 'DELETE',
         'where' => ' WHERE %s',
         'group' => ' GROUP BY %s',
@@ -49,7 +49,7 @@ class SqlserverCompiler extends QueryCompiler
     /**
      * @inheritDoc
      */
-    protected $_selectParts = [
+    protected array $_selectParts = [
         'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
         'offset', 'limit', 'union', 'epilog',
     ];

--- a/src/Database/Statement/BufferResultsTrait.php
+++ b/src/Database/Statement/BufferResultsTrait.php
@@ -28,7 +28,7 @@ trait BufferResultsTrait
      *
      * @var bool
      */
-    protected $_bufferResults = true;
+    protected bool $_bufferResults = true;
 
     /**
      * Whether or not to buffer results in php

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -37,7 +37,7 @@ class BufferedStatement implements Iterator, StatementInterface
      *
      * @var bool
      */
-    protected $_allFetched = false;
+    protected bool $_allFetched = false;
 
     /**
      * The decorated statement
@@ -51,28 +51,28 @@ class BufferedStatement implements Iterator, StatementInterface
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * The in-memory cache containing results from previous iterators
      *
      * @var array
      */
-    protected $buffer = [];
+    protected array $buffer = [];
 
     /**
      * Whether or not this statement has already been executed
      *
      * @var bool
      */
-    protected $_hasExecuted = false;
+    protected bool $_hasExecuted = false;
 
     /**
      * The current iterator index.
      *
      * @var int
      */
-    protected $index = 0;
+    protected int $index = 0;
 
     /**
      * Constructor

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -52,14 +52,14 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * Whether or not this statement has already been executed
      *
      * @var bool
      */
-    protected $_hasExecuted = false;
+    protected bool $_hasExecuted = false;
 
     /**
      * Constructor

--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -30,7 +30,7 @@ abstract class BaseType implements TypeInterface
      *
      * @var string|null
      */
-    protected $_name;
+    protected ?string $_name = null;
 
     /**
      * Constructor

--- a/src/Database/Type/DateTimeFractionalType.php
+++ b/src/Database/Type/DateTimeFractionalType.php
@@ -24,12 +24,12 @@ class DateTimeFractionalType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected $_format = 'Y-m-d H:i:s.u';
+    protected string $_format = 'Y-m-d H:i:s.u';
 
     /**
      * @inheritDoc
      */
-    protected $_marshalFormats = [
+    protected array $_marshalFormats = [
         'Y-m-d H:i',
         'Y-m-d H:i:s',
         'Y-m-d H:i:s.u',

--- a/src/Database/Type/DateTimeTimezoneType.php
+++ b/src/Database/Type/DateTimeTimezoneType.php
@@ -24,12 +24,12 @@ class DateTimeTimezoneType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected $_format = 'Y-m-d H:i:s.uP';
+    protected string $_format = 'Y-m-d H:i:s.uP';
 
     /**
      * @inheritDoc
      */
-    protected $_marshalFormats = [
+    protected array $_marshalFormats = [
         'Y-m-d H:i',
         'Y-m-d H:i:s',
         'Y-m-d H:i:sP',

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -43,21 +43,21 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      *
      * @var bool
      */
-    protected $setToDateStart = false;
+    protected bool $setToDateStart = false;
 
     /**
      * The DateTime format used when converting to string.
      *
      * @var string
      */
-    protected $_format = 'Y-m-d H:i:s';
+    protected string $_format = 'Y-m-d H:i:s';
 
     /**
      * The DateTime formats allowed by `marshal()`.
      *
      * @var array
      */
-    protected $_marshalFormats = [
+    protected array $_marshalFormats = [
         'Y-m-d H:i',
         'Y-m-d H:i:s',
         'Y-m-d\TH:i',
@@ -70,16 +70,16 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      *
      * @var bool
      */
-    protected $_useLocaleMarshal = false;
+    protected bool $_useLocaleMarshal = false;
 
     /**
      * The locale-aware format `marshal()` uses when `_useLocaleParser` is true.
      *
      * See `Cake\I18n\Time::parseDateTime()` for accepted formats.
      *
-     * @var array|string|int
+     * @var array|string|int|null
      */
-    protected $_localeMarshalFormat;
+    protected array|string|int|null $_localeMarshalFormat = null;
 
     /**
      * The classname to use when creating objects.
@@ -87,35 +87,35 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      * @var string
      * @psalm-var class-string<\DateTimeImmutable>
      */
-    protected $_className;
+    protected string $_className;
 
     /**
      * Database time zone.
      *
      * @var \DateTimeZone|null
      */
-    protected $dbTimezone;
+    protected ?DateTimeZone $dbTimezone = null;
 
     /**
      * User time zone.
      *
      * @var \DateTimeZone|null
      */
-    protected $userTimezone;
+    protected ?DateTimeZone $userTimezone = null;
 
     /**
      * Default time zone.
      *
      * @var \DateTimeZone
      */
-    protected $defaultTimezone;
+    protected DateTimeZone $defaultTimezone;
 
     /**
      * Whether database time zone is kept when converting
      *
      * @var bool
      */
-    protected $keepDatabaseTimezone = false;
+    protected bool $keepDatabaseTimezone = false;
 
     /**
      * {@inheritDoc}

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -29,12 +29,12 @@ class DateType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected $_format = 'Y-m-d';
+    protected string $_format = 'Y-m-d';
 
     /**
      * @inheritDoc
      */
-    protected $_marshalFormats = [
+    protected array $_marshalFormats = [
         'Y-m-d',
     ];
 
@@ -44,7 +44,7 @@ class DateType extends DateTimeType
      *
      * @var bool
      */
-    protected $setToDateStart = true;
+    protected bool $setToDateStart = true;
 
     /**
      * @inheritDoc

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -35,7 +35,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      *
      * @var string
      */
-    public static $numberClass = Number::class;
+    public static string $numberClass = Number::class;
 
     /**
      * Whether numbers should be parsed using a locale aware parser
@@ -43,7 +43,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      *
      * @var bool
      */
-    protected $_useLocaleParser = false;
+    protected bool $_useLocaleParser = false;
 
     /**
      * Convert decimal strings into the database format.

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -33,7 +33,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      *
      * @var string
      */
-    public static $numberClass = Number::class;
+    public static string $numberClass = Number::class;
 
     /**
      * Whether numbers should be parsed using a locale aware parser
@@ -41,7 +41,7 @@ class FloatType extends BaseType implements BatchCastingInterface
      *
      * @var bool
      */
-    protected $_useLocaleParser = false;
+    protected bool $_useLocaleParser = false;
 
     /**
      * Convert integer data into the database format.

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -30,7 +30,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     /**
      * @var int
      */
-    protected $_encodingOptions = 0;
+    protected int $_encodingOptions = 0;
 
     /**
      * Convert a value data into a JSON string

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -28,12 +28,12 @@ class TimeType extends DateTimeType
     /**
      * @inheritDoc
      */
-    protected $_format = 'H:i:s';
+    protected string $_format = 'H:i:s';
 
     /**
      * @inheritDoc
      */
-    protected $_marshalFormats = [
+    protected array $_marshalFormats = [
         'H:i:s',
         'H:i',
     ];

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -31,7 +31,7 @@ class TypeFactory
      * @var array<string, string>
      * @psalm-var array<string, class-string<\Cake\Database\TypeInterface>>
      */
-    protected static $_types = [
+    protected static array $_types = [
         'tinyinteger' => Type\IntegerType::class,
         'smallinteger' => Type\IntegerType::class,
         'integer' => Type\IntegerType::class,
@@ -60,7 +60,7 @@ class TypeFactory
      *
      * @var array<\Cake\Database\TypeInterface>
      */
-    protected static $_builtTypes = [];
+    protected static array $_builtTypes = [];
 
     /**
      * Returns a Type object capable of converting a type identified by name.

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -29,7 +29,7 @@ class TypeMap
      *
      * @var array<string>
      */
-    protected $_defaults = [];
+    protected array $_defaults = [];
 
     /**
      * Associative array with the fields and the related types that override defaults this query might contain
@@ -39,7 +39,7 @@ class TypeMap
      *
      * @var array<string>
      */
-    protected $_types = [];
+    protected array $_types = [];
 
     /**
      * Creates an instance with the given defaults

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -27,7 +27,7 @@ trait TypeMapTrait
     /**
      * @var \Cake\Database\TypeMap|null
      */
-    protected $_typeMap;
+    protected ?TypeMap $_typeMap = null;
 
     /**
      * Creates a new TypeMap if $typeMap is an array, otherwise exchanges it for the given one.

--- a/src/Database/TypedResultTrait.php
+++ b/src/Database/TypedResultTrait.php
@@ -26,7 +26,7 @@ trait TypedResultTrait
      *
      * @var string
      */
-    protected $_returnType = 'string';
+    protected string $_returnType = 'string';
 
     /**
      * Gets the type of the value this object will generate.

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -30,14 +30,14 @@ class ValueBinder
      *
      * @var array
      */
-    protected $_bindings = [];
+    protected array $_bindings = [];
 
     /**
      * A counter of the number of parameters bound in this expression object
      *
      * @var int
      */
-    protected $_bindingsCount = 0;
+    protected int $_bindingsCount = 0;
 
     /**
      * Associates a query placeholder to a value and a type

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1058,7 +1058,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function cache($key, $config = 'default')
     {
-        if ($this->_type !== 'select' && $this->_type !== null) {
+        if ($this->_type !== 'select') {
             throw new RuntimeException('You cannot cache the results of non-select queries.');
         }
 
@@ -1073,7 +1073,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function all(): ResultSetInterface
     {
-        if ($this->_type !== 'select' && $this->_type !== null) {
+        if ($this->_type !== 'select') {
             throw new RuntimeException(
                 'You cannot call all() on a non-select query. Use execute() instead.'
             );

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Driver;
-use Cake\Database\Driver\Mysql;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
@@ -153,7 +152,7 @@ class DriverTest extends TestCase
      */
     public function testLastInsertId(): void
     {
-        $connection = $this->getMockBuilder(Mysql::class)
+        $connection = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['lastInsertId'])
             ->getMock();

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -157,7 +157,7 @@ class LoggedQueryTest extends TestCase
 
         $expected = [
             'numRows' => 10,
-            'took' => 15,
+            'took' => 15.0,
         ];
         $this->assertSame($expected, $query->getContext());
     }


### PR DESCRIPTION
This skips adding type hints for a few properties such as StatementDecorator.
