### PR TITLE
Ensure default value for $defaultTable is set in Controller's constructor.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -210,6 +210,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $plugin = $this->request->getParam('plugin');
             $modelClass = ($plugin ? $plugin . '.' : '') . $this->name;
             $this->_setModelClass($modelClass);
+
+            $this->defaultTable = $modelClass;
         }
 
         if ($components !== null) {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -209,6 +209,16 @@ class ControllerTest extends TestCase
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->Comments);
     }
 
+    public function testConstructSetDefaultTable()
+    {
+        Configure::write('App.namespace', 'TestApp');
+
+        $controller = new PostsController();
+        $this->assertInstanceOf(PostsTable::class, $controller->fetchTable());
+
+        Configure::write('App.namespace', 'App');
+    }
+
     /**
      * testConstructClassesWithComponents method
      */


### PR DESCRIPTION
Without this calling `fetchTable()` will throw an exception unless `$defaultTable` is explicitly set.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
