### PR TITLE
PHPDoc deprecated colon prefixed to braced paceholder

### DIFF
--- a/src/Routing/Route/PluginShortRoute.php
+++ b/src/Routing/Route/PluginShortRoute.php
@@ -18,7 +18,7 @@ namespace Cake\Routing\Route;
 
 /**
  * Plugin short route, that copies the plugin param to the controller parameters
- * It is used for supporting /:plugin routes.
+ * It is used for supporting /{plugin} routes.
  */
 class PluginShortRoute extends InflectedRoute
 {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -312,7 +312,7 @@ class RouteBuilder
      * });
      * ```
      *
-     * The above would generate both resource routes for `/articles`, and `/articles/:article_id/comments`.
+     * The above would generate both resource routes for `/articles`, and `/articles/{article_id}/comments`.
      * You can use the `map` option to connect additional resource methods:
      *
      * ```


### PR DESCRIPTION
I found two places where the deprecated colon prefix is used in the PHPDoc. This PR will changed them to the braced placeholder

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
