### PR TITLE
4.4 - Exception trap

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -123,9 +123,7 @@ class Debugger
      * @var array<string, class-string>
      */
     protected $renderers = [
-        // Backwards compatible alias for text that will be deprecated.
         'txt' => TextErrorRenderer::class,
-        'text' => TextErrorRenderer::class,
         // The html alias currently uses no JS and will be deprecated.
         'js' => HtmlErrorRenderer::class,
     ];

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -31,8 +31,8 @@ use Cake\Error\Debug\ReferenceNode;
 use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
-use Cake\Error\Renderer\HtmlRenderer;
-use Cake\Error\Renderer\TextRenderer;
+use Cake\Error\Renderer\HtmlErrorRenderer;
+use Cake\Error\Renderer\TextErrorRenderer;
 use Cake\Log\Log;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -124,10 +124,10 @@ class Debugger
      */
     protected $renderers = [
         // Backwards compatible alias for text that will be deprecated.
-        'txt' => TextRenderer::class,
-        'text' => TextRenderer::class,
+        'txt' => TextErrorRenderer::class,
+        'text' => TextErrorRenderer::class,
         // The html alias currently uses no JS and will be deprecated.
-        'js' => HtmlRenderer::class,
+        'js' => HtmlErrorRenderer::class,
     ];
 
     /**

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -199,7 +199,7 @@ class ErrorHandler extends BaseErrorHandler
     /**
      * Method that can be easily stubbed in testing.
      *
-     * @param \Cake\Http\Response|string $response Either the message or response object.
+     * @param \Psr\Http\Message\ResponseInterface|string $response Either the message or response object.
      * @return void
      */
     protected function _sendResponse($response): void

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -180,7 +180,7 @@ class ErrorTrap
         }
         if (!in_array(ErrorLoggerInterface::class, class_implements($class))) {
             throw new InvalidArgumentException(
-                "Cannot use {$class} as an error renderer. It must implement \Cake\Error\ErrorLoggerInterface."
+                "Cannot use {$class} as an error logger. It must implement \Cake\Error\ErrorLoggerInterface."
             );
         }
 

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -5,8 +5,8 @@ namespace Cake\Error;
 
 use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
-use Cake\Error\Renderer\ConsoleRenderer;
-use Cake\Error\Renderer\HtmlRenderer;
+use Cake\Error\Renderer\ConsoleErrorRenderer;
+use Cake\Error\Renderer\HtmlErrorRenderer;
 use Closure;
 use Exception;
 use InvalidArgumentException;
@@ -77,7 +77,7 @@ class ErrorTrap
         }
 
         /** @var class-string<\Cake\Error\ErrorRendererInterface> */
