### PR TITLE
Rename preserveKeys to keepKeys

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -775,13 +775,13 @@ interface CollectionInterface extends Iterator, JsonSerializable
     /**
      * Returns an array representation of the results
      *
-     * @param bool $preserveKeys whether to use the keys returned by this
+     * @param bool $keepKeys Whether to use the keys returned by this
      * collection as the array keys. Keep in mind that it is valid for iterators
      * to return the same key for different elements, setting this value to false
      * can help getting all items if keys are not important in the result.
      * @return array
      */
-    public function toArray(bool $preserveKeys = true): array;
+    public function toArray(bool $keepKeys = true): array;
 
     /**
      * Returns an numerically-indexed array representation of the results.
@@ -827,13 +827,13 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * You can think of this method as a way to create save points for complex
      * calculations in a collection.
      *
-     * @param bool $preserveKeys whether to use the keys returned by this
+     * @param bool $keepKeys Whether to use the keys returned by this
      * collection as the array keys. Keep in mind that it is valid for iterators
      * to return the same key for different elements, setting this value to false
      * can help getting all items if keys are not important in the result.
      * @return self
      */
-    public function compile(bool $preserveKeys = true): CollectionInterface;
+    public function compile(bool $keepKeys = true): CollectionInterface;
 
     /**
      * Returns a new collection where any operations chained after it are guaranteed
@@ -1052,10 +1052,10 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ```
      *
      * @param int $chunkSize The maximum size for each chunk
-     * @param bool $preserveKeys If the keys of the array should be preserved
+     * @param bool $keepKeys If the keys of the array should be kept
      * @return self
      */
-    public function chunkWithKeys(int $chunkSize, bool $preserveKeys = true): CollectionInterface;
+    public function chunkWithKeys(int $chunkSize, bool $keepKeys = true): CollectionInterface;
 
     /**
      * Returns whether there are elements in this collection

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -673,21 +673,21 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function toArray(bool $preserveKeys = true): array
+    public function toArray(bool $keepKeys = true): array
     {
         $iterator = $this->unwrap();
         if ($iterator instanceof ArrayIterator) {
             $items = $iterator->getArrayCopy();
 
-            return $preserveKeys ? $items : array_values($items);
+            return $keepKeys ? $items : array_values($items);
         }
         // RecursiveIteratorIterator can return duplicate key values causing
         // data loss when converted into an array
-        if ($preserveKeys && get_class($iterator) === RecursiveIteratorIterator::class) {
-            $preserveKeys = false;
+        if ($keepKeys && get_class($iterator) === RecursiveIteratorIterator::class) {
+            $keepKeys = false;
         }
 
-        return iterator_to_array($this, $preserveKeys);
+        return iterator_to_array($this, $keepKeys);
     }
 
     /**
@@ -709,9 +709,9 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function compile(bool $preserveKeys = true): CollectionInterface
+    public function compile(bool $keepKeys = true): CollectionInterface
     {
-        return $this->newCollection($this->toArray($preserveKeys));
+        return $this->newCollection($this->toArray($keepKeys));
     }
 
     /**
@@ -850,11 +850,11 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function chunkWithKeys(int $chunkSize, bool $preserveKeys = true): CollectionInterface
+    public function chunkWithKeys(int $chunkSize, bool $keepKeys = true): CollectionInterface
     {
-        return $this->map(function ($v, $k, $iterator) use ($chunkSize, $preserveKeys) {
+        return $this->map(function ($v, $k, $iterator) use ($chunkSize, $keepKeys) {
             $key = 0;
-            if ($preserveKeys) {
+            if ($keepKeys) {
                 $key = $k;
             }
             $values = [$key => $v];
@@ -863,7 +863,7 @@ trait CollectionTrait
                 if (!$iterator->valid()) {
                     break;
                 }
-                if ($preserveKeys) {
+                if ($keepKeys) {
                     $values[$iterator->key()] = $iterator->current();
                 } else {
                     $values[] = $iterator->current();


### PR DESCRIPTION
This seems like clearer english. We don't normally use "preserve" in APIs and values can be overwritten while the set of keys is kept.
