### PR TITLE
cake 5: Add missing native type hints

### DIFF
--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -91,7 +91,7 @@ class ZipIterator extends MultipleIterator implements CollectionInterface
      * @return array
      */
     #[ReturnTypeWillChange]
-    public function current()
+    public function current(): array
     {
         if ($this->_callback === null) {
             return parent::current();

--- a/src/Command/Helper/ProgressHelper.php
+++ b/src/Command/Helper/ProgressHelper.php
@@ -116,7 +116,7 @@ class ProgressHelper extends Helper
      * @param float|int $num The amount of progress to advance by.
      * @return $this
      */
-    public function increment($num = 1)
+    public function increment(float|int $num = 1)
     {
         $this->_progress = min(max(0, $this->_progress + $num), $this->_total);
 

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -101,7 +101,7 @@ class ConsoleInputOption
         string $short = '',
         string $help = '',
         bool $isBoolean = false,
-        $default = null,
+        mixed $default = null,
         array $choices = [],
         bool $multiple = false,
         bool $required = false

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -49,7 +49,7 @@ abstract class Driver implements DriverInterface
      *
      * @var \PDO
      */
-    protected $_connection;
+    protected PDO $_connection;
 
     /**
      * Configuration data.

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -44,7 +44,7 @@ class BufferedStatement implements Iterator, StatementInterface
      *
      * @var \Cake\Database\StatementInterface
      */
-    protected $statement;
+    protected StatementInterface $statement;
 
     /**
      * The driver for the statement

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -33,7 +33,7 @@ class PDOStatement extends StatementDecorator
      *
      * @var \PDOStatement
      */
-    protected $_statement;
+    protected \PDOStatement $_statement;
 
     /**
      * Constructor

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -44,7 +44,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      *
      * @var \Cake\Database\StatementInterface
      */
-    protected $_statement;
+    protected StatementInterface $_statement;
 
     /**
      * Reference to the driver object associated to this statement.

--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
+use Cake\Database\StatementInterface;
+
 /**
  * Defines the interface that testing fixtures use.
  */
@@ -47,7 +49,7 @@ interface FixtureInterface
      * @return \Cake\Database\StatementInterface|bool on success or if there are no records to insert,
      *  or false on failure.
      */
-    public function insert(ConnectionInterface $connection);
+    public function insert(ConnectionInterface $connection): StatementInterface|bool;
 
     /**
      * Truncates the current fixture.

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -303,7 +303,7 @@ trait DateFormatTrait
      * @param array<int>|string|int $format Format.
      * @return void
      */
-    public static function setToStringFormat($format): void
+    public static function setToStringFormat(array|string|int $format): void
     {
         static::$_toStringFormat = $format;
     }

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -117,7 +117,7 @@ abstract class Association
      *
      * @var array<string>|string|false
      */
-    protected $_foreignKey;
+    protected array|string|false $_foreignKey;
 
     /**
      * A list of conditions to be always included when fetching records from
@@ -148,14 +148,14 @@ abstract class Association
      *
      * @var \Cake\ORM\Table
      */
-    protected $_sourceTable;
+    protected Table $_sourceTable;
 
     /**
      * Target table instance
      *
      * @var \Cake\ORM\Table
      */
-    protected $_targetTable;
+    protected Table $_targetTable;
 
     /**
      * The type of join to be used when adding the association to a query
@@ -170,7 +170,7 @@ abstract class Association
      *
      * @var string
      */
-    protected $_propertyName;
+    protected string $_propertyName;
 
     /**
      * The strategy name to be used to fetch associated records. Some association

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -72,7 +72,7 @@ class BelongsToMany extends Association
      *
      * @var \Cake\ORM\Table
      */
-    protected $_junctionTable;
+    protected Table $_junctionTable;
 
     /**
      * Junction table name
@@ -87,7 +87,7 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected $_junctionAssociationName;
+    protected string $_junctionAssociationName;
 
     /**
      * The name of the property to be set containing data from the junction table
@@ -116,7 +116,7 @@ class BelongsToMany extends Association
      *
      * @var \Cake\ORM\Table|string
      */
-    protected $_through;
+    protected Table|string $_through;
 
     /**
      * Valid strategies for this type of association

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -52,7 +52,7 @@ class Filesystem
      * @param int|null $flags Flags for FilesystemIterator::__construct();
      * @return \Iterator
      */
-    public function find(string $path, $filter = null, ?int $flags = null): Iterator
+    public function find(string $path, mixed $filter = null, ?int $flags = null): Iterator
     {
         $flags = $flags ?? FilesystemIterator::KEY_AS_PATHNAME
             | FilesystemIterator::CURRENT_AS_FILEINFO
@@ -76,7 +76,7 @@ class Filesystem
      * @param int|null $flags Flags for FilesystemIterator::__construct();
      * @return \Iterator
      */
-    public function findRecursive(string $path, $filter = null, ?int $flags = null): Iterator
+    public function findRecursive(string $path, mixed $filter = null, ?int $flags = null): Iterator
     {
         $flags = $flags ?? FilesystemIterator::KEY_AS_PATHNAME
             | FilesystemIterator::CURRENT_AS_FILEINFO
@@ -113,7 +113,7 @@ class Filesystem
      * @param mixed $filter Regex string or callback.
      * @return \Iterator
      */
-    protected function filterIterator(Iterator $iterator, $filter): Iterator
+    protected function filterIterator(Iterator $iterator, mixed $filter): Iterator
     {
         if (is_string($filter)) {
             return new RegexIterator($iterator, $filter);

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -303,7 +303,7 @@ class Xml
      * @return void
      * @throws \Cake\Utility\Exception\XmlException
      */
-    protected static function _fromArray(DOMDocument $dom, DOMDocument|DOMElement $node, $data, string $format): void
+    protected static function _fromArray(DOMDocument $dom, DOMDocument|DOMElement $node, array $data, string $format): void
     {
         if (empty($data) || !is_array($data)) {
             return;

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -46,7 +46,7 @@ class NumberHelper extends Helper
      *
      * @var \Cake\I18n\Number
      */
-    protected $_engine;
+    protected Number $_engine;
 
     /**
      * Default Constructor

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -63,7 +63,7 @@ class TextHelper extends Helper
      *
      * @var \Cake\Utility\Text
      */
-    protected $_engine;
+    protected Text $_engine;
 
     /**
      * Constructor


### PR DESCRIPTION
These are all the native type hints that the phpcs sniff could generate that were skipped.