-        return PHP_SAPI === 'cli' ? ConsoleRenderer::class : HtmlRenderer::class;
+        return PHP_SAPI === 'cli' ? ConsoleErrorRenderer::class : HtmlErrorRenderer::class;
     }
 
     /**

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -31,6 +31,7 @@ use Cake\Event\Event;
 use Cake\Http\Exception\HttpException;
 use Cake\Http\Exception\MissingControllerException;
 use Cake\Http\Response;
+use Cake\Http\ResponseEmitter;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Exception\MissingRouteException;
@@ -279,6 +280,24 @@ class ExceptionRenderer implements ExceptionRendererInterface
         $this->controller->setResponse($response);
 
         return $this->_outputMessage($template);
+    }
+
+    /**
+     * Emit the response content
+     *
+     * @param \Psr\Http\Message\ResponseInterface|string $output The response to output.
+     * @return void
+     */
+    public function write($output): void
+    {
+        if (is_string($output)) {
+            echo $output;
+
+            return;
+        }
+
+        $emitter = new ResponseEmitter();
+        $emitter->emit($output);
     }
 
     /**

--- a/src/Error/ExceptionRendererInterface.php
+++ b/src/Error/ExceptionRendererInterface.php
@@ -21,8 +21,8 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Interface ExceptionRendererInterface
  *
- * @method render(): ResponseInterface|string Render the exception to a string or Http Response.
- * @method write(\Psr\Http\Message\ResponseInterface|string $output): void Write the output to the output stream.
+ * @method \Psr\Http\Message\ResponseInterface|string render() Render the exception to a string or Http Response.
+ * @method void write(\Psr\Http\Message\ResponseInterface|string $output) Write the output to the output stream.
  */
 interface ExceptionRendererInterface
 {

--- a/src/Error/ExceptionRendererInterface.php
+++ b/src/Error/ExceptionRendererInterface.php
@@ -20,13 +20,16 @@ use Psr\Http\Message\ResponseInterface;
 
 /**
  * Interface ExceptionRendererInterface
+ *
+ * @method render(): ResponseInterface|string Render the exception to a string or Http Response.
+ * @method write(\Psr\Http\Message\ResponseInterface|string $output): void Write the output to the output stream.
  */
 interface ExceptionRendererInterface
 {
     /**
      * Renders the response for the exception.
      *
-     * @return \Cake\Http\Response The response to be sent.
+     * @return \Psr\Http\Message\ResponseInterface The response to be sent.
      */
     public function render(): ResponseInterface;
 }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -18,6 +18,13 @@ use Throwable;
  * handler to handle fatal errors. When exceptions are trapped
  * they are 'rendered' using the defined renderers and logged
  * if logging is enabled.
+ *
+ * Exceptions will be logged, then call attached callbacks
+ * and finally render an error page using the configured
+ * `exceptionRenderer`.
+ *
+ * If undefined, an ExceptionRenderer will be selected
+ * based on the current SAPI (CLI or Web).
  */
 class ExceptionTrap
 {
@@ -147,6 +154,7 @@ class ExceptionTrap
     public function register(): void
     {
         set_exception_handler([$this, 'handleException']);
+        // TODO handle fatal errors.
     }
 
     /**
@@ -195,6 +203,10 @@ class ExceptionTrap
 
     /**
      * Trigger an error that occurred during rendering an exception.
+     *
+     * By triggering an E_USER_ERROR we can end up in the default
+     * exception handling which will log the rendering failure,
+     * and hopefully render an error page.
      *
      * @param \Throwable $exception Exception to log
      * @return void

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -1,0 +1,211 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Error;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\Http\ResponseEmitter;
+use Cake\Http\ServerRequestFactory;
+use Cake\Routing\Router;
+use Closure;
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * Entry point to CakePHP's exception handling.
+ *
+ * Using the `register()` method you can attach an ExceptionTrap
+ * to PHP's default exception handler and register a shutdown
+ * handler to handle fatal errors. When exceptions are trapped
+ * they are 'rendered' using the defined renderers and logged
+ * if logging is enabled.
+ */
+class ExceptionTrap
+{
+    use InstanceConfigTrait {
+        getConfig as private _getConfig;
+    }
+
+    /**
+     * See the `Error` key in you `config/app.php`
+     * for details on the keys and their values.
+     *
+     * @var array<string, mixed>
+     */
+    protected $_defaultConfig = [
+        'exceptionRenderer' => ExceptionRenderer::class,
+        'logger' => ErrorLogger::class,
+        'log' => true,
+        'trace' => false,
+    ];
+
+    /**
+     * A list of handling callbacks.
+     *
+     * Callbacks are invoked for each error that is handled.
+     * Callbacks are invoked in the order they are attached.
+     *
+     * @var array<\Closure>
+     */
+    protected $callbacks = [];
+
+    /**
+     * Constructor
+     *
+     * @param array<string, mixed> $options An options array. See $_defaultConfig.
+     */
+    public function __construct(array $options = [])
+    {
+        $this->setConfig($options);
+    }
+
+    /**
+     * Get an instance of the renderer.
+     *
+     * @param \Throwable $exception Exception to render
+     * @return \Cake\Error\ExceptionRendererInterface
+     */
+    public function renderer(Throwable $exception): ExceptionRendererInterface
+    {
+        $request = Router::getRequest();
+        $class = $this->_getConfig('exceptionRenderer');
+
+        if (is_string($class)) {
+            if (in_array(ExceptionRendererInterface::class, class_implements($class))) {
+                throw new InvalidArgumentException(
+                    "Cannot use {$class} as`ExceptionRendererInterface` as an `exceptionRenderer`. " .
+                    'It must implement ' . ExceptionRendererInterface::class
+                );
+            }
+
+            /** @var \Cake\Error\ExceptionRendererInterface $instance */
+            $instance = new $class($exception, $request);
+
+            return $instance;
+        }
+
+        /** @var callable $factory */
+        $factory = $class;
+
+        return $factory($exception, $request);
+    }
+
+    /**
+     * Get an instance of the logger.
+     *
+     * @return \Cake\Error\ErrorLoggerInterface
+     */
+    public function logger(): ErrorLoggerInterface
+    {
+        $class = $this->_getConfig('logger');
+        if (!$class) {
+            $class = $this->_defaultConfig['logger'];
+        }
+        if (!in_array(ErrorLoggerInterface::class, class_implements($class))) {
+            throw new InvalidArgumentException(
+                "Cannot use {$class} as an exception logger. " .
+                "It must implement \Cake\Error\ErrorLoggerInterface."
+            );
+        }
+
+        /** @var \Cake\Error\ErrorLoggerInterface $instance */
+        $instance = new $class($this->_config);
+
+        return $instance;
+    }
+
+    /**
+     * Add a callback to be invoked when an error is handled.
+     *
+     * Your callback should habe the following signature:
+     *
+     * ```
+     * function (\Throwable $error): void
+     * ```
+     *
+     * @param \Closure $closure The Closure to be invoked when an error is handledd.
+     * @return $this
+     */
+    public function addCallback(Closure $closure)
+    {
+        $this->callbacks[] = $closure;
+
+        return $this;
+    }
+
+    /**
+     * Attach this ExceptionTrap to PHP's default exception handler.
+     *
+     * This will replace the existing exception handler, and the
+     * previous exception handler will be discarded.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        set_exception_handler([$this, 'handleException']);
+    }
+
+    /**
+     * Handle uncaught exceptions.
+     *
+     * Uses a template method provided by subclasses to display errors in an
+     * environment appropriate way.
+     *
+     * @param \Throwable $exception Exception instance.
+     * @return void
+     * @throws \Exception When renderer class not found
+     * @see https://secure.php.net/manual/en/function.set-exception-handler.php
+     */
+    public function handleException(Throwable $exception): void
+    {
+        try {
+            $renderer = $this->renderer(
+                $exception,
+            );
+            $response = $renderer->render();
+            $this->sendResponse($response);
+        } catch (Throwable $exception) {
+            $this->logInternalError($exception);
+        }
+    }
+
+    /**
+     * Method that can be easily stubbed in testing.
+     *
+     * @param \Cake\Http\Response|string $response Either the message or response object.
+     * @return void
+     */
+    protected function sendResponse($response)
+    {
+        if (is_string($response)) {
+            echo $response;
+
+            return;
+        }
+
+        $emitter = new ResponseEmitter();
+        $emitter->emit($response);
+    }
+
+    /**
+     * Trigger an error that occurred during rendering an exception.
+     *
+     * @param \Throwable $exception Exception to log
+     * @return void
+     */
+    public function logInternalError(Throwable $exception): void
+    {
+        // Disable trace for internal errors.
+        $this->_config['trace'] = false;
+        $message = sprintf(
+            "[%s] %s (%s:%s)\n%s", // Keeping same message format
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine(),
+            $exception->getTraceAsString()
+        );
+        trigger_error($message, E_USER_ERROR);
+    }
+}

--- a/src/Error/Renderer/ConsoleErrorRenderer.php
+++ b/src/Error/Renderer/ConsoleErrorRenderer.php
@@ -24,7 +24,7 @@ use Cake\Error\PhpError;
  *
  * Writes to STDERR for console environments
  */
-class ConsoleRenderer implements ErrorRendererInterface
+class ConsoleErrorRenderer implements ErrorRendererInterface
 {
     /**
      * @inheritDoc

--- a/src/Error/Renderer/HtmlErrorRenderer.php
+++ b/src/Error/Renderer/HtmlErrorRenderer.php
@@ -25,7 +25,7 @@ use Cake\Error\PhpError;
  *
  * Default output renderer for non CLI SAPI.
  */
-class HtmlRenderer implements ErrorRendererInterface
+class HtmlErrorRenderer implements ErrorRendererInterface
 {
     /**
      * @inheritDoc

--- a/src/Error/Renderer/TextErrorRenderer.php
+++ b/src/Error/Renderer/TextErrorRenderer.php
@@ -24,7 +24,7 @@ use Cake\Error\PhpError;
  *
  * Useful in CLI environments.
  */
-class TextRenderer implements ErrorRendererInterface
+class TextErrorRenderer implements ErrorRendererInterface
 {
     /**
      * @inheritDoc

--- a/src/Error/Renderer/TextExceptionRenderer.php
+++ b/src/Error/Renderer/TextExceptionRenderer.php
@@ -44,7 +44,9 @@ class TextExceptionRenderer
     }
 
     /**
-     * @inheritDoc
+     * Render an exception into a plain text message.
+     *
+     * @return string
      */
     public function render()
     {
@@ -52,8 +54,8 @@ class TextExceptionRenderer
             "%s : %s on line %s of %s\nTrace:\n%s",
             $this->error->getCode(),
             $this->error->getMessage(),
-            $this->error->getLine() ?? '',
-            $this->error->getFile() ?? '',
+            $this->error->getLine(),
+            $this->error->getFile(),
             $this->error->getTraceAsString(),
         );
     }

--- a/src/Error/Renderer/TextExceptionRenderer.php
+++ b/src/Error/Renderer/TextExceptionRenderer.php
@@ -23,7 +23,7 @@ use Throwable;
  *
  * Useful in CI or plain text environments.
  *
- * @todo 5.0 Implement \Cake\Error\ErrorRendererInterface. This implementation can't implement
+ * @todo 5.0 Implement \Cake\Error\ExceptionRendererInterface. This implementation can't implement
  *  the concrete interface because the return types are not compatible.
  */
 class TextExceptionRenderer
@@ -46,7 +46,7 @@ class TextExceptionRenderer
     /**
      * Render an exception into a plain text message.
      *
-     * @return string
+     * @return \Psr\Http\Message\ResponseInterface|string
      */
     public function render()
     {

--- a/src/Error/Renderer/TextExceptionRenderer.php
+++ b/src/Error/Renderer/TextExceptionRenderer.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error\Renderer;
+
+use Throwable;
+
+/**
+ * Plain text exception rendering with a stack trace.
+ *
+ * Useful in CI or plain text environments.
+ *
+ * @todo 5.0 Implement \Cake\Error\ErrorRendererInterface. This implementation can't implement
+ *  the concrete interface because the return types are not compatible.
+ */
+class TextExceptionRenderer
+{
+    /**
+     * @var \Throwable
+     */
+    private $error;
+
+    /**
+     * Constructor.
+     *
+     * @param \Throwable $error The error to render.
+     */
+    public function __construct(Throwable $error)
+    {
+        $this->error = $error;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render()
+    {
+        return sprintf(
+            "%s : %s on line %s of %s\nTrace:\n%s",
+            $this->error->getCode(),
+            $this->error->getMessage(),
+            $this->error->getLine() ?? '',
+            $this->error->getFile() ?? '',
+            $this->error->getTraceAsString(),
+        );
+    }
+
+    /**
+     * Write output to stdout.
+     *
+     * @param string $output The output to print.
+     * @return void
+     */
+    public function write($output): void
+    {
+        echo $output;
+    }
+}

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -25,7 +25,7 @@ use Cake\Error\Debug\ScalarNode;
 use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Error\Debugger;
-use Cake\Error\Renderer\HtmlRenderer;
+use Cake\Error\Renderer\HtmlErrorRenderer;
 use Cake\Form\Form;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
@@ -193,7 +193,7 @@ class DebuggerTest extends TestCase
      */
     public function testAddOutputFormatOverwrite(): void
     {
-        Debugger::addRenderer('test', HtmlRenderer::class);
+        Debugger::addRenderer('test', HtmlErrorRenderer::class);
         Debugger::addFormat('test', [
             'error' => '{:description} : {:path}, line {:line}',
         ]);

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -20,9 +20,9 @@ use Cake\Core\Configure;
 use Cake\Error\ErrorLogger;
 use Cake\Error\ErrorTrap;
 use Cake\Error\PhpError;
-use Cake\Error\Renderer\ConsoleRenderer;
-use Cake\Error\Renderer\HtmlRenderer;
-use Cake\Error\Renderer\TextRenderer;
+use Cake\Error\Renderer\ConsoleErrorRenderer;
+use Cake\Error\Renderer\HtmlErrorRenderer;
+use Cake\Error\Renderer\TextErrorRenderer;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -47,20 +47,20 @@ class ErrorTrapTest extends TestCase
     public function testConfigErrorRendererFallback()
     {
         $trap = new ErrorTrap(['errorRenderer' => null]);
-        $this->assertInstanceOf(ConsoleRenderer::class, $trap->renderer());
+        $this->assertInstanceOf(ConsoleErrorRenderer::class, $trap->renderer());
     }
 
     public function testConfigErrorRenderer()
     {
-        $trap = new ErrorTrap(['errorRenderer' => HtmlRenderer::class]);
-        $this->assertInstanceOf(HtmlRenderer::class, $trap->renderer());
+        $trap = new ErrorTrap(['errorRenderer' => HtmlErrorRenderer::class]);
+        $this->assertInstanceOf(HtmlErrorRenderer::class, $trap->renderer());
     }
 
     public function testConfigRendererHandleUnsafeOverwrite()
     {
         $trap = new ErrorTrap();
         $trap->setConfig('errorRenderer', null);
-        $this->assertInstanceOf(ConsoleRenderer::class, $trap->renderer());
+        $this->assertInstanceOf(ConsoleErrorRenderer::class, $trap->renderer());
     }
 
     public function testLoggerConfigInvalid()
@@ -85,7 +85,7 @@ class ErrorTrapTest extends TestCase
 
     public function testRegisterAndRendering()
     {
-        $trap = new ErrorTrap(['errorRenderer' => TextRenderer::class]);
+        $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
         ob_start();
         trigger_error('Oh no it was bad', E_USER_NOTICE);
@@ -101,7 +101,7 @@ class ErrorTrapTest extends TestCase
             'className' => 'Array',
         ]);
         $trap = new ErrorTrap([
-            'errorRenderer' => TextRenderer::class,
+            'errorRenderer' => TextErrorRenderer::class,
         ]);
         $trap->register();
 
@@ -120,7 +120,7 @@ class ErrorTrapTest extends TestCase
             'className' => 'Array',
         ]);
         Configure::write('debug', false);
-        $trap = new ErrorTrap(['errorRenderer' => TextRenderer::class]);
+        $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
 
         ob_start();
@@ -132,7 +132,7 @@ class ErrorTrapTest extends TestCase
 
     public function testAddCallback()
     {
-        $trap = new ErrorTrap(['errorRenderer' => TextRenderer::class]);
+        $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
         $trap->addCallback(function (PhpError $error) {
             $this->assertEquals(E_USER_NOTICE, $error->getCode());

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -58,6 +58,15 @@ class ExceptionTrapTest extends TestCase
         $this->assertInstanceOf(ExceptionRenderer::class, $trap->renderer($error));
     }
 
+    public function testConfigExceptionRendererFactory()
+    {
+        $trap = new ExceptionTrap(['exceptionRenderer' => function ($err, $req) {
+            return new ExceptionRenderer($err, $req);
+        }]);
+        $error = new InvalidArgumentException('nope');
+        $this->assertInstanceOf(ExceptionRenderer::class, $trap->renderer($error));
+    }
+
     public function testConfigRendererHandleUnsafeOverwrite()
     {
         $this->markTestIncomplete();

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -116,6 +116,7 @@ class ExceptionTrapTest extends TestCase
      *
      * Run in a separate process because HTML output writes headers.
      *
+     * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
     public function testRenderExceptionHtml()

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -16,12 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Error;
 
-use Cake\Core\Configure;
 use Cake\Error\ErrorLogger;
-use Cake\Error\ExceptionTrap;
-use Cake\Error\PhpError;
 use Cake\Error\ExceptionRenderer;
-use Cake\Error\ExceptionRendererInterface;
+use Cake\Error\ExceptionTrap;
 use Cake\Error\Renderer\TextExceptionRenderer;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Error;
+
+use Cake\Core\Configure;
+use Cake\Error\ErrorLogger;
+use Cake\Error\ExceptionTrap;
+use Cake\Error\PhpError;
+use Cake\Error\ExceptionRenderer;
+use Cake\Error\ExceptionRendererInterface;
+use Cake\Error\Renderer\TextExceptionRenderer;
+use Cake\Log\Log;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use stdClass;
+use Throwable;
+
+class ExceptionTrapTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Log::drop('test_error');
+    }
+
+    public function testConfigRendererInvalid()
+    {
+        $trap = new ExceptionTrap(['exceptionRenderer' => stdClass::class]);
+        $this->expectException(InvalidArgumentException::class);
+        $error = new InvalidArgumentException('nope');
+        $trap->renderer($error);
+    }
+
+    public function testConfigExceptionRendererFallback()
+    {
+        $this->markTestIncomplete();
+        $trap = new ExceptionTrap(['exceptionRenderer' => null]);
+        $error = new InvalidArgumentException('nope');
+        $this->assertInstanceOf(ConsoleRenderer::class, $trap->renderer($error));
+    }
+
+    public function testConfigExceptionRenderer()
+    {
+        $trap = new ExceptionTrap(['exceptionRenderer' => ExceptionRenderer::class]);
+        $error = new InvalidArgumentException('nope');
+        $this->assertInstanceOf(ExceptionRenderer::class, $trap->renderer($error));
+    }
+
+    public function testConfigRendererHandleUnsafeOverwrite()
+    {
+        $this->markTestIncomplete();
+        $trap = new ExceptionTrap();
+        $trap->setConfig('exceptionRenderer', null);
+        $error = new InvalidArgumentException('nope');
+        $this->assertInstanceOf(ConsoleRenderer::class, $trap->renderer($error));
+    }
+
+    public function testLoggerConfigInvalid()
+    {
+        $trap = new ExceptionTrap(['logger' => stdClass::class]);
+        $this->expectException(InvalidArgumentException::class);
+        $trap->logger();
+    }
+
+    public function testLoggerConfig()
+    {
+        $trap = new ExceptionTrap(['logger' => ErrorLogger::class]);
+        $this->assertInstanceOf(ErrorLogger::class, $trap->logger());
+    }
+
+    public function testLoggerHandleUnsafeOverwrite()
+    {
+        $trap = new ExceptionTrap();
+        $trap->setConfig('logger', null);
+        $this->assertInstanceOf(ErrorLogger::class, $trap->logger());
+    }
+
+    public function testRenderExceptionText()
+    {
+        $trap = new ExceptionTrap([
+            'exceptionRenderer' => TextExceptionRenderer::class,
+        ]);
+        $error = new InvalidArgumentException('nope');
+
+        ob_start();
+        $trap->handleException($error);
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('nope', $out);
+        $this->assertStringContainsString('ExceptionTrapTest', $out);
+    }
+
+    public function testLogException()
+    {
+        Log::setConfig('test_error', [
+            'className' => 'Array',
+        ]);
+        $trap = new ExceptionTrap();
+        $error = new InvalidArgumentException('nope');
+        $trap->logException($error);
+
+        $logs = Log::engine('test_error')->read();
+        $this->assertStringContainsString('nope', $logs[0]);
+    }
+
+    public function testAddCallback()
+    {
+        $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
+        $trap->addCallback(function (Throwable $error) {
+            $this->assertEquals(100, $error->getCode());
+            $this->assertStringContainsString('nope', $error->getMessage());
+        });
+        $error = new InvalidArgumentException('nope', 100);
+
+        ob_start();
+        $trap->handleException($error);
+        $out = ob_get_clean();
+
+        $this->assertNotEmpty($out);
+    }
+}

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -111,6 +111,30 @@ class ExceptionTrapTest extends TestCase
         $this->assertStringContainsString('ExceptionTrapTest', $out);
     }
 
+    /**
+     * Test integration with HTML exception rendering
+     *
+     * Run in a separate process because HTML output writes headers.
+     *
+     * @runInSeparateProcess
+     */
+    public function testRenderExceptionHtml()
+    {
+        $trap = new ExceptionTrap([
+            'exceptionRenderer' => ExceptionRenderer::class,
+        ]);
+        $error = new InvalidArgumentException('nope');
+
+        ob_start();
+        $trap->handleException($error);
+        $out = ob_get_clean();
+
+        $this->assertStringContainsString('<!DOCTYPE', $out);
+        $this->assertStringContainsString('<html', $out);
+        $this->assertStringContainsString('nope', $out);
+        $this->assertStringContainsString('ExceptionTrapTest', $out);
+    }
+
     public function testLogException()
     {
         Log::setConfig('test_error', [


### PR DESCRIPTION
Add a TextRenderer for making it possible to test Exception trap in CI.

Rename the error renderers so that the Error\Renderer namespace can also contain ExceptionRenderers too.

The interface for ExceptionRenderInterface needs to change, but we can't do that without breaking changes. Instead use method_exists() checks to give weaker emulation of the future interface. I don't love this approach but adding another interface seemed heavy as well because the good name is already in use.

These changes do not include the shutdown_handler for fatal errors. I'll do that separately.

Refs #16228