### PR TITLE
Optimize when constraints are disabled for fixtures

### DIFF
--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -17,9 +17,14 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Configure;
+use Cake\Database\Connection;
 use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\FixtureInterface;
 use Closure;
 use UnexpectedValueException;
 
@@ -130,7 +135,15 @@ class FixtureHelper
     public function insert(array $fixtures): void
     {
         $this->runPerConnection(function (ConnectionInterface $connection, array $groupFixtures) {
-            if ($connection->getDriver() instanceof Postgres) {
+            if ($connection instanceof Connection) {
+                $sortedFixtures = $this->sortByConstraint($connection, $groupFixtures);
+            }
+
+            if (isset($sortedFixtures)) {
+                foreach ($sortedFixtures as $fixture) {
+                    $fixture->insert($connection);
+                }
+            } elseif ($connection->getDriver() instanceof Postgres) {
                 // disabling foreign key constraints is only valid in a transaction
                 $connection->transactional(function () use ($connection, $groupFixtures) {
                     $connection->disableConstraints(function () use ($connection, $groupFixtures) {
@@ -159,11 +172,92 @@ class FixtureHelper
     public function truncate(array $fixtures): void
     {
         $this->runPerConnection(function (ConnectionInterface $connection, array $groupFixtures) {
-            $connection->disableConstraints(function () use ($connection, $groupFixtures) {
-                foreach ($groupFixtures as $fixture) {
+            if ($connection instanceof Connection) {
+                $sortedFixtures = $this->sortByConstraint($connection, $groupFixtures);
+            }
+
+            $driver = $connection->getDriver();
+            if (
+                isset($sortedFixtures) &&
+                (
+                    $driver instanceof Postgres ||
+                    $driver instanceof Sqlite ||
+                    $driver instanceof Sqlserver
+                )
+            ) {
+                foreach (array_reverse($sortedFixtures) as $fixture) {
                     $fixture->truncate($connection);
                 }
-            });
+            } else {
+                $connection->disableConstraints(function () use ($connection, $groupFixtures) {
+                    foreach ($groupFixtures as $fixture) {
+                        $fixture->truncate($connection);
+                    }
+                });
+            }
         }, $fixtures);
+    }
+
+    /**
+     * Sort fixtures with foreign constraints last if possible, otherwise returns null.
+     *
+     * @param \Cake\Database\Connection $connection Database connection
+     * @param array<\Cake\Datasource\FixtureInterface> $fixtures Database fixtures
+     * @return array|null
+     */
+    protected function sortByConstraint(Connection $connection, array $fixtures): ?array
+    {
+        $constrained = [];
+        $unconstrained = [];
+        foreach ($fixtures as $fixture) {
+            $references = $this->getForeignReferences($connection, $fixture);
+            if ($references) {
+                $constrained[$fixture->sourceName()] = ['references' => $references, 'fixture' => $fixture];
+            } else {
+                $unconstrained[] = $fixture;
+            }
+        }
+
+        // Check if any fixtures reference another fixture with constrants
+        // If they do, then there might be cross-dependencies which we don't support sorting
+        foreach ($constrained as ['references' => $references]) {
+            foreach ($references as $reference) {
+                if (isset($constrained[$reference])) {
+                    return null;
+                }
+            }
+        }
+
+        return array_merge($unconstrained, array_column($constrained, 'fixture'));
+    }
+
+    /**
+     * Gets array of foreign references for fixtures table.
+     *
+     * @param \Cake\Database\Connection $connection Database connection
+     * @param \Cake\Datasource\FixtureInterface $fixture Database fixture
+     * @return array
+     */
+    protected function getForeignReferences(Connection $connection, FixtureInterface $fixture): array
+    {
+        static $schemas = [];
+
+        // Get and cache off the schema since TestFixture generates a fake schema based on $fields
+        $tableName = $fixture->sourceName();
+        if (!isset($schemas[$tableName])) {
+            $schemas[$tableName] = $connection->getSchemaCollection()->describe($tableName);
+        }
+        $schema = $schemas[$tableName];
+
+        $references = [];
+        foreach ($schema->constraints() as $constraintName) {
+            $constraint = $schema->getConstraint($constraintName);
+
+            if ($constraint && $constraint['type'] === TableSchema::CONSTRAINT_FOREIGN) {
+                $references[] = $constraint['references'][0];
+            }
+        }
+
+        return $references;
     }
 }

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -69,9 +69,9 @@ class SchemaCacheCommandsTest extends TestCase
      */
     public function tearDown(): void
     {
+        $this->connection->cacheMetadata(false);
         parent::tearDown();
 
-        $this->connection->cacheMetadata('_cake_model_');
         unset($this->connection);
         Cache::drop('orm_cache');
     }

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -55,8 +55,8 @@ class CollectionTest extends TestCase
      */
     public function tearDown(): void
     {
-        parent::tearDown();
         $this->connection->cacheMetadata(false);
+        parent::tearDown();
         unset($this->connection);
     }
 

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -65,9 +65,9 @@ class SchemaCacheTest extends TestCase
      */
     public function tearDown(): void
     {
+        $this->connection->cacheMetadata(false);
         parent::tearDown();
 
-        $this->connection->cacheMetadata(false);
         unset($this->connection);
         Cache::drop('orm_cache');
     }

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -48,9 +48,6 @@ class DatabaseSessionTest extends TestCase
         parent::setUp();
         static::setAppNamespace();
         $this->storage = new DatabaseSession();
-
-        // With metadata caching on SQLServer/windows tests fail.
-        ConnectionManager::get('test')->cacheMetadata(false);
     }
 
     /**

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -22,12 +22,13 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->markTestSkipped('This test requires non-auto-fixtures');
 
         $this->textType = TypeFactory::build('text');
         TypeFactory::map('text', ColumnSchemaAwareType::class);
         // For SQLServer.
         TypeFactory::map('nvarchar', ColumnSchemaAwareType::class);
+
+        $this->markTestSkipped('This test requires non-auto-fixtures');
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/15817

This can be simplified in 5.0 when TestFixture doesn't generate a fake schema based on `$fields`. We can rely on the schema returned by `getTableSchema()` to be the reflected schema.

Mysql does not support truncating a table with references to it at all - even if there are no records.
