### PR TITLE
Append newline to JsonFormatter output by default

### DIFF
--- a/src/Log/Formatter/JsonFormatter.php
+++ b/src/Log/Formatter/JsonFormatter.php
@@ -26,6 +26,7 @@ class JsonFormatter extends AbstractFormatter
     protected $_defaultConfig = [
         'dateFormat' => DATE_ATOM,
         'flags' => JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
+        'appendNewline' => true,
     ];
 
     /**
@@ -42,7 +43,8 @@ class JsonFormatter extends AbstractFormatter
     public function format($level, string $message, array $context = []): string
     {
         $log = ['date' => date($this->_config['dateFormat']), 'level' => (string)$level, 'message' => $message];
+        $json = json_encode($log, $this->_config['flags']);
 
-        return json_encode($log, $this->_config['flags']);
+        return $this->_config['appendNewline'] ? $json . "\n" : $json;
     }
 }

--- a/tests/TestCase/Log/Engine/ConsoleLogTest.php
+++ b/tests/TestCase/Log/Engine/ConsoleLogTest.php
@@ -103,6 +103,27 @@ class ConsoleLogTest extends TestCase
             'stream' => $filename,
             'formatter' => [
                 'className' => JsonFormatter::class,
+            ],
+        ]);
+        $log->log('error', 'test with newline');
+        $fh = fopen($filename, 'r');
+        $line = fgets($fh);
+        $this->assertSame(strlen($line) - 1, strpos($line, "\n"));
+
+        $entry = json_decode($line, true);
+        $this->assertSame('test with newline', $entry['message']);
+    }
+
+    /**
+     * Test json formatter custom flags
+     */
+    public function testJsonFormatterFlags(): void
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'cake_log_test');
+        $log = new ConsoleLog([
+            'stream' => $filename,
+            'formatter' => [
+                'className' => JsonFormatter::class,
                 'flags' => JSON_HEX_QUOT,
             ],
         ]);
@@ -112,8 +133,6 @@ class ConsoleLogTest extends TestCase
         $this->assertStringContainsString('\u0022noes\u0022', $line);
 
         $entry = json_decode($line, true);
-        $this->assertNotNull($entry['date']);
-        $this->assertSame('error', $entry['level']);
         $this->assertSame('oh "noes"', $entry['message']);
     }
 


### PR DESCRIPTION
This is the same default behavior as monolog.