### PR TITLE
Fix up setting helpers as normalized.

### DIFF
--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -343,7 +343,15 @@ class ViewBuilder implements JsonSerializable
      */
     public function setHelpers(array $helpers)
     {
-        $this->_helpers = $helpers;
+        $this->_helpers = [];
+
+        foreach ($helpers as $helper => $config) {
+            if (is_int($helper)) {
+                $helper = $config;
+                $config = [];
+            }
+            $this->addHelper($helper, $config);
+        }
 
         return $this;
     }

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -292,7 +292,7 @@ class DebuggerTest extends TestCase
     public function testExportVar(): void
     {
         $Controller = new Controller();
-        $Controller->viewBuilder()->setHelpers(['Html', 'Form'], false);
+        $Controller->viewBuilder()->setHelpers(['Html', 'Form']);
         $View = $Controller->createView();
         $View->int = 2;
         $View->float = 1.333;
@@ -311,8 +311,12 @@ object(Cake\View\View) id:0 {
   [protected] plugin => null
   [protected] name => ''
   [protected] helpers => [
-    (int) 0 => 'Html',
-    (int) 1 => 'Form'
+    'Html' => [
+      '' => [maximum depth reached]
+    ],
+    'Form' => [
+      '' => [maximum depth reached]
+    ]
   ]
   [protected] templatePath => ''
   [protected] template => ''

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -673,7 +673,7 @@ class ExceptionRendererTest extends TestCase
         $controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->onlyMethods(['render'])
             ->getMock();
-        $controller->viewBuilder()->setHelpers(['Fail', 'Boom'], false);
+        $controller->viewBuilder()->setHelpers(['Fail', 'Boom']);
         $controller->setRequest(new ServerRequest());
         $controller->expects($this->once())
             ->method('render')
@@ -722,7 +722,7 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
 
         $controller = new Controller();
-        $controller->viewBuilder()->setHelpers(['Fail', 'Boom'], false);
+        $controller->viewBuilder()->setHelpers(['Fail', 'Boom']);
         $controller->getEventManager()->on(
             'Controller.beforeRender',
             function (EventInterface $event): void {

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -302,7 +302,7 @@ class MailerTest extends TestCase
         $this->assertInstanceOf(DebugTransport::class, $result);
 
         $result = $this->mailer->viewBuilder()->getHelpers();
-        $this->assertEquals($config['helpers'], $result);
+        $this->assertEquals(['Html' => [], 'Form' => []], $result);
 
         Mailer::drop('test');
     }
@@ -912,7 +912,7 @@ class MailerTest extends TestCase
         $this->mailer->viewBuilder()
             ->setTemplate('custom_helper')
             ->setLayout('default')
-            ->setHelpers(['Time'], false);
+            ->setHelpers(['Time']);
         $this->mailer->setViewVars(['time' => $timestamp]);
 
         $result = $this->mailer->send();
@@ -921,7 +921,7 @@ class MailerTest extends TestCase
         $this->assertStringContainsString('Right now: ' . $dateTime->format($dateTime::ATOM), $result['message']);
 
         $result = $this->mailer->viewBuilder()->getHelpers();
-        $this->assertEquals(['Time'], $result);
+        $this->assertEquals(['Time' => []], $result);
     }
 
     /**

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -219,7 +219,7 @@ class ViewBuilderTest extends TestCase
             ->setTemplate('edit')
             ->setLayout('default')
             ->setTemplatePath('Articles/')
-            ->setHelpers(['Form', 'Html'], false)
+            ->setHelpers(['Form', 'Html'])
             ->setLayoutPath('Admin/')
             ->setTheme('TestTheme')
             ->setPlugin('TestPlugin')

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -289,7 +289,7 @@ class ViewBuilderTest extends TestCase
         $builder
             ->setTemplate('default')
             ->setLayout('test')
-            ->setHelpers(['Html'], false)
+            ->setHelpers(['Html'])
             ->setClassName('JsonView');
 
         $result = json_decode(json_encode($builder), true);
@@ -297,7 +297,7 @@ class ViewBuilderTest extends TestCase
         $expected = [
             '_template' => 'default',
             '_layout' => 'test',
-            '_helpers' => ['Html'],
+            '_helpers' => ['Html' => []],
             '_className' => 'JsonView',
             '_autoLayout' => true,
         ];
@@ -317,7 +317,7 @@ class ViewBuilderTest extends TestCase
         $builder
             ->setTemplate('default')
             ->setLayout('test')
-            ->setHelpers(['Html'], false)
+            ->setHelpers(['Html'])
             ->setClassName('JsonView');
 
         $result = json_encode($builder);
@@ -327,7 +327,7 @@ class ViewBuilderTest extends TestCase
 
         $this->assertSame('default', $builder->getTemplate());
         $this->assertSame('test', $builder->getLayout());
-        $this->assertEquals(['Html'], $builder->getHelpers());
+        $this->assertEquals(['Html' => []], $builder->getHelpers());
         $this->assertSame('JsonView', $builder->getClassName());
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -989,7 +989,7 @@ class ViewTest extends TestCase
      */
     public function testRenderLoadHelper(): void
     {
-        $this->PostsController->viewBuilder()->setHelpers(['Form', 'Number'], false);
+        $this->PostsController->viewBuilder()->setHelpers(['Form', 'Number']);
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
 


### PR DESCRIPTION
Completes https://github.com/cakephp/cakephp/pull/15886

With this, the addHelper() can actually (re)set a helper based on the same name.
If we allow the old messy 4.x way of not normalized input the helper without config array would be in the value, not the (then numeric) key, making replacement impossible, and also adding twice the same helper with different config possible until runtime.

I actually currently have problems with this trying to upgrade an app to 4.3 and new way, as I have no good way of resetting helper config if needed to be defined differently in a subcontroller.
I am not sure how we can backport some of this in a BC way.