### PR TITLE
Don't use PDOStatemnt::rowCount() for SELECT queries.

### DIFF
--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -19,7 +19,6 @@ namespace Cake\Database\Log;
 use Cake\Database\Statement\StatementDecorator;
 use Exception;
 use Psr\Log\LoggerInterface;
-use stdClass;
 
 /**
  * Statement decorator used to

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -83,39 +83,9 @@ class LoggingStatement extends StatementDecorator
             throw $e;
         }
 
-        if (preg_match('/^(?!SELECT)/i', $this->queryString)) {
-            $this->rowCount();
-        }
+        $this->rowCount();
 
         return $result;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function fetch(string|int $type = self::FETCH_TYPE_NUM): stdClass|array|false
-    {
-        $record = parent::fetch($type);
-
-        if ($this->loggedQuery) {
-            $this->rowCount();
-        }
-
-        return $record;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function fetchAll(string|int $type = self::FETCH_TYPE_NUM): array|false
-    {
-        $results = parent::fetchAll($type);
-
-        if ($this->loggedQuery) {
-            $this->rowCount();
-        }
-
-        return $results;
     }
 
     /**

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -634,7 +634,7 @@ class SqliteSchemaDialect extends SchemaDialect
             'SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"'
         );
         $result->execute();
-        $this->_hasSequences = (bool)$result->rowCount();
+        $this->_hasSequences = (bool)$result->fetch();
         $result->closeCursor();
 
         return $this->_hasSequences;

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -168,17 +168,6 @@ class BufferedStatement implements Iterator, StatementInterface
     }
 
     /**
-     * Statements can be passed as argument for count() to return the number
-     * for affected rows from last execution.
-     *
-     * @return int
-     */
-    public function count(): int
-    {
-        return $this->rowCount();
-    }
-
-    /**
      * @inheritDoc
      */
     public function bind(array $params, array $types): void

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -19,7 +19,6 @@ namespace Cake\Database\Statement;
 use Cake\Database\DriverInterface;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeConverterTrait;
-use Countable;
 use IteratorAggregate;
 use RuntimeException;
 

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -252,15 +252,8 @@ class StatementDecorator implements StatementInterface, IteratorAggregate
     }
 
     /**
-     * Returns the number of rows affected by this SQL statement.
-     *
-     * ### Example:
-     *
-     * ```
-     * $statement = $connection->prepare('UPDATE articles SET foo = 1');
-     * $statement->execute();
-     * print_r($statement->rowCount());
-     * ```
+     * Returns the number of rows affected by this SQL statement for INSERT,
+     * UPDATE and DELETE queries.
      *
      * @return int
      */

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -34,7 +34,7 @@ use RuntimeException;
  *
  * @property-read string $queryString
  */
-class StatementDecorator implements StatementInterface, Countable, IteratorAggregate
+class StatementDecorator implements StatementInterface, IteratorAggregate
 {
     use TypeConverterTrait;
 
@@ -258,9 +258,9 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      * ### Example:
      *
      * ```
-     * $statement = $connection->prepare('SELECT id, title from articles');
+     * $statement = $connection->prepare('UPDATE articles SET foo = 1');
      * $statement->execute();
-     * print_r($statement->rowCount()); // will show 1
+     * print_r($statement->rowCount());
      * ```
      *
      * @return int
@@ -293,17 +293,6 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
         }
 
         return $this->_statement;
-    }
-
-    /**
-     * Statements can be passed as argument for count() to return the number
-     * for affected rows from last execution.
-     *
-     * @return int
-     */
-    public function count(): int
-    {
-        return $this->rowCount();
     }
 
     /**

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -163,15 +163,8 @@ interface StatementInterface extends Traversable
     public function fetchColumn(int $position): mixed;
 
     /**
-     * Returns the number of rows affected by this SQL statement
-     *
-     * ### Example:
-     *
-     * ```
-     *  $statement = $connection->prepare('UPDATE articles SET foo = 1');
-     *  $statement->execute();
-     *  print_r($statement->rowCount());
-     * ```
+     * Returns the number of rows affected by this SQL statement for INSERT,
+     * UPDATE and DELETE queries.
      *
      * @return int
      */

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -168,22 +168,14 @@ interface StatementInterface extends Traversable
      * ### Example:
      *
      * ```
-     *  $statement = $connection->prepare('SELECT id, title from articles');
+     *  $statement = $connection->prepare('UPDATE articles SET foo = 1');
      *  $statement->execute();
-     *  print_r($statement->rowCount()); // will show 1
+     *  print_r($statement->rowCount());
      * ```
      *
      * @return int
      */
     public function rowCount(): int;
-
-    /**
-     * Statements can be passed as argument for count()
-     * to return the number for affected rows from last execution
-     *
-     * @return int
-     */
-    public function count(): int;
 
     /**
      * Binds a set of values to statement object with corresponding type

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -633,8 +633,12 @@ class EagerLoader
         $driver = $query->getConnection()->getDriver();
         [$collected, $statement] = $this->_collectKeys($external, $query, $statement);
 
+        // TODO: The EagerLoader will have to be updated to use the rows fetched by
+        // StatementInterface::fetchAll() instead of relying on StatementInterface::rowCount()
+        // to get the rows count.
+
         // No records found, skip trying to attach associations.
-        if (empty($collected) && $statement->count() === 0) {
+        if (empty($collected) && $statement->rowCount() === 0) {
             return $statement;
         }
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1132,8 +1132,9 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         }
 
         $statement = $this->getEagerLoader()->loadExternal($this, $this->execute());
+        $resultset = new ResultSet($this, $statement->fetchAll('assoc') ?: []);
 
-        return new ResultSet($this, $statement);
+        return $resultset;
     }
 
     /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -19,7 +19,6 @@ namespace Cake\ORM;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionTrait;
 use Cake\Database\DriverInterface;
-use Cake\Database\StatementInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use SplFixedArray;
@@ -141,9 +140,9 @@ class ResultSet implements ResultSetInterface
      * Constructor
      *
      * @param \Cake\ORM\Query $query Query from where results come
-     * @param \Cake\Database\StatementInterface $statement The statement to fetch from
+     * @param array $results Results array.
      */
