### PR TITLE
Fix up PHPStan/Psalm for PHP8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
-        "symfony/polyfill-php81": "^1.23.0",
         "cakephp/cakephp-codesniffer": "^4.5",
         "mikey179/vfsstream": "^1.6.10",
         "paragonie/csp-builder": "^2.3",
@@ -111,7 +110,7 @@
             "@psalm"
         ],
         "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:0.12.96 psalm/phar:~4.10.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev symfony/polyfill-php81 phpstan/phpstan:0.12.96 psalm/phar:~4.10.0 && mv composer.backup composer.json",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "cakephp/validation": "self.version"
     },
     "require-dev": {
+        "symfony/polyfill-php81": "^1.23.0",
         "cakephp/cakephp-codesniffer": "^4.5",
         "mikey179/vfsstream": "^1.6.10",
         "paragonie/csp-builder": "^2.3",


### PR DESCRIPTION
Without this we get 19 erors like
```
ERROR: UndefinedAttributeClass - src/Collection/Iterator/ReplaceIterator.php:68:7 - Attribute class ReturnTypeWillChange does not exist (see https://psalm.dev/241)
    #[\ReturnTypeWillChange]
```
when running in PHP8.0

With this, 0 errors now.