### PR TITLE
Escape absolute/scheme-relative URLs too.

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -395,12 +395,8 @@ class HtmlHelper extends Helper
             return null;
         }
 
-        if (strpos($path, '//') !== false) {
-            $url = $path;
-        } else {
-            $url = $this->Url->css($path, $options);
-            $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
-        }
+        $url = $this->Url->css($path, $options);
+        $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
 
         if ($options['once'] && isset($this->_includedAssets[__METHOD__][$path])) {
             return null;
@@ -499,10 +495,9 @@ class HtmlHelper extends Helper
             return null;
         }
 
-        if (strpos($url, '//') === false) {
-            $url = $this->Url->script($url, $options);
-            $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
-        }
+        $url = $this->Url->script($url, $options);
+        $options = array_diff_key($options, ['fullBase' => null, 'pathPrefix' => null]);
+
         if ($options['once'] && isset($this->_includedAssets[__METHOD__][$url])) {
             return null;
         }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -615,8 +615,8 @@ class HtmlHelperTest extends TestCase
         $expected['link']['href'] = 'x:&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;';
         $this->assertHtml($expected, $result);
 
-        $result = $this->Html->css('http://whatever.com/screen.css?1234');
-        $expected['link']['href'] = 'preg:/http:\/\/.*\/screen\.css\?1234/';
+        $result = $this->Html->css('http://whatever.com/screen.css?1234&a=b');
+        $expected['link']['href'] = 'http://whatever.com/screen.css?1234&amp;a=b';
         $this->assertHtml($expected, $result);
 
         Configure::write('App.cssBaseUrl', '//cdn.cakephp.org/css/');
@@ -959,6 +959,18 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->script('test.json.js?foo=bar&other=test');
         $expected = [
             'script' => ['src' => 'js/test.json.js?foo=bar&amp;other=test'],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->script('//domain.com/test.json.js?foo=bar&other=test');
+        $expected = [
+            'script' => ['src' => '//domain.com/test.json.js?foo=bar&amp;other=test'],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->script('https://domain.com/test.json.js?foo=bar&other=test');
+        $expected = [
+            'script' => ['src' => 'https://domain.com/test.json.js?foo=bar&amp;other=test'],
         ];
         $this->assertHtml($expected, $result);
 


### PR DESCRIPTION
Closes cakephp/cakephp#15969.

Targetting `4.next` instead of `4.x` as it could potentially cause double escaping issue for users who are pre-escaping their absolute URLs before passing to these functions.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
