### PR TITLE
Move clause() from CaseExpressionTrait

### DIFF
--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -22,37 +22,16 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\ValueBinder;
 use DateTimeInterface;
-use InvalidArgumentException;
 
 /**
  * Trait that holds shared functionality for case related expressions.
  *
- * @property array<string> $validClauseNames The names of the clauses that are valid for use with the
- * `clause()` method.
  * @property \Cake\Database\TypeMap $_typeMap The type map to use when using an array of conditions for the `WHEN`
  *  value.
  * @internal
  */
 trait CaseExpressionTrait
 {
-    /**
-     * @inheritDoc
-     */
-    public function clause(string $clause)
-    {
-        if (!in_array($clause, $this->validClauseNames, true)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'The `$clause` argument must be one of `%s`, the given value `%s` is invalid.',
-                    implode('`, `', $this->validClauseNames),
-                    $clause
-                )
-            );
-        }
-
-        return $this->{$clause};
-    }
-
     /**
      * Infers the abstract type for the given value.
      *

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -279,6 +279,38 @@ class CaseStatementExpression implements CaseExpressionInterface
     }
 
     /**
+     * Returns the available data for the given clause.
+     *
+     * ### Available clauses
+     *
+     * The following clause names are available:
+     *
+     * * `value` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The case value for a
+     *   `CASE case_value WHEN ...` expression.
+     * * `when (`array<\Cake\Database\Expression\WhenThenExpressionInterface>`)`: An array of self-contained
+     *   `WHEN ... THEN ...` expressions.
+     * * `else` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `ELSE` result value.
+     *
+     * @param string $clause The name of the clause to obtain.
+     * @return array<\Cake\Database\Expression\WhenThenExpressionInterface>|\Cake\Database\ExpressionInterface|object|scalar|null
+     * @throws \InvalidArgumentException In case the given clause name is invalid.
+     */
+    public function clause(string $clause)
+    {
+        if (!in_array($clause, $this->validClauseNames, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The `$clause` argument must be one of `%s`, the given value `%s` is invalid.',
+                    implode('`, `', $this->validClauseNames),
+                    $clause
+                )
+            );
+        }
+
+        return $this->{$clause};
+    }
+
+    /**
      * @inheritDoc
      */
     public function sql(ValueBinder $binder): string

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -216,6 +216,36 @@ class WhenThenExpression implements WhenThenExpressionInterface
     }
 
     /**
+     * Returns the available data for the given clause.
+     *
+     * ### Available clauses
+     *
+     * The following clause names are available:
+     *
+     * * `when (`array<\Cake\Database\Expression\WhenThenExpressionInterface>`)`: An array of self-contained
+     *   `WHEN ... THEN ...` expressions.
+     * * `else` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `ELSE` result value.
+     *
+     * @param string $clause The name of the clause to obtain.
+     * @return array<\Cake\Database\Expression\WhenThenExpressionInterface>|\Cake\Database\ExpressionInterface|object|scalar|null
+     * @throws \InvalidArgumentException In case the given clause name is invalid.
+     */
+    public function clause(string $clause)
+    {
+        if (!in_array($clause, $this->validClauseNames, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The `$clause` argument must be one of `%s`, the given value `%s` is invalid.',
+                    implode('`, `', $this->validClauseNames),
+                    $clause
+                )
+            );
+        }
+
+        return $this->{$clause};
+    }
+
+    /**
      * @inheritDoc
      */
     public function sql(ValueBinder $binder): string


### PR DESCRIPTION
There is no need to share this little function since it accepts different clauses for CaseStatement and WhenThen expressions.

Updated docblock to reflect accepted clauses.