### PR TITLE
Move `value()` functionality into the case expression constructor.

### DIFF
--- a/src/Database/Expression/CaseExpressionInterface.php
+++ b/src/Database/Expression/CaseExpressionInterface.php
@@ -42,24 +42,6 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
     public function clause(string $clause);
 
     /**
-     * Sets the value for the case expression.
-     *
-     * When a value is set, the syntax generated is
-     * `CASE case_value WHEN when_value ... END`, where the
-     * `when_value`'s are compared against the `case_value`.
-     *
-     * When no value is set, the syntax generated is
-     * `CASE WHEN when_conditions ... END`, where the conditions
-     * hold the comparisons.
-     *
-     * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
-     * @param string|null $valueType The case value type. If no type is provided, the type will be tried to be inferred
-     *  from the value.
-     * @return $this
-     */
-    public function value($value, ?string $valueType = null);
-
-    /**
      * Sets the `WHEN` value for a `WHEN ... THEN ...` expression, or a
      * self-contained expression that holds both the value for `WHEN`
      * and the value for `THEN`.
@@ -72,8 +54,8 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * a call to `then()` before invoking `when()` again or `else()`:
      *
      * ```
-     * $case
-     *     ->value($query->identifier('Table.column'))
+     * $queryExpression
+     *     ->case($query->identifier('Table.column'))
      *     ->when(true)
      *     ->then('Yes')
      *     ->when(false)
@@ -94,7 +76,8 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * and must return one, being it the same object, or a custom one:
      *
      * ```
-     * $case
+     * $queryExpression
+     *     ->case()
      *     ->when(function (\Cake\Database\Expression\WhenThenExpressionInterface $whenThen) {
      *         return $whenThen
      *             ->when(['Table.column' => true])
@@ -119,7 +102,8 @@ interface CaseExpressionInterface extends ExpressionInterface, TypedResultInterf
      * `\Cake\Database\Expression\WhenThenExpressionInterface::when()`:
      *
      * ```
-     * $case
+     * $queryExpression
+     *     ->case()
      *     ->when(function (\Cake\Database\Expression\WhenThenExpressionInterface $whenThen) {
      *         return $whenThen
      *             ->when(['unmapped_column' => true], ['unmapped_column' => 'bool'])

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -83,7 +83,10 @@ trait CaseExpressionTrait
             method_exists($value, '__toString')
         ) {
             $type = 'string';
-        } elseif ($value instanceof IdentifierExpression) {
+        } elseif (
+            $this->_typeMap !== null &&
+            $value instanceof IdentifierExpression
+        ) {
             $type = $this->_typeMap->type($value->getIdentifier());
         }
 

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -115,10 +115,10 @@ class CaseStatementExpression implements CaseExpressionInterface
      * case expression variant!
      *
      * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
-     * @param string|null $valueType The case value type. If no type is provided, the type will be tried to be inferred
+     * @param string|null $type The case value type. If no type is provided, the type will be tried to be inferred
      *  from the value.
      */
