### PR TITLE
Add HSTS header to HttpsEnforcerMiddleware

### DIFF
--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -23,6 +23,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use UnexpectedValueException;
 
 /**
  * Enforces use of HTTPS (SSL) for requests.
@@ -38,6 +39,12 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
      * - `statusCode` - Status code to use in case of redirect, defaults to 301 - Permanent redirect.
      * - `headers` - Array of response headers in case of redirect.
      * - `disableOnDebug` - Whether HTTPS check should be disabled when debug is on. Default `true`.
+     * - 'hsts' - Strict-Transport-Security header for HTTPS response configuration. Defaults to `null`.
+     *    If enabled, an array of config options:
+     *
+     *        - 'maxAge' - `max-age` directive value in seconds.
+     *        - 'includeSubDomains' - Whether to include `includeSubDomains` directive. Defaults to `false`.
+     *        - 'preload' - Whether to include 'preload' directive. Defauls to `false`.
      *
      * @var array<string, mixed>
      */
@@ -46,6 +53,7 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
         'statusCode' => 301,
         'headers' => [],
         'disableOnDebug' => true,
+        'hsts' => null,
     ];
 
     /**
@@ -77,7 +85,12 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
             || ($this->config['disableOnDebug']
                 && Configure::read('debug'))
         ) {
-            return $handler->handle($request);
+            $response = $handler->handle($request);
+            if ($this->config['hsts']) {
+                $response = $this->addHsts($response);
+            }
+
+            return $response;
         }
 
         if ($this->config['redirect'] && $request->getMethod() === 'GET') {
@@ -93,5 +106,29 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
         throw new BadRequestException(
             'Requests to this URL must be made with HTTPS.'
         );
+    }
+
+    /**
+     * Adds Strict-Transport-Security header to response.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response Response
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    protected function addHsts(ResponseInterface $response): ResponseInterface
+    {
+        $config = $this->config['hsts'];
+        if (!is_array($config)) {
+            throw new UnexpectedValueException('The `hsts` config must be an array.');
+        }
+
+        $value = 'max-age=' . $config['maxAge'];
+        if ($config['includeSubDomains'] ?? false) {
+            $value .= '; includeSubDomains';
+        }
+        if ($config['preload'] ?? false) {
+            $value .= '; preload';
+        }
+
+        return $response->withHeader('strict-transport-security', $value);
     }
 }

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -25,6 +25,7 @@ use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Laminas\Diactoros\Uri;
 use TestApp\Http\TestRequestHandler;
+use UnexpectedValueException;
 
 /**
  * Test for HttpsEnforcerMiddleware
@@ -60,6 +61,57 @@ class HttpsEnforcerMiddlewareTest extends TestCase
         $result = $middleware->process($request, $handler);
         $this->assertInstanceOf(Response::class, $result);
         $this->assertSame('success', (string)$result->getBody());
+    }
+
+    public function testHstsResponse(): void
+    {
+        $uri = new Uri('https://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri);
+
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response(['body' => 'success']);
+        });
+
+        $middleware = new HttpsEnforcerMiddleware(['hsts' => ['maxAge' => 63072000]]);
+
+        $result = $middleware->process($request, $handler);
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('max-age=63072000', $result->getHeaderLine('strict-transport-security'));
+    }
+
+    public function testHstsResponseWithDirectives(): void
+    {
+        $uri = new Uri('https://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri);
+
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response(['body' => 'success']);
+        });
+
+        $middleware = new HttpsEnforcerMiddleware(['hsts' => ['maxAge' => 63072000, 'includeSubDomains' => true, 'preload' => true]]);
+
+        $result = $middleware->process($request, $handler);
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('max-age=63072000; includeSubDomains; preload', $result->getHeaderLine('strict-transport-security'));
+    }
+
+    public function testHstsResponseInvalidConfig(): void
+    {
+        $uri = new Uri('https://localhost/foo');
+        $request = new ServerRequest();
+        $request = $request->withUri($uri);
+
+        $handler = new TestRequestHandler(function ($req) {
+            return new Response(['body' => 'success']);
+        });
+
+        $middleware = new HttpsEnforcerMiddleware(['hsts' => true]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('The `hsts` config must be an array.');
+        $middleware->process($request, $handler);
     }
 
     public function testRedirect(): void


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/16092

Not sure if the directive options should just be an array of header values, but users can generate an invalid header that way.