### PR TITLE
Make docblock var definitions more concrete.

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -82,7 +82,7 @@ class MemcachedEngine extends CacheEngine
      *
      * Memcached must be compiled with JSON and igbinary support to use these engines
      *
-     * @var array
+     * @var array<string, int>
      */
     protected $_serializers = [];
 

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -30,7 +30,7 @@ class WincacheEngine extends CacheEngine
      * Contains the compiled group names
      * (prefixed with the global configuration prefix)
      *
-     * @var array
+     * @var array<string>
      */
     protected $_compiledGroupNames = [];
 

--- a/src/Collection/Iterator/InsertIterator.php
+++ b/src/Collection/Iterator/InsertIterator.php
@@ -45,7 +45,7 @@ class InsertIterator extends Collection
      * An array containing each of the properties to be traversed to reach the
      * point where the values should be inserted.
      *
-     * @var array
+     * @var array<string>
      */
     protected $_path;
 

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -67,9 +67,9 @@ class I18nExtractCommand extends Command
     protected $_file = '';
 
     /**
-     * Contains all content waiting to be write
+     * Contains all content waiting to be written
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_storage = [];
 
@@ -83,7 +83,7 @@ class I18nExtractCommand extends Command
     /**
      * Extracted strings indexed by domain.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_translations = [];
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -102,7 +102,7 @@ class ConsoleOptionParser
     /**
      * Map of short -> long options, generated when using addOption()
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $_shortOptions = [];
 

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -44,7 +44,7 @@ class ShellDispatcher
     /**
      * List of connected aliases.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected static $_aliases = [];
 

--- a/src/Core/ClassLoader.php
+++ b/src/Core/ClassLoader.php
@@ -26,7 +26,7 @@ class ClassLoader
      * An associative array where the key is a namespace prefix and the value
      * is an array of base directories for classes in that namespace.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $_prefixes = [];
 

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -30,7 +30,7 @@ trait InstanceConfigTrait
     /**
      * Runtime config
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_config = [];
 

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -32,7 +32,7 @@ trait StaticConfigTrait
     /**
      * Configuration sets.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected static $_config = [];
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -47,7 +47,7 @@ class Connection implements ConnectionInterface
     /**
      * Contains the configuration params for this connection.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_config;
 

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -54,7 +54,7 @@ abstract class Driver implements DriverInterface
     /**
      * Configuration data.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_config;
 

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -37,7 +37,7 @@ class FieldTypeConverter
      * An array containing the name of the fields and the Type objects
      * each should use when converting them using batching.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $batchingTypeMap;
 

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -37,7 +37,7 @@ class LoggingStatement extends StatementDecorator
     /**
      * Holds bound params
      *
-     * @var array
+     * @var array<array>
      */
     protected $_compiledParams = [];
 

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -29,7 +29,7 @@ class SqliteSchemaDialect extends SchemaDialect
      * Array containing the foreign keys constraints names
      * Necessary for composite foreign keys to be handled
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_constraintsIdMap = [];
 

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -43,28 +43,28 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * Columns in the table.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $_columns = [];
 
     /**
      * A map with columns to types
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $_typeMap = [];
 
     /**
      * Indexes in the table.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $_indexes = [];
 
     /**
      * Constraints in the table.
      *
-     * @var array
+     * @var array<string, array<string, mixed>>
      */
     protected $_constraints = [];
 

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -56,7 +56,7 @@ class BufferedStatement implements Iterator, StatementInterface
     /**
      * The in-memory cache containing results from previous iterators
      *
-     * @var array
+     * @var array<int, array>
      */
     protected $buffer = [];
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -33,14 +33,14 @@ trait EntityTrait
     /**
      * Holds all fields and their values for this entity.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_fields = [];
 
     /**
      * Holds all fields that have been changed and their original values for this entity.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_original = [];
 
@@ -72,7 +72,7 @@ trait EntityTrait
     /**
      * Holds a cached list of getters/setters per class
      *
-     * @var array
+     * @var array<string, array<string, array<string, string>>>
      */
     protected static $_accessors = [];
 
@@ -88,14 +88,14 @@ trait EntityTrait
     /**
      * List of errors per field as stored in this object.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_errors = [];
 
     /**
      * List of invalid fields and their data for errors upon validation/patching.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_invalid = [];
 

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -27,14 +27,14 @@ abstract class AbstractLocator implements LocatorInterface
     /**
      * Instances that belong to the registry.
      *
-     * @var array<\Cake\Datasource\RepositoryInterface>
+     * @var array<string, \Cake\Datasource\RepositoryInterface>
      */
     protected $instances = [];
 
     /**
      * Contains a list of options that were passed to get() method.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $options = [];
 

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -42,7 +42,7 @@ class FormProtector
     /**
      * Unlocked fields.
      *
-     * @var array
+     * @var array<string>
      */
     protected $unlockedFields = [];
 
