### PR TITLE
cake 5: Add mixed return to cache engine get()

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -233,7 +233,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
      * @return mixed The value of the item from the cache, or $default in case of cache miss.
      * @throws \Cake\Cache\InvalidArgumentException If the $key string is not a legal value.
      */
-    abstract public function get($key, $default = null);
+    abstract public function get($key, $default = null): mixed;
 
     /**
      * Persists data in the cache, uniquely referenced by the given key with an optional expiration TTL time.

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -66,7 +66,7 @@ class ArrayEngine extends CacheEngine
      * @return mixed The cached data, or default value if the data doesn't exist, has
      * expired, or if there was an error fetching it.
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         $key = $this->_key($key);
         if (!isset($this->data[$key])) {

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -157,7 +157,7 @@ class FileEngine extends CacheEngine
      * @return mixed The cached data, or default value if the data doesn't exist, has
      *   expired, or if there was an error fetching it
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         $key = $this->_key($key);
 

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -341,7 +341,7 @@ class MemcachedEngine extends CacheEngine
      * @return mixed The cached data, or default value if the data doesn't exist, has
      * expired, or if there was an error fetching it.
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         $key = $this->_key($key);
         $value = $this->_Memcached->get($key);

--- a/src/Cache/Engine/NullEngine.php
+++ b/src/Cache/Engine/NullEngine.php
@@ -52,7 +52,7 @@ class NullEngine extends CacheEngine
     /**
      * @inheritDoc
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         return $default;
     }

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -164,7 +164,7 @@ class RedisEngine extends CacheEngine
      * @return mixed The cached data, or the default if the data doesn't exist, has
      *   expired, or if there was an error fetching it
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         $value = $this->_Redis->get($this->_key($key));
         if ($value === false) {

--- a/tests/test_app/Plugin/TestPlugin/src/Cache/Engine/TestPluginCacheEngine.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Cache/Engine/TestPluginCacheEngine.php
@@ -36,7 +36,7 @@ class TestPluginCacheEngine extends CacheEngine
     /**
      * @inheritDoc
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
     }
 

--- a/tests/test_app/TestApp/Cache/Engine/TestAppCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/TestAppCacheEngine.php
@@ -41,7 +41,7 @@ class TestAppCacheEngine extends CacheEngine
     /**
      * @inheritDoc
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
     }
 


### PR DESCRIPTION
This is part of a PSR interface, but the mixed return type is covariant.