### PR TITLE
4.4 Remove callbacks from exception/error traps

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -7,20 +7,22 @@ use Cake\Core\Configure;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Error\Renderer\ConsoleErrorRenderer;
 use Cake\Error\Renderer\HtmlErrorRenderer;
-use Closure;
+use Cake\Event\EventDispatcherTrait;
 use Exception;
 use InvalidArgumentException;
 
 /**
  * Entry point to CakePHP's error handling.
  *
- * Using the `register()` method you can attach an ErrorTrap
- * to PHP's default error handler. When errors are trapped
- * they are 'rendered' using the defined renderers and logged
- * if logging is enabled.
+ * Using the `register()` method you can attach an ErrorTrap to PHP's default error handler.
+ *
+ * When errors are trapped, errors are logged (if logging is enabled). Then the `Error.handled` event is triggered.
+ * Finally, errors are 'rendered' using the defined renderer. If no error renderer is defined in configuration
+ * one of the default implementations will be chosen based on the PHP SAPI.
  */
 class ErrorTrap
 {
+    use EventDispatcherTrait;
     use InstanceConfigTrait {
         getConfig as private _getConfig;
     }
@@ -40,16 +42,6 @@ class ErrorTrap
         'extraFatalErrorMemory' => 4 * 1024,
         'trace' => false,
     ];
-
-    /**
-     * A list of handling callbacks.
-     *
-     * Callbacks are invoked for each error that is handled.
-     * Callbacks are invoked in the order they are attached.
-     *
-     * @var array<\Closure>
-     */
-    protected $callbacks = [];
 
     /**
      * Constructor
@@ -104,6 +96,9 @@ class ErrorTrap
      * Will use the configured renderer to generate output
      * and output it.
      *
+     * This method will dispatch the `Error.handled` event which can be listened
+     * to on the global event manager.
+     *
      * @param int $code Code of error
      * @param string $description Error description
      * @param string|null $file File on which error occurred
@@ -128,12 +123,9 @@ class ErrorTrap
         $logger = $this->logger();
 
         try {
-            // Log first incase rendering or callbacks fail.
+            // Log first incase rendering or event listeners fail
             $logger->logMessage($error->getLabel(), $error->getMessage());
-
-            foreach ($this->callbacks as $callback) {
-                $callback($error);
-            }
+            $this->dispatchEvent('Error.handled', ['error' => $error]);
             $renderer->write($renderer->render($error, $debug));
         } catch (Exception $e) {
             $logger->logMessage('error', 'Could not render error. Got: ' . $e->getMessage());
@@ -188,24 +180,5 @@ class ErrorTrap
         $instance = new $class($this->_config);
 
         return $instance;
-    }
-
-    /**
-     * Add a callback to be invoked when an error is handled.
-     *
-     * Your callback should habe the following signature:
-     *
-     * ```
-     * function (\Cake\Error\PhpError $error): void
-     * ```
-     *
-     * @param \Closure $closure The Closure to be invoked when an error is handledd.
-     * @return $this
-     */
-    public function addCallback(Closure $closure)
-    {
-        $this->callbacks[] = $closure;
-
-        return $this;
     }
 }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -14,7 +14,7 @@ use Throwable;
  * Entry point to CakePHP's exception handling.
  *
  * Using the `register()` method you can attach an ExceptionTrap to PHP's default exception handler and register
- * a shutdown handler to handle fatal errors. 
+ * a shutdown handler to handle fatal errors.
  *
  * When exceptions are trapped the `Exception.handled` event is triggered.
  * Then exceptions are logged (if enabled) and finally 'rendered' using the defined renderer.

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -156,7 +156,6 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
         if ($this->errorHandler === null) {
             $errorHandler = $this->getExceptionTrap();
             $errorHandler->logException($exception, $request);
-            $errorHandler->applyCallbacks($exception);
 
             $renderer = $errorHandler->renderer($exception, $request);
         } else {

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -130,11 +130,11 @@ class ErrorTrapTest extends TestCase
         $this->assertSame('', $output);
     }
 
-    public function testAddCallback()
+    public function testEventTriggered()
     {
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
-        $trap->addCallback(function (PhpError $error) {
+        $trap->getEventManager()->on('Error.handled', function ($event, PhpError $error) {
             $this->assertEquals(E_USER_NOTICE, $error->getCode());
             $this->assertStringContainsString('Oh no it was bad', $error->getMessage());
         });

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -162,10 +162,10 @@ class ExceptionTrapTest extends TestCase
         $this->assertStringContainsString('nope', $logs[0]);
     }
 
-    public function testAddCallback()
+    public function testEventTriggered()
     {
         $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
-        $trap->addCallback(function (Throwable $error) {
+        $trap->getEventManager()->on('Exception.handled', function ($event, Throwable $error) {
             $this->assertEquals(100, $error->getCode());
             $this->assertStringContainsString('nope', $error->getMessage());
         });


### PR DESCRIPTION
Use events instead. The event subsystem offers better consistency with the rest of the framework and provides the necessary hooks for DebugKit to easily collect errors and exceptions.

Refs #16228