### PR TITLE
Improve code flow as per bail early principle.

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -76,11 +76,11 @@ class Arguments
      */
     public function getArgumentAt(int $index): ?string
     {
-        if ($this->hasArgumentAt($index)) {
-            return $this->args[$index];
+        if (!$this->hasArgumentAt($index)) {
+            return null;
         }
 
-        return null;
+        return $this->args[$index];
     }
 
     /**

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -197,13 +197,13 @@ class ConsoleIo
      */
     public function out(array|string $message = '', int $newlines = 1, int $level = self::NORMAL): ?int
     {
-        if ($level <= $this->_level) {
-            $this->_lastWritten = $this->_out->write($message, $newlines);
-
-            return $this->_lastWritten;
+        if ($level > $this->_level) {
+            return null;
         }
 
-        return null;
+        $this->_lastWritten = $this->_out->write($message, $newlines);
+
+        return $this->_lastWritten;
     }
 
     /**

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -490,7 +490,7 @@ class RequestHandlerComponent extends Component
     /**
      * Maps a content type alias back to its mime-type(s)
      *
-     * @param array|string $alias String alias to convert back into a content type. Or an array of aliases to map.
+     * @param array<string>|string $alias String alias to convert back into a content type. Or an array of aliases to map.
      * @return array|string|null Null on an undefined alias. String value of the mapped alias type. If an
      *   alias maps to more than one content type, the first one will be returned. If an array is provided
      *   for $alias, an array of mapped types will be returned.
@@ -502,14 +502,14 @@ class RequestHandlerComponent extends Component
         }
 
         $type = $this->getController()->getResponse()->getMimeType($alias);
-        if ($type) {
-            if (is_array($type)) {
-                return $type[0];
-            }
-
-            return $type;
+        if (!$type) {
+            return null;
         }
 
-        return null;
+        if (is_array($type)) {
+            return $type[0];
+        }
+
+        return $type;
     }
 }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -774,11 +774,11 @@ class QueryExpression implements ExpressionInterface, Countable
     protected function _calculateType(ExpressionInterface|string $field): ?string
     {
         $field = $field instanceof IdentifierExpression ? $field->getIdentifier() : $field;
-        if (is_string($field)) {
-            return $this->getTypeMap()->type($field);
+        if (!is_string($field)) {
+            return null;
         }
 
-        return null;
+        return $this->getTypeMap()->type($field);
     }
 
     /**

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -119,10 +119,10 @@ class IntegerType extends BaseType implements BatchCastingInterface
         if ($value === null || $value === '') {
             return null;
         }
-        if (is_numeric($value)) {
-            return (int)$value;
+        if (!is_numeric($value)) {
+            return null;
         }
 
-        return null;
+        return (int)$value;
     }
 }

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -116,10 +116,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      */
     public function marshal(mixed $value): ?int
     {
-        if ($value === null || $value === '') {
-            return null;
-        }
-        if (!is_numeric($value)) {
+        if ($value === null || $value === '' || !is_numeric($value)) {
             return null;
         }
 

--- a/src/Event/EventList.php
+++ b/src/Event/EventList.php
@@ -73,11 +73,11 @@ class EventList implements ArrayAccess, Countable
      */
     public function offsetGet(mixed $offset): mixed
     {
-        if ($this->offsetExists($offset)) {
-            return $this->_events[$offset];
+        if (!$this->offsetExists($offset)) {
+            return null;
         }
 
-        return null;
+        return $this->_events[$offset];
     }
 
     /**

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -440,13 +440,13 @@ class Response extends Message implements ResponseInterface
         }
         libxml_use_internal_errors();
         $data = simplexml_load_string($this->_getBody());
-        if ($data) {
-            $this->_xml = $data;
-
-            return $this->_xml;
+        if (!$data) {
+            return null;
         }
 
-        return null;
+        $this->_xml = $data;
+
+        return $this->_xml;
     }
 
     /**

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -186,11 +186,11 @@ class BodyParserMiddleware implements MiddlewareInterface
             return [];
         }
         $decoded = json_decode($body, true);
-        if (json_last_error() === JSON_ERROR_NONE) {
-            return (array)$decoded;
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
         }
 
-        return null;
+        return (array)$decoded;
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -437,24 +437,27 @@ class ServerRequest implements ServerRequestInterface
         $ref = $this->getEnv('HTTP_REFERER');
 
         $base = Configure::read('App.fullBaseUrl') . $this->webroot;
-        if (!empty($ref) && !empty($base)) {
-            if ($local && str_starts_with($ref, $base)) {
-                $ref = substr($ref, strlen($base));
-                if ($ref === '' || str_starts_with($ref, '//')) {
-                    $ref = '/';
-                }
-                if ($ref[0] !== '/') {
-                    $ref = '/' . $ref;
-                }
-
-                return $ref;
-            }
-            if (!$local) {
-                return $ref;
-            }
+        if (empty($ref) || empty($base)) {
+            return null;
         }
 
-        return null;
+        if ($local && str_starts_with($ref, $base)) {
+            $ref = substr($ref, strlen($base));
+            if ($ref === '' || str_starts_with($ref, '//')) {
+                $ref = '/';
+            }
+            if ($ref[0] !== '/') {
+                $ref = '/' . $ref;
+            }
+
+            return $ref;
+        }
+
+        if ($local) {
+            return null;
+        }
+
+        return $ref;
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -372,18 +372,18 @@ trait DateFormatTrait
         $formatter->setLenient(static::$lenientParsing);
 
         $time = $formatter->parse($time);
-        if ($time !== false) {
-            $dateTime = new DateTimeImmutable('@' . $time);
-
-            if (!($tz instanceof DateTimeZone)) {
-                $tz = new DateTimeZone($tz ?? date_default_timezone_get());
-            }
-            $dateTime = $dateTime->setTimezone($tz);
-
-            return new static($dateTime);
+        if ($time === false) {
+            return null;
         }
 
-        return null;
+        $dateTime = new DateTimeImmutable('@' . $time);
+
+        if (!($tz instanceof DateTimeZone)) {
+            $tz = new DateTimeZone($tz ?? date_default_timezone_get());
+        }
+        $dateTime = $dateTime->setTimezone($tz);
+
+        return new static($dateTime);
     }
 
     /**

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -285,11 +285,11 @@ class Log
     public static function engine(string $name): ?LoggerInterface
     {
         $registry = static::getRegistry();
-        if ($registry->{$name}) {
-            return $registry->{$name};
+        if (!$registry->{$name}) {
+            return null;
         }
 
-        return null;
+        return $registry->{$name};
     }
 
     /**

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -220,11 +220,11 @@ class Socket
             $context
         );
 
-        if ($resource) {
-            return $resource;
+        if (!$resource) {
+            return null;
         }
 
-        return null;
+        return $resource;
     }
 
     /**
@@ -338,11 +338,11 @@ class Socket
      */
     public function lastError(): ?string
     {
-        if (!empty($this->lastError)) {
-            return $this->lastError['num'] . ': ' . $this->lastError['str'];
+        if (empty($this->lastError)) {
+            return null;
         }
 
-        return null;
+        return $this->lastError['num'] . ': ' . $this->lastError['str'];
     }
 
     /**
@@ -396,19 +396,19 @@ class Socket
         }
 
         /** @psalm-suppress PossiblyNullArgument */
-        if (!feof($this->connection)) {
-            $buffer = fread($this->connection, $length);
-            $info = stream_get_meta_data($this->connection);
-            if ($info['timed_out']) {
-                $this->setLastError(E_WARNING, 'Connection timed out');
-
-                return null;
-            }
-
-            return $buffer;
+        if (feof($this->connection)) {
+            return null;
         }
 
-        return null;
+        $buffer = fread($this->connection, $length);
+        $info = stream_get_meta_data($this->connection);
+        if ($info['timed_out']) {
+            $this->setLastError(E_WARNING, 'Connection timed out');
+
+            return null;
+        }
+
+        return $buffer;
     }
 
     /**

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -104,11 +104,11 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      */
     public function rule(string $name): ?ValidationRule
     {
-        if (!empty($this->_rules[$name])) {
-            return $this->_rules[$name];
+        if (empty($this->_rules[$name])) {
+            return null;
         }
 
-        return null;
+        return $this->_rules[$name];
     }
 
     /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -516,11 +516,11 @@ class EntityContext implements ContextInterface
         }
 
         $ruleset = $validator->field($fieldName);
-        if (!$ruleset->isEmptyAllowed()) {
-            return $validator->getNotEmptyMessage($fieldName);
+        if ($ruleset->isEmptyAllowed()) {
+            return null;
         }
 
-        return null;
+        return $validator->getNotEmptyMessage($fieldName);
     }
 
     /**
@@ -544,11 +544,11 @@ class EntityContext implements ContextInterface
         }
 
         $attributes = $this->attributes($field);
-        if (!empty($attributes['length'])) {
-            return (int)$attributes['length'];
+        if (empty($attributes['length'])) {
+            return null;
         }
 
-        return null;
+        return (int)$attributes['length'];
     }
 
     /**

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -102,11 +102,11 @@ class FormContext implements ContextInterface
     protected function _schemaDefault(string $field): mixed
     {
         $field = $this->_form->getSchema()->field($field);
-        if ($field) {
-            return $field['default'];
+        if (!$field) {
+            return null;
         }
 
-        return null;
+        return $field['default'];
     }
 
     /**
@@ -162,11 +162,11 @@ class FormContext implements ContextInterface
         }
 
         $attributes = $this->attributes($field);
-        if (!empty($attributes['length'])) {
-            return $attributes['length'];
+        if (empty($attributes['length'])) {
+            return null;
         }
 
-        return null;
+        return $attributes['length'];
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1050,13 +1050,13 @@ class View implements EventDispatcherInterface
     public function __get(string $name): mixed
     {
         $registry = $this->helpers();
-        if (isset($registry->{$name})) {
-            $this->{$name} = $registry->{$name};
-
-            return $registry->{$name};
+        if (!isset($registry->{$name})) {
+            return null;
         }
 
-        return null;
+        $this->{$name} = $registry->{$name};
+
+        return $registry->{$name};
     }
 
     /**


### PR DESCRIPTION
This makes the code on these methods a bit more consistent with the rest of the classes.
With the bail early principle on the falsey cases (guard clauses) to exit early, and keeping the happy case as final return value where possible.

Also removes some nesting and makes it a bit more human readable in some cases.