### PR TITLE
4.4 - ExceptionTrap::instance()

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -118,7 +118,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
-     * @return \Psr\Http\Message\ResponseInterface A response.
+     * @return \Psr\Http\Message\ResponseInterface A response
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -136,7 +136,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
      *
      * @param \Throwable $exception The exception to handle.
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
-     * @return \Psr\Http\Message\ResponseInterface A response
+     * @return \Psr\Http\Message\ResponseInterface A response.
      */
     public function handleException(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
@@ -145,8 +145,11 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
 
         try {
             $errorHandler->logException($exception, $request);
-            /** @var \Psr\Http\Message\ResponseInterface $response*/
+            /** @var \Psr\Http\Message\ResponseInterface|string $response */
             $response = $renderer->render();
+            if (is_string($response)) {
+                return new Response(['body' => $response, 'status' => 500]);
+            }
         } catch (Throwable $internalException) {
             $errorHandler->logException($internalException, $request);
             $response = $this->handleInternalError();
@@ -177,9 +180,10 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
      */
     protected function handleInternalError(): ResponseInterface
     {
-        $response = new Response(['body' => 'An Internal Server Error Occurred']);
-
-        return $response->withStatus(500);
+        return new Response([
+            'body' => 'An Internal Server Error Occurred',
+            'status' => 500,
+        ]);
     }
 
     /**

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -253,8 +253,8 @@ class ExceptionTrapTest extends TestCase
     }
 
     /**
-    * @dataProvider initialMemoryProvider
-    */
+     * @dataProvider initialMemoryProvider
+     */
     public function testIncreaseMemoryLimit($initial)
     {
         ini_set('memory_limit', $initial);
@@ -267,6 +267,5 @@ class ExceptionTrapTest extends TestCase
         $initialBytes = Text::parseFileSize($initial, false);
         $result = Text::parseFileSize(ini_get('memory_limit'), false);
         $this->assertWithinRange($initialBytes + (4 * 1024 * 1024), $result, 1024);
-
     }
 }

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -268,4 +268,14 @@ class ExceptionTrapTest extends TestCase
         $result = Text::parseFileSize(ini_get('memory_limit'), false);
         $this->assertWithinRange($initialBytes + (4 * 1024 * 1024), $result, 1024);
     }
+
+    public function testSingleton()
+    {
+        $trap = new ExceptionTrap();
+        $trap->register();
+        $this->assertSame($trap, ExceptionTrap::instance());
+
+        $trap->unregister();
+        $this->assertNull(ExceptionTrap::instance());
+    }
 }


### PR DESCRIPTION
* Improve test coverage for `increaseMemoryLimit()`.
* Add global state to ExceptionTrap

I don't really like global state, but in this situation we have natural global state that interfaces with PHP. Having an `instance()` method will allow middleware to get the current globally registered instance.

This may seem a bit dumb as we could make another ExceptionTrap in the middleware. My concern with this that developers would need to add their callbacks twice if they were using that feature which is also new.

There is an argument to remove callback support as userland code could build a renderer/logger that handle their needs. If you think that is a better approach than global state let me know in the discussion.

This pull is building on #16261. There are still some typing errors but I'll get those fixed in #16261

Refs #16228
