### PR TITLE
Deprecate Connection::supportsDynamicConstraints()

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -98,6 +98,11 @@
       <code>$request</code>
     </ArgumentTypeCoercion>
   </file>
+  <file src="src/Database/Connection.php">
+    <DeprecatedMethod occurrences="1">
+        <code>supportsDynamicConstraints</code>
+    </DeprecatedMethod>
+  </file>
   <file src="src/Database/Driver.php">
     <InvalidScalarArgument occurrences="2">
       <code>$value</code>

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -672,6 +672,7 @@ class Connection implements ConnectionInterface
      * to already created tables.
      *
      * @return bool true if driver supports dynamic constraints
+     * @deprecated 4.3.0 Fixtures no longer dynamically drop and create constraints.
      */
     public function supportsDynamicConstraints(): bool
     {

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -137,6 +137,7 @@ interface DriverInterface
      * to already created tables.
      *
      * @return bool True if driver supports dynamic constraints.
+     * @deprecated 4.3.0 Fixtures no longer dynamically drop and create constraints.
      */
     public function supportsDynamicConstraints(): bool;
 


### PR DESCRIPTION
Can we deprecate this function that's only used by the deprecated fixture system?

I didn't add a deprecation warning because I don't know if it will ruin phpunit test output and it's already part of a larger deprecated system.
