### PR TITLE
fixed typo for `RouteBuilder`

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -60,7 +60,7 @@ use UnexpectedValueException;
  * Controllers are created based on request parameters and
  * routing. By default controllers and actions use conventional names.
  * For example `/posts/index` maps to `PostsController::index()`. You can re-map
- * URLs using Router::connect() or RouterBuilder::connect().
+ * URLs using Router::connect() or RouteBuilder::connect().
  *
  * ### Life cycle callbacks
  *

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -206,12 +206,12 @@ class Router
      * @throws \Cake\Core\Exception\CakeException
      * @see \Cake\Routing\RouteBuilder::connect()
      * @see \Cake\Routing\Router::scope()
-     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::connect()` instead.
+     * @deprecated 4.3.0 Use the non-static method `RouteBuilder::connect()` instead.
      */
     public static function connect($route, $defaults = [], $options = []): void
     {
         deprecationWarning(
-            '`Router::connect()` is deprecated, use the non-static method `RouterBuilder::connect()` instead.'
+            '`Router::connect()` is deprecated, use the non-static method `RouteBuilder::connect()` instead.'
         );
 
         static::scope('/', function ($routes) use ($route, $defaults, $options): void {
@@ -816,12 +816,12 @@ class Router
      * @param callable|null $callback The callback to invoke with the scoped collection.
      * @throws \InvalidArgumentException When an invalid callable is provided.
      * @return void
-     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::scope()` instead.
+     * @deprecated 4.3.0 Use the non-static method `RouteBuilder::scope()` instead.
      */
     public static function scope(string $path, $params = [], $callback = null): void
     {
         deprecationWarning(
-            '`Router::scope()` is deprecated, use the non-static method `RouterBuilder::scope()` instead.'
+            '`Router::scope()` is deprecated, use the non-static method `RouteBuilder::scope()` instead.'
         );
 
         $options = [];
@@ -855,12 +855,12 @@ class Router
      *   If you have no parameters, this argument can be a callable.
      * @param callable|null $callback The callback to invoke that builds the prefixed routes.
      * @return void
-     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::prefix()` instead.
+     * @deprecated 4.3.0 Use the non-static method `RouteBuilder::prefix()` instead.
      */
     public static function prefix(string $name, $params = [], $callback = null): void
     {
         deprecationWarning(
-            '`Router::prefix()` is deprecated, use the non-static method `RouterBuilder::prefix()` instead.'
+            '`Router::prefix()` is deprecated, use the non-static method `RouteBuilder::prefix()` instead.'
         );
 
         if (!is_array($params)) {
@@ -892,12 +892,12 @@ class Router
      * @param callable|null $callback The callback to invoke that builds the plugin routes.
      *   Only required when $options is defined
      * @return void
-     * @deprecated 4.3.0 Use the non-static method `RouterBuilder::plugin()` instead.
+     * @deprecated 4.3.0 Use the non-static method `RouteBuilder::plugin()` instead.
      */
     public static function plugin(string $name, $options = [], $callback = null): void
     {
         deprecationWarning(
-            '`Router::plugin()` is deprecated, use the non-static method `RouterBuilder::plugin()` instead.'
+            '`Router::plugin()` is deprecated, use the non-static method `RouteBuilder::plugin()` instead.'
         );
 
         if (!is_array($options)) {


### PR DESCRIPTION
The correct class name appears to be `RouteBuilder`, although it is sometimes referred to as` RouterBuilder`.