### PR TITLE
Improve docblocks and PHPStan found issues.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,11 +151,6 @@ parameters:
 			path: src/Database/Statement/PDOStatement.php
 
 		-
-			message: "#^Property PDOStatement\\:\\:\\$queryString \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: src/Database/Statement/PDOStatement.php
-
-		-
 			message: "#^Cannot unset offset 'args' on array\\{path\\: string, reference\\: mixed\\}\\.$#"
 			count: 1
 			path: src/Error/Debugger.php

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -216,6 +216,10 @@ class FileEngine extends CacheEngine
             return false;
         }
 
+        /**
+         * @psalm-suppress PossiblyNullReference
+         * @var string $path
+         */
         $path = $this->_File->getRealPath();
         unset($this->_File);
 

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -187,6 +187,10 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
         $subcommand = $args->getArgument('subcommand');
 
         $options = [];
+        /**
+         * @var string $key
+         * @var \Cake\Console\BaseCommand|class-string $value
+         */
         foreach ($this->commands as $key => $value) {
             $parts = explode(' ', $key);
             if ($parts[0] !== $name) {
@@ -202,6 +206,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
             // Handle class strings
             if (is_string($value)) {
                 $reflection = new ReflectionClass($value);
+                /** @var \Cake\Console\BaseCommand $value */
                 $value = $reflection->newInstance();
             }
             $parser = $value->getOptionParser();

--- a/src/Command/RoutesCheckCommand.php
+++ b/src/Command/RoutesCheckCommand.php
@@ -43,6 +43,7 @@ class RoutesCheckCommand extends Command
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
+     * @throws \JsonException
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -63,7 +64,7 @@ class RoutesCheckCommand extends Command
 
             $output = [
                 ['Route name', 'URI template', 'Defaults'],
-                [$name, $url, json_encode($route)],
+                [$name, $url, json_encode($route, JSON_THROW_ON_ERROR)],
             ];
             $io->helper('table')->output($output);
             $io->out();

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -32,6 +32,7 @@ class RoutesCommand extends Command
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int|null The exit code or null for success
+     * @throws \JsonException
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
@@ -58,7 +59,7 @@ class RoutesCommand extends Command
 
             if ($args->getOption('verbose')) {
                 ksort($route->defaults);
-                $item[] = json_encode($route->defaults);
+                $item[] = json_encode($route->defaults, JSON_THROW_ON_ERROR);
             }
 
             $output[] = $item;

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -585,6 +585,7 @@ class ConsoleIo
     {
         $name = ucfirst($name);
 
+        /** @var \Cake\Console\Helper */
         return $this->_helpers->load($name, $config);
     }
 

--- a/src/Console/HelperRegistry.php
+++ b/src/Console/HelperRegistry.php
@@ -92,6 +92,7 @@ class HelperRegistry extends ObjectRegistry
      * @param array<string, mixed> $config An array of settings to use for the helper.
      * @return \Cake\Console\Helper The constructed helper class.
      * @psalm-suppress MoreSpecificImplementedParamType
+     * @psalm-param \Cake\Console\Helper|class-string<\Cake\Console\Helper> $class
      */
     protected function _create(object|string $class, string $alias, array $config): Helper
     {
@@ -99,7 +100,6 @@ class HelperRegistry extends ObjectRegistry
             return $class;
         }
 
-        /** @var \Cake\Console\Helper */
         return new $class($this->_io, $config);
     }
 }

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -125,7 +125,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * @param array<string, mixed> $config An array of config to use for the component.
      * @return \Cake\Controller\Component The constructed component class.
      * @psalm-suppress MoreSpecificImplementedParamType
-     * @psalm-param class-string $class
+     * @psalm-param \Cake\Controller\Component|class-string<\Cake\Controller\Component> $class
      */
     protected function _create(object|string $class, string $alias, array $config): Component
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -283,6 +283,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function loadComponent(string $name, array $config = []): Component
     {
+        /** @var \Cake\Controller\Component */
         return $this->components()->load($name, $config);
     }
 
