### PR TITLE
Support type inference from `TypedResultInterface` in case expressions.

### DIFF
--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -20,6 +20,7 @@ use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
+use Cake\Database\TypedResultInterface;
 use Cake\Database\ValueBinder;
 use DateTimeInterface;
 
@@ -67,6 +68,8 @@ trait CaseExpressionTrait
             $value instanceof IdentifierExpression
         ) {
             $type = $this->_typeMap->type($value->getIdentifier());
+        } elseif ($value instanceof TypedResultInterface) {
+            $type = $value->getReturnType();
         }
 
         return $type;

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -21,6 +21,7 @@ use Cake\Chronos\Date as ChronosDate;
 use Cake\Chronos\MutableDate as ChronosMutableDate;
 use Cake\Database\Expression\CaseStatementExpression;
 use Cake\Database\Expression\ComparisonExpression;
+use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\WhenThenExpression;
@@ -218,6 +219,7 @@ class CaseStatementExpressionTest extends TestCase
             [ChronosDate::now(), 'date'],
             [Chronos::now(), 'datetime'],
             [new IdentifierExpression('Table.column'), null],
+            [new FunctionExpression('SUM', ['Table.column' => 'literal'], [], 'integer'), null],
             [new stdClass(), null],
             [null, null],
         ];
@@ -252,6 +254,7 @@ class CaseStatementExpressionTest extends TestCase
             [ChronosDate::now(), 'date'],
             [Chronos::now(), 'datetime'],
             [new IdentifierExpression('Table.column'), null],
+            [new FunctionExpression('SUM', ['Table.column' => 'literal'], [], 'integer'), null],
             [['Table.column' => true], null],
             [new stdClass(), null],
         ];
@@ -287,6 +290,7 @@ class CaseStatementExpressionTest extends TestCase
             [ChronosDate::now(), 'date'],
             [Chronos::now(), 'datetime'],
             [new IdentifierExpression('Table.column'), 'boolean'],
+            [new FunctionExpression('SUM', ['Table.column' => 'literal'], [], 'integer'), 'integer'],
             [new stdClass(), null],
             [null, null],
         ];

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -212,12 +212,19 @@ class CaseStatementExpressionTest extends TestCase
     public function valueTypeInferenceDataProvider(): array
     {
         return [
+            // Values that should have their type inferred because
+            // they will be bound by the case expression.
             ['1', 'string'],
             [1, 'integer'],
             [1.0, 'float'],
             [true, 'boolean'],
             [ChronosDate::now(), 'date'],
             [Chronos::now(), 'datetime'],
+
+            // Values that should not have a type inferred, either
+            // because they are not bound by the case expression,
+            // and/or because their type is obtained differently
+            // (for example from a type map).
             [new IdentifierExpression('Table.column'), null],
             [new FunctionExpression('SUM', ['Table.column' => 'literal'], [], 'integer'), null],
             [new stdClass(), null],
@@ -247,12 +254,19 @@ class CaseStatementExpressionTest extends TestCase
     public function whenTypeInferenceDataProvider(): array
     {
         return [
+            // Values that should have their type inferred because
+            // they will be bound by the case expression.
             ['1', 'string'],
             [1, 'integer'],
             [1.0, 'float'],
             [true, 'boolean'],
             [ChronosDate::now(), 'date'],
             [Chronos::now(), 'datetime'],
+
+            // Values that should not have a type inferred, either
+            // because they are not bound by the case expression,
+            // and/or because their type is obtained differently
+            // (for example from a type map).
             [new IdentifierExpression('Table.column'), null],
             [new FunctionExpression('SUM', ['Table.column' => 'literal'], [], 'integer'), null],
             [['Table.column' => true], null],
@@ -283,6 +297,8 @@ class CaseStatementExpressionTest extends TestCase
     public function resultTypeInferenceDataProvider(): array
     {
         return [
+            // Unless a result type has been set manually, values
+            // should have their type inferred when possible.
             ['1', 'string'],
             [1, 'integer'],
             [1.0, 'float'],


### PR DESCRIPTION
This allows to infer the case expression's result type from the `then()`
and `else()` values when using expressions like `sum()` that provide a
result type themselves.