-    public function __construct($value = null, ?string $valueType = null)
+    public function __construct($value = null, ?string $type = null)
     {
         if (func_num_args() > 0) {
             if (
@@ -138,12 +138,12 @@ class CaseStatementExpression implements CaseExpressionInterface
 
             if (
                 $value !== null &&
-                $valueType === null &&
+                $type === null &&
                 !($value instanceof ExpressionInterface)
             ) {
-                $valueType = $this->inferType($value);
+                $type = $this->inferType($value);
             }
-            $this->valueType = $valueType;
+            $this->valueType = $type;
 
             $this->isSimpleVariant = true;
         }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -351,28 +351,32 @@ class QueryExpression implements ExpressionInterface, Countable
      * Returns a new case expression object.
      *
      * When a value is set, the syntax generated is
-     * `CASE case_value WHEN when_value ... END`, where the
-     * `when_value`'s are compared against the `case_value`.
+     * `CASE case_value WHEN when_value ... END` (simple case),
+     * where the `when_value`'s are compared against the
+     * `case_value`.
      *
      * When no value is set, the syntax generated is
-     * `CASE WHEN when_conditions ... END`, where the conditions
-     * hold the comparisons.
+     * `CASE WHEN when_conditions ... END` (searched case),
+     * where the conditions hold the comparisons.
+     *
+     * Note that `null` is a valid case value, and thus should
+     * only be passed if you actually want to create the simple
+     * case expression variant!
      *
      * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
      * @param string|null $valueType The case value type. If no type is provided, the type will be tried to be inferred
      *  from the value.
      * @return \Cake\Database\Expression\CaseExpressionInterface
-     * @see \Cake\Database\Expression\CaseExpressionInterface::value()
      */
     public function case($value = null, ?string $valueType = null): CaseExpressionInterface
     {
-        $expression = new CaseStatementExpression($this->getTypeMap());
-
         if (func_num_args() > 0) {
-            $expression->value($value, $valueType);
+            $expression = new CaseStatementExpression($value, $valueType);
+        } else {
+            $expression = new CaseStatementExpression();
         }
 
-        return $expression;
+        return $expression->setTypeMap($this->getTypeMap());
     }
 
     /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -364,14 +364,14 @@ class QueryExpression implements ExpressionInterface, Countable
      * case expression variant!
      *
      * @param \Cake\Database\ExpressionInterface|object|scalar|null $value The case value.
-     * @param string|null $valueType The case value type. If no type is provided, the type will be tried to be inferred
+     * @param string|null $type The case value type. If no type is provided, the type will be tried to be inferred
      *  from the value.
      * @return \Cake\Database\Expression\CaseExpressionInterface
      */
-    public function case($value = null, ?string $valueType = null): CaseExpressionInterface
+    public function case($value = null, ?string $type = null): CaseExpressionInterface
     {
         if (func_num_args() > 0) {
-            $expression = new CaseStatementExpression($value, $valueType);
+            $expression = new CaseStatementExpression($value, $type);
         } else {
             $expression = new CaseStatementExpression();
         }

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -162,7 +162,10 @@ class WhenThenExpression implements WhenThenExpressionInterface
                 ));
             }
 
-            if ($type === null) {
+            if (
+                $type === null &&
+                !($when instanceof ExpressionInterface)
+            ) {
                 $type = $this->inferType($when);
             }
         }

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -40,8 +40,7 @@ class CaseExpressionQueryTest extends TestCase
                 return [
                     'name',
                     'category_name' => $query->newExpr()
-                        ->case()
-                        ->value($query->identifier('Products.category'))
+                        ->case($query->identifier('Products.category'))
                         ->when(1)
                         ->then('Touring')
                         ->when(2)
@@ -119,15 +118,13 @@ class CaseExpressionQueryTest extends TestCase
             ->orderAsc('Comments.article_id')
             ->orderDesc(function (QueryExpression $exp, Query $query) {
                 return $query->newExpr()
-                    ->case()
-                    ->value($query->identifier('Comments.article_id'))
+                    ->case($query->identifier('Comments.article_id'))
                     ->when(1)
                     ->then($query->identifier('Comments.user_id'));
             })
             ->orderAsc(function (QueryExpression $exp, Query $query) {
                 return $query->newExpr()
-                    ->case()
-                    ->value($query->identifier('Comments.article_id'))
+                    ->case($query->identifier('Comments.article_id'))
                     ->when(2)
                     ->then($query->identifier('Comments.user_id'));
             })
@@ -328,8 +325,7 @@ class CaseExpressionQueryTest extends TestCase
             ->select(function (Query $query) {
                 return [
                     'val' => $query->newExpr()
-                        ->case()
-                        ->value($query->newExpr(':value'))
+                        ->case($query->newExpr(':value'))
                         ->when($query->newExpr(':when'))
                         ->then($query->newExpr(':then'))
                         ->else($query->newExpr(':else'))


### PR DESCRIPTION
The `value()` method isn't technically needed, passing the value in the constructor also has the benefit of locking the instance to be a simple variant or a searched variant one at construction time, so there's no ambiguity at runtime.

This has the side effect of the type for the value not being inferred anymore when it's an identifier expression, but the fact that this happened in the first place was a side effect in and of itself, and not actually necessary, as it wouldn't be used anyways. For the same reason I've removed inferring types for expressions for `when()` too, it wouldn't be used anyways either.