### PR TITLE
improve error message when a requested pdo extension is missing

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -195,7 +195,7 @@ class Connection implements ConnectionInterface
             $driver = new $className($config);
         }
         if (!$driver->enabled()) {
-            throw new MissingExtensionException(['driver' => get_class($driver)]);
+            throw new MissingExtensionException(['driver' => get_class($driver), 'name' => $config['name']]);
         }
 
         $this->_driver = $driver;

--- a/src/Database/Exception/MissingExtensionException.php
+++ b/src/Database/Exception/MissingExtensionException.php
@@ -27,5 +27,5 @@ class MissingExtensionException extends CakeException
      * @inheritDoc
      */
     // phpcs:ignore Generic.Files.LineLength
-    protected $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency';
+    protected $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency. Requested by connection "%s"';
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -165,12 +165,12 @@ class ConnectionTest extends TestCase
     public function testDisabledDriver(): void
     {
         $this->expectException(MissingExtensionException::class);
-        $this->expectExceptionMessage('Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency');
+        $this->expectExceptionMessage('Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency. Requested by connection "custom_connection_name"');
         $mock = $this->getMockBuilder(Mysql::class)
             ->onlyMethods(['enabled'])
             ->setMockClassName('DriverMock')
             ->getMock();
-        $connection = new Connection(['driver' => $mock]);
+        $connection = new Connection(['driver' => $mock, 'name' => 'custom_connection_name']);
     }
 
     /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9105243/144485461-7d44fbdb-0e6e-441c-b9b4-8a5fe4d7e7f7.png)

As seen in https://discourse.cakephp.org/t/debugkit-4-in-cakephp4/9950/7 it can be pretty hard to help someone who has issues with a MissingExtensionException.

This PR adds the connection name to the exception so one can more easily determine if its e.g. a plugins connection or some other connection which requires a missing pdo extension.