### PR TITLE
Add DriverInterface::supports()

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -579,7 +579,7 @@ class Connection implements ConnectionInterface
         if ($enable === false) {
             $this->_useSavePoints = false;
         } else {
-            $this->_useSavePoints = $this->_driver->supportsSavePoints();
+            $this->_useSavePoints = $this->_driver->supports(DriverInterface::FEATURE_SAVEPOINT);
         }
 
         return $this;
@@ -767,7 +767,7 @@ class Connection implements ConnectionInterface
      */
     public function supportsQuoting(): bool
     {
-        return $this->_driver->supportsQuoting();
+        return $this->_driver->supports(DriverInterface::FEATURE_QUOTE);
     }
 
     /**

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -75,13 +75,6 @@ abstract class Driver implements DriverInterface
     protected $_autoQuoting = false;
 
     /**
-     * Whether or not the server supports common table expressions.
-     *
-     * @var bool|null
-     */
-    protected $supportsCTEs = null;
-
-    /**
      * The server version
      *
      * @var string|null
@@ -273,17 +266,22 @@ abstract class Driver implements DriverInterface
      */
     public function supportsSavePoints(): bool
     {
-        return true;
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
+
+        return $this->supports(static::FEATURE_SAVEPOINT);
     }
 
     /**
      * Returns true if the server supports common table expressions.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_QUOTE)` instead
      */
     public function supportsCTEs(): bool
     {
-        return $this->supportsCTEs === true;
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
+
+        return $this->supports(static::FEATURE_CTE);
     }
 
     /**
@@ -300,12 +298,13 @@ abstract class Driver implements DriverInterface
      * Checks if the driver supports quoting, as PDO_ODBC does not support it.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_QUOTE)` instead
      */
     public function supportsQuoting(): bool
     {
-        $this->connect();
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
 
-        return $this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc';
+        return $this->supports(static::FEATURE_QUOTE);
     }
 
     /**
@@ -425,6 +424,25 @@ abstract class Driver implements DriverInterface
     public function isAutoQuotingEnabled(): bool
     {
         return $this->_autoQuoting;
+    }
+
+    /**
+     * Returns whether the driver supports the feature.
+     *
+     * Defaults to true for "quoting" and "savepoints".
+     *
+     * @param string $feature Driver feature name
+     * @return bool
+     */
+    public function supports(string $feature): bool
+    {
+        switch ($feature) {
+            case static::FEATURE_QUOTE:
+            case static::FEATURE_SAVEPOINT:
+                return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -76,20 +76,6 @@ class Mysql extends Driver
     protected $_schemaDialect;
 
     /**
-     * Whether or not the server supports native JSON
-     *
-     * @var bool|null
-     */
-    protected $_supportsNativeJson;
-
-    /**
-     * Whether or not the connected server supports window functions.
-     *
-     * @var bool|null
-     */
-    protected $_supportsWindowFunctions;
-
-    /**
      * String used to start a database identifier quoting to make it safe
      *
      * @var string
@@ -118,7 +104,7 @@ class Mysql extends Driver
      *
      * @var array
      */
-    protected $featuresToVersionMap = [
+    protected $featureVersions = [
         'mysql' => [
             'json' => '5.7.0',
             'cte' => '8.0.0',
@@ -260,6 +246,25 @@ class Mysql extends Driver
     /**
      * @inheritDoc
      */
+    public function supports(string $feature): bool
+    {
+        switch ($feature) {
+            case static::FEATURE_CTE:
+            case static::FEATURE_JSON:
+            case static::FEATURE_WINDOW:
+                return version_compare(
+                    $this->version(),
+                    $this->featureVersions[$this->serverType][$feature],
+                    '>='
+                );
+        }
+
+        return parent::supports($feature);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function supportsDynamicConstraints(): bool
     {
         return true;
@@ -302,53 +307,38 @@ class Mysql extends Driver
      * Returns true if the server supports common table expressions.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_CTE)` instead
      */
     public function supportsCTEs(): bool
     {
-        if ($this->supportsCTEs === null) {
-            $this->supportsCTEs = version_compare(
-                $this->version(),
-                $this->featuresToVersionMap[$this->serverType]['cte'],
-                '>='
-            );
-        }
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
 
-        return $this->supportsCTEs;
+        return $this->supports(static::FEATURE_CTE);
     }
 
     /**
      * Returns true if the server supports native JSON columns
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_JSON)` instead
      */
     public function supportsNativeJson(): bool
     {
-        if ($this->_supportsNativeJson === null) {
-            $this->_supportsNativeJson = version_compare(
-                $this->version(),
-                $this->featuresToVersionMap[$this->serverType]['json'],
-                '>='
-            );
-        }
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
 
-        return $this->_supportsNativeJson;
+        return $this->supports(static::FEATURE_JSON);
     }
 
     /**
      * Returns true if the connected server supports window functions.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_WINDOW)` instead
      */
     public function supportsWindowFunctions(): bool
     {
-        if ($this->_supportsWindowFunctions === null) {
-            $this->_supportsWindowFunctions = version_compare(
-                $this->version(),
-                $this->featuresToVersionMap[$this->serverType]['window'],
-                '>='
-            );
-        }
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
 
-        return $this->_supportsWindowFunctions;
+        return $this->supports(static::FEATURE_WINDOW);
     }
 }

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -80,11 +80,6 @@ class Postgres extends Driver
     protected $_endQuote = '"';
 
     /**
-     * @inheritDoc
-     */
-    protected $supportsCTEs = true;
-
-    /**
      * Establishes a connection to the database server
      *
      * @return bool true on success
@@ -188,6 +183,21 @@ class Postgres extends Driver
     public function enableForeignKeySQL(): string
     {
         return 'SET CONSTRAINTS ALL IMMEDIATE';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports(string $feature): bool
+    {
+        switch ($feature) {
+            case static::FEATURE_CTE:
+            case static::FEATURE_JSON:
+            case static::FEATURE_WINDOW:
+                return true;
+        }
+
+        return parent::supports($feature);
     }
 
     /**

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -100,6 +100,16 @@ class Sqlite extends Driver
     ];
 
     /**
+     * Mapping of feature to db server version for feature availability checks.
+     *
+     * @var array
+     */
+    protected $featureVersions = [
+        'cte' => '3.8.3',
+        'window' => '3.25.0',
+    ];
+
+    /**
      * Establishes a connection to the database server
      *
      * @return bool true on success
@@ -190,6 +200,24 @@ class Sqlite extends Driver
     public function enableForeignKeySQL(): string
     {
         return 'PRAGMA foreign_keys = ON';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports(string $feature): bool
+    {
+        switch ($feature) {
+            case static::FEATURE_CTE:
+            case static::FEATURE_WINDOW:
+                return version_compare(
+                    $this->version(),
+                    $this->featureVersions[$feature],
+                    '>='
+                );
+        }
+
+        return parent::supports($feature);
     }
 
     /**
@@ -308,27 +336,25 @@ class Sqlite extends Driver
      * Returns true if the server supports common table expressions.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_CTE)` instead
      */
     public function supportsCTEs(): bool
     {
-        if ($this->supportsCTEs === null) {
-            $this->supportsCTEs = version_compare($this->version(), '3.8.3', '>=');
-        }
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
 
-        return $this->supportsCTEs;
+        return $this->supports(static::FEATURE_CTE);
     }
 
     /**
      * Returns true if the connected server supports window functions.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_WINDOW)` instead
      */
     public function supportsWindowFunctions(): bool
     {
-        if ($this->_supportsWindowFunctions === null) {
-            $this->_supportsWindowFunctions = version_compare($this->version(), '3.25.0', '>=');
-        }
+        deprecationWarning('Feature support checks are now implemented by `supports()` with FEATURE_* constants.');
 
-        return $this->_supportsWindowFunctions;
+        return $this->supports(static::FEATURE_WINDOW);
     }
 }

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -99,11 +99,6 @@ class Sqlserver extends Driver
     protected $_endQuote = ']';
 
     /**
-     * @inheritDoc
-     */
-    protected $supportsCTEs = true;
-
-    /**
      * Establishes a connection to the database server.
      *
      * Please note that the PDO::ATTR_PERSISTENT attribute is not supported by
@@ -264,6 +259,25 @@ class Sqlserver extends Driver
     public function enableForeignKeySQL(): string
     {
         return 'EXEC sp_MSforeachtable "ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all"';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports(string $feature): bool
+    {
+        switch ($feature) {
+            case static::FEATURE_CTE:
+            case static::FEATURE_WINDOW:
+                return true;
+
+            case static::FEATURE_QUOTE:
+                $this->connect();
+
+                return $this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc';
+        }
+
+        return parent::supports($feature);
     }
 
     /**

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -25,9 +25,45 @@ use Closure;
  *
  * @method int|null getMaxAliasLength() Returns the maximum alias length allowed.
  * @method int getConnectRetries() Returns the number of connection retry attempts made.
+ * @method bool supports(string $feature) Checks whether a feature is supported by the driver.
  */
 interface DriverInterface
 {
+    /**
+     * Common Table Expressions (with clause) support.
+     *
+     * @var string
+     */
+    public const FEATURE_CTE = 'cte';
+
+    /**
+     * Native JSON data type support.
+     *
+     * @var string
+     */
+    public const FEATURE_JSON = 'json';
+
+    /**
+     * PDO::quote() support.
+     *
+     * @var string
+     */
+    public const FEATURE_QUOTE = 'quote';
+
+    /**
+     * Transaction savepoint support.
+     *
+     * @var string
+     */
+    public const FEATURE_SAVEPOINT = 'savepoint';
+
+    /**
+     * Window function support (all or partial clauses).
+     *
+     * @var string
+     */
+    public const FEATURE_WINDOW = 'window';
+
     /**
      * Establishes a connection to the database server.
      *
@@ -144,6 +180,7 @@ interface DriverInterface
      * Returns whether this driver supports save points for nested transactions.
      *
      * @return bool True if save points are supported, false otherwise.
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_SAVEPOINT)` instead
      */
     public function supportsSavePoints(): bool;
 
@@ -160,6 +197,7 @@ interface DriverInterface
      * Checks if the driver supports quoting.
      *
      * @return bool
+     * @deprecated 4.3.0 Use `supports(DriverInterface::FEATURE_QUOTE)` instead
      */
     public function supportsQuoting(): bool;
 

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\DriverInterface;
 use Cake\Database\Exception\DatabaseException;
 
 /**
@@ -338,7 +339,7 @@ class MysqlSchemaDialect extends SchemaDialect
         }
 
         $out = $this->_driver->quoteIdentifier($name);
-        $nativeJson = $this->_driver->supportsNativeJson();
+        $nativeJson = $this->_driver->supports(DriverInterface::FEATURE_JSON);
 
         $typeMap = [
             TableSchema::TYPE_TINYINTEGER => ' TINYINT',

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\DriverInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
@@ -203,5 +204,60 @@ class MysqlTest extends TestCase
             ['5.5.5-10.4.13-MariaDB-1:10.4.13+maria~focal', '10.4.13-MariaDB-1'],
             ['8.0.0', '8.0.0'],
         ];
+    }
+
+    /**
+     * Tests driver-specific feature support check.
+     */
+    public function testSupports(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Mysql);
+
+        $serverType = $driver->isMariadb() ? 'mariadb' : 'mysql';
+        $featureVersions = [
+            'mysql' => [
+                'json' => '5.7.0',
+                'cte' => '8.0.0',
+                'window' => '8.0.0',
+            ],
+            'mariadb' => [
+                'json' => '10.2.7',
+                'cte' => '10.2.1',
+                'window' => '10.2.0',
+            ],
+        ];
+
+        $this->assertSame(
+            version_compare($driver->version(), $featureVersions[$serverType]['cte'], '>='),
+            $driver->supports(DriverInterface::FEATURE_CTE)
+        );
+        $this->assertSame(
+            version_compare($driver->version(), $featureVersions[$serverType]['json'], '>='),
+            $driver->supports(DriverInterface::FEATURE_CTE)
+        );
+        $this->assertSame(
+            version_compare($driver->version(), $featureVersions[$serverType]['window'], '>='),
+            $driver->supports(DriverInterface::FEATURE_CTE)
+        );
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_QUOTE));
+
+        $this->assertFalse($driver->supports('this-is-fake'));
+    }
+
+    /**
+     * Tests driver-specific feature support check.
+     */
+    public function testDeprecatedSupports(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Mysql);
+
+        $this->deprecated(function () use ($driver) {
+            $this->assertSame($driver->supportsCTEs(), $driver->supports(DriverInterface::FEATURE_CTE));
+            $this->assertSame($driver->supportsNativeJson(), $driver->supports(DriverInterface::FEATURE_JSON));
+            $this->assertSame($driver->supportsWindowFunctions(), $driver->supports(DriverInterface::FEATURE_WINDOW));
+        });
     }
 }

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -16,7 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
+use Cake\Database\Driver\Postgres;
+use Cake\Database\DriverInterface;
 use Cake\Database\Query;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
 
