### PR TITLE
Allow plugin helpers to merge/overwrite with normal helpers. Setup part.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -375,7 +375,8 @@ class View implements EventDispatcherInterface
      * @param array<string, mixed> $config
      * @return void
      */
-    protected function addHelper(string $helper, array $config = []): void {
+    protected function addHelper(string $helper, array $config = []): void
+    {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
             $config = [

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -360,7 +360,7 @@ class View implements EventDispatcherInterface
      * So this method allows you to manipulate them as required after view instance
      * is constructed.
      *
-     * Helpers be added using {@link addHelper()} method.
+     * Helpers can be added using {@link addHelper()} method.
      *
      * @return void
      */

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -360,10 +360,31 @@ class View implements EventDispatcherInterface
      * So this method allows you to manipulate them as required after view instance
      * is constructed.
      *
+     * Helpers be added using {@link addHelper()} method.
+     *
      * @return void
      */
     public function initialize(): void
     {
+    }
+
+    /**
+     * Allows adding helpers from initialize() hook, overwriting any previously set ones.
+     *
+     * @param string $helper
+     * @param array<string, mixed> $config
+     * @return void
+     */
+    protected function addHelper(string $helper, array $config = []): void {
+        [$plugin, $name] = pluginSplit($helper);
+        if ($plugin) {
+            $config = [
+                'class' => $helper,
+                'config' => $config,
+            ];
+        }
+
+        $this->helpers[$name] = $config;
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -369,15 +369,42 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Allows adding helpers from initialize() hook, overwriting any previously set ones.
+     * Allows setting helpers from initialize() hook, overwriting any previously set ones.
      *
      * @param string $helper
      * @param array<string, mixed> $config
      * @return void
      */
+    protected function setHelper(string $helper, array $config = []): void
+    {
+        [$plugin, $name] = pluginSplit($helper);
+        if ($plugin) {
+            $config = [
+                'class' => $helper,
+                'config' => $config,
+            ];
+        }
+
+        $this->helpers[$name] = $config;
+    }
+
+    /**
+     * Allows adding helpers from initialize() hook if no such helper was previously set.
+     *
+     * @param string $helper
+     * @param array<string, mixed> $config
+     * @return void
+     * @throws \RuntimeException When a duplicate is found.
+     */
     protected function addHelper(string $helper, array $config = []): void
     {
         [$plugin, $name] = pluginSplit($helper);
+        if (isset($this->helpers[$name])) {
+            $message = sprintf('The `%s` alias has already been added as helper. Use `setHelper()` instead.', $name);
+
+            throw new RuntimeException($message);
+        }
+
         if ($plugin) {
             $config = [
                 'class' => $helper,

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -379,10 +379,7 @@ class View implements EventDispatcherInterface
     {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
-            $config = [
-                'class' => $helper,
-                'config' => $config,
-            ];
+            $config['className'] = $helper;
         }
 
         $this->helpers[$name] = $config;
@@ -406,10 +403,7 @@ class View implements EventDispatcherInterface
         }
 
         if ($plugin) {
-            $config = [
-                'class' => $helper,
-                'config' => $config,
-            ];
+            $config['className'] = $helper;
         }
 
         $this->helpers[$name] = $config;

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -989,7 +989,7 @@ class ViewTest extends TestCase
      */
     public function testRenderLoadHelper(): void
     {
-        $this->PostsController->viewBuilder()->setHelpers(['Form', 'Number']);
+        $this->PostsController->viewBuilder()->addHelpers(['Form', 'Number']);
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
 
@@ -1000,7 +1000,8 @@ class ViewTest extends TestCase
         // HtmlHelper is loaded in TestView::initialize()
         $this->assertEquals(['Form', 'Number', 'Html'], $attached);
 
-        $this->PostsController->viewBuilder()->addHelpers(
+        // We need to use setHelpers() to allow overwriting now
+        $this->PostsController->viewBuilder()->setHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
         );
         $View = $this->PostsController->createView(TestView::class);
@@ -1010,7 +1011,7 @@ class ViewTest extends TestCase
         $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
-        $expected = ['Form', 'Number', 'Html', 'PluggedHelper'];
+        $expected = ['Html', 'Form', 'Number', 'PluggedHelper'];
         $this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -998,7 +998,7 @@ class ViewTest extends TestCase
 
         $attached = $View->helpers()->loaded();
         // HtmlHelper is loaded in TestView::initialize()
-        $this->assertEquals(['Html', 'Form', 'Number'], $attached);
+        $this->assertEquals(['Form', 'Number', 'Html'], $attached);
 
         $this->PostsController->viewBuilder()->addHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
@@ -1010,7 +1010,7 @@ class ViewTest extends TestCase
         $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
-        $expected = ['Html', 'Form', 'Number', 'PluggedHelper'];
+        $expected = ['Form', 'Number', 'Html', 'PluggedHelper'];
         $this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
     }
 

--- a/tests/test_app/TestApp/View/TestStringTemplate.php
+++ b/tests/test_app/TestApp/View/TestStringTemplate.php
@@ -12,7 +12,7 @@ class TestStringTemplate
     use StringTemplateTrait;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_defaultConfig = [];
 }

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -7,7 +7,7 @@ class TestView extends AppView
 {
     public function initialize(): void
     {
-        $this->addHelper('Html', ['mykey' => 'myval']);
+        $this->setHelper('Html', ['mykey' => 'myval']);
     }
 
     /**

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -7,7 +7,7 @@ class TestView extends AppView
 {
     public function initialize(): void
     {
-        $this->loadHelper('Html', ['mykey' => 'myval']);
+        $this->addHelper('Html', ['mykey' => 'myval']);
     }
 
     /**


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/16120

This deals with the issue of controller coming after initialize() and therefore impossible to exchange certain helpers at runtime from controller.

This used to be possible/working with old syntax and controllers defining everything, but became somewhat a regression in 4.x that needs workaround when trying to get to latest non-deprecated way.
See https://github.com/dereuromark/cakephp-sandbox/commit/431454d28f2dedbc9c5bb300a980ac95a54ad1e9#diff-7ce94e25086141d528159c348420051b7671dedd3575e0250e563537feaa2f50R56

With this, we addHelper() and any addHelper from the controller action will nicely merge and we have the expected result as before.

loadHelper() can still be used from within any template, of course, where needed.