### PR TITLE
add property type declarations to Uri class

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -33,17 +33,17 @@ class Uri implements UriInterface
     /**
      * @var string
      */
-    private $base = '';
+    private string $base = '';
 
     /**
      * @var string
      */
-    private $webroot = '';
+    private string $webroot = '';
 
     /**
      * @var \Psr\Http\Message\UriInterface
      */
-    private $uri;
+    private UriInterface $uri;
 
     /**
      * Constructor


### PR DESCRIPTION
Fixes the following errors from `composer check`

```
 36 | ERROR | [x] Property \Cake\Http\Uri::$base does not have native type hint for its value but it should be possible to add it based on @var annotation "string". (SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint)
 41 | ERROR | [x] Property \Cake\Http\Uri::$webroot does not have native type hint for its value but it should be possible to add it based on @var annotation "string". (SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint)
 46 | ERROR | [x] Property \Cake\Http\Uri::$uri does not have native type hint for its value but it should be possible to add it based on @var annotation "\Psr\Http\Message\UriInterface".
    |       |     (SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint)

```