### PR TITLE
Update sqlite window support version to 3.28.0

### DIFF
--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -106,7 +106,7 @@ class Sqlite extends Driver
      */
     protected $featureVersions = [
         'cte' => '3.8.3',
-        'window' => '3.25.0',
+        'window' => '3.28.0',
     ];
 
     /**


### PR DESCRIPTION
Although 3.25.0 adds the initial support for window functions, 3.28.0 adds some expected features like expression preceding/following.

https://www.sqlite.org/windowfunctions.html

> In SQLite version 3.28.0 (2019-04-16), windows function support was extended to include the EXCLUDE clause, GROUPS frame types, window chaining, and support for "<expr> PRECEDING" and "<expr> FOLLOWING" boundaries in RANGE frames.