### PR TITLE
Add Uri subclass to avoid dynamic properties

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -336,16 +336,6 @@ parameters:
 			path: src/Http/Response.php
 
 		-
-			message: "#^Access to an undefined property Psr\\\\Http\\\\Message\\\\UriInterface\\:\\:\\$base\\.$#"
-			count: 2
-			path: src/Http/ServerRequestFactory.php
-
-		-
-			message: "#^Access to an undefined property Psr\\\\Http\\\\Message\\\\UriInterface\\:\\:\\$webroot\\.$#"
-			count: 3
-			path: src/Http/ServerRequestFactory.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Http/Session.php

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -228,7 +228,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
      *
      * @param array $server The server parameters.
      * @param array $headers The normalized headers
-     * @return \Psr\Http\Message\UriInterface a constructed Uri
+     * @return \Cake\Http\Uri A constructed Uri
      */
     protected static function marshalUriFromSapi(array $server, array $headers): UriInterface
     {
@@ -248,14 +248,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             $uri = $uri->withHost('localhost');
         }
 
-        // Splat on some extra attributes to save
-        // some method calls.
-        /** @psalm-suppress NoInterfaceProperties */
-        $uri->base = $base;
-        /** @psalm-suppress NoInterfaceProperties */
-        $uri->webroot = $webroot;
-
-        return $uri;
+        return Uri::fromLaminas($uri, $base, $webroot);
     }
 
     /**

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -48,7 +48,7 @@ class Uri implements UriInterface
     /**
      * Constructor
      *
-     * @param \Psr\Http\Message\Uri $uri Uri instance to decorate
+     * @param \Psr\Http\Message\UriInterface $uri Uri instance to decorate
      * @param string $base The base path.
      * @param string $webroot The webroot path.
      */

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -154,7 +154,10 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string $scheme Scheme value.
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withScheme($scheme)
     {
@@ -162,7 +165,11 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string $user User value
+     * @param string|null $password Password value.
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withUserInfo($user, $password = null)
     {
@@ -170,7 +177,10 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string $host Host value.
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withHost($host)
     {
@@ -178,7 +188,10 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param int $port Port value
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withPort($port)
     {
@@ -186,7 +199,10 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string $path Path value
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withPath($path)
     {
@@ -194,7 +210,10 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string $query Query value
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withQuery($query)
     {
@@ -202,7 +221,10 @@ class Uri implements UriInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     *
+     * @param string $fragment Fragment value
+     * @return \Psr\Http\Message\UriInterface
      */
     public function withFragment($fragment)
     {

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.3.0
+ * @since         4.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Http;

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -158,7 +158,10 @@ class Uri implements UriInterface
      */
     public function withScheme($scheme)
     {
-        return new static($this->uri->withScheme($scheme), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withScheme($scheme);
+
+        return $new;
     }
 
     /**
@@ -166,7 +169,10 @@ class Uri implements UriInterface
      */
     public function withUserInfo($user, $password = null)
     {
-        return new static($this->uri->withUserInfo($user, $password), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withUserInfo($user, $password);
+
+        return $new;
     }
 
     /**
@@ -174,7 +180,10 @@ class Uri implements UriInterface
      */
     public function withHost($host)
     {
-        return new static($this->uri->withHost($host), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withHost($host);
+
+        return $new;
     }
 
     /**
@@ -182,7 +191,10 @@ class Uri implements UriInterface
      */
     public function withPort($port)
     {
-        return new static($this->uri->withPort($port), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withPort($port);
+
+        return $new;
     }
 
     /**
@@ -190,7 +202,10 @@ class Uri implements UriInterface
      */
     public function withPath($path)
     {
-        return new static($this->uri->withPath($path), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withPath($path);
+
+        return $new;
     }
 
     /**
@@ -198,7 +213,10 @@ class Uri implements UriInterface
      */
     public function withQuery($query)
     {
-        return new static($this->uri->withQuery($query), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withQuery($query);
+
+        return $new;
     }
 
     /**
@@ -206,7 +224,10 @@ class Uri implements UriInterface
      */
     public function withFragment($fragment)
     {
-        return new static($this->uri->withFragment($fragment), $this->base, $this->webroot);
+        $new = clone $this;
+        $new->uri = $this->uri->withFragment($fragment);
+
+        return $new;
     }
 
     /**

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Http;
+
+use Laminas\Diactoros\Uri as LaminasUri;
+
+/**
+ * The base and webroot properties have piggybacked on the Uri for
+ * a long time. To preserve backwards compatibility and avoid dynamic
+ * property errors in PHP 8.2 we use this subclass.
+ */
+class Uri extends LaminasUri
+{
+    /**
+     * @var string
+     */
+    private $base = '';
+
+    /**
+     * @var string
+     */
+    private $webroot = '';
+
+    /**
+     * Create a subclassed Uri that includes additional CakePHP properties
+     *
+     * @param \Laminas\Diactoros\Uri $uri Uri instance to copy
+     * @param string $base The base path.
+     * @param string $webroot The webroot path.
+     * @return self
+     */
+    public static function fromLaminas(LaminasUri $uri, string $base, string $webroot): self
+    {
+        $copy = (new self())
+            ->withScheme($uri->getScheme())
+            ->withHost($uri->getHost())
+            ->withUserInfo($uri->getUserInfo())
+            ->withPort($uri->getPort())
+            ->withPath($uri->getPath())
+            ->withQuery($uri->getQuery())
+            ->withFragment($uri->getFragment());
+
+        $copy->base = $base;
+        $copy->webroot = $webroot;
+
+        return $copy;
+    }
+
+    /**
+     * Backwards compatible property read
+     *
+     * @param string $prop The property to read.
+     * @return string|null
+     */
+    public function __get($prop): ?string
+    {
+        if ($prop !== 'base' && $prop !== 'webroot') {
+            return null;
+        }
+
+        return $this->{$prop};
+    }
+
+    /**
+     * Get the application base path.
+     *
+     * @return string
+     */
+    public function getBase(): string
+    {
+        return $this->base;
+    }
+
+    /**
+     * Get the application webroot path.
+     *
+     * @return string
+     */
+    public function getWebroot(): string
+    {
+        return $this->webroot;
+    }
+}

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -1,16 +1,34 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Http;
 
-use Laminas\Diactoros\Uri as LaminasUri;
+use Psr\Http\Message\UriInterface;
 
 /**
  * The base and webroot properties have piggybacked on the Uri for
  * a long time. To preserve backwards compatibility and avoid dynamic
- * property errors in PHP 8.2 we use this subclass.
+ * property errors in PHP 8.2 we use this implementation that decorates
+ * the Uri from Laminas
+ *
+ * This class is an internal implementation workaround that will be removed in 5.x
+ *
+ * @internal
  */
-class Uri extends LaminasUri
+class Uri implements UriInterface
 {
     /**
      * @var string
@@ -23,43 +41,32 @@ class Uri extends LaminasUri
     private $webroot = '';
 
     /**
-     * Create a subclassed Uri that includes additional CakePHP properties
+     * @var \Psr\Http\Message\UriInterface
+     */
+    private $uri;
+
+    /**
+     * Constructor
      *
-     * @param \Laminas\Diactoros\Uri $uri Uri instance to copy
+     * @param \Psr\Http\Message\Uri $uri Uri instance to decorate
      * @param string $base The base path.
      * @param string $webroot The webroot path.
-     * @return self
      */
-    public static function fromLaminas(LaminasUri $uri, string $base, string $webroot): self
+    public function __construct(UriInterface $uri, string $base, string $webroot)
     {
-        $copy = (new self())
-            ->withScheme($uri->getScheme())
-            ->withHost($uri->getHost())
-            ->withUserInfo($uri->getUserInfo())
-            ->withPort($uri->getPort())
-            ->withPath($uri->getPath())
-            ->withQuery($uri->getQuery())
-            ->withFragment($uri->getFragment());
-
-        $copy->base = $base;
-        $copy->webroot = $webroot;
-
-        return $copy;
+        $this->uri = $uri;
+        $this->base = $base;
+        $this->webroot = $webroot;
     }
 
     /**
-     * Backwards compatible property read
+     * Get the decorated URI
      *
-     * @param string $prop The property to read.
-     * @return string|null
+     * @return \Psr\Http\Message\UriInterface
      */
-    public function __get($prop): ?string
+    public function getUri(): UriInterface
     {
-        if ($prop !== 'base' && $prop !== 'webroot') {
-            return null;
-        }
-
-        return $this->{$prop};
+        return $this->uri;
     }
 
     /**
@@ -80,5 +87,133 @@ class Uri extends LaminasUri
     public function getWebroot(): string
     {
         return $this->webroot;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getScheme()
+    {
+        return $this->uri->getScheme();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAuthority()
+    {
+        return $this->uri->getAuthority();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUserInfo()
+    {
+        return $this->uri->getUserInfo();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHost()
+    {
+        return $this->uri->getHost();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPort()
+    {
+        return $this->uri->getPort();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPath()
+    {
+        return $this->uri->getPath();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getQuery()
+    {
+        return $this->uri->getQuery();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFragment()
+    {
+        return $this->uri->getFragment();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withScheme($scheme)
+    {
+        return $this->uri->withScheme($scheme);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withUserInfo($user, $password = null)
+    {
+        return $this->uri->withUserInfo($user, $password);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withHost($host)
+    {
+        return $this->uri->withHost($host);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withPort($port)
+    {
+        return $this->uri->withPort($port);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withPath($path)
+    {
+        return $this->uri->withPath($path);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withQuery($query)
+    {
+        return $this->uri->withQuery($query);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withFragment($fragment)
+    {
+        return $this->uri->withFragment($fragment);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __toString()
+    {
+        return $this->uri->__toString();
     }
 }

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -154,81 +154,59 @@ class Uri implements UriInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param string $scheme Scheme value.
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withScheme($scheme)
     {
-        return $this->uri->withScheme($scheme);
+        return new static($this->uri->withScheme($scheme), $this->base, $this->webroot);
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param string $user User value
-     * @param string|null $password Password value.
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withUserInfo($user, $password = null)
     {
-        return $this->uri->withUserInfo($user, $password);
+        return new static($this->uri->withUserInfo($user, $password), $this->base, $this->webroot);
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param string $host Host value.
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withHost($host)
     {
-        return $this->uri->withHost($host);
+        return new static($this->uri->withHost($host), $this->base, $this->webroot);
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param int $port Port value
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withPort($port)
     {
-        return $this->uri->withPort($port);
+        return new static($this->uri->withPort($port), $this->base, $this->webroot);
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param string $path Path value
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withPath($path)
     {
-        return $this->uri->withPath($path);
+        return new static($this->uri->withPath($path), $this->base, $this->webroot);
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param string $query Query value
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withQuery($query)
     {
-        return $this->uri->withQuery($query);
+        return new static($this->uri->withQuery($query), $this->base, $this->webroot);
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @param string $fragment Fragment value
-     * @return \Psr\Http\Message\UriInterface
+     * @inheritDoc
      */
     public function withFragment($fragment)
     {
-        return $this->uri->withFragment($fragment);
+        return new static($this->uri->withFragment($fragment), $this->base, $this->webroot);
     }
 
     /**

--- a/tests/TestCase/Http/UriTest.php
+++ b/tests/TestCase/Http/UriTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         4.3.0
+ * @since         4.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Http;

--- a/tests/TestCase/Http/UriTest.php
+++ b/tests/TestCase/Http/UriTest.php
@@ -79,6 +79,7 @@ class UriTest extends TestCase
             $new = $uri->{$method}('value');
             $this->assertNotSame($new, $uri);
             $this->assertNotSame($new, $inner);
+            $this->assertInstanceOf(Uri::class, $new);
         }
     }
 }

--- a/tests/TestCase/Http/UriTest.php
+++ b/tests/TestCase/Http/UriTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\Uri;
+use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Uri as LaminasUri;
+
+/**
+ * Test case for the Uri Shim
+ */
+class UriTest extends TestCase
+{
+    public function testExtraMethods()
+    {
+        $inner = new LaminasUri('/articles/view/1');
+        $uri = new Uri($inner, '/base', '/base/');
+
+        $this->assertSame('/base', $uri->getBase());
+        $this->assertSame('/base/', $uri->getWebroot());
+    }
+
+    public function testWrappedGetMethods()
+    {
+        $inner = (new LaminasUri('/articles/view/1'))
+            ->withPort(80)
+            ->withUserInfo('user', 'pass')
+            ->withQuery('a=b&c=d')
+            ->withFragment('frag');
+
+        $uri = new Uri($inner, '/base', '/base/');
+        $methods = [
+            'getScheme', 'getAuthority', 'getUserInfo',
+            'getHost', 'getPort', 'getPath', 'getQuery', 'getFragment',
+        ];
+        foreach ($methods as $method) {
+            $this->assertSame($inner->{$method}(), $uri->{$method}());
+        }
+    }
+
+    public function testWrappedWithMethods()
+    {
+        $inner = new LaminasUri('/articles/view/1');
+        $uri = new Uri($inner, '/base', '/base/');
+
+        $new = $uri->withPort(80);
+        $this->assertNotSame($new, $uri);
+        $this->assertNotSame($new, $inner);
+        $this->assertSame(80, $new->getPort());
+
+        $new = $uri->withScheme('http');
+        $this->assertNotSame($new, $uri);
+        $this->assertNotSame($new, $inner);
+        $this->assertSame('http', $new->getScheme());
+
+        $new = $uri->withUserInfo('user', 'pass');
+        $this->assertNotSame($new, $uri);
+        $this->assertNotSame($new, $inner);
+        $this->assertSame('user:pass', $new->getUserInfo());
+
+        $methods = [
+            'withHost', 'withPath', 'withQuery', 'withFragment',
+        ];
+        foreach ($methods as $method) {
+            $new = $uri->{$method}('value');
+            $this->assertNotSame($new, $uri);
+            $this->assertNotSame($new, $inner);
+        }
+    }
+}


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/16158

Remove the usage of dynamic properties on Uri by subclassing and making the properties concrete. I'm not sure I like using the builder methods to reconstruct the URI. Another solution I might explore is to create proxy methods, but first I want to profile the runtime impacts of this change.
