### PR TITLE
Throw BadRequestException for invalid HTTP methods when parsing.

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Route;
 
+use Cake\Http\Exception\BadRequestException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -449,13 +450,18 @@ class Route
      * @param string $url The URL to attempt to parse.
      * @param string $method The HTTP method of the request being parsed.
      * @return array|null An array of request parameters, or `null` on failure.
-     * @throws \InvalidArgumentException When method is not an empty string or in `VALID_METHODS` list.
+     * @throws \Cake\Http\Exception\BadRequestException When method is not an empty string and not in `VALID_METHODS` list.
      */
     public function parse(string $url, string $method): ?array
     {
-        if ($method !== '') {
-            $method = $this->normalizeAndValidateMethods($method);
+        try {
+            if ($method !== '') {
+                $method = $this->normalizeAndValidateMethods($method);
+            }
+        } catch (InvalidArgumentException $e) {
+            throw new BadRequestException($e->getMessage());
         }
+
         $compiledRoute = $this->compile();
         [$url, $ext] = $this->_parseExtension($url);
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Routing\Route;
 
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
@@ -1152,6 +1153,24 @@ class RouteTest extends TestCase
         $this->assertSame('Media', $result['controller']);
         $this->assertSame('search', $result['action']);
         $this->assertEquals(['tv', 'shows'], $result['pass']);
+    }
+
+    /**
+     * Test that parse() throws a BadRequestException instead of InvalidArgumentException
+     * for an invalid method.
+     *
+     * @return void
+     */
+    public function testParseException(): void
+    {
+        $this->expectException(BadRequestException::class);
+        $this->expectExceptionMessage('Invalid HTTP method received. `NOPE` is invalid');
+
+        $route = new Route(
+            '/{controller}',
+            ['prefix' => 'Admin', 'action' => 'index']
+        );
+        $route->parse('/posts', 'NOPE');
     }
 
     /**


### PR DESCRIPTION
Errors caused by malformed requests should cause a 4xx error, not a 5xx error.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
