### PR TITLE
RFC: add config key to enable default TransactionStrategy for testing

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -28,6 +28,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\Constraint\EventFired;
 use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\TestSuite\Fixture\FixtureStrategyInterface;
+use Cake\TestSuite\Fixture\TransactionStrategy;
 use Cake\TestSuite\Fixture\TruncateStrategy;
 use Cake\Utility\Inflector;
 use LogicException;
@@ -321,7 +322,11 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getFixtureStrategy(): FixtureStrategyInterface
     {
-        return new TruncateStrategy();
+        if (Configure::read('Test.enableTransactionStrategy', false)) {
+            return new TransactionStrategy();
+        } else {
+            return new TruncateStrategy();
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds the Config Key `Test.enableTransactionStrategy` to enable the TransactionStrategy by default.

The [docs](https://book.cakephp.org/4/en/development/testing.html#fixture-state-managers) already mention that you either can create a base class or a trait to basically do the same for a selected amount of test classes but I thought it would be nice to just enable it "globally" via one config key.

Unfortunately I am not very accustomed to write a test for that since I haven't dealt with this topic that much.

I also started a new "root" Config key `Test` since this is not really `App` specific/relevant and therefore should have its own "config space" in my opinion.

Happy to hear your thoughts 😄 