### PR TITLE
cake 5: Set allowMultipleNulls default to true for IsUnique

### DIFF
--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -37,7 +37,7 @@ class IsUnique
      * @var array<string, mixed>
      */
     protected array $_options = [
-        'allowMultipleNulls' => false,
+        'allowMultipleNulls' => true,
     ];
 
     /**
@@ -45,7 +45,7 @@ class IsUnique
      *
      * ### Options
      *
-     * - `allowMultipleNulls` Allows any field to have multiple null values. Defaults to false.
+     * - `allowMultipleNulls` Allows any field to have multiple null values. Defaults to true.
      *
      * @param array<string> $fields The list of fields to check uniqueness for
      * @param array<string, mixed> $options The options for unique checks.

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -394,7 +394,8 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = $this->getTableLocator()->get('UniqueAuthors');
         $rules = $table->rulesChecker();
         $rules->add($rules->isUnique(
-            ['first_author_id', 'second_author_id']
+            ['first_author_id', 'second_author_id'],
+            ['allowMultipleNulls' => false]
         ));
 
         $entity = new Entity([
@@ -417,8 +418,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = $this->getTableLocator()->get('UniqueAuthors');
         $rules = $table->rulesChecker();
         $rules->add($rules->isUnique(
-            ['first_author_id', 'second_author_id'],
-            ['allowMultipleNulls' => true]
+            ['first_author_id', 'second_author_id']
         ));
 
         $entity = new Entity([


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/15734

This originally defaulted to true in 3.x. The option was dropped in 4.0 for some reason and re-introduced in 4.2. 

This sets the default back to true to mimic SQL behavior.
