### PR TITLE
add info and warning methods to phpdoc in FlashComponent

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -28,6 +28,8 @@ use Throwable;
  * FlashHelper.
  *
  * @method void success(string $message, array $options = []) Set a message using "success" element
+ * @method void info(string $message, array $options = []) Set a message using "info" element
+ * @method void warning(string $message, array $options = []) Set a message using "warning" element
  * @method void error(string $message, array $options = []) Set a message using "error" element
  */
 class FlashComponent extends Component


### PR DESCRIPTION
This adds the `warning()` and `info()` method suggestions to the FlashComponent so IDE's like PHPStorm will show them when using the FlashComponent