### PR TITLE
Fix tuple comparison translator generating invalid `IN` comparisons.

### DIFF
--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -20,6 +20,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Query;
+use RuntimeException;
 
 /**
  * Provides a translator method for tuple comparisons
@@ -55,17 +56,23 @@ trait TupleComparisonTranslatorTrait
             return;
         }
 
+        $operator = strtoupper($expression->getOperator());
+        if (!in_array($operator, ['IN', '='])) {
+            throw new RuntimeException(
+                sprintf(
+                    'Tuple comparison transform only supports the `IN` and `=` operators, `%s` given.',
+                    $operator
+                )
+            );
+        }
+
         $value = $expression->getValue();
         $true = new QueryExpression('1');
 
         if ($value instanceof Query) {
-            $op = $expression->getOperator();
-            if (strtolower($op) === 'in') {
-                $op = '=';
-            }
             $selected = array_values($value->clause('select'));
             foreach ($fields as $i => $field) {
-                $value->andWhere(["$field $op" => new IdentifierExpression($selected[$i])]);
+                $value->andWhere([$field => new IdentifierExpression($selected[$i])]);
             }
             $value->select($true, true);
             $expression->setField($true);

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -56,13 +56,16 @@ trait TupleComparisonTranslatorTrait
         }
 
         $value = $expression->getValue();
-        $op = $expression->getOperator();
         $true = new QueryExpression('1');
 
         if ($value instanceof Query) {
+            $op = $expression->getOperator();
+            if (strtolower($op) === 'in') {
+                $op = '=';
+            }
             $selected = array_values($value->clause('select'));
             foreach ($fields as $i => $field) {
-                $value->andWhere([$field . " $op" => new IdentifierExpression($selected[$i])]);
+                $value->andWhere(["$field $op" => new IdentifierExpression($selected[$i])]);
             }
             $value->select($true, true);
             $expression->setField($true);

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -71,19 +71,13 @@ class TupleComparison extends ComparisonExpression
     public function setValue($value): void
     {
         if ($this->isMulti()) {
-            if (
-                is_array($value) &&
-                !is_array(current($value))
-            ) {
+            if (is_array($value) && !is_array(current($value))) {
                 throw new InvalidArgumentException(
                     'Multi-tuple comparisons require a multi-tuple value, single-tuple given.'
                 );
             }
         } else {
-            if (
-                is_array($value) &&
-                is_array(current($value))
-            ) {
+            if (is_array($value) && is_array(current($value))) {
                 throw new InvalidArgumentException(
                     'Single-tuple comparisons require a single-tuple value, multi-tuple given.'
                 );

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Expression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 use Closure;
+use InvalidArgumentException;
 
 /**
  * This expression represents SQL fragments that are used for comparing one tuple
@@ -47,8 +48,8 @@ class TupleComparison extends ComparisonExpression
     {
         $this->_type = $types;
         $this->setField($fields);
-        $this->setValue($values);
         $this->_operator = $conjunction;
+        $this->setValue($values);
     }
 
     /**
@@ -69,6 +70,26 @@ class TupleComparison extends ComparisonExpression
      */
     public function setValue($value): void
     {
+        if ($this->isMulti()) {
+            if (
+                is_array($value) &&
+                !is_array(current($value))
+            ) {
+                throw new InvalidArgumentException(
+                    'Multi-tuple comparisons require a multi-tuple value, single-tuple given.'
+                );
+            }
+        } else {
+            if (
+                is_array($value) &&
+                is_array(current($value))
+            ) {
+                throw new InvalidArgumentException(
+                    'Single-tuple comparisons require a single-tuple value, multi-tuple given.'
+                );
+            }
+        }
+
         $this->_value = $value;
     }
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1329,7 +1329,13 @@ class ConnectionTest extends TestCase
             ->method('prepare')
             ->will($this->throwException(new Exception('server gone away')));
 
