### PR TITLE
Change return type of StatementInterface::fetchAll().

### DIFF
--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -238,15 +238,13 @@ class BufferedStatement implements Iterator, StatementInterface
     /**
      * @inheritDoc
      */
-    public function fetchAll($type = self::FETCH_TYPE_NUM): array|false
+    public function fetchAll(string|int $type = self::FETCH_TYPE_NUM): array
     {
         if ($this->_allFetched) {
             return $this->buffer;
         }
         $results = $this->statement->fetchAll($type);
-        if ($results !== false) {
-            $this->buffer = array_merge($this->buffer, $results);
-        }
+        $this->buffer = array_merge($this->buffer, $results);
         $this->_allFetched = true;
         $this->statement->closeCursor();
 

--- a/src/Database/Statement/CallbackStatement.php
+++ b/src/Database/Statement/CallbackStatement.php
@@ -68,10 +68,10 @@ class CallbackStatement extends StatementDecorator
      *
      * Each row in the result will be processed by the callback when it is not `false.
      */
-    public function fetchAll(string|int $type = parent::FETCH_TYPE_NUM): array|false
+    public function fetchAll(string|int $type = parent::FETCH_TYPE_NUM): array
     {
         $results = $this->_statement->fetchAll($type);
 
-        return $results !== false ? array_map($this->_callback, $results) : false;
+        return array_map($this->_callback, $results);
     }
 }

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -150,11 +150,11 @@ class PDOStatement extends StatementDecorator
      *  print_r($statement->fetchAll('assoc')); // will show [0 => ['id' => 1, 'title' => 'a title']]
      * ```
      *
-     * @param string|int $type num for fetching columns as positional keys or assoc for column names as keys
-     * @return array|false list of all results from database for this statement, false on failure
+     * @param string|int $type `num` for fetching columns as positional keys or `assoc` for column names as keys.
+     * @return array List of all results from database for this statement.
      * @psalm-assert string $type
      */
-    public function fetchAll(string|int $type = parent::FETCH_TYPE_NUM): array|false
+    public function fetchAll(string|int $type = parent::FETCH_TYPE_NUM): array
     {
         if ($type === static::FETCH_TYPE_NUM) {
             return $this->_statement->fetchAll(PDO::FETCH_NUM);

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -244,10 +244,10 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
      * print_r($statement->fetchAll('assoc')); // will show [0 => ['id' => 1, 'title' => 'a title']]
      * ```
      *
-     * @param string|int $type num for fetching columns as positional keys or assoc for column names as keys
-     * @return array|false List of all results from database for this statement. False on failure.
+     * @param string|int $type `num` for fetching columns as positional keys or `assoc` for column names as keys.
+     * @return array List of all results from database for this statement.
      */
-    public function fetchAll(string|int $type = self::FETCH_TYPE_NUM): array|false
+    public function fetchAll(string|int $type = self::FETCH_TYPE_NUM): array
     {
         return $this->_statement->fetchAll($type);
     }

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -149,10 +149,10 @@ interface StatementInterface extends Traversable
      *  print_r($statement->fetchAll('assoc')); // will show [0 => ['id' => 1, 'title' => 'a title']]
      * ```
      *
-     * @param string|int $type num for fetching columns as positional keys or assoc for column names as keys
-     * @return array|false list of all results from database for this statement or false on failure.
+     * @param string|int $type `num` for fetching columns as positional keys or `assoc` for column names as keys.
+     * @return array List of all results from database for this statement.
      */
-    public function fetchAll(string|int $type = 'num'): array|false;
+    public function fetchAll(string|int $type = self::FETCH_TYPE_NUM): array;
 
     /**
      * Returns the value of the result at position.

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1131,7 +1131,13 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
             return new $decorator($this->_results);
         }
 
+<<<<<<< Updated upstream
         $statement = $this->getEagerLoader()->loadExternal($this, $this->execute());
+=======
+        $results = $this->execute()->fetchAll(StatementInterface::FETCH_TYPE_ASSOC);
+        $results = $this->getEagerLoader()->loadExternal($this, $results);
+        $resultset = new ResultSet($this, $results);
+>>>>>>> Stashed changes
 
         return new ResultSet($this, $statement);
     }


### PR DESCRIPTION
PDOStatment::fetchAll() always return array in PHP 8.0+.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
