### PR TITLE
Update type annotations

### DIFF
--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -72,7 +72,7 @@ trait LocatorAwareTrait
      * Convenience method to get a table instance.
      *
      * @template T of \Cake\ORM\Table
-     * @param class-string<T>|null|string $alias The alias name you want to get. Should be in CamelCase format.
+     * @param class-string<T>|string|null $alias The alias name you want to get. Should be in CamelCase format.
      *  If `null` then the value of $defaultTable property is used.
      * @param array<string, mixed> $options The options you want to build the table with.
      *   If a table has already been loaded the registry options will be ignored.

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -72,7 +72,7 @@ trait LocatorAwareTrait
      * Convenience method to get a table instance.
      *
      * @template T of \Cake\ORM\Table
-     * @param class-string<T> $alias The alias name you want to get. Should be in CamelCase format.
+     * @param class-string<T>|null|string $alias The alias name you want to get. Should be in CamelCase format.
      *  If `null` then the value of $defaultTable property is used.
      * @param array<string, mixed> $options The options you want to build the table with.
      *   If a table has already been loaded the registry options will be ignored.
@@ -81,7 +81,7 @@ trait LocatorAwareTrait
      * @see \Cake\ORM\TableLocator::get()
      * @since 4.3.0
      */
-    public function fetchTable(?string $alias = null, array $options = [])
+    public function fetchTable(?string $alias = null, array $options = []): Table
     {
         $alias = $alias ?? $this->defaultTable;
         if ($alias === null) {

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -71,16 +71,17 @@ trait LocatorAwareTrait
     /**
      * Convenience method to get a table instance.
      *
-     * @param string|null $alias The alias name you want to get. Should be in CamelCase format.
+     * @template T of \Cake\ORM\Table
+     * @param class-string<T> $alias The alias name you want to get. Should be in CamelCase format.
      *  If `null` then the value of $defaultTable property is used.
      * @param array<string, mixed> $options The options you want to build the table with.
      *   If a table has already been loaded the registry options will be ignored.
-     * @return \Cake\ORM\Table
+     * @return T|\Cake\ORM\Table
      * @throws \Cake\Core\Exception\CakeException If `$alias` argument and `$defaultTable` property both are `null`.
      * @see \Cake\ORM\TableLocator::get()
      * @since 4.3.0
      */
-    public function fetchTable(?string $alias = null, array $options = []): Table
+    public function fetchTable(?string $alias = null, array $options = [])
     {
         $alias = $alias ?? $this->defaultTable;
         if ($alias === null) {

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -51,7 +51,7 @@ interface LocatorInterface extends BaseLocatorInterface
      * Get a table instance from the registry.
      *
      * @template T of \Cake\ORM\Table
-     * @param class-string<T>|null|string $alias The alias name you want to get.
+     * @param class-string<T>|string|null $alias The alias name you want to get.
      * @param array<string, mixed> $options The options you want to build the table with.
      * @return T|\Cake\ORM\Table
      */

--- a/src/ORM/Locator/LocatorInterface.php
+++ b/src/ORM/Locator/LocatorInterface.php
@@ -50,9 +50,10 @@ interface LocatorInterface extends BaseLocatorInterface
     /**
      * Get a table instance from the registry.
      *
-     * @param string $alias The alias name you want to get.
+     * @template T of \Cake\ORM\Table
+     * @param class-string<T>|null|string $alias The alias name you want to get.
      * @param array<string, mixed> $options The options you want to build the table with.
-     * @return \Cake\ORM\Table
+     * @return T|\Cake\ORM\Table
      */
     public function get(string $alias, array $options = []): Table;
 


### PR DESCRIPTION
Updated the type annotation for the fetchTable() method.

The return type of the fetchTable() method is defined to be `Cake\ORM\Table`.
However, in a real use case, a table object of a user-defined model is expected.

Example
```php
$usersTable = $this->fetchTable('Users');
$result = $usersTable->userDefinedMethod();
```

In this case, the type of `$usersTable` is `App\Model\Table\UsersTable`, but the return type is defined as `Cake\ORM\Table`.
Editors and static analysis tools will detect such an error.

`Call to an undefined method Cake\ORM\Table::userDefinedMethod(). `

This problem can be solved by using Generics.

[Reference](https://phpstan.org/blog/generics-in-php-using-phpdocs)

thank you .