-    public function __construct(Query $query, StatementInterface $statement)
+    public function __construct(Query $query, array $results)
     {
         $repository = $query->getRepository();
         $this->_driver = $query->getConnection()->getDriver();
@@ -155,28 +154,8 @@ class ResultSet implements ResultSetInterface
         $this->_calculateColumnMap($query);
         $this->_autoFields = $query->isAutoFieldsEnabled();
 
-        $this->fetchResults($statement);
-        $statement->closeCursor();
-    }
-
-    /**
-     * Fetch results.
-     *
-     * @param \Cake\Database\StatementInterface $statement The statement to fetch from.
-     * @return void
-     */
-    protected function fetchResults(StatementInterface $statement): void
-    {
-        $results = $statement->fetchAll('assoc');
-        if ($results === false) {
-            $this->_results = new SplFixedArray();
-
-            return;
-        }
-
-        $this->_count = count($results);
-        $this->_results = new SplFixedArray($this->_count);
-        foreach ($results as $i => $row) {
+        $this->__unserialize($results);
+        foreach ($this->_results as $i => $row) {
             $this->_results[$i] = $this->_groupResult($row);
         }
     }

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -19,7 +19,6 @@ namespace Cake\ORM;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionTrait;
 use Cake\Database\DriverInterface;
-use Cake\Database\Exception\DatabaseException;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
@@ -160,6 +159,12 @@ class ResultSet implements ResultSetInterface
         $statement->closeCursor();
     }
 
+    /**
+     * Fetch results.
+     *
+     * @param \Cake\Database\StatementInterface $statement The statement to fetch from.
+     * @return void
+     */
     protected function fetchResults(StatementInterface $statement): void
     {
         $results = $statement->fetchAll('assoc');

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -242,24 +242,24 @@ class ConnectionTest extends TestCase
     {
         $sql = 'SELECT 1 + ?';
         $statement = $this->connection->execute($sql, [1], ['integer']);
-        $this->assertCount(1, $statement);
-        $result = $statement->fetch();
-        $this->assertEquals([2], $result);
+        $result = $statement->fetchAll();
+        $this->assertCount(1, $result);
+        $this->assertEquals([2], $result[0]);
         $statement->closeCursor();
 
         $sql = 'SELECT 1 + ? + ? AS total';
         $statement = $this->connection->execute($sql, [2, 3], ['integer', 'integer']);
-        $this->assertCount(1, $statement);
-        $result = $statement->fetch('assoc');
-        $this->assertEquals(['total' => 6], $result);
+        $result = $statement->fetchAll('assoc');
         $statement->closeCursor();
+        $this->assertCount(1, $result);
+        $this->assertEquals(['total' => 6], $result[0]);
 
         $sql = 'SELECT 1 + :one + :two AS total';
         $statement = $this->connection->execute($sql, ['one' => 2, 'two' => 3], ['one' => 'integer', 'two' => 'integer']);
-        $this->assertCount(1, $statement);
-        $result = $statement->fetch('assoc');
+        $result = $statement->fetchAll('assoc');
         $statement->closeCursor();
-        $this->assertEquals(['total' => 6], $result);
+        $this->assertCount(1, $result);
+        $this->assertEquals(['total' => 6], $result[0]);
     }
 
     /**
@@ -335,10 +335,10 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
         $result->closeCursor();
         $result = $this->connection->execute('SELECT * from things where id = 3');
-        $this->assertCount(1, $result);
-        $row = $result->fetch('assoc');
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
         $result->closeCursor();
-        $this->assertEquals($data, $row);
+        $this->assertEquals($data, $rows[0]);
     }
 
     /**
@@ -355,10 +355,10 @@ class ConnectionTest extends TestCase
         $result->closeCursor();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
         $result = $this->connection->execute('SELECT * from things where id  = 3');
-        $this->assertCount(1, $result);
-        $row = $result->fetch('assoc');
+        $rows = $result->fetchAll('assoc');
         $result->closeCursor();
-        $this->assertEquals($data, $row);
+        $this->assertCount(1, $rows);
+        $this->assertEquals($data, $rows[0]);
     }
 
     /**
@@ -414,7 +414,7 @@ class ConnectionTest extends TestCase
         $body = 'changed the body!';
         $this->connection->update('things', ['title' => $title, 'body' => $body]);
         $result = $this->connection->execute('SELECT * FROM things WHERE title = ? AND body = ?', [$title, $body]);
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -427,7 +427,7 @@ class ConnectionTest extends TestCase
         $body = 'changed the body!';
         $this->connection->update('things', ['title' => $title, 'body' => $body], ['id' => 2]);
         $result = $this->connection->execute('SELECT * FROM things WHERE title = ? AND body = ?', [$title, $body]);
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -440,7 +440,7 @@ class ConnectionTest extends TestCase
         $body = 'changed the body!';
         $this->connection->update('things', ['title' => $title, 'body' => $body], ['id' => 2, 'body is not null']);
         $result = $this->connection->execute('SELECT * FROM things WHERE title = ? AND body = ?', [$title, $body]);
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -454,11 +454,10 @@ class ConnectionTest extends TestCase
         $values = compact('title', 'body');
         $this->connection->update('things', $values, [], ['body' => 'date']);
         $result = $this->connection->execute('SELECT * FROM things WHERE title = :title AND body = :body', $values, ['body' => 'date']);
-        $this->assertCount(2, $result);
-        $row = $result->fetch('assoc');
-        $this->assertSame('2012-01-01', $row['body']);
-        $row = $result->fetch('assoc');
-        $this->assertSame('2012-01-01', $row['body']);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertSame('2012-01-01', $rows[0]['body']);
+        $this->assertSame('2012-01-01', $rows[1]['body']);
         $result->closeCursor();
     }
 
@@ -472,9 +471,9 @@ class ConnectionTest extends TestCase
         $values = compact('title', 'body');
         $this->connection->update('things', $values, ['id' => '1'], ['body' => 'date', 'id' => 'integer']);
         $result = $this->connection->execute('SELECT * FROM things WHERE title = :title AND body = :body', $values, ['body' => 'date']);
-        $this->assertCount(1, $result);
-        $row = $result->fetch('assoc');
-        $this->assertSame('2012-01-01', $row['body']);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertSame('2012-01-01', $rows[0]['body']);
         $result->closeCursor();
     }
 
@@ -485,7 +484,7 @@ class ConnectionTest extends TestCase
     {
         $this->connection->delete('things');
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -496,17 +495,12 @@ class ConnectionTest extends TestCase
     {
         $this->connection->delete('things', ['id' => '1'], ['id' => 'integer']);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
-        $result->closeCursor();
-
-        $this->connection->delete('things', ['id' => '1'], ['id' => 'integer']);
-        $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
 
         $this->connection->delete('things', ['id' => '2'], ['id' => 'integer']);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -521,7 +515,7 @@ class ConnectionTest extends TestCase
         $this->connection->rollback();
         $this->assertFalse($this->connection->getDriver()->inTransaction());
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
         $result->closeCursor();
 
         $this->connection->begin();
@@ -530,7 +524,7 @@ class ConnectionTest extends TestCase
         $this->connection->commit();
         $this->assertFalse($this->connection->getDriver()->inTransaction());
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
     }
 
     /**
@@ -569,7 +563,7 @@ class ConnectionTest extends TestCase
 
         $this->connection->delete('things', ['id' => 1]);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
 
         $this->connection->commit();
         $this->assertTrue($this->connection->getDriver()->inTransaction());
@@ -577,7 +571,7 @@ class ConnectionTest extends TestCase
         $this->assertFalse($this->connection->getDriver()->inTransaction());
 
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
     }
 
     /**
@@ -593,11 +587,11 @@ class ConnectionTest extends TestCase
 
         $this->connection->delete('things', ['id' => 1]);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $this->connection->rollback();
 
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
     }
 
     /**
@@ -614,13 +608,13 @@ class ConnectionTest extends TestCase
 
         $this->connection->delete('things', ['id' => 1]);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $this->connection->commit();
         $this->connection->commit();
         $this->connection->commit();
 
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
     }
 
     /**
@@ -634,20 +628,20 @@ class ConnectionTest extends TestCase
         $this->connection->delete('things', ['id' => 1]);
 
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
 
         $this->connection->begin();
         $this->connection->delete('things', ['id' => 2]);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
 
         $this->connection->rollback();
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
 
         $this->connection->rollback();
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
     }
 
     /**
@@ -661,20 +655,20 @@ class ConnectionTest extends TestCase
         $this->connection->delete('things', ['id' => 1]);
 
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
 
         $this->connection->begin();
         $this->connection->delete('things', ['id' => 2]);
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
 
         $this->connection->rollback();
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
 
         $this->connection->commit();
         $result = $this->connection->execute('SELECT * FROM things');
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
     }
 
     /**
@@ -930,6 +924,7 @@ class ConnectionTest extends TestCase
     /**
      * @see https://github.com/cakephp/cakephp/issues/14676
      */
+    /*
     public function testLoggerDecoratorDoesNotPrematurelyFetchRecords(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
@@ -958,6 +953,7 @@ class ConnectionTest extends TestCase
         $messages = Log::engine('queries')->read();
         $this->assertCount(2, $messages, 'Select queries without any matching rows should also be logged.');
     }
+    */
 
     /**
      * Tests that begin and rollback are also logged

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -922,40 +922,6 @@ class ConnectionTest extends TestCase
     }
 
     /**
-     * @see https://github.com/cakephp/cakephp/issues/14676
-     */
-    /*
-    public function testLoggerDecoratorDoesNotPrematurelyFetchRecords(): void
-    {
-        Log::setConfig('queries', ['className' => 'Array']);
-        $logger = new QueryLogger();
-        $this->connection->enableQueryLogging(true);
-        $this->connection->setLogger($logger);
-        $st = $this->connection->execute('SELECT * FROM things');
-        $this->assertInstanceOf(LoggingStatement::class, $st);
-
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(0, $messages);
-
-        $expected = [
-            [1, 'a title', 'a body'],
-            [2, 'another title', 'another body'],
-        ];
-        $results = $st->fetchAll();
-        $this->assertEquals($expected, $results);
-
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(1, $messages);
-
-        $st = $this->connection->execute('SELECT * FROM things WHERE id = 0');
-        $this->assertSame(0, $st->rowCount());
-
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(2, $messages, 'Select queries without any matching rows should also be logged.');
-    }
-    */
-
-    /**
      * Tests that begin and rollback are also logged
      */
     public function testLogBeginRollbackTransaction(): void

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -4164,39 +4164,6 @@ class QueryTest extends TestCase
         $this->assertEquals(500, $rowCount);
     }
 
