### PR TITLE
Re-organize controller action argument building

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Controller;
 
+use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\App;
 use Cake\Core\ContainerInterface;
 use Cake\Http\ControllerFactoryInterface;
@@ -25,7 +26,6 @@ use Cake\Http\Runner;
 use Cake\Http\ServerRequest;
 use Cake\Utility\Inflector;
 use Closure;
-use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -156,58 +156,102 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      */
     protected function getActionArgs(Closure $action, array $passedParams): array
     {
-        $args = [];
-        $reflection = new ReflectionFunction($action);
-
-        foreach ($reflection->getParameters() as $parameter) {
-            $position = $parameter->getPosition();
-            $hasDefault = $parameter->isDefaultValueAvailable();
-
-            // If there is no type we can't look in the container
-            // assume the parameter is a passed param
+        $resolved = [];
+        $function = new ReflectionFunction($action);
+        foreach ($function->getParameters() as $parameter) {
             $type = $parameter->getType();
-            if (!$type) {
-                if (count($passedParams)) {
-                    $args[$position] = array_shift($passedParams);
-                } elseif ($hasDefault) {
-                    $args[$position] = $parameter->getDefaultValue();
+            if ($type && !$type instanceof ReflectionNamedType) {
+                // Only single types are supported
+                throw new MissingActionException(sprintf(
+                    'Action %s::%s() has an unsupported type for parameter `%s`.',
+                    $this->controller->getName(),
+                    $function->getName(),
+                    $parameter->getName()
+                ));
+            }
+
+            // Check for dependency injection for classes
+            if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {
+                if ($this->container->has($type->getName())) {
+                    $resolved[] = $this->container->get($type->getName());
+                    continue;
                 }
+
+                // Add default value if provided
+                // Do not allow positional arguments for classes
+                if ($parameter->isDefaultValueAvailable()) {
+                    $resolved[] = $parameter->getDefaultValue();
+                    continue;
+                }
+
+                throw new MissingActionException(sprintf(
+                    'Action %s::%s() cannot inject parameter `%s` from service container.',
+                    $this->controller->getName(),
+                    $function->getName(),
+                    $parameter->getName()
+                ));
+            }
+
+            // Use any passed params as positional arguments
+            if ($passedParams) {
+                $argument = array_shift($passedParams);
+                if ($type instanceof ReflectionNamedType) {
+                    $typedArgument = $this->coerceStringToType($argument, $type);
+
+                    if ($typedArgument === null) {
+                        throw new MissingActionException(sprintf(
+                            'Action %s::%s() cannot coerce "%s" to `%s` for parameter `%s`.',
+                            $this->controller->getName(),
+                            $function->getName(),
+                            $argument,
+                            $type->getName(),
+                            $parameter->getName()
+                        ));
+                    }
+                    $argument = $typedArgument;
+                }
+
+                $resolved[] = $argument;
                 continue;
             }
 
-            $typeName = $type instanceof ReflectionNamedType ? ltrim($type->getName(), '?') : null;
-
-            // Primitive types are passed args as they can't be looked up in the container.
-            // We only handle strings currently.
-            if ($typeName === 'string') {
-                if (count($passedParams)) {
-                    $args[$position] = array_shift($passedParams);
-                } elseif ($hasDefault) {
-                    $args[$position] = $parameter->getDefaultValue();
-                }
+            // Add default value if provided
+            if ($parameter->isDefaultValueAvailable()) {
+                $resolved[] = $parameter->getDefaultValue();
                 continue;
             }
 
-            // Check the container and parameter default value.
-            if ($typeName && $this->container->has($typeName)) {
-                $args[$position] = $this->container->get($typeName);
-            } elseif ($hasDefault) {
-                $args[$position] = $parameter->getDefaultValue();
+            // Variadic parameter can have 0 arguments
+            if ($parameter->isVariadic()) {
+                continue;
             }
 
-            if (!array_key_exists($position, $args)) {
-                throw new InvalidArgumentException(
-                    "Could not resolve action argument `{$parameter->getName()}`. " .
-                    'It has no definition in the container, no passed parameter, and no default value.'
-                );
-            }
+            throw new MissingActionException(sprintf(
+                'Action %s::%s() expected passed parameter for `%s`.',
+                $this->controller->getName(),
+                $function->getName(),
+                $parameter->getName()
+            ));
         }
 
-        if (count($passedParams)) {
-            $args = array_merge($args, $passedParams);
+        return array_merge($resolved, $passedParams);
+    }
+
+    /**
+     * Coerces string argument to primitive type.
+     *
+     * @param string $argument Argument to coerce
+     * @param \ReflectionNamedType $type Parameter type
+     * @return string|float|int|bool|null
+     */
+    protected function coerceStringToType(string $argument, ReflectionNamedType $type)
+    {
+        switch ($type->getName()) {
+            case 'string':
+                return $argument;
         }
 
-        return $args;
+        return null;
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -16,14 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Controller;
 
-use ArgumentCountError;
 use Cake\Controller\ControllerFactory;
+use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\Container;
 use Cake\Http\Exception\MissingControllerException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use stdClass;
 use TestApp\Controller\DependenciesController;
 
@@ -503,8 +502,8 @@ class ControllerFactoryTest extends TestCase
         ]);
         $controller = $this->factory->create($request);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Could not resolve action argument `dep`');
+        $this->expectException(MissingActionException::class);
+        $this->expectExceptionMessage('Action Dependencies::requiredDep() cannot inject parameter `dep` from service container');
         $this->factory->invoke($controller);
     }
 
@@ -520,8 +519,8 @@ class ControllerFactoryTest extends TestCase
         ]);
         $controller = $this->factory->create($request);
 
-        $this->expectException(ArgumentCountError::class);
-        $this->expectExceptionMessage('Too few arguments');
+        $this->expectException(MissingActionException::class);
+        $this->expectExceptionMessage('Action Dependencies::requiredParam() expected passed parameter for `one`');
         $this->factory->invoke($controller);
     }
 
@@ -669,8 +668,29 @@ class ControllerFactoryTest extends TestCase
         ]);
         $controller = $this->factory->create($request);
 
-        $this->expectException(ArgumentCountError::class);
-        $this->expectExceptionMessage('Too few arguments');
+        $this->expectException(MissingActionException::class);
+        $this->expectExceptionMessage('Action Dependencies::requiredString() expected passed parameter for `str`');
+        $this->factory->invoke($controller);
+    }
+
+    /**
+     * Test that required int (non-string)
+     */
+    public function testInvokeRequiredIntParam(): void
+    {
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/requiredInt',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'requiredInt',
+                'pass' => ['one'],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+
+        $this->expectException(MissingActionException::class);
+        $this->expectExceptionMessage('Action Dependencies::requiredInt() cannot coerce "one" to `int` for parameter `one`');
         $this->factory->invoke($controller);
     }
 

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -85,4 +85,9 @@ class DependenciesController extends Controller
     {
         return $this->response->withStringBody(json_encode(compact('one')));
     }
+
+    public function requiredInt(int $one)
+    {
+        return $this->response->withStringBody(json_encode(compact('one')));
+    }
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/15514

This re-organizes the argument resolving and coercion so more types can be supported easier.

Only `string` type coercion is supported. More types will be added in a separate PR for easier reviewing.