### PR TITLE
backport: Allow association binding key to be null during cascadeDelete

### DIFF
--- a/src/ORM/Association/DependentDeleteHelper.php
+++ b/src/ORM/Association/DependentDeleteHelper.php
@@ -42,7 +42,11 @@ class DependentDeleteHelper
         $table = $association->getTarget();
         $foreignKey = array_map([$association, 'aliasField'], (array)$association->getForeignKey());
         $bindingKey = (array)$association->getBindingKey();
-        $conditions = array_combine($foreignKey, $entity->extract($bindingKey));
+        $bindingValue = $entity->extract($bindingKey);
+        if (in_array(null, $bindingValue, true)) {
+            return true;
+        }
+        $conditions = array_combine($foreignKey, $bindingValue);
 
         if ($association->getCascadeCallbacks()) {
             foreach ($association->find()->where($conditions)->all()->toList() as $related) {

--- a/tests/Fixture/NullableAuthorsFixture.php
+++ b/tests/Fixture/NullableAuthorsFixture.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.2.10
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class NullableAuthorsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'author_id' => ['type' => 'integer', 'null' => true],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['author_id' => 3],
+        ['author_id' => null],
+    ];
+}


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/15955