-    /**
-     * Shows that bufferResults(false) will prevent client-side results buffering
-     */
-    // public function testUnbufferedQuery(): void
-    // {
-    //     $query = new Query($this->connection);
-    //     $result = $query->select(['body', 'author_id'])
-    //         ->from('articles')
-    //         ->enableBufferedResults(false)
-    //         ->execute();
-
-    //     if (!method_exists($result, 'bufferResults')) {
-    //         $result->closeCursor();
-    //         $this->markTestSkipped('This driver does not support unbuffered queries');
-    //     }
-
-    //     $this->assertCount(0, $result, 'Unbuffered queries only have a count when results are fetched');
-
-    //     $list = $result->fetchAll('assoc');
-    //     $this->assertCount(3, $list);
-    //     $result->closeCursor();
-
-    //     $query = new Query($this->connection);
-    //     $result = $query->select(['body', 'author_id'])
-    //         ->from('articles')
-    //         ->execute();
-
-    //     $this->assertCount(3, $result, 'Buffered queries can be counted any time.');
-    //     $list = $result->fetchAll('assoc');
-    //     $this->assertCount(3, $list);
-    //     $result->closeCursor();
-    // }
-
     public function testCloneUpdateExpression(): void
     {
         $query = new Query($this->connection);

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -167,7 +167,6 @@ class QueryTest extends TestCase
         $result = $query->select('name', true)->from('authors', true)->order(['name' => 'desc'], true)->execute();
         $this->assertSame(['nate'], $result->fetch());
         $this->assertSame(['mariano'], $result->fetch());
-        $this->assertCount(4, $result);
         $result->closeCursor();
     }
 
@@ -246,21 +245,23 @@ class QueryTest extends TestCase
             ->order(['title' => 'asc'])
             ->execute();
 
-        $this->assertCount(3, $result);
-        $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
-        $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(3, $rows);
+        $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $rows[0]);
+        $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $rows[1]);
         $result->closeCursor();
 
         $result = $query->join('authors', [], true)->execute();
-        $this->assertCount(12, $result, 'Cross join results in 12 records');
+        $this->assertCount(12, $result->fetchAll(), 'Cross join results in 12 records');
         $result->closeCursor();
 
         $result = $query->join([
             ['table' => 'authors', 'type' => 'INNER', 'conditions' => $query->newExpr()->equalFields('author_id', 'authors.id')],
         ], [], true)->execute();
-        $this->assertCount(3, $result);
-        $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
-        $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(3, $rows);
+        $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $rows[0]);
+        $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $rows[1]);
         $result->closeCursor();
     }
 
@@ -408,10 +409,11 @@ class QueryTest extends TestCase
             ->from('articles')
             ->rightJoin(['c' => 'comments'], ['created <' => $time], $types)
             ->execute();
-        $this->assertCount(6, $result);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(6, $rows);
         $this->assertEquals(
             ['title' => null, 'name' => 'First Comment for First Article'],
-            $result->fetch('assoc')
+            $rows[0]
         );
         $result->closeCursor();
     }
@@ -472,7 +474,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['id' => 1, 'title' => 'First Article'])
             ->execute();
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -481,7 +483,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['id' => 100], ['id' => 'integer'])
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -496,8 +498,9 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['id >' => 4])
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['comment' => 'First Comment for Second Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['comment' => 'First Comment for Second Article'], $rows[0]);
         $result->closeCursor();
     }
 
@@ -512,8 +515,9 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['id <' => 2])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['title' => 'First Article'], $rows[0]);
         $result->closeCursor();
     }
 
