### PR TITLE
Fix empty string hiddenField values

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1508,7 +1508,7 @@ class FormHelper extends Helper
                 'name' => $options['name'],
                 'value' => $options['hiddenField'] !== true
                     && $options['hiddenField'] !== '_split'
-                    ? $options['hiddenField'] : '0',
+                    ? (string)$options['hiddenField'] : '0',
                 'form' => $options['form'] ?? null,
                 'secure' => false,
             ];
@@ -1537,8 +1537,8 @@ class FormHelper extends Helper
      * - `label` - Either `false` to disable label around the widget or an array of attributes for
      *    the label tag. `selected` will be added to any classes e.g. `'class' => 'myclass'` where widget
      *    is checked
-     * - `hiddenField` - boolean|string. Set to false to not include a hidden input with a value of ''. 
-     *    Can also be a string to set the value of the hidden input. This is useful for creating 
+     * - `hiddenField` - boolean|string. Set to false to not include a hidden input with a value of ''.
+     *    Can also be a string to set the value of the hidden input. This is useful for creating
      *    radio sets that are non-continuous.
      * - `disabled` - Set to `true` or `disabled` to disable all the radio buttons. Use an array of
      *   values to disable specific radio buttons.
@@ -1565,7 +1565,7 @@ class FormHelper extends Helper
         $hidden = '';
         if ($hiddenField !== false && is_scalar($hiddenField)) {
             $hidden = $this->hidden($fieldName, [
-                'value' => $hiddenField === true ? '' : $hiddenField,
+                'value' => $hiddenField === true ? '' : (string)$hiddenField,
                 'form' => $attributes['form'] ?? null,
                 'name' => $attributes['name'],
             ]);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1480,8 +1480,8 @@ class FormHelper extends Helper
      *
      * - `value` - the value of the checkbox
      * - `checked` - boolean indicate that this checkbox is checked.
-     * - `hiddenField` - boolean to indicate if you want the results of checkbox() to include
-     *    a hidden input with a value of ''.
+     * - `hiddenField` - boolean|string. Set to false to disable a hidden input from
+     *    being generated. Passing a string will define the hidden input value.
      * - `disabled` - create a disabled input.
      * - `default` - Set the default value for the checkbox. This allows you to start checkboxes
      *    as checked, without having to check the POST data. A matching POST data value, will overwrite
@@ -1503,7 +1503,7 @@ class FormHelper extends Helper
         $options['value'] = $value;
 
         $output = '';
-        if ($options['hiddenField']) {
+        if ($options['hiddenField'] !== false && is_scalar($options['hiddenField'])) {
             $hiddenOptions = [
                 'name' => $options['name'],
                 'value' => $options['hiddenField'] !== true
@@ -1537,8 +1537,9 @@ class FormHelper extends Helper
      * - `label` - Either `false` to disable label around the widget or an array of attributes for
      *    the label tag. `selected` will be added to any classes e.g. `'class' => 'myclass'` where widget
      *    is checked
-     * - `hiddenField` - boolean to indicate if you want the results of radio() to include
-     *    a hidden input with a value of ''. This is useful for creating radio sets that are non-continuous.
+     * - `hiddenField` - boolean|string. Set to false to not include a hidden input with a value of ''. 
+     *    Can also be a string to set the value of the hidden input. This is useful for creating 
+     *    radio sets that are non-continuous.
      * - `disabled` - Set to `true` or `disabled` to disable all the radio buttons. Use an array of
      *   values to disable specific radio buttons.
      * - `empty` - Set to `true` to create an input with the value '' as the first option. When `true`
@@ -1562,7 +1563,7 @@ class FormHelper extends Helper
         $radio = $this->widget('radio', $attributes);
 
         $hidden = '';
-        if ($hiddenField) {
+        if ($hiddenField !== false && is_scalar($hiddenField)) {
             $hidden = $this->hidden($fieldName, [
                 'value' => $hiddenField === true ? '' : $hiddenField,
                 'form' => $attributes['form'] ?? null,

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4590,6 +4590,16 @@ class FormHelperTest extends TestCase
             '/label',
         ];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Form->radio('title', ['option A'], ['hiddenField' => '']);
+        $expected = [
+            ['input' => ['type' => 'hidden', 'name' => 'title', 'value' => '']],
+            'label' => ['for' => 'title-0'],
+            ['input' => ['type' => 'radio', 'name' => 'title', 'value' => '0', 'id' => 'title-0']],
+            'option A',
+            '/label',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -5096,6 +5106,28 @@ class FormHelperTest extends TestCase
             ['input' => [
                 'type' => 'hidden', 'name' => 'User[get_spam]',
                 'value' => '1',
+            ]],
+            ['input' => [
+                'type' => 'checkbox', 'name' => 'User[get_spam]',
+                'value' => '0', 'id' => 'user-get-spam',
+            ]],
+            'Get Spam',
+            '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->control('User.get_spam', [
+            'type' => 'checkbox',
+            'value' => '0',
+            'hiddenField' => '',
+        ]);
+        $expected = [
+            'div' => ['class' => 'input checkbox'],
+            'label' => ['for' => 'user-get-spam'],
+            ['input' => [
+                'type' => 'hidden', 'name' => 'User[get_spam]',
+                'value' => '',
             ]],
             ['input' => [
                 'type' => 'checkbox', 'name' => 'User[get_spam]',
@@ -5803,6 +5835,22 @@ class FormHelperTest extends TestCase
                 'name' => 'UserForm[something]',
                 'value' => '1',
             ],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->checkbox('UserForm.something', [
+            'value' => 'Y',
+            'hiddenField' => '',
+        ]);
+        $expected = [
+            ['input' => [
+                'type' => 'hidden', 'name' => 'UserForm[something]',
+                'value' => '',
+            ]],
+            ['input' => [
+                'type' => 'checkbox', 'name' => 'UserForm[something]',
+                'value' => 'Y',
+            ]],
         ];
         $this->assertHtml($expected, $result);
 


### PR DESCRIPTION
While hiddenField is documented it can also be a string. We've had this behavior (with tests) since 2.1 so we might as well keep it. Expand this behavior to with ''.

Align both checkbox() and radio() to handle `hiddenField = ''` consistently as them being different is clunky.

Fixes #16254
