### PR TITLE
Deprecate public Connection::setDriver()

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -135,11 +135,14 @@ class Connection implements ConnectionInterface
     {
         $this->_config = $config;
 
-        $driver = '';
-        if (!empty($config['driver'])) {
-            $driver = $config['driver'];
-        }
-        $this->setDriver($driver, $config);
+        $driverConfig = array_diff_key($config, array_flip([
+            'name',
+            'driver',
+            'log',
+            'cacheMetaData',
+            'cacheKeyPrefix',
+        ]));
+        $this->_driver = $this->createDriver($config['driver'] ?? '', $driverConfig);
 
         if (!empty($config['log'])) {
             $this->enableQueryLogging((bool)$config['log']);
@@ -183,24 +186,43 @@ class Connection implements ConnectionInterface
      * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
      * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
      * @return $this
+     * @deprecated 4.4.0 Setting the driver is deprecated. Use the connection config instead.
      */
     public function setDriver($driver, $config = [])
     {
+        deprecationWarning('Setting the driver is deprecated. Use the connection config instead.');
+
+        $this->_driver = $this->createDriver($driver, $config);
+
+        return $this;
+    }
+
+    /**
+     * Creates driver from name, class name or instance.
+     *
+     * @param \Cake\Database\DriverInterface|string $name Driver name, class name or instance.
+     * @param array $config Driver config if $name is not an instance.
+     * @return \Cake\Database\DriverInterface
+     * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
+     * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
+     */
+    protected function createDriver($name, array $config): DriverInterface
+    {
+        $driver = $name;
         if (is_string($driver)) {
             /** @psalm-var class-string<\Cake\Database\DriverInterface>|null $className */
             $className = App::className($driver, 'Database/Driver');
             if ($className === null) {
-                throw new MissingDriverException(['driver' => $driver]);
+                throw new MissingDriverException(['driver' => $driver, 'connection' => $this->configName()]);
             }
             $driver = new $className($config);
         }
+
         if (!$driver->enabled()) {
-            throw new MissingExtensionException(['driver' => get_class($driver)]);
+            throw new MissingExtensionException(['driver' => get_class($driver), 'connection' => $this->configName()]);
         }
 
-        $this->_driver = $driver;
-
-        return $this;
+        return $driver;
     }
 
     /**

--- a/src/Database/Exception/MissingDriverException.php
+++ b/src/Database/Exception/MissingDriverException.php
@@ -26,5 +26,5 @@ class MissingDriverException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Database driver %s could not be found.';
+    protected $_messageTemplate = 'Could not find driver `%s` for connection `%s`.';
 }

--- a/src/Database/Exception/MissingExtensionException.php
+++ b/src/Database/Exception/MissingExtensionException.php
@@ -26,6 +26,5 @@ class MissingExtensionException extends CakeException
     /**
      * @inheritDoc
      */
-    // phpcs:ignore Generic.Files.LineLength
-    protected $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency';
+    protected $_messageTemplate = 'Could not use driver `%s` for connection `%s` due to missing PHP extension.';
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -36,6 +36,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use DateTime;
+use Error;
 use Exception;
 use InvalidArgumentException;
 use PDO;
@@ -135,7 +136,7 @@ class ConnectionTest extends TestCase
     public function testNoDriver(): void
     {
         $this->expectException(MissingDriverException::class);
-        $this->expectExceptionMessage('Database driver  could not be found.');
+        $this->expectExceptionMessage('Could not find driver `` for connection ``.');
         $connection = new Connection([]);
     }
 
@@ -144,8 +145,7 @@ class ConnectionTest extends TestCase
      */
     public function testEmptyDriver(): void
     {
-        $this->expectException(MissingDriverException::class);
-        $this->expectExceptionMessage('Database driver  could not be found.');
+        $this->expectException(Error::class);
         $connection = new Connection(['driver' => false]);
     }
 
@@ -155,7 +155,7 @@ class ConnectionTest extends TestCase
     public function testMissingDriver(): void
     {
         $this->expectException(MissingDriverException::class);
-        $this->expectExceptionMessage('Database driver \Foo\InvalidDriver could not be found.');
+        $this->expectExceptionMessage('Could not find driver `\Foo\InvalidDriver` for connection ``.');
         $connection = new Connection(['driver' => '\Foo\InvalidDriver']);
     }
 
@@ -165,7 +165,7 @@ class ConnectionTest extends TestCase
     public function testDisabledDriver(): void
     {
         $this->expectException(MissingExtensionException::class);
-        $this->expectExceptionMessage('Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency');
+        $this->expectExceptionMessage('Could not use driver `DriverMock` for connection `` due to missing PHP extension.');
         $mock = $this->getMockBuilder(Mysql::class)
             ->onlyMethods(['enabled'])
             ->setMockClassName('DriverMock')
@@ -985,8 +985,10 @@ class ConnectionTest extends TestCase
             ->getMock();
         $connection->enableQueryLogging(true);
 
-        $driver = $this->getMockFormDriver();
-        $connection->setDriver($driver);
+        $this->deprecated(function () use ($connection) {
+            $driver = $this->getMockFormDriver();
+            $connection->setDriver($driver);
+        });
 
         $connection->begin();
         $connection->begin(); //This one will not be logged

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -183,17 +183,16 @@ class PostgresTest extends TestCase
     public function testHavingReplacesAlias(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
-            ->onlyMethods(['connect', 'getConnection', 'version'])
+            ->onlyMethods(['connect', 'getConnection', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
 
         $query = new Query($connection);
         $query
@@ -215,17 +214,16 @@ class PostgresTest extends TestCase
     public function testHavingWhenNoAliasIsUsed(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Postgres')
-            ->onlyMethods(['connect', 'getConnection', 'version'])
+            ->onlyMethods(['connect', 'getConnection', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
 
         $query = new Query($connection);
         $query

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -234,18 +234,18 @@ class SqlserverTest extends TestCase
     public function testSelectLimitVersion12(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->onlyMethods(['_connect', 'getConnection', 'version'])
+            ->onlyMethods(['_connect', 'getConnection', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->method('version')
             ->will($this->returnValue('12'));
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
 
         $connection = $this->getMockBuilder('Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->method('getDriver')
-            ->will($this->returnValue($driver));
 
         $query = new Query($connection);
         $query->select(['id', 'title'])
@@ -281,20 +281,19 @@ class SqlserverTest extends TestCase
     public function testSelectLimitOldServer(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->onlyMethods(['_connect', 'getConnection', 'version'])
+            ->onlyMethods(['_connect', 'getConnection', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->expects($this->any())
             ->method('version')
             ->will($this->returnValue('8'));
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
 
         $connection = $this->getMockBuilder('Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
 
         $query = new Query($connection);
         $query->select(['id', 'title'])
@@ -408,16 +407,15 @@ class SqlserverTest extends TestCase
     public function testInsertUsesOutput(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->onlyMethods(['_connect', 'getConnection'])
+            ->onlyMethods(['_connect', 'getConnection', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
         $connection = $this->getMockBuilder('Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
         $query = new Query($connection);
         $query->insert(['title'])
             ->into('articles')
@@ -432,20 +430,19 @@ class SqlserverTest extends TestCase
     public function testHavingReplacesAlias(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->onlyMethods(['connect', 'getConnection', 'version'])
+            ->onlyMethods(['connect', 'getConnection', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->expects($this->any())
             ->method('version')
             ->will($this->returnValue('8'));
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
 
         $query = new Query($connection);
         $query
@@ -467,20 +464,19 @@ class SqlserverTest extends TestCase
     public function testHavingWhenNoAliasIsUsed(): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')
-            ->onlyMethods(['connect', 'getConnection', 'version'])
+            ->onlyMethods(['connect', 'getConnection', 'version', 'enabled'])
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->expects($this->any())
             ->method('version')
             ->will($this->returnValue('8'));
+        $driver->method('enabled')
+            ->will($this->returnValue(true));
 
         $connection = $this->getMockBuilder('\Cake\Database\Connection')
-            ->onlyMethods(['connect', 'getDriver', 'setDriver'])
-            ->setConstructorArgs([['log' => false]])
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver, 'log' => false]])
             ->getMock();
-        $connection->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
 
         $query = new Query($connection);
         $query

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -203,7 +203,7 @@ class BelongsToManyTest extends TestCase
     public function testJunctionConnection(): void
     {
         $mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['setDriver'])
+            ->onlyMethods(['createDriver'])
             ->setConstructorArgs([['name' => 'other_source']])
             ->getMock();
         ConnectionManager::setConfig('other_source', $mock);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2342,9 +2342,8 @@ class TableTest extends TestCase
 
         $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->onlyMethods(['begin', 'commit', 'inTransaction'])
-            ->setConstructorArgs([$config])
+            ->setConstructorArgs([['driver' => $this->connection->getDriver()] + $config])
             ->getMock();
-        $connection->setDriver($this->connection->getDriver());
 
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
@@ -2375,9 +2374,9 @@ class TableTest extends TestCase
         $this->expectException(PDOException::class);
         $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->onlyMethods(['begin', 'rollback'])
-            ->setConstructorArgs([ConnectionManager::getConfig('test')])
+            ->setConstructorArgs([['driver' => $this->connection->getDriver()] + ConnectionManager::getConfig('test')])
             ->getMock();
-        $connection->setDriver(ConnectionManager::get('test')->getDriver());
+
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['query', 'getConnection'])
@@ -2415,9 +2414,9 @@ class TableTest extends TestCase
     {
         $connection = $this->getMockBuilder('Cake\Database\Connection')
             ->onlyMethods(['begin', 'rollback'])
-            ->setConstructorArgs([ConnectionManager::getConfig('test')])
+            ->setConstructorArgs([['driver' => $this->connection->getDriver()] + ConnectionManager::getConfig('test')])
             ->getMock();
-        $connection->setDriver(ConnectionManager::get('test')->getDriver());
+
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['query', 'getConnection', 'exists'])


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/16095

We don't really need to support hot-swapping drivers in a connection.

Since we can't hide a public function, this deprecates it in favor of a protected implementation.