@@ -528,7 +532,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['id <=' => 2])
             ->execute();
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -543,7 +547,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['id >=' => 1])
             ->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -558,8 +562,9 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['id !=' => 2])
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['title' => 'First Article'], $rows[0]);
         $result->closeCursor();
     }
 
@@ -574,8 +579,9 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['title LIKE' => 'First Article'])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['title' => 'First Article'], $rows[0]);
         $result->closeCursor();
     }
 
@@ -590,7 +596,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['title like' => '%Article%'])
             ->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -605,7 +611,7 @@ class QueryTest extends TestCase
             ->from('articles')
             ->where(['title not like' => '%Article%'])
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -641,8 +647,9 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['created' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -651,9 +658,10 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['created >' => new DateTime('2007-03-18 10:46:00')], ['created' => 'datetime'])
             ->execute();
-        $this->assertCount(5, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(5, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
+        $this->assertEquals(['id' => 3], $rows[1]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -668,8 +676,9 @@ class QueryTest extends TestCase
                 ['created' => 'datetime']
             )
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -684,8 +693,9 @@ class QueryTest extends TestCase
                 ['created' => 'datetime', 'id' => 'integer']
             )
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 3], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -700,8 +710,9 @@ class QueryTest extends TestCase
                 ['created' => 'datetime', 'id' => 'integer']
             )
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
     }
 
@@ -716,7 +727,7 @@ class QueryTest extends TestCase
             ->from('menu_link_trees')
             ->whereNull(['parent_id'])
             ->execute();
-        $this->assertCount(5, $result);
+        $this->assertCount(5, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -725,7 +736,7 @@ class QueryTest extends TestCase
             ->from('menu_link_trees')
             ->whereNull($this->connection->newQuery()->select('parent_id'))
             ->execute();
-        $this->assertCount(5, $result);
+        $this->assertCount(5, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -734,7 +745,7 @@ class QueryTest extends TestCase
             ->from('menu_link_trees')
             ->whereNull('parent_id')
             ->execute();
-        $this->assertCount(5, $result);
+        $this->assertCount(5, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -749,7 +760,7 @@ class QueryTest extends TestCase
             ->from('menu_link_trees')
             ->whereNotNull(['parent_id'])
             ->execute();
-        $this->assertCount(13, $result);
+        $this->assertCount(13, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -758,7 +769,7 @@ class QueryTest extends TestCase
             ->from('menu_link_trees')
             ->whereNotNull($this->connection->newQuery()->select('parent_id'))
             ->execute();
-        $this->assertCount(13, $result);
+        $this->assertCount(13, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -767,7 +778,7 @@ class QueryTest extends TestCase
             ->from('menu_link_trees')
             ->whereNotNull('parent_id')
             ->execute();
-        $this->assertCount(13, $result);
+        $this->assertCount(13, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -783,9 +794,10 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['id' => ['1', '3']], ['id' => 'integer[]'])
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 3], $rows[1]);
         $result->closeCursor();
     }
 
@@ -834,8 +846,9 @@ class QueryTest extends TestCase
             ->where(['created' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
             ->andWhere(['id' => 1])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -845,7 +858,7 @@ class QueryTest extends TestCase
             ->where(['created' => new DateTime('2007-03-18 10:50:55')], ['created' => 'datetime'])
             ->andWhere(['id' => 2])
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -861,8 +874,9 @@ class QueryTest extends TestCase
             ->andWhere(['created' => new DateTime('2007-03-18 10:45:23')], ['created' => 'datetime'])
             ->andWhere(['id' => 1])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
     }
 
@@ -880,8 +894,9 @@ class QueryTest extends TestCase
                 return $exp->eq('id', 1);
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -894,8 +909,9 @@ class QueryTest extends TestCase
                     ->eq('created', new DateTime('2007-03-18 10:45:23'), 'datetime');
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -908,7 +924,7 @@ class QueryTest extends TestCase
                     ->eq('created', new DateTime('2021-12-30 15:00'), 'datetime');
             })
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -952,8 +968,9 @@ class QueryTest extends TestCase
                 return $exp->eq('created', new DateTime('2007-03-18 10:45:23'), 'datetime');
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -965,7 +982,7 @@ class QueryTest extends TestCase
                 return $exp->eq('created', new DateTime('2022-12-21 12:00'), 'datetime');
             })
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -987,7 +1004,7 @@ class QueryTest extends TestCase
                     ->eq($field, 100, 'integer');
             })
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -1004,8 +1021,9 @@ class QueryTest extends TestCase
                 return $exp->gt('id', 1);
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['title' => 'Second Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['title' => 'Second Article'], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1015,8 +1033,9 @@ class QueryTest extends TestCase
                 return $exp->lt('id', 2);
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['title' => 'First Article'], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1026,7 +1045,7 @@ class QueryTest extends TestCase
                 return $exp->lte('id', 2);
             })
             ->execute();
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1037,7 +1056,7 @@ class QueryTest extends TestCase
                 return $exp->gte('id', 1);
             })
             ->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1048,7 +1067,7 @@ class QueryTest extends TestCase
                 return $exp->lte('id', 1);
             })
             ->execute();
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1059,8 +1078,9 @@ class QueryTest extends TestCase
                 return $exp->notEq('id', 2);
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['title' => 'First Article'], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1071,8 +1091,9 @@ class QueryTest extends TestCase
                 return $exp->like('title', 'First Article');
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['title' => 'First Article'], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['title' => 'First Article'], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1083,7 +1104,7 @@ class QueryTest extends TestCase
                 return $exp->like('title', '%Article%');
             })
             ->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1094,7 +1115,7 @@ class QueryTest extends TestCase
                 return $exp->notLike('title', '%Article%');
             })
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1105,7 +1126,7 @@ class QueryTest extends TestCase
                 return $exp->isNull('published');
             })
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1116,7 +1137,7 @@ class QueryTest extends TestCase
                 return $exp->isNotNull('published');
             })
             ->execute();
-        $this->assertCount(6, $result);
+        $this->assertCount(6, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1127,7 +1148,7 @@ class QueryTest extends TestCase
                 return $exp->in('published', ['Y', 'N']);
             })
             ->execute();
-        $this->assertCount(6, $result);
+        $this->assertCount(6, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1142,9 +1163,10 @@ class QueryTest extends TestCase
                 );
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 2], $rows[1]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1159,8 +1181,9 @@ class QueryTest extends TestCase
                 );
             })
             ->execute();
-        $this->assertCount(4, $result);
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(4, $rows);
+        $this->assertEquals(['id' => 3], $rows[0]);
         $result->closeCursor();
     }
 
@@ -1177,8 +1200,9 @@ class QueryTest extends TestCase
                 return $exp->in('created', '2007-03-18 10:45:23', 'datetime');
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1189,11 +1213,12 @@ class QueryTest extends TestCase
                 return $exp->notIn('created', '2007-03-18 10:45:23', 'datetime');
             })
             ->execute();
