### PR TITLE
Show route collision in routes command

### DIFF
--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -99,7 +99,7 @@ class RoutesCommand extends Command
             }
         }
 
-        if (!empty($duplicateRoutes)) {
+        if ($duplicateRoutes) {
             array_unshift($duplicateRoutes, $header);
             $io->warning('The following route collisions were being detected');
             $io->helper('table')->output($duplicateRoutes);

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -62,7 +62,6 @@ class RoutesCommand extends Command
 
             $output[] = $item;
 
-            // Count route templates
             if (!isset($duplicateRoutesCounter[$route->template])) {
                 $duplicateRoutesCounter[$route->template] = 0;
             }

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -100,7 +100,7 @@ class RoutesCommand extends Command
 
         if ($duplicateRoutes) {
             array_unshift($duplicateRoutes, $header);
-            $io->warning('The following possible route collisions were detected');
+            $io->warning('The following possible route collisions were detected.');
             $io->helper('table')->output($duplicateRoutes);
             $io->out();
         }

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -52,7 +52,7 @@ class RoutesCommand extends Command
                 $route->defaults['prefix'] ?? '',
                 $route->defaults['controller'] ?? '',
                 $route->defaults['action'] ?? '',
-                is_string($methods) ? $methods : implode(', ', $route->defaults['_method']),
+                is_string($methods) ? $methods : implode(', ', $methods),
             ];
 
             if ($args->getOption('verbose')) {
@@ -63,7 +63,7 @@ class RoutesCommand extends Command
             $output[] = $item;
 
             // Count route templates
-            if (!isset($duplicateRoutesCounter[$this->template])) {
+            if (!isset($duplicateRoutesCounter[$route->template])) {
                 $duplicateRoutesCounter[$route->template] = 0;
             }
             $duplicateRoutesCounter[$route->template]++;
@@ -94,7 +94,7 @@ class RoutesCommand extends Command
                     $route->defaults['prefix'] ?? '',
                     $route->defaults['controller'] ?? '',
                     $route->defaults['action'] ?? '',
-                    is_string($methods) ? $methods : implode(', ', $route->defaults['_method']),
+                    is_string($methods) ? $methods : implode(', ', $methods),
                 ];
             }
         }

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -101,7 +101,7 @@ class RoutesCommand extends Command
 
         if ($duplicateRoutes) {
             array_unshift($duplicateRoutes, $header);
-            $io->warning('The following route collisions were detected');
+            $io->warning('The following possible route collisions were detected');
             $io->helper('table')->output($duplicateRoutes);
             $io->out();
         }

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -40,10 +40,10 @@ class RoutesCommand extends Command
             $header[] = 'Defaults';
         }
 
-        $routeCollection = Router::routes();
+        $availableRoutes = Router::routes();
         $output = $duplicateRoutesCounter = [];
 
-        foreach ($routeCollection as $route) {
+        foreach ($availableRoutes as $route) {
             $methods = $route->defaults['_method'] ?? '';
 
             $item = [
@@ -82,8 +82,7 @@ class RoutesCommand extends Command
 
         $duplicateRoutes = [];
 
-        // Check duplicate routes
-        foreach ($routeCollection as $route) {
+        foreach ($availableRoutes as $route) {
             if ($duplicateRoutesCounter[$route->template] > 1) {
                 $methods = $route->defaults['_method'] ?? '';
 

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -40,9 +40,10 @@ class RoutesCommand extends Command
             $header[] = 'Defaults';
         }
 
+        $routeCollection = Router::routes();
         $output = $duplicateRoutesCounter = [];
 
-        foreach (Router::routes() as $route) {
+        foreach ($routeCollection as $route) {
             $methods = $route->defaults['_method'] ?? '';
 
             $item = [
@@ -82,7 +83,7 @@ class RoutesCommand extends Command
         $duplicateRoutes = [];
 
         // Check duplicate routes
-        foreach (Router::routes() as $route) {
+        foreach ($routeCollection as $route) {
             if ($duplicateRoutesCounter[$route->template] > 1) {
                 $methods = $route->defaults['_method'] ?? '';
 

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -101,7 +101,7 @@ class RoutesCommand extends Command
 
         if ($duplicateRoutes) {
             array_unshift($duplicateRoutes, $header);
-            $io->warning('The following route collisions were being detected');
+            $io->warning('The following route collisions were detected');
             $io->helper('table')->output($duplicateRoutes);
             $io->out();
         }

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -63,7 +63,7 @@ class RoutesCommand extends Command
             $output[] = $item;
 
             // Count route templates
-            if (!array_key_exists($route->template, $duplicateRoutesCounter)) {
+            if (!isset($duplicateRoutesCounter[$this->template])) {
                 $duplicateRoutesCounter[$route->template] = 0;
             }
             $duplicateRoutesCounter[$route->template]++;

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -285,4 +285,48 @@ class RoutesCommandTest extends TestCase
         $this->assertExitCode(Command::CODE_ERROR);
         $this->assertErrorContains('do not match');
     }
+
+    /**
+     * Test routes duplicate warning
+     */
+    public function testRouteDuplicateWarning(): void
+    {
+        $builder = Router::createRouteBuilder('/');
+        $builder->connect(
+            new Route('/unique-path', [], ['_name' => '_aRoute'])
+        );
+        $builder->connect(
+            new Route('/unique-path', [], ['_name' => '_bRoute'])
+        );
+
+        $this->exec('routes');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertOutputContainsRow([
+            '<info>Route name</info>',
+            '<info>URI template</info>',
+            '<info>Plugin</info>',
+            '<info>Prefix</info>',
+            '<info>Controller</info>',
+            '<info>Action</info>',
+            '<info>Method(s)</info>',
+        ]);
+        $this->assertOutputContainsRow([
+            '_aRoute',
+            '/unique-path',
+            '',
+            '',
+            '',
+            '',
+            '',
+        ]);
+        $this->assertOutputContainsRow([
+            '_bRoute',
+            '/unique-path',
+            '',
+            '',
+            '',
+            '',
+            '',
+        ]);
+    }
 }


### PR DESCRIPTION
Fixes #16126

Relates to https://github.com/cakephp/debug_kit/pull/852

This PR adds the following warning notice to the command `bin/cake routes`

![image](https://user-images.githubusercontent.com/9105243/147509613-82e33f4c-cd2a-4a74-abc7-5b34c6aefeb3.png)

If no route collision has been detected then no additional info is being printed

![image](https://user-images.githubusercontent.com/9105243/147509685-0d44b2c7-7400-4397-8568-bcb46617089c.png)
