### PR TITLE
Update Controller to directly use the Paginator class.

### DIFF
--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -21,6 +21,7 @@ use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventInterface;
+use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
@@ -495,8 +496,6 @@ class ControllerTest extends TestCase
             ],
         ]));
 
-        $this->assertEquals([], $Controller->paginate);
-
         $this->assertNotContains('Paginator', $Controller->viewBuilder()->getHelpers());
         $this->assertArrayNotHasKey('Paginator', $Controller->viewBuilder()->getHelpers());
 
@@ -541,6 +540,18 @@ class ControllerTest extends TestCase
         $results = $Controller->paginate();
 
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+    }
+
+    public function testPaginateException()
+    {
+        $this->expectException(NotFoundException::class);
+
+        $request = new ServerRequest(['url' => 'controller_posts/index?page=2&limit=100']);
+        $response = new Response();
+
+        $Controller = new Controller($request, $response, 'Posts');
+
+        $Controller->paginate();
     }
 
     /**


### PR DESCRIPTION
Since the introduction of paginator classes the PaginatorComponent has been an unnecessary middleman. It also leads to issues like https://github.com/cakephp/cakephp/issues/16056.

I don't think this change can be backported without causing potential problems for those using customized paginator components. Those upgrading from 4.x to 5.0 will just have to use custom paginator class instead.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
