### PR TITLE
Add driver supports check for disabling constraints outside transactions

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -449,6 +449,7 @@ abstract class Driver implements DriverInterface
     public function supports(string $feature): bool
     {
         switch ($feature) {
+            case static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION:
             case static::FEATURE_QUOTE:
             case static::FEATURE_SAVEPOINT:
                 return true;

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -195,6 +195,9 @@ class Postgres extends Driver
             case static::FEATURE_JSON:
             case static::FEATURE_WINDOW:
                 return true;
+
+            case static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION:
+                return false;
         }
 
         return parent::supports($feature);

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -38,6 +38,13 @@ interface DriverInterface
     public const FEATURE_CTE = 'cte';
 
     /**
+     * Disabling constraints without being in transaction support.
+     *
+     * @var string
+     */
+    public const FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION = 'disable-constraint-without-transaction';
+
+    /**
      * Native JSON data type support.
      *
      * @var string


### PR DESCRIPTION
This adds a supports() check for db-specific behavior.
