### PR TITLE
4.4 -  Start Error Renderer changes

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -31,6 +31,7 @@ use Cake\Error\Debug\ReferenceNode;
 use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
+use Cake\Error\Renderer\HtmlRenderer;
 use Cake\Error\Renderer\TextRenderer;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
@@ -82,6 +83,7 @@ class Debugger
      */
     protected $_templates = [
         'log' => [
+            // These templates are not actually used, as Debugger::log() is called instead.
             'trace' => '{:reference} - {:path}, line {:line}',
             'error' => '{:error} ({:code}): {:description} in [{:file}, line {:line}]',
         ],
@@ -121,9 +123,11 @@ class Debugger
      * @var array<string, class-string>
      */
     protected $renderers = [
-        // Backwards compatible alias for text
+        // Backwards compatible alias for text that will be deprecated.
         'txt' => TextRenderer::class,
         'text' => TextRenderer::class,
+        // The html alias currently uses no JS and will be deprecated.
+        'js' => HtmlRenderer::class,
     ];
 
     /**

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -121,7 +121,9 @@ class Debugger
      * @var array<string, class-string>
      */
     protected $renderers = [
+        // Backwards compatible alias for text
         'txt' => TextRenderer::class,
+        'text' => TextRenderer::class,
     ];
 
     /**

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -31,6 +31,7 @@ use Cake\Error\Debug\ReferenceNode;
 use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
+use Cake\Error\Renderer\TextRenderer;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -108,6 +109,19 @@ class Debugger
             'trace' => "Trace:\n{:trace}\n",
             'context' => "Context:\n{:context}\n",
         ],
+    ];
+
+    /**
+     * Mapping for error renderers.
+     *
+     * Error renderers are replacing output formatting with
+     * an object based system. Having Debugger handle and render errors
+     * will be deprecated and the new ErrorTrap system should be used instead.
+     *
+     * @array <string, class-string>
+     */
+    protected $renderers = [
+        'txt' => TextRenderer::class,
     ];
 
     /**
@@ -443,7 +457,7 @@ class Debugger
                 continue;
             }
             if ($options['format'] === 'points' && $trace['file'] !== '[internal]') {
-                $back[] = ['file' => $trace['file'], 'line' => $trace['line']];
+                $back[] = ['file' => $trace['file'], 'line' => $trace['line'], 'reference' => $reference];
             } elseif ($options['format'] === 'array') {
                 $back[] = $trace;
             } else {
@@ -922,6 +936,16 @@ class Debugger
         ];
         $data += $defaults;
 
+        $outputFormat = $this->_outputFormat;
+        if (isset($this->renderers[$outputFormat])) {
+            $trace = static::trace(['start' => $data['start'], 'format' => 'points']);
+            $error = new PhpError($data['code'], $data['description'], $data['file'], $data['line'], $trace);
+            $renderer = new $this->renderers[$outputFormat]();
+            echo $renderer->render($error);
+
+            return;
+        }
+
         $files = static::trace(['start' => $data['start'], 'format' => 'points']);
         $code = '';
         $file = null;
@@ -956,7 +980,7 @@ class Debugger
 
         $data['trace'] = $trace;
         $data['id'] = 'cakeErr' . uniqid();
-        $tpl = $this->_templates[$this->_outputFormat] + $this->_templates['base'];
+        $tpl = $this->_templates[$outputFormat] + $this->_templates['base'];
 
         if (isset($tpl['links'])) {
             foreach ($tpl['links'] as $key => $val) {

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -118,7 +118,7 @@ class Debugger
      * an object based system. Having Debugger handle and render errors
      * will be deprecated and the new ErrorTrap system should be used instead.
      *
-     * @array <string, class-string>
+     * @var array<string, class-string>
      */
     protected $renderers = [
         'txt' => TextRenderer::class,

--- a/src/Error/ErrorRendererInterface.php
+++ b/src/Error/ErrorRendererInterface.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Error;
 
 /**

--- a/src/Error/ErrorRendererInterface.php
+++ b/src/Error/ErrorRendererInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Error;
+
+/**
+ * Interface for PHP error rendering implementations
+ *
+ * The core provided implementations of this interface are used
+ * by Debugger and ErrorTrap to render PHP errors.
+ */
+interface ErrorRendererInterface
+{
+    /**
+     * Render output for the provided error.
+     *
+     * @param \Cake\Error\PhpError $error The error to be rendered.
+     * @return string The output to be echoed.
+     */
+    public function render(PhpError $error): string;
+}

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -24,7 +24,7 @@ class PhpError
     /**
      * @var int
      */
-    private $level;
+    private $code;
 
     /**
      * @var string

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Error;
 
 /**
@@ -36,22 +49,53 @@ class PhpError
     private $trace;
 
     /**
+     * @var array<int, string>
+     */
+    private $levelMap = [
+        E_PARSE => 'error',
+        E_ERROR => 'error',
+        E_CORE_ERROR => 'error',
+        E_COMPILE_ERROR => 'error',
+        E_USER_ERROR => 'error',
+        E_WARNING => 'warning',
+        E_USER_WARNING => 'warning',
+        E_COMPILE_WARNING => 'warning',
+        E_RECOVERABLE_ERROR => 'warning',
+        E_NOTICE => 'notice',
+        E_USER_NOTICE => 'notice',
+        E_STRICT => 'strict',
+        E_DEPRECATED => 'deprecated',
+        E_USER_DEPRECATED => 'deprecated',
+    ];
+
+    /**
+     * @var array<string, int>
+     */
+    private $logMap = [
+        'error' => LOG_ERR,
+        'warning' => LOG_WARNING,
+        'notice' => LOG_NOTICE,
+        'strict' => LOG_NOTICE,
+        'deprecated' => LOG_NOTICE,
+    ];
+
+    /**
      * Constructor
      *
-     * @param int $level The PHP error constant
+     * @param int $code The PHP error code constant
      * @param string $message The error message.
      * @param string|null $file The filename of the error.
      * @param int|null $line The line number for the error.
      * @param array $trace The backtrace for the error.
      */
     public function __construct(
-        int $level,
+        int $code,
         string $message,
         ?string $file = null,
         ?int $line = null,
         array $trace = [],
     ) {
-        $this->level = $level;
+        $this->code = $code;
         $this->message = $message;
         $this->file = $file;
         $this->line = $line;
@@ -63,9 +107,31 @@ class PhpError
      *
      * @return string
      */
-    public function getLevel(): int
+    public function getCode(): int
     {
-        return $this->level;
+        return $this->code;
+    }
+
+    /**
+     * Get the mapped LOG_ constant.
+     *
+     * @return int
+     */
+    public function getLogLevel(): int
+    {
+        $label = $this->getLabel();
+
+        return $this->logMap[$label] ?? 'error';
+    }
+
+    /**
+     * Get the error code label
+     *
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->levelMap[$this->code] ?? 'error';
     }
 
     /**

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -105,7 +105,7 @@ class PhpError
     /**
      * Get the PHP error constant.
      *
-     * @return string
+     * @return int
      */
     public function getCode(): int
     {

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -93,7 +93,7 @@ class PhpError
         string $message,
         ?string $file = null,
         ?int $line = null,
-        array $trace = [],
+        array $trace = []
     ) {
         $this->code = $code;
         $this->message = $message;

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Error;
+
+/**
+ * Object wrapper around PHP errors that are emitted by `trigger_error()`
+ */
+class PhpError
+{
+    /**
+     * @var int
+     */
+    private $level;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var string|null
+     */
+    private $file;
+
+    /**
+     * @var int|null
+     */
+    private $line;
+
+    /**
+     * Stack trace data. Each item should have a `reference`, `file` and `line` keys.
+     *
+     * @var array<array<string, int>>
+     */
+    private $trace;
+
+    /**
+     * Constructor
+     *
+     * @param int $level The PHP error constant
+     * @param string $message The error message.
+     * @param string|null $file The filename of the error.
+     * @param int|null $line The line number for the error.
+     * @param array $trace The backtrace for the error.
+     */
+    public function __construct(
+        int $level,
+        string $message,
+        ?string $file = null,
+        ?int $line = null,
+        array $trace = [],
+    ) {
+        $this->level = $level;
+        $this->message = $message;
+        $this->file = $file;
+        $this->line = $line;
+        $this->trace = $trace;
+    }
+
+    /**
+     * Get the PHP error constant.
+     *
+     * @return string
+     */
+    public function getLevel(): int
+    {
+        return $this->level;
+    }
+
+    /**
+     * Get the error message.
+     *
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * Get the error file
+     *
+     * @return string|null
+     */
+    public function getFile(): ?string
+    {
+        return $this->file;
+    }
+
+    /**
+     * Get the error line number.
+     *
+     * @return int|null
+     */
+    public function getLine(): ?int
+    {
+        return $this->line;
+    }
+
+    /**
+     * Get the stacktrace as an array.
+     *
+     * @return array
+     */
+    public function getTrace(): array
+    {
+        return $this->trace;
+    }
+
+    /**
+     * Get the stacktrace as a string.
+     *
+     * @return string
+     */
+    public function getTraceAsString(): string
+    {
+        $out = [];
+        foreach ($this->trace as $frame) {
+            $out[] = "{$frame['reference']} {$frame['file']}, line {$frame['line']}";
+        }
+
+        return implode("\n", $out);
+    }
+}

--- a/src/Error/Renderer/HtmlRenderer.php
+++ b/src/Error/Renderer/HtmlRenderer.php
@@ -81,13 +81,14 @@ HTML;
     {
         $selector = $id . '-' . $suffix;
 
+        // phpcs:disable
         return <<<HTML
-<a
-    href="javascript:void(0);"
-    onclick="document.getElementById('{$selector}').style.display = (document.getElementById('{$selector}').style.display == 'none' ? '' : 'none'"
+<a href="javascript:void(0);"
+  onclick="document.getElementById('{$selector}').style.display = (document.getElementById('{$selector}').style.display == 'none' ? '' : 'none'"
 >
     {$text}
 </a>
 HTML;
+        // phpcs:enable
     }
 }

--- a/src/Error/Renderer/HtmlRenderer.php
+++ b/src/Error/Renderer/HtmlRenderer.php
@@ -43,7 +43,7 @@ class HtmlRenderer implements ErrorRendererInterface
         debug($error);
         $errorMessage = sprintf(
             '<b>%s</b> (%s)',
-            h($error->getLabel()),
+            h(ucfirst($error->getLabel())),
             h($error->getCode())
         );
         $toggle = $this->renderToggle($errorMessage, $id, 'trace');

--- a/src/Error/Renderer/HtmlRenderer.php
+++ b/src/Error/Renderer/HtmlRenderer.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error\Renderer;
+
+use Cake\Error\Debugger;
+use Cake\Error\ErrorRendererInterface;
+use Cake\Error\PhpError;
+
+/**
+ * Interactive HTML error rendering with a stack trace.
+ *
+ * Default output renderer for non CLI SAPI.
+ */
+class HtmlRenderer implements ErrorRendererInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function render(PhpError $error): string
+    {
+        $id = 'cakeErr' . uniqid();
+
+        // Some of the error data is not HTML safe so we escape everything.
+        $description = h($error->getMessage());
+        $path = h($error->getFile());
+        $line = h($error->getLine());
+        $trace = h($error->getTraceAsString());
+
+        debug($error);
+        $errorMessage = sprintf(
+            '<b>%s</b> (%s)',
+            h($error->getLabel()),
+            h($error->getCode())
+        );
+        $toggle = $this->renderToggle($errorMessage, $id, 'trace');
+        $codeToggle = $this->renderToggle('Code', $id, 'code');
+        $excerpt = Debugger::excerpt($error->getFile(), $error->getLine(), 1);
+        $code = implode("\n", $excerpt);
+
+        $html = <<<HTML
+<pre class="cake-error">
+    {$toggle}: {$description} [in <b>{$path}</b>, line <b>{$line}</b>]
+    <div id="{:id}-trace" class="cake-stack-trace" style="display: none;">
+        {$codeToggle}
+        <pre id="{$id}-code" class="cake-code-dump" style="display: none;">
+            {$code}
+        </pre>
+        <div class="cake-trace">
+            {$trace}
+        </div>
+    </div>
+</pre>
+HTML;
+
+        return $html;
+    }
+
+    /**
+     * Render a toggle link in the error content.
+     *
+     * @param string $text The text to insert. Assumed to be HTML safe.
+     * @param string $id The error id scope.
+     * @param string $suffix The element selector.
+     * @return string
+     */
+    private function renderToggle(string $text, string $id, string $suffix): string
+    {
+        $selector = $id . '-' . $suffix;
+
+        return <<<HTML
+<a
+    href="javascript:void(0);"
+    onclick="document.getElementById('{$selector}').style.display = (document.getElementById('{$selector}').style.display == 'none' ? '' : 'none'"
+>
+    {$text}
+</a>
+HTML;
+    }
+}

--- a/src/Error/Renderer/TextRenderer.php
+++ b/src/Error/Renderer/TextRenderer.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Error\Renderer;
+
+use Cake\Error\ErrorRendererInterface;
+use Cake\Error\PhpError;
+
+/**
+ * Plain text error rendering with a stack trace.
+ *
+ * Useful in CLI and log file contexts.
+ */
+class TextRenderer implements ErrorRendererInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function render(PhpError $error): string
+    {
+        return sprintf(
+            "%s: %s :: %s on line %s of %s\nTrace:\n%s",
+            $error->getLabel(),
+            $error->getCode(),
+            $error->getMessage(),
+            $error->getLine(),
+            $error->getFile(),
+            $error->getTraceAsString(),
+        );
+    }
+}

--- a/src/Error/Renderer/TextRenderer.php
+++ b/src/Error/Renderer/TextRenderer.php
@@ -1,6 +1,19 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Error\Renderer;
 
 use Cake\Error\ErrorRendererInterface;

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -198,7 +198,7 @@ class DebuggerTest extends TestCase
         $debugger->outputError($data);
         $result = ob_get_clean();
 
-        $this->assertMatchesRegularExpression('#^\<span class\="code\-highlight"\>.*outputError.*\</span\>$#m', $result);
+        $this->assertMatchesRegularExpression('#^\<span class\="code\-highlight"\>.*__LINE__.*\</span\>$#m', $result);
     }
 
     /**
@@ -255,7 +255,7 @@ class DebuggerTest extends TestCase
         $this->assertSame('', $output);
         $this->assertCount(1, $logs);
         // This is silly but that's how it works currently.
-        $this->assertStringContainsString("debug: Cake\Error\Debugger::outputError()", $logs[0]);
+        $this->assertStringContainsString("debug: \nCake\Error\Debugger::outputError()", $logs[0]);
 
         $this->assertStringContainsString("'file' => '{$data['file']}'", $logs[0]);
         $this->assertStringContainsString("'line' => (int) {$data['line']}", $logs[0]);

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -202,6 +202,32 @@ class DebuggerTest extends TestCase
     }
 
     /**
+     * Test plain text output format.
+     */
+    public function testOutputErrorText(): void
+    {
+        Debugger::setOutputFormat('txt');
+
+        ob_start();
+        $debugger = Debugger::getInstance();
+        $data = [
+            'level' => E_NOTICE,
+            'code' => E_NOTICE,
+            'file' => __FILE__,
+            'line' => __LINE__,
+            'description' => 'Error description',
+            'start' => 1,
+        ];
+        $debugger->outputError($data);
+        $result = ob_get_clean();
+
+        $this->assertStringContainsString('notice: 8 :: Error description', $result);
+        $this->assertStringContainsString("on line {$data['line']} of {$data['file']}", $result);
+        $this->assertStringContainsString('Trace:', $result);
+        $this->assertStringContainsString('Cake\Test\TestCase\Error\DebuggerTest::testOutputErrorText()', $result);
+    }
+
+    /**
      * Tests that changes in output formats using Debugger::output() change the templates used.
      */
     public function testAddFormat(): void

