### PR TITLE
cake 5: Add version to deprecationWarning()

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -181,6 +181,7 @@ class Component implements EventListenerInterface
 
         if (!isset($events['Controller.shutdown']) && method_exists($this, 'shutdown')) {
             deprecationWarning(
+                '4.3.0',
                 '`Controller.shutdown` event callback is now `afterFilter()` instead of `shutdown()`.',
                 0
             );

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -272,12 +272,13 @@ if (!function_exists('deprecationWarning')) {
     /**
      * Helper method for outputting deprecation warnings
      *
+     * @param string $version The version that added this deprecation warning.
      * @param string $message The message to output as a deprecation warning.
      * @param int $stackFrame The stack frame to include in the error. Defaults to 1
      *   as that should point to application/plugin code.
      * @return void
      */
-    function deprecationWarning(string $message, int $stackFrame = 1): void
+    function deprecationWarning(string $version, string $message, int $stackFrame = 1): void
     {
         if (!(error_reporting() & E_USER_DEPRECATED)) {
             return;
@@ -298,10 +299,11 @@ if (!function_exists('deprecationWarning')) {
             }
 
             $message = sprintf(
-                '%s - %s, line: %s' . "\n" .
+                'Since %s: %s - %s, line: %s' . "\n" .
                 ' You can disable all deprecation warnings by setting `Error.errorLevel` to' .
                 ' `E_ALL & ~E_USER_DEPRECATED`, or add `%s` to ' .
                 ' `Error.ignoredDeprecationPaths` in your `config/app.php` to mute deprecations from only this file.',
+                $version,
                 $message,
                 $frame['file'],
                 $frame['line'],

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -84,10 +84,10 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabled(): void
     {
         $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
+        $this->expectDeprecationMessageMatches('/Since 5.0.0: This is going away - (.*?)[\/\\\]FunctionsTest.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function (): void {
-            deprecationWarning('This is going away', 2);
+            deprecationWarning('5.0.0', 'This is going away', 2);
         });
     }
 
@@ -97,10 +97,10 @@ class FunctionsTest extends TestCase
     public function testDeprecationWarningEnabledDefaultFrame(): void
     {
         $this->expectDeprecation();
-        $this->expectDeprecationMessageMatches('/This is going away too - (.*?)[\/\\\]TestCase.php, line\: \d+/');
+        $this->expectDeprecationMessageMatches('/Since 5.0.0: This is going away too - (.*?)[\/\\\]TestCase.php, line\: \d+/');
 
         $this->withErrorReporting(E_ALL, function (): void {
-            deprecationWarning('This is going away too');
+            deprecationWarning('5.0.0', 'This is going away too');
         });
     }
 
@@ -113,7 +113,7 @@ class FunctionsTest extends TestCase
 
         Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/*']);
         $this->withErrorReporting(E_ALL, function (): void {
-            deprecationWarning('This will be gone soon');
+            deprecationWarning('5.0.0', 'This will be gone soon');
         });
     }
 
@@ -125,7 +125,7 @@ class FunctionsTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         $this->withErrorReporting(E_ALL ^ E_USER_DEPRECATED, function (): void {
-            deprecationWarning('This is leaving');
+            deprecationWarning('5.0.0', 'This is leaving');
         });
     }
 


### PR DESCRIPTION
This should help document the deprecation. Hopefully, users can find the migration notes for the changes easier if they're upgrading multiple minor versions.

This follows how symfony handles deprecation notices if consistency helps. They include the package name, but not sure we need that.