### PR TITLE
Add explicit dependency on psr/container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1",
         "league/container": "^4.1.1",
+        "psr/container": "^2.0",
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",


### PR DESCRIPTION
I originally added this to cakephp/core, but league/container is under suggest so adding psr/container there doesn't make sense.