### PR TITLE
backport: Fix DateType not clearing time for DateTimeImmutable

### DIFF
--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -15,6 +15,7 @@
 namespace Cake\Database\Type;
 
 use DateTime;
+use DateTimeImmutable;
 
 /**
  * Class DateType
@@ -80,8 +81,8 @@ class DateType extends DateTimeType
     public function marshal($value)
     {
         $date = parent::marshal($value);
-        if ($date instanceof DateTime) {
-            $date->setTime(0, 0, 0);
+        if ($date instanceof DateTime || $date instanceof DateTimeImmutable) {
+            $date = $date->setTime(0, 0, 0);
         }
 
         return $date;


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/15978

This check isn't exclusive since Time and Date will extend DateTime, but doesn't really matter for 3.x.