@@ -236,5 +239,22 @@ class PostgresTest extends TestCase
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS "post_count" ' .
             'GROUP BY posts.author_id HAVING posts.author_id >= :c0';
         $this->assertSame($expected, $query->sql());
+    }
+
+    /**
+     * Tests driver-specific feature support check.
+     */
+    public function testSupports(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Postgres);
+
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_CTE));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_JSON));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_QUOTE));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_WINDOW));
+
+        $this->assertFalse($driver->supports('this-is-fake'));
     }
 }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Driver;
 
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\DriverInterface;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
@@ -530,5 +531,22 @@ class SqlserverTest extends TestCase
             'Exceeded maximum number of parameters (2100) for prepared statements in Sql Server'
         );
         $connection->getDriver()->prepare($query);
+    }
+
+    /**
+     * Tests driver-specific feature support check.
+     */
+    public function testSupports(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Sqlserver);
+
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_CTE));
+        $this->assertFalse($driver->supports(DriverInterface::FEATURE_JSON));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_SAVEPOINT));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_QUOTE));
+        $this->assertTrue($driver->supports(DriverInterface::FEATURE_WINDOW));
+
+        $this->assertFalse($driver->supports('this-is-fake'));
     }
 }

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\DriverInterface;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
@@ -82,34 +83,30 @@ class DriverTest extends TestCase
     }
 
     /**
-     * Test supportsSavePoints().
+     * Tests default implementation of feature support check.
      */
