### PR TITLE
5.x - Fix test fixture polluting the table locator.

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -140,6 +140,10 @@ class TestFixture implements FixtureInterface
             $name = Inflector::camelize($this->table);
             $ormTable = $this->fetchTable($name, ['connection' => $db]);
 
+            // Remove the fetched table from the locator to avoid conflicts
+            // with test cases that need to (re)configure the alias.
+            $this->getTableLocator()->remove($name);
+
             /** @var \Cake\Database\Schema\TableSchema $schema */
             $schema = $ormTable->getSchema();
             $this->_schema = $schema;

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -67,6 +67,21 @@ class FixtureHelperTest extends TestCase
     }
 
     /**
+     * Tests that possible table instances used in the fixture loading mechanism
+     * do not remain in the table locator.
+     */
+    public function testLoadFixturesDoesNotPolluteTheTableLocator(): void
+    {
+        (new FixtureHelper())->loadFixtures([
+            'core.Articles',
+            'plugin.TestPlugin.Blog/Comments',
+        ]);
+
+        $this->assertFalse($this->getTableLocator()->exists('Articles'));
+        $this->assertFalse($this->getTableLocator()->exists('Comments'));
+    }
+
+    /**
      * Tests loading missing fixtures.
      */
     public function testLoadMissingFixtures(): void

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -74,20 +74,25 @@ class TestFixtureTest extends TestCase
     }
 
     /**
-     * Tests init with a table that doesn't exist throws exception.
+     * Tests that trying to reflect with a table that doesn't exist throws an exception.
      */
-    public function testInitMissingTable(): void
+    public function testReflectionMissingTable(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`. The table does not exist.');
-        $fixture = new LettersFixture();
-        $fixture->init();
+        $this->expectExceptionMessage(
+            sprintf(
+                'Cannot describe schema for table `letters` for fixture `%s`. The table does not exist.',
+                LettersFixture::class
+            ),
+        );
+
+        new LettersFixture();
     }
 
     /**
-     * Tests init will reflect schema for table.
+     * Tests schema reflection.
      */
-    public function testInitReflection(): void
+    public function testReflection(): void
     {
         $db = ConnectionManager::get('test');
         $table = new TableSchema('letters', [
@@ -102,20 +107,19 @@ class TestFixtureTest extends TestCase
         }
 
         $fixture = new LettersFixture();
-        $fixture->init();
         $this->assertSame(['id', 'letter'], $fixture->getTableSchema()->columns());
     }
 
     /**
-     * test schema reflection without $import or $fields will reflect the schema
+     * Tests that schema reflection picks up dynamically configured column types.
      */
-    public function testInitReflectSchemaCustomTypes(): void
+    public function testReflectionWithDynamicTypes(): void
     {
         $db = ConnectionManager::get('test');
         $table = new TableSchema('letters', [
             'id' => ['type' => 'integer'],
             'letter' => ['type' => 'string', 'length' => 1],
-            'complex_field' => ['type' => 'json'],
+            'complex_field' => ['type' => 'text'],
         ]);
         $table->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
         $sql = $table->createSql($db);
@@ -128,7 +132,6 @@ class TestFixtureTest extends TestCase
         $table->getSchema()->setColumnType('complex_field', 'json');
 
         $fixture = new LettersFixture();
-        $fixture->init();
         $fixtureSchema = $fixture->getTableSchema();
         $this->assertSame(['id', 'letter', 'complex_field'], $fixtureSchema->columns());
         $this->assertSame('json', $fixtureSchema->getColumnType('complex_field'));


### PR DESCRIPTION
Running individual tests can fail when a fixture fetched a table, and a test then for example tried to configure the same alias. For example

```
vendor/bin/phpunit --filter "/TranslateBehaviorShadowTableTest::testFindWithBTMAssociations/" "tests/TestCase/ORM/Behavior"
```

will yield

> RuntimeException : You cannot configure "TagsTranslations", it already exists in the registry.

It works when running multiple tests because the fixtures are only instantiated once, and after the first test case, the locator is being cleared on teardown, removing the possibly problematic entries for all subsequent tests.

The `init()` in the test had to be removed because initialization already happens in the constructor, and re-initializing would scrap the table with the custom type configured in the test.