### PR TITLE
Throw DatabaseException when the join table key is missing

### DIFF
--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -272,7 +272,7 @@ class QueryCompiler
         foreach ($parts as $join) {
             if (!isset($join['table'])) {
                 throw new DatabaseException(sprintf(
-                    'Could not compile join clause for alias %s. No table was specified. ' .
+                    'Could not compile join clause for alias `%s`. No table was specified. ' .
                     'Use the `table` key to define a table.',
                     $join['alias']
                 ));

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -270,6 +270,13 @@ class QueryCompiler
     {
         $joins = '';
         foreach ($parts as $join) {
+            if (!isset($join['table'])) {
+                throw new DatabaseException(sprintf(
+                    'Could not compile join clause for alias %s. No table was specified. ' .
+                    'Use the `table` key to define a table.',
+                    $join['alias']
+                ));
+            }
             if ($join['table'] instanceof ExpressionInterface) {
                 $join['table'] = '(' . $join['table']->sql($binder) . ')';
             }


### PR DESCRIPTION
This fixes #16043 by throwing a DatabaseException (as @markstory suggested) when a table is missing from a join created through 
```
$items = $this->Table->find('all', [
	'join' => [
		'alias' => [
			// missing table should be here
			'conditions' => '...',
		]
	],
	...
]);
```