### PR TITLE
4.4 - Start ContentTypeNegotiation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -109,6 +109,13 @@
       <code>\Cake\Console\Shell</code>
     </DeprecatedClass>
   </file>
+  <file src="src/Controller/Component/RequestHandlerComponent.php">
+    <DeprecatedMethod occurrences="2">
+      <code>prefers</code>
+      <code>prefers</code>
+      <code>prefers</code>
+    </DeprecatedMethod>
+  </file>
   <file src="src/Controller/Controller.php">
     <DeprecatedMethod occurrences="2">
       <code>loadModel</code>

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -260,7 +260,6 @@ class RequestHandlerComponent extends Component
     public function accepts($type = null)
     {
         $controller = $this->getController();
-        $request = $controller->getRequest();
         /** @var array $accepted */
         $accepted = $controller->getRequest()->accepts();
 

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -252,6 +252,7 @@ class RequestHandlerComponent extends Component
      *   types the client accepts. If a string is passed, returns true
      *   if the client accepts it. If an array is passed, returns true
      *   if the client accepts one or more elements in the array.
+     * @deprecated 4.4.0 Use ContentTypeNegotiation::prefersChoice() or Controller::getViewClasses() instead.
      */
     public function accepts($type = null)
     {
@@ -339,6 +340,7 @@ class RequestHandlerComponent extends Component
      *    a boolean will be returned if that type is preferred.
      *    If an array of types are provided then the first preferred type is returned.
      *    If no type is provided the first preferred type is returned.
+     * @deprecated 4.4.0 Use Controller::getViewClasses() instead.
      */
     public function prefers($type = null)
     {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -22,6 +22,7 @@ use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
+use Cake\Http\ContentTypeNegotiation;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -121,7 +122,9 @@ class RequestHandlerComponent extends Component
      */
     protected function _setExtension(ServerRequest $request, Response $response): void
     {
-        $accept = $request->parseAccept();
+        $content = new ContentTypeNegotiation();
+        $accept = $content->parseAccept($request);
+
         if (empty($accept) || current($accept)[0] === 'text/html') {
             return;
         }
@@ -257,6 +260,7 @@ class RequestHandlerComponent extends Component
     public function accepts($type = null)
     {
         $controller = $this->getController();
+        $request = $controller->getRequest();
         /** @var array $accepted */
         $accepted = $controller->getRequest()->accepts();
 
@@ -345,8 +349,10 @@ class RequestHandlerComponent extends Component
     public function prefers($type = null)
     {
         $controller = $this->getController();
+        $request = $controller->getRequest();
+        $content = new ContentTypeNegotiation();
 
-        $acceptRaw = $controller->getRequest()->parseAccept();
+        $acceptRaw = $content->parseAccept($request);
         if (empty($acceptRaw)) {
             return $type ? $type === $this->ext : $this->ext;
         }

--- a/src/Http/ContentTypeNegotiation.php
+++ b/src/Http/ContentTypeNegotiation.php
@@ -12,66 +12,45 @@ use Psr\Http\Message\RequestInterface;
 class ContentTypeNegotiation
 {
     /**
-     * Get the most preferred content type from a request.
-     *
-     * Parse the Accept header preferences and return the most
-     * preferred type. If multiple types are tied in preference
-     * the first type of that preference value will be returned.
-     *
-     * You can expect null when the request has no Accept header.
-     *
-     * @param \Psr\Http\Message\RequestInterface $request The request to use.
-     * @return string|null The prefered type.
-     */
-    public function prefers(RequestInterface $request): ?string
-    {
-        $parsed = $this->parseAccept($request);
-        if (empty($parsed)) {
-            return null;
-        }
-        $types = array_shift($parsed);
-
-        return $types[0];
-    }
-
-    /**
-     * Perform content type negotiation with a list of valid choices.
-     *
-     * Choose a content-type from a list of values the application
-     * can provide. If there are no matches then `null` will be
-     * returned. You can also expect null when the request has
-     * no `Accept` header.
-     *
-     * @param \Psr\Http\Message\RequestInterface $request The request to use.
-     * @param string[] $types The types that the application can respond with for the provided request.
-     * @return string|null Either the resolved type or `null` if no decision can be made.
-     */
-    public function prefersChoice(RequestInterface $request, array $types): ?string
-    {
-        $parsed = $this->parseAccept($request);
-        foreach ($parsed as $acceptTypes) {
-            $common = array_intersect($acceptTypes, $types);
-            if ($common) {
-                return array_shift($common);
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Parse Accept* headers with qualifier options.
      *
      * Only qualifiers will be extracted, any other accept extensions will be
      * discarded as they are not frequently used.
      *
      * @param \Psr\Http\Message\RequestInterface $request The request to get an accept from.
-     * @param string $header The header name to read.
-     * @return array
+     * @return array<string, array<string>> A mapping of preference values => content types
      */
-    public function parseAccept(RequestInterface $request, string $header = 'Accept'): array
+    public function parseAccept(RequestInterface $request): array
     {
-        $header = $request->getHeaderLine($header);
+        $header = $request->getHeaderLine('Accept');
+
+        return $this->parseQualifiers($header);
+    }
+
+    /**
+     * Parse the Accept-Language header
+     *
+     * Only qualifiers will be extracted, other extensions will be ignored
+     * as they are not frequently used.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request The request to get an accept from.
+     * @return array<string, array<string>> A mapping of preference values => languages
+     */
+    public function parseAcceptLanguage(RequestInterface $request): array
+    {
+        $header = $request->getHeaderLine('Accept-Language');
+
+        return $this->parseQualifiers($header);
+    }
+
+    /**
+     * Parse a header value into preference => value mapping
+     *
+     * @param string $header The header value to parse
+     * @return array<string, array<string>>
+     */
+    protected function parseQualifiers(string $header): array
+    {
         $accept = [];
         if (!$header) {
             return $accept;
@@ -103,5 +82,84 @@ class ContentTypeNegotiation
         krsort($accept);
 
         return $accept;
+    }
+
+    /**
+     * Get the most preferred content type from a request.
+     *
+     * Parse the Accept header preferences and return the most
+     * preferred type. If multiple types are tied in preference
+     * the first type of that preference value will be returned.
+     *
+     * You can expect null when the request has no Accept header.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request The request to use.
+     * @param string[] $choices The supported content type choices.
+     * @return string|null The prefered type or null if there is no match with choices or if the
+     *   request had no Accept header.
+     */
+    public function preferredType(RequestInterface $request, array $choices = []): ?string
+    {
+        $parsed = $this->parseAccept($request);
+        if (empty($parsed)) {
+            return null;
+        }
+        if (empty($choices)) {
+            $preferred = array_shift($parsed);
+
+            return $preferred[0];
+        }
+
+        foreach ($parsed as $acceptTypes) {
+            $common = array_intersect($acceptTypes, $choices);
+            if ($common) {
+                return array_shift($common);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the normalized list of accepted languages
+     *
+     * Language codes in the request will be normalized to lower case and have
+     * `_` replaced with `-`.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request The request to read headers from.
+     * @return array<string> A list of language codes that are accepted.
+     */
+    public function acceptedLanguages(RequestInterface $request): array
+    {
+        $raw = $this->parseAcceptLanguage($request);
+        $accept = [];
+        foreach ($raw as $languages) {
+            foreach ($languages as &$lang) {
+                if (strpos($lang, '_')) {
+                    $lang = str_replace('_', '-', $lang);
+                }
+                $lang = strtolower($lang);
+            }
+            $accept = array_merge($accept, $languages);
+        }
+
+        return $accept;
+    }
+
+    /**
+     * Check if the request accepts a given language code.
+     *
+     * Language codes in the request will be normalized to lower case and have `_` replaced
+     * with `-`.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request The request to read headers from.
+     * @param string $lang The language code to check.
+     * @return bool Whether the request accepts $lang
+     */
+    public function acceptLanguage(RequestInterface $request, string $lang): bool
+    {
+        $accept = $this->acceptedLanguages($request);
+
+        return in_array(strtolower($lang), $accept, true);
     }
 }

--- a/src/Http/ContentTypeNegotiation.php
+++ b/src/Http/ContentTypeNegotiation.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Http;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Negotiates the prefered content type from what the application
+ * provides and what the request has in its Accept header.
+ */
+class ContentTypeNegotiation
+{
+    /**
+     * Get the most preferred content type from a request.
+     *
+     * Parse the Accept header preferences and return the most
+     * preferred type. If multiple types are tied in preference
+     * the first type of that preference value will be returned.
+     *
+     * You can expect null when the request has no Accept header.
+     *
+     * @param Psr\Http\Message\RequestInterface $request
+     * @return string|null The prefered type.
+     */
+    public function prefers(RequestInterface $request): ?string
+    {
+        $accept = $request->getHeaderLine('Accept');
+        if (!$accept) {
+            return null;
+        }
+        $parsed = $this->parseAcceptWithQualifier($accept);
+        if (empty($parsed)) {
+            return null;
+        }
+        $types = array_shift($parsed);
+
+        return $types[0];
+    }
+
+    /**
+     * Perform content type negotiation with a list of valid choices.
+     *
+     * Choose a content-type from a list of values the application
+     * can provide. If there are no matches then `null` will be
+     * returned. You can also expect null when the request has
+     * no Accept header.
+     *
+     * @param Psr\Http\Message\RequestInterface $request The request to read an `Accept` header from.
+     * @param string[] $types The types that the application can respond with for the provided request.
+     * @return string|null Either the resolved type or `null` if no decision can be made.
+     */
+    public function prefersChoice(RequestInterface $request, array $types): ?string
+    {
+        $accept = $request->getHeaderLine('Accept');
+        if (!$accept) {
+            return null;
+        }
+        $parsed = $this->parseAcceptWithQualifier($accept);
+        foreach ($parsed as $qual => $acceptTypes) {
+            $common = array_intersect($acceptTypes, $types);
+            if ($common) {
+                return $common[0];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse Accept* headers with qualifier options.
+     *
+     * Only qualifiers will be extracted, any other accept extensions will be
+     * discarded as they are not frequently used.
+     *
+     * @param string $header Header to parse.
+     * @return array
+     */
+    protected function parseAcceptWithQualifier(string $header): array
+    {
+        $accept = [];
+        $headers = explode(',', $header);
+        foreach (array_filter($headers) as $value) {
+            $prefValue = '1.0';
+            $value = trim($value);
+
+            $semiPos = strpos($value, ';');
+            if ($semiPos !== false) {
+                $params = explode(';', $value);
+                $value = trim($params[0]);
+                foreach ($params as $param) {
+                    $qPos = strpos($param, 'q=');
+                    if ($qPos !== false) {
+                        $prefValue = substr($param, $qPos + 2);
+                    }
+                }
+            }
+
+            if (!isset($accept[$prefValue])) {
+                $accept[$prefValue] = [];
+            }
+            if ($prefValue) {
+                $accept[$prefValue][] = $value;
+            }
+        }
+        krsort($accept);
+
+        return $accept;
+    }
+}

--- a/src/Http/ContentTypeNegotiation.php
+++ b/src/Http/ContentTypeNegotiation.php
@@ -20,16 +20,12 @@ class ContentTypeNegotiation
      *
      * You can expect null when the request has no Accept header.
      *
-     * @param Psr\Http\Message\RequestInterface $request
+     * @param \Psr\Http\Message\RequestInterface $request The request to use.
      * @return string|null The prefered type.
      */
     public function prefers(RequestInterface $request): ?string
     {
-        $accept = $request->getHeaderLine('Accept');
-        if (!$accept) {
-            return null;
-        }
-        $parsed = $this->parseAcceptWithQualifier($accept);
+        $parsed = $this->parseAccept($request);
         if (empty($parsed)) {
             return null;
         }
@@ -44,20 +40,16 @@ class ContentTypeNegotiation
      * Choose a content-type from a list of values the application
      * can provide. If there are no matches then `null` will be
      * returned. You can also expect null when the request has
-     * no Accept header.
+     * no `Accept` header.
      *
-     * @param Psr\Http\Message\RequestInterface $request The request to read an `Accept` header from.
+     * @param \Psr\Http\Message\RequestInterface $request The request to use.
      * @param string[] $types The types that the application can respond with for the provided request.
      * @return string|null Either the resolved type or `null` if no decision can be made.
      */
     public function prefersChoice(RequestInterface $request, array $types): ?string
     {
-        $accept = $request->getHeaderLine('Accept');
-        if (!$accept) {
-            return null;
-        }
-        $parsed = $this->parseAcceptWithQualifier($accept);
-        foreach ($parsed as $qual => $acceptTypes) {
+        $parsed = $this->parseAccept($request);
+        foreach ($parsed as $acceptTypes) {
             $common = array_intersect($acceptTypes, $types);
             if ($common) {
                 return $common[0];
@@ -73,12 +65,17 @@ class ContentTypeNegotiation
      * Only qualifiers will be extracted, any other accept extensions will be
      * discarded as they are not frequently used.
      *
-     * @param string $header Header to parse.
+     * @param \Psr\Http\Message\RequestInterface $request The request to get an accept from.
+     * @param string $header The header name to read.
      * @return array
      */
-    protected function parseAcceptWithQualifier(string $header): array
+    public function parseAccept(RequestInterface $request, string $header = 'Accept'): array
     {
+        $header = $request->getHeaderLine($header);
         $accept = [];
+        if (!$header) {
+            return $accept;
+        }
         $headers = explode(',', $header);
         foreach (array_filter($headers) as $value) {
             $prefValue = '1.0';

--- a/src/Http/ContentTypeNegotiation.php
+++ b/src/Http/ContentTypeNegotiation.php
@@ -52,7 +52,7 @@ class ContentTypeNegotiation
         foreach ($parsed as $acceptTypes) {
             $common = array_intersect($acceptTypes, $types);
             if ($common) {
-                return $common[0];
+                return array_shift($common);
             }
         }
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -552,14 +552,10 @@ class ServerRequest implements ServerRequestInterface
      */
     protected function _acceptHeaderDetector(array $detect): bool
     {
-        $acceptHeaders = explode(',', (string)$this->getEnv('HTTP_ACCEPT'));
-        foreach ($detect['accept'] as $header) {
-            if (in_array($header, $acceptHeaders, true)) {
-                return true;
-            }
-        }
+        $content = new ContentTypeNegotiation();
+        $accepted = $content->preferredType($this, $detect['accept']);
 
-        return false;
+        return $accepted !== null;
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1113,7 +1113,7 @@ class ServerRequest implements ServerRequestInterface
      * of the accepted content types.
      *
      * @return array An array of `prefValue => [content/types]`
-     * @deprecated 4.4.0 Use accepts() or ContentTypeNegotiation instead.
+     * @deprecated 4.4.0 Use `accepts()` or `ContentTypeNegotiation` class instead.
      */
     public function parseAccept(): array
     {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1094,7 +1094,7 @@ class ServerRequest implements ServerRequestInterface
     {
         $content = new ContentTypeNegotiation();
         if ($type) {
-            return $content->prefersChoice($this, [$type]) !== null;
+            return $content->preferredType($this, [$type]) !== null;
         }
 
         $accept = [];
@@ -1125,33 +1125,23 @@ class ServerRequest implements ServerRequestInterface
      *
      * Get the list of accepted languages:
      *
-     * ``` \Cake\Http\ServerRequest::acceptLanguage(); ```
+     * ```$request->acceptLanguage();```
      *
      * Check if a specific language is accepted:
      *
-     * ``` \Cake\Http\ServerRequest::acceptLanguage('es-es'); ```
+     * ```$request->acceptLanguage('es-es');```
      *
      * @param string|null $language The language to test.
      * @return array|bool If a $language is provided, a boolean. Otherwise the array of accepted languages.
      */
     public function acceptLanguage(?string $language = null)
     {
-        $raw = (new ContentTypeNegotiation())->parseAccept($this, 'Accept-Language');
-        $accept = [];
-        foreach ($raw as $languages) {
-            foreach ($languages as &$lang) {
-                if (strpos($lang, '_')) {
-                    $lang = str_replace('_', '-', $lang);
-                }
-                $lang = strtolower($lang);
-            }
-            $accept = array_merge($accept, $languages);
-        }
-        if ($language === null) {
-            return $accept;
+        $content = new ContentTypeNegotiation();
+        if ($language !== null) {
+            return $content->acceptLanguage($this, $language);
         }
 
-        return in_array(strtolower($language), $accept, true);
+        return $content->acceptedLanguages($this);
     }
 
     /**

--- a/tests/TestCase/Http/ContentTypeNegotiationTest.php
+++ b/tests/TestCase/Http/ContentTypeNegotiationTest.php
@@ -118,4 +118,35 @@ class ContentTypeNegotiationTest extends TestCase
             $content->prefersChoice($request, ['image/png', 'text/html'])
         );
     }
+
+    public function testParseAccept()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/json;q=0.5,application/xml;q=0.6,application/pdf;q=0.3',
+            ],
+        ]);
+        $result = $content->parseAccept($request);
+        $expected = [
+            '0.6' => ['application/xml'],
+            '0.5' => ['application/json'],
+            '0.3' => ['application/pdf'],
+        ];
+        $this->assertEquals($expected, $result);
+
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/pdf;q=0.3,application/json;q=0.5,application/xml;q=0.5',
+            ],
+        ]);
+        $result = $content->parseAccept($request);
+        $expected = [
+            '0.5' => ['application/json', 'application/xml'],
+            '0.3' => ['application/pdf'],
+        ];
+        $this->assertEquals($expected, $result, 'Sorting is incorrect.');
+    }
 }

--- a/tests/TestCase/Http/ContentTypeNegotiationTest.php
+++ b/tests/TestCase/Http/ContentTypeNegotiationTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\ContentTypeNegotiation;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+
+class ContentTypeNegotiationTest extends TestCase
+{
+    public function testPrefersNoAccept()
+    {
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+        ]);
+        $content = new ContentTypeNegotiation();
+        $this->assertNull($content->prefers($request));
+
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => '',
+            ],
+        ]);
+        $this->assertNull($content->prefers($request));
+    }
+
+    public function testPrefersFirstMatch()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+        ]);
+        $this->assertEquals('application/json', $content->prefers($request));
+
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/json,application/xml',
+            ],
+        ]);
+        $this->assertEquals('application/json', $content->prefers($request));
+    }
+
+    public function testPrefersQualValue()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5',
+            ],
+        ]);
+        $this->assertEquals('text/xml', $content->prefers($request));
+
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'text/plain;q=0.8,application/json;q=0.9',
+            ],
+        ]);
+        $this->assertEquals('application/json', $content->prefers($request));
+    }
+
+    public function testPrefersChoiceNoMatch()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+        ]);
+        $this->assertNull($content->prefersChoice($request, ['text/html']));
+    }
+
+    public function testPrefersChoiceSimple()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+        ]);
+        $this->assertEquals(
+            'application/json',
+            $content->prefersChoice($request, ['text/html', 'application/json'])
+        );
+    }
+
+    public function testPrefersChoiceQualValue()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'application/json;q=0.5,application/xml;q=0.6,application/pdf;q=0.3',
+            ],
+        ]);
+        $this->assertEquals(
+            'application/json',
+            $content->prefersChoice($request, ['text/html', 'application/json'])
+        );
+        $this->assertEquals(
+            'application/pdf',
+            $content->prefersChoice($request, ['text/html', 'application/pdf'])
+        );
+        $this->assertEquals(
+            'application/json',
+            $content->prefersChoice($request, ['application/json', 'application/pdf'])
+        );
+        $this->assertNull(
+            $content->prefersChoice($request, ['image/png', 'text/html'])
+        );
+    }
+}


### PR DESCRIPTION
Part of #16113

Add the ContentTypeNegotiation utility class. This class extracts some logic that was shared between the Request and RequestHandler. This logic is also required for the new ViewClasses feature described in the linked issue.