### PR TITLE
Make CSP nonces opt-in

### DIFF
--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Cake\Http\Middleware;
 
+use Cake\Core\InstanceConfigTrait;
 use ParagonIE\CSPBuilder\CSPBuilder;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,9 +27,16 @@ use RuntimeException;
 
 /**
  * Content Security Policy Middleware
+ *
+ * ### Options
+ *
+ * - `scriptNonce` Enable to have a nonce policy added to the script-src directive.
+ * - `styleNonce` Enable to have a nonce policy added to the style-src directive.
  */
 class CspMiddleware implements MiddlewareInterface
 {
+    use InstanceConfigTrait;
+
     /**
      * CSP Builder
      *
@@ -37,16 +45,28 @@ class CspMiddleware implements MiddlewareInterface
     protected $csp;
 
     /**
+     * Configuration options.
+     *
+     * @var array<string, mixed>
+     */
+    protected $_defaultConfig = [
+        'scriptNonce' => false,
+        'styleNonce' => false,
+    ];
+
+    /**
      * Constructor
      *
      * @param \ParagonIE\CSPBuilder\CSPBuilder|array $csp CSP object or config array
+     * @param array<string, mixed> $config Configuration options.
      * @throws \RuntimeException
      */
-    public function __construct($csp)
+    public function __construct($csp, array $config = [])
     {
         if (!class_exists(CSPBuilder::class)) {
             throw new RuntimeException('You must install paragonie/csp-builder to use CspMiddleware');
         }
+        $this->setConfig($config);
 
         if (!$csp instanceof CSPBuilder) {
             $csp = new CSPBuilder($csp);
@@ -56,7 +76,7 @@ class CspMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Add nonces to the request and apply the CSP header to the response.
+     * Add nonces (if enabled) to the request and apply the CSP header to the response.
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
@@ -64,10 +84,12 @@ class CspMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = $request
-            ->withAttribute('cspScriptNonce', $this->csp->nonce('script-src'))
-            ->withAttribute('cspStyleNonce', $this->csp->nonce('style-src'));
-
+        if ($this->getConfig('scriptNonce')) {
+            $request = $request->withAttribute('cspScriptNonce', $this->csp->nonce('script-src'));
+        }
+        if ($this->getconfig('styleNonce')) {
+            $request = $request->withAttribute('cspStyleNonce', $this->csp->nonce('style-src'));
+        }
         $response = $handler->handle($request);
 
         /** @var \Psr\Http\Message\ResponseInterface */

--- a/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CspMiddlewareTest.php
@@ -60,14 +60,10 @@ class CspMiddlewareTest extends TestCase
 
         $response = $middleware->process($request, $this->_getRequestHandler());
         $policy = $response->getHeaderLine('Content-Security-Policy');
-        $expected = [
-            'script-src \'self\' https://www.google-analytics.com',
-        ];
 
-        $this->assertNotEmpty($policy);
-        foreach ($expected as $match) {
-            $this->assertStringContainsString($match, $policy);
-        }
+        $expected = 'script-src \'self\' https://www.google-analytics.com';
+        $this->assertStringContainsString($expected, $policy);
+        $this->assertStringNotContainsString('nonce-', $policy);
     }
 
     /**
@@ -77,7 +73,7 @@ class CspMiddlewareTest extends TestCase
     {
         $request = new ServerRequest();
 
-        $middleware = new CspMiddleware([
+        $policy = [
             'script-src' => [
                 'self' => true,
                 'unsafe-inline' => false,
@@ -88,6 +84,10 @@ class CspMiddlewareTest extends TestCase
                 'unsafe-inline' => false,
                 'unsafe-eval' => false,
             ],
+        ];
+        $middleware = new CspMiddleware($policy, [
+            'scriptNonce' => true,
+            'styleNonce' => true,
         ]);
 
         $handler = new TestRequestHandler(function ($request) {
@@ -133,13 +133,8 @@ class CspMiddlewareTest extends TestCase
 
         $response = $middleware->process($request, $this->_getRequestHandler());
         $policy = $response->getHeaderLine('Content-Security-Policy');
-        $expected = [
-            'script-src \'self\' https://www.google-analytics.com',
-        ];
+        $expected = 'script-src \'self\' https://www.google-analytics.com';
 
-        $this->assertNotEmpty($policy);
-        foreach ($expected as $match) {
-            $this->assertStringContainsString($match, $policy);
-        }
+        $this->assertStringContainsString($expected, $policy);
     }
 }


### PR DESCRIPTION
Unfortunately the CSPBuilder library doesn't allow us to read if the policy contains nonce directives. Automatically adding nonces can break applications that use CSP. Making the nonces opt-in allows developers to enable stricter CSP rules when they are ready.
