### PR TITLE
Correcting link for upgrading of deprecated Fixtures

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -75,7 +75,7 @@ class FixtureInjector implements TestListener
                 'You are using the listener based PHPUnit integration. ' .
                 'This fixture system is deprecated, and we recommend you ' .
                 'upgrade to the extension based PHPUnit integration. ' .
-                'See https://book.cakephp.org/4.x/en/appendixes/fixture-upgrade.html',
+                'See https://book.cakephp.org/4/en/appendices/fixture-upgrade.html',
                 0
             );
             $this->_first = $suite;


### PR DESCRIPTION
When running tests the deprecation error provides an incorrect link. The link provided is `https://book.cakephp.org/4.x/en/appendixes/fixture-upgrade.html` when it should be `https://book.cakephp.org/4/en/appendices/fixture-upgrade.html`
