### PR TITLE
Allow plugin helpers to merge/overwrite with normal helpers.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -375,7 +375,8 @@ class View implements EventDispatcherInterface
      * @param array<string, mixed> $config
      * @return void
      */
-    protected function addHelper(string $helper, array $config = []): void {
+    protected function addHelper(string $helper, array $config = []): void
+    {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
             $config = [

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -360,7 +360,7 @@ class View implements EventDispatcherInterface
      * So this method allows you to manipulate them as required after view instance
      * is constructed.
      *
-     * Helpers be added using {@link addHelper()} method.
+     * Helpers can be added using {@link addHelper()} method.
      *
      * @return void
      */

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -360,10 +360,31 @@ class View implements EventDispatcherInterface
      * So this method allows you to manipulate them as required after view instance
      * is constructed.
      *
+     * Helpers be added using {@link addHelper()} method.
+     *
      * @return void
      */
     public function initialize(): void
     {
+    }
+
+    /**
+     * Allows adding helpers from initialize() hook, overwriting any previously set ones.
+     *
+     * @param string $helper
+     * @param array<string, mixed> $config
+     * @return void
+     */
+    protected function addHelper(string $helper, array $config = []): void {
+        [$plugin, $name] = pluginSplit($helper);
+        if ($plugin) {
+            $config = [
+                'class' => $helper,
+                'config' => $config,
+            ];
+        }
+
+        $this->helpers[$name] = $config;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -369,15 +369,42 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Allows adding helpers from initialize() hook, overwriting any previously set ones.
+     * Allows setting helpers from initialize() hook, overwriting any previously set ones.
      *
      * @param string $helper
      * @param array<string, mixed> $config
      * @return void
      */
+    protected function setHelper(string $helper, array $config = []): void
+    {
+        [$plugin, $name] = pluginSplit($helper);
+        if ($plugin) {
+            $config = [
+                'class' => $helper,
+                'config' => $config,
+            ];
+        }
+
+        $this->helpers[$name] = $config;
+    }
+
+    /**
+     * Allows adding helpers from initialize() hook if no such helper was previously set.
+     *
+     * @param string $helper
+     * @param array<string, mixed> $config
+     * @return void
+     * @throws \RuntimeException When a duplicate is found.
+     */
     protected function addHelper(string $helper, array $config = []): void
     {
         [$plugin, $name] = pluginSplit($helper);
+        if (isset($this->helpers[$name])) {
+            $message = sprintf('The `%s` alias has already been added as helper. Use `setHelper()` instead.', $name);
+
+            throw new RuntimeException($message);
+        }
+
         if ($plugin) {
             $config = [
                 'class' => $helper,

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -379,10 +379,7 @@ class View implements EventDispatcherInterface
     {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
-            $config = [
-                'class' => $helper,
-                'config' => $config,
-            ];
+            $config['className'] = $helper;
         }
 
         $this->helpers[$name] = $config;
@@ -406,10 +403,7 @@ class View implements EventDispatcherInterface
         }
 
         if ($plugin) {
-            $config = [
-                'class' => $helper,
-                'config' => $config,
-            ];
+            $config['className'] = $helper;
         }
 
         $this->helpers[$name] = $config;

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\View;
 
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -306,7 +307,7 @@ class ViewBuilder implements JsonSerializable
      * @param string $helper Helper to use.
      * @param array<string, mixed> $options Options.
      * @return $this
-     * @throws \RuntimeException When a duplicate is found.
+     * @throws \Cake\Core\Exception\CakeException When a duplicate is found.
      * @since 4.1.0
      */
     public function addHelper(string $helper, array $options = [])
@@ -355,7 +356,7 @@ class ViewBuilder implements JsonSerializable
      *
      * @param array $helpers Helpers to use.
      * @return $this
-     * @throws \RuntimeException When a duplicate is found.
+     * @throws \Cake\Core\Exception\CakeException When a duplicate is found.
      * @since 4.3.0
      */
     public function addHelpers(array $helpers)

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -306,7 +306,6 @@ class ViewBuilder implements JsonSerializable
      * @param string $helper Helper to use.
      * @param array<string, mixed> $options Options.
      * @return $this
-     * @throws \Cake\Core\Exception\CakeException When a duplicate is found.
      * @since 4.1.0
      */
     public function addHelper(string $helper, array $options = [])

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -301,14 +301,44 @@ class ViewBuilder implements JsonSerializable
     }
 
     /**
-     * Adds a helper to use.
+     * Adds a helper to use if no such helper with this name already exists.
      *
      * @param string $helper Helper to use.
      * @param array<string, mixed> $options Options.
      * @return $this
+     * @throws \RuntimeException When a duplicate is found.
      * @since 4.1.0
      */
     public function addHelper(string $helper, array $options = [])
+    {
+        [$plugin, $name] = pluginSplit($helper);
+        if (isset($this->_helpers[$name])) {
+            $message = sprintf('The `%s` alias has already been added as helper. Use `setHelper()` instead.', $name);
+
+            throw new RuntimeException($message);
+        }
+
+        if ($plugin) {
+            $options = [
+                'class' => $helper,
+                'config' => $options,
+            ];
+        }
+
+        $this->_helpers[$name] = $options;
+
+        return $this;
+    }
+
+    /**
+     * Adds a helper to use, overwriting any existing one with that name.
+     *
+     * @param string $helper Helper to use.
+     * @param array<string, mixed> $options Options.
+     * @return $this
+     * @since 4.4.0
+     */
+    public function setHelper(string $helper, array $options = [])
     {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
@@ -324,10 +354,11 @@ class ViewBuilder implements JsonSerializable
     }
 
     /**
-     * Adds helpers to use by merging with existing ones.
+     * Adds helpers to use if no helper with those names already exists.
      *
      * @param array $helpers Helpers to use.
      * @return $this
+     * @throws \RuntimeException When a duplicate is found.
      * @since 4.3.0
      */
     public function addHelpers(array $helpers)

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -340,10 +340,7 @@ class ViewBuilder implements JsonSerializable
     {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
-            $options = [
-                'class' => $helper,
-                'config' => $options,
-            ];
+            $options['className'] = $helper;
         }
 
         $this->_helpers[$name] = $options;

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -315,14 +315,11 @@ class ViewBuilder implements JsonSerializable
         if (isset($this->_helpers[$name])) {
             $message = sprintf('The `%s` alias has already been added as helper. Use `setHelper()` instead.', $name);
 
-            throw new RuntimeException($message);
+            throw new CakeException($message);
         }
 
         if ($plugin) {
-            $options = [
-                'class' => $helper,
-                'config' => $options,
-            ];
+            $options['className'] = $helper;
         }
 
         $this->_helpers[$name] = $options;

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -310,7 +310,15 @@ class ViewBuilder implements JsonSerializable
      */
     public function addHelper(string $helper, array $options = [])
     {
-        $this->_helpers[$helper] = $options;
+        [$plugin, $name] = pluginSplit($helper);
+        if ($plugin) {
+            $options = [
+                'class' => $helper,
+                'config' => $options,
+            ];
+        }
+
+        $this->_helpers[$name] = $options;
 
         return $this;
     }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -22,6 +22,7 @@ use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingViewException;
 use Cake\View\ViewBuilder;
+use RuntimeException;
 
 /**
  * View builder test case.
@@ -193,7 +194,7 @@ class ViewBuilderTest extends TestCase
     {
         $builder = new ViewBuilder();
         $builder->addHelper('Form');
-        $builder->addHelpers(['Form' => ['config' => 'value']]);
+        $builder->setHelpers(['Form' => ['config' => 'value']]);
 
         $helpers = $builder->getHelpers();
         $expected = [
@@ -441,14 +442,28 @@ class ViewBuilderTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $helpers['Text']);
     }
 
+    /**
+     * @return void
+     */
+    public function testAddHelperException(): void
+    {
+        $builder = new ViewBuilder();
+        $builder->addHelper('Form', ['some' => 'config']);
+        $builder->addHelper('Text', ['foo' => 'bar']);
+
+        $this->expectException(RuntimeException::class);
+
+        $builder->addHelper('MyPlugin.Form');
+    }
+
     public function testAddHelperPluginOptions(): void
     {
         $builder = new ViewBuilder();
         $builder->addHelper('Form', ['some' => 'config']);
         $builder->addHelper('Text', ['foo' => 'bar']);
 
-        $builder->addHelper('MyPlugin.Form');
-        $builder->addHelper('MyPlugin.Text', ['foo' => 'other']);
+        $builder->setHelper('MyPlugin.Form');
+        $builder->setHelper('MyPlugin.Text', ['foo' => 'other']);
 
         $helpers = $builder->getHelpers();
         $expected = [

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -468,14 +468,11 @@ class ViewBuilderTest extends TestCase
         $helpers = $builder->getHelpers();
         $expected = [
             'Form' => [
-                'class' => 'MyPlugin.Form',
-                'config' => [],
+                'className' => 'MyPlugin.Form',
             ],
             'Text' => [
-                'class' => 'MyPlugin.Text',
-                'config' => [
-                    'foo' => 'other',
-                ],
+                'foo' => 'other',
+                'className' => 'MyPlugin.Text',
             ],
         ];
 

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingViewException;
 use Cake\View\ViewBuilder;
-use RuntimeException;
 
 /**
  * View builder test case.
@@ -451,7 +451,7 @@ class ViewBuilderTest extends TestCase
         $builder->addHelper('Form', ['some' => 'config']);
         $builder->addHelper('Text', ['foo' => 'bar']);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
 
         $builder->addHelper('MyPlugin.Form');
     }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -440,4 +440,30 @@ class ViewBuilderTest extends TestCase
         $helpers = $builder->getHelpers();
         $this->assertSame(['foo' => 'bar'], $helpers['Text']);
     }
+
+    public function testAddHelperPluginOptions(): void
+    {
+        $builder = new ViewBuilder();
+        $builder->addHelper('Form', ['some' => 'config']);
+        $builder->addHelper('Text', ['foo' => 'bar']);
+
+        $builder->addHelper('MyPlugin.Form');
+        $builder->addHelper('MyPlugin.Text', ['foo' => 'other']);
+
+        $helpers = $builder->getHelpers();
+        $expected = [
+            'Form' => [
+                'class' => 'MyPlugin.Form',
+                'config' => [],
+            ],
+            'Text' => [
+                'class' => 'MyPlugin.Text',
+                'config' => [
+                    'foo' => 'other',
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $helpers);
+    }
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -989,7 +989,7 @@ class ViewTest extends TestCase
      */
     public function testRenderLoadHelper(): void
     {
-        $this->PostsController->viewBuilder()->setHelpers(['Form', 'Number']);
+        $this->PostsController->viewBuilder()->addHelpers(['Form', 'Number']);
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
 
@@ -1000,7 +1000,8 @@ class ViewTest extends TestCase
         // HtmlHelper is loaded in TestView::initialize()
         $this->assertEquals(['Form', 'Number', 'Html'], $attached);
 
-        $this->PostsController->viewBuilder()->addHelpers(
+        // We need to use setHelpers() to allow overwriting now
+        $this->PostsController->viewBuilder()->setHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
         );
         $View = $this->PostsController->createView(TestView::class);
@@ -1010,7 +1011,7 @@ class ViewTest extends TestCase
         $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
-        $expected = ['Form', 'Number', 'Html', 'PluggedHelper'];
+        $expected = ['Html', 'Form', 'Number', 'PluggedHelper'];
         $this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -998,7 +998,7 @@ class ViewTest extends TestCase
 
         $attached = $View->helpers()->loaded();
         // HtmlHelper is loaded in TestView::initialize()
-        $this->assertEquals(['Html', 'Form', 'Number'], $attached);
+        $this->assertEquals(['Form', 'Number', 'Html'], $attached);
 
         $this->PostsController->viewBuilder()->addHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
@@ -1010,7 +1010,7 @@ class ViewTest extends TestCase
         $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
-        $expected = ['Html', 'Form', 'Number', 'PluggedHelper'];
+        $expected = ['Form', 'Number', 'Html', 'PluggedHelper'];
         $this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1000,7 +1000,7 @@ class ViewTest extends TestCase
         // HtmlHelper is loaded in TestView::initialize()
         $this->assertEquals(['Html', 'Form', 'Number'], $attached);
 
-        $this->PostsController->viewBuilder()->addHelpers(
+        $this->PostsController->viewBuilder()->setHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
         );
         $View = $this->PostsController->createView(TestView::class);

--- a/tests/test_app/TestApp/View/TestStringTemplate.php
+++ b/tests/test_app/TestApp/View/TestStringTemplate.php
@@ -12,7 +12,7 @@ class TestStringTemplate
     use StringTemplateTrait;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -7,7 +7,7 @@ class TestView extends AppView
 {
     public function initialize(): void
     {
-        $this->addHelper('Html', ['mykey' => 'myval']);
+        $this->setHelper('Html', ['mykey' => 'myval']);
     }
 
     /**

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -7,7 +7,7 @@ class TestView extends AppView
 {
     public function initialize(): void
     {
-        $this->loadHelper('Html', ['mykey' => 'myval']);
+        $this->addHelper('Html', ['mykey' => 'myval']);
     }
 
     /**


### PR DESCRIPTION
Is there any downside of normalizing directly on setting?
It seems this is the only way to allow plugin and normal helpers to be used side by side properly.

        $this->initialize();
        $this->loadHelpers();

In one scenario a plugin overwrites specific helpers, or the other way around.
Using a non-normalized way makes them end up twice in the config, failing then on load due to the same name in the end, MyPluginOne.Form vs MyPluginTwo.Form etc.

If we merge using normalized from the start, we can skip this part in the ObjectRegistry in the future, and also dont have any issues with overwriting - especially since you dont have access to the defined helpers and cannot unset one specific one, only all.

---

In a different case the AppView in initialize() defines certain helpers globally using ->loadHelper() as per docs
But in specific controllers I need a custom/different config or helper and here, `->viewBuilder()->addHelper()` leads to the duplicate loaded exception. The controller ones are set via action and therefore they come after the init part ran already.
Here, it would be best if it wouldnt directly loadHelpers, but addHelper() in the view, until actually loading all of them IMO.