### PR TITLE
Use addHelpers() instead of bool flag param.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -420,7 +420,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
     {
         $builder = $this->controller->viewBuilder();
         $builder
-            ->setHelpers([], false)
+            ->setHelpers([])
             ->setLayoutPath('')
             ->setTemplatePath('Error');
         $view = $this->controller->createView('View');

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -425,7 +425,7 @@ class Mailer implements EventListenerInterface
         }
 
         if (array_key_exists('helpers', $config)) {
-            $this->viewBuilder()->setHelpers($config['helpers'], false);
+            $this->viewBuilder()->setHelpers($config['helpers']);
             unset($config['helpers']);
         }
         if (array_key_exists('viewRenderer', $config)) {

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -101,7 +101,7 @@ class Renderer
         $this->viewBuilder()
             ->setClassName(View::class)
             ->setLayout('default')
-            ->setHelpers(['Html'], false);
+            ->setHelpers(['Html']);
 
         return $this;
     }

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -310,13 +310,7 @@ class ViewBuilder implements JsonSerializable
      */
     public function addHelper(string $helper, array $options = [])
     {
-        if ($options) {
-            $array = [$helper => $options];
-        } else {
-            $array = [$helper];
-        }
-
-        $this->_helpers = array_merge($this->_helpers, $array);
+        $this->_helpers[$helper] = $options;
 
         return $this;
     }

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -345,15 +345,10 @@ class ViewBuilder implements JsonSerializable
      * Sets the helpers to use.
      *
      * @param array $helpers Helpers to use.
-     * @param bool $merge Whether to merge existing data with the new data.
      * @return $this
      */
-    public function setHelpers(array $helpers, bool $merge = true)
+    public function setHelpers(array $helpers)
     {
-        if ($merge) {
-            deprecationWarning('The $merge param is deprecated, use addHelper()/addHelpers() instead.');
-            $helpers = array_merge($this->_helpers, $helpers);
-        }
         $this->_helpers = $helpers;
 
         return $this;

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -322,7 +322,8 @@ class CellTest extends TestCase
         $view = new View($request, $response, null, ['helpers' => $helpers]);
 
         $cell = $view->cell('Articles');
-        $this->assertSame($helpers, $cell->viewBuilder()->getHelpers());
+        $expected = array_combine($helpers, [[], [], []]);
+        $this->assertSame($expected, $cell->viewBuilder()->getHelpers());
     }
 
     /**

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -201,27 +201,6 @@ class ViewBuilderTest extends TestCase
 
         $helpers = $builder->getHelpers();
         $expected = [
-            'Form',
-            'Form' => [
-                'config' => 'value',
-            ],
-        ];
-        $this->assertSame($expected, $helpers);
-    }
-
-    /**
-     * Tests that adding non-assoc and assoc merge properly.
-     *
-     * @return void
-     */
-    public function testAddHelpers(): void
-    {
-        $builder = new ViewBuilder();
-        $builder->addHelper('Form');
-        $builder->addHelpers(['Form' => ['config' => 'value']]);
-
-        $helpers = $builder->getHelpers();
-        $expected = [
             'Form' => [
                 'config' => 'value',
             ],

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -112,7 +112,6 @@ class ViewBuilderTest extends TestCase
     public function arrayPropertyProvider(): array
     {
         return [
-            ['helpers', ['Html', 'Form']],
             ['options', ['key' => 'value']],
         ];
     }
@@ -203,6 +202,26 @@ class ViewBuilderTest extends TestCase
         $helpers = $builder->getHelpers();
         $expected = [
             'Form',
+            'Form' => [
+                'config' => 'value',
+            ],
+        ];
+        $this->assertSame($expected, $helpers);
+    }
+
+    /**
+     * Tests that adding non-assoc and assoc merge properly.
+     *
+     * @return void
+     */
+    public function testAddHelpers(): void
+    {
+        $builder = new ViewBuilder();
+        $builder->addHelper('Form');
+        $builder->addHelpers(['Form' => ['config' => 'value']]);
+
+        $helpers = $builder->getHelpers();
+        $expected = [
             'Form' => [
                 'config' => 'value',
             ],
@@ -431,9 +450,9 @@ class ViewBuilderTest extends TestCase
 
         $helpers = $builder->getHelpers();
         $expected = [
-            'Form',
-            'Time',
-            'Text',
+            'Form' => [],
+            'Time' => [],
+            'Text' => [],
         ];
         $this->assertSame($expected, $helpers);
     }


### PR DESCRIPTION
This was also on the list of cleanups
I also added a normalization on the helpers as assoc arrays.
I always had issues with merging them, as they appear twice in the list, once as key and once as value if different levels add helpers with different config.
What do you think?
Could we in general normalize all such configs also for components, behaviors and alike?
This makes it also easier to find out if a helper got added by just checking the key instead of key + in_array etc games.

We will want to deprecate in 4.3 here to allow an upgrade path.