### PR TITLE
5.x - Fix accepted types for association sorting/ordering.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -155,9 +155,9 @@ class BelongsToMany extends Association
     /**
      * Order in which target records should be returned
      *
-     * @var mixed
+     * @var \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string|null
      */
-    protected mixed $_sort = null;
+    protected ExpressionInterface|Closure|array|string|null $_sort = null;
 
     /**
      * Sets the name of the field representing the foreign key to the target table.
@@ -213,7 +213,8 @@ class BelongsToMany extends Association
     /**
      * Sets the sort order in which target records should be returned.
      *
-     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $sort A find() compatible order clause
+     * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $sort
+     *  A find() compatible order clause
      * @return $this
      */
     public function setSort(ExpressionInterface|Closure|array|string $sort)
@@ -226,7 +227,7 @@ class BelongsToMany extends Association
     /**
      * Gets the sort order in which target records should be returned.
      *
-     * @return \Cake\Database\ExpressionInterface|\Closure|array|string|null
+     * @return \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string|null
      */
     public function getSort(): ExpressionInterface|Closure|array|string|null
     {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -19,6 +19,7 @@ namespace Cake\ORM\Association;
 use Cake\Collection\Collection;
 use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\InvalidPropertyInterface;
 use Cake\ORM\Association;
@@ -39,9 +40,9 @@ class HasMany extends Association
     /**
      * Order in which target records should be returned
      *
-     * @var mixed
+     * @var \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string|null
      */
-    protected mixed $_sort = null;
+    protected ExpressionInterface|Closure|array|string|null $_sort = null;
 
     /**
      * The type of join to be used when adding the association to a query
@@ -601,10 +602,11 @@ class HasMany extends Association
     /**
      * Sets the sort order in which target records should be returned.
      *
-     * @param mixed $sort A find() compatible order clause
+     * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $sort
+     *  A find() compatible order clause
      * @return $this
      */
-    public function setSort(mixed $sort)
+    public function setSort(ExpressionInterface|Closure|array|string $sort)
     {
         $this->_sort = $sort;
 
@@ -614,9 +616,9 @@ class HasMany extends Association
     /**
      * Gets the sort order in which target records should be returned.
      *
-     * @return mixed
+     * @return \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string|null
      */
-    public function getSort(): mixed
+    public function getSort(): ExpressionInterface|Closure|array|string|null
     {
         return $this->_sort;
     }

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -18,6 +18,7 @@ namespace Cake\ORM\Association\Loader;
 
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 use Cake\ORM\Association;
 use Cake\ORM\Query;
@@ -91,9 +92,9 @@ class SelectLoader
     /**
      * The sorting options for loading the association
      *
-     * @var array|string|null
+     * @var \Cake\Database\ExpressionInterface|\Closure|array|string|null
      */
-    protected array|string|null $sort = null;
+    protected ExpressionInterface|Closure|array|string|null $sort = null;
 
     /**
      * Copies the options array to properties in this class. The keys in the array correspond

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -145,6 +145,39 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Tests that sorting works using the accepted types for `setSort()`.
+     */
+    public function testSorting(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+        $assoc = $articles->belongsToMany('Tags');
+
+        $field = 'Tags.id';
+        $driver = $articles->getConnection()->getDriver();
+        if ($driver->isAutoQuotingEnabled()) {
+            $field = $driver->quoteIdentifier($field);
+        }
+
+        $assoc->setSort("$field DESC");
+        $result = $articles->get(1, ['contain' => 'Tags']);
+        $this->assertSame([2, 1], array_column($result['tags'], 'id'));
+
+        $assoc->setSort(['Tags.id' => 'DESC']);
+        $result = $articles->get(1, ['contain' => 'Tags']);
+        $this->assertSame([2, 1], array_column($result['tags'], 'id'));
+
+        $assoc->setSort(function () {
+            return ['Tags.id' => 'DESC'];
+        });
+        $result = $articles->get(1, ['contain' => 'Tags']);
+        $this->assertSame([2, 1], array_column($result['tags'], 'id'));
+
+        $assoc->setSort(new OrderClauseExpression('Tags.id', 'DESC'));
+        $result = $articles->get(1, ['contain' => 'Tags']);
+        $this->assertSame([2, 1], array_column($result['tags'], 'id'));
+    }
+
+    /**
      * Tests requiresKeys() method
      */
     public function testRequiresKeys(): void

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
@@ -125,8 +126,22 @@ class BelongsToManyTest extends TestCase
     {
         $assoc = new BelongsToMany('Test');
         $this->assertNull($assoc->getSort());
+
+        $assoc->setSort('id ASC');
+        $this->assertSame('id ASC', $assoc->getSort());
+
         $assoc->setSort(['id' => 'ASC']);
-        $this->assertEquals(['id' => 'ASC'], $assoc->getSort());
+        $this->assertSame(['id' => 'ASC'], $assoc->getSort());
+
+        $closure = function () {
+            return ['id' => 'ASC'];
+        };
+        $assoc->setSort($closure);
+        $this->assertSame($closure, $assoc->getSort());
+
+        $expression = new OrderClauseExpression('id', 'ASC');
+        $assoc->setSort($expression);
+        $this->assertSame($expression, $assoc->getSort());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\OrderByExpression;
+use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\IdentifierQuoter;
@@ -157,8 +158,22 @@ class HasManyTest extends TestCase
     {
         $assoc = new HasMany('Test');
         $this->assertNull($assoc->getSort());
+
+        $assoc->setSort('id ASC');
+        $this->assertSame('id ASC', $assoc->getSort());
+
         $assoc->setSort(['id' => 'ASC']);
-        $this->assertEquals(['id' => 'ASC'], $assoc->getSort());
+        $this->assertSame(['id' => 'ASC'], $assoc->getSort());
+
+        $closure = function () {
+            return ['id' => 'ASC'];
+        };
+        $assoc->setSort($closure);
+        $this->assertSame($closure, $assoc->getSort());
+
+        $expression = new OrderClauseExpression('id', 'ASC');
+        $assoc->setSort($expression);
+        $this->assertSame($expression, $assoc->getSort());
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -177,6 +177,39 @@ class HasManyTest extends TestCase
     }
 
     /**
+     * Tests that sorting works using the accepted types for `setSort()`.
+     */
+    public function testSorting(): void
+    {
+        $authors = $this->getTableLocator()->get('Authors');
+        $assoc = $authors->hasMany('Articles');
+
+        $field = 'Articles.id';
+        $driver = $authors->getConnection()->getDriver();
+        if ($driver->isAutoQuotingEnabled()) {
+            $field = $driver->quoteIdentifier($field);
+        }
+
+        $assoc->setSort("$field DESC");
+        $result = $authors->get(1, ['contain' => 'Articles']);
+        $this->assertSame([3, 1], array_column($result['articles'], 'id'));
+
+        $assoc->setSort(['Articles.id' => 'DESC']);
+        $result = $authors->get(1, ['contain' => 'Articles']);
+        $this->assertSame([3, 1], array_column($result['articles'], 'id'));
+
+        $assoc->setSort(function () {
+            return ['Articles.id' => 'DESC'];
+        });
+        $result = $authors->get(1, ['contain' => 'Articles']);
+        $this->assertSame([3, 1], array_column($result['articles'], 'id'));
+
+        $assoc->setSort(new OrderClauseExpression('Articles.id', 'DESC'));
+        $result = $authors->get(1, ['contain' => 'Articles']);
+        $this->assertSame([3, 1], array_column($result['articles'], 'id'));
+    }
+
+    /**
      * Tests requiresKeys() method
      */
     public function testRequiresKeys(): void


### PR DESCRIPTION
Would anyone like to see functional tests for sorting using the various types?

For now I've only added tests that basically just ensure that the given types are being accepted by the getter/setter, with assertions that basically do nothing. Eventually it should be covered by `Query::order()` tests, but theoretically things could break along the way, like for example in the `SelectLoader` where the `$sort` property wouldn't accept the types.

With all those native type declarations in "internal" code where configuration flows through, it might be reasonable adding more functional tests in general, where previously things relied on final consumers being tested.