@@ -107,7 +107,7 @@ class FormProtector
     /**
      * Determine which fields of a form should be used for hash.
      *
-     * @param array|string $field Reference to field to be secured. Can be dot
+     * @param array<string>|string $field Reference to field to be secured. Can be dot
      *   separated string to indicate nesting or array of fieldname parts.
      * @param bool $lock Whether this field should be part of the validation
      *   or excluded as part of the unlockedFields. Default `true`.

--- a/src/Form/Schema.php
+++ b/src/Form/Schema.php
@@ -24,7 +24,7 @@ class Schema
     /**
      * The fields in this schema.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $_fields = [];
 

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -56,7 +56,7 @@ class CorsBuilder
     /**
      * The headers that have been queued so far.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_headers = [];
 

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -46,8 +46,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
     /**
      * The queue of middlewares.
      *
-     * @var array
-     * @psalm-var array<int, mixed>
+     * @var array<int, mixed>
      */
     protected $queue = [];
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -386,7 +386,7 @@ class Response implements ResponseInterface
     /**
      * File range. Used for requesting ranges of files.
      *
-     * @var array
+     * @var array<int>
      */
     protected $_fileRange = [];
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1551,6 +1551,10 @@ class Response implements ResponseInterface
         $this->_setHeader('Content-Length', (string)($end - $start + 1));
         $this->_setHeader('Content-Range', 'bytes ' . $start . '-' . $end . '/' . $fileSize);
         $this->_setStatus(206);
+        /**
+         * @var int $start
+         * @var int $end
+         */
         $this->_fileRange = [$start, $end];
     }
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -129,7 +129,7 @@ class Behavior implements EventListenerInterface
      * Stores the reflected method + finder methods per class.
      * This prevents reflecting the same class multiple times in a single process.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected static $_reflectionCache = [];
 

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -106,7 +106,7 @@ class CounterCacheBehavior extends Behavior
     /**
      * Store the fields which should be ignored
      *
-     * @var array
+     * @var array<string, array<string, bool>>
      */
     protected $_ignoreDirty = [];
 

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -34,14 +34,14 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * Contains a list of locations where table classes should be looked for.
      *
