### PR TITLE
Use phpstan level 1 to check basic tests sanity.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,3 +247,7 @@ jobs:
     - name: Run phpstan
       if: success() || failure()
       run: vendor/bin/phpstan.phar analyse --error-format=github
+
+    - name: Run phpstan for tests
+      if: success() || failure()
+      run: vendor/bin/phpstan.phar analyse -c tests/phpstan.neon --error-format=github

--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
             "@phpstan",
             "@psalm"
         ],
+        "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
         "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.96 psalm/phar:~4.10.0 && mv composer.backup composer.json",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4917,6 +4917,7 @@ class QueryTest extends TestCase
     public function testStringExpression(): void
     {
         $driver = $this->connection->getDriver();
+        $collation = null;
         if ($driver instanceof Mysql) {
             if (version_compare($this->connection->getDriver()->version(), '5.7.0', '<')) {
                 $collation = 'utf8_general_ci';
@@ -4953,6 +4954,7 @@ class QueryTest extends TestCase
     public function testIdentifierCollation(): void
     {
         $driver = $this->connection->getDriver();
+        $collation = null;
         if ($driver instanceof Mysql) {
             if (version_compare($this->connection->getDriver()->version(), '5.7.0', '<')) {
                 $collation = 'utf8_general_ci';

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -55,6 +55,16 @@ class BelongsToManyTest extends TestCase
     ];
 
     /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $tag;
+
+    /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $article;
+
+    /**
      * Set up
      */
     public function setUp(): void

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -41,6 +41,21 @@ class BelongsToTest extends TestCase
     protected $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
 
     /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $company;
+
+    /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $client;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $companiesTypeMap;
+
+    /**
      * Set up
      */
     public function setUp(): void

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -51,6 +51,26 @@ class HasManyTest extends TestCase
     ];
 
     /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $author;
+
+    /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $article;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $articlesTypeMap;
+
+    /**
+     * @var bool
+     */
+    protected $autoQuote;
+
+    /**
      * Set up
      */
     public function setUp(): void

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -38,6 +38,16 @@ class HasOneTest extends TestCase
     protected $fixtures = ['core.Users', 'core.Profiles'];
 
     /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $user;
+
+    /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $profile;
+
+    /**
      * @var bool
      */
     protected $listenerCalled = false;

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -37,6 +37,31 @@ class CounterCacheBehaviorTest extends TestCase
     protected $post;
 
     /**
+     * @var \TestApp\Model\Table\PublishedPostsTable
+     */
+    protected $user;
+
+    /**
+     * @var \TestApp\Model\Table\PublishedPostsTable
+     */
+    protected $category;
+
+    /**
+     * @var \TestApp\Model\Table\PublishedPostsTable
+     */
+    protected $comment;
+
+    /**
+     * @var \TestApp\Model\Table\PublishedPostsTable
+     */
+    protected $userCategoryPosts;
+
+    /**
+     * @var \Cake\Datasource\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
      * Fixture
      *
      * @var array<string>

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -35,6 +35,16 @@ class BehaviorRegistryTest extends TestCase
     protected $Behaviors;
 
     /**
+     * @var \Cake\ORM\Table
+     */
+    protected $Table;
+
+    /**
+     * @var \Cake\Event\EventManagerInterface
+     */
+    protected $EventManager;
+
+    /**
      * setup method.
      */
     public function setUp(): void

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -31,6 +31,51 @@ use InvalidArgumentException;
 class EagerLoaderTest extends TestCase
 {
     /**
+     * @var \Cake\Datasource\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var \Cake\ORM\Table
+     */
+    protected $table;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $clientsTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $ordersTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $orderTypesTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $stuffTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $stuffTypesTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $companiesTypeMap;
+
+    /**
+     * @var \Cake\Database\TypeMap
+     */
+    protected $categoriesTypeMap;
+
+    /**
      * setUp method
      */
     public function setUp(): void

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -46,6 +46,11 @@ class ResultSetTest extends TestCase
     protected $fixtureData;
 
     /**
+     * @var \Cake\Datasource\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
      * setup
      */
     public function setUp(): void

--- a/tests/TestCase/ORM/SaveOptionsBuilderTest.php
+++ b/tests/TestCase/ORM/SaveOptionsBuilderTest.php
@@ -48,10 +48,10 @@ class SaveOptionsBuilderTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->connection = ConnectionManager::get('test');
+        $connection = ConnectionManager::get('test');
         $this->table = new Table([
             'table' => 'articles',
-            'connection' => $this->connection,
+            'connection' => $connection,
         ]);
 
         $this->table->belongsTo('Authors');

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use DateTime;

--- a/tests/TestCase/ORM/TableComplexIdTest.php
+++ b/tests/TestCase/ORM/TableComplexIdTest.php
@@ -41,7 +41,6 @@ class TableComplexIdTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->connection = ConnectionManager::get('test');
         static::setAppNamespace();
     }
 

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -35,12 +35,17 @@ use TypeError;
 class XmlTest extends TestCase
 {
     /**
+     * @var string
+     */
+    protected $appEncoding;
+
+    /**
      * setUp method
      */
     public function setUp(): void
     {
         parent::setUp();
-        $this->_appEncoding = Configure::read('App.encoding');
+        $this->appEncoding = Configure::read('App.encoding');
         Configure::write('App.encoding', 'UTF-8');
     }
 
@@ -50,7 +55,7 @@ class XmlTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        Configure::write('App.encoding', $this->_appEncoding);
+        Configure::write('App.encoding', $this->appEncoding);
     }
 
     public function testExceptionChainingForInvalidInput(): void

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1,0 +1,10 @@
+parameters:
+	level: 1
+	treatPhpDocTypesAsCertain: false
+	bootstrapFiles:
+		- bootstrap.php
+	paths:
+		- TestCase/
+	earlyTerminatingMethodCalls:
+		Cake\Console\Shell:
+			- abort

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -4,7 +4,15 @@ parameters:
 	bootstrapFiles:
 		- bootstrap.php
 	paths:
-		- TestCase/
+		- TestCase/Collection/
+		- TestCase/Core/
+		- TestCase/Database/
+		- TestCase/Datasource/
+		- TestCase/Event/
+		- TestCase/ORM/
+		- TestCase/Utility/
+		- TestCase/Validation/
+
 	earlyTerminatingMethodCalls:
 		Cake\Console\Shell:
 			- abort


### PR DESCRIPTION
RFC/WIP

I adapted this quite some time ago and I recommend we also do that for core.

It adds very basic sanity checks that helped me in the past
- Valid PSR file structure and class naming
- Basic PHP validity (e.g. reports now undefined class properties, in light of possible 8.2 changes)

E.g.
```
  Line   Console/CommandRunnerTest.php                                       
 ------ -------------------------------------------------------------------- 
  406    Class Cake\Test\TestCase\Console\stdClass not found.                
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols  
  408    Class Cake\Test\TestCase\Console\stdClass not found.                
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols  
```
https://github.com/cakephp/cakephp/pull/15963/checks?check_run_id=3710160043

We can adapt our test classes to that standard, we don't however have to go further than level 1 to keep things simple.
30 seconds worth spending in CI runtime.

What do you think?

Given the amount of work to add all props we could start with a subset for now.