### PR TITLE
Handle finder array in replaceLinks()

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1202,7 +1202,13 @@ class BelongsToMany extends Association
                     ->where(array_combine($prefixedForeignKey, $primaryValue));
                 $finder = $this->getFinder();
                 if ($finder) {
-                    $existing = $target->callFinder($finder, $existing);
+                    if (is_array($finder)) {
+                        /** @var array<string, mixed> $finderOptions */
+                        $finderOptions = key($finder);
+                        /** @var string $finder */
+                        $finder = current($finder);
+                    }
+                    $existing = $target->callFinder($finder, $existing, $finderOptions ?? []);
                 }
 
                 $jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1200,15 +1200,9 @@ class BelongsToMany extends Association
                     ->where($this->targetConditions())
                     ->where($this->junctionConditions())
                     ->where(array_combine($prefixedForeignKey, $primaryValue));
-                $finder = $this->getFinder();
+                [$finder, $finderOptions] = $this->_extractFinder($this->getFinder());
                 if ($finder) {
-                    if (is_array($finder)) {
-                        /** @var array<string, mixed> $finderOptions */
-                        $finderOptions = key($finder);
-                        /** @var string $finder */
-                        $finder = current($finder);
-                    }
-                    $existing = $target->callFinder($finder, $existing, $finderOptions ?? []);
+                    $existing = $target->callFinder($finder, $existing, $finderOptions);
                 }
 
                 $jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/15985

@markstory I forgot this was failing in psalm when I merged. The finder can be an array which we don't handle. Association::find() handles this, but BelongsToMany::find() implementation does more than we want here.

Apparently it doesn't happen in the test cases. Can we just assume it's always a string finder?