### PR TITLE
Fix some query part expressions not being cloned.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -578,7 +578,6 @@ class Query implements ExpressionInterface, IteratorAggregate
         }
         $this->_parts['modifier'] = array_merge($this->_parts['modifier'], $modifiers);
 
-
         return $this;
     }
 
@@ -2334,24 +2333,29 @@ class Query implements ExpressionInterface, IteratorAggregate
                     switch ($name) {
                         case 'join':
                             if ($piece['table'] instanceof ExpressionInterface) {
+                                /** @psalm-suppress PossiblyUndefinedMethod */
                                 $this->_parts[$name][$i]['table'] = clone $piece['table'];
                             }
                             if ($piece['conditions'] instanceof ExpressionInterface) {
+                                /** @psalm-suppress PossiblyUndefinedMethod */
                                 $this->_parts[$name][$i]['conditions'] = clone $piece['conditions'];
                             }
                             break;
 
                         case 'window':
                             if ($piece['name'] instanceof ExpressionInterface) {
+                                /** @psalm-suppress PossiblyUndefinedMethod */
                                 $this->_parts[$name][$i]['name'] = clone $piece['name'];
                             }
                             if ($piece['window'] instanceof ExpressionInterface) {
+                                /** @psalm-suppress PossiblyUndefinedMethod */
                                 $this->_parts[$name][$i]['window'] = clone $piece['window'];
                             }
                             break;
 
                         case 'union':
                             if ($piece['query'] instanceof ExpressionInterface) {
+                                /** @psalm-suppress PossiblyUndefinedMethod */
                                 $this->_parts[$name][$i]['query'] = clone $piece['query'];
                             }
                             break;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2327,9 +2327,36 @@ class Query implements ExpressionInterface, IteratorAggregate
             }
             if (is_array($part)) {
                 foreach ($part as $i => $piece) {
-                    if ($piece instanceof ExpressionInterface) {
-                        /** @psalm-suppress PossiblyUndefinedMethod */
-                        $this->_parts[$name][$i] = clone $piece;
+                    switch ($name) {
+                        case 'join':
+                            if ($piece['table'] instanceof ExpressionInterface) {
+                                $this->_parts[$name][$i]['table'] = clone $piece['table'];
+                            }
+                            if ($piece['conditions'] instanceof ExpressionInterface) {
+                                $this->_parts[$name][$i]['conditions'] = clone $piece['conditions'];
+                            }
+                            break;
+
+                        case 'window':
+                            if ($piece['name'] instanceof ExpressionInterface) {
+                                $this->_parts[$name][$i]['name'] = clone $piece['name'];
+                            }
+                            if ($piece['window'] instanceof ExpressionInterface) {
+                                $this->_parts[$name][$i]['window'] = clone $piece['window'];
+                            }
+                            break;
+
+                        case 'union':
+                            if ($piece['query'] instanceof ExpressionInterface) {
+                                $this->_parts[$name][$i]['query'] = clone $piece['query'];
+                            }
+                            break;
+
+                        default:
+                            if ($piece instanceof ExpressionInterface) {
+                                /** @psalm-suppress PossiblyUndefinedMethod */
+                                $this->_parts[$name][$i] = clone $piece;
+                            }
                     }
                 }
             }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2330,41 +2330,16 @@ class Query implements ExpressionInterface, IteratorAggregate
             }
             if (is_array($part)) {
                 foreach ($part as $i => $piece) {
-                    switch ($name) {
-                        case 'join':
-                            if ($piece['table'] instanceof ExpressionInterface) {
+                    if (is_array($piece)) {
+                        foreach ($piece as $j => $value) {
+                            if ($value instanceof ExpressionInterface) {
                                 /** @psalm-suppress PossiblyUndefinedMethod */
-                                $this->_parts[$name][$i]['table'] = clone $piece['table'];
+                                $this->_parts[$name][$i][$j] = clone $value;
                             }
-                            if ($piece['conditions'] instanceof ExpressionInterface) {
-                                /** @psalm-suppress PossiblyUndefinedMethod */
-                                $this->_parts[$name][$i]['conditions'] = clone $piece['conditions'];
-                            }
-                            break;
-
-                        case 'window':
-                            if ($piece['name'] instanceof ExpressionInterface) {
-                                /** @psalm-suppress PossiblyUndefinedMethod */
-                                $this->_parts[$name][$i]['name'] = clone $piece['name'];
-                            }
-                            if ($piece['window'] instanceof ExpressionInterface) {
-                                /** @psalm-suppress PossiblyUndefinedMethod */
-                                $this->_parts[$name][$i]['window'] = clone $piece['window'];
-                            }
-                            break;
-
-                        case 'union':
-                            if ($piece['query'] instanceof ExpressionInterface) {
-                                /** @psalm-suppress PossiblyUndefinedMethod */
-                                $this->_parts[$name][$i]['query'] = clone $piece['query'];
-                            }
-                            break;
-
-                        default:
-                            if ($piece instanceof ExpressionInterface) {
-                                /** @psalm-suppress PossiblyUndefinedMethod */
-                                $this->_parts[$name][$i] = clone $piece;
-                            }
+                        }
+                    } elseif ($piece instanceof ExpressionInterface) {
+                        /** @psalm-suppress PossiblyUndefinedMethod */
+                        $this->_parts[$name][$i] = clone $piece;
                     }
                 }
             }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -573,7 +573,11 @@ class Query implements ExpressionInterface, IteratorAggregate
         if ($overwrite) {
             $this->_parts['modifier'] = [];
         }
-        $this->_parts['modifier'] = array_merge($this->_parts['modifier'], (array)$modifiers);
+        if (!is_array($modifiers)) {
+            $modifiers = [$modifiers];
+        }
+        $this->_parts['modifier'] = array_merge($this->_parts['modifier'], $modifiers);
+
 
         return $this;
     }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -21,10 +21,12 @@ use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
+use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\StringExpression;
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\Expression\WindowExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
 use Cake\Database\Statement\StatementDecorator;
@@ -4507,6 +4509,326 @@ class QueryTest extends TestCase
         $this->assertCount(3, $list);
         $result->closeCursor();
     }
