### PR TITLE
Add new `CASE` expression.

### DIFF
--- a/src/Database/Expression/CaseExpressionInterface.php
+++ b/src/Database/Expression/CaseExpressionInterface.php
@@ -23,11 +23,23 @@ use Cake\Database\TypeMap;
 interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterface
 {
     /**
-     * Returns the case value for a `CASE case_value WHEN ...` expression.
+     * Returns the available data for the given clause.
      *
-     * @return \Cake\Database\ExpressionInterface|object|scalar|null
+     * ### Available clauses
+     *
+     * The following clause names are available:
+     *
+     * * `value` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The case value for a
+     *   `CASE case_value WHEN ...` expression.
+     * * `when (`array<\Cake\Database\Expression\WhenThenExpressionInterface>`)`: An array of self-contained
+     *   `WHEN ... THEN ...` expressions.
+     * * `else` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `ELSE` result value.
+     *
+     * @param string $clause The name of the clause to obtain.
+     * @return array<\Cake\Database\Expression\WhenThenExpressionInterface>|\Cake\Database\ExpressionInterface|object|scalar|null
+     * @throws \InvalidArgumentException In case the given clause name is invalid.
      */
-    public function getValue();
+    public function clause(string $clause);
 
     /**
      * Sets the value for the case expression.
@@ -52,13 +64,6 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * @return string|null
      */
     public function getValueType(): ?string;
-
-    /**
-     * Returns the `WHEN ... THEN ...` statement expressions.
-     *
-     * @return \Cake\Database\Expression\WhenThenExpressionInterface[]
-     */
-    public function getWhen(): array;
 
     /**
      * Sets the `WHEN` value for a `WHEN ... THEN ...` expression, or a
@@ -257,14 +262,6 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * @see when()
      */
     public function then($result, ?string $type = null);
-
-    /**
-     * Returns the `ELSE` result value.
-     *
-     * @return \Cake\Database\ExpressionInterface|object|scalar|null The result value, or `null` if none has been set
-     *  yet.
-     */
-    public function getElse();
 
     /**
      * Sets the `ELSE` result value.

--- a/src/Database/Expression/CaseExpressionInterface.php
+++ b/src/Database/Expression/CaseExpressionInterface.php
@@ -1,0 +1,332 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\TypedResultInterface;
+use Cake\Database\TypeMap;
+
+interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterface
+{
+    /**
+     * Returns the case value for a `CASE case_value WHEN ...` expression.
+     *
+     * @return \Cake\Database\ExpressionInterface|object|scalar|null
+     */
+    public function getValue();
+
+    /**
+     * Sets the value for the case expression.
+     *
+     * When a value is set, the syntax generated is
+     * `CASE case_value WHEN when_value ... END`, where the
+     * `when_value`'s are compared against the `case_value`.
+     *
+     * When no value is set, the syntax generated is
+     * `CASE WHEN when_conditions ... END`, where the conditions
+     * hold the comparisons.
+     *
+     * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
+     * @param string|null $valueType The case value type.
+     * @return $this
+     */
+    public function value($value, ?string $valueType = null);
+
+    /**
+     * Returns the case value type.
+     *
+     * @return string|null
+     */
+    public function getValueType(): ?string;
+
+    /**
+     * Returns the `WHEN ... THEN ...` statement expressions.
+     *
+     * @return \Cake\Database\Expression\WhenThenExpressionInterface[]
+     */
+    public function getWhen(): array;
+
+    /**
+     * Sets the `WHEN` value for a `WHEN ... THEN ...` expression, or a
+     * self-contained expression that holds both the value for `WHEN`
+     * and the value for `THEN`.
+     *
+     * ### Order based syntax
+     *
+     * When passing a value other than a self-contained
+     * `\Cake\Database\Expression\WhenThenExpressionInterface`,
+     * instance, the `WHEN ... THEN ...` statement must be closed off with
+     * a call to `then()` before invoking `when()` again or `else()`:
+     *
+     * ```
+     * $case
+     *     ->value($query->identifier('Table.column'))
+     *     ->when(true)
+     *     ->then('Yes')
+     *     ->when(false)
+     *     ->then('No')
+     *     ->else('Maybe');
+     * ```
+     *
+     * ### Self-contained expressions
+     *
+     * When passing an instance of `\Cake\Database\Expression\WhenThenExpressionInterface`,
+     * being it directly, or via a callable, then there is no need to close
+     * using `then()` on this object, instead the statement will be closed
+     * on the `\Cake\Database\Expression\WhenThenExpressionInterface`
+     * object using
+     * `\Cake\Database\Expression\WhenThenExpressionInterface::then()`.
+     *
+     * Callables will receive an instance of `\Cake\Database\Expression\WhenThenExpressionInterface`,
+     * and must return one, being it the same object, or a custom one:
+     *
+     * ```
+     * $case
+     *     ->when(function (\Cake\Database\Expression\WhenThenExpressionInterface $whenThen) {
+     *         return $whenThen
+     *             ->when(['Table.column' => true])
+     *             ->then('Yes');
+     *     })
+     *     ->when(function (\Cake\Database\Expression\WhenThenExpressionInterface $whenThen) {
+     *         return $whenThen
+     *             ->when(['Table.column' => false])
+     *             ->then('No');
+     *     })
+     *     ->else('Maybe');
+     * ```
+     *
+     * ### Type handling
+     *
+     * The types provided via the `$type` argument will be merged with the
+     * type map set for this expression. When using callables for `$when`,
+     * the `\Cake\Database\Expression\WhenThenExpressionInterface`
+     * instance received by the callables will inherit that type map, however
+     * the types passed here will _not_ be merged in case of using callables,
+     * instead the types must be passed in
+     * `\Cake\Database\Expression\WhenThenExpressionInterface::when()`:
+     *
+     * ```
+     * $case
+     *     ->when(function (\Cake\Database\Expression\WhenThenExpressionInterface $whenThen) {
+     *         return $whenThen
+     *             ->when(['unmapped_column' => true], ['unmapped_column' => 'bool'])
+     *             ->then('Yes');
+     *     })
+     *     ->when(function (\Cake\Database\Expression\WhenThenExpressionInterface $whenThen) {
+     *         return $whenThen
+     *             ->when(['unmapped_column' => false], ['unmapped_column' => 'bool'])
+     *             ->then('No');
+     *     })
+     *     ->else('Maybe');
+     * ```
+     *
+     * ### User data safety
+     *
+     * When passing user data, be aware that allowing a user defined array
+     * to be passed, is a potential SQL injection vulnerability, as it
+     * allows for raw SQL to slip in!
+     *
+     * The following is _unsafe_ usage that must be avoided:
+     *
+     * ```
+     * $case
+     *      ->when($userData)
+     * ```
+     *
+     * A safe variant for the above would be to define a single type for
+     * the value:
+     *
+     * ```
+     * $case
+     *      ->when($userData, 'integer')
+     * ```
+     *
+     * This way an exception would be triggered when an array is passed for
+     * the value, thus preventing raw SQL from slipping in, and all other
+     * types of values would be forced to be bound as an integer.
+     *
+     * Another way to safely pass user data is when using a conditions
+     * array, and passing user data only on the value side of the array
+     * entries, which will cause them to be bound:
+     *
+     * ```
+     * $case
+     *      ->when([
+     *          'Table.column' => $userData,
+     *      ])
+     * ```
+     *
+     * Lastly, data can also be bound manually:
+     *
+     * ```
+     * $query
+     *      ->select([
+     *          'val' => $query->newExpr()
+     *              ->case()
+     *              ->when($query->newExpr(':userData'))
+     *              ->then(123)
+     *      ])
+     *      ->bind(':userData', $userData, 'integer')
+     * ```
+     *
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|object|scalar $when The `WHEN` value. When using an
+     *  array of conditions, it must be compatible with `\Cake\Database\Query::where()`. Note that this argument is
+     *  _not_ completely safe for use with user data, as a user supplied array would allow for raw SQL to slip in! If
+     *  you plan to use user data, either pass a single type for the `$type` argument (which forces the `$when` value to
+     *  be a non-array, and then always binds the data), use a conditions array where the user data is only passed on
+     *  the value side of the array entries, or custom bindings!
+     * @param array|string|null $type The when value type. Either an associative array when using array style
+     *  conditions, or else a string. If no type is provided, the type will be tried to be inferred from the value.
+     * @return $this
+     * @throws \LogicException In case this a closing `then()` call is required before calling this method.
+     * @throws \LogicException In case the callable doesn't return an instance of
+     *  `\Cake\Database\Expression\WhenThenExpressionInterface`.
+     * @see then()
+     */
+    public function when($when, $type = []);
+
+    /**
+     * Sets the `THEN` result value for the last `WHEN ... THEN ...`
+     * statement that was opened using `when()`.
+     *
+     * ### Order based syntax
+     *
+     * This method can only be invoked in case `when()` was previously
+     * used with a value other than a closure or an instance of
+     * `\Cake\Database\Expression\WhenThenExpressionInterface`:
+     *
+     * ```
+     * $case
+     *     ->when(['Table.column' => true])
+     *     ->then('Yes')
+     *     ->when(['Table.column' => false])
+     *     ->then('No')
+     *     ->else('Maybe');
+     * ```
+     *
+     * The following would all fail with an exception:
+     *
+     * ```
+     * $case
+     *     ->when(['Table.column' => true])
+     *     ->when(['Table.column' => false])
+     *     // ...
+     * ```
+     *
+     * ```
+     * $case
+     *     ->when(['Table.column' => true])
+     *     ->else('Maybe')
+     *     // ...
+     * ```
+     *
+     * ```
+     * $case
+     *     ->then('Yes')
+     *     // ...
+     * ```
+     *
+     * ```
+     * $case
+     *     ->when(['Table.column' => true])
+     *     ->then('Yes')
+     *     ->then('No')
+     *     // ...
+     * ```
+     *
+     * @param \Cake\Database\ExpressionInterface|object|scalar|null $result The result value.
+     * @param string|null $type The result type. If no type is provided, the type will be tried to be inferred from the
+     *  value.
+     * @return $this
+     * @throws \LogicException In case `when()` wasn't previously called with a value other than a closure or an
+     *  instance of `\Cake\Database\Expression\WhenThenExpressionInterface`.
+     * @see when()
+     */
+    public function then($result, ?string $type = null);
+
+    /**
+     * Returns the `ELSE` result value.
+     *
+     * @return \Cake\Database\ExpressionInterface|object|scalar|null The result value, or `null` if none has been set
+     *  yet.
+     */
+    public function getElse();
+
+    /**
+     * Sets the `ELSE` result value.
+     *
+     * @param \Cake\Database\ExpressionInterface|object|scalar|null $result The result value.
+     * @param string|null $type The result type. If no type is provided, the type will be tried to be inferred from the
+     *  value.
+     * @return $this
+     * @throws \LogicException In case a closing `then()` call is required before calling this method.
+     * @throws \InvalidArgumentException In case the `$result` argument is neither a scalar value, nor an object, an
+     *  instance of `\Cake\Database\ExpressionInterface`, or `null`.
+     * @see then()
+     */
+    public function else($result, ?string $type = null);
+
+    /**
+     * Returns the type of the `ELSE` result value.
+     *
+     * @return string|null The result type, or `null` if none has been set yet.
+     */
+    public function getElseType(): ?string;
+
+    /**
+     * Returns the abstract type that this expression will return.
+     *
+     * If no type has been explicitly set via `setReturnType()`, this
+     * method will try to obtain the type from the result types of the
+     * `then()` and `else() `calls. All types must be identical in order
+     * for this to work, otherwise the type will default to `string`.
+     *
+     * @return string
+     * @see setReturnType()
+     */
+    public function getReturnType(): string;
+
+    /**
+     * Sets the abstract type that this expression will return.
+     *
+     * If no type is being explicitly set via this method, then the
+     * `getReturnType()` method will try to infer the type from the
+     * result types of the `then()` and `else() `calls.
+     *
+     * @param string $type The type name to use.
+     * @return $this
+     * @see getReturnType()
+     */
+    public function setReturnType(string $type);
+
+    /**
+     * Sets the type map to use when using an array of conditions
+     * for the `WHEN` value.
+     *
+     * @param array|\Cake\Database\TypeMap $typeMap Either an array that is used to create a new
+     *  `\Cake\Database\TypeMap` instance, or an instance of `\Cake\Database\TypeMap`.
+     * @return $this
+     */
+    public function setTypeMap($typeMap);
+
+    /**
+     * Returns the type map.
+     *
+     * @return \Cake\Database\TypeMap
+     */
+    public function getTypeMap(): TypeMap;
+}

--- a/src/Database/Expression/CaseExpressionInterface.php
+++ b/src/Database/Expression/CaseExpressionInterface.php
@@ -59,13 +59,6 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
     public function value($value, ?string $valueType = null);
 
     /**
-     * Returns the case value type.
-     *
-     * @return string|null
-     */
-    public function getValueType(): ?string;
-
-    /**
      * Sets the `WHEN` value for a `WHEN ... THEN ...` expression, or a
      * self-contained expression that holds both the value for `WHEN`
      * and the value for `THEN`.
@@ -276,13 +269,6 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * @see then()
      */
     public function else($result, ?string $type = null);
-
-    /**
-     * Returns the type of the `ELSE` result value.
-     *
-     * @return string|null The result type, or `null` if none has been set yet.
-     */
-    public function getElseType(): ?string;
 
     /**
      * Returns the abstract type that this expression will return.

--- a/src/Database/Expression/CaseExpressionInterface.php
+++ b/src/Database/Expression/CaseExpressionInterface.php
@@ -53,7 +53,8 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * hold the comparisons.
      *
      * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
-     * @param string|null $valueType The case value type.
+     * @param string|null $valueType The case value type. If no type is provided, the type will be tried to be inferred
+     *  from the value.
      * @return $this
      */
     public function value($value, ?string $valueType = null);

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -36,7 +36,7 @@ trait CaseExpressionTrait
      * @param mixed $value The value for which to infer the type.
      * @return string|null The abstract type, or `null` if it could not be inferred.
      */
