### PR TITLE
cake 5: Re-organize action parameter type casting

### DIFF
--- a/src/Core/Invoker.php
+++ b/src/Core/Invoker.php
@@ -1,0 +1,152 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use Closure;
+use InvalidArgumentException;
+use ReflectionFunction;
+use ReflectionNamedType;
+
+class Invoker
+{
+    /**
+     * @var \Cake\Core\ContainerInterface
+     */
+    protected ContainerInterface $container;
+
+    /**
+     * @param \Cake\Core\ContainerInterface $container Containter instance
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Invokes callable with supplied arguments and loads missing
+     * arguments from the container if the type is valid.
+     *
+     * @param \Closure $closure Function to invoke
+     * @param array<mixed> $arguments Function arguments
+     * @return mixed
+     * @throws \InvalidArgumentException When unable to find argument for parameters.
+     */
+    public function invoke(Closure $closure, array $arguments): mixed
+    {
+        return $closure(...$this->resolveArguments($closure, $arguments));
+    }
+
+    /**
+     * Invokes callable with supplied arguments and loads missing
+     * arguments from the container if the type is valid.
+     *
+     * String arguments are coerced to parameter type for
+     * float, int and bool types.
+     *
+     * @param \Closure $closure Function to invoke
+     * @param array<mixed> $arguments Function arguments
+     * @return mixed
+     * @throws \InvalidArgumentException When unable to find argument for parameters.
+     */
+    public function invokeWithCoercion(Closure $closure, array $arguments)
+    {
+        return $closure(...$this->resolveArguments($closure, $arguments, ['coerce' => true]));
+    }
+
+    /**
+     * Resolves passed in arguments to function parameters.
+     *
+     * Loads missing parameters from container if the type is valid.
+     *
+     * @param \Closure $closure Function to resolve
+     * @param array<mixed> $arguments Function arguments
+     * @param array<string, mixed> $options Resolution options
+     */
+    public function resolveArguments(Closure $closure, array $arguments, array $options = []): array
+    {
+        $resolved = [];
+        $function = new ReflectionFunction($closure);
+        foreach ($function->getParameters() as $parameter) {
+            $name = $parameter->getName();
+            $type = $parameter->getType();
+            $typeName = $type instanceof ReflectionNamedType ? ltrim($type->getName(), '?') : null;
+
+            if (array_key_exists($name, $arguments)) {
+                $argument = $arguments[$name];
+                unset($arguments[$name]);
+
+                if (!empty($options['coerce']) && is_string($argument)) {
+                    $resolved[] = $this->coercePrimitiveType($argument, $typeName);
+                } else {
+                    $resolved[] = $argument;
+                }
+                continue;
+            }
+
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                if ($this->container->has($typeName)) {
+                    $resolved[] = $this->container->get($typeName);
+                    continue;
+                }
+            }
+
+            if ($arguments) {
+                $argument = array_shift($arguments);
+                if (!empty($options['coerce']) && is_string($argument)) {
+                    $resolved[] = $this->coercePrimitiveType($argument, $typeName);
+                } else {
+                    $resolved[] = $argument;
+                }
+                continue;
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $resolved[] = $parameter->getDefaultValue();
+                continue;
+            }
+
+            if ($parameter->isVariadic()) {
+                continue;
+            }
+
+            throw new InvalidArgumentException("Unable to find argument for parameter `$name`.");
+        }
+
+        return array_merge($resolved, $arguments);
+    }
+
+    /**
+     * Coerces string argument to primitive type.
+     *
+     * @param string $argument Argument to coerce
+     * @param string|null $typeName Parameter type name or null for no type
+     * @return string|float|int|bool
+     */
+    protected function coercePrimitiveType(string $argument, ?string $typeName): string|float|int|bool
+    {
+        if ($typeName === null) {
+            return $argument;
+        }
+
+        switch ($typeName) {
+            case 'string':
+                return $argument;
+        }
+
+        throw new InvalidArgumentException("Coercing argument to `$typeName` is not supported.");
+    }
+}

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Controller;
 
-use ArgumentCountError;
 use Cake\Controller\ControllerFactory;
 use Cake\Core\Container;
 use Cake\Http\Exception\MissingControllerException;
@@ -499,7 +498,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Could not resolve action argument `dep`');
+        $this->expectExceptionMessage('Unable to find argument for parameter `dep`');
         $this->factory->invoke($controller);
     }
 
@@ -515,8 +514,8 @@ class ControllerFactoryTest extends TestCase
         ]);
         $controller = $this->factory->create($request);
 
-        $this->expectException(ArgumentCountError::class);
-        $this->expectExceptionMessage('Too few arguments');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to find argument for parameter `one`');
         $this->factory->invoke($controller);
     }
 
@@ -664,8 +663,29 @@ class ControllerFactoryTest extends TestCase
         ]);
         $controller = $this->factory->create($request);
 
-        $this->expectException(ArgumentCountError::class);
-        $this->expectExceptionMessage('Too few arguments');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to find argument for parameter `str`');
+        $this->factory->invoke($controller);
+    }
+
+    /**
+     * Test that required int (non-string)
+     */
+    public function testInvokeRequiredIntParam(): void
+    {
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/requiredInt',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'requiredInt',
+                'pass' => ['one'],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Coercing argument to `int` is not supported');
         $this->factory->invoke($controller);
     }
 

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -85,4 +85,9 @@ class DependenciesController extends Controller
     {
         return $this->response->withStringBody(json_encode(compact('one')));
     }
+
+    public function requiredInt(int $one)
+    {
+        return $this->response->withStringBody(json_encode(compact('one')));
+    }
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/15514

This re-organizes the code that determines if a passed parameter type is supported. Supports only `string` primitive types still, but it provides a structure for extending this.

We don't support union types. They will fallback to container lookup which should fail with a null type name.