### PR TITLE
Add ContentNegotiationMiddleware.

### DIFF
--- a/src/Controller/Middleware/ContentNegotiationMiddleware.php
+++ b/src/Controller/Middleware/ContentNegotiationMiddleware.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license incontentTypeion, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Controller\Middleware;
+
+use Cake\Controller\Controller;
+use Cake\Http\Exception\NotAcceptableException;
+use Cake\Http\ServerRequest;
+use Cake\Utility\Hash;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class ContentNegotiationMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var \Cake\Controller\Controller
+     */
+    protected $controller;
+
+    /**
+     * @var array<string, string|null>
+     */
+    protected $validTypes = [];
+
+    public function __construct(Controller $controller, array $validTypes = [])
+    {
+        $this->controller = $controller;
+
+        $validTypes += ['json' => 'Json'];
+
+        $this->validTypes = Hash::normalize($validTypes);
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $contentType = $request instanceof ServerRequest ? $this->getContentType($request) : 'html';
+
+        if (in_array($contentType, ['htm', 'html'], true)) {
+            return $handler->handle($request);
+        }
+
+        $this->renderAs($contentType);
+
+        return $handler->handle($request);
+    }
+
+    protected function getContentType(ServerRequest $request): string
+    {
+        $contentType = $request->getParam('_ext');
+        if ($contentType) {
+            return $contentType;
+        }
+
+        $accept = $request->parseAccept();
+        if (empty($accept) || current($accept)[0] !== 'text/html') {
+            return 'html';
+        }
+
+        /** @var array $accepts */
+        $accepts = $this->controller->getResponse()->mapType($accept);
+        $preferredTypes = current($accepts);
+        if (array_intersect($preferredTypes, ['html', 'xhtml'])) {
+            return 'html';
+        }
+
+        $validTypes = array_keys($this->validTypes);
+        foreach ($accepts as $types) {
+            $matchedTypes = array_intersect($validTypes, $types);
+            if ($matchedTypes) {
+                return current($matchedTypes);
+            }
+        }
+
+        throw new NotAcceptableException();
+    }
+
+    protected function renderAs(string $contentType): void
+    {
+        $this->controller->setResponse(
+            $this->controller->getResponse()->withType($contentType)
+        );
+
+        $builder = $this->controller->viewBuilder();
+        if ($builder->getClassName() !== null) {
+            return;
+        }
+
+        $viewClass = $this->validTypes[$contentType];
+        if ($viewClass !== null) {
+            $builder->setClassName($viewClass);
+        }
+    }
+}


### PR DESCRIPTION
This is meant to be a replacement for the `RequestHandlerComponent`. This middleware addresses the issues with `RequestHandlerComponent` and related use of `Router::extensions()` mentioned [here](https://github.com/cakephp/cakephp/pull/15971#issuecomment-927886156).

If the extension/type is found in currently matched URL then it's always used. But when relying on `Accept` header only the types explicitly set as valid types are allowed. If a non valid type is used for the request then a `NotAcceptableException` is thrown.

The `$validTypes` can be set as a type => viewClass map or just allowed type with no view class mapping. For the latter only `Response::withType()` will be used to set the `Content-Type` for the response and no view class switching will be done.

`RequestHandlerComponent::beforeRender()` also checks for HTTP caching headers to avoid rending the view. This should be handled using a separate middleware.