### PR TITLE
Add prefer lowest version validation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,8 @@ jobs:
         fi
 
     - name: Prefer lowest check
-      run: |
-        if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
-          composer lowest-setup && composer lowest
-        fi
+      if: matrix.prefer-lowest == 'prefer-lowest'
+      run: composer lowest-setup && composer lowest
 
     - name: Submit code coverage
       if: matrix.php-version == '8.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,12 @@ jobs:
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --testsuite=database
         fi
 
+    - name: Prefer lowest check
+      run: |
+        if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
+          composer lowest-setup && composer lowest
+        fi
+
     - name: Submit code coverage
       if: matrix.php-version == '8.0'
       uses: codecov/codecov-action@v1

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1",
-        "league/container": "^4.1.1",
+        "league/container": "^4.2.0",
         "psr/container": "^1.1 || ^2.0",
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,8 @@
         ],
         "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
         "stan-setup": "cp composer.json composer.backup && composer require --dev symfony/polyfill-php81 phpstan/phpstan:~1.0.0 psalm/phar:~4.11.0 && mv composer.backup composer.json",
+        "lowest": "validate-prefer-lowest",
+        "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",
         "test-coverage": "phpunit --coverage-clover=clover.xml"
     },


### PR DESCRIPTION
Will show an error/warning if the versions promised are not actually possible to "get"

Right now this still fails with
```
> validate-prefer-lowest
1 error (make sure you ran `composer update --prefer-lowest` before):
 - psr/container: Defined `1.1.0.0` as minimum, but is `2.0.0.0`
```

With this we will get notified now in the future if at any point we lose our promised min constraint.
