### PR TITLE
Use ubuntu 20.04 for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   testsuite:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Ubuntu 20.04 packages include sqlite 3.34.1 which is much more up to date than 18.04 and supports features we need to test.
