### PR TITLE
Add "acceptTypes" config for RequestHandlerComponent.

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -64,12 +64,17 @@ class RequestHandlerComponent extends Component
      * - `checkHttpCache` - Whether to check for HTTP cache. Default `true`.
      * - `viewClassMap` - Mapping between type and view classes. If undefined
      *   JSON, XML, and AJAX will be mapped. Defining any types will omit the defaults.
+     * - `acceptTypes` - The content type aliases for which the `Accept` header
+     *   should be checked for extension detection. For e.g. setting the
+     *   value to `['csv']` would mean for `Accept` header with value `text/csv`
+     *   the `csv` extension would be set.
      *
      * @var array<string, mixed>
      */
     protected $_defaultConfig = [
         'checkHttpCache' => true,
         'viewClassMap' => [],
+        'acceptTypes' => [],
     ];
 
     /**
@@ -80,6 +85,11 @@ class RequestHandlerComponent extends Component
      */
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
+        $extensions = Router::extensions();
+        if ($extensions) {
+            $this->_defaultConfig['acceptTypes'] = $extensions;
+        }
+
         $config += [
             'viewClassMap' => [
                 'json' => 'Json',
@@ -133,9 +143,10 @@ class RequestHandlerComponent extends Component
             return;
         }
 
-        $extensions = array_unique(
-            array_merge(Router::extensions(), array_keys($this->getConfig('viewClassMap')))
-        );
+        $extensions = array_unique(array_merge(
+            (array)$this->getConfig('acceptTypes'),
+            array_keys($this->getConfig('viewClassMap'))
+        ));
         foreach ($accepts as $types) {
             $ext = array_intersect($extensions, $types);
             if ($ext) {


### PR DESCRIPTION
This allows specifying the valid content types for extension detection on controller basis instead of having them globally enabled due to use of `Router::extensions()`.
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