-     * @var array
+     * @var array<string>
      */
     protected $locations = [];
 
     /**
      * Configuration for aliases.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $_config = [];
 

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -41,7 +41,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * Configuration for aliases.
      *
-     * @var array<string, array>
+     * @var array<string, array|null>
      */
     protected $_config = [];
 

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -30,7 +30,7 @@ class ContextFactory
     /**
      * Context providers.
      *
-     * @var array
+     * @var array<string, array>
      */
     protected $providers = [];
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -158,7 +158,7 @@ class View implements EventDispatcherInterface
     /**
      * An array of variables
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $viewVars = [];
 

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -26,7 +26,7 @@ class FixturizedTestCase extends TestCase
     /**
      * Fixtures to use in this test
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Categories', 'core.Articles'];
 

--- a/tests/TestCase/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Auth/BasicAuthenticateTest.php
@@ -32,7 +32,7 @@ class BasicAuthenticateTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.AuthUsers', 'core.Users'];
 

--- a/tests/TestCase/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Auth/DigestAuthenticateTest.php
@@ -36,7 +36,7 @@ class DigestAuthenticateTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.AuthUsers', 'core.Users'];
 

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -33,7 +33,7 @@ class FormAuthenticateTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.AuthUsers', 'core.Users'];
 

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -32,7 +32,7 @@ class SchemaCacheCommandsTest extends TestCase
     /**
      * Fixtures.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Articles', 'core.Tags'];
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -41,7 +41,7 @@ class ShellTest extends TestCase
     /**
      * Fixtures used in this test case
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles',

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -54,7 +54,7 @@ class AuthComponentTest extends TestCase
     /**
      * fixtures property
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.AuthUsers', 'core.Users'];
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -38,7 +38,7 @@ class PaginatorComponentTest extends TestCase
     /**
      * fixtures property
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Posts', 'core.Articles', 'core.ArticlesTags',

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -46,7 +46,7 @@ class ControllerTest extends TestCase
     /**
      * fixtures property
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Comments',

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -48,7 +48,7 @@ use ReflectionProperty;
 class ConnectionTest extends TestCase
 {
     /**
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Things'];
 

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -33,7 +33,7 @@ class CollectionTest extends TestCase
     protected $connection;
 
     /**
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Users',

--- a/tests/TestCase/Database/SchemaCacheTest.php
+++ b/tests/TestCase/Database/SchemaCacheTest.php
@@ -30,7 +30,7 @@ class SchemaCacheTest extends TestCase
     /**
      * Fixtures.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Articles', 'core.Tags'];
 

--- a/tests/TestCase/Datasource/PaginatorTest.php
+++ b/tests/TestCase/Datasource/PaginatorTest.php
@@ -26,7 +26,7 @@ class PaginatorTest extends TestCase
     /**
      * fixtures property
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Posts', 'core.Articles', 'core.Tags', 'core.ArticlesTags',

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -39,7 +39,7 @@ class SmtpTransportTest extends TestCase
     protected $socket;
 
     /**
-     * @var array
+     * @var array<string, string>
      */
     protected $credentials = [
         'username' => 'mark',

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -42,7 +42,7 @@ class BelongsToManyTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -36,7 +36,7 @@ class BelongsToTest extends TestCase
     /**
      * Fixtures to use.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -39,7 +39,7 @@ class HasManyTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Comments',

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -33,7 +33,7 @@ class HasOneTest extends TestCase
     /**
      * Fixtures to load
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Users', 'core.Profiles'];
 

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -28,7 +28,7 @@ class AssociationProxyTest extends TestCase
     /**
      * Fixtures to be loaded
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles', 'core.Authors', 'core.Comments',

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -29,7 +29,7 @@ class BehaviorRegressionTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.NumberTrees',

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -39,7 +39,7 @@ class CounterCacheBehaviorTest extends TestCase
     /**
      * Fixture
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.CounterCacheCategories',

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -35,7 +35,7 @@ class TimestampBehaviorTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Users',

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorTest.php
@@ -38,7 +38,7 @@ class TranslateBehaviorTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -29,7 +29,7 @@ class TreeBehaviorTest extends TestCase
     /**
      * fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.MenuLinkTrees',

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -26,7 +26,7 @@ class BindingKeyTest extends TestCase
     /**
      * Fixture to be used
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.AuthUsers',

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -37,7 +37,7 @@ class CompositeKeysTest extends TestCase
     /**
      * Fixture to be used
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.CompositeIncrements',

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -37,7 +37,7 @@ class QueryRegressionTest extends TestCase
     /**
      * Fixture to be used
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -48,7 +48,7 @@ class QueryTest extends TestCase
     /**
      * Fixture to be used
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -31,7 +31,7 @@ use Cake\TestSuite\TestCase;
 class ResultSetTest extends TestCase
 {
     /**
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -38,7 +38,7 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Fixtures to be loaded
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles', 'core.Tags', 'core.ArticlesTags', 'core.Authors', 'core.Comments',

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -28,7 +28,7 @@ use RuntimeException;
 class SaveOptionsBuilderTest extends TestCase
 {
     /**
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Articles',

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -29,7 +29,7 @@ class TableComplexIdTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.DateKeys',

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -28,7 +28,7 @@ class TableRegressionTest extends TestCase
     /**
      * Fixture to be used
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.Authors',

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -28,7 +28,7 @@ class TableUuidTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = [
         'core.BinaryUuidItems',

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -36,7 +36,7 @@ class TestFixtureTest extends TestCase
     /**
      * Fixtures for this test.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Posts'];
 

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -27,7 +27,7 @@ class InflectorTest extends TestCase
     /**
      * A list of chars to test transliteration.
      *
-     * @var array
+     * @var array<string, array>
      */
     public static $maps = [
         'de' => [ /* German */

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -37,7 +37,7 @@ class EntityContextTest extends TestCase
     /**
      * Fixtures to use.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Articles', 'core.Comments', 'core.Tags', 'core.ArticlesTags'];
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -52,7 +52,7 @@ class FormHelperTest extends TestCase
     /**
      * Fixtures to be used
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Articles', 'core.Comments'];
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -51,7 +51,7 @@ class ViewTest extends TestCase
     /**
      * Fixtures used in this test.
      *
-     * @var array
+     * @var array<string>
      */
     protected $fixtures = ['core.Posts', 'core.Users'];
 


### PR DESCRIPTION
a few more and we could one day get rid of

    checkMissingIterableValueType: false

only like 2000 more to go. :)