@@ -307,6 +308,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
 
         if ($this->components()->has($name)) {
+            /** @var \Cake\Controller\Component */
             return $this->components()->get($name);
         }
 

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -153,8 +153,8 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
                 $failure = sprintf(
                     ' The `%s` key has a value of `%s` but previously had a value of `%s`',
                     $key,
-                    json_encode($value),
-                    json_encode($existingConfig[$key])
+                    json_encode($value, JSON_THROW_ON_ERROR),
+                    json_encode($existingConfig[$key], JSON_THROW_ON_ERROR)
                 );
                 break;
             }

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -229,12 +229,20 @@ class PluginCollection implements Iterator, Countable
      * @param array<string, mixed> $config Configuration options for the plugin.
      * @return \Cake\Core\PluginInterface
      * @throws \Cake\Core\Exception\MissingPluginException When plugin instance could not be created.
+     * @throws \InvalidArgumentException When class name cannot be found.
+     * @psalm-param class-string<\Cake\Core\PluginInterface>|string $name
      */
     public function create(string $name, array $config = []): PluginInterface
     {
         if (str_contains($name, '\\')) {
-            /** @var \Cake\Core\PluginInterface */
-            return new $name($config);
+            if (!class_exists($name)) {
+                throw new InvalidArgumentException('Class not exists: ' . $name);
+            }
+
+            /** @var \Cake\Core\PluginInterface $plugin */
+            $plugin = new $name($config);
+
+            return $plugin;
         }
 
         $config += ['name' => $name];

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -236,7 +236,7 @@ class PluginCollection implements Iterator, Countable
     {
         if (str_contains($name, '\\')) {
             if (!class_exists($name)) {
-                throw new InvalidArgumentException('Class not exists: ' . $name);
+                throw new InvalidArgumentException("Class `{$name}` does not exist.");
             }
 
             /** @var \Cake\Core\PluginInterface $plugin */

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -85,6 +85,9 @@ trait StaticConfigTrait
 
             return;
         }
+        if (!is_string($key)) {
+            throw new LogicException('If config is not null, key must be a string.');
+        }
 
         if (isset(static::$_config[$key])) {
             /** @psalm-suppress PossiblyInvalidArgument */

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -436,9 +436,9 @@ abstract class Driver implements DriverInterface
      */
     public function newTableSchema(string $table, array $columns = []): TableSchemaInterface
     {
+        /** @var class-string<\Cake\Database\Schema\TableSchemaInterface> $className */
         $className = $this->_config['tableSchema'] ?? TableSchema::class;
 
-        /** @var \Cake\Database\Schema\TableSchemaInterface */
         return new $className($table, $columns);
     }
 

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -58,7 +58,7 @@ class PDOStatement extends StatementDecorator
     {
         if ($property === 'queryString') {
             /** @psalm-suppress NoInterfaceProperties */
-            return $this->_statement->queryString ?? null;
+            return $this->_statement->queryString;
         }
 
         throw new RuntimeException("Cannot access undefined property `$property`.");

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -56,7 +56,7 @@ class BinaryType extends BaseType
             return null;
         }
         if (is_string($value)) {
-            return fopen('data:text/plain;base64,' . base64_encode($value), 'rb');
+            return fopen('data:text/plain;base64,' . base64_encode($value), 'rb') ?: null;
         }
         if (is_resource($value)) {
             return $value;

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -119,6 +119,7 @@ class BinaryUuidType extends BaseType
      */
     protected function convertBinaryUuidToString(mixed $binary): string
     {
+        /** @var string $string */
         $string = unpack('H*', $binary);
 
         $string = preg_replace(

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -39,6 +39,7 @@ class JsonType extends BaseType implements BatchCastingInterface
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
      * @return string|null
      * @throws \InvalidArgumentException
+     * @throws \JsonException
      */
     public function toDatabase(mixed $value, DriverInterface $driver): ?string
     {
@@ -50,7 +51,7 @@ class JsonType extends BaseType implements BatchCastingInterface
             return null;
         }
 
-        return json_encode($value, $this->_encodingOptions);
+        return json_encode($value, JSON_THROW_ON_ERROR | $this->_encodingOptions);
     }
 
     /**

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -79,8 +79,10 @@ class ConnectionRegistry extends ObjectRegistry
         if (is_string($class)) {
             unset($config['className']);
 
-            /** @var \Cake\Datasource\ConnectionInterface */
-            return new $class($config);
+            /** @var \Cake\Datasource\ConnectionInterface $connection */
+            $connection = new $class($config);
+
+            return $connection;
         }
 
         if ($class instanceof Closure) {

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -963,6 +963,7 @@ class Debugger
             /** @var array $trace */
             $trace = static::trace(['start' => $data['start'], 'format' => 'points']);
             $error = new PhpError($data['code'], $data['description'], $data['file'], $data['line'], $trace);
+            /** @var \Cake\Error\ErrorRendererInterface $renderer */
             $renderer = new $this->renderers[$outputFormat]();
             echo $renderer->render($error, Configure::read('debug'));
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -780,7 +780,7 @@ class Cookie implements CookieInterface
      */
     protected function _flatten(array $array): string
     {
-        return json_encode($array);
+        return json_encode($array, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -122,7 +122,9 @@ class MessagesFileLoader
             throw new RuntimeException(sprintf('Could not find class %s', "{$name}FileParser"));
         }
 
-        $messages = (new $class())->parse($file);
+        /** @var \Cake\I18n\Parser\MoFileParser|\Cake\I18n\Parser\PoFileParser $object */
+        $object = new $class();
+        $messages = $object->parse($file);
         $package = new Package('default');
         $package->setMessages($messages);
 

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -119,7 +119,7 @@ abstract class BaseLog extends AbstractLogger
     /**
      * Replaces placeholders in message string with context values.
      *
-     * @param \Stringable|string $message Formatted message
+     * @param \Stringable|string $message Formatted message.
      * @param array $context Context for placeholder values.
      * @return string
      */
@@ -142,6 +142,7 @@ abstract class BaseLog extends AbstractLogger
 
         $placeholders = array_intersect($matches[1], array_keys($context));
         $replacements = [];
+        $jsonFlags = JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE;
 
         foreach ($placeholders as $key) {
             $value = $context[$key];
@@ -152,17 +153,17 @@ abstract class BaseLog extends AbstractLogger
             }
 
             if (is_array($value)) {
-                $replacements['{' . $key . '}'] = json_encode($value, JSON_UNESCAPED_UNICODE);
+                $replacements['{' . $key . '}'] = json_encode($value, $jsonFlags);
                 continue;
             }
 
             if ($value instanceof JsonSerializable) {
-                $replacements['{' . $key . '}'] = json_encode($value, JSON_UNESCAPED_UNICODE);
+                $replacements['{' . $key . '}'] = json_encode($value, $jsonFlags);
                 continue;
             }
 
             if ($value instanceof ArrayObject) {
-                $replacements['{' . $key . '}'] = json_encode($value->getArrayCopy(), JSON_UNESCAPED_UNICODE);
+                $replacements['{' . $key . '}'] = json_encode($value->getArrayCopy(), $jsonFlags);
                 continue;
             }
 
@@ -173,7 +174,7 @@ abstract class BaseLog extends AbstractLogger
 
             if (is_object($value)) {
                 if (method_exists($value, 'toArray')) {
-                    $replacements['{' . $key . '}'] = json_encode($value->toArray(), JSON_UNESCAPED_UNICODE);
+                    $replacements['{' . $key . '}'] = json_encode($value->toArray(), $jsonFlags);
                     continue;
                 }
 
@@ -188,7 +189,7 @@ abstract class BaseLog extends AbstractLogger
                 }
 
                 if (method_exists($value, '__debugInfo')) {
-                    $replacements['{' . $key . '}'] = json_encode($value->__debugInfo(), JSON_UNESCAPED_UNICODE);
+                    $replacements['{' . $key . '}'] = json_encode($value->__debugInfo(), $jsonFlags);
                     continue;
                 }
             }

--- a/src/Log/Formatter/JsonFormatter.php
+++ b/src/Log/Formatter/JsonFormatter.php
@@ -43,7 +43,7 @@ class JsonFormatter extends AbstractFormatter
     public function format($level, string $message, array $context = []): string
     {
         $log = ['date' => date($this->_config['dateFormat']), 'level' => (string)$level, 'message' => $message];
-        $json = json_encode($log, $this->_config['flags']);
+        $json = json_encode($log, JSON_THROW_ON_ERROR | $this->_config['flags']);
 
         return $this->_config['appendNewline'] ? $json . "\n" : $json;
     }

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -70,8 +70,10 @@ class LogEngineRegistry extends ObjectRegistry
     protected function _create(callable|object|string $class, string $alias, array $config): LoggerInterface
     {
         if (is_string($class)) {
-            /** @var \Psr\Log\LoggerInterface */
-            return new $class($config);
+            /** @var \Psr\Log\LoggerInterface $object */
+            $object = new $class($config);
+
+            return $object;
         }
 
         if (is_callable($class)) {

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -73,8 +73,10 @@ class TransportRegistry extends ObjectRegistry
             return $class;
         }
 
-        /** @var \Cake\Mailer\AbstractTransport */
-        return new $class($config);
+        /** @var \Cake\Mailer\AbstractTransport $object */
+        $object = new $class($config);
+
+        return $object;
     }
 
     /**

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -306,8 +306,10 @@ class TableLocator extends AbstractLocator implements LocatorInterface
      */
     protected function _create(array $options): Table
     {
-        /** @var \Cake\ORM\Table */
-        return new $options['className']($options);
+        /** @var class-string<\Cake\ORM\Table> $class */
+        $class = $options['className'];
+
+        return new $class($options);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -863,6 +863,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ));
         }
 
+        /** @var \Cake\ORM\Behavior $behavior */
         $behavior = $this->_behaviors->get($name);
 
         return $behavior;
@@ -1535,7 +1536,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     'get-%s-%s-%s',
                     $this->getConnection()->configName(),
                     $this->getTable(),
-                    json_encode($primaryKey)
+                    json_encode($primaryKey, JSON_THROW_ON_ERROR)
                 );
             }
             $query->cache($cacheKey, $cacheConfig);

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -160,7 +160,7 @@ trait CookieCryptTrait
      */
     protected function _implode(array $array): string
     {
-        return json_encode($array);
+        return json_encode($array, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -204,6 +204,7 @@ class Filesystem
         );
 
         $result = true;
+        /** @var \SplFileInfo $fileInfo */
         foreach ($iterator as $fileInfo) {
             $isWindowsLink = DIRECTORY_SEPARATOR === '\\' && $fileInfo->getType() === 'link';
             if ($fileInfo->getType() === self::TYPE_DIR || $isWindowsLink) {
@@ -247,6 +248,7 @@ class Filesystem
         $iterator = new FilesystemIterator($source);
 
         $result = true;
+        /** @var \SplFileInfo $fileInfo */
         foreach ($iterator as $fileInfo) {
             if ($fileInfo->isDir()) {
                 $result = $result && $this->copyDir(

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -172,7 +172,7 @@ class Security
             static::$_instance = $instance;
         }
         if (isset(static::$_instance)) {
-            /** @psalm-suppress LessSpecificReturnStatement */
+            /** @var \Cake\Utility\Crypto\OpenSsl */
             return static::$_instance;
         }
         throw new InvalidArgumentException(

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -681,6 +681,7 @@ class PaginatorHelper extends Helper
             return $this->_defaultModel;
         }
 
+        /** @var array<string, mixed> $params */
         $params = $this->_View->getRequest()->getAttribute('paging');
         if (!$params) {
             return null;

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -340,13 +340,13 @@ class StringTemplate
      * Adds a class and returns a unique list either in array or space separated
      *
      * @param mixed $input The array or string to add the class to
-     * @param array<string>|string|bool|null $newClass the new class or classes to add
+     * @param array<string>|string|false|null $newClass the new class or classes to add
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
      * @return array<string>|string|null
      */
     public function addClass(
         mixed $input,
-        array|string|bool|null $newClass,
+        array|string|false|null $newClass,
         string $useIndex = 'class'
     ): array|string|null {
         // NOOP

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1224,6 +1224,7 @@ class View implements EventDispatcherInterface
      */
     public function loadHelper(string $name, array $config = []): Helper
     {
+        /** @var \Cake\View\Helper */
         return $this->helpers()->load($name, $config);
     }
 

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -592,8 +592,10 @@ class ViewBuilder implements JsonSerializable
         ];
         $data += $this->_options;
 
-        /** @var \Cake\View\View */
-        return new $className($request, $response, $events, $data);
+        /** @var \Cake\View\View $view */
+        $view = new $className($request, $response, $events, $data);
+
+        return $view;
     }
 
     /**

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -199,7 +199,7 @@ class SelectBoxWidget extends BasicWidget
      * @param string $label The optgroup label text
      * @param \ArrayAccess|array $optgroup The opt group data.
      * @param array|null $disabled The options to disable.
-     * @param array|string|int|bool|null $selected The options to select.
+     * @param array|string|int|false|null $selected The options to select.
      * @param array $templateVars Additional template variables.
      * @param bool $escape Toggle HTML escaping
      * @return string Formatted template string
@@ -208,7 +208,7 @@ class SelectBoxWidget extends BasicWidget
         string $label,
         ArrayAccess|array $optgroup,
         ?array $disabled,
-        array|string|int|bool|null $selected,
+        array|string|int|false|null $selected,
         array $templateVars,
         bool $escape
     ): string {
@@ -236,7 +236,7 @@ class SelectBoxWidget extends BasicWidget
      *
      * @param iterable $options The options to render.
      * @param array<string>|null $disabled The options to disable.
-     * @param array|string|int|bool|null $selected The options to select.
+     * @param array|string|int|false|null $selected The options to select.
      * @param array $templateVars Additional template variables.
      * @param bool $escape Toggle HTML escaping.
      * @return array<string> Option elements.
@@ -244,7 +244,7 @@ class SelectBoxWidget extends BasicWidget
     protected function _renderOptions(
         iterable $options,
         ?array $disabled,
-        array|string|int|bool|null $selected,
+        array|string|int|false|null $selected,
         array $templateVars,
         bool $escape
     ): array {
@@ -277,6 +277,7 @@ class SelectBoxWidget extends BasicWidget
                 'templateVars' => [],
             ];
             if (is_array($val) && isset($val['text'], $val['value'])) {
+                /** @var array<string, mixed> $optAttrs */
                 $optAttrs = $val;
                 $key = $optAttrs['value'];
             }

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -19,6 +19,7 @@ namespace Cake\View;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cake\Utility\Xml;
+use Cake\View\Exception\SerializationFailureException;
 
 /**
  * A view class that is used for creating XML responses.
@@ -146,6 +147,14 @@ class XmlView extends SerializedView
             $options['pretty'] = true;
         }
 
-        return Xml::fromArray($data, $options)->saveXML();
+        /** @var string|false $result */
+        $result = Xml::fromArray($data, $options)->saveXML();
+        if ($result === false) {
+            throw new SerializationFailureException(
+                'XML serialization of View data failed.'
+            );
+        }
+
+        return $result;
     }
 }


### PR DESCRIPTION
From
314 errors           
to
278 errors     

in level 7

Most remaining are about `|false` or `int|string` issues that are "dirty".
But there also some concerning ones we might want to also throw more meaningful exceptions.

Many `psalm-suppress` should probably rather be `var`, as this would then also be OK for phpstan.
Or we catch it and throw exceptions etc.