### PR TITLE
Removes need for one baseline silencing.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -156,11 +156,6 @@ parameters:
 			path: src/Controller/ControllerFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$autoload_function of function spl_autoload_register expects callable\\(string\\)\\: void, array\\(\\$this\\(Cake\\\\Core\\\\ClassLoader\\), 'loadClass'\\) given\\.$#"
-			count: 1
-			path: src/Core/ClassLoader.php
-
-		-
 			message: "#^Array \\(array\\<TObject\\>\\) does not accept object\\.$#"
 			count: 1
 			path: src/Core/ObjectRegistry.php

--- a/src/Core/ClassLoader.php
+++ b/src/Core/ClassLoader.php
@@ -37,7 +37,9 @@ class ClassLoader
      */
     public function register(): void
     {
-        spl_autoload_register([$this, 'loadClass']);
+        /** @var callable $callable */
+        $callable = [$this, 'loadClass'];
+        spl_autoload_register($callable);
     }
 
     /**


### PR DESCRIPTION
With PHP8 the signature param name changes, and as such noise as
```
         Ignored error pattern #^Parameter \#1 \$autoload_function of function spl_autoload_register expects   
         callable\(string\)\: void, array\(\$this\(Cake\\Core\\ClassLoader\), 'loadClass'\) given\.$# in path  
         /media/mark/f42d91bd-14bc-4e71-936f-96ed99135be4/www/git/cakephp/src/Core/ClassLoader.php was not     
         matched in reported errors.                                                                           
  40     Parameter #1 $callback of function spl_autoload_register expects (callable(string): void)|null,       
         array($this(Cake\Core\ClassLoader), 'loadClass') given.   
```
appears and cannot be silenced across PHP 7+8

So this resolves this a bit cleaner for now.