### PR TITLE
Fix PaginatorComponent ignoring default config

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -23,6 +23,7 @@ use Cake\Datasource\Paginator;
 use Cake\Datasource\ResultSetInterface;
 use Cake\Http\Exception\NotFoundException;
 use InvalidArgumentException;
+use UnexpectedValueException;
 
 /**
  * This component is used to handle automatic model data pagination. The primary way to use this
@@ -38,28 +39,6 @@ use InvalidArgumentException;
 class PaginatorComponent extends Component
 {
     /**
-     * Default pagination settings.
-     *
-     * When calling paginate() these settings will be merged with the configuration
-     * you provide.
-     *
-     * - `maxLimit` - The maximum limit users can choose to view. Defaults to 100
-     * - `limit` - The initial number of items per page. Defaults to 20.
-     * - `page` - The starting page, defaults to 1.
-     * - `allowedParameters` - A list of parameters users are allowed to set using request
-     *   parameters. Modifying this list will allow users to have more influence
-     *   over pagination, be careful with what you permit.
-     *
-     * @var array<string, mixed>
-     */
-    protected $_defaultConfig = [
-        'page' => 1,
-        'limit' => 20,
-        'maxLimit' => 100,
-        'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
-    ];
-
-    /**
      * Datasource paginator instance.
      *
      * @var \Cake\Datasource\Paginator
@@ -71,6 +50,10 @@ class PaginatorComponent extends Component
      */
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
+        if (!empty($this->_defaultConfig)) {
+            throw new UnexpectedValueException('Default configuration must be set using a custom Paginator class.');
+        }
+
         if (isset($config['paginator'])) {
             if (!$config['paginator'] instanceof Paginator) {
                 throw new InvalidArgumentException('Paginator must be an instance of ' . Paginator::class);
@@ -81,7 +64,7 @@ class PaginatorComponent extends Component
             $this->_paginator = new Paginator();
         }
 
-        parent::__construct($registry, $config);
+        parent::__construct($registry, $this->_config);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -31,7 +31,9 @@ use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use stdClass;
+use TestApp\Controller\Component\CustomPaginatorComponent;
 use TestApp\Datasource\CustomPaginator;
+use UnexpectedValueException;
 
 class PaginatorComponentTest extends TestCase
 {
@@ -99,6 +101,12 @@ class PaginatorComponentTest extends TestCase
 
         $component->setPaginator($paginator);
         $this->assertSame($paginator, $component->getPaginator());
+    }
+
+    public function testInvalidDefaultConfig(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        new CustomPaginatorComponent($this->registry);
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/Component/CustomPaginatorComponent.php
+++ b/tests/test_app/TestApp/Controller/Component/CustomPaginatorComponent.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Controller\Component;
+
+use Cake\Controller\Component\PaginatorComponent;
+
+class CustomPaginatorComponent extends PaginatorComponent
+{
+    protected $_defaultConfig = [
+        'page' => 1,
+        'limit' => 20,
+        'maxLimit' => 100,
+        'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+    ];
+}


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/16056

The component should not have $_defaultConfig set as it's impossible to use those values without overwriting the defaults in Paginator itself.

