### PR TITLE
Run autoquote test in separate task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,11 @@ jobs:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
           vendor/bin/phpunit --verbose
+          
+    - name: Run PHPUnit (autoquote enabled)
+      env:
+        DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
+      run: |
           set CAKE_TEST_AUTOQUOTE=1
           vendor/bin/phpunit --verbose --testsuite=database
 


### PR DESCRIPTION
By default, powershell won't exit when a command fails. If a non-db test fails and the auto-quote pass succeeds then the job returns success.
