### PR TITLE
cake 5: Add native type hints for ORM properties

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -96,21 +96,21 @@ abstract class Association
      *
      * @var string
      */
-    protected $_name;
+    protected string $_name;
 
     /**
      * The class name of the target table object
      *
      * @var string
      */
-    protected $_className;
+    protected string $_className;
 
     /**
      * The field name in the owning side table that is used to match with the foreignKey
      *
      * @var array<string>|string|null
      */
-    protected $_bindingKey;
+    protected array|string|null $_bindingKey = null;
 
     /**
      * The name of the field representing the foreign key to the table to load
@@ -125,7 +125,7 @@ abstract class Association
      *
      * @var \Closure|array
      */
-    protected $_conditions = [];
+    protected Closure|array $_conditions = [];
 
     /**
      * Whether the records on the target table are dependent on the source table,
@@ -134,14 +134,14 @@ abstract class Association
      *
      * @var bool
      */
-    protected $_dependent = false;
+    protected bool $_dependent = false;
 
     /**
      * Whether or not cascaded deletes should also fire callbacks.
      *
      * @var bool
      */
-    protected $_cascadeCallbacks = false;
+    protected bool $_cascadeCallbacks = false;
 
     /**
      * Source table instance
@@ -162,7 +162,7 @@ abstract class Association
      *
      * @var string
      */
-    protected $_joinType = Query::JOIN_TYPE_LEFT;
+    protected string $_joinType = Query::JOIN_TYPE_LEFT;
 
     /**
      * The property name that should be filled with data from the target table
@@ -178,7 +178,7 @@ abstract class Association
      *
      * @var string
      */
-    protected $_strategy = self::STRATEGY_JOIN;
+    protected string $_strategy = self::STRATEGY_JOIN;
 
     /**
      * The default finder name to use for fetching rows from the target table
@@ -186,14 +186,14 @@ abstract class Association
      *
      * @var array|string
      */
-    protected $_finder = 'all';
+    protected array|string $_finder = 'all';
 
     /**
      * Valid strategies for this association. Subclasses can narrow this down.
      *
      * @var array<string>
      */
