### PR TITLE
Add deprecation notice for old-fixtures

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -69,6 +69,12 @@ class FixtureInjector implements TestListener
     public function startTestSuite(TestSuite $suite): void
     {
         if (empty($this->_first)) {
+            deprecationWarning(
+                'You are using the listener based PHPUnit integration. ' .
+                'This fixture system is deprecated, and we recommend you ' .
+                'upgrade to the extension based PHPUnit integration. ' .
+                'See https://book.cakephp.org/4.x/en/appendixes/fixture-upgrade.html'
+            );
             $this->_first = $suite;
         }
     }

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -25,6 +25,8 @@ use PHPUnit\Framework\TestSuite;
 /**
  * Test listener used to inject a fixture manager in all tests that
  * are composed inside a Test Suite
+ *
+ * @deprecated 4.3.0
  */
 class FixtureInjector implements TestListener
 {


### PR DESCRIPTION
I considered putting this deprecation into the TestFixture class but was concerned about flooding output for non-trivial sized applications. I thought that a single warning was a better option. Upgrading to the new fixtures can be done at the very end of the upgrade cycle or even after all the application code is working, so one message should be enough.