### PR TITLE
#15956 Enable hybrid test fixtures strategies.

### DIFF
--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -50,6 +50,10 @@ class TransactionStrategy implements FixtureStrategyInterface
      */
     public function setupTest(array $fixtureNames): void
     {
+        if (empty($fixtureNames)) {
+            return;
+        }
+
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
 
         $this->helper->runPerConnection(function ($connection) {

--- a/src/TestSuite/Fixture/TruncateStrategy.php
+++ b/src/TestSuite/Fixture/TruncateStrategy.php
@@ -44,6 +44,10 @@ class TruncateStrategy implements FixtureStrategyInterface
      */
     public function setupTest(array $fixtureNames): void
     {
+        if (empty($fixtureNames)) {
+            return;
+        }
+
         $this->fixtures = $this->helper->loadFixtures($fixtureNames);
         $this->helper->insert($this->fixtures);
     }

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -261,11 +261,8 @@ abstract class TestCase extends BaseTestCase
     protected function setupFixtures(): void
     {
         $fixtureNames = $this->getFixtures();
-        if (empty($fixtureNames)) {
-            return;
-        }
 
-        if (static::$fixtureManager) {
+        if (!empty($fixtureNames) && static::$fixtureManager) {
             if (!$this->autoFixtures) {
                 deprecationWarning('`$autoFixtures` is deprecated and will be removed in 5.0.', 0);
             }


### PR DESCRIPTION
<!---

The aim of this PR is to enable strategies that handle the truncation of the test DB both with and without fixtures. In the actual implementation, this is not possible.

This is further documented [here](https://github.com/cakephp/cakephp/issues/15956).

-->
