### PR TITLE
Support leading 0s when coercing action argument to int

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -260,7 +260,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             case 'float':
                 return is_numeric($argument) ? (float)$argument : null;
             case 'int':
-                return filter_var($argument, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+                return ctype_digit($argument) ? (int)$argument : null;
             case 'bool':
                 return $argument === '0' ? false : ($argument === '1' ? true : null);
         }

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -684,7 +684,7 @@ class ControllerFactoryTest extends TestCase
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'requiredTyped',
-                'pass' => ['1.0', '2', '0'],
+                'pass' => ['1.0', '02', '0'],
             ],
         ]);
         $controller = $this->factory->create($request);


### PR DESCRIPTION
This seems likely and users probably don't want to generate confusing errors for this.