### PR TITLE
Allow for excluding views from listTables()

### DIFF
--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -61,9 +61,9 @@ class CachedCollection implements CollectionInterface
     /**
      * @inheritDoc
      */
-    public function listTables(): array
+    public function listTables(array $options = []): array
     {
-        return $this->collection->listTables();
+        return $this->collection->listTables($options);
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -71,11 +71,10 @@ class CachedCollection implements CollectionInterface
         return $this->collection->listTablesOptions($options);
     }
 
-
     /**
      * @inheritDoc
      */
-    public function listTablesExcludeViews() : array
+    public function listTablesExcludeViews(): array
     {
         return $this->listTablesOptions(['excludeViews' => true]);
     }
@@ -83,7 +82,7 @@ class CachedCollection implements CollectionInterface
     /**
      * @inheritDoc
      */
-    public function listTables() : array
+    public function listTables(): array
     {
         return $this->listTablesOptions([]);
     }

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -20,7 +20,6 @@ use Psr\SimpleCache\CacheInterface;
 
 /**
  * Decorates a schema collection and adds caching
- *
  */
 class CachedCollection implements CollectionInterface
 {

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -79,7 +79,7 @@ class CachedCollection implements CollectionInterface
      */
     public function listTables(): array
     {
-        return $this->listTablesAndViews();
+        return $this->collection->listTables();
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -20,6 +20,11 @@ use Psr\SimpleCache\CacheInterface;
 
 /**
  * Decorates a schema collection and adds caching
+ *
+ * @method array listTablesOptions(array $options = []) Get the list of tables available in the current connection.
+ *    Allows for an options array which can be used to modify the results.
+ * @method array listTablesExcludeViews() Get the list of tables, excluding any views,
+ *    available in the current connection.
  */
 class CachedCollection implements CollectionInterface
 {
@@ -61,9 +66,26 @@ class CachedCollection implements CollectionInterface
     /**
      * @inheritDoc
      */
-    public function listTables(array $options = []): array
+    public function listTablesOptions(array $options = []): array
     {
-        return $this->collection->listTables($options);
+        return $this->collection->listTablesOptions($options);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function listTablesExcludeViews() : array
+    {
+        return $this->listTablesOptions(['excludeViews' => true]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function listTables() : array
+    {
+        return $this->listTablesOptions([]);
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -21,10 +21,10 @@ use Psr\SimpleCache\CacheInterface;
 /**
  * Decorates a schema collection and adds caching
  *
- * @method array listTablesOptions(array $options = []) Get the list of tables available in the current connection.
- *    Allows for an options array which can be used to modify the results.
- * @method array listTablesExcludeViews() Get the list of tables, excluding any views,
- *    available in the current connection.
+ * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
+ * This will include any views in the schema.
+ * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
+ * This will exclude any views in the schema.
  */
 class CachedCollection implements CollectionInterface
 {
@@ -66,17 +66,17 @@ class CachedCollection implements CollectionInterface
     /**
      * @inheritDoc
      */
-    public function listTablesOptions(array $options = []): array
+    public function listTablesAndViews(): array
     {
-        return $this->collection->listTablesOptions($options);
+        return $this->collection->listTablesAndViews();
     }
 
     /**
      * @inheritDoc
      */
-    public function listTablesExcludeViews(): array
+    public function listTablesWithoutViews(): array
     {
-        return $this->listTablesOptions(['excludeViews' => true]);
+        return $this->collection->listTablesWithoutViews();
     }
 
     /**
@@ -84,7 +84,7 @@ class CachedCollection implements CollectionInterface
      */
     public function listTables(): array
     {
-        return $this->listTablesOptions([]);
+        return $this->listTablesAndViews();
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -79,7 +79,7 @@ class CachedCollection implements CollectionInterface
      */
     public function listTables(): array
     {
-        return $this->collection->listTables();
+        return $this->collection->listTablesAndViews();
     }
 
     /**

--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -21,10 +21,6 @@ use Psr\SimpleCache\CacheInterface;
 /**
  * Decorates a schema collection and adds caching
  *
- * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
- * This will include any views in the schema.
- * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
- * This will exclude any views in the schema.
  */
 class CachedCollection implements CollectionInterface
 {

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -26,9 +26,9 @@ use PDOException;
  * Used to access information about the tables,
  * and other data in a database.
  *
- * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
+ * @method array<string> listTablesAndViews() Get the list of tables available in the current connection.
  * This will include any views in the schema.
- * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
+ * @method array<string> listTablesWithoutViews() Get the list of tables available in the current connection.
  * This will exclude any views in the schema.
  */
 class Collection implements CollectionInterface

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -82,7 +82,7 @@ class Collection implements CollectionInterface
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTablesExcludeViews() : array
+    public function listTablesExcludeViews(): array
     {
         return $this->listTablesOptions(['excludeViews' => true]);
     }
@@ -92,7 +92,7 @@ class Collection implements CollectionInterface
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTables() : array
+    public function listTables(): array
     {
         return $this->listTablesOptions([]);
     }

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -58,9 +58,9 @@ class Collection implements CollectionInterface
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTables(): array
+    public function listTables(array $options = []): array
     {
-        [$sql, $params] = $this->_dialect->listTablesSql($this->_connection->config());
+        [$sql, $params] = $this->_dialect->listTablesSql(array_merge($this->_connection->config(), $options));
         $result = [];
         $statement = $this->_connection->execute($sql, $params);
         while ($row = $statement->fetch()) {

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -25,6 +25,11 @@ use PDOException;
  *
  * Used to access information about the tables,
  * and other data in a database.
+ *
+ * @method array listTablesOptions(array $options = []) Get the list of tables available in the current connection.
+ *    Allows for an options array which can be used to modify the results.
+ * @method array listTablesExcludeViews() Get the list of tables, excluding any views,
+ *    available in the current connection.
  */
 class Collection implements CollectionInterface
 {
@@ -54,11 +59,12 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * Get the list of tables available in the current connection.
+     * Get the list of tables available in the current connection. Allows for
+     * an options array which can be used to modify the results.
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTables(array $options = []): array
+    public function listTablesOptions(array $options = []): array
     {
         [$sql, $params] = $this->_dialect->listTablesSql(array_merge($this->_connection->config(), $options));
         $result = [];
@@ -69,6 +75,26 @@ class Collection implements CollectionInterface
         $statement->closeCursor();
 
         return $result;
+    }
+
+    /**
+     * Get the list of tables, excluding any views, available in the current connection.
+     *
+     * @return array<string> The list of tables in the connected database/schema.
+     */
+    public function listTablesExcludeViews() : array
+    {
+        return $this->listTablesOptions(['excludeViews' => true]);
+    }
+
+    /**
+     * Get the list of tables available in the current connection.
+     *
+     * @return array<string> The list of tables in the connected database/schema.
+     */
+    public function listTables() : array
+    {
+        return $this->listTablesOptions([]);
     }
 
     /**

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -84,7 +84,15 @@ class Collection implements CollectionInterface
      */
     public function listTables(): array
     {
-        return $this->listTablesAndViews();
+        [$sql, $params] = $this->_dialect->listTablesSql($this->_connection->config());
+        $result = [];
+        $statement = $this->_connection->execute($sql, $params);
+        while ($row = $statement->fetch()) {
+            $result[] = $row[0];
+        }
+        $statement->closeCursor();
+
+        return $result;
     }
 
     /**

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -79,7 +79,7 @@ class Collection implements CollectionInterface
     /**
      * Get the list of tables available in the current connection.
      *
-     * @deprecated in 4.3.2 Use {@link listTablesAndViews()} instead.
+     * @deprecated in 4.3.3 Use {@link listTablesAndViews()} instead.
      * @return array<string> The list of tables in the connected database/schema.
      */
     public function listTables(): array

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -78,6 +78,7 @@ class Collection implements CollectionInterface
 
     /**
      * Get the list of tables available in the current connection.
+     *
      * @deprecated
      * @return array<string> The list of tables in the connected database/schema.
      */
@@ -85,6 +86,7 @@ class Collection implements CollectionInterface
     {
         return $this->listTablesAndViews();
     }
+
     /**
      * Get the list of tables available in the current connection.
      *

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -79,12 +79,12 @@ class Collection implements CollectionInterface
     /**
      * Get the list of tables available in the current connection.
      *
-     * @deprecated
+     * @deprecated in 4.3.2 Use {@link listTablesAndViews()} instead.
      * @return array<string> The list of tables in the connected database/schema.
      */
     public function listTables(): array
     {
-        [$sql, $params] = $this->_dialect->listTablesSql($this->_connection->config());
+        [$sql, $params] = $this->_dialect->listTablesAndViewsSql($this->_connection->config());
         $result = [];
         $statement = $this->_connection->execute($sql, $params);
         while ($row = $statement->fetch()) {

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -26,10 +26,10 @@ use PDOException;
  * Used to access information about the tables,
  * and other data in a database.
  *
- * @method array listTablesOptions(array $options = []) Get the list of tables available in the current connection.
- *    Allows for an options array which can be used to modify the results.
- * @method array listTablesExcludeViews() Get the list of tables, excluding any views,
- *    available in the current connection.
+ * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
+ * This will include any views in the schema.
+ * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
+ * This will exclude any views in the schema.
  */
 class Collection implements CollectionInterface
 {
@@ -59,14 +59,13 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * Get the list of tables available in the current connection. Allows for
-     * an options array which can be used to modify the results.
+     * Get the list of tables, excluding any views, available in the current connection.
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTablesOptions(array $options = []): array
+    public function listTablesWithoutViews(): array
     {
-        [$sql, $params] = $this->_dialect->listTablesSql(array_merge($this->_connection->config(), $options));
+        [$sql, $params] = $this->_dialect->listTablesWithoutViewsSql($this->_connection->config());
         $result = [];
         $statement = $this->_connection->execute($sql, $params);
         while ($row = $statement->fetch()) {
@@ -78,23 +77,30 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * Get the list of tables, excluding any views, available in the current connection.
-     *
+     * Get the list of tables available in the current connection.
+     * @deprecated
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTablesExcludeViews(): array
+    public function listTables(): array
     {
-        return $this->listTablesOptions(['excludeViews' => true]);
+        return $this->listTablesAndViews();
     }
-
     /**
      * Get the list of tables available in the current connection.
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTables(): array
+    public function listTablesAndViews(): array
     {
-        return $this->listTablesOptions([]);
+        [$sql, $params] = $this->_dialect->listTablesAndViewsSql($this->_connection->config());
+        $result = [];
+        $statement = $this->_connection->execute($sql, $params);
+        while ($row = $statement->fetch()) {
+            $result[] = $row[0];
+        }
+        $statement->closeCursor();
+
+        return $result;
     }
 
     /**

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -22,9 +22,9 @@ namespace Cake\Database\Schema;
  * Used to access information about the tables,
  * and other data in a database.
  *
- * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
+ * @method array<string> listTablesAndViews() Get the list of tables available in the current connection.
  * This will include any views in the schema.
- * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
+ * @method array<string> listTablesWithoutViews() Get the list of tables available in the current connection.
  * This will exclude any views in the schema.
  */
 interface CollectionInterface

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -29,7 +29,7 @@ interface CollectionInterface
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTables(array $options = []): array;
+    public function listTables(): array;
 
     /**
      * Get the column metadata for a table.

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -32,7 +32,7 @@ interface CollectionInterface
     /**
      * Get the list of tables available in the current connection.
      *
-     * @deprecated in 4.3.2
+     * @deprecated in 4.3.3
      * @return array<string> The list of tables in the connected database/schema.
      */
     public function listTables(): array;

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -32,7 +32,7 @@ interface CollectionInterface
     /**
      * Get the list of tables available in the current connection.
      *
-     * @deprecated
+     * @deprecated in 4.3.2
      * @return array<string> The list of tables in the connected database/schema.
      */
     public function listTables(): array;

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -29,7 +29,7 @@ interface CollectionInterface
      *
      * @return array<string> The list of tables in the connected database/schema.
      */
-    public function listTables(): array;
+    public function listTables(array $options = []): array;
 
     /**
      * Get the column metadata for a table.

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -31,6 +31,7 @@ interface CollectionInterface
 {
     /**
      * Get the list of tables available in the current connection.
+     *
      * @deprecated
      * @return array<string> The list of tables in the connected database/schema.
      */

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -21,6 +21,11 @@ namespace Cake\Database\Schema;
  *
  * Used to access information about the tables,
  * and other data in a database.
+ *
+ * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
+ * This will include any views in the schema.
+ * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
+ * This will exclude any views in the schema.
  */
 interface CollectionInterface
 {

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -26,7 +26,7 @@ interface CollectionInterface
 {
     /**
      * Get the list of tables available in the current connection.
-     *
+     * @deprecated
      * @return array<string> The list of tables in the connected database/schema.
      */
     public function listTables(): array;

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -36,7 +36,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated
+     * @deprecated 4.3.2 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array<mixed> An array of (sql, params) to execute.

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -39,7 +39,11 @@ class MysqlSchemaDialect extends SchemaDialect
     public function listTablesSql(array $config): array
     {
         return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']) .
-        ((array_key_exists("exclude_views", $config) && $config['exclude_views'] == true) ? " WHERE Table_type = 'FULL TABLE'" : "")
+        (
+            array_key_exists("excludeViews", $config) && $config['excludeViews'] === true
+            ? ' WHERE Table_type = "FULL TABLE"'
+            : ' '
+        )
         , []];
     }
 

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -38,7 +38,9 @@ class MysqlSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        return ['SHOW TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
+        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']) .
+        ((array_key_exists("exclude_views", $config) && $config['exclude_views'] == true) ? " WHERE Table_type = 'FULL TABLE'" : "")
+        , []];
     }
 
     /**

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -34,8 +34,12 @@ class MysqlSchemaDialect extends SchemaDialect
     protected $_driver;
 
     /**
+     * Generate the SQL to list the tables and views.
+     *
      * @deprecated
-     * @inheritDoc
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
     {
@@ -47,7 +51,7 @@ class MysqlSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesWithoutViewsSql(array $config): array
     {
@@ -62,7 +66,7 @@ class MysqlSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesAndViewsSql(array $config): array
     {

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -34,17 +34,39 @@ class MysqlSchemaDialect extends SchemaDialect
     protected $_driver;
 
     /**
+     * @deprecated
      * @inheritDoc
      */
     public function listTablesSql(array $config): array
     {
-        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']) .
-        (
-            array_key_exists('excludeViews', $config) && $config['excludeViews'] === true
-            ? ' WHERE Table_type = "BASE TABLE"'
-            : ' '
-        )
+        return $this->listTablesAndViewsSql($config);
+    }
+
+    /**
+     * Generate the SQL to list the tables, excluding all views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesWithoutViewsSql(array $config): array
+    {
+        return [
+            'SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database'])
+            . ' WHERE Table_type LIKE "%TABLE%"'
         , []];
+    }
+
+    /**
+     * Generate the SQL to list the tables and views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesAndViewsSql(array $config): array
+    {
+        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
     }
 
     /**

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -40,7 +40,7 @@ class MysqlSchemaDialect extends SchemaDialect
     {
         return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']) .
         (
-            array_key_exists("excludeViews", $config) && $config['excludeViews'] === true
+            array_key_exists('excludeViews', $config) && $config['excludeViews'] === true
             ? ' WHERE Table_type = "FULL TABLE"'
             : ' '
         )

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -36,7 +36,7 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.2 Use {@link listTablesAndViewsSql()} instead.
+     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array<mixed> An array of (sql, params) to execute.

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -41,7 +41,7 @@ class MysqlSchemaDialect extends SchemaDialect
         return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']) .
         (
             array_key_exists('excludeViews', $config) && $config['excludeViews'] === true
-            ? ' WHERE Table_type = "FULL TABLE"'
+            ? ' WHERE Table_type = "BASE TABLE"'
             : ' '
         )
         , []];

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -46,6 +46,7 @@ class PostgresSchemaDialect extends SchemaDialect
         $sql = 'SELECT table_name as name FROM information_schema.tables
                 WHERE table_schema = ? AND table_type = \'BASE TABLE\' ORDER BY name';
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
+
         return [$sql, [$schema]];
     }
 

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -28,7 +28,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated
+     * @deprecated 4.3.2 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -34,7 +34,8 @@ class PostgresSchemaDialect extends SchemaDialect
         if (array_key_exists('excludeViews', $config) && $config['excludeViews'] === true) {
             $table_type_sql = " AND table_type = 'BASE TABLE' ";
         }
-        $sql = 'SELECT table_name as name FROM information_schema.tables WHERE table_schema = ? ' . $tableTypeSql . ' ORDER BY name';
+        $sql = 'SELECT table_name as name FROM information_schema.tables
+                WHERE table_schema = ? ' . $tableTypeSql . ' ORDER BY name';
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
 
         return [$sql, [$schema]];

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -32,7 +32,7 @@ class PostgresSchemaDialect extends SchemaDialect
     {
         $tableTypeSql = '';
         if (array_key_exists('excludeViews', $config) && $config['excludeViews'] === true) {
-            $table_type_sql = " AND table_type = 'BASE TABLE' ";
+            $tableTypeSql = " AND table_type = 'BASE TABLE' ";
         }
         $sql = 'SELECT table_name as name FROM information_schema.tables
                 WHERE table_schema = ? ' . $tableTypeSql . ' ORDER BY name';

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -28,7 +28,7 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.2 Use {@link listTablesAndViewsSql()} instead.
+     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -30,11 +30,11 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        $table_type_sql = "";
-        if (array_key_exists("excludeViews", $config) && $config['excludeViews'] === true) {
+        $tableTypeSql = '';
+        if (array_key_exists('excludeViews', $config) && $config['excludeViews'] === true) {
             $table_type_sql = " AND table_type = 'BASE TABLE' ";
         }
-        $sql = "SELECT table_name as name FROM information_schema.tables WHERE table_schema = ? $table_type_sql ORDER BY name";
+        $sql = 'SELECT table_name as name FROM information_schema.tables WHERE table_schema = ? ' . $tableTypeSql . ' ORDER BY name';
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
 
         return [$sql, [$schema]];

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -26,8 +26,12 @@ use Cake\Database\Exception\DatabaseException;
 class PostgresSchemaDialect extends SchemaDialect
 {
     /**
+     * Generate the SQL to list the tables and views.
+     *
      * @deprecated
-     * @inheritDoc
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
     {
@@ -39,7 +43,7 @@ class PostgresSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesWithoutViewsSql(array $config): array
     {
@@ -55,7 +59,7 @@ class PostgresSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesAndViewsSql(array $config): array
     {

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -26,16 +26,40 @@ use Cake\Database\Exception\DatabaseException;
 class PostgresSchemaDialect extends SchemaDialect
 {
     /**
+     * @deprecated
      * @inheritDoc
      */
     public function listTablesSql(array $config): array
     {
-        $tableTypeSql = '';
-        if (array_key_exists('excludeViews', $config) && $config['excludeViews'] === true) {
-            $tableTypeSql = " AND table_type = 'BASE TABLE' ";
-        }
+        return $this->listTablesAndViewsSql($config);
+    }
+
+    /**
+     * Generate the SQL to list the tables, excluding all views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesWithoutViewsSql(array $config): array
+    {
         $sql = 'SELECT table_name as name FROM information_schema.tables
-                WHERE table_schema = ? ' . $tableTypeSql . ' ORDER BY name';
+                WHERE table_schema = ? AND table_type = \'BASE TABLE\' ORDER BY name';
+        $schema = empty($config['schema']) ? 'public' : $config['schema'];
+        return [$sql, [$schema]];
+    }
+
+    /**
+     * Generate the SQL to list the tables and views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesAndViewsSql(array $config): array
+    {
+        $sql = 'SELECT table_name as name FROM information_schema.tables
+                WHERE table_schema = ? ORDER BY name';
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
 
         return [$sql, [$schema]];

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -30,7 +30,11 @@ class PostgresSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        $sql = 'SELECT table_name as name FROM information_schema.tables WHERE table_schema = ? ORDER BY name';
+        $table_type_sql = "";
+        if (array_key_exists("excludeViews", $config) && $config['excludeViews'] === true) {
+            $table_type_sql = " AND table_type = 'BASE TABLE' ";
+        }
+        $sql = "SELECT table_name as name FROM information_schema.tables WHERE table_schema = ? $table_type_sql ORDER BY name";
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
 
         return [$sql, [$schema]];

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -26,8 +26,9 @@ use InvalidArgumentException;
  *
  * This class contains methods that are common across
  * the various SQL dialects.
- * @method array<string,mixed> listTablesAndViewsSql() Generate the SQL to list the tables and views.
- * @method array<string,mixed> listTablesWithoutViewsSql() Generate the SQL to list the tables, excluding all views.
+ *
+ * @method array<mixed> listTablesAndViewsSql(array $config) Generate the SQL to list the tables and views.
+ * @method array<mixed> listTablesWithoutViewsSql(array $config) Generate the SQL to list the tables, excluding all views.
  */
 abstract class SchemaDialect
 {

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -186,7 +186,7 @@ abstract class SchemaDialect
     /**
      * Generate the SQL to list the tables.
      *
-     * @deprecated
+     * @deprecated 4.3.2
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -26,10 +26,8 @@ use InvalidArgumentException;
  *
  * This class contains methods that are common across
  * the various SQL dialects.
- * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
- * This will include any views in the schema.
- * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
- * This will exclude any views in the schema.
+ * @method array<string,mixed> listTablesAndViewsSql() Generate the SQL to list the tables and views.
+ * @method array<string,mixed> listTablesWithoutViewsSql() Generate the SQL to list the tables, excluding all views.
  */
 abstract class SchemaDialect
 {
@@ -186,6 +184,7 @@ abstract class SchemaDialect
 
     /**
      * Generate the SQL to list the tables.
+     *
      * @deprecated
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -26,6 +26,10 @@ use InvalidArgumentException;
  *
  * This class contains methods that are common across
  * the various SQL dialects.
+ * @method array<string,mixed> listTablesAndViews() Get the list of tables available in the current connection.
+ * This will include any views in the schema.
+ * @method array<string,mixed> listTablesWithoutViews() Get the list of tables available in the current connection.
+ * This will exclude any views in the schema.
  */
 abstract class SchemaDialect
 {
@@ -188,24 +192,6 @@ abstract class SchemaDialect
      * @return array An array of (sql, params) to execute.
      */
     abstract public function listTablesSql(array $config): array;
-
-    /**
-     * Generate the SQL to list the tables, excluding all views.
-     *
-     * @param array<string, mixed> $config The connection configuration to use for
-     *    getting tables from.
-     * @return array An array of (sql, params) to execute.
-     */
-    abstract public function listTablesWithoutViewsSql(array $config): array;
-
-    /**
-     * Generate the SQL to list the tables and views.
-     *
-     * @param array<string, mixed> $config The connection configuration to use for
-     *    getting tables from.
-     * @return array An array of (sql, params) to execute.
-     */
-    abstract public function listTablesAndViewsSql(array $config): array;
 
     /**
      * Generate the SQL to describe a table.

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -186,7 +186,7 @@ abstract class SchemaDialect
     /**
      * Generate the SQL to list the tables.
      *
-     * @deprecated 4.3.2
+     * @deprecated 4.3.3
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -182,12 +182,30 @@ abstract class SchemaDialect
 
     /**
      * Generate the SQL to list the tables.
-     *
+     * @deprecated
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
     abstract public function listTablesSql(array $config): array;
+
+    /**
+     * Generate the SQL to list the tables, excluding all views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    abstract public function listTablesWithoutViewsSql(array $config): array;
+
+    /**
+     * Generate the SQL to list the tables and views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    abstract public function listTablesAndViewsSql(array $config): array;
 
     /**
      * Generate the SQL to describe a table.

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -152,9 +152,39 @@ class SqliteSchemaDialect extends SchemaDialect
     }
 
     /**
+     * @deprecated
      * @inheritDoc
      */
     public function listTablesSql(array $config): array
+    {
+        return $this->listTablesWithoutViewsSql($config);
+    }
+
+    /**
+     * Generate the SQL to list the tables and views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesAndViewsSql(array $config): array
+    {
+        return [
+            'SELECT name FROM sqlite_master ' .
+            'WHERE (type="table" OR type="view") ' .
+            'AND name != "sqlite_sequence" ORDER BY name',
+            [],
+        ];
+    }
+
+    /**
+     * Generate the SQL to list the tables, excluding all views.
+     *
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
+     */
+    public function listTablesWithoutViewsSql(array $config): array
     {
         return [
             'SELECT name FROM sqlite_master WHERE type="table" ' .

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -154,7 +154,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.2 Use {@link listTablesAndViewsSql()} instead.
+     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -152,8 +152,12 @@ class SqliteSchemaDialect extends SchemaDialect
     }
 
     /**
+     * Generate the SQL to list the tables and views.
+     *
      * @deprecated
-     * @inheritDoc
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
     {
@@ -165,7 +169,7 @@ class SqliteSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesAndViewsSql(array $config): array
     {
@@ -182,7 +186,7 @@ class SqliteSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesWithoutViewsSql(array $config): array
     {

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -154,7 +154,7 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated
+     * @deprecated 4.3.2 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -33,9 +33,11 @@ class SqlserverSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        $tableTypeSql = "TABLE_TYPE = 'BASE TABLE'";
-        if (!array_key_exists('excludeViews', $config) || $config['excludeViews'] === false) {
-            $tableTypeSql .= " OR TABLE_TYPE = 'VIEW'";
+        $tableTypeSql = "(TABLE_TYPE = 'BASE TABLE'";
+        if (!array_key_exists('excludeViews', $config) || $config['excludeViews'] == false) {
+            $tableTypeSql .= " OR TABLE_TYPE = 'VIEW')";
+        } else {
+            $tableTypeSql .= ")";
         }
         $sql = "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -33,11 +33,9 @@ class SqlserverSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        $tableTypeSql = "(TABLE_TYPE = 'BASE TABLE'";
+        $tableTypeSql = "TABLE_TYPE = 'BASE TABLE'";
         if (!array_key_exists('excludeViews', $config) || $config['excludeViews'] == false) {
-            $tableTypeSql .= " OR TABLE_TYPE = 'VIEW')";
-        } else {
-            $tableTypeSql .= ")";
+            $tableTypeSql .= " OR TABLE_TYPE = 'VIEW'";
         }
         $sql = "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -31,7 +31,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated
+     * @deprecated Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -33,10 +33,14 @@ class SqlserverSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
+        $table_type_sql = "TABLE_TYPE = 'BASE TABLE'";
+        if (!array_key_exists("excludeViews", $config) || $config['excludeViews'] === false) {
+            $table_type_sql .= " OR TABLE_TYPE = 'VIEW'";
+        }
         $sql = "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = ?
-            AND (TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW')
+            AND ($table_type_sql)
             ORDER BY TABLE_NAME";
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
 

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -33,14 +33,14 @@ class SqlserverSchemaDialect extends SchemaDialect
      */
     public function listTablesSql(array $config): array
     {
-        $table_type_sql = "TABLE_TYPE = 'BASE TABLE'";
-        if (!array_key_exists("excludeViews", $config) || $config['excludeViews'] === false) {
-            $table_type_sql .= " OR TABLE_TYPE = 'VIEW'";
+        $tableTypeSql = "TABLE_TYPE = 'BASE TABLE'";
+        if (!array_key_exists('excludeViews', $config) || $config['excludeViews'] === false) {
+            $tableTypeSql .= " OR TABLE_TYPE = 'VIEW'";
         }
         $sql = "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES
             WHERE TABLE_SCHEMA = ?
-            AND ($table_type_sql)
+            AND ($tableTypeSql)
             ORDER BY TABLE_NAME";
         $schema = empty($config['schema']) ? static::DEFAULT_SCHEMA_NAME : $config['schema'];
 

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -31,7 +31,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated Use {@link listTablesAndViewsSql()} instead.
+     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -29,12 +29,16 @@ class SqlserverSchemaDialect extends SchemaDialect
     public const DEFAULT_SCHEMA_NAME = 'dbo';
 
     /**
+     * Generate the SQL to list the tables and views.
+     *
      * @deprecated
-     * @inheritDoc
+     * @param array<string, mixed> $config The connection configuration to use for
+     *    getting tables from.
+     * @return array An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
     {
-        return $this->listTablesAndViewsSql();
+        return $this->listTablesAndViewsSql($config);
     }
 
     /**
@@ -42,7 +46,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesAndViewsSql(array $config): array
     {
@@ -61,7 +65,7 @@ class SqlserverSchemaDialect extends SchemaDialect
      *
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
-     * @return array An array of (sql, params) to execute.
+     * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesWithoutViewsSql(array $config): array
     {

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -120,7 +120,7 @@ class ConnectionHelper
         $connection = ConnectionManager::get($connectionName);
         $collection = $connection->getSchemaCollection();
 
-        $allTables = $collection->listTables();
+        $allTables = $collection->listTablesExcludeViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         $schemas = array_map(function ($table) use ($collection) {
             return $collection->describe($table);

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -89,8 +89,6 @@ class ConnectionHelper
         $allTables = [];
         if (method_exists($collection, 'listTablesWithoutViews')) {
             $allTables = $collection->listTablesWithoutViews();
-        } else {
-            $allTables = $collection->listTables();
         }
 
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -86,7 +86,13 @@ class ConnectionHelper
         $connection = ConnectionManager::get($connectionName);
         $collection = $connection->getSchemaCollection();
 
-        $allTables = $collection->listTablesExcludeViews();
+        $allTables = [];
+        if (method_exists($collection, "listTablesWithoutViews")) {
+            $allTables = $collection->listTablesWithoutViews();
+        } else {
+            $allTables = $collection->listTables();
+        }
+
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         $schemas = array_map(function ($table) use ($collection) {
             return $collection->describe($table);
@@ -120,7 +126,7 @@ class ConnectionHelper
         $connection = ConnectionManager::get($connectionName);
         $collection = $connection->getSchemaCollection();
 
-        $allTables = $collection->listTablesExcludeViews();
+        $allTables = $collection->listTablesWithoutViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         $schemas = array_map(function ($table) use ($collection) {
             return $collection->describe($table);

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -86,7 +86,7 @@ class ConnectionHelper
         $connection = ConnectionManager::get($connectionName);
         $collection = $connection->getSchemaCollection();
 
-        $allTables = $collection->listTables(['exclude_views' => true]);
+        $allTables = $collection->listTablesExcludeViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         $schemas = array_map(function ($table) use ($collection) {
             return $collection->describe($table);

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -87,7 +87,7 @@ class ConnectionHelper
         $collection = $connection->getSchemaCollection();
 
         $allTables = [];
-        if (method_exists($collection, "listTablesWithoutViews")) {
+        if (method_exists($collection, 'listTablesWithoutViews')) {
             $allTables = $collection->listTablesWithoutViews();
         } else {
             $allTables = $collection->listTables();

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -86,7 +86,7 @@ class ConnectionHelper
         $connection = ConnectionManager::get($connectionName);
         $collection = $connection->getSchemaCollection();
 
-        $allTables = $collection->listTables();
+        $allTables = $collection->listTables(['exclude_views' => true]);
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
         $schemas = array_map(function ($table) use ($collection) {
             return $collection->describe($table);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -295,7 +295,7 @@ class FixtureManager
         try {
             $createTables = function (ConnectionInterface $db, array $fixtures) use ($test): void {
                 /** @var array<\Cake\Datasource\FixtureInterface> $fixtures */
-                $tables = $db->getSchemaCollection()->listTables();
+                $tables = $db->getSchemaCollection()->listTablesAndViews();
                 $configName = $db->configName();
                 $this->_insertionMap[$configName] = $this->_insertionMap[$configName] ?? [];
 
@@ -467,7 +467,7 @@ class FixtureManager
         }
 
         if (!$this->isFixtureSetup($connection->configName(), $fixture)) {
-            $sources = $connection->getSchemaCollection()->listTables();
+            $sources = $connection->getSchemaCollection()->listTablesAndViews();
             $this->_setupTable($fixture, $connection, $sources, $dropTables);
         }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -262,6 +262,7 @@ class MysqlSchemaTest extends TestCase
         $connection->execute('DROP TABLE IF EXISTS schema_articles');
         $connection->execute('DROP TABLE IF EXISTS schema_authors');
         $connection->execute('DROP TABLE IF EXISTS schema_json');
+        $connection->execute('DROP VIEW IF EXISTS schema_articles_v');
 
         $table = <<<SQL
             CREATE TABLE schema_authors (
@@ -290,6 +291,12 @@ SQL;
 SQL;
         $connection->execute($table);
 
+        $table = <<<SQL
+            CREATE OR REPLACE VIEW schema_articles_v
+                AS SELECT 1
+SQL;
+        $connection->execute($table);
+
         if ($connection->getDriver()->supports(DriverInterface::FEATURE_JSON)) {
             $table = <<<SQL
                 CREATE TABLE schema_json (
@@ -315,8 +322,10 @@ SQL;
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
+        $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
         $this->assertIsArray($resultNoViews);
+        $this->assertNotContains('schema_articles_v', $resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
     }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -315,16 +315,17 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-
         $schema = new SchemaCollection($connection);
-        $result = $schema->listTables();
-        $resultAll = $schema->listTablesAndViews();
-        $resultNoViews = $schema->listTablesWithoutViews();
 
+        $result = $schema->listTables();
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
+
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
+
         $this->assertIsArray($resultAll);
         $this->assertContains('schema_articles', $resultAll);
         $this->assertContains('schema_articles_v', $resultAll);

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -311,10 +311,13 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
+        $resultNoViews = $schema->listTablesExcludeViews();
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultNoViews);
+        $this->assertContains('schema_articles', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -318,12 +318,17 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
-        $resultNoViews = $schema->listTablesExcludeViews();
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultAll);
+        $this->assertContains('schema_articles', $resultAll);
+        $this->assertContains('schema_articles_v', $resultAll);
+        $this->assertContains('schema_authors', $resultAll);
         $this->assertIsArray($resultNoViews);
         $this->assertNotContains('schema_articles_v', $resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -291,16 +291,17 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-
         $schema = new SchemaCollection($connection);
-        $result = $schema->listTables();
-        $resultAll = $schema->listTablesAndViews();
-        $resultNoViews = $schema->listTablesWithoutViews();
 
+        $result = $schema->listTables();
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
+
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
+
         $this->assertIsArray($resultAll);
         $this->assertContains('schema_articles', $resultAll);
         $this->assertContains('schema_articles_v', $resultAll);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -287,9 +287,12 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
+        $resultNoViews = $schema->listTablesExcludeViews();
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultNoViews);
+        $this->assertContains('schema_articles', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -50,6 +50,7 @@ class PostgresSchemaTest extends TestCase
 
         $connection->execute('DROP TABLE IF EXISTS schema_articles');
         $connection->execute('DROP TABLE IF EXISTS schema_authors');
+        $connection->execute('DROP VIEW IF EXISTS schema_articles_v');
 
         $table = <<<SQL
 CREATE TABLE schema_authors (
@@ -87,6 +88,15 @@ SQL;
         $connection->execute($table);
         $connection->execute('COMMENT ON COLUMN "schema_articles"."title" IS \'a title\'');
         $connection->execute('CREATE INDEX "author_idx" ON "schema_articles" ("author_id")');
+
+        $connection->execute($table);
+
+        $table = <<<SQL
+CREATE VIEW schema_articles_v AS
+SELECT * FROM schema_articles
+)
+SQL;
+        $connection->execute($table);
     }
 
     /**
@@ -291,8 +301,10 @@ SQL;
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertContains('schema_articles_v', $result);
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
+        $this->assertNotContains('schema_articles_v', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -48,9 +48,9 @@ class PostgresSchemaTest extends TestCase
     {
         $this->_needsConnection();
 
+        $connection->execute('DROP VIEW IF EXISTS schema_articles_v');
         $connection->execute('DROP TABLE IF EXISTS schema_articles');
         $connection->execute('DROP TABLE IF EXISTS schema_authors');
-        $connection->execute('DROP VIEW IF EXISTS schema_articles_v');
 
         $table = <<<SQL
 CREATE TABLE schema_authors (
@@ -89,12 +89,9 @@ SQL;
         $connection->execute('COMMENT ON COLUMN "schema_articles"."title" IS \'a title\'');
         $connection->execute('CREATE INDEX "author_idx" ON "schema_articles" ("author_id")');
 
-        $connection->execute($table);
-
         $table = <<<SQL
 CREATE VIEW schema_articles_v AS
 SELECT * FROM schema_articles
-)
 SQL;
         $connection->execute($table);
     }

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -294,14 +294,20 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
-        $resultNoViews = $schema->listTablesExcludeViews();
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
+
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
-        $this->assertContains('schema_authors', $result);
         $this->assertContains('schema_articles_v', $result);
+        $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultAll);
+        $this->assertContains('schema_articles', $resultAll);
+        $this->assertContains('schema_articles_v', $resultAll);
+        $this->assertContains('schema_authors', $resultAll);
         $this->assertIsArray($resultNoViews);
-        $this->assertContains('schema_articles', $resultNoViews);
         $this->assertNotContains('schema_articles_v', $resultNoViews);
+        $this->assertContains('schema_articles', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -286,13 +286,20 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
+        $resultAll = $schema->listTablesAndViews();
         $resultNoViews = $schema->listTablesExcludeViews();
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertNotContains('view_schema_articles', $result);
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
+        $this->assertNotContains('view_schema_articles', $resultNoViews);
+        $this->assertIsArray($resultAll);
+        $this->assertContains('schema_articles', $result);
+        $this->assertContains('schema_authors', $result);
+        $this->assertContains('view_schema_articles', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -287,7 +287,7 @@ SQL;
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
         $resultAll = $schema->listTablesAndViews();
-        $resultNoViews = $schema->listTablesWithoutViewsSql();
+        $resultNoViews = $schema->listTablesWithoutViews();
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -292,14 +292,15 @@ SQL;
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
-        $this->assertContains('view_schema_articles', $result);
+        $this->assertNotContains('view_schema_articles', $result);
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
         $this->assertNotContains('view_schema_articles', $resultNoViews);
+
         $this->assertIsArray($resultAll);
-        $this->assertContains('schema_articles', $result);
-        $this->assertContains('schema_authors', $result);
-        $this->assertContains('view_schema_articles', $result);
+        $this->assertContains('schema_articles', $resultAll);
+        $this->assertContains('schema_authors', $resultAll);
+        $this->assertContains('view_schema_articles', $resultAll);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -283,16 +283,17 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-
         $schema = new SchemaCollection($connection);
-        $result = $schema->listTables();
-        $resultAll = $schema->listTablesAndViews();
-        $resultNoViews = $schema->listTablesWithoutViews();
 
+        $result = $schema->listTables();
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
-        $this->assertNotContains('view_schema_articles', $result);
+        $this->assertContains('view_schema_articles', $result);
+
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
+
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
         $this->assertNotContains('view_schema_articles', $resultNoViews);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -292,7 +292,7 @@ SQL;
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
-        $this->assertNotContains('view_schema_articles', $result);
+        $this->assertContains('view_schema_articles', $result);
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
         $this->assertNotContains('view_schema_articles', $resultNoViews);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -287,7 +287,7 @@ SQL;
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
         $resultAll = $schema->listTablesAndViews();
-        $resultNoViews = $schema->listTablesExcludeViews();
+        $resultNoViews = $schema->listTablesWithoutViewsSql();
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -286,10 +286,13 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
+        $resultNoViews = $schema->listTablesExcludeViews();
 
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultNoViews);
+        $this->assertContains('schema_articles', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -49,6 +49,7 @@ class SqlserverSchemaTest extends TestCase
 
         $connection->execute("IF OBJECT_ID('schema_articles', 'U') IS NOT NULL DROP TABLE schema_articles");
         $connection->execute("IF OBJECT_ID('schema_authors', 'U') IS NOT NULL DROP TABLE schema_authors");
+        $connection->execute("IF OBJECT_ID('schema_articles_v', 'V') IS NOT NULL DROP TABLE schema_articles_v");
 
         $table = <<<SQL
 CREATE TABLE schema_authors (
@@ -82,6 +83,12 @@ CONSTRAINT [author_idx] FOREIGN KEY ([author_id]) REFERENCES [schema_authors] ([
 SQL;
         $connection->execute($table);
         $connection->execute('CREATE INDEX [author_idx] ON [schema_articles] ([author_id])');
+
+        $table = <<<SQL
+CREATE VIEW schema_articles_v AS
+SELECT * FROM schema_articles
+SQL;
+        $connection->execute($table);
     }
 
     /**
@@ -341,8 +348,10 @@ SQL;
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertContains('schema_articles_v', $result);
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
+        $this->assertNotContains('schema_articles_v', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -351,7 +351,7 @@ SQL;
         $this->assertContains('schema_articles_v', $result);
         $this->assertIsArray($resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
-        $this->assertNotContains('schema_articles_v', $result);
+        $this->assertNotContains('schema_articles_v', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -341,16 +341,17 @@ SQL;
     {
         $connection = ConnectionManager::get('test');
         $this->_createTables($connection);
-
         $schema = new SchemaCollection($connection);
-        $result = $schema->listTables();
-        $resultAll = $schema->listTablesAndViews();
-        $resultNoViews = $schema->listTablesWithoutViews();
 
+        $result = $schema->listTables();
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
+
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
+
         $this->assertIsArray($resultAll);
         $this->assertContains('schema_articles', $resultAll);
         $this->assertContains('schema_articles_v', $resultAll);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -337,9 +337,12 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
+        $resultNoViews = $schema->listTablesExcludeViews();
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
         $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultNoViews);
+        $this->assertContains('schema_articles', $resultNoViews);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -47,9 +47,9 @@ class SqlserverSchemaTest extends TestCase
     {
         $this->_needsConnection();
 
+        $connection->execute("IF OBJECT_ID('schema_articles_v', 'V') IS NOT NULL DROP VIEW schema_articles_v");
         $connection->execute("IF OBJECT_ID('schema_articles', 'U') IS NOT NULL DROP TABLE schema_articles");
         $connection->execute("IF OBJECT_ID('schema_authors', 'U') IS NOT NULL DROP TABLE schema_authors");
-        $connection->execute("IF OBJECT_ID('schema_articles_v', 'V') IS NOT NULL DROP TABLE schema_articles_v");
 
         $table = <<<SQL
 CREATE TABLE schema_authors (

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -344,14 +344,20 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->listTables();
-        $resultNoViews = $schema->listTablesExcludeViews();
+        $resultAll = $schema->listTablesAndViews();
+        $resultNoViews = $schema->listTablesWithoutViews();
+
         $this->assertIsArray($result);
         $this->assertContains('schema_articles', $result);
-        $this->assertContains('schema_authors', $result);
         $this->assertContains('schema_articles_v', $result);
+        $this->assertContains('schema_authors', $result);
+        $this->assertIsArray($resultAll);
+        $this->assertContains('schema_articles', $resultAll);
+        $this->assertContains('schema_articles_v', $resultAll);
+        $this->assertContains('schema_authors', $resultAll);
         $this->assertIsArray($resultNoViews);
-        $this->assertContains('schema_articles', $resultNoViews);
         $this->assertNotContains('schema_articles_v', $resultNoViews);
+        $this->assertContains('schema_articles', $resultNoViews);
     }
 
     /**


### PR DESCRIPTION
Adds an option to listTables in Cake\Database\Schema\Collection to allow for excluding_views from a list of all tables. It seems like in many cases it's helpful to get a list of ALL tables and views together, but in the case of dropping all tables, then it's better to only work on a list of all the actual tables.

Closes #16122