-    protected function _inferType($value): ?string
+    protected function inferType($value): ?string
     {
         $type = null;
 
@@ -75,7 +75,7 @@ trait CaseExpressionTrait
      * @param string|null $type The value type.
      * @return string
      */
-    protected function _compileNullableValue(ValueBinder $binder, $value, ?string $type = null): string
+    protected function compileNullableValue(ValueBinder $binder, $value, ?string $type = null): string
     {
         if (
             $type !== null &&

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Chronos\Date;
+use Cake\Chronos\MutableDate;
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Query;
+use Cake\Database\ValueBinder;
+use DateTimeInterface;
+
+trait CaseExpressionTrait
+{
+    /**
+     * Infers the abstract type for the given value.
+     *
+     * @param mixed $value The value for which to infer the type.
+     * @return string|null The abstract type, or `null` if it could not be inferred.
+     */
+    protected function _inferType($value): ?string
+    {
+        $type = null;
+
+        if (is_string($value)) {
+            $type = 'string';
+        } elseif (is_int($value)) {
+            $type = 'integer';
+        } elseif (is_float($value)) {
+            $type = 'float';
+        } elseif (is_bool($value)) {
+            $type = 'boolean';
+        } elseif (
+            $value instanceof Date ||
+            $value instanceof MutableDate
+        ) {
+            $type = 'date';
+        } elseif ($value instanceof DateTimeInterface) {
+            $type = 'datetime';
+        } elseif (
+            is_object($value) &&
+            method_exists($value, '__toString')
+        ) {
+            $type = 'string';
+        } elseif ($value instanceof IdentifierExpression) {
+            $type = $this->getTypeMap()->type($value->getIdentifier());
+        }
+
+        return $type;
+    }
+
+    /**
+     * Compiles a nullable value to SQL.
+     *
+     * @param \Cake\Database\ValueBinder $binder The value binder to use.
+     * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The value to compile.
+     * @param string|null $type The value type.
+     * @return string
+     */
+    protected function _compileNullableValue(ValueBinder $binder, $value, ?string $type = null): string
+    {
+        if (
+            $type !== null &&
+            !($value instanceof ExpressionInterface)
+        ) {
+            $value = $this->_castToExpression($value, $type);
+        }
+
+        if ($value === null) {
+            $value = 'NULL';
+        } elseif ($value instanceof Query) {
+            $value = sprintf('(%s)', $value->sql($binder));
+        } elseif ($value instanceof ExpressionInterface) {
+            $value = $value->sql($binder);
+        } else {
+            $placeholder = $binder->placeholder('c');
+            $binder->bind($placeholder, $value, $type);
+            $value = $placeholder;
+        }
+
+        return $value;
+    }
+}

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -26,6 +26,10 @@ use DateTimeInterface;
 /**
  * Trait that holds shared functionality for case related expressions.
  *
+ * @property array<string> $validClauseNames The names of the clauses that are valid for use with the
+ * `clause()` method.
+ * @property \Cake\Database\TypeMap $_typeMap The type map to use when using an array of conditions for the `WHEN`
+ *  value.
  * @internal
  */
 trait CaseExpressionTrait
@@ -61,7 +65,7 @@ trait CaseExpressionTrait
         ) {
             $type = 'string';
         } elseif ($value instanceof IdentifierExpression) {
-            $type = $this->getTypeMap()->type($value->getIdentifier());
+            $type = $this->_typeMap->type($value->getIdentifier());
         }
 
         return $type;

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -22,6 +22,7 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use DateTimeInterface;
+use InvalidArgumentException;
 
 /**
  * Trait that holds shared functionality for case related expressions.
@@ -34,6 +35,24 @@ use DateTimeInterface;
  */
 trait CaseExpressionTrait
 {
+    /**
+     * @inheritDoc
+     */
+    public function clause(string $clause)
+    {
+        if (!in_array($clause, $this->validClauseNames, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The `$clause` argument must be one of `%s`, the given value `%s` is invalid.',
+                    implode('`, `', $this->validClauseNames),
+                    $clause
+                )
+            );
+        }
+
+        return $this->{$clause};
+    }
+
     /**
      * Infers the abstract type for the given value.
      *

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -23,6 +23,11 @@ use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use DateTimeInterface;
 
+/**
+ * Trait that holds shared functionality for case related expressions.
+ *
+ * @internal
+ */
 trait CaseExpressionTrait
 {
     /**

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -230,8 +230,6 @@ class CaseStatementExpression implements CaseExpressionInterface
             $type = $this->inferType($result);
         }
 
-        $this->whenBuffer = null;
-
         $this->else = $result;
         $this->elseType = $type;
 

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -95,9 +95,10 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function __construct(?TypeMap $typeMap = null)
     {
-        if ($typeMap !== null) {
-            $this->setTypeMap($typeMap);
+        if ($typeMap === null) {
+            $typeMap = new TypeMap();
         }
+        $this->_typeMap = $typeMap;
     }
 
     /**

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -32,6 +32,18 @@ class CaseStatementExpression implements CaseExpressionInterface
     use TypeMapTrait;
 
     /**
+     * The names of the clauses that are valid for use with the
+     * `clause()` method.
+     *
+     * @var array<string>
+     */
+    protected $validClauseNames = [
+        'value',
+        'when',
+        'else',
+    ];
+
+    /**
      * Whether this is a simple case expression.
      *
      * @var bool
@@ -104,14 +116,6 @@ class CaseStatementExpression implements CaseExpressionInterface
     /**
      * @inheritDoc
      */
-    public function getValue()
-    {
-        return $this->value;
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function value($value, ?string $valueType = null)
     {
         if (
@@ -148,14 +152,6 @@ class CaseStatementExpression implements CaseExpressionInterface
     public function getValueType(): ?string
     {
         return $this->valueType;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getWhen(): array
-    {
-        return $this->when;
     }
 
     /**
@@ -211,14 +207,6 @@ class CaseStatementExpression implements CaseExpressionInterface
         $this->when[] = $whenThen;
 
         return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getElse()
-    {
-        return $this->else;
     }
 
     /**

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -36,56 +36,56 @@ class CaseStatementExpression implements CaseExpressionInterface
      *
      * @var bool
      */
-    protected $_isSimpleVariant = false;
+    protected $isSimpleVariant = false;
 
     /**
      * The case value.
      *
      * @var \Cake\Database\ExpressionInterface|object|scalar|null
      */
-    protected $_value = null;
+    protected $value = null;
 
     /**
      * The case value type.
      *
      * @var string|null
      */
-    protected $_valueType = null;
+    protected $valueType = null;
 
     /**
      * The `WHEN ... THEN ...` expressions.
      *
      * @var \Cake\Database\Expression\WhenThenExpressionInterface[]
      */
-    protected $_when = [];
+    protected $when = [];
 
     /**
      * Buffer that holds values and types for use with `then()`.
      *
      * @var array|null
      */
-    protected $_whenBuffer = null;
+    protected $whenBuffer = null;
 
     /**
      * The else part result value.
      *
      * @var mixed|null
      */
-    protected $_else = null;
+    protected $else = null;
 
     /**
      * The else part result type.
      *
      * @var string|null
      */
-    protected $_elseType = null;
+    protected $elseType = null;
 
     /**
      * The return type.
      *
      * @var string|null
      */
-    protected $_returnType = null;
+    protected $returnType = null;
 
     /**
      * Constructor.
@@ -105,7 +105,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function getValue()
     {
-        return $this->_value;
+        return $this->value;
     }
 
     /**
@@ -126,17 +126,17 @@ class CaseStatementExpression implements CaseExpressionInterface
             ));
         }
 
-        $this->_value = $value;
+        $this->value = $value;
 
         if (
             $value !== null &&
             $valueType === null
         ) {
-            $valueType = $this->_inferType($value);
+            $valueType = $this->inferType($value);
         }
-        $this->_valueType = $valueType;
+        $this->valueType = $valueType;
 
-        $this->_isSimpleVariant = true;
+        $this->isSimpleVariant = true;
 
         return $this;
     }
@@ -146,7 +146,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function getValueType(): ?string
     {
-        return $this->_valueType;
+        return $this->valueType;
     }
 
     /**
@@ -154,7 +154,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function getWhen(): array
     {
-        return $this->_when;
+        return $this->when;
     }
 
     /**
@@ -162,7 +162,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function when($when, $type = null)
     {
-        if ($this->_whenBuffer !== null) {
+        if ($this->whenBuffer !== null) {
             throw new LogicException(
                 'Cannot add new `WHEN` value while an open `when()` buffer is present, ' .
                 'it must first be closed using `then()`.'
@@ -181,9 +181,9 @@ class CaseStatementExpression implements CaseExpressionInterface
         }
 
         if ($when instanceof WhenThenExpressionInterface) {
-            $this->_when[] = $when;
+            $this->when[] = $when;
         } else {
-            $this->_whenBuffer = ['when' => $when, 'type' => $type];
+            $this->whenBuffer = ['when' => $when, 'type' => $type];
         }
 
         return $this;
@@ -194,7 +194,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function then($result, ?string $type = null)
     {
-        if ($this->_whenBuffer === null) {
+        if ($this->whenBuffer === null) {
             throw new LogicException(
                 'There is no `when()` buffer present, ' .
                 'you must first open one before calling `then()`.'
@@ -202,10 +202,10 @@ class CaseStatementExpression implements CaseExpressionInterface
         }
 
         $whenThen = (new WhenThenExpression($this->getTypeMap()))
-            ->when($this->_whenBuffer['when'], $this->_whenBuffer['type'])
+            ->when($this->whenBuffer['when'], $this->whenBuffer['type'])
             ->then($result, $type);
 
-        $this->_whenBuffer = null;
+        $this->whenBuffer = null;
 
         $this->when($whenThen);
 
@@ -217,7 +217,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function getElse()
     {
-        return $this->_else;
+        return $this->else;
     }
 
     /**
@@ -225,7 +225,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function else($result, ?string $type = null)
     {
-        if ($this->_whenBuffer !== null) {
+        if ($this->whenBuffer !== null) {
             throw new LogicException(
                 'Cannot set `ELSE` value when an open `when()` buffer is present, ' .
                 'it must first be closed using `then()`.'
@@ -246,13 +246,13 @@ class CaseStatementExpression implements CaseExpressionInterface
         }
 
         if ($type === null) {
-            $type = $this->_inferType($result);
+            $type = $this->inferType($result);
         }
 
-        $this->_whenBuffer = null;
+        $this->whenBuffer = null;
 
-        $this->_else = $result;
-        $this->_elseType = $type;
+        $this->else = $result;
+        $this->elseType = $type;
 
         return $this;
     }
@@ -262,7 +262,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function getElseType(): ?string
     {
-        return $this->_elseType;
+        return $this->elseType;
     }
 
     /**
@@ -270,20 +270,20 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function getReturnType(): string
     {
-        if ($this->_returnType !== null) {
-            return $this->_returnType;
+        if ($this->returnType !== null) {
+            return $this->returnType;
         }
 
         $types = [];
-        foreach ($this->_when as $when) {
+        foreach ($this->when as $when) {
             $type = $when->getThenType();
             if ($type !== null) {
                 $types[] = $type;
             }
         }
 
-        if ($this->_elseType !== null) {
-            $types[] = $this->_elseType;
+        if ($this->elseType !== null) {
+            $types[] = $this->elseType;
         }
 
         $types = array_unique($types);
@@ -299,7 +299,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function setReturnType(string $type)
     {
-        $this->_returnType = $type;
+        $this->returnType = $type;
 
         return $this;
     }
@@ -309,7 +309,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        if ($this->_whenBuffer !== null) {
+        if ($this->whenBuffer !== null) {
             throw new LogicException(
                 sprintf(
                     'Cannot compile incomplete `\%s` expression, there is an open `when()` buffer present ' .
@@ -319,7 +319,7 @@ class CaseStatementExpression implements CaseExpressionInterface
             );
         }
 
-        if (empty($this->_when)) {
+        if (empty($this->when)) {
             throw new LogicException(
                 sprintf(
                     'Cannot compile incomplete `\%s` expression, there are no `WHEN ... THEN ...` statements.',
@@ -329,17 +329,17 @@ class CaseStatementExpression implements CaseExpressionInterface
         }
 
         $value = '';
-        if ($this->_isSimpleVariant) {
-            $value = $this->_compileNullableValue($binder, $this->_value, $this->_valueType) . ' ';
+        if ($this->isSimpleVariant) {
+            $value = $this->compileNullableValue($binder, $this->value, $this->valueType) . ' ';
         }
 
         $whenThenExpressions = [];
-        foreach ($this->_when as $whenThen) {
+        foreach ($this->when as $whenThen) {
             $whenThenExpressions[] = $whenThen->sql($binder);
         }
         $whenThen = implode(' ', $whenThenExpressions);
 
-        $else = $this->_compileNullableValue($binder, $this->_else, $this->_elseType);
+        $else = $this->compileNullableValue($binder, $this->else, $this->elseType);
 
         return "CASE {$value}{$whenThen} ELSE $else END";
     }
@@ -349,7 +349,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function traverse(Closure $callback)
     {
-        if ($this->_whenBuffer !== null) {
+        if ($this->whenBuffer !== null) {
             throw new LogicException(
                 sprintf(
                     'Cannot traverse incomplete `\%s` expression, there is an open `when()` buffer present ' .
@@ -359,19 +359,19 @@ class CaseStatementExpression implements CaseExpressionInterface
             );
         }
 
-        if ($this->_value instanceof ExpressionInterface) {
-            $callback($this->_value);
-            $this->_value->traverse($callback);
+        if ($this->value instanceof ExpressionInterface) {
+            $callback($this->value);
+            $this->value->traverse($callback);
         }
 
-        foreach ($this->_when as $when) {
+        foreach ($this->when as $when) {
             $callback($when);
             $when->traverse($callback);
         }
 
-        if ($this->_else instanceof ExpressionInterface) {
-            $callback($this->_else);
-            $this->_else->traverse($callback);
+        if ($this->else instanceof ExpressionInterface) {
+            $callback($this->else);
+            $this->else->traverse($callback);
         }
 
         return $this;
@@ -384,7 +384,7 @@ class CaseStatementExpression implements CaseExpressionInterface
      */
     public function __clone()
     {
-        if ($this->_whenBuffer !== null) {
+        if ($this->whenBuffer !== null) {
             throw new LogicException(
                 sprintf(
                     'Cannot clone incomplete `\%s` expression, there is an open `when()` buffer present ' .
@@ -394,16 +394,16 @@ class CaseStatementExpression implements CaseExpressionInterface
             );
         }
 
-        if ($this->_value instanceof ExpressionInterface) {
-            $this->_value = clone $this->_value;
+        if ($this->value instanceof ExpressionInterface) {
+            $this->value = clone $this->value;
         }
 
-        foreach ($this->_when as $key => $when) {
-            $this->_when[$key] = clone $this->_when[$key];
+        foreach ($this->when as $key => $when) {
+            $this->when[$key] = clone $this->when[$key];
         }
 
-        if ($this->_else instanceof ExpressionInterface) {
-            $this->_else = clone $this->_else;
+        if ($this->else instanceof ExpressionInterface) {
+            $this->else = clone $this->else;
         }
     }
 }

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -67,7 +67,7 @@ class CaseStatementExpression implements CaseExpressionInterface
     /**
      * The `WHEN ... THEN ...` expressions.
      *
-     * @var \Cake\Database\Expression\WhenThenExpressionInterface[]
+     * @var array<\Cake\Database\Expression\WhenThenExpressionInterface>
      */
     protected $when = [];
 
@@ -81,7 +81,7 @@ class CaseStatementExpression implements CaseExpressionInterface
     /**
      * The else part result value.
      *
-     * @var mixed|null
+     * @var \Cake\Database\ExpressionInterface|object|scalar|null
      */
     protected $else = null;
 

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -208,7 +208,7 @@ class CaseStatementExpression implements CaseExpressionInterface
 
         $this->whenBuffer = null;
 
-        $this->when($whenThen);
+        $this->when[] = $whenThen;
 
         return $this;
     }

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -1,0 +1,409 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Type\ExpressionTypeCasterTrait;
+use Cake\Database\TypeMap;
+use Cake\Database\TypeMapTrait;
+use Cake\Database\ValueBinder;
+use Closure;
+use InvalidArgumentException;
+use LogicException;
+
+class CaseStatementExpression implements CaseExpressionInterface
+{
+    use CaseExpressionTrait;
+    use ExpressionTypeCasterTrait;
+    use TypeMapTrait;
+
+    /**
+     * Whether this is a simple case expression.
+     *
+     * @var bool
+     */
+    protected $_isSimpleVariant = false;
+
+    /**
+     * The case value.
+     *
+     * @var \Cake\Database\ExpressionInterface|object|scalar|null
+     */
+    protected $_value = null;
+
+    /**
+     * The case value type.
+     *
+     * @var string|null
+     */
+    protected $_valueType = null;
+
+    /**
+     * The `WHEN ... THEN ...` expressions.
+     *
+     * @var \Cake\Database\Expression\WhenThenExpressionInterface[]
+     */
+    protected $_when = [];
+
+    /**
+     * Buffer that holds values and types for use with `then()`.
+     *
+     * @var array|null
+     */
+    protected $_whenBuffer = null;
+
+    /**
+     * The else part result value.
+     *
+     * @var mixed|null
+     */
+    protected $_else = null;
+
+    /**
+     * The else part result type.
+     *
+     * @var string|null
+     */
+    protected $_elseType = null;
+
+    /**
+     * The return type.
+     *
+     * @var string|null
+     */
+    protected $_returnType = null;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\Database\TypeMap|null $typeMap The type map to use when using an array of conditions for the `WHEN`
+     *  value.
+     */
+    public function __construct(?TypeMap $typeMap = null)
+    {
+        if ($typeMap !== null) {
+            $this->setTypeMap($typeMap);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getValue()
+    {
+        return $this->_value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function value($value, ?string $valueType = null)
+    {
+        if (
+            $value !== null &&
+            !is_scalar($value) &&
+            !(is_object($value) && !($value instanceof Closure))
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'The `$value` argument must be either `null`, a scalar value, an object, ' .
+                'or an instance of `\%s`, `%s` given.',
+                ExpressionInterface::class,
+                getTypeName($value)
+            ));
+        }
+
+        $this->_value = $value;
+
+        if (
+            $value !== null &&
+            $valueType === null
+        ) {
+            $valueType = $this->_inferType($value);
+        }
+        $this->_valueType = $valueType;
+
+        $this->_isSimpleVariant = true;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getValueType(): ?string
+    {
+        return $this->_valueType;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getWhen(): array
+    {
+        return $this->_when;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function when($when, $type = null)
+    {
+        if ($this->_whenBuffer !== null) {
+            throw new LogicException(
+                'Cannot add new `WHEN` value while an open `when()` buffer is present, ' .
+                'it must first be closed using `then()`.'
+            );
+        }
+
+        if ($when instanceof Closure) {
+            $when = $when(new WhenThenExpression($this->getTypeMap()));
+            if (!($when instanceof WhenThenExpressionInterface)) {
+                throw new LogicException(sprintf(
+                    '`when()` callables must return an instance of `\%s`, `%s` given.',
+                    WhenThenExpressionInterface::class,
+                    getTypeName($when)
+                ));
+            }
+        }
+
+        if ($when instanceof WhenThenExpressionInterface) {
+            $this->_when[] = $when;
+        } else {
+            $this->_whenBuffer = ['when' => $when, 'type' => $type];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function then($result, ?string $type = null)
+    {
+        if ($this->_whenBuffer === null) {
+            throw new LogicException(
+                'There is no `when()` buffer present, ' .
+                'you must first open one before calling `then()`.'
+            );
+        }
+
+        $whenThen = (new WhenThenExpression($this->getTypeMap()))
+            ->when($this->_whenBuffer['when'], $this->_whenBuffer['type'])
+            ->then($result, $type);
+
+        $this->_whenBuffer = null;
+
+        $this->when($whenThen);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getElse()
+    {
+        return $this->_else;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function else($result, ?string $type = null)
+    {
+        if ($this->_whenBuffer !== null) {
+            throw new LogicException(
+                'Cannot set `ELSE` value when an open `when()` buffer is present, ' .
+                'it must first be closed using `then()`.'
+            );
+        }
+
+        if (
+            $result !== null &&
+            !is_scalar($result) &&
+            !(is_object($result) && !($result instanceof Closure))
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'The `$result` argument must be either `null`, a scalar value, an object, ' .
+                'or an instance of `\%s`, `%s` given.',
+                ExpressionInterface::class,
+                getTypeName($result)
+            ));
+        }
+
+        if ($type === null) {
+            $type = $this->_inferType($result);
+        }
+
+        $this->_whenBuffer = null;
+
+        $this->_else = $result;
+        $this->_elseType = $type;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getElseType(): ?string
+    {
+        return $this->_elseType;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getReturnType(): string
+    {
+        if ($this->_returnType !== null) {
+            return $this->_returnType;
+        }
+
+        $types = [];
+        foreach ($this->_when as $when) {
+            $type = $when->getThenType();
+            if ($type !== null) {
+                $types[] = $type;
+            }
+        }
+
+        if ($this->_elseType !== null) {
+            $types[] = $this->_elseType;
+        }
+
+        $types = array_unique($types);
+        if (count($types) === 1) {
+            return $types[0];
+        }
+
+        return 'string';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setReturnType(string $type)
+    {
+        $this->_returnType = $type;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        if ($this->_whenBuffer !== null) {
+            throw new LogicException(
+                sprintf(
+                    'Cannot compile incomplete `\%s` expression, there is an open `when()` buffer present ' .
+                    'that must be closed using `then()`.',
+                    CaseExpressionInterface::class
+                )
+            );
+        }
+
+        if (empty($this->_when)) {
+            throw new LogicException(
+                sprintf(
+                    'Cannot compile incomplete `\%s` expression, there are no `WHEN ... THEN ...` statements.',
+                    CaseExpressionInterface::class
+                )
+            );
+        }
+
+        $value = '';
+        if ($this->_isSimpleVariant) {
+            $value = $this->_compileNullableValue($binder, $this->_value, $this->_valueType) . ' ';
+        }
+
+        $whenThenExpressions = [];
+        foreach ($this->_when as $whenThen) {
+            $whenThenExpressions[] = $whenThen->sql($binder);
+        }
+        $whenThen = implode(' ', $whenThenExpressions);
+
+        $else = $this->_compileNullableValue($binder, $this->_else, $this->_elseType);
+
+        return "CASE {$value}{$whenThen} ELSE $else END";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function traverse(Closure $callback)
+    {
+        if ($this->_whenBuffer !== null) {
+            throw new LogicException(
+                sprintf(
+                    'Cannot traverse incomplete `\%s` expression, there is an open `when()` buffer present ' .
+                    'that must be closed using `then()`.',
+                    CaseExpressionInterface::class
+                )
+            );
+        }
+
+        if ($this->_value instanceof ExpressionInterface) {
+            $callback($this->_value);
+            $this->_value->traverse($callback);
+        }
+
+        foreach ($this->_when as $when) {
+            $callback($when);
+            $when->traverse($callback);
+        }
+
+        if ($this->_else instanceof ExpressionInterface) {
+            $callback($this->_else);
+            $this->_else->traverse($callback);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clones the inner expression objects.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        if ($this->_whenBuffer !== null) {
+            throw new LogicException(
+                sprintf(
+                    'Cannot clone incomplete `\%s` expression, there is an open `when()` buffer present ' .
+                    'that must be closed using `then()`.',
+                    CaseExpressionInterface::class
+                )
+            );
+        }
+
+        if ($this->_value instanceof ExpressionInterface) {
+            $this->_value = clone $this->_value;
+        }
+
+        foreach ($this->_when as $key => $when) {
+            $this->_when[$key] = clone $this->_when[$key];
+        }
+
+        if ($this->_else instanceof ExpressionInterface) {
+            $this->_else = clone $this->_else;
+        }
+    }
+}

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -149,14 +149,6 @@ class CaseStatementExpression implements CaseExpressionInterface
     /**
      * @inheritDoc
      */
-    public function getValueType(): ?string
-    {
-        return $this->valueType;
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function when($when, $type = null)
     {
         if ($this->whenBuffer !== null) {
@@ -249,14 +241,6 @@ class CaseStatementExpression implements CaseExpressionInterface
     /**
      * @inheritDoc
      */
-    public function getElseType(): ?string
-    {
-        return $this->elseType;
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function getReturnType(): string
     {
         if ($this->returnType !== null) {
@@ -265,7 +249,7 @@ class CaseStatementExpression implements CaseExpressionInterface
 
         $types = [];
         foreach ($this->when as $when) {
-            $type = $when->getThenType();
+            $type = $when->getResultType();
             if ($type !== null) {
                 $types[] = $type;
             }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -342,7 +342,19 @@ class QueryExpression implements ExpressionInterface, Countable
      */
     public function addCase($conditions, $values = [], $types = [])
     {
+        deprecationWarning('QueryExpression::addCase() is deprecated, use case() instead.');
+
         return $this->add(new CaseExpression($conditions, $values, $types));
+    }
+
+    /**
+     * Returns a new case expression object.
+     *
+     * @return \Cake\Database\Expression\CaseExpressionInterface
+     */
+    public function case(): CaseExpressionInterface
+    {
+        return new CaseStatementExpression($this->getTypeMap());
     }
 
     /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -350,11 +350,29 @@ class QueryExpression implements ExpressionInterface, Countable
     /**
      * Returns a new case expression object.
      *
+     * When a value is set, the syntax generated is
+     * `CASE case_value WHEN when_value ... END`, where the
+     * `when_value`'s are compared against the `case_value`.
+     *
+     * When no value is set, the syntax generated is
+     * `CASE WHEN when_conditions ... END`, where the conditions
+     * hold the comparisons.
+     *
+     * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
+     * @param string|null $valueType The case value type. If no type is provided, the type will be tried to be inferred
+     *  from the value.
      * @return \Cake\Database\Expression\CaseExpressionInterface
+     * @see \Cake\Database\Expression\CaseExpressionInterface::value()
      */
-    public function case(): CaseExpressionInterface
+    public function case($value = null, ?string $valueType = null): CaseExpressionInterface
     {
-        return new CaseStatementExpression($this->getTypeMap());
+        $expression = new CaseStatementExpression($this->getTypeMap());
+
+        if (func_num_args() > 0) {
+            $expression->value($value, $valueType);
+        }
+
+        return $expression;
     }
 
     /**

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -226,16 +226,6 @@ class WhenThenExpression implements WhenThenExpressionInterface
     }
 
     /**
-     * Returns the type map.
-     *
-     * @return \Cake\Database\TypeMap
-     */
-    protected function getTypeMap(): TypeMap
-    {
-        return $this->_typeMap;
-    }
-
-    /**
      * @inheritDoc
      */
     public function sql(ValueBinder $binder): string

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -43,21 +43,21 @@ class WhenThenExpression implements WhenThenExpressionInterface
      *
      * @var \Cake\Database\ExpressionInterface|object|scalar|null
      */
-    protected $_when = null;
+    protected $when = null;
 
     /**
      * The `WHEN` value type.
      *
      * @var array|string|null
      */
-    protected $_whenType = null;
+    protected $whenType = null;
 
     /**
      * The `THEN` value.
      *
      * @var mixed
      */
-    protected $_then = null;
+    protected $then = null;
 
     /**
      * Whether the `THEN` value has been defined, eg whether `then()`
@@ -65,14 +65,14 @@ class WhenThenExpression implements WhenThenExpressionInterface
      *
      * @var bool
      */
-    protected $_hasThenBeenDefined = false;
+    protected $hasThenBeenDefined = false;
 
     /**
      * The `THEN` result type.
      *
      * @var string|null
      */
-    protected $_thenType = null;
+    protected $thenType = null;
 
     /**
      * Constructor.
@@ -93,7 +93,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function getWhen()
     {
-        return $this->_when;
+        return $this->when;
     }
 
     /**
@@ -160,12 +160,12 @@ class WhenThenExpression implements WhenThenExpressionInterface
             }
 
             if ($type === null) {
-                $type = $this->_inferType($when);
+                $type = $this->inferType($when);
             }
         }
 
-        $this->_when = $when;
-        $this->_whenType = $type;
+        $this->when = $when;
+        $this->whenType = $type;
 
         return $this;
     }
@@ -175,7 +175,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function getWhenType()
     {
-        return $this->_whenType;
+        return $this->whenType;
     }
 
     /**
@@ -183,7 +183,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function getThen()
     {
-        return $this->_then;
+        return $this->then;
     }
 
     /**
@@ -204,15 +204,15 @@ class WhenThenExpression implements WhenThenExpressionInterface
             ));
         }
 
-        $this->_then = $result;
+        $this->then = $result;
 
         if ($type === null) {
-            $type = $this->_inferType($result);
+            $type = $this->inferType($result);
         }
 
-        $this->_thenType = $type;
+        $this->thenType = $type;
 
-        $this->_hasThenBeenDefined = true;
+        $this->hasThenBeenDefined = true;
 
         return $this;
     }
@@ -222,7 +222,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function getThenType(): ?string
     {
-        return $this->_thenType;
+        return $this->thenType;
     }
 
     /**
@@ -240,7 +240,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        if ($this->_when === null) {
+        if ($this->when === null) {
             throw new LogicException(
                 sprintf(
                     'Cannot compile incomplete `\%s`, the value for `WHEN` is missing.',
@@ -249,7 +249,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
             );
         }
 
-        if (!$this->_hasThenBeenDefined) {
+        if (!$this->hasThenBeenDefined) {
             throw new LogicException(
                 sprintf(
                     'Cannot compile incomplete `\%s`, the value for `THEN` is missing.',
@@ -258,12 +258,12 @@ class WhenThenExpression implements WhenThenExpressionInterface
             );
         }
 
-        $when = $this->_when;
+        $when = $this->when;
         if (
-            is_string($this->_whenType) &&
+            is_string($this->whenType) &&
             !($when instanceof ExpressionInterface)
         ) {
-            $when = $this->_castToExpression($when, $this->_whenType);
+            $when = $this->_castToExpression($when, $this->whenType);
         }
         if ($when instanceof Query) {
             $when = sprintf('(%s)', $when->sql($binder));
@@ -271,8 +271,8 @@ class WhenThenExpression implements WhenThenExpressionInterface
             $when = $when->sql($binder);
         } else {
             $placeholder = $binder->placeholder('c');
-            if (is_string($this->_whenType)) {
-                $whenType = $this->_whenType;
+            if (is_string($this->whenType)) {
+                $whenType = $this->whenType;
             } else {
                 $whenType = null;
             }
@@ -280,7 +280,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
             $when = $placeholder;
         }
 
-        $then = $this->_compileNullableValue($binder, $this->_then, $this->_thenType);
+        $then = $this->compileNullableValue($binder, $this->then, $this->thenType);
 
         return "WHEN $when THEN $then";
     }
@@ -290,14 +290,14 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function traverse(Closure $callback)
     {
-        if ($this->_when instanceof ExpressionInterface) {
-            $callback($this->_when);
-            $this->_when->traverse($callback);
+        if ($this->when instanceof ExpressionInterface) {
+            $callback($this->when);
+            $this->when->traverse($callback);
         }
 
-        if ($this->_then instanceof ExpressionInterface) {
-            $callback($this->_then);
-            $this->_then->traverse($callback);
+        if ($this->then instanceof ExpressionInterface) {
+            $callback($this->then);
+            $this->then->traverse($callback);
         }
 
         return $this;
@@ -310,12 +310,12 @@ class WhenThenExpression implements WhenThenExpressionInterface
      */
     public function __clone()
     {
-        if ($this->_when instanceof ExpressionInterface) {
-            $this->_when = clone $this->_when;
+        if ($this->when instanceof ExpressionInterface) {
+            $this->when = clone $this->when;
         }
 
-        if ($this->_then instanceof ExpressionInterface) {
-            $this->_then = clone $this->_then;
+        if ($this->then instanceof ExpressionInterface) {
+            $this->then = clone $this->then;
         }
     }
 }

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -176,14 +176,6 @@ class WhenThenExpression implements WhenThenExpressionInterface
     /**
      * @inheritDoc
      */
-    public function getWhenType()
-    {
-        return $this->whenType;
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function then($result, ?string $type = null)
     {
         if (
@@ -215,7 +207,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
     /**
      * @inheritDoc
      */
-    public function getThenType(): ?string
+    public function getResultType(): ?string
     {
         return $this->thenType;
     }

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -66,7 +66,7 @@ class WhenThenExpression implements WhenThenExpressionInterface
     /**
      * The `THEN` value.
      *
-     * @var mixed
+     * @var \Cake\Database\ExpressionInterface|object|scalar|null
      */
     protected $then = null;
 

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -1,0 +1,321 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Query;
+use Cake\Database\Type\ExpressionTypeCasterTrait;
+use Cake\Database\TypeMap;
+use Cake\Database\ValueBinder;
+use Closure;
+use InvalidArgumentException;
+use LogicException;
+
+class WhenThenExpression implements WhenThenExpressionInterface
+{
+    use CaseExpressionTrait;
+    use ExpressionTypeCasterTrait;
+
+    /**
+     * The type map to use when using an array of conditions for the
+     * `WHEN` value.
+     *
+     * @var \Cake\Database\TypeMap
+     */
+    protected $_typeMap;
+
+    /**
+     * Then `WHEN` value.
+     *
+     * @var \Cake\Database\ExpressionInterface|object|scalar|null
+     */
+    protected $_when = null;
+
+    /**
+     * The `WHEN` value type.
+     *
+     * @var array|string|null
+     */
+    protected $_whenType = null;
+
+    /**
+     * The `THEN` value.
+     *
+     * @var mixed
+     */
+    protected $_then = null;
+
+    /**
+     * Whether the `THEN` value has been defined, eg whether `then()`
+     * has been invoked.
+     *
+     * @var bool
+     */
+    protected $_hasThenBeenDefined = false;
+
+    /**
+     * The `THEN` result type.
+     *
+     * @var string|null
+     */
+    protected $_thenType = null;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\Database\TypeMap|null $typeMap The type map to use when using an array of conditions for the `WHEN`
+     *  value.
+     */
+    public function __construct(?TypeMap $typeMap = null)
+    {
+        if ($typeMap === null) {
+            $typeMap = new TypeMap();
+        }
+        $this->_typeMap = $typeMap;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getWhen()
+    {
+        return $this->_when;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function when($when, $type = null)
+    {
+        if (
+            !(is_array($when) && !empty($when)) &&
+            !is_scalar($when) &&
+            !is_object($when)
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'The `$when` argument must be either a non-empty array, a scalar value, an object, ' .
+                'or an instance of `\%s`, `%s` given.',
+                ExpressionInterface::class,
+                is_array($when) ? '[]' : getTypeName($when)
+            ));
+        }
+
+        if (
+            $type !== null &&
+            !is_array($type) &&
+            !is_string($type)
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'The `$type` argument must be either an array, a string, or `null`, `%s` given.',
+                getTypeName($type)
+            ));
+        }
+
+        if (is_array($when)) {
+            if (
+                $type !== null &&
+                !is_array($type)
+            ) {
+                throw new InvalidArgumentException(sprintf(
+                    'When using an array for the `$when` argument, the `$type` argument must be an ' .
+                    'array too, `%s` given.',
+                    getTypeName($type)
+                ));
+            }
+
+            // avoid dirtying the type map for possible consecutive `when()` calls
+            $typeMap = clone $this->_typeMap;
+            if (
+                is_array($type) &&
+                count($type) > 0
+            ) {
+                $typeMap = $typeMap->setTypes($type);
+            }
+
+            $when = new QueryExpression($when, $typeMap);
+        } else {
+            if (
+                $type !== null &&
+                !is_string($type)
+            ) {
+                throw new InvalidArgumentException(sprintf(
+                    'When using a non-array value for the `$when` argument, the `$type` argument must ' .
+                    'be a string, `%s` given.',
+                    getTypeName($type)
+                ));
+            }
+
+            if ($type === null) {
+                $type = $this->_inferType($when);
+            }
+        }
+
+        $this->_when = $when;
+        $this->_whenType = $type;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getWhenType()
+    {
+        return $this->_whenType;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getThen()
+    {
+        return $this->_then;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function then($result, ?string $type = null)
+    {
+        if (
+            $result !== null &&
+            !is_scalar($result) &&
+            !(is_object($result) && !($result instanceof Closure))
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'The `$result` argument must be either `null`, a scalar value, an object, ' .
+                'or an instance of `\%s`, `%s` given.',
+                ExpressionInterface::class,
+                getTypeName($result)
+            ));
+        }
+
+        $this->_then = $result;
+
+        if ($type === null) {
+            $type = $this->_inferType($result);
+        }
+
+        $this->_thenType = $type;
+
+        $this->_hasThenBeenDefined = true;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getThenType(): ?string
+    {
+        return $this->_thenType;
+    }
+
+    /**
+     * Returns the type map.
+     *
+     * @return \Cake\Database\TypeMap
+     */
+    protected function getTypeMap(): TypeMap
+    {
+        return $this->_typeMap;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sql(ValueBinder $binder): string
+    {
+        if ($this->_when === null) {
+            throw new LogicException(
+                sprintf(
+                    'Cannot compile incomplete `\%s`, the value for `WHEN` is missing.',
+                    WhenThenExpressionInterface::class
+                )
+            );
+        }
+
+        if (!$this->_hasThenBeenDefined) {
+            throw new LogicException(
+                sprintf(
+                    'Cannot compile incomplete `\%s`, the value for `THEN` is missing.',
+                    WhenThenExpressionInterface::class
+                )
+            );
+        }
+
+        $when = $this->_when;
+        if (
+            is_string($this->_whenType) &&
+            !($when instanceof ExpressionInterface)
+        ) {
+            $when = $this->_castToExpression($when, $this->_whenType);
+        }
+        if ($when instanceof Query) {
+            $when = sprintf('(%s)', $when->sql($binder));
+        } elseif ($when instanceof ExpressionInterface) {
+            $when = $when->sql($binder);
+        } else {
+            $placeholder = $binder->placeholder('c');
+            if (is_string($this->_whenType)) {
+                $whenType = $this->_whenType;
+            } else {
+                $whenType = null;
+            }
+            $binder->bind($placeholder, $when, $whenType);
+            $when = $placeholder;
+        }
+
+        $then = $this->_compileNullableValue($binder, $this->_then, $this->_thenType);
+
+        return "WHEN $when THEN $then";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function traverse(Closure $callback)
+    {
+        if ($this->_when instanceof ExpressionInterface) {
+            $callback($this->_when);
+            $this->_when->traverse($callback);
+        }
+
+        if ($this->_then instanceof ExpressionInterface) {
+            $callback($this->_then);
+            $this->_then->traverse($callback);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Clones the inner expression objects.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        if ($this->_when instanceof ExpressionInterface) {
+            $this->_when = clone $this->_when;
+        }
+
+        if ($this->_then instanceof ExpressionInterface) {
+            $this->_then = clone $this->_then;
+        }
+    }
+}

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -31,6 +31,17 @@ class WhenThenExpression implements WhenThenExpressionInterface
     use ExpressionTypeCasterTrait;
 
     /**
+     * The names of the clauses that are valid for use with the
+     * `clause()` method.
+     *
+     * @var array<string>
+     */
+    protected $validClauseNames = [
+        'when',
+        'then',
+    ];
+
+    /**
      * The type map to use when using an array of conditions for the
      * `WHEN` value.
      *
@@ -86,14 +97,6 @@ class WhenThenExpression implements WhenThenExpressionInterface
             $typeMap = new TypeMap();
         }
         $this->_typeMap = $typeMap;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getWhen()
-    {
-        return $this->when;
     }
 
     /**
@@ -176,14 +179,6 @@ class WhenThenExpression implements WhenThenExpressionInterface
     public function getWhenType()
     {
         return $this->whenType;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getThen()
-    {
-        return $this->then;
     }
 
     /**

--- a/src/Database/Expression/WhenThenExpressionInterface.php
+++ b/src/Database/Expression/WhenThenExpressionInterface.php
@@ -60,14 +60,6 @@ interface WhenThenExpressionInterface extends ExpressionInterface
     public function when($when, $type = null);
 
     /**
-     * Returns the `WHEN` value type.
-     *
-     * @return array|string|null
-     * @see when()
-     */
-    public function getWhenType();
-
-    /**
      * Sets the `THEN` result value.
      *
      * @param \Cake\Database\ExpressionInterface|object|scalar|null $result The result value.
@@ -78,10 +70,10 @@ interface WhenThenExpressionInterface extends ExpressionInterface
     public function then($result, ?string $type = null);
 
     /**
-     * Returns the `THEN` result value type.
+     * Returns the expression's result value type.
      *
      * @return string|null
      * @see then()
      */
-    public function getThenType(): ?string;
+    public function getResultType(): ?string;
 }

--- a/src/Database/Expression/WhenThenExpressionInterface.php
+++ b/src/Database/Expression/WhenThenExpressionInterface.php
@@ -21,11 +21,20 @@ use Cake\Database\ExpressionInterface;
 interface WhenThenExpressionInterface extends ExpressionInterface
 {
     /**
-     * Returns the `WHEN` value.
+     * Returns the available data for the given clause.
      *
+     * ### Available clauses
+     *
+     * The following clause names are available:
+     *
+     * * `when` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `WHEN` value.
+     * * `then` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `THEN` result value.
+     *
+     * @param string $clause The name of the clause to obtain.
      * @return \Cake\Database\ExpressionInterface|object|scalar|null
+     * @throws \InvalidArgumentException In case the given clause name is invalid.
      */
-    public function getWhen();
+    public function clause(string $clause);
 
     /**
      * Sets the `WHEN` value.
@@ -57,13 +66,6 @@ interface WhenThenExpressionInterface extends ExpressionInterface
      * @see when()
      */
     public function getWhenType();
-
-    /**
-     * Returns the `THEN` result value.
-     *
-     * @return \Cake\Database\ExpressionInterface|object|scalar|null The result value.
-     */
-    public function getThen();
 
     /**
      * Sets the `THEN` result value.

--- a/src/Database/Expression/WhenThenExpressionInterface.php
+++ b/src/Database/Expression/WhenThenExpressionInterface.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Expression;
+
+use Cake\Database\ExpressionInterface;
+
+interface WhenThenExpressionInterface extends ExpressionInterface
+{
+    /**
+     * Returns the `WHEN` value.
+     *
+     * @return \Cake\Database\ExpressionInterface|object|scalar|null
+     */
+    public function getWhen();
+
+    /**
+     * Sets the `WHEN` value.
+     *
+     * @param \Cake\Database\ExpressionInterface|array|object|scalar $when The `WHEN` value. When using an array of
+     *  conditions, it must be compatible with `\Cake\Database\Query::where()`. Note that this argument is _not_
+     *  completely safe for use with user data, as a user supplied array would allow for raw SQL to slip in! If you
+     *  plan to use user data, either pass a single type for the `$type` argument (which forces the `$when` value to be
+     *  a non-array, and then always binds the data), use a conditions array where the user data is only passed on the
+     *  value side of the array entries, or custom bindings!
+     * @param array|string|null $type The when value type. Either an associative array when using array style
+     *  conditions, or else a string. If no type is provided, the type will be tried to be inferred from the value.
+     * @return $this
+     * @throws \InvalidArgumentException In case the `$when` argument is neither a non-empty array, nor a scalar value,
+     *  an object, or an instance of `\Cake\Database\ExpressionInterface`.
+     * @throws \InvalidArgumentException In case the `$type` argument is neither an array, a string, nor null.
+     * @throws \InvalidArgumentException In case the `$when` argument is an array, and the `$type` argument is neither
+     * an array, nor null.
+     * @throws \InvalidArgumentException In case the `$when` argument is a non-array value, and the `$type` argument is
+     * neither a string, nor null.
+     * @see CaseExpressionInterface::when() for a more detailed usage explanation.
+     */
+    public function when($when, $type = null);
+
+    /**
+     * Returns the `WHEN` value type.
+     *
+     * @return array|string|null
+     * @see when()
+     */
+    public function getWhenType();
+
+    /**
+     * Returns the `THEN` result value.
+     *
+     * @return \Cake\Database\ExpressionInterface|object|scalar|null The result value.
+     */
+    public function getThen();
+
+    /**
+     * Sets the `THEN` result value.
+     *
+     * @param \Cake\Database\ExpressionInterface|object|scalar|null $result The result value.
+     * @param string|null $type The result type. If no type is provided, the type will be inferred from the given
+     *  result value.
+     * @return $this
+     */
+    public function then($result, ?string $type = null);
+
+    /**
+     * Returns the `THEN` result value type.
+     *
+     * @return string|null
+     * @see then()
+     */
+    public function getThenType(): ?string;
+}

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -1,0 +1,2225 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Expression;
+
+use Cake\Chronos\Chronos;
+use Cake\Chronos\Date as ChronosDate;
+use Cake\Chronos\MutableDate as ChronosMutableDate;
+use Cake\Database\Expression\CaseStatementExpression;
+use Cake\Database\Expression\ComparisonExpression;
+use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
+use Cake\Database\Expression\WhenThenExpression;
+use Cake\Database\Expression\WhenThenExpressionInterface;
+use Cake\Database\TypeFactory;
+use Cake\Database\TypeMap;
+use Cake\Database\ValueBinder;
+use Cake\Datasource\ConnectionManager;
+use Cake\I18n\Date;
+use Cake\I18n\FrozenDate;
+use Cake\I18n\FrozenTime;
+use Cake\I18n\Time;
+use Cake\Test\test_app\TestApp\Database\Expression\CustomWhenThenExpression;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use LogicException;
+use stdClass;
+use TestApp\Database\Type\CustomExpressionType;
+use TestApp\View\Object\TestObjectWithToString;
+use TypeError;
+
+class CaseStatementExpressionTest extends TestCase
+{
+    // region Type handling
+
+    public function testExpressionTypeCastingSimpleCase(): void
+    {
+        TypeFactory::map('custom', CustomExpressionType::class);
+
+        $expression = (new CaseStatementExpression())
+            ->value(1, 'custom')
+            ->when(1, 'custom')
+            ->then(2, 'custom')
+            ->else(3, 'custom');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE CUSTOM(:param0) WHEN CUSTOM(:param1) THEN CUSTOM(:param2) ELSE CUSTOM(:param3) END',
+            $sql
+        );
+    }
+
+    public function testExpressionTypeCastingNullValues(): void
+    {
+        TypeFactory::map('custom', CustomExpressionType::class);
+
+        $expression = (new CaseStatementExpression())
+            ->value(null, 'custom')
+            ->when(1, 'custom')
+            ->then(null, 'custom')
+            ->else(null, 'custom');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE CUSTOM(:param0) WHEN CUSTOM(:param1) THEN CUSTOM(:param2) ELSE CUSTOM(:param3) END',
+            $sql
+        );
+    }
+
+    public function testExpressionTypeCastingSearchedCase(): void
+    {
+        TypeFactory::map('custom', CustomExpressionType::class);
+
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column' => true], ['Table.column' => 'custom'])
+            ->then(1, 'custom')
+            ->else(2, 'custom');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN Table.column = (CUSTOM(:param0)) THEN CUSTOM(:param1) ELSE CUSTOM(:param2) END',
+            $sql
+        );
+    }
+
+    public function testGetReturnType(): void
+    {
+        // all provided `then` and `else` types are the same, return
+        // type can be inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1, 'integer')
+            ->when(['Table.column_b' => true])
+            ->then(2, 'integer')
+            ->else(3, 'integer');
+        $this->assertSame('integer', $expression->getReturnType());
+
+        // all provided `then` an `else` types are the same, one `then`
+        // type is `null`, return type can be inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1)
+            ->when(['Table.column_b' => true])
+            ->then(2, 'integer')
+            ->else(3, 'integer');
+        $this->assertSame('integer', $expression->getReturnType());
+
+        // all `then` types are null, an `else` type was provided,
+        // return type can be inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1)
+            ->when(['Table.column_b' => true])
+            ->then(2)
+            ->else(3, 'integer');
+        $this->assertSame('integer', $expression->getReturnType());
+
+        // all provided `then` types are the same, the `else` type is
+        // `null`, return type can be inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1, 'integer')
+            ->when(['Table.column_b' => true])
+            ->then(2, 'integer')
+            ->else(3);
+        $this->assertSame('integer', $expression->getReturnType());
+
+        // no `then` or `else` types were provided, they are all `null`,
+        // and will be derived from the passed value, return type can be
+        // inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1)
+            ->when(['Table.column_b' => true])
+            ->then(2)
+            ->else(3);
+        $this->assertSame('integer', $expression->getReturnType());
+
+        // all `then` and `else` point to columns of the same type,
+        // return type can be inferred
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'boolean',
+            'Table.column_b' => 'boolean',
+            'Table.column_c' => 'boolean',
+        ]);
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when(['Table.column_a' => true])
+            ->then(new IdentifierExpression('Table.column_a'))
+            ->when(['Table.column_b' => true])
+            ->then(new IdentifierExpression('Table.column_b'))
+            ->else(new IdentifierExpression('Table.column_c'));
+        $this->assertSame('boolean', $expression->getReturnType());
+
+        // all `then` and `else` use the same custom type, return type
+        // can be inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1, 'custom')
+            ->when(['Table.column_b' => true])
+            ->then(2, 'custom')
+            ->else(3, 'custom');
+        $this->assertSame('custom', $expression->getReturnType());
+
+        // all `then` and `else` types were provided, but an explicit
+        // return type was set, return type will be overwritten
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(1, 'integer')
+            ->when(['Table.column_b' => true])
+            ->then(2, 'integer')
+            ->else(3, 'integer')
+            ->setReturnType('string');
+        $this->assertSame('string', $expression->getReturnType());
+
+        // all `then` and `else` types are different, return type
+        // cannot be inferred
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->then(true)
+            ->when(['Table.column_b' => true])
+            ->then(1)
+            ->else(null);
+        $this->assertSame('string', $expression->getReturnType());
+    }
+
+    public function testSetReturnType(): void
+    {
+        $expression = (new CaseStatementExpression())->else('1');
+        $this->assertSame('string', $expression->getReturnType());
+
+        $expression->setReturnType('float');
+        $this->assertSame('float', $expression->getReturnType());
+    }
+
+    public function typeInferenceDataProvider(): array
+    {
+        return [
+            ['1', 'string'],
+            [1, 'integer'],
+            [1.0, 'float'],
+            [true, 'boolean'],
+            [ChronosDate::now(), 'date'],
+            [Chronos::now(), 'datetime'],
+            [new IdentifierExpression('Table.column'), 'boolean'],
+            [new stdClass(), null],
+            [null, null],
+        ];
+    }
+
+    /**
+     * @dataProvider typeInferenceDataProvider
+     * @param mixed $value The value from which to infer the type.
+     * @param string|null $type The expected type.
+     */
+    public function testInferValueType($value, ?string $type): void
+    {
+        $expression = (new CaseStatementExpression(new TypeMap(['Table.column' => 'boolean'])))
+            ->value($value)
+            ->when(1)
+            ->then(2);
+        $this->assertSame($type, $expression->getValueType());
+    }
+
+    /**
+     * @dataProvider typeInferenceDataProvider
+     * @param mixed $value The value from which to infer the type.
+     * @param string|null $type The expected type.
+     */
+    public function testInferWhenType($value, ?string $type): void
+    {
+        $this->skipIf(
+            $value === null,
+            '`\Cake\Database\Expression\CaseExpression::when()` does not accept `null`'
+        );
+
+        $expression = (new CaseStatementExpression(new TypeMap(['Table.column' => 'boolean'])))
+            ->when($value)
+            ->then(1);
+        $this->assertSame($type, $expression->getWhen()[0]->getWhenType());
+    }
+
+    /**
+     * @dataProvider typeInferenceDataProvider
+     * @param mixed $value The value from which to infer the type.
+     * @param string|null $type The expected type.
+     */
+    public function testInferThenType($value, ?string $type): void
+    {
+        $expression = (new CaseStatementExpression(new TypeMap(['Table.column' => 'boolean'])))
+            ->when(['Table.column' => true])
+            ->then($value);
+        $this->assertSame($type, $expression->getWhen()[0]->getThenType());
+    }
+
+    /**
+     * @dataProvider typeInferenceDataProvider
+     * @param mixed $value The value from which to infer the type.
+     * @param string|null $type The expected type.
+     */
+    public function testInferElseType($value, ?string $type): void
+    {
+        $expression = (new CaseStatementExpression(new TypeMap(['Table.column' => 'boolean'])))
+            ->else($value);
+        $this->assertSame($type, $expression->getElseType());
+    }
+
+    public function testWhenArrayValueInheritTypeMap(): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'boolean',
+            'Table.column_b' => 'string',
+        ]);
+
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when(['Table.column_a' => true])
+            ->then(1)
+            ->when(['Table.column_b' => 'foo'])
+            ->then(2)
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => true,
+                    'type' => 'boolean',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 'foo',
+                    'type' => 'string',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c3',
+                ],
+                ':c4' => [
+                    'value' => 3,
+                    'type' => 'integer',
+                    'placeholder' => 'c4',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testWhenArrayValueWithExplicitTypes(): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'boolean',
+            'Table.column_b' => 'string',
+        ]);
+
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when(['Table.column_a' => 123], ['Table.column_a' => 'integer'])
+            ->then(1)
+            ->when(['Table.column_b' => 'foo'])
+            ->then(2)
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 123,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 'foo',
+                    'type' => 'string',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c3',
+                ],
+                ':c4' => [
+                    'value' => 3,
+                    'type' => 'integer',
+                    'placeholder' => 'c4',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testWhenCallableArrayValueInheritTypeMap(): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'boolean',
+            'Table.column_b' => 'string',
+        ]);
+
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen
+                    ->when(['Table.column_a' => true])
+                    ->then(1);
+            })
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen
+                    ->when(['Table.column_b' => 'foo'])
+                    ->then(2);
+            })
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => true,
+                    'type' => 'boolean',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 'foo',
+                    'type' => 'string',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c3',
+                ],
+                ':c4' => [
+                    'value' => 3,
+                    'type' => 'integer',
+                    'placeholder' => 'c4',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testWhenCallableArrayValueWithExplicitTypes(): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'boolean',
+            'Table.column_b' => 'string',
+        ]);
+
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen
+                    ->when(['Table.column_a' => 123], ['Table.column_a' => 'integer'])
+                    ->then(1);
+            })
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen
+                    ->when(['Table.column_b' => 'foo'])
+                    ->then(2);
+            })
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 123,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 'foo',
+                    'type' => 'string',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c3',
+                ],
+                ':c4' => [
+                    'value' => 3,
+                    'type' => 'integer',
+                    'placeholder' => 'c4',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testWhenArrayValueRequiresArrayTypeValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'When using an array for the `$when` argument, the `$type` ' .
+            'argument must be an array too, `string` given.'
+        );
+
+        (new CaseStatementExpression())
+            ->when(['Table.column' => 123], 'integer')
+            ->then(1);
+    }
+
+    public function testWhenNonArrayValueRequiresStringTypeValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'When using a non-array value for the `$when` argument, ' .
+            'the `$type` argument must be a string, `array` given.'
+        );
+
+        (new CaseStatementExpression())
+            ->when(123, ['Table.column' => 'integer'])
+            ->then(1);
+    }
+
+    public function testInternalTypeMapChangesAreNonPersistent(): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column' => 'integer',
+        ]);
+
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when(['Table.column' => 123])
+            ->then(1)
+            ->when(['Table.column' => 'foo'], ['Table.column' => 'string'])
+            ->then('bar')
+            ->when(['Table.column' => 456])
+            ->then(2);
+
+        $valueBinder = new ValueBinder();
+        $expression->sql($valueBinder);
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 123,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 'foo',
+                    'type' => 'string',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => 'bar',
+                    'type' => 'string',
+                    'placeholder' => 'c3',
+                ],
+                ':c4' => [
+                    'value' => 456,
+                    'type' => 'integer',
+                    'placeholder' => 'c4',
+                ],
+                ':c5' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c5',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+
+        $this->assertSame($typeMap, $expression->getTypeMap());
+    }
+
+    // endregion
+
+    // region SQL injections
+
+    public function testSqlInjectionViaTypedCaseValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value('1 THEN 1 END; DELETE * FROM foo; --', 'integer')
+            ->when(1)
+            ->then(2);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c2',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaUntypedCaseValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value('1 THEN 1 END; DELETE * FROM foo; --')
+            ->when(1)
+            ->then(2);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'string',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c2',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaTypedWhenValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when('1 THEN 1 END; DELETE * FROM foo; --', 'integer')
+            ->then(1);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN :c0 THEN :c1 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaTypedWhenArrayValueIsNotPossible(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'When using an array for the `$when` argument, the `$type` ' .
+            'argument must be an array too, `string` given.'
+        );
+
+        (new CaseStatementExpression())
+            ->when(['1 THEN 1 END; DELETE * FROM foo; --' => '123'], 'integer')
+            ->then(1);
+    }
+
+    public function testSqlInjectionViaUntypedWhenValueIsNotPossible()
+    {
+        $expression = (new CaseStatementExpression())
+            ->when('1 THEN 1 END; DELETE * FROM foo; --')
+            ->then(1);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN :c0 THEN :c1 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'string',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaUntypedWhenArrayValueIsPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(['1 THEN 1 END; DELETE * FROM foo; --' => '123'])
+            ->then(1);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE WHEN 1 THEN 1 END; DELETE * FROM foo; -- :c0 THEN :c1 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => '123',
+                    'type' => null,
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaTypedThenValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value(1)
+            ->when(2)
+            ->then('1 THEN 1 END; DELETE * FROM foo; --', 'integer');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'integer',
+                    'placeholder' => 'c2',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaUntypedThenValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value(1)
+            ->when(2)
+            ->then('1 THEN 1 END; DELETE * FROM foo; --');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'string',
+                    'placeholder' => 'c2',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaTypedElseValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value(1)
+            ->when(2)
+            ->then(3)
+            ->else('1 THEN 1 END; DELETE * FROM foo; --', 'integer');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE :c0 WHEN :c1 THEN :c2 ELSE :c3 END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 3,
+                    'type' => 'integer',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'integer',
+                    'placeholder' => 'c3',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    public function testSqlInjectionViaUntypedElseValueIsNotPossible(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value(1)
+            ->when(2)
+            ->then(3)
+            ->else('1 THEN 1 END; DELETE * FROM foo; --');
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE :c0 WHEN :c1 THEN :c2 ELSE :c3 END',
+            $sql
+        );
+        $this->assertSame(
+            [
+                ':c0' => [
+                    'value' => 1,
+                    'type' => 'integer',
+                    'placeholder' => 'c0',
+                ],
+                ':c1' => [
+                    'value' => 2,
+                    'type' => 'integer',
+                    'placeholder' => 'c1',
+                ],
+                ':c2' => [
+                    'value' => 3,
+                    'type' => 'integer',
+                    'placeholder' => 'c2',
+                ],
+                ':c3' => [
+                    'value' => '1 THEN 1 END; DELETE * FROM foo; --',
+                    'type' => 'string',
+                    'placeholder' => 'c3',
+                ],
+            ],
+            $valueBinder->bindings()
+        );
+    }
+
+    // endregion
+
+    // region Getters
+
+    public function testGetValue(): void
+    {
+        $expression = new CaseStatementExpression();
+
+        $this->assertNull($expression->getValue());
+
+        $expression
+            ->value(1)
+            ->when(1)
+            ->then(2);
+
+        $this->assertSame(1, $expression->getValue());
+    }
+
+    public function testGetValueType(): void
+    {
+        $expression = new CaseStatementExpression();
+
+        $this->assertNull($expression->getValueType());
+
+        $expression->value(1);
+
+        $this->assertSame('integer', $expression->getValueType());
+    }
+
+    public function testGetWhen(): void
+    {
+        $when = ['Table.column' => true];
+
+        $expression = new CaseStatementExpression();
+        $this->assertSame([], $expression->getWhen());
+
+        $expression
+            ->when($when)
+            ->then(1);
+
+        $this->assertCount(1, $expression->getWhen());
+        $this->assertInstanceOf(WhenThenExpressionInterface::class, $expression->getWhen()[0]);
+    }
+
+    public function testWhenArrayValueGetWhen(): void
+    {
+        $when = ['Table.column' => true];
+
+        $expression = new CaseStatementExpression();
+        $this->assertSame([], $expression->getWhen());
+
+        $expression
+            ->when($when)
+            ->then(1);
+
+        $this->assertEquals(
+            new QueryExpression($when),
+            $expression->getWhen()[0]->getWhen()
+        );
+    }
+
+    public function testWhenNonArrayValueGetWhen(): void
+    {
+        $expression = new CaseStatementExpression();
+        $this->assertSame([], $expression->getWhen());
+
+        $expression
+            ->when(1)
+            ->then(2);
+
+        $this->assertSame(1, $expression->getWhen()[0]->getWhen());
+    }
+
+    public function testWhenGetWhenType(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen;
+            });
+
+        $this->assertNull($expression->getWhen()[0]->getWhenType());
+
+        $expression->getWhen()[0]->when(1);
+
+        $this->assertSame('integer', $expression->getWhen()[0]->getWhenType());
+
+        $types = [
+            'Table.column' => 'boolean',
+        ];
+        $expression->getWhen()[0]->when(['Table.column' => true], $types);
+
+        $this->assertSame($types, $expression->getWhen()[0]->getWhenType());
+    }
+
+    public function testWhenGetThen(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen;
+            });
+
+        $this->assertNull($expression->getWhen()[0]->getThen());
+
+        $expression->getWhen()[0]->then(1);
+
+        $this->assertSame(1, $expression->getWhen()[0]->getThen());
+    }
+
+    public function testWhenGetThenType(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen;
+            });
+
+        $this->assertNull($expression->getWhen()[0]->getThenType());
+
+        $expression->getWhen()[0]->then(1);
+
+        $this->assertSame('integer', $expression->getWhen()[0]->getThenType());
+    }
+
+    public function testGetElse(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column' => true])
+            ->then(1)
+            ->else(2);
+
+        $this->assertSame(2, $expression->getElse());
+    }
+
+    public function testGetElseType(): void
+    {
+        $expression = new CaseStatementExpression();
+
+        $this->assertNull($expression->getElseType());
+
+        $expression->else(1);
+
+        $this->assertSame('integer', $expression->getElseType());
+    }
+
+    // endregion
+
+    // region Order based syntax
+
+    public function testWhenThenElse(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(['Table.column_a' => true, 'Table.column_b IS' => null])
+            ->then(1)
+            ->when(['Table.column_c' => true, 'Table.column_d IS NOT' => null])
+            ->then(2)
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE ' .
+            'WHEN (Table.column_a = :c0 AND (Table.column_b) IS NULL) THEN :c1 ' .
+            'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
+            'ELSE :c4 ' .
+            'END',
+            $sql
+        );
+    }
+
+    public function testWhenBeforeClosingThenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot add new `WHEN` value while an open `when()` buffer is present, ' .
+            'it must first be closed using `then()`.'
+        );
+
+        (new CaseStatementExpression())
+            ->when(['Table.column_a' => true])
+            ->when(['Table.column_b' => true]);
+    }
+
+    public function testElseBeforeClosingThenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot set `ELSE` value when an open `when()` buffer is present, ' .
+            'it must first be closed using `then()`.'
+        );
+
+        (new CaseStatementExpression())
+            ->when(['Table.column' => true])
+            ->else(1);
+    }
+
+    public function testThenBeforeOpeningWhenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'There is no `when()` buffer present, ' .
+            'you must first open one before calling `then()`.'
+        );
+
+        (new CaseStatementExpression())
+            ->then(1);
+    }
+
+    // endregion
+
+    // region Callable syntax
+
+    public function testWhenCallables(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen
+                    ->when([
+                        'Table.column_a' => true,
+                        'Table.column_b IS' => null,
+                    ])
+                    ->then(1);
+            })
+            ->when(function (WhenThenExpressionInterface $whenThen) {
+                return $whenThen
+                    ->when([
+                        'Table.column_c' => true,
+                        'Table.column_d IS NOT' => null,
+                    ])
+                    ->then(2);
+            })
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE ' .
+            'WHEN (Table.column_a = :c0 AND (Table.column_b) IS NULL) THEN :c1 ' .
+            'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
+            'ELSE :c4 ' .
+            'END',
+            $sql
+        );
+    }
+
+    public function testWhenCallablesWithCustomWhenThenExpressions(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(function () {
+                return (new CustomWhenThenExpression())
+                    ->when([
+                        'Table.column_a' => true,
+                        'Table.column_b IS' => null,
+                    ])
+                    ->then(1);
+            })
+            ->when(function () {
+                return (new CustomWhenThenExpression())
+                    ->when([
+                        'Table.column_c' => true,
+                        'Table.column_d IS NOT' => null,
+                    ])
+                    ->then(2);
+            })
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE ' .
+            'WHEN (Table.column_a = :c0 AND (Table.column_b) IS NULL) THEN :c1 ' .
+            'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
+            'ELSE :c4 ' .
+            'END',
+            $sql
+        );
+    }
+
+    public function testWhenCallablesWithInvalidReturnTypeFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            '`when()` callables must return an instance of ' .
+            '`\Cake\Database\Expression\WhenThenExpressionInterface`, `NULL` given.'
+        );
+
+        $this->deprecated(function () {
+            (new CaseStatementExpression())
+                ->when(function () {
+                    return null;
+                });
+        });
+    }
+
+    // endregion
+
+    // region Self-contained values
+
+    public function testSelfContainedWhenThenExpressions(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(
+                (new WhenThenExpression())
+                    ->when([
+                        'Table.column_a' => true,
+                        'Table.column_b IS' => null,
+                    ])
+                    ->then(1)
+            )
+            ->when(
+                (new WhenThenExpression())
+                    ->when([
+                        'Table.column_c' => true,
+                        'Table.column_d IS NOT' => null,
+                    ])
+                    ->then(2)
+            )
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE ' .
+            'WHEN (Table.column_a = :c0 AND (Table.column_b) IS NULL) THEN :c1 ' .
+            'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
+            'ELSE :c4 ' .
+            'END',
+            $sql
+        );
+    }
+
+    public function testSelfContainedCustomWhenThenExpressions(): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(
+                (new CustomWhenThenExpression())
+                    ->when([
+                        'Table.column_a' => true,
+                        'Table.column_b IS' => null,
+                    ])
+                    ->then(1)
+            )
+            ->when(
+                (new CustomWhenThenExpression())
+                    ->when([
+                        'Table.column_c' => true,
+                        'Table.column_d IS NOT' => null,
+                    ])
+                    ->then(2)
+            )
+            ->else(3);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+        $this->assertSame(
+            'CASE ' .
+            'WHEN (Table.column_a = :c0 AND (Table.column_b) IS NULL) THEN :c1 ' .
+            'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
+            'ELSE :c4 ' .
+            'END',
+            $sql
+        );
+    }
+
+    // endregion
+
+    // region Incomplete states
+
+    public function testCompilingEmptyCaseExpressionFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot compile incomplete `\Cake\Database\Expression\CaseExpressionInterface` ' .
+            'expression, there are no `WHEN ... THEN ...` statements.'
+        );
+
+        $this->deprecated(function () {
+            (new CaseStatementExpression())->sql(new ValueBinder());
+        });
+    }
+
+    public function testCompilingNonClosedWhenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot compile incomplete `\Cake\Database\Expression\CaseExpressionInterface` ' .
+            'expression, there is an open `when()` buffer present that must be closed using `then()`.'
+        );
+
+        $this->deprecated(function () {
+            (new CaseStatementExpression())
+                ->when(['Table.column' => true])
+                ->sql(new ValueBinder());
+        });
+    }
+
+    public function testCompilingWhenThenExpressionWithMissingWhenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot compile incomplete `\Cake\Database\Expression\WhenThenExpressionInterface`, ' .
+            'the value for `WHEN` is missing.'
+        );
+
+        $this->deprecated(function () {
+            (new CaseStatementExpression())
+                ->when(function (WhenThenExpressionInterface $whenThen) {
+                    return $whenThen->then(1);
+                })
+                ->sql(new ValueBinder());
+        });
+    }
+
+    public function testCompilingWhenThenExpressionWithMissingThenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot compile incomplete `\Cake\Database\Expression\WhenThenExpressionInterface`, ' .
+            'the value for `THEN` is missing.'
+        );
+
+        $this->deprecated(function () {
+            (new CaseStatementExpression())
+                ->when(function (WhenThenExpressionInterface $whenThen) {
+                    return $whenThen->when(1);
+                })
+                ->sql(new ValueBinder());
+        });
+    }
+
+    // endregion
+
+    // region Valid values
+
+    public function validCaseValuesDataProvider(): array
+    {
+        $values = [];
+        $this->deprecated(function () use (&$values) {
+            $values = [
+                [null, 'NULL', null],
+                ['0', null, 'string'],
+                [0, null, 'integer'],
+                [0.0, null, 'float'],
+                ['foo', null, 'string'],
+                [true, null, 'boolean'],
+                [Date::now(), null, 'date'],
+                [FrozenDate::now(), null, 'date'],
+                [ChronosDate::now(), null, 'date'],
+                [ChronosMutableDate::now(), null, 'date'],
+                [Time::now(), null, 'datetime'],
+                [FrozenTime::now(), null, 'datetime'],
+                [Chronos::now(), null, 'datetime'],
+                [new IdentifierExpression('Table.column'), 'Table.column', null],
+                [new QueryExpression('Table.column'), 'Table.column', null],
+                [ConnectionManager::get('test')->newQuery()->select('a'), '(SELECT a)', null],
+                [new TestObjectWithToString(), null, 'string'],
+                [new stdClass(), null, null],
+            ];
+        });
+
+        return $values;
+    }
+
+    /**
+     * @dataProvider validCaseValuesDataProvider
+     * @param mixed $value The case value.
+     * @param string|null $sqlValue The expected SQL string value.
+     * @param string|null $type The expected bound type.
+     */
+    public function testValidCaseValue($value, ?string $sqlValue, ?string $type): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->value($value)
+            ->when(1)
+            ->then(2);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+
+        if ($sqlValue) {
+            $this->assertEqualsSql(
+                "CASE $sqlValue WHEN :c0 THEN :c1 ELSE NULL END",
+                $sql
+            );
+
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => 1,
+                        'type' => 'integer',
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => 2,
+                        'type' => 'integer',
+                        'placeholder' => 'c1',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        } else {
+            $this->assertEqualsSql(
+                'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
+                $sql
+            );
+
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => $value,
+                        'type' => $type,
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => 1,
+                        'type' => 'integer',
+                        'placeholder' => 'c1',
+                    ],
+                    ':c2' => [
+                        'value' => 2,
+                        'type' => 'integer',
+                        'placeholder' => 'c2',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        }
+    }
+
+    public function validWhenValuesSimpleCaseDataProvider(): array
+    {
+        $values = [];
+        $this->deprecated(function () use (&$values) {
+            $values = [
+                ['0', null, 'string'],
+                [0, null, 'integer'],
+                [0.0, null, 'float'],
+                ['foo', null, 'string'],
+                [true, null, 'boolean'],
+                [new stdClass(), null, null],
+                [new TestObjectWithToString(), null, 'string'],
+                [Date::now(), null, 'date'],
+                [FrozenDate::now(), null, 'date'],
+                [ChronosDate::now(), null, 'date'],
+                [ChronosMutableDate::now(), null, 'date'],
+                [Time::now(), null, 'datetime'],
+                [FrozenTime::now(), null, 'datetime'],
+                [Chronos::now(), null, 'datetime'],
+                [
+                    new IdentifierExpression('Table.column'),
+                    'CASE :c0 WHEN Table.column THEN :c1 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => true,
+                            'type' => 'boolean',
+                            'placeholder' => 'c0',
+                        ],
+                        ':c1' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c1',
+                        ],
+                    ],
+                ],
+                [
+                    new QueryExpression('Table.column'),
+                    'CASE :c0 WHEN Table.column THEN :c1 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => true,
+                            'type' => 'boolean',
+                            'placeholder' => 'c0',
+                        ],
+                        ':c1' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c1',
+                        ],
+                    ],
+                ],
+                [
+                    ConnectionManager::get('test')->newQuery()->select('a'),
+                    'CASE :c0 WHEN (SELECT a) THEN :c1 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => true,
+                            'type' => 'boolean',
+                            'placeholder' => 'c0',
+                        ],
+                        ':c1' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c1',
+                        ],
+                    ],
+                ],
+                [
+                    [
+                        'Table.column_a' => 1,
+                        'Table.column_b' => 'foo',
+                    ],
+                    'CASE :c0 WHEN (Table.column_a = :c1 AND Table.column_b = :c2) THEN :c3 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => true,
+                            'type' => 'boolean',
+                            'placeholder' => 'c0',
+                        ],
+                        ':c1' => [
+                            'value' => 1,
+                            'type' => 'integer',
+                            'placeholder' => 'c1',
+                        ],
+                        ':c2' => [
+                            'value' => 'foo',
+                            'type' => 'string',
+                            'placeholder' => 'c2',
+                        ],
+                        ':c3' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c3',
+                        ],
+                    ],
+                ],
+            ];
+        });
+
+        return $values;
+    }
+
+    /**
+     * @dataProvider validWhenValuesSimpleCaseDataProvider
+     * @param mixed $value The when value.
+     * @param string|null $expectedSql The expected SQL string.
+     * @param array|string|null $typeOrBindings The expected bound type(s).
+     */
+    public function testValidWhenValueSimpleCase($value, ?string $expectedSql, $typeOrBindings = null): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'integer',
+            'Table.column_b' => 'string',
+        ]);
+        $expression = (new CaseStatementExpression($typeMap))
+            ->value(true)
+            ->when($value)
+            ->then(2);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+
+        if ($expectedSql) {
+            $this->assertEqualsSql($expectedSql, $sql);
+            $this->assertSame($typeOrBindings, $valueBinder->bindings());
+        } else {
+            $this->assertEqualsSql('CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END', $sql);
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => true,
+                        'type' => 'boolean',
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => $value,
+                        'type' => $typeOrBindings,
+                        'placeholder' => 'c1',
+                    ],
+                    ':c2' => [
+                        'value' => 2,
+                        'type' => 'integer',
+                        'placeholder' => 'c2',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        }
+    }
+
+    public function validWhenValuesSearchedCaseDataProvider(): array
+    {
+        $values = [];
+        $this->deprecated(function () use (&$values) {
+            $values = [
+                ['0', null, 'string'],
+                [0, null, 'integer'],
+                [0.0, null, 'float'],
+                ['foo', null, 'string'],
+                [true, null, 'boolean'],
+                [new stdClass(), null, null],
+                [new TestObjectWithToString(), null, 'string'],
+                [Date::now(), null, 'date'],
+                [FrozenDate::now(), null, 'date'],
+                [ChronosDate::now(), null, 'date'],
+                [ChronosMutableDate::now(), null, 'date'],
+                [Time::now(), null, 'datetime'],
+                [FrozenTime::now(), null, 'datetime'],
+                [Chronos::now(), null, 'datetime'],
+                [
+                    new IdentifierExpression('Table.column'),
+                    'CASE WHEN Table.column THEN :c0 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c0',
+                        ],
+                    ],
+                ],
+                [
+                    new QueryExpression('Table.column'),
+                    'CASE WHEN Table.column THEN :c0 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c0',
+                        ],
+                    ],
+                ],
+                [
+                    ConnectionManager::get('test')->newQuery()->select('a'),
+                    'CASE WHEN (SELECT a) THEN :c0 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c0',
+                        ],
+                    ],
+                ],
+                [
+                    [
+                        'Table.column_a' => 1,
+                        'Table.column_b' => 'foo',
+                    ],
+                    'CASE WHEN (Table.column_a = :c0 AND Table.column_b = :c1) THEN :c2 ELSE NULL END',
+                    [
+                        ':c0' => [
+                            'value' => 1,
+                            'type' => 'integer',
+                            'placeholder' => 'c0',
+                        ],
+                        ':c1' => [
+                            'value' => 'foo',
+                            'type' => 'string',
+                            'placeholder' => 'c1',
+                        ],
+                        ':c2' => [
+                            'value' => 2,
+                            'type' => 'integer',
+                            'placeholder' => 'c2',
+                        ],
+                    ],
+                ],
+            ];
+        });
+
+        return $values;
+    }
+
+    /**
+     * @dataProvider validWhenValuesSearchedCaseDataProvider
+     * @param mixed $value The when value.
+     * @param string|null $expectedSql The expected SQL string.
+     * @param array|string|null $typeOrBindings The expected bound type(s).
+     */
+    public function testValidWhenValueSearchedCase($value, ?string $expectedSql, $typeOrBindings = null): void
+    {
+        $typeMap = new TypeMap([
+            'Table.column_a' => 'integer',
+            'Table.column_b' => 'string',
+        ]);
+        $expression = (new CaseStatementExpression($typeMap))
+            ->when($value)
+            ->then(2);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+
+        if ($expectedSql) {
+            $this->assertEqualsSql($expectedSql, $sql);
+            $this->assertSame($typeOrBindings, $valueBinder->bindings());
+        } else {
+            $this->assertEqualsSql('CASE WHEN :c0 THEN :c1 ELSE NULL END', $sql);
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => $value,
+                        'type' => $typeOrBindings,
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => 2,
+                        'type' => 'integer',
+                        'placeholder' => 'c1',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        }
+    }
+
+    public function validThenValuesDataProvider(): array
+    {
+        $values = [];
+        $this->deprecated(function () use (&$values) {
+            $values = [
+                [null, 'NULL', null],
+                ['0', null, 'string'],
+                [0, null, 'integer'],
+                [0.0, null, 'float'],
+                ['foo', null, 'string'],
+                [true, null, 'boolean'],
+                [Date::now(), null, 'date'],
+                [FrozenDate::now(), null, 'date'],
+                [ChronosDate::now(), null, 'date'],
+                [ChronosMutableDate::now(), null, 'date'],
+                [Time::now(), null, 'datetime'],
+                [FrozenTime::now(), null, 'datetime'],
+                [Chronos::now(), null, 'datetime'],
+                [new IdentifierExpression('Table.column'), 'Table.column', null],
+                [new QueryExpression('Table.column'), 'Table.column', null],
+                [ConnectionManager::get('test')->newQuery()->select('a'), '(SELECT a)', null],
+                [new TestObjectWithToString(), null, 'string'],
+                [new stdClass(), null, null],
+            ];
+        });
+
+        return $values;
+    }
+
+    /**
+     * @dataProvider validThenValuesDataProvider
+     * @param mixed $value The then value.
+     * @param string|null $sqlValue The expected SQL string value.
+     * @param string|null $type The expected bound type.
+     */
+    public function testValidThenValue($value, ?string $sqlValue, ?string $type): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(1)
+            ->then($value);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+
+        if ($sqlValue) {
+            $this->assertEqualsSql(
+                "CASE WHEN :c0 THEN $sqlValue ELSE NULL END",
+                $sql
+            );
+
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => 1,
+                        'type' => 'integer',
+                        'placeholder' => 'c0',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        } else {
+            $this->assertEqualsSql(
+                'CASE WHEN :c0 THEN :c1 ELSE NULL END',
+                $sql
+            );
+
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => 1,
+                        'type' => 'integer',
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => $value,
+                        'type' => $type,
+                        'placeholder' => 'c1',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        }
+    }
+
+    public function validElseValuesDataProvider(): array
+    {
+        $values = [];
+        $this->deprecated(function () use (&$values) {
+            $values = [
+                [null, 'NULL', null],
+                ['0', null, 'string'],
+                [0, null, 'integer'],
+                [0.0, null, 'float'],
+                ['foo', null, 'string'],
+                [true, null, 'boolean'],
+                [Date::now(), null, 'date'],
+                [FrozenDate::now(), null, 'date'],
+                [ChronosDate::now(), null, 'date'],
+                [ChronosMutableDate::now(), null, 'date'],
+                [Time::now(), null, 'datetime'],
+                [FrozenTime::now(), null, 'datetime'],
+                [Chronos::now(), null, 'datetime'],
+                [new IdentifierExpression('Table.column'), 'Table.column', null],
+                [new QueryExpression('Table.column'), 'Table.column', null],
+                [ConnectionManager::get('test')->newQuery()->select('a'), '(SELECT a)', null],
+                [new TestObjectWithToString(), null, 'string'],
+                [new stdClass(), null, null],
+            ];
+        });
+
+        return $values;
+    }
+
+    /**
+     * @dataProvider validElseValuesDataProvider
+     * @param mixed $value The else value.
+     * @param string|null $sqlValue The expected SQL string value.
+     * @param string|null $type The expected bound type.
+     */
+    public function testValidElseValue($value, ?string $sqlValue, ?string $type): void
+    {
+        $expression = (new CaseStatementExpression())
+            ->when(1)
+            ->then(2)
+            ->else($value);
+
+        $valueBinder = new ValueBinder();
+        $sql = $expression->sql($valueBinder);
+
+        if ($sqlValue) {
+            $this->assertEqualsSql(
+                "CASE WHEN :c0 THEN :c1 ELSE $sqlValue END",
+                $sql
+            );
+
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => 1,
+                        'type' => 'integer',
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => 2,
+                        'type' => 'integer',
+                        'placeholder' => 'c1',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        } else {
+            $this->assertEqualsSql(
+                'CASE WHEN :c0 THEN :c1 ELSE :c2 END',
+                $sql
+            );
+
+            $this->assertSame(
+                [
+                    ':c0' => [
+                        'value' => 1,
+                        'type' => 'integer',
+                        'placeholder' => 'c0',
+                    ],
+                    ':c1' => [
+                        'value' => 2,
+                        'type' => 'integer',
+                        'placeholder' => 'c1',
+                    ],
+                    ':c2' => [
+                        'value' => $value,
+                        'type' => $type,
+                        'placeholder' => 'c2',
+                    ],
+                ],
+                $valueBinder->bindings()
+            );
+        }
+    }
+
+    // endregion
+
+    // region Invalid values
+
+    public function invalidCaseValuesDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [[], 'array'],
+            [
+                function () {
+                },
+                'Closure',
+            ],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidCaseValuesDataProvider
+     * @param mixed $value The case value.
+     * @param string $typeName The expected error type name.
+     */
+    public function testInvalidCaseValue($value, string $typeName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The `$value` argument must be either `null`, a scalar value, an object, ' .
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `$typeName` given."
+        );
+
+        (new CaseStatementExpression())
+            ->value($value);
+    }
+
+    public function invalidWhenValueDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [null, 'NULL'],
+            [[], '[]'],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidWhenValueDataProvider
+     * @param mixed $value The when value.
+     * @param string $typeName The expected error type name.
+     */
+    public function testInvalidWhenValue($value, string $typeName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The `$when` argument must be either a non-empty array, a scalar value, an object, ' .
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `$typeName` given."
+        );
+
+        (new CaseStatementExpression())
+            ->when($value)
+            ->then(1);
+    }
+
+    public function invalidWhenTypeDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [1, 'integer'],
+            [1.0, 'double'],
+            [new stdClass(), 'stdClass'],
+            [
+                function () {
+                },
+                'Closure',
+            ],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidWhenTypeDataProvider
+     * @param mixed $type The when type.
+     * @param string $typeName The expected error type name.
+     */
+    public function testInvalidWhenType($type, string $typeName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "The `\$type` argument must be either an array, a string, or `null`, `$typeName` given."
+        );
+
+        (new CaseStatementExpression())
+            ->when(1, $type)
+            ->then(1);
+    }
+
+    public function invalidThenValueDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [[], 'array'],
+            [
+                function () {
+                },
+                'Closure',
+            ],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidThenValueDataProvider
+     * @param mixed $value The then value.
+     * @param string $typeName The expected error type name.
+     */
+    public function testInvalidThenValue($value, string $typeName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The `$result` argument must be either `null`, a scalar value, an object, ' .
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `$typeName` given."
+        );
+
+        (new CaseStatementExpression())
+            ->when(1)
+            ->then($value);
+    }
+
+    public function invalidThenTypeDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [1],
+            [1.0],
+            [new stdClass()],
+            [
+                function () {
+                },
+            ],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidThenTypeDataProvider
+     * @param mixed $type The then type.
+     */
+    public function testInvalidThenType($type): void
+    {
+        $this->expectException(TypeError::class);
+
+        (new CaseStatementExpression())
+            ->when(1)
+            ->then(1, $type);
+    }
+
+    public function invalidElseValueDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [[], 'array'],
+            [
+                function () {
+                },
+                'Closure',
+            ],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidElseValueDataProvider
+     * @param mixed $value The else value.
+     * @param string $typeName The expected error type name.
+     */
+    public function testInvalidElseValue($value, string $typeName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The `$result` argument must be either `null`, a scalar value, an object, ' .
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `$typeName` given."
+        );
+
+        (new CaseStatementExpression())
+            ->when(1)
+            ->then(1)
+            ->else($value);
+    }
+
+    public function invalidElseTypeDataProvider(): array
+    {
+        $res = fopen('data:text/plain,123', 'rb');
+        fclose($res);
+
+        return [
+            [1],
+            [1.0],
+            [new stdClass()],
+            [
+                function () {
+                },
+                'Closure',
+            ],
+            [$res, 'resource (closed)'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidElseTypeDataProvider
+     * @param mixed $type The else type.
+     */
+    public function testInvalidElseType($type): void
+    {
+        $this->expectException(TypeError::class);
+
+        (new CaseStatementExpression())
+            ->when(1)
+            ->then(1)
+            ->else(1, $type);
+    }
+
+    // endregion
+
+    // region Traversal
+
+    public function testTraverse(): void
+    {
+        $value = new IdentifierExpression('Table.column');
+        $conditionsA = ['Table.column_a' => true, 'Table.column_b IS' => null];
+        $resultA = new QueryExpression('1');
+        $conditionsB = ['Table.column_c' => true, 'Table.column_d IS NOT' => null];
+        $resultB = new QueryExpression('2');
+        $else = new QueryExpression('3');
+
+        $expression = (new CaseStatementExpression())
+            ->value($value)
+            ->when($conditionsA)
+            ->then($resultA)
+            ->when($conditionsB)
+            ->then($resultB)
+            ->else($else);
+
+        $expressions = [];
+        $expression->traverse(function ($expression) use (&$expressions) {
+            $expressions[] = $expression;
+        });
+
+        $this->assertCount(14, $expressions);
+        $this->assertInstanceOf(IdentifierExpression::class, $expressions[0]);
+        $this->assertSame($value, $expressions[0]);
+        $this->assertInstanceOf(WhenThenExpressionInterface::class, $expressions[1]);
+        $this->assertEquals(new QueryExpression($conditionsA), $expressions[2]);
+        $this->assertEquals(new ComparisonExpression('Table.column_a', true), $expressions[3]);
+        $this->assertSame($resultA, $expressions[6]);
+        $this->assertInstanceOf(WhenThenExpressionInterface::class, $expressions[7]);
+        $this->assertEquals(new QueryExpression($conditionsB), $expressions[8]);
+        $this->assertEquals(new ComparisonExpression('Table.column_c', true), $expressions[9]);
+        $this->assertSame($resultB, $expressions[12]);
+        $this->assertSame($else, $expressions[13]);
+    }
+
+    public function testTraverseBeforeClosingThenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot traverse incomplete `\Cake\Database\Expression\CaseExpressionInterface` ' .
+            'expression, there is an open `when()` buffer present that must be closed using `then()`.'
+        );
+
+        $this->deprecated(function () {
+            $expression = (new CaseStatementExpression())
+                ->when(['Table.column' => true]);
+
+            $expression->traverse(
+                function () {
+                }
+            );
+        });
+    }
+
+    // endregion
+
+    // region Cloning
+
+    public function testClone(): void
+    {
+        $value = new IdentifierExpression('Table.column');
+        $conditionsA = ['Table.column_a' => true, 'Table.column_b IS' => null];
+        $resultA = new QueryExpression('1');
+        $conditionsB = ['Table.column_c' => true, 'Table.column_d IS NOT' => null];
+        $resultB = new QueryExpression('2');
+        $else = new QueryExpression('3');
+
+        $expression = (new CaseStatementExpression())
+            ->value($value)
+            ->when($conditionsA)
+            ->then($resultA)
+            ->when($conditionsB)
+            ->then($resultB)
+            ->else($else);
+        $clone = clone $expression;
+
+        $this->assertEquals($clone, $expression);
+        $this->assertNotSame($clone, $expression);
+    }
+
+    public function testCloneBeforeClosingThenFails(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Cannot clone incomplete `\Cake\Database\Expression\CaseExpressionInterface` ' .
+            'expression, there is an open `when()` buffer present that must be closed using `then()`.'
+        );
+
+        $this->deprecated(function () {
+            $expression = (new CaseStatementExpression())
+                ->when(['Table.column' => true]);
+
+            clone $expression;
+        });
+    }
+
+    // endregion
+}

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -200,4 +200,15 @@ class QueryExpressionTest extends TestCase
             $expr->sql(new ValueBinder())
         );
     }
