### PR TITLE
Drop unneeded dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "cakephp/chronos": "^2.2",
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
-        "laminas/laminas-httphandlerrunner": "^1.1",
         "league/container": "^4.1.1",
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -23,19 +23,12 @@ namespace Cake\Http;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
 use Laminas\Diactoros\RelativeStream;
-use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * Emits a Response to the PHP Server API.
- *
- * This emitter offers a few changes from the emitters offered by
- * diactoros:
- *
- * - It logs headers sent using CakePHP's logging tools.
- * - Cookies are emitted using setcookie() to not conflict with ext/session
  */
-class ResponseEmitter implements EmitterInterface
+class ResponseEmitter
 {
     /**
      * Maximum output buffering size for each iteration.

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -23,7 +23,6 @@ use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
 use InvalidArgumentException;
-use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -116,11 +115,11 @@ class Server implements EventDispatcherInterface
      * Emit the response using the PHP SAPI.
      *
      * @param \Psr\Http\Message\ResponseInterface $response The response to emit
-     * @param \Laminas\HttpHandlerRunner\Emitter\EmitterInterface|null $emitter The emitter to use.
+     * @param \Cake\Http\ResponseEmitter|null $emitter The emitter to use.
      *   When null, a SAPI Stream Emitter will be used.
      * @return void
      */
-    public function emit(ResponseInterface $response, ?EmitterInterface $emitter = null): void
+    public function emit(ResponseInterface $response, ?ResponseEmitter $emitter = null): void
     {
         if (!$emitter) {
             $emitter = new ResponseEmitter();

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -22,6 +22,7 @@ use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
 use Cake\Http\CallbackStream;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\ResponseEmitter;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
 use Cake\Http\Session;
@@ -248,7 +249,7 @@ class ServerTest extends TestCase
             ->withHeader('X-First', 'first')
             ->withHeader('X-Second', 'second');
 
-        $emitter = $this->getMockBuilder('Laminas\HttpHandlerRunner\Emitter\EmitterInterface')->getMock();
+        $emitter = $this->getMockBuilder(ResponseEmitter::class)->getMock();
         $emitter->expects($this->once())
             ->method('emit')
             ->with($final);


### PR DESCRIPTION
There's no real need to implement laminas/http-handlerrunner's EmitterInterface.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