-        $this->expectException(Exception::class);
-        $conn->query('SELECT 1');
+        try {
+            $conn->query('SELECT 1');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+        }
+
+        $prop->setValue($conn, $oldDriver);
+        $conn->rollback();
     }
 }

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 
 /**
  * Tests TupleComparison class
@@ -141,5 +142,31 @@ class TupleComparisonTest extends TestCase
         $f = new TupleComparison(new QueryExpression('a, b'), $value);
         $binder = new ValueBinder();
         $this->assertSame('(a, b) = (:tuple0, :tuple1)', $f->sql($binder));
+    }
+
+    public function testMultiTupleComparisonRequiresMultiTupleValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multi-tuple comparisons require a multi-tuple value, single-tuple given.');
+
+        new TupleComparison(
+            ['field1', 'field2'],
+            [1, 1],
+            ['integer', 'integer'],
+            'IN'
+        );
+    }
+
+    public function tesSingleTupleComparisonRequiresSingleTupleValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Single-tuple comparisons require a single-tuple value, multi-tuple given.');
+
+        new TupleComparison(
+            ['field1', 'field2'],
+            [[1, 1], [2, 2]],
+            ['integer', 'integer'],
+            '='
+        );
     }
 }

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -157,7 +157,7 @@ class TupleComparisonTest extends TestCase
         );
     }
 
-    public function tesSingleTupleComparisonRequiresSingleTupleValue(): void
+    public function testSingleTupleComparisonRequiresSingleTupleValue(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Single-tuple comparisons require a single-tuple value, multi-tuple given.');

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -17,10 +17,13 @@ declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Database\QueryTests;
 
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\TupleComparison;
 use Cake\TestSuite\TestCase;
+use PDOException;
 use RuntimeException;
 
 /**
@@ -76,5 +79,197 @@ class TupleComparisonQueryTest extends TestCase
             ->orderAsc('Articles.id')
             ->disableHydration()
             ->toArray();
+    }
+
+    public function testInWithMultiResultSubquery(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $query = $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    $articles
+                        ->subquery()
+                        ->select(['ArticlesAlias.id', 'ArticlesAlias.author_id'])
+                        ->from(['ArticlesAlias' => $articles->getTable()])
+                        ->where(['ArticlesAlias.author_id' => 1]),
+                    [],
+                    'IN'
+                ),
+            ])
+            ->orderAsc('Articles.id')
+            ->disableHydration();
+
+        $expected = [
+            [
+                'id' => 1,
+                'author_id' => 1,
+            ],
+            [
+                'id' => 3,
+                'author_id' => 1,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testInWithSingleResultSubquery(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $query = $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    $articles
+                        ->subquery()
+                        ->select(['ArticlesAlias.id', 'ArticlesAlias.author_id'])
+                        ->from(['ArticlesAlias' => $articles->getTable()])
+                        ->where(['ArticlesAlias.id' => 1]),
+                    [],
+                    'IN'
+                ),
+            ])
+            ->disableHydration();
+
+        $expected = [
+            [
+                'id' => 1,
+                'author_id' => 1,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testInWithMultiArrayValues(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $query = $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    [[1, 1], [3, 1]],
+                    ['integer', 'integer'],
+                    'IN'
+                ),
+            ])
+            ->orderAsc('Articles.id')
+            ->disableHydration();
+
+        $expected = [
+            [
+                'id' => 1,
+                'author_id' => 1,
+            ],
+            [
+                'id' => 3,
+                'author_id' => 1,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testEqualWithMultiResultSubquery(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $driver = $articles->getConnection()->getDriver();
+        if (
+            $driver instanceof Mysql ||
+            $driver instanceof Postgres
+        ) {
+            $this->expectException(PDOException::class);
+            $this->expectExceptionMessageMatches('/cardinality violation/i');
+        } else {
+            // Due to the way tuple comparisons are being translated, the DBMS will
+            // not run into a cardinality violation scenario.
+            $this->markTestSkipped(
+                'Sqlite and Sqlserver currently do not fail with subqueries returning incompatible results.'
+            );
+        }
+
+        $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    $articles
+                        ->subquery()
+                        ->select(['ArticlesAlias.id', 'ArticlesAlias.author_id'])
+                        ->from(['ArticlesAlias' => $articles->getTable()])
+                        ->where(['ArticlesAlias.author_id' => 1]),
+                    [],
+                    '='
+                ),
+            ])
+            ->orderAsc('Articles.id')
+            ->disableHydration()
+            ->toArray();
+    }
+
+    public function testEqualWithSingleResultSubquery(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $query = $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    $articles
+                        ->subquery()
+                        ->select(['ArticlesAlias.id', 'ArticlesAlias.author_id'])
+                        ->from(['ArticlesAlias' => $articles->getTable()])
+                        ->where(['ArticlesAlias.id' => 1]),
+                    [],
+                    '='
+                ),
+            ])
+            ->disableHydration();
+
+        $expected = [
+            [
+                'id' => 1,
+                'author_id' => 1,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    public function testEqualWithSingleArrayValue(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $query = $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    [1, 1],
+                    ['integer', 'integer'],
+                    '='
+                ),
+            ])
+            ->orderAsc('Articles.id')
+            ->disableHydration();
+
+        $expected = [
+            [
+                'id' => 1,
+                'author_id' => 1,
+            ],
+        ];
+        $this->assertSame($expected, $query->toArray());
     }
 }

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\Database\QueryTests;
+
+use Cake\Database\Driver\Sqlite;
+use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Expression\TupleComparison;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+/**
+ * Tuple comparison query tests.
+ *
+ * These tests are specifically relevant in the context of Sqlite and
+ * Sqlserver, for which the tuple comparison will be transformed when
+ * composite fields are used.
+ *
+ * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
+ */
+class TupleComparisonQueryTest extends TestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected $fixtures = [
+        'core.Articles',
+    ];
+
+    public function testTransformWithInvalidOperator(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        $driver = $articles->getConnection()->getDriver();
+        if (
+            $driver instanceof Sqlite ||
+            $driver instanceof Sqlserver
+        ) {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage(
+                'Tuple comparison transform only supports the `IN` and `=` operators, `NOT IN` given.'
+            );
+        } else {
+            $this->markTestSkipped('Tuple comparisons are only being transformed for Sqlite and Sqlserver.');
+        }
+
+        $articles
+            ->find()
+            ->select(['Articles.id', 'Articles.author_id'])
+            ->where([
+                new TupleComparison(
+                    ['Articles.id', 'Articles.author_id'],
+                    $articles
+                        ->subquery()
+                        ->select(['ArticlesAlias.id', 'ArticlesAlias.author_id'])
+                        ->from(['ArticlesAlias' => $articles->getTable()])
+                        ->where(['ArticlesAlias.author_id' => 1]),
+                    [],
+                    'NOT IN'
+                ),
+            ])
+            ->orderAsc('Articles.id')
+            ->disableHydration()
+            ->toArray();
+    }
+}

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -19,7 +19,6 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
-use Cake\Database\Expression\TupleComparison;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\FrozenTime;
@@ -1750,50 +1749,5 @@ class QueryRegressionTest extends TestCase
 
         $result = $query->first()->get('value');
         $this->assertSame('mariano appended', $result);
