### PR TITLE
Fix IDE found issues/smells.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,17 +6,7 @@ parameters:
 			path: src/Auth/DigestAuthenticate.php
 
 		-
-			message: "#^Method Cake\\\\Auth\\\\Storage\\\\MemoryStorage\\:\\:redirectUrl\\(\\) should return array\\|string\\|null but return statement is missing\\.$#"
-			count: 1
-			path: src/Auth/Storage/MemoryStorage.php
-
-		-
 			message: "#^Constructor of class Cake\\\\Auth\\\\Storage\\\\SessionStorage has an unused parameter \\$response\\.$#"
-			count: 1
-			path: src/Auth/Storage/SessionStorage.php
-
-		-
-			message: "#^Method Cake\\\\Auth\\\\Storage\\\\SessionStorage\\:\\:redirectUrl\\(\\) should return array\\|string\\|null but return statement is missing\\.$#"
 			count: 1
 			path: src/Auth/Storage/SessionStorage.php
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     colors="true"
     bootstrap="tests/bootstrap.php"
     backupGlobals="true"
+    convertDeprecationsToExceptions="true"
     >
 
     <testsuites>

--- a/src/Auth/Storage/MemoryStorage.php
+++ b/src/Auth/Storage/MemoryStorage.php
@@ -75,5 +75,7 @@ class MemoryStorage implements StorageInterface
         }
 
         $this->_redirectUrl = $url;
+
+        return null;
     }
 }

--- a/src/Auth/Storage/SessionStorage.php
+++ b/src/Auth/Storage/SessionStorage.php
@@ -138,5 +138,7 @@ class SessionStorage implements StorageInterface
         }
 
         $this->_session->write($this->_config['redirect'], $url);
