### PR TITLE
Use nullable type hints instead of |null

### DIFF
--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -177,7 +177,7 @@ interface QueryInterface
      * @param int|null $limit number of records to be returned
      * @return $this
      */
-    public function limit(int|null $limit);
+    public function limit(?int $limit);
 
     /**
      * Sets the number of records that should be skipped from the original result set
@@ -197,7 +197,7 @@ interface QueryInterface
      * @param int|null $offset number of records to be skipped
      * @return $this
      */
-    public function offset(int|null $offset);
+    public function offset(?int $offset);
 
     /**
      * Adds a single or multiple fields to be used in the ORDER clause for this query.

--- a/src/Http/Cookie/CookieInterface.php
+++ b/src/Http/Cookie/CookieInterface.php
@@ -192,7 +192,7 @@ interface CookieInterface
      * @param \DateTimeInterface $time The time to test against. Defaults to 'now' in UTC.
      * @return bool
      */
-    public function isExpired(DateTimeInterface|null $time = null): bool;
+    public function isExpired(?DateTimeInterface $time = null): bool;
 
     /**
      * Check if the cookie is HTTP only


### PR DESCRIPTION
The convention we were following is nullable type hints for single types. This is what slevomat generates and what php tends to use.

These 3 were probably manually fixed.
