### PR TITLE
Rename LocatorAwareTrait::getTable() to fetchTable().

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -93,7 +93,7 @@ trait ModelAwareTrait
      * @throws \Cake\Datasource\Exception\MissingModelException If the model class cannot be found.
      * @throws \UnexpectedValueException If $modelClass argument is not provided
      *   and ModelAwareTrait::$modelClass property value is empty.
-     * @deprecated 4.3.0 Use `LocatorAwareTrait::getTable()` instead.
+     * @deprecated 4.3.0 Use `LocatorAwareTrait::fetchTable()` instead.
      */
     public function loadModel(?string $modelClass = null, ?string $modelType = null): RepositoryInterface
     {

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -80,7 +80,7 @@ trait LocatorAwareTrait
      * @see \Cake\ORM\TableLocator::get()
      * @since 4.3.0
      */
-    public function getTable(?string $alias = null, array $options = []): Table
+    public function fetchTable(?string $alias = null, array $options = []): Table
     {
         $alias = $alias ?? $this->defaultTable;
         if ($alias === null) {

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -64,26 +64,27 @@ class LocatorAwareTraitTest extends TestCase
         $this->assertSame($newLocator, $subjectLocator);
     }
 
-    public function testGetTable(): void
+    public function testFetchTable(): void
     {
         $stub = new LocatorAwareStub('Articles');
 
-        $result = $stub->getTable();
+        $result = $stub->fetchTable();
         $this->assertInstanceOf(Table::class, $result);
 
-        $result = $stub->getTable('Comments');
+        $result = $stub->fetchTable('Comments');
         $this->assertInstanceOf(Table::class, $result);
 
-        $result = $stub->getTable(PaginatorPostsTable::class);
+        $result = $stub->fetchTable(PaginatorPostsTable::class);
         $this->assertInstanceOf(PaginatorPostsTable::class, $result);
         $this->assertSame('PaginatorPosts', $result->getAlias());
     }
 
-    public function testGetTableException()
+    public function testfetchTableException()
     {
         $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('You must provide an `$alias` or set the `$defaultTable` property.');
 
         $stub = new LocatorAwareStub();
-        $stub->getTable();
+        $stub->fetchTable();
     }
 }


### PR DESCRIPTION
This avoid name collisions when the trait is attached to classes which already have a getTable() method, like the Table class.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
