### PR TITLE
Add deprecation for RequestHandlerComponent

### DIFF
--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -38,7 +38,18 @@ use Cake\Utility\Inflector;
  * It can also check for HTTP caching headers like `Last-Modified`, `If-Modified-Since`
  * etc. and return a response accordingly.
  *
+ * ## Replacing Deprecated methods
+ *
+ * - Replace `accepts()` with `$this->request->accepts()`.
+ * - Replace `requestedWith()` with a custom request detector.
+ *   eg. `$this->request->is('json')`
+ * - Replace `prefers()` with `ContentTypeNegotiation` or the negotiation features
+ *   on `Controller`.
+ * - Replace `renderAs()` with controller content negotiation features on `Controller`.
+ * - Replace `checkHttpCache` option with `CheckHttpCacheComponent`.
+ *
  * @link https://book.cakephp.org/4/en/controllers/components/request-handling.html
+ * @deprecated 4.4.0 Use altenative methods listed above.
  */
 class RequestHandlerComponent extends Component
 {

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -38,18 +38,9 @@ use Cake\Utility\Inflector;
  * It can also check for HTTP caching headers like `Last-Modified`, `If-Modified-Since`
  * etc. and return a response accordingly.
  *
- * ## Replacing Deprecated methods
- *
- * - Replace `accepts()` with `$this->request->accepts()`.
- * - Replace `requestedWith()` with a custom request detector.
- *   eg. `$this->request->is('json')`
- * - Replace `prefers()` with `ContentTypeNegotiation` or the negotiation features
- *   on `Controller`.
- * - Replace `renderAs()` with controller content negotiation features on `Controller`.
- * - Replace `checkHttpCache` option with `CheckHttpCacheComponent`.
- *
  * @link https://book.cakephp.org/4/en/controllers/components/request-handling.html
- * @deprecated 4.4.0 Use altenative methods listed above.
+ * @deprecated 4.4.0 See the 4.4 migration guide for how to upgrade.
+ *   https://book.cakephp.org/4/en/appendices/4-4-migration-guide.html#requesthandlercomponent
  */
 class RequestHandlerComponent extends Component
 {


### PR DESCRIPTION
This follows the approach we took with `AuthComponent`. RequestHandler
is used in *many* applications and the new features are still pretty
fresh. A soft deprecation will give users more time to upgrade as the
upgrade requires non-trivial changes.

The docs mention a `CheckHttpCacheComponent`. That component still needs
to be written though, and I will extract that component in a separate pull request.