### PR TITLE
Update cache key used by Table::get()

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1531,7 +1531,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($cacheConfig) {
             if (!$cacheKey) {
                 $cacheKey = sprintf(
-                    'get:%s.%s%s',
+                    'get-%s.%s%s',
                     $this->getConnection()->configName(),
                     $this->getTable(),
                     json_encode($primaryKey)

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1531,7 +1531,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($cacheConfig) {
             if (!$cacheKey) {
                 $cacheKey = sprintf(
-                    'get-%s.%s%s',
+                    'get-%s-%s-%s',
                     $this->getConnection()->configName(),
                     $this->getTable(),
                     json_encode($primaryKey)

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5347,7 +5347,7 @@ class TableTest extends TestCase
         return [
             [
                 ['fields' => ['id'], 'cache' => 'default'],
-                'get:test.table_name[10]', 'default',
+                'get-test-table_name-[10]', 'default',
             ],
             [
                 ['fields' => ['id'], 'cache' => 'default', 'key' => 'custom_key'],


### PR DESCRIPTION
Make the cache key used by Table::get() to be compatible with FileEngine. While it isn't a great to use local files for ORM query results, it can be useful in local development environments. We shouldn't use cache keys that won't work in all engines.

Fixes #16108