### PR TITLE
Disable slash escaping by default in JsonFormatter

### DIFF
--- a/src/Log/Formatter/JsonFormatter.php
+++ b/src/Log/Formatter/JsonFormatter.php
@@ -25,7 +25,7 @@ class JsonFormatter extends AbstractFormatter
      */
     protected $_defaultConfig = [
         'dateFormat' => DATE_ATOM,
-        'flags' => JSON_UNESCAPED_UNICODE,
+        'flags' => JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
     ];
 
     /**


### PR DESCRIPTION
This leaves forward slashes alone. This should be preferred for logging format.