-        $this->assertCount(5, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 4], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 5], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(5, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
+        $this->assertEquals(['id' => 3], $rows[1]);
+        $this->assertEquals(['id' => 4], $rows[2]);
+        $this->assertEquals(['id' => 5], $rows[3]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1208,8 +1233,9 @@ class QueryTest extends TestCase
                 );
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1224,7 +1250,7 @@ class QueryTest extends TestCase
                 );
             })
             ->execute();
-        $this->assertCount(5, $result);
+        $this->assertCount(5, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -1239,8 +1265,10 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['created IN' => '2007-03-18 10:45:23'])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1249,7 +1277,7 @@ class QueryTest extends TestCase
             ->from('comments')
             ->where(['created NOT IN' => '2007-03-18 10:45:23'])
             ->execute();
-        $this->assertCount(5, $result);
+        $this->assertCount(5, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -1322,12 +1350,11 @@ class QueryTest extends TestCase
             })
             ->execute();
 
-        $this->assertCount(2, $result);
-        $first = $result->fetch('assoc');
-        $this->assertEquals(5, $first['id']);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(5, $rows[0]['id']);
 
-        $second = $result->fetch('assoc');
-        $this->assertEquals(6, $second['id']);
+        $this->assertEquals(6, $rows[1]['id']);
         $result->closeCursor();
     }
 
@@ -1349,12 +1376,11 @@ class QueryTest extends TestCase
             })
             ->execute();
 
-        $this->assertCount(2, $result);
-        $first = $result->fetch('assoc');
-        $this->assertEquals(4, $first['id']);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(4, $rows[0]['id']);
 
-        $second = $result->fetch('assoc');
-        $this->assertEquals(5, $second['id']);
+        $this->assertEquals(5, $rows[1]['id']);
         $result->closeCursor();
     }
 
@@ -1375,12 +1401,11 @@ class QueryTest extends TestCase
             })
             ->execute();
 
-        $this->assertCount(2, $result);
-        $first = $result->fetch('assoc');
-        $this->assertEquals(5, $first['id']);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(5, $rows[0]['id']);
 
-        $second = $result->fetch('assoc');
-        $this->assertEquals(6, $second['id']);
+        $this->assertEquals(6, $rows[1]['id']);
         $result->closeCursor();
     }
 
@@ -1402,12 +1427,11 @@ class QueryTest extends TestCase
             })
             ->execute();
 
-        $this->assertCount(2, $result);
-        $first = $result->fetch('assoc');
-        $this->assertEquals(4, $first['id']);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(4, $rows[0]['id']);
 
-        $second = $result->fetch('assoc');
-        $this->assertEquals(5, $second['id']);
+        $this->assertEquals(5, $rows[1]['id']);
         $result->closeCursor();
     }
 
@@ -1426,8 +1450,9 @@ class QueryTest extends TestCase
                 return $exp->add($and);
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1440,7 +1465,7 @@ class QueryTest extends TestCase
                 return $exp->add($and);
             })
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1455,8 +1480,9 @@ class QueryTest extends TestCase
                 return $exp->add($and);
             })
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1470,9 +1496,10 @@ class QueryTest extends TestCase
                 return $or->add($and);
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 3], $rows[1]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1487,9 +1514,10 @@ class QueryTest extends TestCase
                 return $or;
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 2], $rows[1]);
         $result->closeCursor();
     }
 
@@ -1509,9 +1537,10 @@ class QueryTest extends TestCase
                 );
             })
             ->execute();
-        $this->assertCount(5, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(5, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 3], $rows[1]);
         $result->closeCursor();
 
         $query = new Query($this->connection);
@@ -1524,7 +1553,7 @@ class QueryTest extends TestCase
                 );
             })
             ->execute();
-        $this->assertCount(6, $result);
+        $this->assertCount(6, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -1542,9 +1571,11 @@ class QueryTest extends TestCase
                 'not' => ['or' => ['id' => 1, 'id >' => 2], 'id' => 3],
             ])
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 2], $rows[1]);
         $result->closeCursor();
     }
 
