### PR TITLE
Remove redundant listTablesAndViews method

### DIFF
--- a/src/Database/Schema/CachedCollection.php
+++ b/src/Database/Schema/CachedCollection.php
@@ -61,14 +61,6 @@ class CachedCollection implements CollectionInterface
     /**
      * @inheritDoc
      */
-    public function listTablesAndViews(): array
-    {
-        return $this->collection->listTablesAndViews();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function listTablesWithoutViews(): array
     {
         return $this->collection->listTablesWithoutViews();
@@ -79,7 +71,7 @@ class CachedCollection implements CollectionInterface
      */
     public function listTables(): array
     {
-        return $this->collection->listTablesAndViews();
+        return $this->collection->listTables();
     }
 
     /**

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -25,11 +25,6 @@ use PDOException;
  *
  * Used to access information about the tables,
  * and other data in a database.
- *
- * @method array<string> listTablesAndViews() Get the list of tables available in the current connection.
- * This will include any views in the schema.
- * @method array<string> listTablesWithoutViews() Get the list of tables available in the current connection.
- * This will exclude any views in the schema.
  */
 class Collection implements CollectionInterface
 {
@@ -77,30 +72,11 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * Get the list of tables available in the current connection.
+     * Get the list of tables and views available in the current connection.
      *
-     * @deprecated in 4.3.3 Use {@link listTablesAndViews()} instead.
-     * @return array<string> The list of tables in the connected database/schema.
+     * @return array<string> The list of tables and views in the connected database/schema.
      */
     public function listTables(): array
-    {
-        [$sql, $params] = $this->_dialect->listTablesAndViewsSql($this->_connection->config());
-        $result = [];
-        $statement = $this->_connection->execute($sql, $params);
-        while ($row = $statement->fetch()) {
-            $result[] = $row[0];
-        }
-        $statement->closeCursor();
-
-        return $result;
-    }
-
-    /**
-     * Get the list of tables available in the current connection.
-     *
-     * @return array<string> The list of tables in the connected database/schema.
-     */
-    public function listTablesAndViews(): array
     {
         [$sql, $params] = $this->_dialect->listTablesAndViewsSql($this->_connection->config());
         $result = [];

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -78,7 +78,7 @@ class Collection implements CollectionInterface
      */
     public function listTables(): array
     {
-        [$sql, $params] = $this->_dialect->listTablesAndViewsSql($this->_connection->config());
+        [$sql, $params] = $this->_dialect->listTablesSql($this->_connection->config());
         $result = [];
         $statement = $this->_connection->execute($sql, $params);
         while ($row = $statement->fetch()) {

--- a/src/Database/Schema/CollectionInterface.php
+++ b/src/Database/Schema/CollectionInterface.php
@@ -22,8 +22,6 @@ namespace Cake\Database\Schema;
  * Used to access information about the tables,
  * and other data in a database.
  *
- * @method array<string> listTablesAndViews() Get the list of tables available in the current connection.
- * This will include any views in the schema.
  * @method array<string> listTablesWithoutViews() Get the list of tables available in the current connection.
  * This will exclude any views in the schema.
  */
@@ -32,7 +30,6 @@ interface CollectionInterface
     /**
      * Get the list of tables available in the current connection.
      *
-     * @deprecated in 4.3.3
      * @return array<string> The list of tables in the connected database/schema.
      */
     public function listTables(): array;

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -36,14 +36,13 @@ class MysqlSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array<mixed> An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
     {
-        return $this->listTablesAndViewsSql($config);
+        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
     }
 
     /**
@@ -59,18 +58,6 @@ class MysqlSchemaDialect extends SchemaDialect
             'SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database'])
             . ' WHERE Table_type LIKE "%TABLE%"'
         , []];
-    }
-
-    /**
-     * Generate the SQL to list the tables and views.
-     *
-     * @param array<string, mixed> $config The connection configuration to use for
-     *    getting tables from.
-     * @return array<mixed> An array of (sql, params) to execute.
-     */
-    public function listTablesAndViewsSql(array $config): array
-    {
-        return ['SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database']), []];
     }
 
     /**

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -56,7 +56,7 @@ class MysqlSchemaDialect extends SchemaDialect
     {
         return [
             'SHOW FULL TABLES FROM ' . $this->_driver->quoteIdentifier($config['database'])
-            . ' WHERE Table_type LIKE "%TABLE%"'
+            . ' WHERE TABLE_TYPE = "BASE TABLE"'
         , []];
     }
 

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -28,14 +28,17 @@ class PostgresSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
     {
-        return $this->listTablesAndViewsSql($config);
+        $sql = 'SELECT table_name as name FROM information_schema.tables
+                WHERE table_schema = ? ORDER BY name';
+        $schema = empty($config['schema']) ? 'public' : $config['schema'];
+
+        return [$sql, [$schema]];
     }
 
     /**
@@ -49,22 +52,6 @@ class PostgresSchemaDialect extends SchemaDialect
     {
         $sql = 'SELECT table_name as name FROM information_schema.tables
                 WHERE table_schema = ? AND table_type = \'BASE TABLE\' ORDER BY name';
-        $schema = empty($config['schema']) ? 'public' : $config['schema'];
-
-        return [$sql, [$schema]];
-    }
-
-    /**
-     * Generate the SQL to list the tables and views.
-     *
-     * @param array<string, mixed> $config The connection configuration to use for
-     *    getting tables from.
-     * @return array<mixed> An array of (sql, params) to execute.
-     */
-    public function listTablesAndViewsSql(array $config): array
-    {
-        $sql = 'SELECT table_name as name FROM information_schema.tables
-                WHERE table_schema = ? ORDER BY name';
         $schema = empty($config['schema']) ? 'public' : $config['schema'];
 
         return [$sql, [$schema]];

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -27,7 +27,6 @@ use InvalidArgumentException;
  * This class contains methods that are common across
  * the various SQL dialects.
  *
- * @method array<mixed> listTablesAndViewsSql(array $config) Generate the SQL to list the tables and views.
  * @method array<mixed> listTablesWithoutViewsSql(array $config) Generate the SQL to list the tables, excluding all views.
  */
 abstract class SchemaDialect
@@ -186,7 +185,6 @@ abstract class SchemaDialect
     /**
      * Generate the SQL to list the tables.
      *
-     * @deprecated 4.3.3
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -154,24 +154,11 @@ class SqliteSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
-    {
-        return $this->listTablesWithoutViewsSql($config);
-    }
-
-    /**
-     * Generate the SQL to list the tables and views.
-     *
-     * @param array<string, mixed> $config The connection configuration to use for
-     *    getting tables from.
-     * @return array<mixed> An array of (sql, params) to execute.
-     */
-    public function listTablesAndViewsSql(array $config): array
     {
         return [
             'SELECT name FROM sqlite_master ' .

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -31,24 +31,11 @@ class SqlserverSchemaDialect extends SchemaDialect
     /**
      * Generate the SQL to list the tables and views.
      *
-     * @deprecated 4.3.3 Use {@link listTablesAndViewsSql()} instead.
      * @param array<string, mixed> $config The connection configuration to use for
      *    getting tables from.
      * @return array An array of (sql, params) to execute.
      */
     public function listTablesSql(array $config): array
-    {
-        return $this->listTablesAndViewsSql($config);
-    }
-
-    /**
-     * Generate the SQL to list the tables and views.
-     *
-     * @param array<string, mixed> $config The connection configuration to use for
-     *    getting tables from.
-     * @return array<mixed> An array of (sql, params) to execute.
-     */
-    public function listTablesAndViewsSql(array $config): array
     {
         $sql = "SELECT TABLE_NAME
             FROM INFORMATION_SCHEMA.TABLES

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -86,9 +86,10 @@ class ConnectionHelper
         $connection = ConnectionManager::get($connectionName);
         $collection = $connection->getSchemaCollection();
 
-        $allTables = [];
         if (method_exists($collection, 'listTablesWithoutViews')) {
             $allTables = $collection->listTablesWithoutViews();
+        } else {
+            $allTables = $collection->listTables();
         }
 
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -295,7 +295,7 @@ class FixtureManager
         try {
             $createTables = function (ConnectionInterface $db, array $fixtures) use ($test): void {
                 /** @var array<\Cake\Datasource\FixtureInterface> $fixtures */
-                $tables = $db->getSchemaCollection()->listTablesAndViews();
+                $tables = $db->getSchemaCollection()->listTables();
                 $configName = $db->configName();
                 $this->_insertionMap[$configName] = $this->_insertionMap[$configName] ?? [];
 
@@ -467,7 +467,7 @@ class FixtureManager
         }
 
         if (!$this->isFixtureSetup($connection->configName(), $fixture)) {
-            $sources = $connection->getSchemaCollection()->listTablesAndViews();
+            $sources = $connection->getSchemaCollection()->listTables();
             $this->_setupTable($fixture, $connection, $sources, $dropTables);
         }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -323,13 +323,7 @@ SQL;
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
 
-        $resultAll = $schema->listTablesAndViews();
         $resultNoViews = $schema->listTablesWithoutViews();
-
-        $this->assertIsArray($resultAll);
-        $this->assertContains('schema_articles', $resultAll);
-        $this->assertContains('schema_articles_v', $resultAll);
-        $this->assertContains('schema_authors', $resultAll);
         $this->assertIsArray($resultNoViews);
         $this->assertNotContains('schema_articles_v', $resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -299,13 +299,7 @@ SQL;
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
 
-        $resultAll = $schema->listTablesAndViews();
         $resultNoViews = $schema->listTablesWithoutViews();
-
-        $this->assertIsArray($resultAll);
-        $this->assertContains('schema_articles', $resultAll);
-        $this->assertContains('schema_articles_v', $resultAll);
-        $this->assertContains('schema_authors', $resultAll);
         $this->assertIsArray($resultNoViews);
         $this->assertNotContains('schema_articles_v', $resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -291,17 +291,11 @@ SQL;
         $this->assertContains('schema_authors', $result);
         $this->assertContains('view_schema_articles', $result);
 
-        $resultAll = $schema->listTablesAndViews();
         $resultNoViews = $schema->listTablesWithoutViews();
-
         $this->assertIsArray($resultNoViews);
+        $this->assertContains('schema_authors', $resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);
         $this->assertNotContains('view_schema_articles', $resultNoViews);
-
-        $this->assertIsArray($resultAll);
-        $this->assertContains('schema_articles', $resultAll);
-        $this->assertContains('schema_authors', $resultAll);
-        $this->assertContains('view_schema_articles', $resultAll);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -349,13 +349,7 @@ SQL;
         $this->assertContains('schema_articles_v', $result);
         $this->assertContains('schema_authors', $result);
 
-        $resultAll = $schema->listTablesAndViews();
         $resultNoViews = $schema->listTablesWithoutViews();
-
-        $this->assertIsArray($resultAll);
-        $this->assertContains('schema_articles', $resultAll);
-        $this->assertContains('schema_articles_v', $resultAll);
-        $this->assertContains('schema_authors', $resultAll);
         $this->assertIsArray($resultNoViews);
         $this->assertNotContains('schema_articles_v', $resultNoViews);
         $this->assertContains('schema_articles', $resultNoViews);


### PR DESCRIPTION
I feel that this method can be removed and `listTables()` can be un-deprecated if we normalize all of the driver dialects. The only divergent implementation was sqlite. This driver is rarely used for production scenarios but is a great in local development and CI. Because of how SQLite is used I think the risk is low and its divergence is not documented and can be interpreted as a defect. I recognize that we generally don't update the code to the docs but I think this situation is more complex. There exist 3 other implementations of the same method that all work differently and all 4 are documented the same way makes me believe that we can treat this as a bug.

I also would like to add as little API scope as possible as we are shipping this method in a bug fix. The reason for that is that I see views being included in truncation loops as a defect in the new fixture system and the only solution is to add a new method :shrug:

Related to #16123