### PR TITLE
Fix custom type overrides not be using in fixtures

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -250,9 +250,9 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             $this->_schema = $table->getSchema();
         } catch (CakeException $e) {
             $message = sprintf(
-                'Cannot describe schema for table `%s` for fixture `%s`: the table does not exist.',
+                'Cannot describe schema for table `%s` for fixture `%s`. The table does not exist.',
                 $this->table,
-                static::class,
+                static::class
             );
             throw new CakeException($message, null, $e);
         }

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -245,20 +245,17 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     protected function _schemaFromReflection(): void
     {
         $db = ConnectionManager::get($this->connection());
-        $schemaCollection = $db->getSchemaCollection();
-        $tables = $schemaCollection->listTables();
-
-        if (!in_array($this->table, $tables, true)) {
-            throw new CakeException(
-                sprintf(
-                    'Cannot describe schema for table `%s` for fixture `%s`: the table does not exist.',
-                    $this->table,
-                    static::class
-                )
+        try {
+            $table = $this->fetchTable($this->table, ['connection' => $db]);
+            $this->_schema = $table->getSchema();
+        } catch (CakeException $e) {
+            $message = sprintf(
+                'Cannot describe schema for table `%s` for fixture `%s`: the table does not exist.',
+                $this->table,
+                static::class,
             );
+            throw new CakeException($message, null, $e);
         }
-
-        $this->_schema = $schemaCollection->describe($this->table);
     }
 
     /**

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -249,7 +249,9 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             $name = Inflector::camelize($this->table);
             $ormTable = $this->fetchTable($name, ['connection' => $db]);
 
-            $this->_schema = $ormTable->getSchema();
+            /** @var \Cake\Database\Schema\TableSchema $schema */
+            $schema = $ormTable->getSchema();
+            $this->_schema = $schema;
         } catch (CakeException $e) {
             $message = sprintf(
                 'Cannot describe schema for table `%s` for fixture `%s`. The table does not exist.',

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -246,8 +246,10 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     {
         $db = ConnectionManager::get($this->connection());
         try {
-            $table = $this->fetchTable($this->table, ['connection' => $db]);
-            $this->_schema = $table->getSchema();
+            $name = Inflector::camelize($this->table);
+            $ormTable = $this->fetchTable($name, ['connection' => $db]);
+
+            $this->_schema = $ormTable->getSchema();
         } catch (CakeException $e) {
             $message = sprintf(
                 'Cannot describe schema for table `%s` for fixture `%s`. The table does not exist.',

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -56,6 +56,7 @@ class TestFixtureTest extends TestCase
     {
         parent::tearDown();
         Log::reset();
+        ConnectionManager::get('test')->execute('DROP TABLE IF EXISTS letters');
     }
 
     /**
@@ -138,7 +139,7 @@ class TestFixtureTest extends TestCase
     public function testInitNoImportNoFieldsException(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`: the table does not exist.');
+        $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`. The table does not exist.');
         $fixture = new LettersFixture();
         $fixture->init();
     }
@@ -163,10 +164,6 @@ class TestFixtureTest extends TestCase
         $fixture = new LettersFixture();
         $fixture->init();
         $this->assertSame(['id', 'letter'], $fixture->getTableSchema()->columns());
-
-        // Cleanup.
-        $db = ConnectionManager::get('test');
-        $db->execute('DROP TABLE letters');
     }
 
     /**
@@ -193,12 +190,9 @@ class TestFixtureTest extends TestCase
         $fixture = new LettersFixture();
         $fixture->init();
         $fixtureSchema = $fixture->getTableSchema();
+        $this->assertSame($table->getSchema(), $fixtureSchema);
         $this->assertSame(['id', 'letter', 'complex_field'], $fixtureSchema->columns());
         $this->assertSame('json', $fixtureSchema->getColumnType('complex_field'));
-
-        // Cleanup.
-        $db = ConnectionManager::get('test');
-        $db->execute('DROP TABLE letters');
     }
 
     /**

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -184,13 +184,12 @@ class TestFixtureTest extends TestCase
             $db->execute($stmt);
         }
 
-        $table = $this->fetchTable('Letters');
+        $table = $this->fetchTable('Letters', ['connection' => $db]);
         $table->getSchema()->setColumnType('complex_field', 'json');
 
         $fixture = new LettersFixture();
         $fixture->init();
         $fixtureSchema = $fixture->getTableSchema();
-        $this->assertSame($table->getSchema(), $fixtureSchema);
         $this->assertSame(['id', 'letter', 'complex_field'], $fixtureSchema->columns());
         $this->assertSame('json', $fixtureSchema->getColumnType('complex_field'));
     }


### PR DESCRIPTION
When fixtures are reflecting schema they should use the ORM table
classes to get the schema data, as tables can re-map types and fixtures
and tests are likely to rely on those custom types.

Fixes #16067