### PR TITLE
Fix column schema aware type test to work with auto-fixtures.

### DIFF
--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -11,7 +11,7 @@ use TestApp\Database\Type\ColumnSchemaAwareType;
 class ColumnSchemaAwareTypeIntegrationTest extends TestCase
 {
     protected $fixtures = [
-        //'core.ColumnSchemaAwareTypeValues',
+        'core.ColumnSchemaAwareTypeValues',
     ];
 
     /**
@@ -21,14 +21,12 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
 
     public function setUp(): void
     {
-        parent::setUp();
-
         $this->textType = TypeFactory::build('text');
         TypeFactory::map('text', ColumnSchemaAwareType::class);
         // For SQLServer.
         TypeFactory::map('nvarchar', ColumnSchemaAwareType::class);
 
-        $this->markTestSkipped('This test requires non-auto-fixtures');
+        parent::setUp();
     }
 
     public function tearDown(): void


### PR DESCRIPTION
The types need to be mapped before the fixtures are being set up.