### PR TITLE
Move test connection initialization to hook

### DIFF
--- a/src/TestSuite/Fixture/PHPUnitExtension.php
+++ b/src/TestSuite/Fixture/PHPUnitExtension.php
@@ -26,9 +26,11 @@ use PHPUnit\Runner\BeforeFirstTestHook;
 class PHPUnitExtension implements BeforeFirstTestHook
 {
     /**
-     * Constructor. Set the record only fixture manager as the singleton.
+     * Initializes before any tests are run.
+     *
+     * @return void
      */
-    public function __construct()
+    public function executeBeforeFirstTest(): void
     {
         $helper = new ConnectionHelper();
         $helper->addTestAliases();
@@ -42,17 +44,5 @@ class PHPUnitExtension implements BeforeFirstTestHook
                 'scopes' => ['queriesLog'],
             ]);
         }
-    }
-
-    /**
-     * First test hook.
-     *
-     * @return void
-     */
-    public function executeBeforeFirstTest(): void
-    {
-        // Do nothing as we setup in the constructor
-        // to avoid applications hitting non-test DB
-        // during bootstrap.
     }
 }

--- a/tests/TestCase/TestSuite/Fixture/PHPUnitExtensionTest.php
+++ b/tests/TestCase/TestSuite/Fixture/PHPUnitExtensionTest.php
@@ -24,6 +24,12 @@ use Cake\TestSuite\TestCase;
 
 class PHPUnitExtensionTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        ConnectionManager::dropAlias('fixture_schema');
+        ConnectionManager::drop('test_fixture_schema');
+    }
+
     /**
      * Test connection aliasing during construction.
      */
@@ -36,9 +42,8 @@ class PHPUnitExtensionTest extends TestCase
             'database' => TMP . 'fixture_schema.sqlite',
         ]);
         $this->assertNotContains('fixture_schema', ConnectionManager::configured());
-        $extension = new PHPUnitExtension();
 
-        $this->assertContains('test_fixture_schema', ConnectionManager::configured());
+        (new PHPUnitExtension())->executeBeforeFirstTest();
         $this->assertSame(
             ConnectionManager::get('test_fixture_schema'),
             ConnectionManager::get('fixture_schema')
@@ -47,7 +52,5 @@ class PHPUnitExtensionTest extends TestCase
             ConnectionManager::get('test'),
             ConnectionManager::get('default')
         );
-        $this->assertNull($extension->executeBeforeFirstTest());
-        ConnectionManager::drop('test_fixture_schema');
     }
 }


### PR DESCRIPTION
This relies on the hook behavior instead of when the object is constructed.