### PR TITLE
Ignore limit if no order exists when building subquery

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -404,7 +404,8 @@ class SelectLoader
         $filterQuery->contain([], true);
         $filterQuery->setValueBinder(new ValueBinder());
 
-        if (!$filterQuery->clause('limit')) {
+        // Ignore limit if there is no order since we need all rows to find matches
+        if (!$filterQuery->clause('limit') || !$filterQuery->clause('order')) {
             $filterQuery->limit(null);
             $filterQuery->order([], true);
             $filterQuery->offset(null);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -681,6 +681,51 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Tests using subquery strategy when parent query
+     * that contains limit without order.
+     */
+    public function testSubqueryWithLimit()
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->hasMany('Articles', [
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
+        $query = $Authors->find();
+        $result = $query
+            ->contain('Articles')
+            ->first();
+
+        if (in_array($result->name, ['mariano', 'larry'])) {
+            $this->assertNotEmpty($result->articles);
+        } else {
+            $this->assertEmpty($result->articles);
+        }
+    }
+
+    /**
+     * Tests using subquery strategy when parent query
+     * that contains limit with order.
+     */
+    public function testSubqueryWithLimitAndOrder()
+    {
+        $Authors = $this->getTableLocator()->get('Authors');
+        $Authors->hasMany('Articles', [
+            'strategy' => Association::STRATEGY_SUBQUERY,
+        ]);
+
+        $query = $Authors->find();
+        $result = $query
+            ->contain('Articles')
+            ->order(['name' => 'ASC'])
+            ->limit(2)
+            ->toArray();
+
+        $this->assertCount(0, $result[0]->articles);
+        $this->assertCount(1, $result[1]->articles);
+    }
+
+    /**
      * Assertion method for order by clause contents.
      *
      * @param array $expected The expected join clause.


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/14480