### PR TITLE
cake 5: Default coalesce() return type to float

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -123,7 +123,7 @@ class FunctionsBuilder
      */
     public function coalesce(array $args, array $types = []): FunctionExpression
     {
-        return new FunctionExpression('COALESCE', $args, $types, current($types) ?: 'string');
+        return new FunctionExpression('COALESCE', $args, $types, current($types) ?: 'float');
     }
 
     /**

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1678,16 +1678,19 @@ class QueryRegressionTest extends TestCase
             ->find()
             ->select(function (Query $q) use ($table) {
                 return [
-                    'value' => $q->func()->coalesce([
-                        $table
-                            ->getAssociation('Authors')
-                            ->find()
-                            ->select(['Authors.name'])
-                            ->where(function (QueryExpression $exp) {
-                                return $exp->equalFields('Authors.id', 'Articles.author_id');
-                            }),
-                        '1',
-                    ]),
+                    'value' => $q->func()->coalesce(
+                        [
+                            $table
+                                ->getAssociation('Authors')
+                                ->find()
+                                ->select(['Authors.name'])
+                                ->where(function (QueryExpression $exp) {
+                                    return $exp->equalFields('Authors.id', 'Articles.author_id');
+                                }),
+                            '1',
+                        ],
+                        ['string']
+                    ),
                 ];
             });
 


### PR DESCRIPTION
For me, coalesce() is almost always cleaning up after a sum or other math operation with 0 entries. Seems like it should be the same return type as sum or max.