### PR TITLE
Simplify code.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -851,17 +851,13 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
                 $settings
             );
         } catch (PageOutOfBoundsException $exception) {
-            // Nothing to do here, NotFoundException will be thrown below.
+            throw new NotFoundException(null, null, $exception);
         }
 
         $paging = $paginator->getPagingParams() + (array)$this->request->getAttribute('paging', []);
         $this->setRequest($this->request->withAttribute('paging', $paging));
 
-        if (isset($results)) {
-            return $results;
-        }
-
-        throw new NotFoundException(null, null, $exception ?? null);
+        return $results;
     }
 
     /**


### PR DESCRIPTION
Setting paging params to request even when PageOutOfBoundsException is
thrown is not necessary. The exception's attributes already have that info.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
