### PR TITLE
Properly test for exception being thrown.

### DIFF
--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1332,8 +1332,8 @@ class ConnectionTest extends TestCase
         try {
             $conn->query('SELECT 1');
         } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
         }
+        $this->assertInstanceOf(Exception::class, $e ?? null);
 
         $prop->setValue($conn, $oldDriver);
         $conn->rollback();


### PR DESCRIPTION
I was a bit too quick with it yesterday, the proper replacement for `expectException()` needs to assert irrespective of whether `catch()` is being invoked.