@@ -1988,7 +2019,7 @@ class QueryTest extends TestCase
         $result = $query->select(['articles.id'])
             ->group(['articles.id'])
             ->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
     }
 
     /**
@@ -2001,13 +2032,13 @@ class QueryTest extends TestCase
             ->select(['author_id'])
             ->from(['a' => 'articles'])
             ->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
 
         $result = $query->distinct()->execute();
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
 
         $result = $query->select(['id'])->distinct(false)->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
     }
 
     /**
@@ -2022,8 +2053,8 @@ class QueryTest extends TestCase
             ->from(['a' => 'articles'])
             ->order(['author_id' => 'ASC'])
             ->execute();
-        $this->assertCount(2, $result);
         $results = $result->fetchAll('assoc');
+        $this->assertCount(2, $results);
         $this->assertEquals(
             [3, 1],
             collection($results)->sortBy('author_id')->extract('author_id')->toList()
@@ -2036,8 +2067,8 @@ class QueryTest extends TestCase
             ->from(['a' => 'articles'])
             ->order(['author_id' => 'ASC'])
             ->execute();
-        $this->assertCount(2, $result);
         $results = $result->fetchAll('assoc');
+        $this->assertCount(2, $results);
         $this->assertEquals(
             [3, 1],
             collection($results)->sortBy('author_id')->extract('author_id')->toList()
@@ -2152,7 +2183,7 @@ class QueryTest extends TestCase
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
             ->execute();
-        $this->assertCount(0, $result);
+        $this->assertCount(0, $result->fetchAll());
 
         $query = new Query($this->connection);
         $result = $query
@@ -2211,11 +2242,11 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection);
         $result = $query->select('id')->from('articles')->limit(1)->execute();
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
 
         $query = new Query($this->connection);
         $result = $query->select('id')->from('articles')->limit(2)->execute();
-        $this->assertCount(2, $result);
+        $this->assertCount(2, $result->fetchAll());
     }
 
     /**
@@ -2229,24 +2260,27 @@ class QueryTest extends TestCase
             ->offset(0)
             ->order(['id' => 'ASC'])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
 
         $query = new Query($this->connection);
         $result = $query->select('id')->from('comments')
             ->limit(1)
             ->offset(1)
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
 
         $query = new Query($this->connection);
         $result = $query->select('id')->from('comments')
             ->limit(1)
             ->offset(2)
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+            $this->assertEquals(['id' => 3], $rows[0]);
 
         $query = new Query($this->connection);
         $result = $query->select('id')->from('articles')
@@ -2254,13 +2288,15 @@ class QueryTest extends TestCase
             ->limit(1)
             ->offset(0)
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 3], $rows[0]);
 
         $result = $query->limit(2)->offset(1)->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
+        $this->assertEquals(['id' => 1], $rows[1]);
 
         $query = new Query($this->connection);
         $query->select('id')->from('comments')
@@ -2300,8 +2336,9 @@ class QueryTest extends TestCase
             ->page(1)
             ->execute();
 
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
 
         $query = new Query($this->connection);
         $result = $query->select('id')->from('comments')
@@ -2309,8 +2346,9 @@ class QueryTest extends TestCase
             ->page(2)
             ->order(['id' => 'asc'])
             ->execute();
-        $this->assertCount(1, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
 
         $query = new Query($this->connection);
         $query->select('id')->from('comments')->page(3, 10);
@@ -2344,7 +2382,6 @@ class QueryTest extends TestCase
             ->limit(2)
             ->page(3)
             ->execute();
-        $this->assertCount(2, $result);
         $this->assertEquals(
             [
                 ['id' => '6', 'ids_added' => '4'],
@@ -2485,9 +2522,10 @@ class QueryTest extends TestCase
                 return $exp->exists($subQuery);
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 1], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 3], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 1], $rows[0]);
+        $this->assertEquals(['id' => 3], $rows[1]);
 
         $query = new Query($this->connection);
         $subQuery = (new Query($this->connection))
@@ -2503,9 +2541,10 @@ class QueryTest extends TestCase
                 return $exp->notExists($subQuery);
             })
             ->execute();
-        $this->assertCount(2, $result);
-        $this->assertEquals(['id' => 2], $result->fetch('assoc'));
-        $this->assertEquals(['id' => 4], $result->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(2, $rows);
+        $this->assertEquals(['id' => 2], $rows[0]);
+        $this->assertEquals(['id' => 4], $rows[1]);
     }
 
     /**
@@ -2521,17 +2560,17 @@ class QueryTest extends TestCase
             ->from('articles')
             ->join(['b' => $subquery])
             ->execute();
-        $this->assertCount(self::ARTICLE_COUNT * self::AUTHOR_COUNT, $result, 'Cross join causes multiplication');
+        $this->assertCount(self::ARTICLE_COUNT * self::AUTHOR_COUNT, $result->fetchAll(), 'Cross join causes multiplication');
         $result->closeCursor();
 
         $subquery->where(['id' => 1]);
         $result = $query->execute();
-        $this->assertCount(3, $result);
+        $this->assertCount(3, $result->fetchAll());
         $result->closeCursor();
 
         $query->join(['b' => ['table' => $subquery, 'conditions' => [$query->newExpr()->equalFields('b.id', 'articles.id')]]], [], true);
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertCount(1, $result->fetchAll());
         $result->closeCursor();
     }
 
@@ -2546,8 +2585,8 @@ class QueryTest extends TestCase
             ->from(['c' => 'comments'])
             ->union($union)
             ->execute();
-        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
         $rows = $result->fetchAll();
+        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $rows);
         $result->closeCursor();
 
         $union->select(['foo' => 'id', 'bar' => 'title']);
@@ -2559,8 +2598,9 @@ class QueryTest extends TestCase
 
         $query->select(['foo' => 'id', 'bar' => 'comment'])->union($union);
         $result = $query->execute();
-        $this->assertCount(self::COMMENT_COUNT + self::AUTHOR_COUNT, $result);
-        $this->assertNotEquals($rows, $result->fetchAll());
+        $rows2 = $result->fetchAll();
+        $this->assertCount(self::COMMENT_COUNT + self::AUTHOR_COUNT, $rows2);
+        $this->assertNotEquals($rows, $rows2);
         $result->closeCursor();
 
         $union = (new Query($this->connection))
@@ -2568,8 +2608,9 @@ class QueryTest extends TestCase
             ->from(['c' => 'articles']);
         $query->select(['id', 'comment'], true)->union($union, true);
         $result = $query->execute();
-        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
-        $this->assertEquals($rows, $result->fetchAll());
+        $rows3 = $result->fetchAll();
+        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $rows3);
+        $this->assertEquals($rows, $rows3);
         $result->closeCursor();
     }
 
@@ -2594,10 +2635,7 @@ class QueryTest extends TestCase
             ->order(['c.id' => 'asc'])
             ->union($union)
             ->execute();
-        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
-
-        $rows = $result->fetchAll();
-        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
+        $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result->fetchAll());
     }
 
     /**
@@ -2611,8 +2649,8 @@ class QueryTest extends TestCase
             ->from(['c' => 'comments'])
             ->union($union)
             ->execute();
-        $this->assertCount(self::ARTICLE_COUNT + self::COMMENT_COUNT, $result);
-        $rows = $result->fetchAll();
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(self::ARTICLE_COUNT + self::COMMENT_COUNT, $rows);
         $result->closeCursor();
 
         $union->select(['foo' => 'id', 'bar' => 'title']);
@@ -2624,8 +2662,9 @@ class QueryTest extends TestCase
 
         $query->select(['foo' => 'id', 'bar' => 'comment'])->unionAll($union);
         $result = $query->execute();
-        $this->assertCount(1 + self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
-        $this->assertNotEquals($rows, $result->fetchAll());
+        $rows2 = $result->fetchAll();
+        $this->assertCount(1 + self::COMMENT_COUNT + self::ARTICLE_COUNT, $rows2);
+        $this->assertNotEquals($rows, $rows2);
         $result->closeCursor();
     }
 
@@ -2698,7 +2737,7 @@ class QueryTest extends TestCase
 
         $result = $query->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertCount(self::AUTHOR_COUNT, $result);
+        $this->assertSame(self::AUTHOR_COUNT, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2718,7 +2757,7 @@ class QueryTest extends TestCase
 
         $result = $query->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertCount(self::AUTHOR_COUNT, $result);
+        $this->assertSame(self::AUTHOR_COUNT, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2737,7 +2776,7 @@ class QueryTest extends TestCase
 
         $result = $query->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertCount(self::AUTHOR_COUNT, $result);
+        $this->assertSame(self::AUTHOR_COUNT, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2829,7 +2868,7 @@ class QueryTest extends TestCase
         $this->assertQuotedQuery('UPDATE <authors> SET <name> = :', $result, !$this->autoQuote);
 
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2853,7 +2892,7 @@ class QueryTest extends TestCase
 
         $this->assertQuotedQuery(' WHERE <id> = :c2$', $result, !$this->autoQuote);
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2879,7 +2918,7 @@ class QueryTest extends TestCase
         $this->assertQuotedQuery('WHERE <id> = :', $result, !$this->autoQuote);
 
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2904,7 +2943,7 @@ class QueryTest extends TestCase
         );
 
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->rowCount());
         $result->closeCursor();
     }
 
@@ -2931,7 +2970,7 @@ class QueryTest extends TestCase
         );
 
         $result = $query->execute();
-        $this->assertCount(6, $result);
+        $this->assertSame(6, $result->rowCount());
         $result->closeCursor();
 
         $result = (new Query($this->connection))->select(['created', 'updated'])->from('comments')->execute();
@@ -2961,7 +3000,7 @@ class QueryTest extends TestCase
 
         $this->assertQuotedQuery(' WHERE <id> = :c2$', $result, !$this->autoQuote);
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->rowCount());
 
         $query = new Query($this->connection);
         $result = $query->select('created')->from('comments')->where(['id' => 1])->execute();
@@ -2993,7 +3032,7 @@ class QueryTest extends TestCase
 
         $this->assertQuotedQuery(' WHERE <id> = :c2$', $result, !$this->autoQuote);
         $result = $query->execute();
-        $this->assertCount(1, $result);
+        $this->assertSame(1, $result->rowCount());
     }
 
     /**
@@ -3139,7 +3178,7 @@ class QueryTest extends TestCase
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
         if (!$this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertCount(1, $result, '1 row should be inserted');
+            $this->assertSame(1, $result->rowCount(), '1 row should be inserted');
         }
 
         $expected = [
@@ -3199,7 +3238,7 @@ class QueryTest extends TestCase
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
         if (!$this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertCount(1, $result, '1 row should be inserted');
+            $this->assertSame(1, $result->rowCount(), '1 row should be inserted');
         }
 
         $expected = [
@@ -3234,7 +3273,7 @@ class QueryTest extends TestCase
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
         if (!$this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertCount(2, $result, '2 rows should be inserted');
+            $this->assertSame(2, $result->rowCount(), '2 rows should be inserted');
         }
 
         $expected = [
@@ -3289,14 +3328,15 @@ class QueryTest extends TestCase
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
         if (!$this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertCount(1, $result);
+            $this->assertSame(1, $result->rowCount());
         }
 
         $result = (new Query($this->connection))->select('*')
             ->from('articles')
             ->where(['author_id' => 99])
             ->execute();
-        $this->assertCount(1, $result);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
         $expected = [
             'id' => 4,
             'title' => 'mariano',
@@ -3304,7 +3344,7 @@ class QueryTest extends TestCase
             'author_id' => 99,
             'published' => 'N',
         ];
-        $this->assertEquals($expected, $result->fetch('assoc'));
+        $this->assertEquals($expected, $rows[0]);
     }
 
     /**
@@ -3348,14 +3388,15 @@ class QueryTest extends TestCase
 
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
         if (!$this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertCount(1, $result);
+            $this->assertSame(1, $result->rowCount());
         }
 
         $result = (new Query($this->connection))->select('*')
             ->from('articles')
             ->where(['author_id' => 99])
             ->execute();
-        $this->assertCount(1, $result);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
         $expected = [
             'id' => 4,
             'title' => 'jose',
@@ -3363,7 +3404,7 @@ class QueryTest extends TestCase
             'author_id' => '99',
             'published' => 'N',
         ];
-        $this->assertEquals($expected, $result->fetch('assoc'));
+        $this->assertEquals($expected, $rows[0]);
 
         $subquery = new Query($this->connection);
         $subquery->select(['name'])
@@ -3375,17 +3416,18 @@ class QueryTest extends TestCase
             ->into('articles')
             ->values(['title' => $subquery, 'author_id' => 100]);
         $result = $query->execute();
-        $result->closeCursor();
         //PDO_SQLSRV returns -1 for successful inserts when using INSERT ... OUTPUT
         if (!$this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertCount(1, $result);
+            $this->assertSame(1, $result->rowCount());
         }
+        $result->closeCursor();
 
         $result = (new Query($this->connection))->select('*')
             ->from('articles')
             ->where(['author_id' => 100])
             ->execute();
-        $this->assertCount(1, $result);
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
         $expected = [
             'id' => 5,
             'title' => 'mariano',
@@ -3393,7 +3435,7 @@ class QueryTest extends TestCase
             'author_id' => '100',
             'published' => 'N',
         ];
-        $this->assertEquals($expected, $result->fetch('assoc'));
+        $this->assertEquals($expected, $rows[0]);
     }
 
     /**
@@ -3650,7 +3692,7 @@ class QueryTest extends TestCase
         $results = $query
             ->where(['created >=' => new DateTime('2007-03-18 10:50:00')], $types, true)
             ->execute();
-        $this->assertCount(6, $results, 'All 6 rows should match.');
+        $this->assertCount(6, $results->fetchAll(), 'All 6 rows should match.');
     }
 
     /**
@@ -4025,13 +4067,14 @@ class QueryTest extends TestCase
             ->sql();
         $this->assertQuotedQuery('WHERE \(<name>\) IS NULL', $sql, !$this->autoQuote);
 
-        $results = (new Query($this->connection))
+        $result = (new Query($this->connection))
             ->select(['name'])
             ->from(['authors'])
             ->where(['name IS' => 'larry'])
             ->execute();
-        $this->assertCount(1, $results);
-        $this->assertEquals(['name' => 'larry'], $results->fetch('assoc'));
+        $rows = $result->fetchAll('assoc');
+        $this->assertCount(1, $rows);
+        $this->assertEquals(['name' => 'larry'], $rows[0]);
     }
 
     /**
@@ -4083,7 +4126,7 @@ class QueryTest extends TestCase
             ->from(['authors'])
             ->where(['name IS NOT' => 'larry'])
             ->execute();
-        $this->assertCount(3, $results);
+        $this->assertCount(3, $results->fetchAll());
         $this->assertNotEquals(['name' => 'larry'], $results->fetch('assoc'));
     }
 
@@ -4124,35 +4167,35 @@ class QueryTest extends TestCase
     /**
      * Shows that bufferResults(false) will prevent client-side results buffering
      */
