### PR TITLE
3.x Fix Router::reverse() not being compatible with setPass()

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -859,7 +859,13 @@ class Router
             $params['_matchedRoute'],
             $params['_name']
         );
-        $params = array_merge($params, $pass);
+        foreach ($pass as $i => $passedValue) {
+            // Remove passed values that are also route keys
+            if (in_array($passedValue, $params, true)) {
+                unset($pass[$i]);
+            }
+        }
+        $params = array_merge($params, array_values($pass));
         if (!empty($url)) {
             $params['?'] = $url;
         }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2811,7 +2811,6 @@ class RouterTest extends TestCase
         $request = new ServerRequest([
             'url' => '/articles/first-post',
             'params' => [
-                'lang' => 'eng',
                 'controller' => 'Articles',
                 'action' => 'view',
                 'pass' => ['first-post'],

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2802,6 +2802,26 @@ class RouterTest extends TestCase
         $this->assertEquals('/eng/posts/view/1', $result);
     }
 
+    public function testReverseRouteKeyAndPass()
+    {
+        Router::reload();
+        $routes = Router::createRouteBuilder('/');
+        $routes->connect('/articles/{slug}', ['controller' => 'Articles', 'action' => 'view'])->setPass(['slug']);
+
+        $request = new ServerRequest([
+            'url' => '/articles/first-post',
+            'params' => [
+                'lang' => 'eng',
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => ['first-post'],
+                'slug' => 'first-post',
+            ],
+        ]);
+        $result = Router::reverse($request);
+        $this->assertSame('/articles/first-post', $result);
+    }
+
     public function testReverseArrayQuery()
     {
         Router::connect('/:lang/:controller/:action/*', [], ['lang' => '[a-z]{3}']);


### PR DESCRIPTION
Backport to 3.x from #16130

Fixes #16119