### PR TITLE
Add method to add a renderer to Debugger

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -31,6 +31,7 @@ use Cake\Error\Debug\ReferenceNode;
 use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
+use Cake\Error\ErrorRendererInterface;
 use Cake\Error\Renderer\HtmlRenderer;
 use Cake\Error\Renderer\TextRenderer;
 use Cake\Log\Log;
@@ -918,8 +919,25 @@ class Debugger
         } else {
             $self->_templates[$format] = $strings;
         }
+        unset($self->renderers[$format]);
 
         return $self->_templates[$format];
+    }
+
+    /**
+     * Add a renderer to the current instance.
+     *
+     * @param string $name The alias for the the renderer.
+     * @param string $class The classname of the renderer to use.
+     * @return void
+     */
+    public static function addRenderer(string $name, string $class): void
+    {
+        if (!in_array(ErrorRendererInterface::class, class_implements($class))) {
+            throw new InvalidArgumentException('Invalid renderer class. $class must implement ' . ErrorRendererInterface::class);
+        }
+        $self = Debugger::getInstance();
+        $self->renderers[$name] = $class;
     }
 
     /**

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -31,7 +31,6 @@ use Cake\Error\Debug\ReferenceNode;
 use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
-use Cake\Error\ErrorRendererInterface;
 use Cake\Error\Renderer\HtmlRenderer;
 use Cake\Error\Renderer\TextRenderer;
 use Cake\Log\Log;

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -927,7 +927,7 @@ class Debugger
      * Add a renderer to the current instance.
      *
      * @param string $name The alias for the the renderer.
-     * @param class-string $class The classname of the renderer to use.
+     * @param class-string<\Cake\Error\ErrorRendererInterface> $class The classname of the renderer to use.
      * @return void
      */
     public static function addRenderer(string $name, string $class): void

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -927,13 +927,15 @@ class Debugger
      * Add a renderer to the current instance.
      *
      * @param string $name The alias for the the renderer.
-     * @param string $class The classname of the renderer to use.
+     * @param class-string $class The classname of the renderer to use.
      * @return void
      */
     public static function addRenderer(string $name, string $class): void
     {
         if (!in_array(ErrorRendererInterface::class, class_implements($class))) {
-            throw new InvalidArgumentException('Invalid renderer class. $class must implement ' . ErrorRendererInterface::class);
+            throw new InvalidArgumentException(
+                'Invalid renderer class. $class must implement ' . ErrorRendererInterface::class
+            );
         }
         $self = Debugger::getInstance();
         $self->renderers[$name] = $class;

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -180,7 +180,16 @@ class DebuggerTest extends TestCase
     }
 
     /**
-     * Test setOutputFormat overwrite
+     * Test invalid class and addRenderer()
+     */
+    public function testAddRendererInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Debugger::addRenderer('test', stdClass::class);
+    }
+
+    /**
+     * Test addFormat() overwriting addRenderer()
      */
     public function testAddOutputFormatOverwrite(): void
     {

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -25,6 +25,7 @@ use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Error\Debugger;
+use Cake\Error\Renderer\HtmlRenderer;
 use Cake\Form\Form;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
@@ -176,6 +177,33 @@ class DebuggerTest extends TestCase
         $result = ob_get_clean();
         $this->assertStringContainsString('&lt;script&gt;', $result);
         $this->assertStringNotContainsString('<script>', $result);
+    }
+
+    /**
+     * Test setOutputFormat overwrite
+     */
+    public function testAddOutputFormatOverwrite(): void
+    {
+        Debugger::addRenderer('test', HtmlRenderer::class);
+        Debugger::addFormat('test', [
+            'error' => '{:description} : {:path}, line {:line}',
+        ]);
+        Debugger::setOutputFormat('test');
+
+        ob_start();
+        $debugger = Debugger::getInstance();
+        $data = [
+            'error' => 'Notice',
+            'code' => E_NOTICE,
+            'level' => E_NOTICE,
+            'description' => 'Oh no!',
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ];
+        $debugger->outputError($data);
+        $result = ob_get_clean();
+        $this->assertStringContainsString('Oh no! :', $result);
+        $this->assertStringContainsString(", line {$data['line']}", $result);
     }
 
     /**


### PR DESCRIPTION
While Debugger handling errors is going to be deprecated this method will let people with custom formatters migrate incrementally.