### PR TITLE
Allow aliasing connections that aren't configured yet

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -153,16 +153,9 @@ class ConnectionManager
      * @param string $source The existing connection to alias.
      * @param string $alias The alias name that resolves to `$source`.
      * @return void
-     * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When aliasing a
-     * connection that does not exist.
      */
     public static function alias(string $source, string $alias): void
     {
-        if (empty(static::$_config[$source])) {
-            throw new MissingDatasourceConfigException(
-                sprintf('Cannot create alias of "%s" as it does not exist.', $source)
-            );
-        }
         static::$_aliasMap[$alias] = $source;
     }
 

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -16,7 +16,6 @@ namespace Cake\Test\TestCase\Datasource;
 use BadMethodCallException;
 use Cake\Core\Exception\CakeException;
 use Cake\Datasource\ConnectionManager;
-use Cake\Datasource\Exception\MissingDatasourceConfigException;
 use Cake\Datasource\Exception\MissingDatasourceException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -196,16 +195,6 @@ class ConnectionManagerTest extends TestCase
         ConnectionManager::alias('test_variant', 'other_name');
         $result = ConnectionManager::get('test_variant');
         $this->assertSame($result, ConnectionManager::get('other_name'));
-    }
-
-    /**
-     * Test alias() raises an error when aliasing an undefined connection.
-     */
-    public function testAliasError(): void
-    {
-        $this->expectException(MissingDatasourceConfigException::class);
-        $this->assertNotContains('test_kaboom', ConnectionManager::configured());
-        ConnectionManager::alias('test_kaboom', 'other_name');
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/15895

This pushes the exception to `ConnectionManager::get()`. Previously, `ConnectionManager::alias()` hid that the `test_` connection didn't exist.

If we're going to ignore that `test_` doesn't exist, then let's just allow any alias to exist and throw the exception if that alias is actually used.
