### PR TITLE
Add else when condition is not an array

### DIFF
--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -64,11 +64,15 @@ class CaseExpression implements ExpressionInterface
      */
     public function __construct($conditions = [], $values = [], $types = [])
     {
+        $conditions = is_array($conditions) ? $conditions : [$conditions];
+        $values = is_array($values) ? $values : [$values];
+        $types = is_array($types) ? $types : [$types];
+
         if (!empty($conditions)) {
             $this->add($conditions, $values, $types);
         }
 
-        if (is_array($conditions) && is_array($values) && count($values) > count($conditions)) {
+        if (count($values) > count($conditions)) {
             end($values);
             $key = key($values);
             $this->elseValue($values[$key], $types[$key] ?? null);
@@ -88,15 +92,9 @@ class CaseExpression implements ExpressionInterface
      */
     public function add($conditions = [], $values = [], $types = [])
     {
-        if (!is_array($conditions)) {
-            $conditions = [$conditions];
-        }
-        if (!is_array($values)) {
-            $values = [$values];
-        }
-        if (!is_array($types)) {
-            $types = [$types];
-        }
+        $conditions = is_array($conditions) ? $conditions : [$conditions];
+        $values = is_array($values) ? $values : [$values];
+        $types = is_array($types) ? $types : [$types];
 
         $this->_addExpressions($conditions, $values, $types);
 

--- a/tests/TestCase/Database/Expression/CaseExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseExpressionTest.php
@@ -43,6 +43,10 @@ class CaseExpressionTest extends TestCase
         $expected = 'CASE WHEN test = :c0 THEN :param1 WHEN test2 = :c2 THEN :param3 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
 
+        $caseExpression = new CaseExpression($expr, ['foobar', 'else']);
+        $expected = 'CASE WHEN test = :c0 THEN :param1 ELSE :param2 END';
+        $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));
+
         $caseExpression = new CaseExpression([$expr], ['foobar', 'else']);
         $expected = 'CASE WHEN test = :c0 THEN :param1 ELSE :param2 END';
         $this->assertSame($expected, $caseExpression->sql(new ValueBinder()));


### PR DESCRIPTION
If there is a single, non-array condition, the else value should still be added when $values is larger than $conditions.


