### PR TITLE
Fix case expression api docs

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -148,6 +148,11 @@
       <code>$value</code>
     </InvalidScalarArgument>
   </file>
+  <file src="src/Database/Expression/QueryExpression.php">
+    <DeprecatedClass occurrences="1">
+      <code>new CaseExpression($conditions, $values, $types)</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Database/Schema/MysqlSchemaDialect.php">
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$_driver</code>
@@ -245,9 +250,6 @@
     <DeprecatedTrait occurrences="1">
       <code>ModelAwareTrait</code>
     </DeprecatedTrait>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;defaultTable</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/ORM/Locator/LocatorAwareTrait.php">
     <DeprecatedClass occurrences="1">

--- a/src/Database/Expression/CaseExpression.php
+++ b/src/Database/Expression/CaseExpression.php
@@ -23,6 +23,8 @@ use Closure;
 
 /**
  * This class represents a SQL Case statement
+ *
+ * @deprecated 4.3.0 Use CaseStatementExpression instead or Query::case()
  */
 class CaseExpression implements ExpressionInterface
 {

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -25,6 +25,9 @@ use Closure;
 use InvalidArgumentException;
 use LogicException;
 
+/**
+ * Represents a SQL case statement with a fluid API
+ */
 class CaseStatementExpression implements ExpressionInterface, TypedResultInterface
 {
     use CaseExpressionTrait;
@@ -275,7 +278,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
      *      ->bind(':userData', $userData, 'integer')
      * ```
      *
-     * @param \Cake\Database\ExpressionInterface|\Closure|array|object|scalar $when The `WHEN` value. When using an
+     * @param \Cake\Database\ExpressionInterface|\Closure|object|array|scalar $when The `WHEN` value. When using an
      *  array of conditions, it must be compatible with `\Cake\Database\Query::where()`. Note that this argument is
      *  _not_ completely safe for use with user data, as a user supplied array would allow for raw SQL to slip in! If
      *  you plan to use user data, either pass a single type for the `$type` argument (which forces the `$when` value to
@@ -488,14 +491,12 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
      *
      * The following clause names are available:
      *
-     * * `value` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The case value for a
-     *   `CASE case_value WHEN ...` expression.
-     * * `when (`array<\Cake\Database\Expression\WhenThenExpression>`)`: An array of self-contained
-     *   `WHEN ... THEN ...` expressions.
-     * * `else` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `ELSE` result value.
+     * * `value`: The case value for a `CASE case_value WHEN ...` expression.
+     * * `when`: An array of `WHEN ... THEN ...` expressions.
+     * * `else`: The `ELSE` result value.
      *
      * @param string $clause The name of the clause to obtain.
-     * @return array<\Cake\Database\Expression\WhenThenExpression>|\Cake\Database\ExpressionInterface|object|scalar|null
+     * @return \Cake\Database\ExpressionInterface|object|array<\Cake\Database\Expression\WhenThenExpression>|scalar|null
      * @throws \InvalidArgumentException In case the given clause name is invalid.
      */
     public function clause(string $clause)

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -339,6 +339,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * @param array<string> $types Associative array of types to be associated with the values
      * passed in $values
      * @return $this
+     * @deprecated 4.3.0 Use Query::case() or CaseStatementExpression instead
      */
     public function addCase($conditions, $values = [], $types = [])
     {

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -25,6 +25,9 @@ use Closure;
 use InvalidArgumentException;
 use LogicException;
 
+/**
+ * Represents a SQL when/then clause with a fluid API
+ */
 class WhenThenExpression implements ExpressionInterface
 {
     use CaseExpressionTrait;
@@ -102,7 +105,7 @@ class WhenThenExpression implements ExpressionInterface
     /**
      * Sets the `WHEN` value.
      *
-     * @param \Cake\Database\ExpressionInterface|array|object|scalar $when The `WHEN` value. When using an array of
+     * @param \Cake\Database\ExpressionInterface|object|array|scalar $when The `WHEN` value. When using an array of
      *  conditions, it must be compatible with `\Cake\Database\Query::where()`. Note that this argument is _not_
      *  completely safe for use with user data, as a user supplied array would allow for raw SQL to slip in! If you
      *  plan to use user data, either pass a single type for the `$type` argument (which forces the `$when` value to be
@@ -248,8 +251,8 @@ class WhenThenExpression implements ExpressionInterface
      *
      * The following clause names are available:
      *
-     * * `when` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `WHEN` value.
-     * * `then` (`\Cake\Database\ExpressionInterface|object|scalar|null`): The `THEN` result value.
+     * * `when`: The `WHEN` value.
+     * * `then`: The `THEN` result value.
      *
      * @param string $clause The name of the clause to obtain.
      * @return \Cake\Database\ExpressionInterface|object|scalar|null


### PR DESCRIPTION
Clean up the API docs rendering. Add deprecated tag for CaseExpression and addCase().