### PR TITLE
Add backwards compatibility shim for attributes

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http;
 
+use Error;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -57,6 +58,21 @@ class Uri implements UriInterface
         $this->uri = $uri;
         $this->base = $base;
         $this->webroot = $webroot;
+    }
+
+    /**
+     * Backwards compatibility shim for previously dynamic properties.
+     *
+     * @param string $name The attribute to read.
+     * @return mixed
+     */
+    public function __get(string $name): mixed
+    {
+        if ($name === 'base' || $name === 'webroot') {
+            return $this->{$name};
+        }
+
+        throw new Error("Cannot access attribute `{$name}`");
     }
 
     /**

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Http;
 
-use Error;
 use Psr\Http\Message\UriInterface;
+use UnexpectedValueException;
 
 /**
  * The base and webroot properties have piggybacked on the Uri for
@@ -71,7 +71,7 @@ class Uri implements UriInterface
         if ($name === 'base' || $name === 'webroot') {
             return $this->{$name};
         }
-        throw new Error("Undefined property via __get('{$name}')");
+        throw new UnexpectedValueException("Undefined property via __get('{$name}')");
     }
 
     /**

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -71,8 +71,7 @@ class Uri implements UriInterface
         if ($name === 'base' || $name === 'webroot') {
             return $this->{$name};
         }
-
-        throw new Error("Cannot access attribute `{$name}`");
+        throw new Error("Undefined property via __get('{$name}')");
     }
 
     /**

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -66,7 +66,7 @@ class Uri implements UriInterface
      * @param string $name The attribute to read.
      * @return mixed
      */
-    public function __get(string $name): mixed
+    public function __get(string $name)
     {
         if ($name === 'base' || $name === 'webroot') {
             return $this->{$name};

--- a/tests/TestCase/Http/UriTest.php
+++ b/tests/TestCase/Http/UriTest.php
@@ -44,6 +44,7 @@ class UriTest extends TestCase
         $this->assertSame('/base/', $uri->webroot);
 
         $this->expectException(Error::class);
+        $this->expectExceptionMessage('Undefined property via __get');
         $uri->uri;
     }
 

--- a/tests/TestCase/Http/UriTest.php
+++ b/tests/TestCase/Http/UriTest.php
@@ -18,8 +18,8 @@ namespace Cake\Test\TestCase\Http;
 
 use Cake\Http\Uri;
 use Cake\TestSuite\TestCase;
-use Error;
 use Laminas\Diactoros\Uri as LaminasUri;
+use UnexpectedValueException;
 
 /**
  * Test case for the Uri Shim
@@ -43,7 +43,7 @@ class UriTest extends TestCase
         $this->assertSame('/base', $uri->base);
         $this->assertSame('/base/', $uri->webroot);
 
-        $this->expectException(Error::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Undefined property via __get');
         $uri->uri;
     }

--- a/tests/TestCase/Http/UriTest.php
+++ b/tests/TestCase/Http/UriTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Http;
 
 use Cake\Http\Uri;
 use Cake\TestSuite\TestCase;
+use Error;
 use Laminas\Diactoros\Uri as LaminasUri;
 
 /**
@@ -32,6 +33,18 @@ class UriTest extends TestCase
 
         $this->assertSame('/base', $uri->getBase());
         $this->assertSame('/base/', $uri->getWebroot());
+    }
+
+    public function testMagicAttributes()
+    {
+        $inner = new LaminasUri('/articles/view/1');
+        $uri = new Uri($inner, '/base', '/base/');
+
+        $this->assertSame('/base', $uri->base);
+        $this->assertSame('/base/', $uri->webroot);
+
+        $this->expectException(Error::class);
+        $uri->uri;
     }
 
     public function testWrappedGetMethods()


### PR DESCRIPTION
The base and webroot values used to be accessible on the Uri object returned by createUri(). This change restores that behavior.
