### PR TITLE
Inject the ServerRequest in the dependency container by default

### DIFF
--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -28,6 +28,8 @@ use Throwable;
  * FlashHelper.
  *
  * @method void success(string $message, array $options = []) Set a message using "success" element
+ * @method void info(string $message, array $options = []) Set a message using "info" element
+ * @method void warning(string $message, array $options = []) Set a message using "warning" element
  * @method void error(string $message, array $options = []) Set a message using "error" element
  */
 class FlashComponent extends Component

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -79,10 +79,9 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             throw $this->missingController($request);
         }
 
-        // If the controller has a container definition
-        // add the request as a service.
+        // Get the controller from the container if defined.
+        // The request is in the container by default.
         if ($this->container->has($className)) {
-            $this->container->add(ServerRequest::class, $request);
             $controller = $this->container->get($className);
         } else {
             $controller = $reflection->newInstance($request);

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -294,6 +294,7 @@ abstract class BaseApplication implements
     /**
      * Invoke the application.
      *
+     * - Add the request to the container, enabling its injection into other services.
      * - Convert the PSR response into CakePHP equivalents.
      * - Create the controller that will handle this request.
      * - Invoke the controller.
@@ -304,6 +305,8 @@ abstract class BaseApplication implements
     public function handle(
         ServerRequestInterface $request
     ): ResponseInterface {
+        $this->getContainer()->add(ServerRequest::class, $request);
+
         if ($this->controllerFactory === null) {
             $this->controllerFactory = new ControllerFactory($this->getContainer());
         }

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -88,7 +88,7 @@ class TableRegistry
      * @param string $alias The alias name you want to get.
      * @param array<string, mixed> $options The options you want to build the table with.
      * @return \Cake\ORM\Table
-     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\TableLocator::get()} instead. Will be removed in 5.0.
+     * @deprecated 3.6.0 Use {@link \Cake\ORM\Locator\LocatorAwareTrait::fetchTable()} instead. Will be removed in 5.0.
      */
     public static function get(string $alias, array $options = []): Table
     {

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -269,15 +269,6 @@ class ControllerFactoryTest extends TestCase
      */
     public function testCreateWithContainerDependenciesWithController(): void
     {
-        $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
-        $this->container->add(DependenciesController::class)
-            ->addArgument(ServerRequest::class)
-            ->addArgument(null)
-            ->addArgument(null)
-            ->addArgument(null)
-            ->addArgument(null)
-            ->addArgument(stdClass::class);
-
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/index',
             'params' => [
@@ -286,6 +277,16 @@ class ControllerFactoryTest extends TestCase
                 'action' => 'index',
             ],
         ]);
+        $this->container->add(stdClass::class, json_decode('{"key":"value"}'));
+        $this->container->add(ServerRequest::class, $request);
+        $this->container->add(DependenciesController::class)
+            ->addArgument(ServerRequest::class)
+            ->addArgument(null)
+            ->addArgument(null)
+            ->addArgument(null)
+            ->addArgument(null)
+            ->addArgument(stdClass::class);
+
         $controller = $this->factory->create($request);
         $this->assertInstanceOf(DependenciesController::class, $controller);
         $this->assertSame($controller->inject, $this->container->get(stdClass::class));

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -22,6 +22,7 @@ use Cake\Core\Container;
 use Cake\Core\ContainerInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
@@ -74,6 +75,7 @@ class BaseApplicationTest extends TestCase
         $result = $app->handle($request);
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertSame('Hello Jane', '' . $result->getBody());
+        $this->assertSame($request, $app->getContainer()->get(ServerRequest::class));
     }
 
     /**


### PR DESCRIPTION
Description

Services will often have the server request as a dependency. This PR proposes to have the server request, in the state as it is presented to the controller, added to the container under the ServerRequest::class key.

This will facilitate the injection of the server request in other services and move pieces of logic that would be placed in middlewares into services themselves.