### PR TITLE
[4.x][datasource] Widen psr/log range and include v2

### DIFF
--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=7.2.0",
         "cakephp/core": "^4.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1 || ^2",
         "psr/simple-cache": "^1.0"
     },
     "suggest": {


### PR DESCRIPTION
As this package is only a consumer of `psr/log` it shouldn't block any packages building on it for using the never v2. Note that v3 will be different due to the added return type hint.
