### PR TITLE
Fix up assoc array declarations in docblock.

### DIFF
--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -59,7 +59,7 @@ class CaseExpression implements ExpressionInterface
      * @param \Cake\Database\ExpressionInterface|array $values Associative array of values to be associated with the
      * conditions passed in $conditions. If there are more $values than $conditions,
      * the last $value is used as the `ELSE` value.
-     * @param array<string|int, string> $types Associative array of types to be associated with the values
+     * @param array<string> $types Associative array of types to be associated with the values
      * passed in $values
      */
     public function __construct($conditions = [], $values = [], $types = [])
@@ -83,7 +83,7 @@ class CaseExpression implements ExpressionInterface
      * @param \Cake\Database\ExpressionInterface|array $conditions Must be a ExpressionInterface instance,
      *   or an array of ExpressionInterface instances.
      * @param \Cake\Database\ExpressionInterface|array $values Associative array of values of each condition
-     * @param array<string|int, string> $types Associative array of types to be associated with the values
+     * @param array<string> $types Associative array of types to be associated with the values
      * @return $this
      */
     public function add($conditions = [], $values = [], $types = [])
@@ -108,8 +108,8 @@ class CaseExpression implements ExpressionInterface
      * If no matching true value, then it is defaulted to '1'.
      *
      * @param array $conditions Array of ExpressionInterface instances.
-     * @param array<string|int, mixed> $values Associative array of values of each condition
-     * @param array<string|int, string> $types Associative array of types to be associated with the values
+     * @param array<mixed> $values Associative array of values of each condition
+     * @param array<string> $types Associative array of types to be associated with the values
      * @return void
      */
     protected function _addExpressions(array $conditions, array $values, array $types): void

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -59,7 +59,7 @@ class CaseExpression implements ExpressionInterface
      * @param \Cake\Database\ExpressionInterface|array $values Associative array of values to be associated with the
      * conditions passed in $conditions. If there are more $values than $conditions,
      * the last $value is used as the `ELSE` value.
-     * @param array<string, string> $types Associative array of types to be associated with the values
+     * @param array<string|int, string> $types Associative array of types to be associated with the values
      * passed in $values
      */
     public function __construct($conditions = [], $values = [], $types = [])
@@ -83,7 +83,7 @@ class CaseExpression implements ExpressionInterface
      * @param \Cake\Database\ExpressionInterface|array $conditions Must be a ExpressionInterface instance,
      *   or an array of ExpressionInterface instances.
      * @param \Cake\Database\ExpressionInterface|array $values Associative array of values of each condition
-     * @param array<string, string> $types Associative array of types to be associated with the values
+     * @param array<string|int, string> $types Associative array of types to be associated with the values
      * @return $this
      */
     public function add($conditions = [], $values = [], $types = [])
@@ -108,8 +108,8 @@ class CaseExpression implements ExpressionInterface
      * If no matching true value, then it is defaulted to '1'.
      *
      * @param array $conditions Array of ExpressionInterface instances.
-     * @param array<string, mixed> $values Associative array of values of each condition
-     * @param array<string, string>|array<string> $types Associative array of types to be associated with the values
+     * @param array<string|int, mixed> $values Associative array of values of each condition
+     * @param array<string|int, string> $types Associative array of types to be associated with the values
      * @return void
      */
     protected function _addExpressions(array $conditions, array $values, array $types): void
@@ -138,7 +138,9 @@ class CaseExpression implements ExpressionInterface
             }
 
             if ($value === 'identifier') {
-                $value = new IdentifierExpression($keyValues[$k]);
+                /** @var string $identifier */
+                $identifier = $keyValues[$k];
+                $value = new IdentifierExpression($identifier);
                 $this->_values[] = $value;
                 continue;
             }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -336,7 +336,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param \Cake\Database\ExpressionInterface|array $values Associative array of values to be associated with the
      * conditions passed in $conditions. If there are more $values than $conditions,
      * the last $value is used as the `ELSE` value.
-     * @param array<string|int, string> $types Associative array of types to be associated with the values
+     * @param array<string> $types Associative array of types to be associated with the values
      * passed in $values
      * @return $this
      */

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -336,7 +336,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param \Cake\Database\ExpressionInterface|array $values Associative array of values to be associated with the
      * conditions passed in $conditions. If there are more $values than $conditions,
      * the last $value is used as the `ELSE` value.
-     * @param array<string, string> $types Associative array of types to be associated with the values
+     * @param array<string|int, string> $types Associative array of types to be associated with the values
      * passed in $values
      * @return $this
      */


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/16012

The whole type situation in that code is super messy, I guess this is the closest we can get.