### PR TITLE
Make ShadowTable the default strategy for TranslateBehavior.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -18,7 +18,7 @@ namespace Cake\ORM\Behavior;
 
 use Cake\I18n\I18n;
 use Cake\ORM\Behavior;
-use Cake\ORM\Behavior\Translate\EavStrategy;
+use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
 use Cake\ORM\Behavior\Translate\TranslateStrategyInterface;
 use Cake\ORM\Marshaller;
 use Cake\ORM\PropertyMarshalInterface;
@@ -62,6 +62,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         'strategy' => 'subquery',
         'tableLocator' => null,
         'validator' => false,
+        'strategyClass' => null,
     ];
 
     /**
@@ -70,7 +71,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * @var string
      * @psalm-var class-string<\Cake\ORM\Behavior\Translate\TranslateStrategyInterface>
      */
-    protected static string $defaultStrategyClass = EavStrategy::class;
+    protected static string $defaultStrategyClass = ShadowTableStrategy::class;
 
     /**
      * Translation strategy instance.

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM\Behavior;
 
 use Cake\Database\Driver\Sqlserver;
 use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Behavior\Translate\EavStrategy;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Entity\NumberTree;
 
@@ -52,7 +53,10 @@ class BehaviorRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('NumberTrees');
         $table->setPrimaryKey(['id']);
         $table->addBehavior('Tree');
-        $table->addBehavior('Translate', ['fields' => ['name']]);
+        $table->addBehavior('Translate', [
+            'fields' => ['name'],
+            'strategyClass' => EavStrategy::class,
+        ]);
         $table->setEntityClass(NumberTree::class);
 
         /** @var \TestApp\Model\Entity\NumberTree[] $all */

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -36,7 +36,7 @@ use TestApp\Model\Table\CustomI18nTable;
 /**
  * Translate behavior test case
  */
-class TranslateBehaviorTest extends TestCase
+class TranslateBehaviorEavTest extends TestCase
 {
     /**
      * fixtures

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -55,9 +55,9 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      */
     public static function setUpBeforeClass(): void
     {
-        TranslateBehavior::setDefaultStrategyClass(ShadowTableStrategy::class);
-
         parent::setUpBeforeClass();
+
+        TranslateBehavior::setDefaultStrategyClass(ShadowTableStrategy::class);
     }
 
     /**
@@ -65,9 +65,9 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
      */
     public static function tearDownAfterClass(): void
     {
-        TranslateBehavior::setDefaultStrategyClass(EavStrategy::class);
-
         parent::tearDownAfterClass();
+
+        TranslateBehavior::setDefaultStrategyClass(ShadowTableStrategy::class);
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -20,7 +20,6 @@ use Cake\Database\Driver\Postgres;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\I18n;
-use Cake\ORM\Behavior\Translate\EavStrategy;
 use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
 use Cake\ORM\Behavior\TranslateBehavior;
 use Cake\Utility\Hash;
@@ -30,7 +29,7 @@ use TestApp\Model\Entity\TranslateBakedArticle;
 /**
  * TranslateBehavior test case
  */
-class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
+class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
 {
     protected array $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -23,6 +23,9 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\QueryInterface;
 use Cake\I18n\I18n;
+use Cake\ORM\Behavior\Translate\EavStrategy;
+use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
+use Cake\ORM\Behavior\TranslateBehavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Locator\TableLocator;
 use Cake\TestSuite\TestCase;
@@ -50,6 +53,26 @@ class TranslateBehaviorTest extends TestCase
         'core.Comments',
         'core.Translates',
     ];
+
+    /**
+     * setUpBeforeClass
+     */
+    public static function setUpBeforeClass(): void
+    {
+        TranslateBehavior::setDefaultStrategyClass(EavStrategy::class);
+
+        parent::setUpBeforeClass();
+    }
+
+    /**
+     * tearDownAfterClass
+     */
+    public static function tearDownAfterClass(): void
+    {
+        TranslateBehavior::setDefaultStrategyClass(ShadowTableStrategy::class);
+
+        parent::tearDownAfterClass();
+    }
 
     public function tearDown(): void
     {


### PR DESCRIPTION
The EavStrategy which uses one row per field is quite wasteful and can
also be a performance killer for large apps.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
