### PR TITLE
Return empty string when no data for session id

### DIFF
--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -86,7 +86,7 @@ class CacheSession implements SessionHandlerInterface
         $value = Cache::read($id, $this->_options['config']);
 
         if ($value === null) {
-            return false;
+            return '';
         }
 
         return $value;

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -122,14 +122,20 @@ class DatabaseSession implements SessionHandlerInterface
             ->first();
 
         if (empty($result)) {
-            return false;
+            return '';
         }
 
         if (is_string($result['data'])) {
             return $result['data'];
         }
 
-        return stream_get_contents($result['data']);
+        $session = stream_get_contents($result['data']);
+
+        if ($session === false) {
+            return '';
+        }
+
+        return $session;
     }
 
     /**

--- a/tests/TestCase/Http/Session/DatabaseSessionTest.php
+++ b/tests/TestCase/Http/Session/DatabaseSessionTest.php
@@ -116,7 +116,7 @@ class DatabaseSessionTest extends TestCase
         $this->assertSame($expected, $result);
 
         $result = $this->storage->read('made up value');
-        $this->assertFalse($result);
+        $this->assertSame('', $result);
     }
 
     /**
@@ -127,7 +127,7 @@ class DatabaseSessionTest extends TestCase
         $this->assertTrue($this->storage->write('foo', 'Some value'));
 
         $this->assertTrue($this->storage->destroy('foo'), 'Destroy failed');
-        $this->assertFalse($this->storage->read('foo'), 'Value still present.');
+        $this->assertSame('', $this->storage->read('foo'), 'Value still present.');
         $this->assertTrue($this->storage->destroy('foo'), 'Destroy should always return true');
     }
 
@@ -144,7 +144,7 @@ class DatabaseSessionTest extends TestCase
 
         sleep(1);
         $storage->gc(0);
-        $this->assertFalse($storage->read('foo'));
+        $this->assertSame('', $storage->read('foo'));
     }
 
     /**


### PR DESCRIPTION
Revert the read failure return type from https://github.com/cakephp/cakephp/pull/15578.

This is causing session_open() to fail when there is no data. Seems to be a documentation problem in php.

https://github.com/php/doc-en/issues/970
