### PR TITLE
Fix dynamic property creation warnings on PHP 8.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - php-version: '8.1'
             db-type: 'sqlite'
           - php-version: '8.2'
-            db-type: 'sqlite'
+            db-type: 'mysql'
 
     services:
       redis:

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -58,6 +58,11 @@ class SecurityComponentTest extends TestCase
     protected $oldSalt;
 
     /**
+     * @var \Cake\Controller\Component\SecurityComponent
+     */
+    protected $Security;
+
+    /**
      * setUp method
      *
      * Initializes environment state.

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -113,7 +113,9 @@ class ModelAwareTraitTest extends TestCase
 
         $stub->modelFactory('Table', function ($name) {
             $mock = $this->getMockBuilder(RepositoryInterface::class)->getMock();
-            $mock->name = $name;
+            $mock->expects($this->any())
+                ->method('getAlias')
+                ->willReturn($name);
 
             return $mock;
         });
@@ -121,11 +123,13 @@ class ModelAwareTraitTest extends TestCase
         $result = $stub->loadModel('Magic', 'Table');
         $this->assertInstanceOf(RepositoryInterface::class, $result);
         $this->assertInstanceOf(RepositoryInterface::class, $stub->Magic);
-        $this->assertSame('Magic', $stub->Magic->name);
+        $this->assertSame('Magic', $stub->Magic->getAlias());
 
         $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
         $mock2 = $this->getMockBuilder(RepositoryInterface::class)->getMock();
-        $mock2->alias = 'Foo';
+        $mock2->expects($this->any())
+            ->method('getAlias')
+            ->willReturn('Foo');
         $locator->expects($this->any())
             ->method('get')
             ->willReturn($mock2);
@@ -133,7 +137,7 @@ class ModelAwareTraitTest extends TestCase
         $stub->modelFactory('MyType', $locator);
         $result = $stub->loadModel('Foo', 'MyType');
         $this->assertInstanceOf(RepositoryInterface::class, $result);
-        $this->assertSame('Foo', $stub->Foo->alias);
+        $this->assertSame('Foo', $stub->Foo->getAlias());
     }
 
     public function testModelFactoryException(): void

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -43,11 +43,11 @@ use Cake\View\Exception\MissingLayoutException;
 use Cake\View\Exception\MissingTemplateException;
 use Exception;
 use OutOfBoundsException;
-use PDOException;
 use RuntimeException;
 use TestApp\Controller\Admin\ErrorController;
 use TestApp\Error\Exception\MissingWidgetThing;
 use TestApp\Error\Exception\MissingWidgetThingException;
+use TestApp\Error\Exception\MyPDOException;
 use TestApp\Error\MyCustomExceptionRenderer;
 use TestApp\Error\TestAppsExceptionRenderer;
 
@@ -937,7 +937,7 @@ class ExceptionRendererTest extends TestCase
      */
     public function testPDOException(): void
     {
-        $exception = new PDOException('There was an error in the SQL query');
+        $exception = new MyPDOException('There was an error in the SQL query');
         $exception->queryString = 'SELECT * from poo_query < 5 and :seven';
         $exception->params = ['seven' => 7];
         $ExceptionRenderer = new ExceptionRenderer($exception);

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -35,6 +35,11 @@ class FlashHelperTest extends TestCase
     protected $View;
 
     /**
+     * @var \Cake\View\Helper\FlashHelper
+     */
+    protected $Flash;
+
+    /**
      * setUp method
      */
     public function setUp(): void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -72,6 +72,11 @@ class FormHelperTest extends TestCase
     protected $Form;
 
     /**
+     * @var \Cake\View\View
+     */
+    protected $View;
+
+    /**
      * setUp method
      */
     public function setUp(): void

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -33,10 +33,10 @@ use Cake\View\View;
 use Exception;
 use InvalidArgumentException;
 use LogicException;
-use PDOException;
 use RuntimeException;
 use TestApp\Controller\ThemePostsController;
 use TestApp\Controller\ViewPostsController;
+use TestApp\Error\Exception\MyPDOException;
 use TestApp\View\Helper\TestBeforeAfterHelper;
 use TestApp\View\Object\TestObjectWithoutToString;
 use TestApp\View\Object\TestObjectWithToString;
@@ -1060,7 +1060,7 @@ class ViewTest extends TestCase
      */
     public function testRenderUsingLayoutArgument(): void
     {
-        $error = new PDOException();
+        $error = new MyPDOException();
         $error->queryString = 'this is sql string';
         $message = 'it works';
         $trace = $error->getTrace();

--- a/tests/test_app/TestApp/Error/Exception/MyPDOException.php
+++ b/tests/test_app/TestApp/Error/Exception/MyPDOException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Error\Exception;
+
+use PDOException;
+
+/**
+ * Exception class for testing error page for PDOException
+ */
+class MyPDOException extends PDOException
+{
+    public $queryString;
+
+    public $params;
+}

--- a/tests/test_app/TestApp/Http/Client/Adapter/CakeStreamWrapper.php
+++ b/tests/test_app/TestApp/Http/Client/Adapter/CakeStreamWrapper.php
@@ -18,6 +18,8 @@ class CakeStreamWrapper implements ArrayAccess
         ],
     ];
 
+    public $context;
+
     public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
         if ($path === 'http://throw_exception/') {

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -8,6 +8,7 @@ use Cake\Datasource\ModelAwareTrait;
 /**
  * Testing stub.
  */
+#[\AllowDynamicProperties]
 class Stub
 {
     use ModelAwareTrait;


### PR DESCRIPTION
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
