### PR TITLE
Fix up phpstan template issue in internal classes.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -451,11 +451,6 @@ parameters:
 			path: src/TestSuite/ConsoleIntegrationTestCase.php
 
 		-
-			message: "#^PHPDoc tag @template TCode for class Cake\\\\TestSuite\\\\Constraint\\\\Response\\\\StatusCodeBase with bound type array\\<int, int\\> is not supported\\.$#"
-			count: 1
-			path: src/TestSuite/Constraint/Response/StatusCodeBase.php
-
-		-
 			message: "#^Parameter \\#1 \\$connection of method Cake\\\\Database\\\\Schema\\\\SqlGeneratorInterface\\:\\:addConstraintSql\\(\\) expects Cake\\\\Database\\\\Connection, Cake\\\\Datasource\\\\ConnectionInterface given\\.$#"
 			count: 1
 			path: src/TestSuite/Fixture/TestFixture.php

--- a/src/TestSuite/Constraint/Response/StatusCodeBase.php
+++ b/src/TestSuite/Constraint/Response/StatusCodeBase.php
@@ -19,20 +19,18 @@ namespace Cake\TestSuite\Constraint\Response;
  * StatusCodeBase
  *
  * @internal
- * @template TCode as array<int, int>|int
  */
 abstract class StatusCodeBase extends ResponseBase
 {
     /**
-     * @var array|int
-     * @psalm-var TCode
+     * @var array<int, int>|int
      */
     protected $code;
 
     /**
      * Check assertion
      *
-     * @param array|int $other Array of min/max status codes, or a single code
+     * @param array<int, int>|int $other Array of min/max status codes, or a single code
      * @return bool
      * @psalm-suppress MoreSpecificImplementedParamType
      */

--- a/src/TestSuite/Constraint/Response/StatusError.php
+++ b/src/TestSuite/Constraint/Response/StatusError.php
@@ -19,12 +19,11 @@ namespace Cake\TestSuite\Constraint\Response;
  * StatusError
  *
  * @internal
- * @extends \Cake\TestSuite\Constraint\Response\StatusCodeBase<array<int, int>>
  */
 class StatusError extends StatusCodeBase
 {
     /**
-     * @var array<int, int>
+     * @var array<int, int>|int
      */
     protected $code = [400, 429];
 

--- a/src/TestSuite/Constraint/Response/StatusFailure.php
+++ b/src/TestSuite/Constraint/Response/StatusFailure.php
@@ -19,12 +19,11 @@ namespace Cake\TestSuite\Constraint\Response;
  * StatusFailure
  *
  * @internal
- * @extends \Cake\TestSuite\Constraint\Response\StatusCodeBase<array<int, int>>
  */
 class StatusFailure extends StatusCodeBase
 {
     /**
-     * @var array<int, int>
+     * @var array<int, int>|int
      */
     protected $code = [500, 505];
 

--- a/src/TestSuite/Constraint/Response/StatusOk.php
+++ b/src/TestSuite/Constraint/Response/StatusOk.php
@@ -19,12 +19,11 @@ namespace Cake\TestSuite\Constraint\Response;
  * StatusOk
  *
  * @internal
- * @extends \Cake\TestSuite\Constraint\Response\StatusCodeBase<array<int, int>>
  */
 class StatusOk extends StatusCodeBase
 {
     /**
-     * @var array<int, int>
+     * @var array<int, int>|int
      */
     protected $code = [200, 204];
 

--- a/src/TestSuite/Constraint/Response/StatusSuccess.php
+++ b/src/TestSuite/Constraint/Response/StatusSuccess.php
@@ -19,12 +19,11 @@ namespace Cake\TestSuite\Constraint\Response;
  * StatusSuccess
  *
  * @internal
- * @extends \Cake\TestSuite\Constraint\Response\StatusCodeBase<array<int, int>>
  */
 class StatusSuccess extends StatusCodeBase
 {
     /**
-     * @var array<int, int>
+     * @var array<int, int>|int
      */
     protected $code = [200, 308];
 


### PR DESCRIPTION
As per https://github.com/rectorphp/rector/issues/6766#issuecomment-950230562

it unblocks latest phpstan and rector usage on the code base as well as extending code bases.
no more memory leak.

For internal classes the current doc update should be fine for now as it is.