+    public function testCloneUpdateExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->update($query->newExpr('update'));
+
+        $clause = $query->clause('update');
+        $clauseClone = (clone $query)->clause('update');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value, $clauseClone[$key]);
+            $this->assertNotSame($value, $clauseClone[$key]);
+        }
+    }
+
+    public function testCloneSetExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->update('table')
+            ->set(['column' => $query->newExpr('value')]);
+
+        $clause = $query->clause('set');
+        $clauseClone = (clone $query)->clause('set');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneValuesExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->insert(['column'])
+            ->into('table')
+            ->values(['column' => $query->newExpr('value')]);
+
+        $clause = $query->clause('values');
+        $clauseClone = (clone $query)->clause('values');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneWithExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->with(
+                new CommonTableExpression(
+                    'cte',
+                    new Query($this->connection)
+                )
+            )
+            ->with(function (CommonTableExpression $cte, Query $query) {
+                return $cte
+                    ->name('cte2')
+                    ->query($query);
+            });
+
+        $clause = $query->clause('with');
+        $clauseClone = (clone $query)->clause('with');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value, $clauseClone[$key]);
+            $this->assertNotSame($value, $clauseClone[$key]);
+        }
+    }
+
+    public function testCloneSelectExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->select($query->newExpr('select'))
+            ->select(['alias' => $query->newExpr('select')]);
+
+        $clause = $query->clause('select');
+        $clauseClone = (clone $query)->clause('select');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value, $clauseClone[$key]);
+            $this->assertNotSame($value, $clauseClone[$key]);
+        }
+    }
+
+    public function testCloneDistinctExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->distinct($query->newExpr('distinct'));
+
+        $clause = $query->clause('distinct');
+        $clauseClone = (clone $query)->clause('distinct');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneModifierExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->modifier($query->newExpr('modifier'));
+
+        $clause = $query->clause('modifier');
+        $clauseClone = (clone $query)->clause('modifier');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value, $clauseClone[$key]);
+            $this->assertNotSame($value, $clauseClone[$key]);
+        }
+    }
+
+    public function testCloneFromExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->from(['alias' => new Query($this->connection)]);
+
+        $clause = $query->clause('from');
+        $clauseClone = (clone $query)->clause('from');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value, $clauseClone[$key]);
+            $this->assertNotSame($value, $clauseClone[$key]);
+        }
+    }
+
+    public function testCloneJoinExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->innerJoin(
+                ['alias_inner' => new Query($this->connection)],
+                ['alias_inner.fk = parent.pk']
+            )
+            ->leftJoin(
+                ['alias_left' => new Query($this->connection)],
+                ['alias_left.fk = parent.pk']
+            )
+            ->rightJoin(
+                ['alias_right' => new Query($this->connection)],
+                ['alias_right.fk = parent.pk']
+            );
+
+        $clause = $query->clause('join');
+        $clauseClone = (clone $query)->clause('join');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value['table'], $clauseClone[$key]['table']);
+            $this->assertNotSame($value['table'], $clauseClone[$key]['table']);
+
+            $this->assertEquals($value['conditions'], $clauseClone[$key]['conditions']);
+            $this->assertNotSame($value['conditions'], $clauseClone[$key]['conditions']);
+        }
+    }
+
+    public function testCloneWhereExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->where($query->newExpr('where'))
+            ->where(['field' => $query->newExpr('where')]);
+
+        $clause = $query->clause('where');
+        $clauseClone = (clone $query)->clause('where');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneGroupExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->group($query->newExpr('group'));
+
+        $clause = $query->clause('group');
+        $clauseClone = (clone $query)->clause('group');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value, $clauseClone[$key]);
+            $this->assertNotSame($value, $clauseClone[$key]);
+        }
+    }
+
+    public function testCloneHavingExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->having($query->newExpr('having'));
+
+        $clause = $query->clause('having');
+        $clauseClone = (clone $query)->clause('having');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneWindowExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->window('window1', new WindowExpression())
+            ->window('window2', function (WindowExpression $window) {
+                return $window;
+            });
+
+        $clause = $query->clause('window');
+        $clauseClone = (clone $query)->clause('window');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value['name'], $clauseClone[$key]['name']);
+            $this->assertNotSame($value['name'], $clauseClone[$key]['name']);
+
+            $this->assertEquals($value['window'], $clauseClone[$key]['window']);
+            $this->assertNotSame($value['window'], $clauseClone[$key]['window']);
+        }
+    }
+
+    public function testCloneOrderExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query
+            ->order($query->newExpr('order'))
+            ->orderAsc($query->newExpr('order_asc'))
+            ->orderDesc($query->newExpr('order_desc'));
+
+        $clause = $query->clause('order');
+        $clauseClone = (clone $query)->clause('order');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneLimitExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->limit($query->newExpr('1'));
+
+        $clause = $query->clause('limit');
+        $clauseClone = (clone $query)->clause('limit');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneOffsetExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->offset($query->newExpr('1'));
+
+        $clause = $query->clause('offset');
+        $clauseClone = (clone $query)->clause('offset');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
+    public function testCloneUnionExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->where(['id' => 1]);
+
+        $query2 = new Query($this->connection);
+        $query2->where(['id' => 2]);
+
+        $query->union($query2);
+
+        $clause = $query->clause('union');
+        $clauseClone = (clone $query)->clause('union');
+
+        $this->assertIsArray($clause);
+
+        foreach ($clause as $key => $value) {
+            $this->assertEquals($value['query'], $clauseClone[$key]['query']);
+            $this->assertNotSame($value['query'], $clauseClone[$key]['query']);
+        }
+    }
+
+    public function testCloneEpilogExpression(): void
+    {
+        $query = new Query($this->connection);
+        $query->epilog($query->newExpr('epilog'));
+
+        $clause = $query->clause('epilog');
+        $clauseClone = (clone $query)->clause('epilog');
+
+        $this->assertInstanceOf(ExpressionInterface::class, $clause);
+
+        $this->assertEquals($clause, $clauseClone);
+        $this->assertNotSame($clause, $clauseClone);
+    }
+
 
     /**
      * Test that cloning goes deep.

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4520,6 +4520,7 @@ class QueryTest extends TestCase
         $this->assertCount(3, $list);
         $result->closeCursor();
     }
+
     public function testCloneUpdateExpression(): void
     {
         $query = new Query($this->connection);
@@ -4839,7 +4840,6 @@ class QueryTest extends TestCase
         $this->assertEquals($clause, $clauseClone);
         $this->assertNotSame($clause, $clauseClone);
     }
-
 
     /**
      * Test that cloning goes deep.

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2230,6 +2230,17 @@ class QueryTest extends TestCase
             $result->sql(),
             !$this->autoQuote
         );
+
+        $query = new Query($this->connection);
+        $result = $query
+            ->select(['city', 'state', 'country'])
+            ->from(['addresses'])
+            ->modifier($query->newExpr('EXPRESSION'));
+        $this->assertQuotedQuery(
+            'SELECT EXPRESSION <city>, <state>, <country> FROM <addresses>',
+            $result->sql(),
+            !$this->autoQuote
+        );
     }
 
     /**


### PR DESCRIPTION
Some parts have an array structure that stores possible expressions in a
nested fashion, these require some specific logic in order to properly
clone them.