### PR TITLE
Revert FixtureManager::_runOperation() to 4.2 behavior

### DIFF
--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -19,7 +19,6 @@ namespace Cake\TestSuite\Fixture;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\ConstraintsInterface;
-use Cake\Database\Driver\Postgres;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaAwareInterface;
 use Cake\Datasource\ConnectionInterface;
@@ -392,18 +391,11 @@ class FixtureManager
             if ($logQueries && !$this->_debug) {
                 $db->disableQueryLogging();
             }
-            if ($db->getDriver() instanceof Postgres) {
-                // disabling foreign key constraints is only valid in a transaction
-                $db->transactional(function (ConnectionInterface $db) use ($fixtures, $operation): void {
-                    $db->disableConstraints(function (ConnectionInterface $db) use ($fixtures, $operation): void {
-                        $operation($db, $fixtures);
-                    });
-                });
-            } else {
+            $db->transactional(function (ConnectionInterface $db) use ($fixtures, $operation): void {
                 $db->disableConstraints(function (ConnectionInterface $db) use ($fixtures, $operation): void {
                     $operation($db, $fixtures);
                 });
-            }
+            });
             if ($logQueries) {
                 $db->enableQueryLogging(true);
             }


### PR DESCRIPTION
This change was made to FixtureDataManager before that system was re-written into FixtureHelper and strategies. It was copied to FixtureManager for symmetry, but it affects the legacy fixture behavior. https://github.com/cakephp/cakephp/commit/0c5938f73b25b08d7846197ac3078854830d137b

I made this change originally when removing the deprecated autoFixtures flag from internal tests which must have revealed foreign key dependency issues.