### PR TITLE
Split Router::extensions() combined setter/getter

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -744,7 +744,7 @@ class Router
     public static function extensions($extensions = null, $merge = true): array
     {
         if ($extensions !== null) {
-            deprecationWarning('Setting extensions is deprecated, use setExtensions() instead.');
+            deprecationWarning('Setting extensions with extensions() is deprecated, use setExtensions() instead.');
             static::setExtensions($extensions, $merge);
 
             return static::$_defaultExtensions;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -720,38 +720,68 @@ class Router
     }
 
     /**
-     * Get or set valid extensions for all routes connected later.
+     * Gets or sets valid extensions for all routes connected later.
      *
      * Instructs the router to parse out file extensions
      * from the URL. For example, http://example.com/posts.rss would yield a file
      * extension of "rss". The file extension itself is made available in the
      * controller as `$this->request->getParam('_ext')`, and is used by the RequestHandler
      * component to automatically switch to alternate layouts and templates, and
-     * load helpers corresponding to the given content, i.e. RssHelper. Switching
+     * load helpers corresponding to the given content, i.e. RSS/CSV/JSON. Switching
      * layouts and helpers requires that the chosen extension has a defined mime type
-     * in `Cake\Http\Response`.
+     * in `\Cake\Http\Response`.
      *
      * A string or an array of valid extensions can be passed to this method.
      * If called without any parameters it will return current list of set extensions.
      *
-     * @param array<string>|string|null $extensions List of extensions to be added.
+     * Deprecated: Setting extensions is deprecated since 4.3.0. Use setExtensions() instead.
+     *
+     * @param array<string>|string|null $extensions List of extensions to be added. Deprecated since 4.3.0.
      * @param bool $merge Whether to merge with or override existing extensions.
-     *   Defaults to `true`.
+     *   Defaults to `true`. Deprecated since 4.3.0.
      * @return array<string> Array of extensions Router is configured to parse.
      */
     public static function extensions($extensions = null, $merge = true): array
     {
-        $collection = static::$_collection;
-        if ($extensions === null) {
-            return array_unique(array_merge(static::$_defaultExtensions, $collection->getExtensions()));
+        if ($extensions !== null) {
+            deprecationWarning('Setting extensions is deprecated, use setExtensions() instead.');
+            static::setExtensions($extensions, $merge);
+
+            return static::$_defaultExtensions;
         }
 
+        $collection = static::$_collection;
+
+        return array_unique(array_merge(static::$_defaultExtensions, $collection->getExtensions()));
+    }
+
+    /**
+     * Sets valid extensions for all routes connected later.
+     *
+     * Instructs the router to parse out file extensions from the URL.
+     * For example, http://example.com/posts.rss would yield a file
+     * extension of "rss". The file extension itself is made available in the
+     * controller as `$this->request->getParam('_ext')`, and is used by the RequestHandler
+     * component to automatically switch to alternate layouts and templates, and
+     * load helpers corresponding to the given content, i.e. RSS/CSV/JSON. Switching
+     * layouts and helpers requires that the chosen extension has a defined mime type
+     * in `\Cake\Http\Response`.
+     *
+     * A string or an array of valid extensions can be passed to this method.
+     *
+     * @param array<string>|string|null $extensions List of extensions to be added.
+     * @param bool $merge Whether to merge with or override existing extensions.
+     *   Defaults to `true`.
+     * @return void
+     */
+    public static function setExtensions($extensions = null, bool $merge = true): void
+    {
         $extensions = (array)$extensions;
         if ($merge) {
             $extensions = array_unique(array_merge(static::$_defaultExtensions, $extensions));
         }
 
-        return static::$_defaultExtensions = $extensions;
+        static::$_defaultExtensions = $extensions;
     }
 
     /**

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -154,7 +154,7 @@ class RequestHandlerComponentTest extends TestCase
             ->withHeader('Accept', 'application/json, application/javascript, */*; q=0.01')
             ->withHeader('X-Requested-With', 'XMLHttpRequest'));
         $this->RequestHandler->setExt(null);
-        Router::extensions('json', false);
+        Router::setExtensions('json', false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertSame('json', $this->RequestHandler->ext);
@@ -181,7 +181,7 @@ class RequestHandlerComponentTest extends TestCase
         Router::reload();
         $this->Controller->setRequest($this->request->withHeader('Accept', 'application/json, application/javascript, */*; q=0.01'));
         $this->RequestHandler->setExt(null);
-        Router::extensions(['rss', 'json'], false);
+        Router::setExtensions(['rss', 'json'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertSame('json', $this->RequestHandler->ext);
@@ -213,13 +213,13 @@ class RequestHandlerComponentTest extends TestCase
             'application/json, application/javascript, application/xml, */*; q=0.01'
         ));
         $this->RequestHandler->setExt(null);
-        Router::extensions(['xml', 'json'], false);
+        Router::setExtensions(['xml', 'json'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertSame('xml', $this->RequestHandler->ext);
 
         $this->RequestHandler->setExt(null);
-        Router::extensions(['json', 'xml'], false);
+        Router::setExtensions(['json', 'xml'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertSame('json', $this->RequestHandler->ext);
@@ -263,7 +263,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testInititalizeFirefoxHeaderNotXml(): void
     {
         $_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;image/png,image/jpeg,image/*;q=0.9,*/*;q=0.8';
-        Router::extensions(['xml', 'json'], false);
+        Router::setExtensions(['xml', 'json'], false);
 
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
@@ -276,7 +276,7 @@ class RequestHandlerComponentTest extends TestCase
     {
         $this->assertNull($this->RequestHandler->ext);
         $extensions = Router::extensions();
-        Router::extensions('xml', false);
+        Router::setExtensions('xml', false);
 
         $request = new ServerRequest([
             'environment' => ['HTTP_ACCEPT' => 'text/plain'],
@@ -286,7 +286,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
         $this->assertNull($this->RequestHandler->ext);
 
-        Router::extensions($extensions, false);
+        Router::setExtensions($extensions, false);
     }
 
     /**
@@ -383,7 +383,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testDefaultExtensions($extension): void
     {
-        Router::extensions([$extension], false);
+        Router::setExtensions([$extension], false);
 
         $this->Controller->setRequest($this->request->withParam('_ext', $extension));
         $this->RequestHandler->startup(new Event('Controller.startup', $this->Controller));
@@ -406,7 +406,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testDefaultExtensionsOverwrittenByAcceptHeader($extension): void
     {
-        Router::extensions([$extension], false);
+        Router::setExtensions([$extension], false);
 
         $request = $this->request->withHeader(
             'Accept',
@@ -432,7 +432,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testJsonViewLoaded(): void
     {
-        Router::extensions(['json', 'xml', 'ajax'], false);
+        Router::setExtensions(['json', 'xml', 'ajax'], false);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'json'));
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->startup($event);
@@ -451,7 +451,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testXmlViewLoaded(): void
     {
-        Router::extensions(['json', 'xml', 'ajax'], false);
+        Router::setExtensions(['json', 'xml', 'ajax'], false);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'xml'));
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->startup($event);
@@ -470,7 +470,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testAjaxViewLoaded(): void
     {
-        Router::extensions(['json', 'xml', 'ajax'], false);
+        Router::setExtensions(['json', 'xml', 'ajax'], false);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'ajax'));
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->startup($event);
@@ -488,7 +488,7 @@ class RequestHandlerComponentTest extends TestCase
      */
     public function testNoViewClassExtension(): void
     {
-        Router::extensions(['json', 'xml', 'ajax', 'csv'], false);
+        Router::setExtensions(['json', 'xml', 'ajax', 'csv'], false);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'csv'));
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->startup($event);
@@ -508,7 +508,7 @@ class RequestHandlerComponentTest extends TestCase
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('Invoked extension not recognized/configured: foo');
 
-        Router::extensions(['json', 'foo'], false);
+        Router::setExtensions(['json', 'foo'], false);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'foo'));
         $event = new Event('Controller.startup', $this->Controller);
         $this->RequestHandler->startup($event);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1625,6 +1625,27 @@ class RouterTest extends TestCase
     }
 
     /**
+     * testExtensions method for setting
+     *
+     * @deprecated
+     */
+    public function testSetExtensionsDeprecated(): void
+    {
+        Router::extensions('rss', false);
+        $this->assertContains('rss', Router::extensions());
+
+        $this->_connectDefaultRoutes();
+
+        $result = Router::parseRequest($this->makeRequest('/posts.rss', 'GET'));
+        $this->assertSame('rss', $result['_ext']);
+
+        $result = Router::parseRequest($this->makeRequest('/posts.xml', 'GET'));
+        $this->assertArrayNotHasKey('_ext', $result);
+
+        Router::extensions(['xml']);
+    }
+
+    /**
      * Test that route builders propagate extensions to the top.
      */
     public function testExtensionsWithScopedRoutes(): void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -670,7 +670,7 @@ class RouterTest extends TestCase
         Router::connect('/reset/*', ['admin' => true, 'controller' => 'Users', 'action' => 'reset']);
         Router::connect('/tests', ['controller' => 'Tests', 'action' => 'index']);
         Router::connect('/admin/{controller}/{action}/*', ['prefix' => 'Admin']);
-        Router::extensions('rss', false);
+        Router::setExtensions('rss', false);
 
         $request = new ServerRequest([
             'params' => [
@@ -926,7 +926,7 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithExtensionInCurrentRequest(): void
     {
-        Router::extensions('rss');
+        Router::setExtensions('rss');
         Router::scope('/', function (RouteBuilder $r): void {
             $r->fallbacks('InflectedRoute');
         });
@@ -1610,7 +1610,7 @@ class RouterTest extends TestCase
      */
     public function testSetExtensions(): void
     {
-        Router::extensions('rss', false);
+        Router::setExtensions('rss', false);
         $this->assertContains('rss', Router::extensions());
 
         $this->_connectDefaultRoutes();
@@ -1621,7 +1621,7 @@ class RouterTest extends TestCase
         $result = Router::parseRequest($this->makeRequest('/posts.xml', 'GET'));
         $this->assertArrayNotHasKey('_ext', $result);
 
-        Router::extensions(['xml']);
+        Router::setExtensions(['xml']);
     }
 
     /**
@@ -1629,7 +1629,7 @@ class RouterTest extends TestCase
      */
     public function testExtensionsWithScopedRoutes(): void
     {
-        Router::extensions(['json']);
+        Router::setExtensions(['json']);
 
         Router::scope('/', function (RouteBuilder $routes): void {
             $routes->setExtensions('rss');
@@ -1678,7 +1678,7 @@ class RouterTest extends TestCase
      */
     public function testExtensionParsing(): void
     {
-        Router::extensions('rss', false);
+        Router::setExtensions('rss', false);
         $this->_connectDefaultRoutes();
 
         $result = Router::parseRequest($this->makeRequest('/posts.rss', 'GET'));
@@ -1708,7 +1708,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::extensions(['rss', 'xml'], false);
+        Router::setExtensions(['rss', 'xml'], false);
         $this->_connectDefaultRoutes();
 
         $result = Router::parseRequest($this->makeRequest('/posts.xml', 'GET'));
@@ -1760,7 +1760,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         Router::reload();
-        Router::extensions('rss', false);
+        Router::setExtensions('rss', false);
         Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
         $expected = [
@@ -2553,7 +2553,7 @@ class RouterTest extends TestCase
     public function testReverseWithExtension(): void
     {
         Router::connect('/{controller}/{action}/*');
-        Router::extensions('json', false);
+        Router::setExtensions('json', false);
 
         $request = new ServerRequest([
             'url' => '/posts/view/1.json',
@@ -2748,7 +2748,7 @@ class RouterTest extends TestCase
      */
     public function testScopeExtensionsContained(): void
     {
-        Router::extensions(['json']);
+        Router::setExtensions(['json']);
         Router::scope('/', function (RouteBuilder $routes): void {
             $this->assertEquals(['json'], $routes->getExtensions(), 'Should default to global extensions.');
             $routes->setExtensions(['rss']);


### PR DESCRIPTION
One of the last combined set/get methods in the core.
With this, we should have a clean API now, using the set* part for setting, and the normal method for getting in line with the others we split.

Also consistent with RouteBuilder usage

    $routes->scope('/', function (RouteBuilder $routes) {
        $routes->setExtensions(['json', 'xml']);
    });
    