### PR TITLE
Allow ignoring FixtureInjector deprecation warning

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -75,7 +75,8 @@ class FixtureInjector implements TestListener
                 'You are using the listener based PHPUnit integration. ' .
                 'This fixture system is deprecated, and we recommend you ' .
                 'upgrade to the extension based PHPUnit integration. ' .
-                'See https://book.cakephp.org/4.x/en/appendixes/fixture-upgrade.html'
+                'See https://book.cakephp.org/4.x/en/appendixes/fixture-upgrade.html',
+                0
             );
             $this->_first = $suite;
         }


### PR DESCRIPTION
Users need to ignore FixtureInjector.php itself instead of the parent.