### PR TITLE
Simplify setting types in TypeMap

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -73,7 +73,7 @@ class QueryExpression implements ExpressionInterface, Countable
         $this->setTypeMap($types);
         $this->setConjunction(strtoupper($conjunction));
         if (!empty($conditions)) {
-            $this->add($conditions, $this->getTypeMap()->getTypes());
+            $this->add($conditions);
         }
     }
 

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -66,7 +66,6 @@ class FieldTypeConverter
     public function __construct(TypeMap $typeMap, DriverInterface $driver)
     {
         $this->_driver = $driver;
-        $map = $typeMap->toArray();
         $types = TypeFactory::buildAll();
 
         $simpleMap = $batchingMap = [];
@@ -85,7 +84,7 @@ class FieldTypeConverter
             $simpleMap[$k] = $type;
         }
 
-        foreach ($map as $field => $type) {
+        foreach ($typeMap->getTypes() as $field => $type) {
             if (isset($simpleMap[$type])) {
                 $simpleResult[$field] = $simpleMap[$type];
                 continue;

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2312,7 +2312,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
         $typeMap = $this->getSelectTypeMap();
         $driver = $this->getConnection()->getDriver();
 
-        if ($this->typeCastEnabled && $typeMap->toArray()) {
+        if ($this->typeCastEnabled && $typeMap->getTypes()) {
             $statement = new CallbackStatement($statement, $driver, new FieldTypeConverter($typeMap, $driver));
         }
 
@@ -2455,7 +2455,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $sql,
             'params' => $params,
-            'defaultTypes' => $this->getDefaultTypes(),
+            'types' => $this->getTypes(),
             'decorators' => count($this->_resultDecorators),
             'executed' => $this->_iterator ? true : false,
         ];

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -17,118 +17,47 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 /**
- * Implements default and single-use mappings for columns to their associated types
+ * Maps fields to types.
  */
 class TypeMap
 {
     /**
-     * Associative array with the default fields and the related types this query might contain.
-     *
-     * Used to avoid repetition when calling multiple functions inside this class that
-     * may require a custom type for a specific field.
-     *
-     * @var array<string, string>
+     * @var array<string>
      */
-    protected array $_defaults = [];
+    protected array $_types;
 
     /**
-     * Associative array with the fields and the related types that override defaults this query might contain
-     *
-     * Used to avoid repetition when calling multiple functions inside this class that
-     * may require a custom type for a specific field.
-     *
-     * @var array<string, string>
+     * @param array<string> $types Map of fields to types
      */
-    protected array $_types = [];
-
-    /**
-     * Creates an instance with the given defaults
-     *
-     * @param array<string, string> $defaults The defaults to use.
-     */
-    public function __construct(array $defaults = [])
+    public function __construct(array $types = [])
     {
-        $this->setDefaults($defaults);
+        $this->_types = $types;
     }
 
     /**
-     * Configures a map of fields and associated type.
+     * Sets types for fields.
      *
-     * These values will be used as the default mapping of types for every function
-     * in this instance that supports a `$types` param.
+     * If a field is already mapped, the type is replaced.
      *
-     * This method is useful when you want to avoid repeating type definitions
-     * as setting types overwrites the last set of types.
-     *
-     * ### Example
-     *
+     * Example:
      * ```
-     * $query->setDefaults(['created' => 'datetime', 'is_visible' => 'boolean']);
+     * $typeMap->setTypes(['id' => 'integer']);
      * ```
      *
-     * This method will replace all the existing default mappings with the ones provided.
-     * To add into the mappings use `addDefaults()`.
-     *
-     * @param array<string, string> $defaults Associative array where keys are field names and values
-     * are the correspondent type.
-     * @return $this
-     */
-    public function setDefaults(array $defaults)
-    {
-        $this->_defaults = $defaults;
-
-        return $this;
-    }
-
-    /**
-     * Returns the currently configured types.
-     *
-     * @return array<string, string>
-     */
-    public function getDefaults(): array
-    {
-        return $this->_defaults;
-    }
-
-    /**
-     * Add additional default types into the type map.
-     *
-     * If a key already exists it will not be overwritten.
-     *
-     * @param array<string, string> $types The additional types to add.
-     * @return void
-     */
-    public function addDefaults(array $types): void
-    {
-        $this->_defaults += $types;
-    }
-
-    /**
-     * Sets a map of fields and their associated types for single-use.
-     *
-     * ### Example
-     *
-     * ```
-     * $query->setTypes(['created' => 'time']);
-     * ```
-     *
-     * This method will replace all the existing type maps with the ones provided.
-     *
-     * @param array<string, string> $types Associative array where keys are field names and values
-     * are the correspondent type.
+     * @param array<string> $types Map of fields to types
      * @return $this
      */
     public function setTypes(array $types)
     {
-        $this->_types = $types;
+        $this->_types = array_merge($this->_types, $types);
 
         return $this;
     }
 
     /**
-     * Gets a map of fields and their associated types for single-use.
+     * Gets map of fields to types.
      *
-     * @return array<string, string>
+     * @return array<string>
      */
     public function getTypes(): array
     {
@@ -136,25 +65,13 @@ class TypeMap
     }
 
     /**
-     * Returns the type of the given column. If there is no single use type is configured,
-     * the column type will be looked for inside the default mapping. If neither exist,
-     * null will be returned.
+     * Returns type for a specific field or null if not set.
      *
-     * @param string|int $column The type for a given column
+     * @param string|int $field Field name to map
      * @return string|null
      */
-    public function type(string|int $column): ?string
+    public function type(string|int $field): ?string
     {
-        return $this->_types[$column] ?? $this->_defaults[$column] ?? null;
-    }
-
-    /**
-     * Returns an array of all types mapped types
-     *
-     * @return array<string, string>
-     */
-    public function toArray(): array
-    {
-        return $this->_types + $this->_defaults;
+        return $this->_types[$field] ?? null;
     }
 }

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -57,33 +57,27 @@ trait TypeMapTrait
     }
 
     /**
-     * Overwrite the default type mappings for fields
-     * in the implementing object.
+     * Sets types for names or aliases.
      *
-     * This method is useful if you need to set type mappings that are shared across
-     * multiple functions/expressions in a query.
+     * If a field is already mapped, it is replaced.
      *
-     * To add a default without overwriting existing ones
-     * use `getTypeMap()->addDefaults()`
-     *
-     * @param array<string, string> $types The array of types to set.
+     * @param array<string, string> $types Map of fields to types
      * @return $this
-     * @see \Cake\Database\TypeMap::setDefaults()
      */
-    public function setDefaultTypes(array $types)
+    public function setTypes(array $types)
     {
-        $this->getTypeMap()->setDefaults($types);
+        $this->getTypeMap()->setTypes($types);
 
         return $this;
     }
 
     /**
-     * Gets default types of current type map.
+     * Gets map of fields to types.
      *
      * @return array<string, string>
      */
-    public function getDefaultTypes(): array
+    public function getTypes(): array
     {
-        return $this->getTypeMap()->getDefaults();
+        return $this->getTypeMap()->getTypes();
     }
 }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -349,10 +349,10 @@ class SelectLoader
         string $operator
     ): TupleComparison {
         $types = [];
-        $defaults = $query->getDefaultTypes();
+        $queryTypes = $query->getTypes();
         foreach ($keys as $k) {
-            if (isset($defaults[$k])) {
-                $types[] = $defaults[$k];
+            if (isset($queryTypes[$k])) {
+                $types[] = $queryTypes[$k];
             }
         }
 

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -127,7 +127,7 @@ class SelectWithPivotLoader extends SelectLoader
             'includeFields' => false,
             'propertyPath' => $this->junctionProperty,
         ]);
