### PR TITLE
Disable test for subquery association strategy with limit and order on sql server

### DIFF
--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
@@ -709,6 +710,8 @@ class HasManyTest extends TestCase
      */
     public function testSubqueryWithLimitAndOrder()
     {
+        $this->skipIf(ConnectionManager::get('test')->getDriver() instanceof Sqlserver, 'Sql Server does not support ORDER BY on field not in GROUP BY');
+
         $Authors = $this->getTableLocator()->get('Authors');
         $Authors->hasMany('Articles', [
             'strategy' => Association::STRATEGY_SUBQUERY,


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/16030
Refs https://github.com/cakephp/cakephp/pull/16008

@markstory 