-    public function testSupportsSavePoints(): void
+    public function testSupports(): void
     {
-        $result = $this->driver->supportsSavePoints();
-        $this->assertTrue($result);
+        $this->assertTrue($this->driver->supports(DriverInterface::FEATURE_SAVEPOINT));
+        $this->assertTrue($this->driver->supports(DriverInterface::FEATURE_QUOTE));
+
+        $this->assertFalse($this->driver->supports(DriverInterface::FEATURE_CTE));
+        $this->assertFalse($this->driver->supports(DriverInterface::FEATURE_JSON));
+        $this->assertFalse($this->driver->supports(DriverInterface::FEATURE_WINDOW));
+
+        $this->assertFalse($this->driver->supports('this-is-fake'));
     }
 
     /**
-     * Test supportsQuoting().
+     * Tests deprecated supports checks.
      */
-    public function testSupportsQuoting(): void
+    public function testDeprecatedSupports(): void
     {
-        $connection = $this->getMockBuilder(PDO::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getAttribute'])
-            ->getMock();
-
-        $connection
-            ->expects($this->once())
-            ->method('getAttribute')
-            ->with(PDO::ATTR_DRIVER_NAME)
-            ->willReturn('mysql');
-
-        $this->driver->setConnection($connection);
-
-        $result = $this->driver->supportsQuoting();
-        $this->assertTrue($result);
+        $this->deprecated(function () {
+            $this->assertSame($this->driver->supportsCTEs(), $this->driver->supports(DriverInterface::FEATURE_CTE));
+            $this->assertSame($this->driver->supportsSavePoints(), $this->driver->supports(DriverInterface::FEATURE_SAVEPOINT));
+            $this->assertSame($this->driver->supportsQuoting(), $this->driver->supports(DriverInterface::FEATURE_QUOTE));
+        });
     }
 
     /**

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTests.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\QueryTests;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\DriverInterface;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query;
@@ -52,7 +53,7 @@ class CommonTableExpressionQueryTests extends TestCase
         $this->autoQuote = $this->connection->getDriver()->isAutoQuotingEnabled();
 
         $this->skipIf(
-            !$this->connection->getDriver()->supportsCTEs(),
+            !$this->connection->getDriver()->supports(DriverInterface::FEATURE_CTE),
             'The current driver does not support common table expressions.'
         );
     }

--- a/tests/TestCase/Database/QueryTests/WindowQueryTests.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTests.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\QueryTests;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\DriverInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\Query;
@@ -60,7 +61,7 @@ class WindowQueryTests extends TestCase
             $driver instanceof Mysql ||
             $driver instanceof Sqlite
         ) {
-            $this->skipTests = !$this->connection->getDriver()->supportsWindowFunctions();
+            $this->skipTests = !$this->connection->getDriver()->supports(DriverInterface::FEATURE_WINDOW);
         } else {
             $this->skipTests = false;
         }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Schema;
 
 use Cake\Database\Driver;
 use Cake\Database\Driver\Mysql;
+use Cake\Database\DriverInterface;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\MysqlSchemaDialect;
 use Cake\Database\Schema\TableSchema;
@@ -289,7 +290,7 @@ SQL;
 SQL;
         $connection->execute($table);
 
-        if ($connection->getDriver()->supportsNativeJson()) {
+        if ($connection->getDriver()->supports(DriverInterface::FEATURE_JSON)) {
             $table = <<<SQL
                 CREATE TABLE schema_json (
                     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -1329,7 +1330,7 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-        $this->skipIf(!$connection->getDriver()->supportsNativeJson(), 'Does not support native json');
+        $this->skipIf(!$connection->getDriver()->supports(DriverInterface::FEATURE_JSON), 'Does not support native json');
         $this->skipIf($connection->getDriver()->isMariadb(), 'MariaDb internally uses TEXT for JSON columns');
 
         $schema = new SchemaCollection($connection);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -21,6 +21,7 @@ use Cake\Collection\Collection;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
+use Cake\Database\DriverInterface;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
@@ -3876,7 +3877,7 @@ class QueryTest extends TestCase
     public function testWith(): void
     {
         $this->skipIf(
-            !$this->connection->getDriver()->supportsCTEs(),
+            !$this->connection->getDriver()->supports(DriverInterface::FEATURE_CTE),
             'The current driver does not support common table expressions.'
         );
         $this->skipIf(
@@ -3884,7 +3885,7 @@ class QueryTest extends TestCase
                 $this->connection->getDriver() instanceof Mysql ||
                 $this->connection->getDriver() instanceof Sqlite
             ) &&
-            !$this->connection->getDriver()->supportsWindowFunctions(),
+            !$this->connection->getDriver()->supports(DriverInterface::FEATURE_WINDOW),
             'The current driver does not support window functions.'
         );
 


### PR DESCRIPTION
We often have the problem of adding new features that are conditionally supported. This requires a new function added to the common interface which is always a BC or awkward for type annotations.

I would like to add `DriverInterface::supports()` which accepts a string with the feature name. This allows supporting arbitrary features in a few drivers without affecting the API for all drivers.

The default implementation in Driver would return false for unknown features which is how you'd expect untested/unsupported features to work.

The core features are defined in `DriverInterface` as constants which does not cause a BC and can be updated without further BC.

Users can define their own feature names without interfering with any core code.