-        $query->getTypeMap()->addDefaults($types);
+        $query->setTypes($types);
 
         return $query;
     }

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -94,7 +94,7 @@ class LazyEagerLoader
                     return $exp->in($source->aliasField($primaryKey), $keys->toList());
                 }
 
-                $types = array_intersect_key($q->getDefaultTypes(), array_flip($primaryKey));
+                $types = array_intersect_key($q->getTypes(), array_flip($primaryKey));
                 $primaryKey = array_map([$source, 'aliasField'], $primaryKey);
 
                 return new TupleComparison($primaryKey, $keys->toList(), $types, 'IN');

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -272,13 +272,12 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     public function addDefaultTypes(Table $table)
     {
-        $alias = $table->getAlias();
-        $map = $table->getSchema()->typeMap();
         $fields = [];
-        foreach ($map as $f => $type) {
+        $alias = $table->getAlias();
+        foreach ($table->getSchema()->typeMap() as $f => $type) {
             $fields[$f] = $fields[$alias . '.' . $f] = $fields[$alias . '__' . $f] = $type;
         }
-        $this->getTypeMap()->addDefaults($fields);
+        $this->setTypes($fields);
 
         return $this;
     }
@@ -1196,7 +1195,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      */
     protected function _addDefaultSelectTypes(): void
     {
-        $typeMap = $this->getTypeMap()->getDefaults();
+        $typeMap = $this->getTypes();
         $select = $this->clause('select');
         $types = [];
 
@@ -1213,7 +1212,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
                 $types[$alias] = $typeMap[$value];
             }
         }
