### PR TITLE
Add driver supports check for truncating with foreign keys active

### DIFF
--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -193,6 +193,7 @@ class Postgres extends Driver
         switch ($feature) {
             case static::FEATURE_CTE:
             case static::FEATURE_JSON:
+            case static::FEATURE_TRUNCATE_WITH_CONSTRAINTS:
             case static::FEATURE_WINDOW:
                 return true;
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -215,6 +215,9 @@ class Sqlite extends Driver
                     $this->featureVersions[$feature],
                     '>='
                 );
+
+            case static::FEATURE_TRUNCATE_WITH_CONSTRAINTS:
+                return true;
         }
 
         return parent::supports($feature);

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -268,6 +268,7 @@ class Sqlserver extends Driver
     {
         switch ($feature) {
             case static::FEATURE_CTE:
+            case static::FEATURE_TRUNCATE_WITH_CONSTRAINTS:
             case static::FEATURE_WINDOW:
                 return true;
 

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -66,6 +66,13 @@ interface DriverInterface
     public const FEATURE_SAVEPOINT = 'savepoint';
 
     /**
+     * Truncate with foreign keys attached support.
+     *
+     * @var string
+     */
+    public const FEATURE_TRUNCATE_WITH_CONSTRAINTS = 'truncate-with-constraints';
+
+    /**
      * Window function support (all or partial clauses).
      *
      * @var string


### PR DESCRIPTION
This is the last db-specific behavior in FixtureHelper and ConnectionHelper.