-    }
-
-    /**
-     * Tests that tuple comparisons can use multiple fields and subqueries
-     * for an `IN` lookup of multiple results.
-     *
-     * This test is specifically relevant in the context of Sqlite and
-     * Sqlserver, for which the tuple comparison will be transformed when
-     * composite keys are used.
-     *
-     * @see \Cake\Database\Driver\TupleComparisonTranslatorTrait::_transformTupleComparison()
-     */
-    public function testTupleComparisonWithCompositeKeysAndSubqueries(): void
-    {
-        $articles = $this->getTableLocator()->get('Articles');
-
-        $query = $articles
-            ->find()
-            ->select(['id', 'author_id'])
-            ->where(
-                new TupleComparison(
-                    ['Articles.id', 'Articles.author_id'],
-                    $articles
-                        ->subquery()
-                        ->select(['ArticlesAlias.id', 'ArticlesAlias.author_id'])
-                        ->from(['ArticlesAlias' => $articles->getTable()])
-                        ->where(['ArticlesAlias.author_id' => 1]),
-                    [],
-                    'IN'
-                )
-            )
-            ->orderAsc('id')
-            ->disableHydration();
-
-        $expected = [
-            [
-                'id' => 1,
-                'author_id' => 1,
-            ],
-            [
-                'id' => 3,
-                'author_id' => 1,
-            ],
-        ];
-        $this->assertSame($expected, $query->toArray());
     }
 }


### PR DESCRIPTION
Before this change, the tuple comparison translator would rewrite the conditions of the subquery used in the provided test case to something that would generate SQL like this:

```sql
WHERE (
    ArticlesAlias.author_id = :c0 AND
    Articles.id IN ArticlesAlias.id AND
    Articles.author_id IN ArticlesAlias.author_id
)
```

Those `IN` comparisons are invalid. Before #15777 the field on the right hand side would have been wrapped in parentheses, eg

```sql
Articles.id IN (ArticlesAlias.id) AND
Articles.author_id IN (ArticlesAlias.author_id)
```

so it worked by accident so to speak.

With this change, the comparisons will now use `=` instead of `IN`, eg

```sql
Articles.id = ArticlesAlias.id AND
Articles.author_id = ArticlesAlias.author_id
```