### PR TITLE
Fix regression in Router::reverse() handling pass data

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -650,18 +650,29 @@ class Router
         }
         $pass = $params['pass'] ?? [];
 
+        $template = $params['_matchedRoute'] ?? null;
         unset(
             $params['pass'],
             $params['_matchedRoute'],
             $params['_name']
         );
-        foreach ($pass as $i => $passedValue) {
-            // Remove passed values that are also route keys
-            if (in_array($passedValue, $params, true)) {
-                unset($pass[$i]);
+        $route = null;
+        if ($template) {
+            // Locate the route that was used to match this route
+            // so we can access the pass parameter configuration.
+            foreach (static::getRouteCollection()->routes() as $maybe) {
+                if ($maybe->template === $template) {
+                    $route = $maybe;
+                    break;
+                }
             }
         }
-        $params = array_merge($params, array_values($pass));
+        if ($route) {
+            // If we found a route, slice off the number of passed args.
+            $routePass = $route->options['pass'] ?? [];
+            $pass = array_slice($pass, count($routePass));
+        }
+        $params = array_merge($params, $pass);
 
         return $params;
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2503,10 +2503,66 @@ class RouterTest extends TestCase
                 'action' => 'view',
                 'pass' => ['first-post'],
                 'slug' => 'first-post',
+                '_matchedRoute' => '/articles/{slug}',
             ],
         ]);
         $result = Router::reverse($request);
         $this->assertSame('/articles/first-post', $result);
+    }
+
+    public function testReverseRouteKeyAndPassDuplicateValues(): void
+    {
+        Router::reload();
+        $routes = Router::createRouteBuilder('/');
+        $routes->connect('/authors/{author_id}/articles/{id}', ['controller' => 'Articles', 'action' => 'view'])
+            ->setPass(['id']);
+
+        $request = new ServerRequest([
+            'url' => '/authors/1/articles/1',
+            'params' => [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => ['1'],
+                'author_id' => '1',
+                'id' => '1',
+                '_matchedRoute' => '/authors/{author_id}/articles/{id}',
+            ],
+        ]);
+        $result = Router::reverse($request);
+        $this->assertSame('/authors/1/articles/1', $result);
+
+        Router::reload();
+        $routes = Router::createRouteBuilder('/');
+        $routes->connect('/authors/{author_id}/articles/{id}/*', ['controller' => 'Articles', 'action' => 'view'])
+            ->setPass(['id', 'author_id']);
+
+        $request = new ServerRequest([
+            'url' => '/authors/88/articles/11',
+            'params' => [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => ['11', '88', '99'],
+                'author_id' => '88',
+                'id' => '11',
+                '_matchedRoute' => '/authors/{author_id}/articles/{id}/*',
+            ],
+        ]);
+        $result = Router::reverse($request);
+        $this->assertSame('/authors/88/articles/11/99', $result);
+
+        $request = new ServerRequest([
+            'url' => '/authors/1/articles/1/1',
+            'params' => [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => ['1', '1', '1'],
+                'author_id' => '1',
+                'id' => '1',
+                '_matchedRoute' => '/authors/{author_id}/articles/{id}/*',
+            ],
+        ]);
+        $result = Router::reverse($request);
+        $this->assertSame('/authors/1/articles/1/1', $result);
     }
 
     public function testReverseArrayQuery(): void


### PR DESCRIPTION
When two route parameters have the same value and one is defined as a passed parameter, the pass array had the too many values removed.

Fixes #16148