### PR TITLE
Disable truncating all tables by default

### DIFF
--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -59,7 +59,7 @@ class SchemaLoader
         $paths,
         string $connectionName,
         bool $dropTables = true,
-        bool $truncateTables = true
+        bool $truncateTables = false
     ): void {
         $files = (array)$paths;
 

--- a/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
@@ -100,14 +100,14 @@ class SchemaLoaderTest extends TestCase
         ]);
 
         $schemaFile = $this->createSchemaFile('schema_loader_first');
-        $this->loader->loadSqlFiles($schemaFile, 'test_schema_loader');
+        $this->loader->loadSqlFiles($schemaFile, 'test_schema_loader', true, true);
         $connection = ConnectionManager::get('test_schema_loader');
 
         $result = $connection->getSchemaCollection()->listTables();
         $this->assertEquals(['schema_loader_first'], $result);
 
         $schemaFile = $this->createSchemaFile('schema_loader_second');
-        $this->loader->loadSqlFiles($schemaFile, 'test_schema_loader');
+        $this->loader->loadSqlFiles($schemaFile, 'test_schema_loader', true, true);
 
         $result = $connection->getSchemaCollection()->listTables();
         $this->assertEquals(['schema_loader_second'], $result);


### PR DESCRIPTION
If we are dropping all tables by default, we don't need to truncate all tables as well. Users can configure the options to suite their needs.
