### PR TITLE
fix: correct class on exception text of CommandCollection->add()

### DIFF
--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -67,7 +67,7 @@ class CommandCollection implements IteratorAggregate, Countable
             $class = is_string($command) ? $command : get_class($command);
             throw new InvalidArgumentException(sprintf(
                 "Cannot use '%s' for command '%s'. " .
-                "It is not a subclass of Cake\Console\Shell or Cake\Command\CommandInterface.",
+                "It is not a subclass of Cake\Console\Shell or Cake\Command\Command.",
                 $class,
                 $name
             ));


### PR DESCRIPTION
The exception text in `add()` references the wrong class path; likely a typo.  See point 2 of discussion here: https://stackoverflow.com/a/69328477/1282424