### PR TITLE
Gracefully handle CLI arguments parsing.

### DIFF
--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -48,6 +48,20 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function parseArgv(array $argv, ConsoleIo $io, ConsoleOptionParser $parser)
+    {
+        $args = parent::parseArgv($argv, $io, $parser);
+
+        if (!$args instanceof Arguments) {
+            return static::CODE_SUCCESS;
+        }
+
+        return $args;
+    }
+
+    /**
      * Gets the option parser instance and configures it.
      *
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to build

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -152,18 +152,11 @@ abstract class BaseCommand implements CommandInterface
         $this->initialize();
 
         $parser = $this->getOptionParser();
-        try {
-            [$options, $arguments] = $parser->parse($argv);
-            $args = new Arguments(
-                $arguments,
-                $options,
-                $parser->argumentNames()
-            );
-        } catch (ConsoleException $e) {
-            $io->err('Error: ' . $e->getMessage());
-
-            return static::CODE_ERROR;
+        $args = $this->parseArgv($argv, $io, $parser);
+        if (!$args instanceof Arguments) {
+            return $args;
         }
+
         $this->setOutputLevel($args, $io);
 
         if ($args->getOption('help')) {
@@ -177,6 +170,31 @@ abstract class BaseCommand implements CommandInterface
         }
 
         return $this->execute($args, $io);
+    }
+
+    /**
+     * Parse arguments from the CLI environment into \Cake\Console\Arguments instance.
+     *
+     * @param array $argv Arguments from the CLI environment.
+     * @param \Cake\Console\ConsoleIo $io The console io.
+     * @param \Cake\Console\ConsoleOptionParser $parser The options parser.
+     * @return int|\Cake\Console\Arguments
+     */
+    protected function parseArgv(array $argv, ConsoleIo $io, ConsoleOptionParser $parser)
+    {
+        try {
+            [$options, $arguments] = $parser->parse($argv);
+
+            return new Arguments(
+                $arguments,
+                $options,
+                $parser->argumentNames()
+            );
+        } catch (ConsoleException $e) {
+            $io->err('Error: ' . $e->getMessage());
+
+            return static::CODE_ERROR;
+        }
     }
 
     /**

--- a/tests/TestCase/Command/CompletionCommandTest.php
+++ b/tests/TestCase/Command/CompletionCommandTest.php
@@ -57,7 +57,7 @@ class CompletionCommandTest extends TestCase
     public function testStartup(): void
     {
         $this->exec('completion');
-        $this->assertExitCode(Command::CODE_ERROR);
+        $this->assertExitCode(Command::CODE_SUCCESS);
 
         $this->assertOutputNotContains('Welcome to CakePHP');
     }


### PR DESCRIPTION
Currently the CompletionCommand shows an error message and hangs in case of exception.

For e.g. using `<tab>` after already typing 2 arguments results in `Received too many arguments...` error message being shown. 
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
