### PR TITLE
Fix .gitignore so potential icon assets are tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ error.log
 ._*
 .Spotlight-V100
 .Trashes
-Icon?
+Icon
 ehthumbs.db
 Thumbs.db
 


### PR DESCRIPTION
This fixes issue #16138 by using GitHub's `.gitignore` [template suggestion](https://github.com/github/gitignore/blob/master/Global/macOS.gitignore#L7)