--- a/tests/TestCase/Error/PhpErrorTest.php
+++ b/tests/TestCase/Error/PhpErrorTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Error;
+
+use Cake\Error\PhpError;
+use Cake\TestSuite\TestCase;
+
+class PhpErrorTest extends TestCase
+{
+    public function testBasicGetters()
+    {
+        $error = new PhpError(E_ERROR, 'something bad');
+        $this->assertEquals(E_ERROR, $error->getCode());
+        $this->assertEquals('something bad', $error->getMessage());
+        $this->assertNull($error->getFile());
+        $this->assertNull($error->getLine());
+        $this->assertEquals([], $error->getTrace());
+        $this->assertEquals('', $error->getTraceAsString());
+    }
+
+    public static function errorCodeProvider(): array
+    {
+        // [php error code, label, log-level]
+        return [
+            [E_ERROR, 'error', LOG_ERR],
+            [E_WARNING, 'warning', LOG_WARNING],
+            [E_NOTICE, 'notice', LOG_NOTICE],
+            [E_STRICT, 'strict', LOG_NOTICE],
+            [E_STRICT, 'strict', LOG_NOTICE],
+            [E_USER_DEPRECATED, 'deprecated', LOG_NOTICE],
+        ];
+    }
+
+    /**
+     * @dataProvider errorCodeProvider
+     */
+    public function testMappings($phpCode, $label, $logLevel)
+    {
+        $error = new PhpError($phpCode, 'something bad');
+        $this->assertEquals($phpCode, $error->getCode());
+        $this->assertEquals($label, $error->getLabel());
+        $this->assertEquals($logLevel, $error->getLogLevel());
+    }
+
+    public function testGetTraceAsString()
+    {
+        $trace = [
+            ['file' => 'a.php', 'line' => 10, 'reference' => 'TestObject::a()'],
+            ['file' => 'b.php', 'line' => 5, 'reference' => '[main]'],
+        ];
+        $error = new PhpError(E_ERROR, 'something bad', __FILE__, __LINE__, $trace);
+        $this->assertEquals($trace, $error->getTrace());
+        $expected = [
+            'TestObject::a() a.php, line 10',
+            '[main] b.php, line 5',
+        ];
+        $this->assertEquals(implode("\n", $expected), $error->getTraceAsString());
+        $this->assertEquals('error', $error->getLabel());
+    }
+}


### PR DESCRIPTION
Start building out the new Error rendering sub-system. These changes include the object wrapper for PHP Errors and simple renderer to act as a proof of concept on how the new system can deprecate the existing formatting mess in Debugger.

We won't be able to remove any templates or formating logic as userland code could have custom formats, or extend/reference the existing template strings. :cry: 