### PR TITLE
Add per-TestCase fixture strategy setup and teardown

### DIFF
--- a/src/TestSuite/Fixture/FixtureStrategyInterface.php
+++ b/src/TestSuite/Fixture/FixtureStrategyInterface.php
@@ -22,6 +22,13 @@ namespace Cake\TestSuite\Fixture;
 interface FixtureStrategyInterface
 {
     /**
+     * Called before all tests are run for TestCase.
+     *
+     * @return void
+     */
+    public function setupStrategy(): void;
+
+    /**
      * Called before each test run in each TestCase.
      *
      * @param array<string> $fixtureNames Name of fixtures used by test.
@@ -35,4 +42,11 @@ interface FixtureStrategyInterface
      * @return void
      */
     public function teardownTest(): void;
+
+    /**
+     * Called after all tests are run for TestCase.
+     *
+     * @return void
+     */
+    public function teardownStrategy(): void;
 }

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -48,6 +48,13 @@ class TransactionStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    public function setupStrategy(): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function setupTest(array $fixtureNames): void
     {
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
@@ -86,5 +93,12 @@ class TransactionStrategy implements FixtureStrategyInterface
                 $connection->rollback(true);
             }
         }, $this->fixtures);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function teardownStrategy(): void
+    {
     }
 }

--- a/src/TestSuite/Fixture/TruncateStrategy.php
+++ b/src/TestSuite/Fixture/TruncateStrategy.php
@@ -42,6 +42,13 @@ class TruncateStrategy implements FixtureStrategyInterface
     /**
      * @inheritDoc
      */
+    public function setupStrategy(): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function setupTest(array $fixtureNames): void
     {
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
@@ -54,5 +61,12 @@ class TruncateStrategy implements FixtureStrategyInterface
     public function teardownTest(): void
     {
         $this->helper->truncate($this->fixtures);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function teardownStrategy(): void
+    {
     }
 }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -86,7 +86,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * @var \Cake\TestSuite\Fixture\FixtureStrategyInterface|null
      */
-    protected $fixtureStrategy = null;
+    protected static $fixtureStrategy = null;
 
     /**
      * Configure values to restore at end of test.
@@ -213,6 +213,29 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * @inheritDoc
+     */
+    public static function setUpBeforeClass(): void
+    {
+        if (static::$fixtureManager) {
+            return;
+        }
+
+        static::$fixtureStrategy = static::getFixtureStrategy();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass(): void
+    {
+        if (static::$fixtureStrategy) {
+            static::$fixtureStrategy->teardownStrategy();
+            static::$fixtureStrategy = null;
+        }
+    }
+
+    /**
      * Setup the test case, backup the static object values so they can be restored.
      * Specifically backs up the contents of Configure and paths in App if they have
      * not already been backed up.
@@ -273,8 +296,9 @@ abstract class TestCase extends BaseTestCase
             return;
         }
 
-        $this->fixtureStrategy = $this->getFixtureStrategy();
-        $this->fixtureStrategy->setupTest($fixtureNames);
+        if (static::$fixtureStrategy) {
+            static::$fixtureStrategy->setupTest($fixtureNames);
+        }
     }
 
     /**
@@ -284,9 +308,8 @@ abstract class TestCase extends BaseTestCase
      */
     protected function teardownFixtures(): void
     {
-        if ($this->fixtureStrategy) {
-            $this->fixtureStrategy->teardownTest();
-            $this->fixtureStrategy = null;
+        if (static::$fixtureStrategy) {
+            static::$fixtureStrategy->teardownTest();
         }
     }
 
@@ -295,7 +318,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return \Cake\TestSuite\Fixture\FixtureStrategyInterface
      */
-    protected function getFixtureStrategy(): FixtureStrategyInterface
+    protected static function getFixtureStrategy(): FixtureStrategyInterface
     {
         return new TruncateStrategy();
     }


### PR DESCRIPTION
This allows support for more specialized strategies. Changing the interface in the future will be difficult.