-    public function testUnbufferedQuery(): void
-    {
-        $query = new Query($this->connection);
-        $result = $query->select(['body', 'author_id'])
-            ->from('articles')
-            ->enableBufferedResults(false)
-            ->execute();
+    // public function testUnbufferedQuery(): void
+    // {
+    //     $query = new Query($this->connection);
+    //     $result = $query->select(['body', 'author_id'])
+    //         ->from('articles')
+    //         ->enableBufferedResults(false)
+    //         ->execute();
 
-        if (!method_exists($result, 'bufferResults')) {
-            $result->closeCursor();
-            $this->markTestSkipped('This driver does not support unbuffered queries');
-        }
+    //     if (!method_exists($result, 'bufferResults')) {
+    //         $result->closeCursor();
+    //         $this->markTestSkipped('This driver does not support unbuffered queries');
+    //     }
 
-        $this->assertCount(0, $result, 'Unbuffered queries only have a count when results are fetched');
+    //     $this->assertCount(0, $result, 'Unbuffered queries only have a count when results are fetched');
 
-        $list = $result->fetchAll('assoc');
-        $this->assertCount(3, $list);
-        $result->closeCursor();
+    //     $list = $result->fetchAll('assoc');
+    //     $this->assertCount(3, $list);
+    //     $result->closeCursor();
 
-        $query = new Query($this->connection);
-        $result = $query->select(['body', 'author_id'])
-            ->from('articles')
-            ->execute();
+    //     $query = new Query($this->connection);
+    //     $result = $query->select(['body', 'author_id'])
+    //         ->from('articles')
+    //         ->execute();
 
-        $this->assertCount(3, $result, 'Buffered queries can be counted any time.');
-        $list = $result->fetchAll('assoc');
-        $this->assertCount(3, $list);
-        $result->closeCursor();
-    }
+    //     $this->assertCount(3, $result, 'Buffered queries can be counted any time.');
+    //     $list = $result->fetchAll('assoc');
+    //     $this->assertCount(3, $list);
+    //     $result->closeCursor();
+    // }
 
     public function testCloneUpdateExpression(): void
     {
@@ -4832,8 +4875,9 @@ class QueryTest extends TestCase
             ->from($table)
             ->where($conditions)
             ->execute();
-        $this->assertCount($count, $result, 'Row count is incorrect');
-        $this->assertEquals($rows, $result->fetchAll('assoc'));
+        $results = $result->fetchAll('assoc');
+        $this->assertCount($count, $results, 'Row count is incorrect');
+        $this->assertEquals($rows, $results);
         $result->closeCursor();
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -1038,14 +1038,14 @@ SQL;
             ->will($this->returnValue($driver));
 
         $statement = $this->getMockBuilder('\PDOStatement')
-            ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetchAll'])
+            ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
             ->getMock();
         $driver->getConnection()->expects($this->once())
             ->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
             ->will($this->returnValue($statement));
         $statement->expects($this->once())
-            ->method('fetchAll')
+            ->method('fetch')
             ->will($this->returnValue(['1']));
         $statement->method('execute')->will($this->returnValue(true));
 
@@ -1069,7 +1069,7 @@ SQL;
             ->will($this->returnValue($driver));
 
         $statement = $this->getMockBuilder('\PDOStatement')
-            ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetchAll'])
+            ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
             ->getMock();
         $driver->getConnection()
             ->expects($this->once())
@@ -1077,8 +1077,8 @@ SQL;
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
             ->will($this->returnValue($statement));
         $statement->expects($this->once())
-            ->method('fetchAll')
-            ->will($this->returnValue([]));
+            ->method('fetch')
+            ->will($this->returnValue(false));
         $statement->method('execute')->will($this->returnValue(true));
 
         $table = new TableSchema('articles');

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -21,7 +21,6 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\IdentifierQuoter;
-use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Association;
@@ -414,8 +413,7 @@ class HasManyTest extends TestCase
             ->with('all')
             ->will($this->returnValue($query));
 
-        $stmt = $this->getMockBuilder(StatementInterface::class)->getMock();
-        $results = new ResultSet($query, $stmt);
+        $results = new ResultSet($query, []);
 
         $results->__unserialize([
             ['id' => 1, 'title' => 'article 1', 'author_id' => 2, 'site_id' => 10],

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -25,7 +25,6 @@ use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
-use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
@@ -854,10 +853,7 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection, $this->table);
 
-        $stmt = $this->getMockBuilder(StatementInterface::class)->getMock();
-        $stmt->method('rowCount')
-            ->will($this->returnValue(9));
-        $results = new ResultSet($query, $stmt);
+        $results = new ResultSet($query, []);
         $query->setResult($results);
         $this->assertSame($results, $query->all());
     }
@@ -1817,9 +1813,7 @@ class QueryTest extends TestCase
             ->onlyMethods(['execute'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
-        $resultSet = $this->getMockBuilder('Cake\ORM\ResultSet')
-            ->setConstructorArgs([$query, $this->getMockBuilder(StatementInterface::class)->getMock()])
-            ->getMock();
+        $resultSet = new ResultSet($query, []);
 
         $query->expects($this->never())
             ->method('execute');

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Log\QueryLogger;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
@@ -84,23 +83,6 @@ class ResultSetTest extends TestCase
             $second[] = $result;
         }
         $this->assertEquals($first, $second);
-    }
-
-    /**
-     * Test that streaming results cannot be rewound
-     */
-    public function testRewindStreaming(): void
-    {
-        $query = $this->table->find('all')->enableBufferedResults(false);
-        $results = $query->all();
-        $first = $second = [];
-        foreach ($results as $result) {
-            $first[] = $result;
-        }
-        $this->expectException(DatabaseException::class);
-        foreach ($results as $result) {
-            $second[] = $result;
-        }
     }
 
     /**
@@ -350,10 +332,8 @@ class ResultSetTest extends TestCase
 
         $row = ['Other__field' => 'test'];
         $statement = $this->getMockBuilder('Cake\Database\StatementInterface')->getMock();
-        $statement->method('fetch')
-            ->will($this->onConsecutiveCalls($row, $row));
-        $statement->method('rowCount')
-            ->will($this->returnValue(1));
+        $statement->method('fetchAll')
+            ->will($this->returnValue([$row]));
 
         $result = new ResultSet($query, $statement);
 

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -335,7 +335,7 @@ class ResultSetTest extends TestCase
         $statement->method('fetchAll')
             ->will($this->returnValue([$row]));
 
-        $result = new ResultSet($query, $statement);
+        $result = new ResultSet($query, $statement->fetchAll());
 
         $result->valid();
         $this->assertNotEmpty($result->current());

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2862,8 +2862,7 @@ class TableTest extends TestCase
         $this->assertTrue($result);
 
         $query = $table->find('all', $conditions);
-        $results = $query->execute();
-        $this->assertCount(0, $results, 'Find should fail.');
+        $this->assertCount(0, $query->all(), 'Find should fail.');
     }
 
     /**
@@ -2957,7 +2956,7 @@ class TableTest extends TestCase
 
         $articles = $table->getAssociation('articles')->getTarget();
         $query = $articles->find('all')->where(['author_id' => $entity->id]);
-        $this->assertCount(2, $query->execute(), 'Should find rows.');
+        $this->assertCount(2, $query->all(), 'Should find rows.');
     }
 
     /**


### PR DESCRIPTION
The overall goal here is:

- Avoid using `PDOStatemnt::rowCount()` to get row count for SELECT queries. It's behavior is inconsistent across db and the PHP manual recommends not doing so.
- Remove `BufferedStatement`.
- Change `EagerLoader` and associations code to work the `ResultSet` to inject related records instead of using `StatementInterface` instance.

`ResultSet` is now constructed using array of records instead of a statement object so it's always buffered.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
