### PR TITLE
Deprecate Association::setName().

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -246,9 +246,16 @@ abstract class Association
      *
      * @param string $name Name to be assigned
      * @return $this
+     * @deprecated 4.3.0 Changing the association name after object creation is
+     *   no longer supported. The name should only be set through the constructor.
      */
     public function setName(string $name)
     {
+        deprecationWarning(
+            'Changing the association name after object creation is no longer supported.'
+            . ' The name should only be set through the constructor'
+        );
+
         if ($this->_targetTable !== null) {
             $alias = $this->_targetTable->getAlias();
             if ($alias !== $name) {

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -77,42 +77,58 @@ class AssociationTest extends TestCase
 
     /**
      * Tests that setName()
+     *
+     * @deprecated
      */
     public function testSetName(): void
     {
-        $this->assertSame('Foo', $this->association->getName());
-        $this->assertSame($this->association, $this->association->setName('Bar'));
-        $this->assertSame('Bar', $this->association->getName());
+        $this->deprecated(function () {
+            $this->assertSame('Foo', $this->association->getName());
+            $this->assertSame($this->association, $this->association->setName('Bar'));
+            $this->assertSame('Bar', $this->association->getName());
+        });
     }
 
     /**
      * Tests that setName() succeeds before the target table is resolved.
+     *
+     * @deprecated
      */
     public function testSetNameBeforeTarget(): void
     {
-        $this->association->setName('Bar');
-        $this->assertSame('Bar', $this->association->getName());
+        $this->deprecated(function () {
+            $this->association->setName('Bar');
+            $this->assertSame('Bar', $this->association->getName());
+        });
     }
 
     /**
      * Tests that setName() fails after the target table is resolved.
+     *
+     * @deprecated
      */
     public function testSetNameAfterTarget(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Association name "Bar" does not match target table alias');
-        $this->association->getTarget();
-        $this->association->setName('Bar');
+        $this->deprecated(function () {
+            $this->association->getTarget();
+            $this->association->setName('Bar');
+        });
     }
 
     /**
      * Tests that setName() succeeds if name equals target table alias.
+     *
+     * @deprecated
      */
     public function testSetNameToTargetAlias(): void
     {
-        $alias = $this->association->getTarget()->getAlias();
-        $this->association->setName($alias);
-        $this->assertSame($alias, $this->association->getName());
+        $this->deprecated(function () {
+            $alias = $this->association->getTarget()->getAlias();
+            $this->association->setName($alias);
+            $this->assertSame($alias, $this->association->getName());
+        });
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4091,9 +4091,8 @@ class TableTest extends TestCase
             ->getMock();
 
         try {
-            $articles->belongsTo('authors')
+            $articles->belongsTo('Articles')
                 ->setForeignKey('author_id')
-                ->setName('Authors')
                 ->setTarget($authors)
                 ->setBindingKey('id')
                 ->setConditions([])
@@ -4115,9 +4114,8 @@ class TableTest extends TestCase
             ->getMock();
 
         try {
-            $authors->hasOne('articles')
+            $authors->hasOne('Articles')
                 ->setForeignKey('author_id')
-                ->setName('Articles')
                 ->setDependent(true)
                 ->setBindingKey('id')
                 ->setConditions([])
@@ -4141,9 +4139,8 @@ class TableTest extends TestCase
             ->getMock();
 
         try {
-            $authors->hasMany('articles')
+            $authors->hasMany('Articles')
                 ->setForeignKey('author_id')
-                ->setName('Articles')
                 ->setDependent(true)
                 ->setSort(['created' => 'DESC'])
                 ->setBindingKey('id')
@@ -4168,9 +4165,8 @@ class TableTest extends TestCase
             ->setConstructorArgs([['table' => 'authors', 'connection' => $this->connection]])
             ->getMock();
         try {
-            $authors->belongsToMany('articles')
+            $authors->belongsToMany('Articles')
                 ->setForeignKey('author_id')
-                ->setName('Articles')
                 ->setDependent(true)
                 ->setTargetForeignKey('article_id')
                 ->setBindingKey('id')


### PR DESCRIPTION
Changing the association name after object creation isn't reflected in the collection
nor the target table. Hence it's quite limiting and best to deprecate and remove this method.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
