### PR TITLE
Simplify expression operator parsing and support multi-word operators

### DIFF
--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -801,35 +801,6 @@ class CaseStatementExpressionTest extends TestCase
         );
     }
 
-    public function testSqlInjectionViaUntypedWhenArrayValueIsPossible(): void
-    {
-        $expression = (new CaseStatementExpression())
-            ->when(['1 THEN 1 END; DELETE * FROM foo; --' => '123'])
-            ->then(1);
-
-        $valueBinder = new ValueBinder();
-        $sql = $expression->sql($valueBinder);
-        $this->assertSame(
-            'CASE WHEN 1 THEN 1 END; DELETE * FROM foo; -- :c0 THEN :c1 ELSE NULL END',
-            $sql
-        );
-        $this->assertSame(
-            [
-                ':c0' => [
-                    'value' => '123',
-                    'type' => null,
-                    'placeholder' => 'c0',
-                ],
-                ':c1' => [
-                    'value' => 1,
-                    'type' => 'integer',
-                    'placeholder' => 'c1',
-                ],
-            ],
-            $valueBinder->bindings()
-        );
-    }
-
     public function testSqlInjectionViaTypedThenValueIsNotPossible(): void
     {
         $expression = (new CaseStatementExpression(1))

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -41,6 +41,58 @@ class QueryExpressionTest extends TestCase
     }
 
     /**
+     * Tests conditions with multi-word operators.
+     *
+     * @return void
+     */
+    public function testMultiWordOperators(): void
+    {
+        $expr = new QueryExpression(['FUNC(Users.first + Users.last) is not' => 'me']);
+        $this->assertSame('FUNC(Users.first + Users.last) != :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['FUNC(Users.name + Users.id) not similar to' => 'pattern']);
+        $this->assertSame('FUNC(Users.name + Users.id) NOT SIMILAR TO :c0', $expr->sql(new ValueBinder()));
+    }
+
+    /**
+     * Tests conditions with symbol operators.
+     *
+     * @return void
+     */
+    public function testSymbolOperators(): void
+    {
+        $expr = new QueryExpression(['Users.name =' => 'pattern']);
+        $this->assertSame('Users.name = :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name !=' => 'pattern']);
+        $this->assertSame('Users.name != :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name <>' => 'pattern']);
+        $this->assertSame('Users.name <> :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name >=' => 'pattern']);
+        $this->assertSame('Users.name >= :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name <=' => 'pattern']);
+        $this->assertSame('Users.name <= :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name !~' => 'pattern']);
+        $this->assertSame('Users.name !~ :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name *' => 'pattern']);
+        $this->assertSame('Users.name * :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name -' => 'pattern']);
+        $this->assertSame('Users.name - :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name \\' => 'pattern']);
+        $this->assertSame('Users.name \\ :c0', $expr->sql(new ValueBinder()));
+
+        $expr = new QueryExpression(['Users.name @>' => 'pattern']);
+        $this->assertSame('Users.name @> :c0', $expr->sql(new ValueBinder()));
+    }
+
+    /**
      * Test and() and or() calls work transparently
      */
     public function testAndOrCalls(): void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1561,7 +1561,7 @@ class QueryTest extends TestCase
 
         $sql = $query->sql();
         $this->assertQuotedQuery(
-            'SELECT <id> FROM <articles> WHERE <id> in \\(:c0,:c1\\)',
+            'SELECT <id> FROM <articles> WHERE <id> IN \\(:c0,:c1\\)',
             $sql,
             !$this->autoQuote
         );
@@ -1602,7 +1602,7 @@ class QueryTest extends TestCase
             ->whereNotInList('id', [1, 3]);
 
         $this->assertQuotedQuery(
-            'SELECT <id> FROM <articles> WHERE <id> not in \\(:c0,:c1\\)',
+            'SELECT <id> FROM <articles> WHERE <id> NOT IN \\(:c0,:c1\\)',
             $query->sql(),
             !$this->autoQuote
         );
@@ -1643,7 +1643,7 @@ class QueryTest extends TestCase
             ->whereNotInListOrNull('id', [1, 3]);
 
         $this->assertQuotedQuery(
-            'SELECT <id> FROM <articles> WHERE \\(<id> not in \\(:c0,:c1\\) OR \\(<id>\\) IS NULL\\)',
+            'SELECT <id> FROM <articles> WHERE \\(<id> NOT IN \\(:c0,:c1\\) OR \\(<id>\\) IS NULL\\)',
             $query->sql(),
             !$this->autoQuote
         );
@@ -2791,7 +2791,7 @@ class QueryTest extends TestCase
         $this->assertQuotedQuery(
             'DELETE FROM <authors> WHERE \(' .
                 '<id> = :c0 OR \(<name>\) IS NULL OR \(<email>\) IS NOT NULL OR \(' .
-                    '<name> not in \(:c1,:c2\) AND \(' .
+                    '<name> NOT IN \(:c1,:c2\) AND \(' .
                         '<name> = :c3 OR <name> = :c4 OR \(SELECT <e>\.<name> WHERE <e>\.<name> = :c5\)' .
                     '\)' .
                 '\)' .
@@ -3026,7 +3026,7 @@ class QueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE <authors> SET <name> = :c0 WHERE \(' .
                 '<id> = :c1 OR \(<name>\) IS NULL OR \(<email>\) IS NOT NULL OR \(' .
-                    '<name> not in \(:c2,:c3\) AND \(' .
+                    '<name> NOT IN \(:c2,:c3\) AND \(' .
                         '<name> = :c4 OR <name> = :c5 OR \(SELECT <e>\.<name> WHERE <e>\.<name> = :c6\)' .
                     '\)' .
                 '\)' .


### PR DESCRIPTION
The operator is any letter + space + symbol combination at the end of the condition. If a condition has a complex expression, that will include a parenthesis. Even though expressions can contain spaces, there will be a ) at the end which prevents it from being pulled into the operator match.

This change also converts the operator to upper case so the generated SQL matches the expected convention.

The usual caveat applies that an identifier with spaces must be quoted through an Expression object and cannot be in a condition string.
