### PR TITLE
Specify behavior of configRequest more precisely

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -271,6 +271,7 @@ trait IntegrationTestTrait
      *
      * You can call this method multiple times to append into
      * the current state.
+     * Sub-keys like 'headers' will be reset, though.
      *
      * @param array $data The request data to use.
      * @return void


### PR DESCRIPTION
We just tested the behavior in 3.10, but I assume this applies for 4.x, too.

Should be backported to 3.x, too.