### PR TITLE
Fix belongstomany delete callbacks getting wrong entity type

### DIFF
--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -33,6 +33,7 @@ use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use RuntimeException;
+use TestApp\Model\Entity\ArticlesTag;
 
 /**
  * Tests BelongsToMany class
@@ -909,6 +910,35 @@ class BelongsToManyTest extends TestCase
         $other = $joint->find()->where(['tag_id' => 1])->toArray();
         $this->assertCount(1, $other, 'Non matching joint record should remain.');
         $this->assertSame(1, $other[0]->article_id);
+    }
+
+    /**
+     * Test that replaceLinks() loads junction records with the correct entity class
+     */
+    public function testReplaceLinksFetchCorrectJunctionEntity(): void
+    {
+        $joint = $this->getTableLocator()->get('ArticlesTags');
+        $articles = $this->getTableLocator()->get('Articles');
+        $tags = $this->getTableLocator()->get('Tags');
+
+        $assoc = $articles->belongsToMany('Tags', [
+            'sourceTable' => $articles,
+            'targetTable' => $tags,
+            'through' => $joint,
+            'joinTable' => 'articles_tags',
+        ]);
+        $joint->setEntityClass(ArticlesTag::class);
+
+        $joint->getEventManager()->on('Model.afterDelete', function ($event, $entity) {
+            $this->assertInstanceOf(ArticlesTag::class, $entity);
+            $this->assertNotEmpty($entity->tag_id);
+            $this->assertNotEmpty($entity->article_id);
+        });
+
+        $entity = $articles->get(1, ['contain' => 'Tags']);
+        $this->assertCount(2, $entity->tags);
+
+        $assoc->replaceLinks($entity, []);
     }
 
     /**


### PR DESCRIPTION
Previously the query used would have the target table as the root table, and *join* the junction table. This would cause the junction table entities to use the target table entity class.

Now the junction table is used as the root and the association target is joined on. I've also removed the column subsetting so that entities passed to callbacks include their complete property sets.

Targeting this for 4.3 as the change in behavior while more correct could cause problems for applications.

Fixes #15977
