### PR TITLE
Clarify assoc behavior and merging.

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -290,7 +290,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      * Constructor.
      *
      * @param string $table The table name.
-     * @param array $columns The list of columns for the schema.
+     * @param array<string, array> $columns The list of columns for the schema.
      */
     public function __construct(string $table, array $columns = [])
     {
@@ -674,7 +674,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
      */
     public function setOptions(array $options)
     {
-        $this->_options = array_merge($this->_options, $options);
+        $this->_options = $options + $this->_options;
 
         return $this;
     }

--- a/src/Datasource/SchemaInterface.php
+++ b/src/Datasource/SchemaInterface.php
@@ -53,7 +53,7 @@ interface SchemaInterface
      * - `comment` The comment for the column.
      *
      * @param string $name The name of the column
-     * @param array|string $attrs The attributes for the column or the type name.
+     * @param array<string, mixed>|string $attrs The attributes for the column or the type name.
      * @return $this
      */
     public function addColumn(string $name, array|string $attrs);
@@ -100,7 +100,7 @@ interface SchemaInterface
     public function getColumnType(string $name): ?string;
 
     /**
-     * Sets the type of a column.
+     * Sets the type of column.
      *
      * @param string $name The column to set the type of.
      * @param string $type The type to set the column to.
@@ -132,14 +132,14 @@ interface SchemaInterface
      * Returns an array where the keys are the column names in the schema
      * and the values the database type they have.
      *
-     * @return array
+     * @return array<string, string>
      */
     public function typeMap(): array;
 
     /**
      * Get a hash of columns and their default values.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function defaultValues(): array;
 
@@ -160,7 +160,7 @@ interface SchemaInterface
      * Table options allow you to set platform specific table level options.
      * For example the engine type in MySQL.
      *
-     * @return array An array of options.
+     * @return array<string, mixed> An array of options.
      */
     public function getOptions(): array;
 }

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -122,7 +122,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Constructor
      *
-     * @param array $headers Unparsed headers.
+     * @param array<string> $headers Unparsed headers.
      * @param string $body The response body.
      */
     public function __construct(array $headers = [], string $body = '')
@@ -171,7 +171,7 @@ class Response extends Message implements ResponseInterface
      * - Decodes the status code and reasonphrase.
      * - Parses and normalizes header names + values.
      *
-     * @param array $headers Headers to parse.
+     * @param array<string> $headers Headers to parse.
      * @return void
      */
     protected function _parseHeaders(array $headers): void

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -107,7 +107,7 @@ class ViewBuilder implements JsonSerializable
      * This options array lets you provide custom constructor
      * arguments to application/plugin view classes.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected array $_options = [];
 
@@ -423,7 +423,7 @@ class ViewBuilder implements JsonSerializable
     }
 
     /**
-     * Gets the name of the layout file to render the view inside of.
+     * Gets the name of the layout file to render the view inside.
      *
      * @return string|null
      */
@@ -469,7 +469,7 @@ class ViewBuilder implements JsonSerializable
     public function setOptions(array $options, bool $merge = true)
     {
         if ($merge) {
-            $options = array_merge($this->_options, $options);
+            $options += $this->_options;
         }
         $this->_options = $options;
 
@@ -479,7 +479,7 @@ class ViewBuilder implements JsonSerializable
     /**
      * Gets additional options for the view.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getOptions(): array
     {

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -180,8 +180,8 @@ class ViewBuilderTest extends TestCase
             $builder = new ViewBuilder();
             $builder->{$set}($value);
 
-            $builder->{$set}(['Merged'], true);
-            $this->assertSame(array_merge($value, ['Merged']), $builder->{$get}(), 'Should merge');
+            $builder->{$set}(['merged' => 'Merged'], true);
+            $this->assertSame(['merged' => 'Merged'] + $value, $builder->{$get}(), 'Should merge');
 
             $builder->{$set}($value, false);
             $this->assertSame($value, $builder->{$get}(), 'Should replace');
@@ -346,19 +346,18 @@ class ViewBuilderTest extends TestCase
     }
 
     /**
-     * test setOptions() with 2 strings in array, merge true.
+     * test setOptions() with 2 assoc strings in array, merge true.
      */
     public function testSetOptionsMultiple(): void
     {
         $builder = new ViewBuilder();
-        $builder->setOptions(['oldOption'], false);
+        $builder->setOptions(['key' => 'oldOption'], false);
 
-        $option = ['newOption', 'anotherOption'];
+        $option = ['anotherKey' => 'anotherOption', 'key' => 'newOption'];
         $builder->setOptions($option);
-        $expects = ['oldOption', 'newOption', 'anotherOption'];
+        $expects = ['key' => 'newOption', 'anotherKey' => 'anotherOption'];
 
         $result = $builder->getOptions();
-        $this->assertContainsOnly('string', $result);
         $this->assertEquals($expects, $result);
     }
 


### PR DESCRIPTION
Makes this consistent with
- setOptions() from RuleInvoker
- assoc behavior of such string keyed option arrays

```
There were 2 failures:

1) Cake\Test\TestCase\View\ViewBuilderTest::testArrayPropertyMerge with data set #0 ('options', array('value'))
Should merge
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
+    0 => 'Merged'
     'key' => 'value'
-    0 => 'Merged'
 )

/home/runner/work/cakephp/cakephp/tests/TestCase/View/ViewBuilderTest.php:184
/home/runner/work/cakephp/cakephp/src/TestSuite/TestCase.php:182
/home/runner/work/cakephp/cakephp/tests/TestCase/View/ViewBuilderTest.php:188

2) Cake\Test\TestCase\View\ViewBuilderTest::testSetOptionsMultiple
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'oldOption'
-    1 => 'newOption'
-    2 => 'anotherOption'
+    0 => 'newOption'
+    1 => 'anotherOption'
 )

/home/runner/work/cakephp/cakephp/tests/TestCase/View/ViewBuilderTest.php:362
```

Do we want to support this behavior in 5.x?
Or shall we just fix up the test cases to match the general expectation of assoc here?

I don't see how the test case demos here show any usefulness of the array_merge() as it was.
As you cannot properly reference the options anyway without a clear key to access them.