### PR TITLE
Fix duplicate logging definition.

### DIFF
--- a/src/TestSuite/Fixture/PHPUnitExtension.php
+++ b/src/TestSuite/Fixture/PHPUnitExtension.php
@@ -38,6 +38,7 @@ class PHPUnitExtension implements BeforeFirstTestHook
         $enableLogging = in_array('--debug', $_SERVER['argv'] ?? [], true);
         if ($enableLogging) {
             $helper->enableQueryLogging();
+            Log::drop('queries');
             Log::setConfig('queries', [
                 'className' => 'Console',
                 'stream' => 'php://stderr',


### PR DESCRIPTION
When using the default skeleton app and the `--debug` flag for PHPUnit you would get a fatal error because `queries` already existed. Replacing that logging configuration gets us the results we need.