### PR TITLE
Fix inflector for species singular.

### DIFF
--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -81,6 +81,7 @@ class Inflector
         '/(x|ch|ss|sh)es$/i' => '\1',
         '/(m)ovies$/i' => '\1\2ovie',
         '/(s)eries$/i' => '\1\2eries',
+        '/(s)pecies$/i' => '\1\2pecies',
         '/([^aeiouy]|qu)ies$/i' => '\1y',
         '/(tive)s$/i' => '\1',
         '/(hive)s$/i' => '\1',

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -190,6 +190,8 @@ class InflectorTest extends TestCase
             ['', ''],
             ['cache', 'caches'],
             ['lens', 'lenses'],
+            ['species', 'species'],
+            ['animal_species', 'animal_species'],
         ];
     }
 

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -92,6 +92,10 @@ class InflectorTest extends TestCase
     public function testInflectingSingulars(string $singular, string $plural): void
     {
         $this->assertSame($singular, Inflector::singularize($plural));
+
+        $singular = Inflector::camelize($singular);
+        $plural = Inflector::camelize($plural);
+        $this->assertSame($singular, Inflector::singularize($plural));
     }
 
     /**
@@ -222,6 +226,10 @@ class InflectorTest extends TestCase
      */
     public function testInflectingPlurals(string $plural, string $singular): void
     {
+        $this->assertSame($plural, Inflector::pluralize($singular));
+
+        $plural = Inflector::camelize($plural);
+        $singular = Inflector::camelize($singular);
         $this->assertSame($plural, Inflector::pluralize($singular));
     }
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/16041

Not sure if that's the right fix since simple `species` already worked.