+
+    /**
+     * Test deprecated adding of case statement.
+     */
+    public function testDeprecatedAddCaseStatement(): void
+    {
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage('QueryExpression::addCase() is deprecated, use case() instead.');
+
+        (new QueryExpression())->addCase([]);
+    }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1872,16 +1872,18 @@ class QueryTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $query = new Query($this->connection);
-        $query->select(['id'])
-            ->from('articles')
-            ->orderAsc(function (QueryExpression $exp, Query $query) {
-                return $exp->addCase(
-                    [$query->newExpr()->add(['author_id' => 1])],
-                    [1, $query->identifier('id')],
-                    ['integer', null]
-                );
-            })
-            ->orderAsc('id');
+        $this->deprecated(function () use ($query) {
+            $query->select(['id'])
+                ->from('articles')
+                ->orderAsc(function (QueryExpression $exp, Query $query) {
+                    return $exp->addCase(
+                        [$query->newExpr()->add(['author_id' => 1])],
+                        [1, $query->identifier('id')],
+                        ['integer', null]
+                    );
+                })
+                ->orderAsc('id');
+        });
         $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1934,16 +1936,18 @@ class QueryTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $query = new Query($this->connection);
-        $query->select(['id'])
-            ->from('articles')
-            ->orderDesc(function (QueryExpression $exp, Query $query) {
-                return $exp->addCase(
-                    [$query->newExpr()->add(['author_id' => 1])],
-                    [1, $query->identifier('id')],
-                    ['integer', null]
-                );
-            })
-            ->orderDesc('id');
+        $this->deprecated(function () use ($query) {
+            $query->select(['id'])
+                ->from('articles')
+                ->orderDesc(function (QueryExpression $exp, Query $query) {
+                    return $exp->addCase(
+                        [$query->newExpr()->add(['author_id' => 1])],
+                        [1, $query->identifier('id')],
+                        ['integer', null]
+                    );
+                })
+                ->orderDesc('id');
+        });
         $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -4107,24 +4111,28 @@ class QueryTest extends TestCase
     public function testSqlCaseStatement(): void
     {
         $query = new Query($this->connection);
-        $publishedCase = $query
-            ->newExpr()
-            ->addCase(
-                $query
+        $publishedCase = null;
+        $notPublishedCase = null;
+        $this->deprecated(function () use ($query, &$publishedCase, &$notPublishedCase) {
+            $publishedCase = $query
                 ->newExpr()
-                ->add(['published' => 'Y']),
-                1,
-                'integer'
-            );
-        $notPublishedCase = $query
-            ->newExpr()
-            ->addCase(
-                $query
-                    ->newExpr()
-                    ->add(['published' => 'N']),
-                1,
-                'integer'
-            );
+                ->addCase(
+                    $query
+                        ->newExpr()
+                        ->add(['published' => 'Y']),
+                    1,
+                    'integer'
+                );
+            $notPublishedCase = $query
+                ->newExpr()
+                ->addCase(
+                    $query
+                        ->newExpr()
+                        ->add(['published' => 'N']),
+                    1,
+                    'integer'
+                );
+        });
 
         // Postgres requires the case statement to be cast to a integer
         if ($this->connection->getDriver() instanceof Postgres) {
@@ -4171,13 +4179,16 @@ class QueryTest extends TestCase
             'Not published',
             'None',
         ];
+        $this->deprecated(function () use ($query, $conditions, $values) {
+            $query
+                ->select([
+                    'id',
+                    'comment',
+                    'status' => $query->newExpr()->addCase($conditions, $values),
+                ])
+                ->from(['comments']);
+        });
         $results = $query
-            ->select([
-                'id',
-                'comment',
-                'status' => $query->newExpr()->addCase($conditions, $values),
-            ])
-            ->from(['comments'])
             ->execute()
             ->fetchAll('assoc');
 
@@ -4758,18 +4769,20 @@ class QueryTest extends TestCase
         $stmt->closeCursor();
 
         $subquery = new Query($connection);
-        $subquery
-            ->select(
-                $subquery->newExpr()->addCase(
-                    [$subquery->newExpr()->add(['a.published' => 'N'])],
-                    [1, 0],
-                    ['integer', 'integer']
+        $this->deprecated(function () use ($subquery) {
+            $subquery
+                ->select(
+                    $subquery->newExpr()->addCase(
+                        [$subquery->newExpr()->add(['a.published' => 'N'])],
+                        [1, 0],
+                        ['integer', 'integer']
+                    )
                 )
-            )
-            ->from(['a' => 'articles'])
-            ->where([
-                'a.id = articles.id',
-            ]);
+                ->from(['a' => 'articles'])
+                ->where([
+                    'a.id = articles.id',
+                ]);
+        });
 
         $query
             ->select(['id'])

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -1,0 +1,350 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\QueryTests;
+
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Expression\QueryExpression;
+use Cake\ORM\Query;
+use Cake\Test\Fixture\ArticlesFixture;
+use Cake\Test\Fixture\CommentsFixture;
+use Cake\Test\Fixture\ProductsFixture;
+use Cake\TestSuite\TestCase;
+
+class CaseExpressionQueryTest extends TestCase
+{
+    protected $fixtures = [
+        ArticlesFixture::class,
+        CommentsFixture::class,
+        ProductsFixture::class,
+    ];
+
+    public function testSimpleCase(): void
+    {
+        $query = $this->getTableLocator()->get('Products')
+            ->find()
+            ->select(function (Query $query) {
+                return [
+                    'name',
+                    'category_name' => $query->newExpr()
+                        ->case()
+                        ->value($query->identifier('Products.category'))
+                        ->when(1)
+                        ->then('Touring')
+                        ->when(2)
+                        ->then('Urban')
+                        ->else('Other'),
+                ];
+            })
+            ->orderAsc('category')
+            ->orderAsc('name')
+            ->disableHydration();
+
+        $expected = [
+            [
+                'name' => 'First product',
+                'category_name' => 'Touring',
+            ],
+            [
+                'name' => 'Second product',
+                'category_name' => 'Urban',
+            ],
+            [
+                'name' => 'Third product',
+                'category_name' => 'Other',
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testSearchedCase(): void
+    {
+        $query = $this->getTableLocator()->get('Products')
+            ->find()
+            ->select(function (Query $query) {
+                return [
+                    'name',
+                    'price',
+                    'price_range' => $query->newExpr()
+                        ->case()
+                        ->when(['price <' => 20])
+                        ->then('Under $20')
+                        ->when(['price >=' => 20, 'price <' => 30])
+                        ->then('Under $30')
+                        ->else('$30 and above'),
+                ];
+            })
+            ->orderAsc('price')
+            ->orderAsc('name')
+            ->disableHydration();
+
+        $expected = [
+            [
+                'name' => 'First product',
+                'price' => 10,
+                'price_range' => 'Under $20',
+            ],
+            [
+                'name' => 'Second product',
+                'price' => 20,
+                'price_range' => 'Under $30',
+            ],
+            [
+                'name' => 'Third product',
+                'price' => 30,
+                'price_range' => '$30 and above',
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testOrderByCase(): void
+    {
+        $query = $this->getTableLocator()->get('Comments')
+            ->find()
+            ->select(['article_id', 'user_id'])
+            ->orderAsc('Comments.article_id')
+            ->orderDesc(function (QueryExpression $exp, Query $query) {
+                return $query->newExpr()
+                    ->case()
+                    ->value($query->identifier('Comments.article_id'))
+                    ->when(1)
+                    ->then($query->identifier('Comments.user_id'));
+            })
+            ->orderAsc(function (QueryExpression $exp, Query $query) {
+                return $query->newExpr()
+                    ->case()
+                    ->value($query->identifier('Comments.article_id'))
+                    ->when(2)
+                    ->then($query->identifier('Comments.user_id'));
+            })
+            ->disableHydration();
+
+        $expected = [
+            [
+                'article_id' => 1,
+                'user_id' => 4,
+            ],
+            [
+                'article_id' => 1,
+                'user_id' => 2,
+            ],
+            [
+                'article_id' => 1,
+                'user_id' => 1,
+            ],
+            [
+                'article_id' => 1,
+                'user_id' => 1,
+            ],
+            [
+                'article_id' => 2,
+                'user_id' => 1,
+            ],
+            [
+                'article_id' => 2,
+                'user_id' => 2,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testHavingByCase(): void
+    {
+        $articlesTable = $this->getTableLocator()->get('Articles');
+        $articlesTable->hasMany('Comments');
+
+        $query = $articlesTable
+            ->find()
+            ->select(['Articles.title'])
+            ->leftJoinWith('Comments')
+            ->group(['Articles.id', 'Articles.title'])
+            ->having(function (QueryExpression $exp, Query $query) {
+                $expression = $query->newExpr()
+                    ->case()
+                    ->when(['Comments.published' => 'Y'])
+                    ->then(1);
+
+                if ($query->getConnection()->getDriver() instanceof Postgres) {
+                    $expression = $query->func()->cast($expression, 'integer');
+                }
+
+                return $exp->gt(
+                    $query->func()->sum($expression),
+                    2,
+                    'integer'
+                );
+            })
+            ->disableHydration();
+
+        $expected = [
+            [
+                'title' => 'First Article',
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testUpdateFromCase(): void
+    {
+        $commentsTable = $this->getTableLocator()->get('Comments');
+
+        $this->assertSame(5, $commentsTable->find()->where(['Comments.published' => 'Y'])->count());
+        $this->assertSame(1, $commentsTable->find()->where(['Comments.published' => 'N'])->count());
+
+        $commentsTable->updateAll(
+            [
+                'published' =>
+                    $commentsTable->query()->newExpr()
+                        ->case()
+                        ->when(['published' => 'Y'])
+                        ->then('N')
+                        ->else('Y'),
+            ],
+            '1 = 1'
+        );
+
+        $this->assertSame(1, $commentsTable->find()->where(['Comments.published' => 'Y'])->count());
+        $this->assertSame(5, $commentsTable->find()->where(['Comments.published' => 'N'])->count());
+    }
+
+    public function testInferredReturnType(): void
+    {
+        $query = $this->getTableLocator()->get('Products')
+            ->find()
+            ->select(function (Query $query) {
+                $expression = $query->newExpr()
+                    ->case()
+                    ->when(['Products.price <' => 20])
+                    ->then(true)
+                    ->else(false);
+
+                if ($query->getConnection()->getDriver() instanceof Postgres) {
+                    $expression = $query->func()->cast($expression, 'boolean');
+                }
+
+                return [
+                    'Products.name',
+                    'Products.price',
+                    'is_cheap' => $expression,
+                ];
+            })
+            ->disableHydration();
+
+        $expected = [
+            [
+                'name' => 'First product',
+                'price' => 10,
+                'is_cheap' => true,
+            ],
+            [
+                'name' => 'Second product',
+                'price' => 20,
+                'is_cheap' => false,
+            ],
+            [
+                'name' => 'Third product',
+                'price' => 30,
+                'is_cheap' => false,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testOverwrittenReturnType(): void
+    {
+        $query = $this->getTableLocator()->get('Products')
+            ->find()
+            ->select(function (Query $query) {
+                return [
+                    'name',
+                    'price',
+                    'is_cheap' => $query->newExpr()
+                        ->case()
+                        ->when(['price <' => 20])
+                        ->then(1)
+                        ->else(0)
+                        ->setReturnType('boolean'),
+                ];
+            })
+            ->orderAsc('price')
+            ->orderAsc('name')
+            ->disableHydration();
+
+        $expected = [
+            [
+                'name' => 'First product',
+                'price' => 10,
+                'is_cheap' => true,
+            ],
+            [
+                'name' => 'Second product',
+                'price' => 20,
+                'is_cheap' => false,
+            ],
+            [
+                'name' => 'Third product',
+                'price' => 30,
+                'is_cheap' => false,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function bindingValueDataProvider(): array
+    {
+        return [
+            ['1', 3],
+            ['2', 4],
+        ];
+    }
+
+    /**
+     * @dataProvider bindingValueDataProvider
+     * @param string $when The `WHEN` value.
+     * @param int $result The result value.
+     */
+    public function testBindValues(string $when, int $result): void
+    {
+        $value = '1';
+        $then = '3';
+        $else = '4';
+
+        $query = $this->getTableLocator()->get('Products')
+            ->find()
+            ->select(function (Query $query) {
+                return [
+                    'val' => $query->newExpr()
+                        ->case()
+                        ->value($query->newExpr(':value'))
+                        ->when($query->newExpr(':when'))
+                        ->then($query->newExpr(':then'))
+                        ->else($query->newExpr(':else'))
+                        ->setReturnType('integer'),
+                ];
+            })
+            ->bind(':value', $value, 'integer')
+            ->bind(':when', $when, 'integer')
+            ->bind(':then', $then, 'integer')
+            ->bind(':else', $else, 'integer')
+            ->disableHydration();
+
+        $expected = [
+            'val' => $result,
+        ];
+        $this->assertSame($expected, $query->first());
+    }
+}

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1482,10 +1482,12 @@ class QueryRegressionTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
-        $query->orderDesc($query->newExpr()->addCase(
-            [$query->newExpr()->add(['id' => 3])],
-            [1, 0]
-        ));
+        $this->deprecated(function () use ($query) {
+            $query->orderDesc($query->newExpr()->addCase(
+                [$query->newExpr()->add(['id' => 3])],
+                [1, 0]
+            ));
+        });
         $query->order(['title' => 'desc']);
         // Executing the normal query before getting the count
         $query->all();
@@ -1493,10 +1495,12 @@ class QueryRegressionTest extends TestCase
 
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
-        $query->orderDesc($query->newExpr()->addCase(
-            [$query->newExpr()->add(['id' => 3])],
-            [1, 0]
-        ));
+        $this->deprecated(function () use ($query) {
+            $query->orderDesc($query->newExpr()->addCase(
+                [$query->newExpr()->add(['id' => 3])],
+                [1, 0]
+            ));
+        });
         $query->orderDesc($query->newExpr()->add(['id' => 3]));
         // Not executing the query first, just getting the count
         $this->assertSame(3, $query->count());

--- a/tests/test_app/TestApp/Database/Expression/CustomWhenThenExpression.php
+++ b/tests/test_app/TestApp/Database/Expression/CustomWhenThenExpression.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\test_app\TestApp\Database\Expression;
+
+use Cake\Database\Expression\WhenThenExpression;
+
+class CustomWhenThenExpression extends WhenThenExpression
+{
+}

--- a/tests/test_app/TestApp/Database/Type/CustomExpressionType.php
+++ b/tests/test_app/TestApp/Database/Type/CustomExpressionType.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Database\Type;
+
+use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\ExpressionInterface;
+use Cake\Database\Type\ExpressionTypeInterface;
+use Cake\Database\Type\StringType;
+
+class CustomExpressionType extends StringType implements ExpressionTypeInterface
+{
+    public function toExpression($value): ExpressionInterface
+    {
+        return new FunctionExpression('CUSTOM', [$value]);
+    }
+}

--- a/tests/test_app/TestApp/Stub/CaseStatementExpressionStub.php
+++ b/tests/test_app/TestApp/Stub/CaseStatementExpressionStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cake\Test\test_app\TestApp\Stub;
+
+use Cake\Database\Expression\CaseStatementExpression;
+
+class CaseStatementExpressionStub extends CaseStatementExpression
+{
+    /**
+     * Returns the case value type.
+     *
+     * @return string|null
+     */
+    public function getValueType(): ?string
+    {
+        return $this->valueType;
+    }
+
+    /**
+     * Returns the type of the `ELSE` result value.
+     *
+     * @return string|null The result type, or `null` if none has been set yet.
+     */
+    public function getElseType(): ?string
+    {
+        return $this->elseType;
+    }
+}

--- a/tests/test_app/TestApp/Stub/CaseStatementExpressionStub.php
+++ b/tests/test_app/TestApp/Stub/CaseStatementExpressionStub.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Cake\Test\test_app\TestApp\Stub;
 

--- a/tests/test_app/TestApp/Stub/WhenThenExpressionStub.php
+++ b/tests/test_app/TestApp/Stub/WhenThenExpressionStub.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cake\Test\test_app\TestApp\Stub;
+
+use Cake\Database\Expression\WhenThenExpression;
+
+class WhenThenExpressionStub extends WhenThenExpression
+{
+    /**
+     * Returns the `WHEN` value type.
+     *
+     * @return array|string|null
+     * @see when()
+     */
+    public function getWhenType(): ?string
+    {
+        return $this->whenType;
+    }
+}

--- a/tests/test_app/TestApp/Stub/WhenThenExpressionStub.php
+++ b/tests/test_app/TestApp/Stub/WhenThenExpressionStub.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Cake\Test\test_app\TestApp\Stub;
 


### PR DESCRIPTION
Since the previous discussions regarding a new syntax didn't really go anywhere, I thought it might be best to just throw something new into the room and go from there. This is more or less directly ported from some private code of mine, for now I've just made some minor adjustments and added some specific test for it to better fit in the core, so please don't hesitate to trash it, pick only what you like, or even outright completely dismiss it - everything is for sale!

I know that especially the previously suggested `->when()->then()` syntax was controversial in regard to defining multiple `WHEN THEN`'s, but from my experience I can say that it's quite nice to use in most situations, and still very much readable if you don't have looots of `WHEN THEN`'s.

The expressions make use of the current query's type map and automatically bind conditions accordingly. Types for non-condition values are being inferred when possible, and bound accordingly too. I bring that up because the second argument of the `when()`, `then()`, `else()` methods is reserved for specifying types, which is another reason why I preferred splitting `WHEN` and `THEN` into multiple methods, as otherwise the syntax would again become a bit cumbersome when it's something like `add($when, $whenType, $then, $thenType)`.

So that being said, in its current state there's support for a call-order based syntax:

```php
$queryExpression
    ->case()
    ->when(['Table.column' => true])
    ->then('Yes')
    ->when(['Table.column' => false])
    ->then('No')
    ->else('Maybe');
```

(which will scream at you when used incorrectly, for example when doing something like `when(1)->else(2)` or `then(1)->then(2)`), and a callable syntax with self-contained `WHEN ... THEN ...` expressions:

```php
$queryExpression
    ->case()
    ->when(function (WhenThenExpressionInterface $whenThen) {
        return $whenThen
            ->when(['Table.column' => true])
            ->then('Yes');
    })
    ->when(function (WhenThenExpressionInterface $whenThen) {
        return $whenThen
            ->when(['Table.column' => false])
            ->then('No');
    })
    ->else('Possibly');
```

Additionally to the searched case variant, the simple case variant (eg `CASE value WHEN ...`) is supported too:

```php
$queryExpression
    ->case()
    ->value($query->identifier('Table.column'))
    ->when(true)
    ->then('Yes')
    ->when(false)
    ->then('No')
    ->else("Yesn't");
```

And to sprinkle in some more potential for contention, column names _must_ be passed as `IdentifierExpression` instances, as strings will simply be bound as strings.

refs #11793, #14753, #11896