-    protected $_validStrategies = [
+    protected array $_validStrategies = [
         self::STRATEGY_JOIN,
         self::STRATEGY_SELECT,
         self::STRATEGY_SUBQUERY,

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -38,7 +38,7 @@ class BelongsTo extends Association
      *
      * @var array<string>
      */
-    protected $_validStrategies = [
+    protected array $_validStrategies = [
         self::STRATEGY_JOIN,
         self::STRATEGY_SELECT,
     ];

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -58,14 +58,14 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected $_joinType = Query::JOIN_TYPE_INNER;
+    protected string $_joinType = Query::JOIN_TYPE_INNER;
 
     /**
      * The strategy name to be used to fetch associated records.
      *
      * @var string
      */
-    protected $_strategy = self::STRATEGY_SELECT;
+    protected string $_strategy = self::STRATEGY_SELECT;
 
     /**
      * Junction table instance
@@ -79,7 +79,7 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected $_junctionTableName;
+    protected string $_junctionTableName;
 
     /**
      * The name of the hasMany association from the target table
@@ -95,21 +95,21 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected $_junctionProperty = '_joinData';
+    protected string $_junctionProperty = '_joinData';
 
     /**
      * Saving strategy to be used by this association
      *
      * @var string
      */
-    protected $_saveStrategy = self::SAVE_REPLACE;
+    protected string $_saveStrategy = self::SAVE_REPLACE;
 
     /**
      * The name of the field representing the foreign key to the target table
      *
      * @var array<string>|string|null
      */
-    protected $_targetForeignKey;
+    protected array|string|null $_targetForeignKey = null;
 
     /**
      * The table instance for the junction relation.
@@ -123,7 +123,7 @@ class BelongsToMany extends Association
      *
      * @var array<string>
      */
-    protected $_validStrategies = [
+    protected array $_validStrategies = [
         self::STRATEGY_SELECT,
         self::STRATEGY_SUBQUERY,
     ];
@@ -136,28 +136,28 @@ class BelongsToMany extends Association
      *
      * @var bool
      */
-    protected $_dependent = true;
+    protected bool $_dependent = true;
 
     /**
      * Filtered conditions that reference the target table.
      *
      * @var array|null
      */
-    protected $_targetConditions;
+    protected ?array $_targetConditions = null;
 
     /**
      * Filtered conditions that reference the junction table.
      *
      * @var array|null
      */
-    protected $_junctionConditions;
+    protected ?array $_junctionConditions = null;
 
     /**
      * Order in which target records should be returned
      *
      * @var mixed
      */
-    protected $_sort;
+    protected mixed $_sort = null;
 
     /**
      * Sets the name of the field representing the foreign key to the target table.

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -41,28 +41,28 @@ class HasMany extends Association
      *
      * @var mixed
      */
-    protected $_sort;
+    protected mixed $_sort = null;
 
     /**
      * The type of join to be used when adding the association to a query
      *
      * @var string
      */
-    protected $_joinType = Query::JOIN_TYPE_INNER;
+    protected string $_joinType = Query::JOIN_TYPE_INNER;
 
     /**
      * The strategy name to be used to fetch associated records.
      *
      * @var string
      */
-    protected $_strategy = self::STRATEGY_SELECT;
+    protected string $_strategy = self::STRATEGY_SELECT;
 
     /**
      * Valid strategies for this type of association
      *
      * @var array<string>
      */
-    protected $_validStrategies = [
+    protected array $_validStrategies = [
         self::STRATEGY_SELECT,
         self::STRATEGY_SUBQUERY,
     ];
@@ -86,7 +86,7 @@ class HasMany extends Association
      *
      * @var string
      */
-    protected $_saveStrategy = self::SAVE_APPEND;
+    protected string $_saveStrategy = self::SAVE_APPEND;
 
     /**
      * Returns whether or not the passed table is the owning side for this

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -36,7 +36,7 @@ class HasOne extends Association
      *
      * @var array<string>
      */
-    protected $_validStrategies = [
+    protected array $_validStrategies = [
         self::STRATEGY_JOIN,
         self::STRATEGY_SELECT,
     ];

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -37,42 +37,42 @@ class SelectLoader
      *
      * @var string
      */
-    protected $alias;
+    protected string $alias;
 
     /**
      * The alias of the source association
      *
      * @var string
      */
-    protected $sourceAlias;
+    protected string $sourceAlias;
 
     /**
      * The alias of the target association
      *
      * @var string
      */
-    protected $targetAlias;
+    protected string $targetAlias;
 
     /**
      * The foreignKey to the target association
      *
      * @var array|string
      */
-    protected $foreignKey;
+    protected array|string $foreignKey;
 
     /**
      * The strategy to use for loading, either select or subquery
      *
      * @var string
      */
-    protected $strategy;
+    protected string $strategy;
 
     /**
      * The binding key for the source association.
      *
-     * @var string
+     * @var array|string
      */
-    protected $bindingKey;
+    protected array|string $bindingKey;
 
     /**
      * A callable that will return a query object used for loading the association results
@@ -86,14 +86,14 @@ class SelectLoader
      *
      * @var string
      */
-    protected $associationType;
+    protected string $associationType;
 
     /**
      * The sorting options for loading the association
      *
-     * @var string
+     * @var array|string|null
      */
-    protected $sort;
+    protected array|string|null $sort = null;
 
     /**
      * Copies the options array to properties in this class. The keys in the array correspond

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -16,7 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association\Loader;
 
+use Cake\Database\ExpressionInterface;
+use Cake\ORM\Association\HasMany;
 use Cake\ORM\Query;
+use Closure;
 use RuntimeException;
 
 /**
@@ -31,28 +34,28 @@ class SelectWithPivotLoader extends SelectLoader
      *
      * @var string
      */
-    protected $junctionAssociationName;
+    protected string $junctionAssociationName;
 
     /**
      * The property name for the junction association, where its results should be nested at.
      *
      * @var string
      */
-    protected $junctionProperty;
+    protected string $junctionProperty;
 
     /**
      * The junction association instance
      *
      * @var \Cake\ORM\Association\HasMany
      */
-    protected $junctionAssoc;
+    protected HasMany $junctionAssoc;
 
     /**
      * Custom conditions for the junction association
      *
      * @var \Cake\Database\ExpressionInterface|\Closure|array|string|null
      */
-    protected $junctionConditions;
+    protected ExpressionInterface|Closure|array|string|null $junctionConditions = null;
 
     /**
      * @inheritDoc

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -40,7 +40,7 @@ class AssociationCollection implements IteratorAggregate
      *
      * @var array<\Cake\ORM\Association>
      */
-    protected $_items = [];
+    protected array $_items = [];
 
     /**
      * Constructor.

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -121,7 +121,7 @@ class Behavior implements EventListenerInterface
      *
      * @var \Cake\ORM\Table
      */
-    protected $_table;
+    protected Table $_table;
 
     /**
      * Reflection method cache for behaviors.
@@ -131,7 +131,7 @@ class Behavior implements EventListenerInterface
      *
      * @var array
      */
-    protected static $_reflectionCache = [];
+    protected static array $_reflectionCache = [];
 
     /**
      * Default configuration
@@ -140,7 +140,7 @@ class Behavior implements EventListenerInterface
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [];
+    protected array $_defaultConfig = [];
 
     /**
      * Constructor

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -108,7 +108,7 @@ class CounterCacheBehavior extends Behavior
      *
      * @var array
      */
-    protected $_ignoreDirty = [];
+    protected array $_ignoreDirty = [];
 
     /**
      * beforeSave callback.

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -46,7 +46,7 @@ class TimestampBehavior extends Behavior
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'implementedFinders' => [],
         'implementedMethods' => [
             'timestamp' => 'timestamp',
@@ -66,7 +66,7 @@ class TimestampBehavior extends Behavior
      *
      * @var \Cake\I18n\DateTime|null
      */
-    protected $_ts;
+    protected ?DateTime $_ts = null;
 
     /**
      * Initialize hook

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -54,7 +54,7 @@ class EavStrategy implements TranslateStrategyInterface
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fields' => [],
         'translationTable' => 'I18n',
         'defaultLocale' => null,

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -47,7 +47,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'fields' => [],
         'defaultLocale' => null,
         'referenceName' => null,

--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -32,7 +32,7 @@ trait TranslateStrategyTrait
      *
      * @var \Cake\ORM\Table
      */
-    protected $table;
+    protected Table $table;
 
     /**
      * The locale name that will be used to override fields in the bound table
@@ -40,14 +40,14 @@ trait TranslateStrategyTrait
      *
      * @var string|null
      */
-    protected $locale;
+    protected ?string $locale = null;
 
     /**
      * Instance of Table responsible for translating
      *
      * @var \Cake\ORM\Table
      */
-    protected $translationTable;
+    protected Table $translationTable;
 
     /**
      * Return translation table instance.

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -47,7 +47,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'implementedFinders' => ['translations' => 'findTranslations'],
         'implementedMethods' => [
             'setLocale' => 'setLocale',
@@ -70,14 +70,14 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * @var string
      * @psalm-var class-string<\Cake\ORM\Behavior\Translate\TranslateStrategyInterface>
      */
-    protected static $defaultStrategyClass = EavStrategy::class;
+    protected static string $defaultStrategyClass = EavStrategy::class;
 
     /**
      * Translation strategy instance.
      *
      * @var \Cake\ORM\Behavior\Translate\TranslateStrategyInterface|null
      */
-    protected $strategy;
+    protected ?TranslateStrategyInterface $strategy = null;
 
     /**
      * Constructor

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -45,7 +45,7 @@ class TreeBehavior extends Behavior
      *
      * @var string
      */
-    protected $_primaryKey;
+    protected string $_primaryKey = '';
 
     /**
      * Default config
@@ -54,7 +54,7 @@ class TreeBehavior extends Behavior
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'implementedFinders' => [
             'path' => 'findPath',
             'children' => 'findChildren',

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -41,21 +41,21 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
      *
      * @var \Cake\ORM\Table
      */
-    protected $_table;
+    protected Table $_table;
 
     /**
      * Method mappings.
      *
      * @var array
      */
-    protected $_methodMap = [];
+    protected array $_methodMap = [];
 
     /**
      * Finder method mappings.
      *
      * @var array
      */
-    protected $_finderMap = [];
+    protected array $_finderMap = [];
 
     /**
      * Constructor

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -33,21 +33,21 @@ class EagerLoadable
      *
      * @var string
      */
-    protected $_name;
+    protected string $_name;
 
     /**
      * A list of other associations to load from this level.
      *
      * @var array<\Cake\ORM\EagerLoadable>
      */
-    protected $_associations = [];
+    protected array $_associations = [];
 
     /**
      * The Association class instance to use for loading the records.
      *
      * @var \Cake\ORM\Association|null
      */
-    protected $_instance;
+    protected ?Association $_instance = null;
 
     /**
      * A list of options to pass to the association object for loading
@@ -55,7 +55,7 @@ class EagerLoadable
      *
      * @var array
      */
-    protected $_config = [];
+    protected array $_config = [];
 
     /**
      * A dotted separated string representing the path of associations
@@ -63,7 +63,7 @@ class EagerLoadable
      *
      * @var string
      */
-    protected $_aliasPath;
+    protected string $_aliasPath;
 
     /**
      * A dotted separated string representing the path of entity properties
@@ -79,14 +79,14 @@ class EagerLoadable
      *
      * @var string|null
      */
-    protected $_propertyPath;
+    protected ?string $_propertyPath = null;
 
     /**
      * Whether or not this level can be fetched using a join.
      *
      * @var bool
      */
-    protected $_canBeJoined = false;
+    protected bool $_canBeJoined = false;
 
     /**
      * Whether or not this level was meant for a "matching" fetch
@@ -94,7 +94,7 @@ class EagerLoadable
      *
      * @var bool|null
      */
-    protected $_forMatching;
+    protected ?bool $_forMatching = null;
 
     /**
      * The property name where the association result should be nested
@@ -110,7 +110,7 @@ class EagerLoadable
      *
      * @var string|null
      */
-    protected $_targetProperty;
+    protected ?string $_targetProperty = null;
 
     /**
      * Constructor. The $config parameter accepts the following array

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -36,7 +36,7 @@ class EagerLoader
      *
      * @var array
      */
-    protected $_containments = [];
+    protected array $_containments = [];
 
     /**
      * Contains a nested array with the compiled containments tree
@@ -44,7 +44,7 @@ class EagerLoader
      *
      * @var \Cake\ORM\EagerLoadable|array<\Cake\ORM\EagerLoadable>|null
      */
-    protected $_normalized;
+    protected EagerLoadable|array|null $_normalized = null;
 
     /**
      * List of options accepted by associations in contain()
@@ -52,7 +52,7 @@ class EagerLoader
      *
      * @var array
      */
-    protected $_containOptions = [
+    protected array $_containOptions = [
         'associations' => 1,
         'foreignKey' => 1,
         'conditions' => 1,
@@ -71,21 +71,21 @@ class EagerLoader
      *
      * @var array<\Cake\ORM\EagerLoadable>
      */
-    protected $_loadExternal = [];
+    protected array $_loadExternal = [];
 
     /**
      * Contains a list of the association names that are to be eagerly loaded
      *
      * @var array
      */
-    protected $_aliasList = [];
+    protected array $_aliasList = [];
 
     /**
      * Another EagerLoader instance that will be used for 'matching' associations.
      *
      * @var \Cake\ORM\EagerLoader|null
      */
-    protected $_matching;
+    protected ?EagerLoader $_matching = null;
 
     /**
      * A map of table aliases pointing to the association objects they represent
@@ -93,7 +93,7 @@ class EagerLoader
      *
      * @var array
      */
-    protected $_joinsMap = [];
+    protected array $_joinsMap = [];
 
     /**
      * Controls whether or not fields from associated tables
@@ -102,7 +102,7 @@ class EagerLoader
      *
      * @var bool
      */
-    protected $_autoFields = true;
+    protected bool $_autoFields = true;
 
     /**
      * Sets the list of associations that should be eagerly loaded along for a

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -29,7 +29,7 @@ class PersistenceFailedException extends CakeException
      *
      * @var \Cake\Datasource\EntityInterface
      */
-    protected $_entity;
+    protected EntityInterface $_entity;
 
     /**
      * @inheritDoc

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -28,7 +28,7 @@ trait LocatorAwareTrait
      *
      * @var \Cake\ORM\Locator\LocatorInterface|null
      */
-    protected $_tableLocator;
+    protected ?LocatorInterface $_tableLocator = null;
 
     /**
      * Sets the table locator.

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -36,14 +36,14 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      *
      * @var array
      */
-    protected $locations = [];
+    protected array $locations = [];
 
     /**
      * Configuration for aliases.
      *
      * @var array
      */
-    protected $_config = [];
+    protected array $_config = [];
 
     /**
      * Instances that belong to the registry.
@@ -58,7 +58,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      *
      * @var array<\Cake\ORM\Table>
      */
-    protected $_fallbacked = [];
+    protected array $_fallbacked = [];
 
     /**
      * Fallback class to use
@@ -66,14 +66,14 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      * @var string
      * @psalm-var class-string<\Cake\ORM\Table>
      */
-    protected $fallbackClassName = Table::class;
+    protected string $fallbackClassName = Table::class;
 
     /**
      * Whether fallback class should be used if a table class could not be found.
      *
      * @var bool
      */
-    protected $allowFallbackClass = true;
+    protected bool $allowFallbackClass = true;
 
     /**
      * Constructor.

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -45,7 +45,7 @@ class Marshaller
      *
      * @var \Cake\ORM\Table
      */
-    protected $_table;
+    protected Table $_table;
 
     /**
      * Constructor.

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -75,7 +75,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @var bool|null
      */
-    protected $_hasFields;
+    protected ?bool $_hasFields = null;
 
     /**
      * Tracks whether or not the original query should include
@@ -83,21 +83,21 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @var bool|null
      */
-    protected $_autoFields;
+    protected ?bool $_autoFields = null;
 
     /**
      * Whether to hydrate results into entity objects
      *
      * @var bool
      */
-    protected $_hydrate = true;
+    protected bool $_hydrate = true;
 
     /**
      * Whether aliases are generated for fields.
      *
      * @var bool
      */
-    protected $aliasingEnabled = true;
+    protected bool $aliasingEnabled = true;
 
     /**
      * A callable function that can be used to calculate the total amount of
@@ -113,14 +113,14 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @var \Cake\ORM\EagerLoader|null
      */
-    protected $_eagerLoader;
+    protected ?EagerLoader $_eagerLoader = null;
 
     /**
      * True if the beforeFind event has already been triggered for this query
      *
      * @var bool
      */
-    protected $_beforeFindFired = false;
+    protected bool $_beforeFindFired = false;
 
     /**
      * The COUNT(*) for the query.
@@ -129,7 +129,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @var int|null
      */
-    protected $_resultsCount;
+    protected ?int $_resultsCount = null;
 
     /**
      * Constructor

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -18,6 +18,7 @@ namespace Cake\ORM;
 
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionTrait;
+use Cake\Database\DriverInterface;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\EntityInterface;
@@ -37,37 +38,37 @@ class ResultSet implements ResultSetInterface
     /**
      * Database statement holding the results
      *
-     * @var \Cake\Database\StatementInterface
+     * @var \Cake\Database\StatementInterface|null
      */
-    protected $_statement;
+    protected ?StatementInterface $_statement = null;
 
     /**
      * Points to the next record number that should be fetched
      *
      * @var int
      */
-    protected $_index = 0;
+    protected int $_index = 0;
 
     /**
      * Last record fetched from the statement
      *
      * @var \Cake\Datasource\EntityInterface|array
      */
-    protected $_current;
+    protected EntityInterface|array $_current = [];
 
     /**
      * Default table instance
      *
      * @var \Cake\ORM\Table
      */
-    protected $_defaultTable;
+    protected Table $_defaultTable;
 
     /**
      * The default table alias
      *
      * @var string
      */
-    protected $_defaultAlias;
+    protected string $_defaultAlias;
 
     /**
      * List of associations that should be placed under the `_matchingData`
@@ -75,14 +76,14 @@ class ResultSet implements ResultSetInterface
      *
      * @var array
      */
-    protected $_matchingMap = [];
+    protected array $_matchingMap = [];
 
     /**
      * List of associations that should be eager loaded.
      *
      * @var array
      */
-    protected $_containMap = [];
+    protected array $_containMap = [];
 
     /**
      * Map of fields that are fetched from the statement with
@@ -90,7 +91,7 @@ class ResultSet implements ResultSetInterface
      *
      * @var array
      */
-    protected $_map = [];
+    protected array $_map = [];
 
     /**
      * List of matching associations and the column keys to expect
@@ -98,49 +99,49 @@ class ResultSet implements ResultSetInterface
      *
      * @var array
      */
-    protected $_matchingMapColumns = [];
+    protected array $_matchingMapColumns = [];
 
     /**
      * Results that have been fetched or hydrated into the results.
      *
      * @var \SplFixedArray|array
      */
-    protected $_results = [];
+    protected SplFixedArray|array $_results = [];
 
     /**
      * Whether to hydrate results into objects or not
      *
      * @var bool
      */
-    protected $_hydrate = true;
+    protected bool $_hydrate = true;
 
     /**
      * Tracks value of $_autoFields property of $query passed to constructor.
      *
      * @var bool|null
      */
-    protected $_autoFields;
+    protected ?bool $_autoFields = null;
 
     /**
      * The fully namespaced name of the class to use for hydrating results
      *
      * @var string
      */
-    protected $_entityClass;
+    protected string $_entityClass;
 
     /**
      * Whether or not to buffer results fetched from the statement
      *
      * @var bool
      */
-    protected $_useBuffering = true;
+    protected bool $_useBuffering = true;
 
     /**
      * Holds the count of records in this result set
      *
-     * @var int
+     * @var int|null
      */
-    protected $_count;
+    protected ?int $_count = null;
 
     /**
      * The Database driver object.
@@ -149,7 +150,7 @@ class ResultSet implements ResultSetInterface
      *
      * @var \Cake\Database\DriverInterface
      */
-    protected $_driver;
+    protected DriverInterface $_driver;
 
     /**
      * Constructor
@@ -257,8 +258,11 @@ class ResultSet implements ResultSetInterface
             }
         }
 
-        $this->_current = $this->_fetchResult();
-        $valid = $this->_current !== false;
+        $current = $this->_fetchResult();
+        $valid = $current !== false;
+        if ($valid) {
+            $this->_current = $current;
+        }
 
         if ($valid && $this->_useBuffering) {
             $this->_results[$this->_index] = $this->_current;

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -32,21 +32,21 @@ class ExistsIn
      *
      * @var array
      */
-    protected $_fields;
+    protected array $_fields;
 
     /**
      * The repository where the field will be looked for
      *
      * @var \Cake\ORM\Table|\Cake\ORM\Association|string
      */
-    protected $_repository;
+    protected Table|Association|string $_repository;
 
     /**
      * Options for the constructor
      *
      * @var array
      */
-    protected $_options = [];
+    protected array $_options = [];
 
     /**
      * Constructor.

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -29,14 +29,14 @@ class IsUnique
      *
      * @var array<string>
      */
-    protected $_fields;
+    protected array $_fields;
 
     /**
      * The unique check options
      *
      * @var array
      */
-    protected $_options = [
+    protected array $_options = [
         'allowMultipleNulls' => false,
     ];
 

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -46,14 +46,14 @@ class LinkConstraint
      *
      * @var \Cake\ORM\Association|string
      */
-    protected $_association;
+    protected Association|string $_association;
 
     /**
      * The link status that is required to be present in order for the check to succeed.
      *
      * @var string
      */
-    protected $_requiredLinkState;
+    protected string $_requiredLinkState;
 
     /**
      * Constructor.

--- a/src/ORM/Rule/ValidCount.php
+++ b/src/ORM/Rule/ValidCount.php
@@ -30,7 +30,7 @@ class ValidCount
      *
      * @var string
      */
-    protected $_field;
+    protected string $_field;
 
     /**
      * Constructor.

--- a/src/ORM/SaveOptionsBuilder.php
+++ b/src/ORM/SaveOptionsBuilder.php
@@ -36,14 +36,14 @@ class SaveOptionsBuilder extends ArrayObject
      *
      * @var array
      */
-    protected $_options = [];
+    protected array $_options = [];
 
     /**
      * Table object.
      *
      * @var \Cake\ORM\Table
      */
-    protected $_table;
+    protected Table $_table;
 
     /**
      * Constructor.

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -191,7 +191,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @var string|null
      */
-    protected $_table;
+    protected ?string $_table = null;
 
     /**
      * Human name giving to this particular instance. Multiple objects representing
@@ -199,64 +199,64 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      *
      * @var string|null
      */
-    protected $_alias;
+    protected ?string $_alias = null;
 
     /**
      * Connection instance
      *
      * @var \Cake\Database\Connection|null
      */
-    protected $_connection;
+    protected ?Connection $_connection = null;
 
     /**
      * The schema object containing a description of this table fields
      *
      * @var \Cake\Database\Schema\TableSchemaInterface|null
      */
-    protected $_schema;
+    protected ?TableSchemaInterface $_schema = null;
 
     /**
      * The name of the field that represents the primary key in the table
      *
      * @var array<string>|string|null
      */
-    protected $_primaryKey;
+    protected array|string|null $_primaryKey = null;
 
     /**
      * The name of the field that represents a human readable representation of a row
      *
      * @var array<string>|string|null
      */
-    protected $_displayField;
+    protected array|string|null $_displayField = null;
 
     /**
      * The associations container for this Table.
      *
      * @var \Cake\ORM\AssociationCollection
      */
-    protected $_associations;
+    protected AssociationCollection $_associations;
 
     /**
      * BehaviorRegistry for this table
      *
      * @var \Cake\ORM\BehaviorRegistry
      */
-    protected $_behaviors;
+    protected BehaviorRegistry $_behaviors;
 
     /**
      * The name of the class that represent a single row for this table
      *
-     * @var string
-     * @psalm-var class-string<\Cake\Datasource\EntityInterface>
+     * @var string|null
+     * @psalm-var class-string<\Cake\Datasource\EntityInterface>|null
      */
-    protected $_entityClass;
+    protected ?string $_entityClass = null;
 
     /**
      * Registry key used to create this table object
      *
      * @var string|null
      */
-    protected $_registryAlias;
+    protected ?string $_registryAlias = null;
 
     /**
      * Initializes a new instance

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -211,7 +211,6 @@ class AssociationTest extends TestCase
     public function testInvalidTableFetchedFromRegistry(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->getTableLocator()->get('Test');
 
         $config = [
             'className' => TestTable::class,
@@ -223,6 +222,7 @@ class AssociationTest extends TestCase
             ])
             ->setConstructorArgs(['Test', $config])
             ->getMock();
+        $this->association->setSource($this->getTableLocator()->get('Test'));
 
         $this->association->getTarget();
     }

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Model/Table/TestPluginThreeCommentsTable.php
@@ -23,5 +23,5 @@ use Cake\ORM\Table;
  */
 class TestPluginThreeCommentsTable extends Table
 {
-    protected $_table = 'test_plugin_three_comments';
+    protected ?string $_table = 'test_plugin_three_comments';
 }

--- a/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/DuplicateBehavior.php
@@ -23,7 +23,7 @@ use Cake\ORM\Behavior;
  */
 class DuplicateBehavior extends Behavior
 {
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'implementedFinders' => [
             'children' => 'findChildren',
         ],

--- a/tests/test_app/TestApp/Model/Behavior/Test2Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test2Behavior.php
@@ -7,7 +7,7 @@ use Cake\ORM\Behavior;
 
 class Test2Behavior extends Behavior
 {
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'implementedFinders' => [
             'foo' => 'findFoo',
         ],

--- a/tests/test_app/TestApp/Model/Table/ContactsTable.php
+++ b/tests/test_app/TestApp/Model/Table/ContactsTable.php
@@ -8,30 +8,23 @@ use Cake\ORM\Table;
 class ContactsTable extends Table
 {
     /**
-     * Default schema
-     *
-     * @var array
-     */
-    protected $_schema = [
-        'id' => ['type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'],
-        'name' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
-        'email' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
-        'phone' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
-        'password' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
-        'published' => ['type' => 'date', 'null' => true, 'default' => null, 'length' => null],
-        'created' => ['type' => 'date', 'null' => '1', 'default' => '', 'length' => ''],
-        'updated' => ['type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null],
-        'age' => ['type' => 'integer', 'null' => '', 'default' => '', 'length' => null],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * Initializes the schema
      *
      * @param array $config
      */
     public function initialize(array $config): void
     {
-        $this->setSchema($this->_schema);
+        $this->setSchema([
+            'id' => ['type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'],
+            'name' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
+            'email' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
+            'phone' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
+            'password' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
+            'published' => ['type' => 'date', 'null' => true, 'default' => null, 'length' => null],
+            'created' => ['type' => 'date', 'null' => '1', 'default' => '', 'length' => ''],
+            'updated' => ['type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null],
+            'age' => ['type' => 'integer', 'null' => '', 'default' => '', 'length' => null],
+            '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+        ]);
     }
 }

--- a/tests/test_app/TestApp/Model/Table/MyUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/MyUsersTable.php
@@ -15,5 +15,5 @@ class MyUsersTable extends Table
      *
      * @var string
      */
-    protected $_table = 'users';
+    protected ?string $_table = 'users';
 }

--- a/tests/test_app/TestApp/Model/Table/PostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PostsTable.php
@@ -21,5 +21,5 @@ use Cake\ORM\Table;
 
 class PostsTable extends Table
 {
-    protected $_table = 'posts';
+    protected ?string $_table = 'posts';
 }

--- a/tests/test_app/TestApp/Model/Table/ValidateUsersTable.php
+++ b/tests/test_app/TestApp/Model/Table/ValidateUsersTable.php
@@ -8,31 +8,24 @@ use Cake\ORM\Table;
 class ValidateUsersTable extends Table
 {
     /**
-     * schema method
-     *
-     * @var array
-     */
-    protected $_schema = [
-        'id' => ['type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'],
-        'name' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
-        'email' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
-        'balance' => ['type' => 'float', 'null' => false, 'length' => 5, 'precision' => 2],
-        'cost_decimal' => ['type' => 'decimal', 'null' => false, 'length' => 6, 'precision' => 3],
-        'null_decimal' => ['type' => 'decimal', 'null' => false, 'length' => null, 'precision' => null],
-        'ratio' => ['type' => 'decimal', 'null' => false, 'length' => 10, 'precision' => 6],
-        'population' => ['type' => 'decimal', 'null' => false, 'length' => 15, 'precision' => 0],
-        'created' => ['type' => 'date', 'null' => '1', 'default' => '', 'length' => ''],
-        'updated' => ['type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * Initializes the schema
      *
      * @param array $config
      */
     public function initialize(array $config): void
     {
-        $this->setSchema($this->_schema);
+        $this->setSchema([
+            'id' => ['type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'],
+            'name' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
+            'email' => ['type' => 'string', 'null' => '', 'default' => '', 'length' => '255'],
+            'balance' => ['type' => 'float', 'null' => false, 'length' => 5, 'precision' => 2],
+            'cost_decimal' => ['type' => 'decimal', 'null' => false, 'length' => 6, 'precision' => 3],
+            'null_decimal' => ['type' => 'decimal', 'null' => false, 'length' => null, 'precision' => null],
+            'ratio' => ['type' => 'decimal', 'null' => false, 'length' => 10, 'precision' => 6],
+            'population' => ['type' => 'decimal', 'null' => false, 'length' => 15, 'precision' => 0],
+            'created' => ['type' => 'date', 'null' => '1', 'default' => '', 'length' => ''],
+            'updated' => ['type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null],
+            '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+        ]);
     }
 }


### PR DESCRIPTION
I gave up on Association. The keys and tables *must* have a value but cannot be null and are not initialized. 
