### PR TITLE
4.4 - Add Controller::viewClasses() and support content negotiation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -406,4 +406,9 @@
       <code>defaultCurrency</code>
     </DeprecatedMethod>
   </file>
+  <file src="src/View/SerializedView.php">
+    <DeprecatedProperty occurrences="1">
+      <code>$this-&gt;_responseType</code>
+    </DeprecatedProperty>
+  </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -407,7 +407,7 @@
     </DeprecatedMethod>
   </file>
   <file src="src/View/SerializedView.php">
-    <DeprecatedProperty occurrences="1">
+    <DeprecatedProperty occurrences="3">
       <code>$this-&gt;_responseType</code>
     </DeprecatedProperty>
   </file>

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -793,6 +793,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if (empty($possibleViewClasses)) {
             return null;
         }
+        // Controller or component has already made a view class decision.
+        // That decision should overwrite the framework behavior.
         if ($this->viewBuilder()->getClassName() !== null) {
             return null;
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -758,7 +758,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($builder->getTemplate() === null) {
             $builder->setTemplate($this->request->getParam('action'));
         }
-        // TODO should this only be done if builder->getViewClass() is null?
         $viewClass = $this->chooseViewClass();
         $view = $this->createView($viewClass);
 
@@ -798,6 +797,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     protected function chooseViewClass(): ?string
     {
+        if ($this->viewBuilder()->getClassName() !== null) {
+            return null;
+        }
+
         $possibleViewClasses = $this->getViewClasses();
         if (empty($possibleViewClasses)) {
             return null;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -764,12 +764,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         $contents = $view->render();
         $response = $view->getResponse()->withStringBody($contents);
 
-        $viewContentType = $view->getContentType();
-        $responseType = $response->getHeaderLine('Content-Type');
-        if ($viewContentType && ($responseType === '' || substr($responseType, 0, 9) === 'text/html')) {
-            $response = $response->withHeader('Content-Type', $viewContentType);
-        }
-
         return $this->setResponse($response)->response;
     }
 
@@ -791,8 +785,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Use the view classes defined on this controller to view
      * selection based on content-type negotiation.
      *
-     * TODO: Should this also consider $request->getParam('_ext') as well?
-     *
      * @return string|null The chosen view class or null for no decision.
      */
     protected function chooseViewClass(): ?string
@@ -807,7 +799,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         $typeMap = [];
         foreach ($possibleViewClasses as $class) {
-            $viewContentType = $class::getContentType();
+            $viewContentType = $class::contentType();
             if ($viewContentType && !isset($typeMap[$viewContentType])) {
                 $typeMap[$viewContentType] = $class;
             }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -768,7 +768,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     }
 
     /**
-     * Get the list of View classes this controller can negotiate with.
+     * Get the View classes this controller can perform content negotiation with.
      *
      * Each view class must implement the `getContentType()` hook method
      * to participate in negotiation.

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -782,7 +782,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @see Cake\Http\ContentTypeNegotiation
      * @return array<string>
      */
-    public function getViewClasses(): array
+    public function viewClasses(): array
     {
         return [];
     }
@@ -797,7 +797,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     protected function chooseViewClass(): ?string
     {
-        $possibleViewClasses = $this->getViewClasses();
+        $possibleViewClasses = $this->viewClasses();
         if (empty($possibleViewClasses)) {
             return null;
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -758,12 +758,20 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($builder->getTemplate() === null) {
             $builder->setTemplate($this->request->getParam('action'));
         }
+        // TODO should this only be done if builder->getViewClass() is null?
         $viewClass = $this->chooseViewClass();
         $view = $this->createView($viewClass);
-        $contents = $view->render();
-        $this->setResponse($view->getResponse()->withStringBody($contents));
 
-        return $this->response;
+        $contents = $view->render();
+        $response = $view->getResponse()->withStringBody($contents);
+
+        $viewContentType = $view->getContentType();
+        $responseType = $response->getHeaderLine('Content-Type');
+        if ($viewContentType && ($responseType === '' || substr($responseType, 0, 9) === 'text/html')) {
+            $response = $response->withHeader('Content-Type', $viewContentType);
+        }
+
+        return $this->setResponse($response)->response;
     }
 
     /**

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -33,7 +33,7 @@ class AjaxView extends View
      *
      * @return string
      */
-    public static function getContentType(): string
+    public static function contentType(): string
     {
         return 'text/html';
     }

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -29,11 +29,12 @@ class AjaxView extends View
     protected $layout = 'ajax';
 
     /**
-     * @inheritDoc
+     * Get content type for this view.
+     *
+     * @return string
      */
-    public function initialize(): void
+    public static function getContentType(): string
     {
-        parent::initialize();
-        $this->setResponse($this->getResponse()->withType('ajax'));
+        return 'text/html';
     }
 }

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -100,7 +100,7 @@ class JsonView extends SerializedView
      *
      * @return string The JSON content type.
      */
-    public static function getContentType(): string
+    public static function contentType(): string
     {
         return 'application/json';
     }

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -73,13 +73,6 @@ class JsonView extends SerializedView
     protected $subDir = 'json';
 
     /**
-     * Response type.
-     *
-     * @var string
-     */
-    protected $_responseType = 'json';
-
-    /**
      * Default config options.
      *
      * Use ViewBuilder::setOption()/setOptions() in your controller to set these options.
@@ -101,6 +94,16 @@ class JsonView extends SerializedView
         'jsonOptions' => null,
         'jsonp' => null,
     ];
+
+    /**
+     * Mime-type this view class renders as.
+     *
+     * @return string The JSON content type.
+     */
+    public static function getContentType(): string
+    {
+        return 'application/json';
+    }
 
     /**
      * Render a JSON view.

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -29,6 +29,7 @@ abstract class SerializedView extends View
      * Response type.
      *
      * @var string
+     * @deprecated 4.4.0 Implement ``public static getContentType(): string`` instead.
      */
     protected $_responseType;
 
@@ -54,7 +55,14 @@ abstract class SerializedView extends View
     public function initialize(): void
     {
         parent::initialize();
-        $this->setResponse($this->getResponse()->withType($this->_responseType));
+        $response = $this->getResponse();
+        $contentType = static::getContentType();
+        if ($contentType) {
+            $response = $response->withType($contentType);
+        } else {
+            $response = $response->withType($this->_responseType);
+        }
+        $this->setResponse($response);
     }
 
     /**

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -29,7 +29,7 @@ abstract class SerializedView extends View
      * Response type.
      *
      * @var string
-     * @deprecated 4.4.0 Implement ``public static getContentType(): string`` instead.
+     * @deprecated 4.4.0 Implement ``public static contentType(): string`` instead.
      */
     protected $_responseType;
 
@@ -55,14 +55,10 @@ abstract class SerializedView extends View
     public function initialize(): void
     {
         parent::initialize();
-        $response = $this->getResponse();
-        $contentType = static::getContentType();
-        if ($contentType) {
-            $response = $response->withType($contentType);
-        } else {
-            $response = $response->withType($this->_responseType);
+        if ($this->_responseType) {
+            $response = $this->getResponse()->withType($this->_responseType);
+            $this->setResponse($response);
         }
-        $this->setResponse($response);
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -363,6 +363,26 @@ class View implements EventDispatcherInterface
      */
     public function initialize(): void
     {
+        $this->setContentType();
+    }
+
+    /**
+     * Set the response content-type based on the view's contentType()
+     *
+     * @return void
+     */
+    protected function setContentType(): void
+    {
+        $viewContentType = $this->contentType();
+        if (!$viewContentType) {
+            return;
+        }
+        $response = $this->getResponse();
+        $responseType = $response->getHeaderLine('Content-Type');
+        if ($responseType === '' || substr($responseType, 0, 9) === 'text/html') {
+            $response = $response->withType($viewContentType);
+        }
+        $this->setResponse($response);
     }
 
     /**
@@ -370,7 +390,7 @@ class View implements EventDispatcherInterface
      *
      * @return string Either the content type or '' which means no type.
      */
-    public static function getContentType(): string
+    public static function contentType(): string
     {
         return '';
     }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -366,6 +366,16 @@ class View implements EventDispatcherInterface
     }
 
     /**
+     * Mime-type this view class renders as.
+     *
+     * @return string Either the content type or '' which means no type.
+     */
+    public static function getContentType(): string
+    {
+        return '';
+    }
+
+    /**
      * Gets the request instance.
      *
      * @return \Cake\Http\ServerRequest

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -75,13 +75,6 @@ class XmlView extends SerializedView
     protected $subDir = 'xml';
 
     /**
-     * Response type.
-     *
-     * @var string
-     */
-    protected $_responseType = 'xml';
-
-    /**
      * Default config options.
      *
      * Use ViewBuilder::setOption()/setOptions() in your controller to set these options.
@@ -101,6 +94,16 @@ class XmlView extends SerializedView
         'xmlOptions' => null,
         'rootNode' => null,
     ];
+
+    /**
+     * Mime-type this view class renders as.
+     *
+     * @return string The JSON content type.
+     */
+    public static function getContentType(): string
+    {
+        return 'application/xml';
+    }
 
     /**
      * @inheritDoc

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -100,7 +100,7 @@ class XmlView extends SerializedView
      *
      * @return string The JSON content type.
      */
-    public static function getContentType(): string
+    public static function contentType(): string
     {
         return 'application/xml';
     }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -346,7 +346,7 @@ class ControllerTest extends TestCase
         $controller = new ContentTypesController($request, new Response());
         $controller->plain();
         $response = $controller->render();
-        $this->assertSame('text/plain', $response->getHeaderLine('Content-Type'));
+        $this->assertSame('text/plain; charset=UTF-8', $response->getHeaderLine('Content-Type'));
         $this->assertStringContainsString('hello world', $response->getBody() . '');
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -310,7 +310,7 @@ class ControllerTest extends TestCase
         $controller = new ContentTypesController($request, new Response());
         $controller->all();
         $response = $controller->render();
-        $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'),);
+        $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
         $this->assertStringContainsString('hello world', $response->getBody() . '');
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -306,6 +306,20 @@ class ControllerTest extends TestCase
         $this->assertStringContainsString('hello world', $response->getBody() . '');
     }
 
+    public function testRenderViewClassesSetContentTypeHeader()
+    {
+        $request = new ServerRequest([
+            'url' => '/',
+            'environment' => ['HTTP_ACCEPT' => 'text/plain'],
+            'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'plain'],
+        ]);
+        $controller = new ContentTypesController($request, new Response());
+        $controller->plain();
+        $response = $controller->render();
+        $this->assertSame('text/plain', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('hello world', $response->getBody() . '');
+    }
+
     /**
      * test view rendering changing response
      */

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -350,6 +350,20 @@ class ControllerTest extends TestCase
         $this->assertStringContainsString('hello world', $response->getBody() . '');
     }
 
+    public function testRenderViewClassesUsesExt()
+    {
+        $request = new ServerRequest([
+            'url' => '/',
+            'environment' => [],
+            'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'all', '_ext' => 'json'],
+        ]);
+        $controller = new ContentTypesController($request, new Response());
+        $controller->all();
+        $response = $controller->render();
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+        $this->assertNotEmpty(json_decode($response->getBody() . ''), 'Body should be json');
+    }
+
     /**
      * test view rendering changing response
      */

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1810,9 +1810,9 @@ TEXT;
     /**
      * Somewhat pointless, but helps ensure BC for defaults.
      */
-    public function testGetContentType()
+    public function testContentType()
     {
-        $this->assertSame('', $this->View->getContentType());
+        $this->assertSame('', $this->View->contentType());
     }
 
     protected function checkException(string $message): void

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1807,6 +1807,14 @@ TEXT;
         $this->assertSame('TestPlugin', $this->View->getPlugin());
     }
 
+    /**
+     * Somewhat pointless, but helps ensure BC for defaults.
+     */
+    public function testGetContentType()
+    {
+        $this->assertSame('', $this->View->getContentType());
+    }
+
     protected function checkException(string $message): void
     {
         if (version_compare(PHP_VERSION, '7.4', '>=')) {

--- a/tests/test_app/TestApp/Controller/ContentTypesController.php
+++ b/tests/test_app/TestApp/Controller/ContentTypesController.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Controller;
+
+use Cake\View\JsonView;
+use Cake\View\XmlView;
+
+
+/**
+ * ContentTypesController class
+ */
+class ContentTypesController extends AppController
+{
+    /**
+     * @var array<string>
+     */
+    protected $viewClasses = [];
+
+    public function getViewClasses(): array
+    {
+        return $this->viewClasses;
+    }
+
+    public function all()
+    {
+        $this->viewClasses = [JsonView::class, XmlView::class];
+        $this->set('data', ['hello', 'world']);
+        $this->viewBuilder()->setOption('serialize', ['data']);
+    }
+}

--- a/tests/test_app/TestApp/Controller/ContentTypesController.php
+++ b/tests/test_app/TestApp/Controller/ContentTypesController.php
@@ -18,7 +18,7 @@ namespace TestApp\Controller;
 
 use Cake\View\JsonView;
 use Cake\View\XmlView;
-
+use TestApp\View\PlainTextView;
 
 /**
  * ContentTypesController class
@@ -40,5 +40,11 @@ class ContentTypesController extends AppController
         $this->viewClasses = [JsonView::class, XmlView::class];
         $this->set('data', ['hello', 'world']);
         $this->viewBuilder()->setOption('serialize', ['data']);
+    }
+
+    public function plain()
+    {
+        $this->viewClasses = [PlainTextView::class];
+        $this->set('body', 'hello world');
     }
 }

--- a/tests/test_app/TestApp/Controller/ContentTypesController.php
+++ b/tests/test_app/TestApp/Controller/ContentTypesController.php
@@ -30,7 +30,7 @@ class ContentTypesController extends AppController
      */
     protected $viewClasses = [];
 
-    public function getViewClasses(): array
+    public function viewClasses(): array
     {
         return $this->viewClasses;
     }

--- a/tests/test_app/TestApp/Controller/ContentTypesController.php
+++ b/tests/test_app/TestApp/Controller/ContentTypesController.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @link          https://cakephp.org CakePHP(tm) Project
- * @since         3.0.0
+ * @since         4.4.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace TestApp\Controller;

--- a/tests/test_app/TestApp/View/PlainTextView.php
+++ b/tests/test_app/TestApp/View/PlainTextView.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\View;
+
+use Cake\View\View;
+
+/**
+ * CustomJsonView class
+ */
+class PlainTextView extends View
+{
+    public static function getContentType(): string
+    {
+        return 'text/plain';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(?string $template = null, $layout = null): string
+    {
+        return $this->get('body') ?? '';
+    }
+}

--- a/tests/test_app/TestApp/View/PlainTextView.php
+++ b/tests/test_app/TestApp/View/PlainTextView.php
@@ -22,7 +22,10 @@ use Cake\View\View;
  */
 class PlainTextView extends View
 {
-    public static function getContentType(): string
+    /**
+     * @inheritDoc
+     */
+    public static function contentType(): string
     {
         return 'text/plain';
     }

--- a/tests/test_app/templates/ContentTypes/all.php
+++ b/tests/test_app/templates/ContentTypes/all.php
@@ -1,0 +1,1 @@
+<?= implode(' ', $data) ?>


### PR DESCRIPTION
Add the controller and view hook methods for doing content negotiation. I have a few open questions on how this should work.

* [x] Should we be mapping `_ext` to a content type and using in place of the `Accept` header if it exists?
* [x] Given that these new methods have no setter do we need the `get` prefix? Would `Controller::viewClasses()` and `View::contentType()` be a simpler/better method names?

Part of #16113