### PR TITLE
Fix TypeError in CsrfProtectionMiddleware

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -23,6 +23,7 @@ use Cake\Http\Exception\InvalidCsrfTokenException;
 use Cake\Http\Response;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -151,7 +152,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         if (is_string($cookieData) && strlen($cookieData) > 0) {
             try {
                 $request = $request->withAttribute('csrfToken', $this->saltToken($cookieData));
-            } catch (RuntimeException $e) {
+            } catch (InvalidArgumentException $e) {
                 $cookieData = null;
             }
         }
@@ -282,7 +283,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         }
         $decoded = base64_decode($token, true);
         if ($decoded === false) {
-            throw new RuntimeException('Invalid token data.');
+            throw new InvalidArgumentException('Invalid token data.');
         }
 
         $length = strlen($decoded);


### PR DESCRIPTION
When a cookie contains non-empty data that does not match the old token format and also is not base64 encoded we should assume it is invalid and generate a new CSRF token on GET requests. For non-GET requests this will result in a CSRF validation error.

Fixes #15868