### PR TITLE
Remove triggerBeforeFind() from cleanCopy() and add to count()

### DIFF
--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -176,10 +176,9 @@ class Paginator implements PaginatorInterface
         $data = $this->extractData($object, $params, $settings);
         $query = $this->getQuery($object, $query, $data);
 
-        $cleanQuery = clone $query;
         $results = $query->all();
         $data['numResults'] = count($results);
-        $data['count'] = $this->getCount($cleanQuery, $data);
+        $data['count'] = $this->getCount($query, $data);
 
         $pagingParams = $this->buildParams($data);
         $alias = $object->getAlias();

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -248,9 +248,9 @@ class PaginatorComponentTest extends TestCase
     public function testPaginateNestedEagerLoader(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->belongsToMany('Tags');
+        $articles->belongsToMany('Tags')->setStrategy('subquery');
         $tags = $this->getTableLocator()->get('Tags');
-        $tags->belongsToMany('Authors');
+        $tags->belongsToMany('Authors')->setStrategy('subquery');
 
         $articles->getEventManager()->on('Model.beforeFind', function (EventInterface $event, Query $query): void {
             $query ->matching('Tags', function (Query $q) {

--- a/tests/TestCase/Datasource/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/PaginatorTestTrait.php
@@ -147,9 +147,9 @@ trait PaginatorTestTrait
     public function testPaginateNestedEagerLoader(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->belongsToMany('Tags');
+        $articles->belongsToMany('Tags')->setStrategy('subquery');
         $tags = $this->getTableLocator()->get('Tags');
-        $tags->belongsToMany('Authors');
+        $tags->belongsToMany('Authors')->setStrategy('subquery');
         $articles->getEventManager()->on('Model.beforeFind', function ($event, $query): void {
             $query ->matching('Tags', function ($q) {
                 return $q->matching('Authors', function ($q) {

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1623,7 +1623,7 @@ class QueryTest extends TestCase
 
         $query = $table->find();
         $result = $query->count();
-        $this->assertSame(3, $result);
+        $this->assertSame(1, $result);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/15141

Calling beforeFind with the original query before it's modified doesn't make much sense.