-        $this->getSelectTypeMap()->addDefaults($types);
+        $this->getSelectTypeMap()->setTypes($types);
     }
 
     /**

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -69,7 +69,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
             ->select('id')
             ->from('ordered_uuid_items')
             ->order('id')
-            ->setDefaultTypes(['id' => 'ordered_uuid']);
+            ->setTypes(['id' => 'ordered_uuid']);
 
         $query->setSelectTypeMap($query->getTypeMap());
         $results = $query->execute()->fetchAll('assoc');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -3628,32 +3628,6 @@ class QueryTest extends TestCase
     }
 
     /**
-     * Tests that default types are passed to functions accepting a $types param
-     */
-    public function testDefaultTypes(): void
-    {
-        $query = new Query($this->connection);
-        $this->assertEquals([], $query->getDefaultTypes());
-        $types = ['id' => 'integer', 'created' => 'datetime'];
-        $this->assertSame($query, $query->setDefaultTypes($types));
-        $this->assertSame($types, $query->getDefaultTypes());
-
-        $results = $query->select(['id', 'comment'])
-            ->from('comments')
-            ->where(['created >=' => new DateTime('2007-03-18 10:55:00')])
-            ->execute();
-        $expected = [['id' => '6', 'comment' => 'Second Comment for Second Article']];
-        $this->assertEquals($expected, $results->fetchAll('assoc'));
-
-        // Now test default can be overridden
-        $types = ['created' => 'date'];
-        $results = $query
-            ->where(['created >=' => new DateTime('2007-03-18 10:50:00')], $types, true)
-            ->execute();
-        $this->assertCount(6, $results, 'All 6 rows should match.');
-    }
-
-    /**
      * Tests parameter binding
      */
     public function testBind(): void
@@ -3919,7 +3893,7 @@ class QueryTest extends TestCase
     {
         $query = (new Query($this->connection))->select('*')
             ->from('articles')
-            ->setDefaultTypes(['id' => 'integer'])
+            ->setTypes(['id' => 'integer'])
             ->where(['id' => '1']);
 
         $expected = [
@@ -3928,7 +3902,7 @@ class QueryTest extends TestCase
             'params' => [
                 ':c0' => ['value' => '1', 'type' => 'integer', 'placeholder' => 'c0'],
             ],
-            'defaultTypes' => ['id' => 'integer'],
+            'types' => ['id' => 'integer'],
             'decorators' => 0,
             'executed' => false,
         ];
@@ -3942,7 +3916,7 @@ class QueryTest extends TestCase
             'params' => [
                 ':c0' => ['value' => '1', 'type' => 'integer', 'placeholder' => 'c0'],
             ],
-            'defaultTypes' => ['id' => 'integer'],
+            'types' => ['id' => 'integer'],
             'decorators' => 0,
             'executed' => true,
         ];
@@ -4606,7 +4580,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection);
         $query->select('id')
             ->from('comments')
-            ->setDefaultTypes(['created' => 'datetime'])
+            ->setTypes(['created' => 'datetime'])
             ->where(function ($expr) {
                 $from = new DateTime('2007-03-18 10:45:00');
                 $to = new DateTime('2007-03-18 10:48:00');

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Log\Engine;
 
 use ArrayObject;
-use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\Http\Response;
 use Cake\ORM\Entity;
@@ -81,7 +80,6 @@ class BaseLogTest extends TestCase
             'obj' => function (): void {
             },
             'to-string' => new Response(['body' => 'response body']),
-            'to-array' => new TypeMap(['my-type']),
         ];
         $this->logger->log(
             LogLevel::INFO,
@@ -118,13 +116,6 @@ class BaseLogTest extends TestCase
             $context
         );
         $this->assertSame('no placeholder holders', $this->logger->getMessage());
-
-        $this->logger->log(
-            LogLevel::INFO,
-            '{to-array}',
-            $context
-        );
-        $this->assertSame('["my-type"]', $this->logger->getMessage());
 
         $this->logger->log(
             LogLevel::INFO,

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -205,7 +205,7 @@ class EagerLoaderTest extends TestCase
                         'type' => 'LEFT',
                         'conditions' => new QueryExpression([
                             ['clients.id' => new IdentifierExpression('foo.client_id')],
-                        ], new TypeMap($this->clientsTypeMap->getDefaults())),
+                        ], new TypeMap($this->clientsTypeMap->getTypes())),
                     ]],
                 ],
                 [

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2551,7 +2551,7 @@ class QueryTest extends TestCase
             '(help)' => 'This is a Query object, to get the results execute or iterate it.',
             'sql' => $query->sql(),
             'params' => $query->getValueBinder()->bindings(),
-            'defaultTypes' => [
+            'types' => [
                 'authors__id' => 'integer',
                 'authors.id' => 'integer',
                 'id' => 'integer',

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3537,7 +3537,7 @@ class TableTest extends TestCase
         $this->assertInstanceOf('Cake\ORM\Query', $result);
         $this->assertNull($result->clause('limit'));
         $expected = new QueryExpression();
-        $expected->getTypeMap()->setDefaults($this->usersTypeMap->toArray());
+        $expected->getTypeMap()->setTypes($this->usersTypeMap->getTypes());
         $expected->add(
             ['or' => ['Users.author_id' => 1, 'Users.published' => 'Y']]
         );


### PR DESCRIPTION
This needs TypeMap-specific tests. Everything seemed to be an integration test.

Type type map is actually a map of `string` or `int` fields to types. The integer types are used for things like function arguments.