+
+        return null;
     }
 }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -717,7 +717,7 @@ class I18nExtractCommand extends Command
     protected function _getStrings(int &$position, int $target): array
     {
         $strings = [];
-        $count = count($strings);
+        $count = 0;
         while (
             $count < $target
             && ($this->_tokens[$position] === ','

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -143,7 +143,7 @@ class ServerCommand extends Command
 
         $port = ':' . $this->_port;
         $io->out(sprintf('built-in server is running in http://%s%s/', $this->_host, $port));
-        $io->out(sprintf('You can exit with <info>`CTRL-C`</info>'));
+        $io->out('You can exit with <info>`CTRL-C`</info>');
         system($command);
 
         return static::CODE_SUCCESS;

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -248,7 +248,7 @@ abstract class BaseCommand implements CommandInterface
      *
      * @param \Cake\Console\CommandInterface|string $command The command class name or command instance.
      * @param array $args The arguments to invoke the command with.
-     * @param \Cake\Console\ConsoleIo $io The ConsoleIo instance to use for the executed command.
+     * @param \Cake\Console\ConsoleIo|null $io The ConsoleIo instance to use for the executed command.
      * @return int|null The exit code or null for success of the command.
      */
     public function executeCommand($command, array $args = [], ?ConsoleIo $io = null): ?int

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -279,7 +279,6 @@ class ShellDispatcher
 
             $other = static::alias($shell);
             if ($other) {
-                $other = $aliases[$shell];
                 if ($other !== $plugin) {
                     Log::write(
                         'debug',

--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -66,7 +66,7 @@ class TaskRegistry extends ObjectRegistry
      * and Cake\Core\ObjectRegistry::unload()
      *
      * @param string $class The classname that is missing.
-     * @param string $plugin The plugin the task is missing in.
+     * @param string|null $plugin The plugin the task is missing in.
      * @return void
      * @throws \Cake\Console\Exception\MissingTaskException
      */

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -246,7 +246,7 @@ class RequestHandlerComponent extends Component
      *
      * Returns true if the client accepts XML.
      *
-     * @param array|string|null $type Can be null (or no parameter), a string type name, or an
+     * @param array<string>|string|null $type Can be null (or no parameter), a string type name, or an
      *   array of types
      * @return array|bool|string|null If null or no parameter is passed, returns an array of content
      *   types the client accepts. If a string is passed, returns true

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -248,7 +248,7 @@ class RequestHandlerComponent extends Component
      *
      * @param array|string|null $type Can be null (or no parameter), a string type name, or an
      *   array of types
-     * @return mixed If null or no parameter is passed, returns an array of content
+     * @return array|bool|string|null If null or no parameter is passed, returns an array of content
      *   types the client accepts. If a string is passed, returns true
      *   if the client accepts it. If an array is passed, returns true
      *   if the client accepts one or more elements in the array.
@@ -317,9 +317,11 @@ class RequestHandlerComponent extends Component
             return $controller->getResponse()->mapType($contentType);
         }
 
-        if (is_string($type)) {
-            return $type === $controller->getResponse()->mapType($contentType);
+        if (!is_string($type)) {
+            return null;
         }
+
+        return $type === $controller->getResponse()->mapType($contentType);
     }
 
     /**

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -94,11 +94,10 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
     /**
      * Invoke a controller's action and wrapping methods.
      *
-     * @param mixed $controller The controller to invoke.
+     * @param \Cake\Controller\Controller $controller The controller to invoke.
      * @return \Psr\Http\Message\ResponseInterface The response
      * @throws \Cake\Controller\Exception\MissingActionException If controller action is not found.
      * @throws \UnexpectedValueException If return value of action method is not null or ResponseInterface instance.
-     * @psalm-param \Cake\Controller\Controller $controller
      */
     public function invoke($controller): ResponseInterface
     {
@@ -160,7 +159,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         $args = [];
         $reflection = new ReflectionFunction($action);
 
-        foreach ($reflection->getParameters() as $i => $parameter) {
+        foreach ($reflection->getParameters() as $parameter) {
             $position = $parameter->getPosition();
             $hasDefault = $parameter->isDefaultValueAvailable();
 

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -326,9 +326,8 @@ class PluginCollection implements Iterator, Countable
      * Filter the plugins to those with the named hook enabled.
      *
      * @param string $hook The hook to filter plugins by
-     * @return \Generator&\Cake\Core\PluginInterface[] A generator containing matching plugins.
+     * @return \Generator<\Cake\Core\PluginInterface> A generator containing matching plugins.
      * @throws \InvalidArgumentException on invalid hooks
-     * @psalm-return \Generator<\Cake\Core\PluginInterface>
      */
     public function with(string $hook): Generator
     {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -389,7 +389,7 @@ abstract class Driver implements DriverInterface
             return $this->_connection->lastInsertId($table);
         }
 
-        return $this->_connection->lastInsertId($table, $column);
+        return $this->_connection->lastInsertId($table);
     }
 
     /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -736,7 +736,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param string $field The value from which the actual field and operator will
      * be extracted.
      * @param mixed $value The value to be bound to a placeholder for the field
-     * @return \Cake\Database\ExpressionInterface|string
+     * @return \Cake\Database\ExpressionInterface
      * @throws \InvalidArgumentException If operator is invalid or missing on NULL usage.
      */
     protected function _parseCondition(string $field, $value)

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -46,7 +46,7 @@ class FieldTypeConverter
      * at the moment this object is created. Used so that the types list
      * is not fetched on each single row of the results.
      *
-     * @var array<\Cake\Database\TypeInterface>|array<\Cake\Database\Type\BatchCastingInterface>
+     * @var array<\Cake\Database\TypeInterface|\Cake\Database\Type\BatchCastingInterface>
      */
     protected $types;
 

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -221,7 +221,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     protected function _defaultValue($type, $default)
     {
         if ($default === null) {
-            return $default;
+            return null;
         }
 
         // remove () surrounding value (NULL) but leave () at the end of functions

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -89,7 +89,7 @@ class BufferedStatement implements Iterator, StatementInterface
      * Magic getter to return $queryString as read-only.
      *
      * @param string $property internal property to get
-     * @return mixed
+     * @return string|null
      */
     public function __get(string $property)
     {
@@ -97,6 +97,8 @@ class BufferedStatement implements Iterator, StatementInterface
             /** @psalm-suppress NoInterfaceProperties */
             return $this->statement->queryString;
         }
+
+        return null;
     }
 
     /**
@@ -225,7 +227,7 @@ class BufferedStatement implements Iterator, StatementInterface
     }
 
     /**
-     * @inheritDoc
+     * @return array
      */
     public function fetchAssoc(): array
     {

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -50,7 +50,7 @@ class PDOStatement extends StatementDecorator
      * Magic getter to return PDOStatement::$queryString as read-only.
      *
      * @param string $property internal property to get
-     * @return mixed
+     * @return string|null
      */
     public function __get(string $property)
     {
@@ -58,6 +58,8 @@ class PDOStatement extends StatementDecorator
             /** @psalm-suppress NoInterfaceProperties */
             return $this->_statement->queryString;
         }
+
+        return null;
     }
 
     /**

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -76,7 +76,7 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      * Magic getter to return $queryString as read-only.
      *
      * @param string $property internal property to get
-     * @return mixed
+     * @return string|null
      */
     public function __get(string $property)
     {
@@ -84,6 +84,8 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
             /** @psalm-suppress NoInterfaceProperties */
             return $this->_statement->queryString;
         }
+
+        return null;
     }
 
     /**

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -72,7 +72,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
     public function toPHP($value, DriverInterface $driver): ?int
     {
         if ($value === null) {
-            return $value;
+            return null;
         }
 
         return (int)$value;

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1058,6 +1058,8 @@ trait EntityTrait
                 if ($val instanceof EntityInterface) {
                     return $val->getErrors();
                 }
+
+                return null;
             }, (array)$object);
 
             return array_filter($array);

--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -61,7 +61,7 @@ class RuleInvoker
      * rule $scope.
      *
      * @param callable $rule The rule to be invoked.
-     * @param ?string $name The name of the rule. Used in error messsages.
+     * @param ?string $name The name of the rule. Used in error messages.
      * @param array<string, mixed> $options The options for the rule. See above.
      */
     public function __construct(callable $rule, ?string $name, array $options = [])

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -307,7 +307,7 @@ class RulesChecker
      * Utility method for decorating any callable so that if it returns false, the correct
      * property in the entity is marked as invalid.
      *
-     * @param callable $rule The rule to decorate
+     * @param callable|\Cake\Datasource\RuleInvoker $rule The rule to decorate
      * @param array|string|null $name The alias for a rule or an array of options
      * @param array<string, mixed> $options The options containing the error message and field.
      * @return \Cake\Datasource\RuleInvoker

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -322,7 +322,7 @@ abstract class BaseErrorHandler
      * Log an error for the exception if applicable.
      *
      * @param \Throwable $exception The exception to log a message for.
-     * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
+     * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request.
      * @return bool
      */
     public function logException(Throwable $exception, ?ServerRequestInterface $request = null): bool

--- a/src/Error/Debug/DebugContext.php
+++ b/src/Error/Debug/DebugContext.php
@@ -31,7 +31,7 @@ class DebugContext
     /**
      * @var int
      */
-    private $maxDepth = 0;
+    private $maxDepth;
 
     /**
      * @var int

--- a/src/Error/Debug/PropertyNode.php
+++ b/src/Error/Debug/PropertyNode.php
@@ -40,7 +40,7 @@ class PropertyNode implements NodeInterface
      * Constructor
      *
      * @param string $name The property name
-     * @param string $visibility The visibility of the property.
+     * @param string|null $visibility The visibility of the property.
      * @param \Cake\Error\Debug\NodeInterface $value The property value node.
      */
     public function __construct(string $name, ?string $visibility, NodeInterface $value)

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -121,7 +121,7 @@ class ExceptionRenderer implements ExceptionRendererInterface
      * Creates the controller to perform rendering on the error response.
      *
      * @param \Throwable $exception Exception.
-     * @param \Cake\Http\ServerRequest $request The request if this is set it will be used
+     * @param \Cake\Http\ServerRequest|null $request The request if this is set it will be used
      *   instead of creating a new one.
      */
     public function __construct(Throwable $exception, ?ServerRequest $request = null)

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -416,7 +416,7 @@ class File
     /**
      * Returns the full path of the file.
      *
-     * @return string|false Full path to the file, or false on failure
+     * @return string|null Full path to the file, or null on failure
      */
     public function pwd()
     {

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -349,7 +349,7 @@ class Folder
      */
     public static function isRegisteredStreamWrapper(string $path): bool
     {
-        return preg_match('/^[^:\/\/]+?(?=:\/\/)/', $path, $matches) &&
+        return preg_match('/^[^:\/]+?(?=:\/\/)/', $path, $matches) &&
             in_array($matches[0], stream_get_wrappers(), true);
     }
 
@@ -646,13 +646,12 @@ class Folder
         if ($this->create($nextPathname, $mode)) {
             if (!file_exists($pathname)) {
                 $old = umask(0);
+                umask($old);
                 if (mkdir($pathname, $mode, true)) {
-                    umask($old);
                     $this->_messages[] = sprintf('%s created', $pathname);
 
                     return true;
                 }
-                umask($old);
                 $this->_errors[] = sprintf('%s NOT created', $pathname);
 
                 return false;

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -88,8 +88,8 @@ abstract class BaseApplication implements
      * Constructor
      *
      * @param string $configDir The directory the bootstrap configuration is held in.
-     * @param \Cake\Event\EventManagerInterface $eventManager Application event manager instance.
-     * @param \Cake\Http\ControllerFactoryInterface $controllerFactory Controller factory.
+     * @param \Cake\Event\EventManagerInterface|null $eventManager Application event manager instance.
+     * @param \Cake\Http\ControllerFactoryInterface|null $controllerFactory Controller factory.
      */
     public function __construct(
         string $configDir,

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -241,7 +241,7 @@ class Cookie implements CookieInterface
     protected static function dateTimeInstance($expires): ?DateTimeInterface
     {
         if ($expires === null) {
-            return $expires;
+            return null;
         }
 
         if ($expires instanceof DateTimeInterface) {
@@ -732,7 +732,7 @@ class Cookie implements CookieInterface
      * This method will expand serialized complex data,
      * on first use.
      *
-     * @param string $path Path to read the data from
+     * @param string|null $path Path to read the data from
      * @return mixed
      */
     public function read(?string $path = null)

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -210,8 +210,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Gets the iterator
      *
-     * @return array<\Cake\Http\Cookie\CookieInterface>
-     * @psalm-return \Traversable<string, \Cake\Http\Cookie\CookieInterface>
+     * @return \Traversable<string, \Cake\Http\Cookie\CookieInterface>
      */
     public function getIterator(): Traversable
     {

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -164,7 +164,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
      * @param string $option Option value. Available Values: 'deny', 'sameorigin', 'allow-from <uri>'
-     * @param string $url URL if mode is `allow-from`
+     * @param string|null $url URL if mode is `allow-from`
      * @return $this
      */
     public function setXFrameOptions(string $option = self::SAMEORIGIN, ?string $url = null)
@@ -192,8 +192,6 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      */
     public function setXssProtection(string $mode = self::XSS_BLOCK)
     {
-        $mode = $mode;
-
         if ($mode === self::XSS_BLOCK) {
             $mode = self::XSS_ENABLED_BLOCK;
         }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1433,7 +1433,7 @@ class Response implements ResponseInterface
         if ($options['download']) {
             $agent = (string)env('HTTP_USER_AGENT');
 
-            if ($agent && preg_match('%Opera(/| )([0-9].[0-9]{1,2})%', $agent)) {
+            if ($agent && preg_match('%Opera([/ ])([0-9].[0-9]{1,2})%', $agent)) {
                 $contentType = 'application/octet-stream';
             } elseif ($agent && preg_match('/MSIE ([0-9].[0-9]{1,2})/', $agent)) {
                 $contentType = 'application/force-download';
@@ -1463,7 +1463,7 @@ class Response implements ResponseInterface
     /**
      * Convenience method to set a string into the response body
      *
-     * @param string $string The string to be sent
+     * @param string|null $string The string to be sent
      * @return static
      */
     public function withStringBody(?string $string)

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -68,7 +68,7 @@ class Server implements EventDispatcherInterface
      * - Run the middleware queue including the application.
      *
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The request to use or null.
-     * @param \Cake\Http\MiddlewareQueue $middlewareQueue MiddlewareQueue or null.
+     * @param \Cake\Http\MiddlewareQueue|null $middlewareQueue MiddlewareQueue or null.
      * @return \Psr\Http\Message\ResponseInterface
      * @throws \RuntimeException When the application does not make a response.
      */

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -453,7 +453,7 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string $name The method called
      * @param array $params Array of parameters for the method call
-     * @return mixed
+     * @return bool
      * @throws \BadMethodCallException when an invalid method is called.
      */
     public function __call(string $name, array $params)

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -45,11 +45,11 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
      * order to marshal the request URI and headers.
      *
      * @see fromServer()
-     * @param array $server $_SERVER superglobal
-     * @param array $query $_GET superglobal
-     * @param array $parsedBody $_POST superglobal
-     * @param array $cookies $_COOKIE superglobal
-     * @param array $files $_FILES superglobal
+     * @param array|null $server $_SERVER superglobal
+     * @param array|null $query $_GET superglobal
+     * @param array|null $parsedBody $_POST superglobal
+     * @param array|null $cookies $_COOKIE superglobal
+     * @param array|null $files $_FILES superglobal
      * @return \Cake\Http\ServerRequest
      * @throws \InvalidArgumentException for invalid file values
      */

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -62,7 +62,7 @@ class Translator
      * @param string $locale The locale being used.
      * @param \Cake\I18n\Package $package The Package containing keys and translations.
      * @param \Cake\I18n\FormatterInterface $formatter A message formatter.
-     * @param \Cake\I18n\Translator $fallback A fallback translator.
+     * @param \Cake\I18n\Translator|null $fallback A fallback translator.
      */
     public function __construct(
         string $locale,

--- a/src/Log/Engine/ArrayLog.php
+++ b/src/Log/Engine/ArrayLog.php
@@ -55,7 +55,7 @@ class ArrayLog extends BaseLog
      * @param string $message The message you want to log.
      * @param array $context Additional information about the logged message
      * @return void success of write.
-     * @see Cake\Log\Log::$_levels
+     * @see \Cake\Log\Log::$_levels
      */
     public function log($level, $message, array $context = [])
     {

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -92,7 +92,7 @@ class ConsoleLog extends BaseLog
      * @param string $message The message you want to log.
      * @param array $context Additional information about the logged message
      * @return void success of write.
-     * @see Cake\Log\Log::$_levels
+     * @see \Cake\Log\Log::$_levels
      */
     public function log($level, $message, array $context = [])
     {

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -122,7 +122,7 @@ class FileLog extends BaseLog
      * @param string $message The message you want to log.
      * @param array $context Additional information about the logged message
      * @return void
-     * @see Cake\Log\Log::$_levels
+     * @see \Cake\Log\Log::$_levels
      */
     public function log($level, $message, array $context = []): void
     {

--- a/src/Log/Engine/SyslogLog.php
+++ b/src/Log/Engine/SyslogLog.php
@@ -116,7 +116,7 @@ class SyslogLog extends BaseLog
      * @param string $message The message you want to log.
      * @param array $context Additional information about the logged message
      * @return void
-     * @see Cake\Log\Log::$_levels
+     * @see \Cake\Log\Log::$_levels
      */
     public function log($level, $message, array $context = []): void
     {

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -955,7 +955,7 @@ class Message implements JsonSerializable, Serializable
      *
      * @param array<string> $include List of headers.
      * @param string $eol End of line string for concatenating headers.
-     * @param \Closure $callback Callback to run each header value through before stringifying.
+     * @param \Closure|null $callback Callback to run each header value through before stringifying.
      * @return string
      * @see Message::getHeaders()
      */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -930,12 +930,13 @@ class BelongsToMany extends Association
             }
         );
 
+        /** @var array<\Cake\Datasource\EntityInterface> $existing */
         $existing = $sourceEntity->get($property) ?: [];
         if (!$options['cleanProperty'] || empty($existing)) {
             return true;
         }
 
-        /** @var \SplObjectStorage<\Cake\Datasource\EntityInterface, null> $storage*/
+        /** @var \SplObjectStorage<\Cake\Datasource\EntityInterface, null> $storage */
         $storage = new SplObjectStorage();
         foreach ($targetEntities as $e) {
             $storage->attach($e);
@@ -993,7 +994,7 @@ class BelongsToMany extends Association
      * Any string expressions, or expression objects will
      * also be returned in this list.
      *
-     * @return mixed Generally an array. If the conditions
+     * @return array|\Closure|null Generally an array. If the conditions
      *   are not an array, the association conditions will be
      *   returned unmodified.
      */

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -369,8 +369,7 @@ class AssociationCollection implements IteratorAggregate
     /**
      * Allow looping through the associations
      *
-     * @return array<\Cake\ORM\Association>
-     * @psalm-return \Traversable<string, \Cake\ORM\Association>
+     * @return \Traversable<string, \Cake\ORM\Association>
      */
     public function getIterator(): Traversable
     {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -137,7 +137,7 @@ class EagerLoader
         if ($queryBuilder) {
             if (!is_string($associations)) {
                 throw new InvalidArgumentException(
-                    sprintf('Cannot set containments. To use $queryBuilder, $associations must be a string')
+                    'Cannot set containments. To use $queryBuilder, $associations must be a string'
                 );
             }
 
@@ -754,7 +754,7 @@ class EagerLoader
      * will be normalized
      * @param bool $asMatching Whether this join results should be treated as a
      * 'matching' association.
-     * @param string $targetProperty The property name where the results of the join should be nested at.
+     * @param string|null $targetProperty The property name where the results of the join should be nested at.
      * If not passed, the default property for the association will be used.
      * @return void
      */

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -42,7 +42,7 @@ class PersistenceFailedException extends CakeException
      * @param \Cake\Datasource\EntityInterface $entity The entity on which the persistence operation failed
      * @param array|string $message Either the string of the error message, or an array of attributes
      *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
-     * @param int $code The code of the error, is also the HTTP status code for the error.
+     * @param int|null $code The code of the error, is also the HTTP status code for the error.
      * @param \Throwable|null $previous the previous exception.
      */
     public function __construct(EntityInterface $entity, $message, ?int $code = null, ?Throwable $previous = null)

--- a/src/TestSuite/Constraint/Console/ExitCode.php
+++ b/src/TestSuite/Constraint/Console/ExitCode.php
@@ -32,7 +32,7 @@ class ExitCode extends Constraint
     /**
      * Constructor
      *
-     * @param int $exitCode Exit code
+     * @param int|null $exitCode Exit code
      */
     public function __construct(?int $exitCode)
     {

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -79,8 +79,6 @@ class FixtureHelper
             } else {
                 /** @psalm-var class-string<\Cake\Datasource\FixtureInterface> */
                 $className = $fixtureName;
-                /** @psalm-suppress PossiblyFalseArgument */
-                $name = preg_replace('/Fixture\z/', '', substr(strrchr($fixtureName, '\\'), 1));
             }
 
             if (isset($fixtures[$className])) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -59,7 +59,7 @@ class FixtureManager
     /**
      * A map of connection names and the fixture currently in it.
      *
-     * @var array
+     * @var array<string, array<\Cake\Datasource\FixtureInterface>>
      */
     protected $_insertionMap = [];
 
@@ -90,7 +90,8 @@ class FixtureManager
     }
 
     /**
-     * @inheritDoc
+     * @param \Cake\TestSuite\TestCase $test Test case
+     * @return void
      */
     public function fixturize(TestCase $test): void
     {
@@ -103,7 +104,7 @@ class FixtureManager
     }
 
     /**
-     * @inheritDoc
+     * @return \Cake\Datasource\FixtureInterface[]
      */
     public function loaded(): array
     {
@@ -111,13 +112,14 @@ class FixtureManager
     }
 
     /**
-     * @inheritDoc
+     * @return array<string>
      */
     public function getInserted(): array
     {
         $inserted = [];
         foreach ($this->_insertionMap as $fixtures) {
             foreach ($fixtures as $fixture) {
+                /** @var \Cake\TestSuite\Fixture\TestFixture $fixture */
                 $inserted[] = $fixture->table;
             }
         }
@@ -280,7 +282,9 @@ class FixtureManager
     }
 
     /**
-     * @inheritDoc
+     * @param \Cake\TestSuite\TestCase $test Test case
+     * @return void
+     * @throws \RuntimeException
      */
     public function load(TestCase $test): void
     {
@@ -440,7 +444,7 @@ class FixtureManager
         $truncate = function (ConnectionInterface $db, array $fixtures): void {
             $configName = $db->configName();
 
-            foreach ($fixtures as $name => $fixture) {
+            foreach ($fixtures as $fixture) {
                 if (
                     $this->isFixtureSetup($configName, $fixture)
                     && $fixture instanceof ConstraintsInterface
@@ -453,7 +457,11 @@ class FixtureManager
     }
 
     /**
-     * @inheritDoc
+     * @param string $name Name
+     * @param \Cake\Datasource\ConnectionInterface|null $connection Connection
+     * @param bool $dropTables Drop all tables prior to loading schema files
+     * @return void
+     * @throws \UnexpectedValueException
      */
     public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -659,7 +659,6 @@ trait IntegrationTestTrait
 
         if ($this->_csrfToken === true) {
             $middleware = new CsrfProtectionMiddleware();
-            $token = null;
             if (!isset($this->_cookie[$this->_csrfKeyName]) && !isset($this->_session[$this->_csrfKeyName])) {
                 $token = $middleware->createToken();
             } elseif (isset($this->_cookie[$this->_csrfKeyName])) {

--- a/src/TestSuite/LegacyCommandRunner.php
+++ b/src/TestSuite/LegacyCommandRunner.php
@@ -27,7 +27,7 @@ class LegacyCommandRunner
      * Mimics functionality of Cake\Console\CommandRunner
      *
      * @param array $argv Argument array
-     * @param \Cake\Console\ConsoleIo $io A ConsoleIo instance.
+     * @param \Cake\Console\ConsoleIo|null $io A ConsoleIo instance.
      * @return int
      */
     public function run(array $argv, ?ConsoleIo $io = null): int

--- a/src/TestSuite/LegacyShellDispatcher.php
+++ b/src/TestSuite/LegacyShellDispatcher.php
@@ -34,7 +34,7 @@ class LegacyShellDispatcher extends ShellDispatcher
      *
      * @param array $args Argument array
      * @param bool $bootstrap Initialize environment
-     * @param \Cake\Console\ConsoleIo $io ConsoleIo
+     * @param \Cake\Console\ConsoleIo|null $io ConsoleIo
      */
     public function __construct(array $args = [], bool $bootstrap = true, ?ConsoleIo $io = null)
     {

--- a/src/Utility/MergeVariablesTrait.php
+++ b/src/Utility/MergeVariablesTrait.php
@@ -99,7 +99,7 @@ trait MergeVariablesTrait
      * @param array $current The current merged value.
      * @param array $parent The parent class' value.
      * @param bool $isAssoc Whether the merging should be done in associative mode.
-     * @return mixed The updated value.
+     * @return array The updated value.
      */
     protected function _mergePropertyData(array $current, array $parent, bool $isAssoc)
     {

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -441,8 +441,8 @@ class Text
      */
     protected static function _wordWrap(string $text, int $width = 72, string $break = "\n", bool $cut = false): string
     {
+        $parts = [];
         if ($cut) {
-            $parts = [];
             while (mb_strlen($text) > 0) {
                 $part = mb_substr($text, 0, $width);
                 $parts[] = trim($part);
@@ -452,7 +452,6 @@ class Text
             return implode($break, $parts);
         }
 
-        $parts = [];
         while (mb_strlen($text) > 0) {
             if ($width >= mb_strlen($text)) {
                 $parts[] = trim($text);

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -190,7 +190,7 @@ class ValidationRule
     protected function _addValidatorProps(array $validator = []): void
     {
         foreach ($validator as $key => $value) {
-            if (!isset($value) || empty($value)) {
+            if (empty($value)) {
                 continue;
             }
             if ($key === 'rule' && is_array($value) && !is_callable($value)) {

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -215,8 +215,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns an iterator for each of the rules to be applied
      *
-     * @return array<\Cake\Validation\ValidationRule>
-     * @psalm-return \Traversable<string, \Cake\Validation\ValidationRule>
+     * @return \Traversable<string, \Cake\Validation\ValidationRule>
      */
     public function getIterator(): Traversable
     {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -461,8 +461,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns an iterator for each of the fields to be validated
      *
-     * @return array<\Cake\Validation\ValidationSet>
-     * @psalm-return \Traversable<string, \Cake\Validation\ValidationSet>
+     * @return \Traversable<string, \Cake\Validation\ValidationSet>
      */
     public function getIterator(): Traversable
     {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -109,7 +109,7 @@ abstract class Cell implements EventDispatcherInterface
      *
      * @param \Cake\Http\ServerRequest $request The request to use in the cell.
      * @param \Cake\Http\Response $response The response to use in the cell.
-     * @param \Cake\Event\EventManagerInterface $eventManager The eventManager to bind events to.
+     * @param \Cake\Event\EventManagerInterface|null $eventManager The eventManager to bind events to.
      * @param array<string, mixed> $cellOptions Cell options to apply.
      */
     public function __construct(
@@ -158,6 +158,7 @@ abstract class Cell implements EventDispatcherInterface
      * @return string The rendered cell.
      * @throws \Cake\View\Exception\MissingCellTemplateException
      *   When a MissingTemplateException is raised during rendering.
+     * @throws \BadMethodCallException
      */
     public function render(?string $template = null): string
     {

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -54,7 +54,6 @@ trait CellTrait
      * @param array<string, mixed> $options Options for Cell's constructor
      * @return \Cake\View\Cell The cell instance
      * @throws \Cake\View\Exception\MissingCellException If Cell class was not found.
-     * @throws \BadMethodCallException If Cell class does not specified cell action.
      */
     protected function cell(string $cell, array $data = [], array $options = []): Cell
     {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -485,6 +485,8 @@ class EntityContext implements ContextInterface
 
             return false;
         }
+
+        return null;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2329,9 +2329,6 @@ class FormHelper extends Helper
         if ($isDisabled) {
             $options['secure'] = self::SECURE_SKIP;
         }
-        if ($options['secure'] === self::SECURE_SKIP) {
-            return $options;
-        }
 
         return $options;
     }

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -146,7 +146,7 @@ class TextHelper extends Helper
         );
         // phpcs:disable Generic.Files.LineLength
         $text = preg_replace_callback(
-            '#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www\.[^\s\n\%\ <]+[^\s<\n\%\,\.\ <](?<!\))#i',
+            '#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www\.[^\s\n\%\ <]+[^\s<\n\%\,\.\ ](?<!\))#i',
             [&$this, '_insertPlaceHolder'],
             $text
         );

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -855,6 +855,7 @@ class View implements EventDispatcherInterface
     {
         if (is_array($name)) {
             if (is_array($value)) {
+                /** @var array|false $data */
                 $data = array_combine($name, $value);
                 if ($data === false) {
                     throw new RuntimeException(
@@ -1077,16 +1078,18 @@ class View implements EventDispatcherInterface
      * Magic accessor for helpers.
      *
      * @param string $name Name of the attribute to get.
-     * @return mixed
+     * @return \Cake\View\Helper|null
      */
     public function __get(string $name)
     {
         $registry = $this->helpers();
-        if (isset($registry->{$name})) {
-            $this->{$name} = $registry->{$name};
-
-            return $registry->{$name};
+        if (!isset($registry->{$name})) {
+            return null;
         }
+
+        $this->{$name} = $registry->{$name};
+
+        return $registry->{$name};
     }
 
     /**
@@ -1169,6 +1172,7 @@ class View implements EventDispatcherInterface
         ob_start();
 
         try {
+            // Avoiding $templateFile here due to collision with extract() vars.
             include func_get_arg(0);
         } catch (Throwable $exception) {
             while (ob_get_level() > $bufferLevel) {

--- a/templates/Error/duplicate_named_route.php
+++ b/templates/Error/duplicate_named_route.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         3.3.1
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \Cake\Core\Exception\CakeException $error
  */
 
 use Cake\Error\Debugger;

--- a/templates/Error/fatal_error.php
+++ b/templates/Error/fatal_error.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         2.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \Cake\Core\Exception\CakeException $error
  */
 $this->layout = 'dev_error';
 

--- a/templates/Error/missing_action.php
+++ b/templates/Error/missing_action.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $action
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/templates/Error/missing_behavior.php
+++ b/templates/Error/missing_behavior.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         1.3.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $class
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/templates/Error/missing_cell_template.php
+++ b/templates/Error/missing_cell_template.php
@@ -11,6 +11,8 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $name
+ * @var string $file
  */
 $this->layout = 'dev_error';
 

--- a/templates/Error/missing_component.php
+++ b/templates/Error/missing_component.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $class
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/templates/Error/missing_connection.php
+++ b/templates/Error/missing_connection.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $message
  */
 $this->layout = 'dev_error';
 

--- a/templates/Error/missing_controller.php
+++ b/templates/Error/missing_controller.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $class
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/templates/Error/missing_datasource.php
+++ b/templates/Error/missing_datasource.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         2.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $class
  */
 $pluginDot = empty($plugin) ? null : $plugin . '.';
 

--- a/templates/Error/missing_datasource_config.php
+++ b/templates/Error/missing_datasource_config.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         2.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $message
  */
 $this->layout = 'dev_error';
 

--- a/templates/Error/missing_helper.php
+++ b/templates/Error/missing_helper.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $class
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/templates/Error/missing_layout.php
+++ b/templates/Error/missing_layout.php
@@ -11,6 +11,8 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $file
+ * @var array<string> $paths
  */
 
 $this->layout = 'dev_error';

--- a/templates/Error/missing_plugin.php
+++ b/templates/Error/missing_plugin.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         2.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $plugin
  */
 use Cake\Core\Configure;
 

--- a/templates/Error/missing_route.php
+++ b/templates/Error/missing_route.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \Cake\Core\Exception\CakeException $error
  */
 
 use Cake\Error\Debugger;

--- a/templates/Error/missing_template.php
+++ b/templates/Error/missing_template.php
@@ -11,6 +11,8 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         0.10.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $file
+ * @var array<string> $paths
  */
 use Cake\Utility\Inflector;
 

--- a/templates/Error/missing_view.php
+++ b/templates/Error/missing_view.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var string $class
  */
 use Cake\Core\Configure;
 use Cake\Core\Plugin;

--- a/templates/Error/pdo_error.php
+++ b/templates/Error/pdo_error.php
@@ -38,7 +38,7 @@ $this->start('subheading');
 <?php endif; ?>
 <?php if (!empty($error->params)) : ?>
         <strong>SQL Query Params: </strong>
-        <pre><?= h(Debugger::dump($error->params)); ?></pre>
+        <pre><?php Debugger::dump($error->params); ?></pre>
 <?php endif; ?>
 <?= $this->element('auto_table_warning'); ?>
 <?php $this->end() ?>

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -11,6 +11,7 @@
  * @link          https://cakephp.org CakePHP(tm) Project
  * @since         3.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var \Cake\Core\Exception\CakeException $error
  */
 use Cake\Error\Debugger;
 ?>

--- a/tests/TestCase/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Auth/ControllerAuthorizeTest.php
@@ -76,7 +76,6 @@ class ControllerAuthorizeTest extends TestCase
 
         $this->controller->expects($this->once())
             ->method('isAuthorized')
-            ->with($user)
             ->will($this->returnValue(true));
 
         $this->assertTrue($this->auth->authorize($user, $request));

--- a/tests/test_app/TestApp/Controller/AuthTestController.php
+++ b/tests/test_app/TestApp/Controller/AuthTestController.php
@@ -114,9 +114,10 @@ class AuthTestController extends Controller
     /**
      * isAuthorized method
      *
+     * @param \ArrayAccess|array $user User
      * @return void
      */
-    public function isAuthorized()
+    public function isAuthorized($user)
     {
     }
 }


### PR DESCRIPTION
The PHPStorm IDE gets quite powerful in smell detection topics

- `@inheritDoc` used for member without parent members with doc comments 
- null missing on docblock param/return
- missing return values for non void
- return value of void used
- unused local var
- resolve mixed to concrete where possible
- sprintf() without args issue
- duplication removal of if/loops
- duplication in regex removal
- passing non existing args to functions/methods

An actual bug/no-op has also been found and resolved