### PR TITLE
Add matched route instance as request attribute

### DIFF
--- a/src/Command/RoutesCheckCommand.php
+++ b/src/Command/RoutesCheckCommand.php
@@ -58,7 +58,7 @@ class RoutesCheckCommand extends Command
                 }
             }
 
-            unset($route['_matchedRoute']);
+            unset($route['_route'], $route['_matchedRoute']);
             ksort($route);
 
             $output = [

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -139,8 +139,11 @@ class RoutingMiddleware implements MiddlewareInterface
                 $params = Router::parseRequest($request) + $params;
                 if (isset($params['_middleware'])) {
                     $middleware = $params['_middleware'];
-                    unset($params['_middleware']);
                 }
+                $route = $params['_route'];
+                unset($params['_middleware'], $params['_route']);
+
+                $request = $request->withAttribute('route', $route);
                 /** @var \Cake\Http\ServerRequest $request */
                 $request = $request->withAttribute('params', $params);
                 Router::setRequest($request);

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -539,6 +539,8 @@ class Route
                 }
             }
         }
+
+        $route['_route'] = $this;
         $route['_matchedRoute'] = $this->template;
         if (count($this->middleware) > 0) {
             $route['_middleware'] = $this->middleware;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -643,7 +643,9 @@ class Router
      */
     public static function reverseToArray($params): array
     {
+        $route = null;
         if ($params instanceof ServerRequest) {
+            $route = $params->getAttribute('route');
             $queryString = $params->getQueryParams();
             $params = $params->getAttribute('params');
             $params['?'] = $queryString;
@@ -656,8 +658,7 @@ class Router
             $params['_matchedRoute'],
             $params['_name']
         );
-        $route = null;
-        if ($template) {
+        if (!$route && $template) {
             // Locate the route that was used to match this route
             // so we can access the pass parameter configuration.
             foreach (static::getRouteCollection()->routes() as $maybe) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -221,7 +221,7 @@ class Router
     }
 
     /**
-     * Get the routing parameters for the request is possible.
+     * Get the routing parameters for the request if possible.
      *
      * @param \Cake\Http\ServerRequest $request The request to parse request data from.
      * @return array Parsed elements from URL.

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -23,6 +23,7 @@ use Cake\Core\HttpApplicationInterface;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Middleware\RoutingMiddleware;
+use Cake\Routing\Route\Route;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
@@ -111,6 +112,22 @@ class RoutingMiddlewareTest extends TestCase
                 '_matchedRoute' => '/articles',
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
+
+            return new Response();
+        });
+        $middleware = new RoutingMiddleware($this->app());
+        $middleware->process($request, $handler);
+    }
+
+    /**
+     * Test that Router sets matched routes instance.
+     */
+    public function testRouterSetRoute(): void
+    {
+        $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/articles']);
+        $handler = new TestRequestHandler(function ($req) {
+            $this->assertInstanceOf(Route::class, $req->getAttribute('route'));
+            $this->assertSame('/articles', $req->getAttribute('route')->staticPath());
 
             return new Response();
         });

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -496,14 +496,15 @@ class RouteTest extends TestCase
         $this->assertMatchesRegularExpression($result, '/posts/08/01/2007/title-of-post');
         $result = $route->parse('/posts/08/01/2007/title-of-post', 'GET');
 
-        $this->assertCount(7, $result);
-        $this->assertEquals($result['controller'], 'Posts');
-        $this->assertEquals($result['action'], 'view');
-        $this->assertEquals($result['year'], '2007');
-        $this->assertEquals($result['month'], '08');
-        $this->assertEquals($result['day'], '01');
-        $this->assertEquals($result['pass'][0], 'title-of-post');
-        $this->assertEquals($result['_matchedRoute'], '/posts/{month}/{day}/{year}/*');
+        $this->assertCount(8, $result);
+        $this->assertSame('Posts', $result['controller']);
+        $this->assertSame('view', $result['action']);
+        $this->assertSame('2007', $result['year']);
+        $this->assertSame('08', $result['month']);
+        $this->assertSame('01', $result['day']);
+        $this->assertSame('title-of-post', $result['pass'][0]);
+        $this->assertSame($route, $result['_route']);
+        $this->assertSame('/posts/{month}/{day}/{year}/*', $result['_matchedRoute']);
 
         $route = new Route(
             '/{extra}/page/{slug}/*',
@@ -1090,6 +1091,7 @@ class RouteTest extends TestCase
             'controller' => 'Articles',
             'action' => 'index',
             'pass' => [],
+            '_route' => $route,
             '_matchedRoute' => '/fallback',
         ];
         $this->assertEquals($expected, $result, 'Should match, domain is correct');
@@ -1205,6 +1207,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'display',
             'pass' => ['home'],
+            '_route' => $route,
             '_matchedRoute' => '/{controller}',
         ];
         $this->assertEquals($expected, $result);
@@ -1222,6 +1225,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'display',
             'pass' => ['home'],
+            '_route' => $route,
             '_matchedRoute' => '/{controller}',
             '_middleware' => ['auth', 'cookie'],
         ];
@@ -1241,6 +1245,7 @@ class RouteTest extends TestCase
             'action' => 'index',
             'pass' => [],
             '_method' => 'POST',
+            '_route' => $route,
             '_matchedRoute' => '/sample',
         ];
         $this->assertEquals($expected, $route->parse('/sample', 'post'));
@@ -1264,6 +1269,7 @@ class RouteTest extends TestCase
             'action' => 'index',
             'pass' => [],
             '_method' => ['PUT', 'POST'],
+            '_route' => $route,
             '_matchedRoute' => '/sample',
         ];
         $this->assertEquals($expected, $route->parse('/sample', 'POST'));
@@ -1335,6 +1341,7 @@ class RouteTest extends TestCase
             'controller' => 'BlogPosts',
             'action' => 'other',
             'pass' => [],
+            '_route' => $route,
             '_matchedRoute' => '/blog/{action}/*',
         ];
         $this->assertEquals($expected, $result);
@@ -1354,6 +1361,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'edit',
             'pass' => ['1', '2', '0'],
+            '_route' => $route,
             '_matchedRoute' => '/{controller}/{action}/*',
         ];
         $this->assertEquals($expected, $result);
@@ -1430,6 +1438,7 @@ class RouteTest extends TestCase
             'action' => 'view',
             'slug' => 'my-title',
             'pass' => ['my-title'],
+            '_route' => $route,
             '_matchedRoute' => '/{controller}/{action}/{slug}',
         ];
         $this->assertEquals($expected, $result, 'Slug should have moved');
@@ -1446,6 +1455,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             'pass' => ['1/2/3/foo:bar'],
+            '_route' => $route,
             '_matchedRoute' => '/{controller}/{action}/**',
         ];
         $this->assertEquals($expected, $result);
@@ -1455,6 +1465,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             'pass' => ['http://example.com'],
+            '_route' => $route,
             '_matchedRoute' => '/{controller}/{action}/**',
         ];
         $this->assertEquals($expected, $result);
@@ -1471,6 +1482,7 @@ class RouteTest extends TestCase
             'controller' => 'Categories',
             'action' => 'index',
             'pass' => ['موبایل'],
+            '_route' => $route,
             '_matchedRoute' => '/category/**',
         ];
         $this->assertEquals($expected, $result);
@@ -1581,6 +1593,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             'pass' => [],
+            '_route' => $route,
             '_matchedRoute' => '/{section}',
         ];
         $this->assertEquals($expected, $result);
@@ -1592,6 +1605,7 @@ class RouteTest extends TestCase
             'controller' => 'Posts',
             'action' => 'index',
             'pass' => [],
+            '_route' => $route,
             '_matchedRoute' => '/{section}',
         ];
         $this->assertEquals($expected, $result);
@@ -1610,6 +1624,7 @@ class RouteTest extends TestCase
             'controller' => 'Products',
             'action' => 'test',
             'pass' => ['xx%2Fyy'],
+            '_route' => $route,
             '_matchedRoute' => '/products/tests/*',
         ];
         $this->assertEquals($expected, $result);
@@ -1626,6 +1641,7 @@ class RouteTest extends TestCase
             'action' => 'view',
             'slug' => 'xx%2Fyy',
             'pass' => [],
+            '_route' => $route,
             '_matchedRoute' => '/products/view/{slug}',
         ];
         $this->assertEquals($expected, $result);
@@ -1696,6 +1712,7 @@ class RouteTest extends TestCase
             'controller' => 'Pages',
             'action' => 'display',
             'pass' => ['home'],
+            '_route' => $route,
             '_matchedRoute' => '/',
         ];
         $this->assertEquals($expected, $route->parse('/', 'GET'));

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -172,8 +172,13 @@ class RouteBuilderTest extends TestCase
             'pass' => [],
             '_matchedRoute' => '/articles',
         ];
-        $this->assertEquals($expected, $this->collection->parse('/articles'));
-        $this->assertEquals($expected, $this->collection->parse('/articles/'));
+        $result = $this->collection->parse('/articles');
+        unset($result['_route']);
+        $this->assertEquals($expected, $result);
+
+        $result = $this->collection->parse('/articles/');
+        unset($result['_route']);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -200,7 +205,9 @@ class RouteBuilderTest extends TestCase
             'plugin' => null,
             '_matchedRoute' => '/my-articles/view',
         ];
-        $this->assertEquals($expected, $this->collection->parse('/my-articles/view'));
+        $result = $this->collection->parse('/my-articles/view');
+        unset($result['_route']);
+        $this->assertEquals($expected, $result);
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
@@ -222,7 +229,9 @@ class RouteBuilderTest extends TestCase
             'action' => 'index',
             '_matchedRoute' => '/admin/bookmarks',
         ];
-        $this->assertEquals($expected, $this->collection->parse('/admin/bookmarks'));
+        $result = $this->collection->parse('/admin/bookmarks');
+        unset($result['_route']);
+        $this->assertEquals($expected, $result);
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
@@ -243,7 +252,9 @@ class RouteBuilderTest extends TestCase
             'action' => 'view',
             '_matchedRoute' => '/blog/articles/view',
         ];
-        $this->assertEquals($expected, $this->collection->parse('/blog/articles/view'));
+        $result = $this->collection->parse('/blog/articles/view');
+        unset($result['_route']);
+        $this->assertEquals($expected, $result);
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);
@@ -265,7 +276,9 @@ class RouteBuilderTest extends TestCase
             'action' => 'view',
             '_matchedRoute' => '/admin/blog/articles/view',
         ];
-        $this->assertEquals($expected, $this->collection->parse('/admin/blog/articles/view'));
+        $result = $this->collection->parse('/admin/blog/articles/view');
+        unset($result['_route']);
+        $this->assertEquals($expected, $result);
 
         $url = $expected['_matchedRoute'];
         unset($expected['_matchedRoute']);

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -83,6 +83,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
 
         $result = $this->collection->parse('/b/');
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'index',
@@ -94,6 +95,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->collection->parse('/b/the-thing?one=two');
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'view',
@@ -107,6 +109,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->collection->parse('/b/media/search');
+        unset($result['_route']);
         $expected = [
             'key' => 'value',
             'pass' => [],
@@ -118,6 +121,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->collection->parse('/b/media/search/thing');
+        unset($result['_route']);
         $expected = [
             'key' => 'value',
             'pass' => ['thing'],
@@ -140,6 +144,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
 
         $result = $this->collection->parse('/b/');
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'index',
@@ -151,6 +156,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->collection->parse('/b/the-thing?one=two');
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'view',
@@ -164,6 +170,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->collection->parse('/b/media/search');
+        unset($result['_route']);
         $expected = [
             'key' => 'value',
             'pass' => [],
@@ -176,6 +183,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = $this->collection->parse('/b/media/search/thing');
+        unset($result['_route']);
         $expected = [
             'key' => 'value',
             'pass' => ['thing'],
@@ -198,6 +206,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/ден/{day}-{month}', ['controller' => 'Events', 'action' => 'index']);
         $url = '/%D0%B4%D0%B5%D0%BD/15-%D0%BE%D0%BA%D1%82%D0%BE%D0%BC%D0%B2%D1%80%D0%B8?test=foo';
         $result = $this->collection->parse($url);
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'plugin' => null,
@@ -212,6 +221,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => $url]);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
     }
 
@@ -227,6 +237,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/{controller}/{action}', [], ['routeClass' => 'InflectedRoute']);
 
         $result = $this->collection->parse('/articles/add');
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'add',
@@ -273,6 +284,7 @@ class RouteCollectionTest extends TestCase
             ],
         ]);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'index',
@@ -289,6 +301,7 @@ class RouteCollectionTest extends TestCase
             ],
         ]);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $this->assertEquals($expected, $result, 'Should match, domain is a matching subdomain');
 
         $request = new ServerRequest([
@@ -356,6 +369,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => '/b/']);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'index',
@@ -368,6 +382,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => '/b/media/search']);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'key' => 'value',
             'pass' => [],
@@ -380,6 +395,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => '/b/media/search/thing']);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'key' => 'value',
             'pass' => ['thing'],
@@ -392,6 +408,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => '/b/the-thing?one=two']);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'controller' => 'Articles',
             'action' => 'view',
@@ -415,6 +432,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => '/b/alta/confirmaci%C3%B3n']);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'controller' => 'Media',
             'action' => 'confirm',
@@ -426,6 +444,7 @@ class RouteCollectionTest extends TestCase
 
         $request = new ServerRequest(['url' => '/b/alta/confirmación']);
         $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2713,7 +2713,8 @@ class RouterTest extends TestCase
 
     public function testReverseToArrayRequestQuery(): void
     {
-        Router::connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
+        $builder = Router::createRouteBuilder('/');
+        $route = $builder->connect('/{lang}/{controller}/{action}/*', [], ['lang' => '[a-z]{3}']);
         $request = new ServerRequest([
             'url' => '/eng/posts/view/1',
             'params' => [
@@ -2734,6 +2735,12 @@ class RouterTest extends TestCase
                 'test' => 'value',
             ],
         ];
+        $this->assertEquals($expected, $actual);
+
+        $request = $request->withAttribute('route', $route)
+            ->withQueryParams(['x' => 'y']);
+        $expected['?'] = ['x' => 'y'];
+        $actual = Router::reverseToArray($request);
         $this->assertEquals($expected, $actual);
     }
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -184,6 +184,7 @@ class RouterTest extends TestCase
         Router::connect('/{controller}', ['action' => 'index', '_method' => ['GET', 'POST']]);
 
         $result = Router::parseRequest($this->makeRequest('/Posts', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'plugin' => null,
@@ -195,6 +196,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/Posts', 'POST'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'plugin' => null,
@@ -411,9 +413,11 @@ class RouterTest extends TestCase
             '_matchedRoute' => '/*',
         ];
         $result = Router::parseRequest($this->makeRequest('/0', 'GET'));
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('0', 'GET'));
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
     }
 
@@ -1211,6 +1215,7 @@ class RouterTest extends TestCase
             ['value', 'somevalue', 'othervalue']
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
+        unset($result['_route']);
         $expected = [
             'value' => '2007',
             'somevalue' => '08',
@@ -1230,6 +1235,7 @@ class RouterTest extends TestCase
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
+        unset($result['_route']);
         $expected = [
             'year' => '2007',
             'month' => '08',
@@ -1249,6 +1255,7 @@ class RouterTest extends TestCase
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/01/2007/08/title-of-post-here', 'GET'));
+        unset($result['_route']);
         $expected = [
             'day' => '01',
             'year' => '2007',
@@ -1268,6 +1275,7 @@ class RouterTest extends TestCase
             ['year' => $Year, 'month' => $Month, 'day' => $Day]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/08/01/2007/title-of-post-here', 'GET'));
+        unset($result['_route']);
         $expected = [
             'month' => '08',
             'day' => '01',
@@ -1286,6 +1294,7 @@ class RouterTest extends TestCase
             ['controller' => 'Posts', 'action' => 'view']
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
+        unset($result['_route']);
         $expected = [
             'year' => '2007',
             'month' => '08',
@@ -1301,6 +1310,7 @@ class RouterTest extends TestCase
         Router::reload();
         $this->_connectDefaultRoutes();
         $result = Router::parseRequest($this->makeRequest('/pages/display/home', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => null,
             'pass' => ['home'],
@@ -1311,14 +1321,17 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('pages/display/home/', 'GET'));
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('pages/display/home', 'GET'));
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
 
         Router::reload();
         Router::connect('/page/*', ['controller' => 'Test']);
         $result = Router::parseRequest($this->makeRequest('/page/my-page', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['my-page'],
             'plugin' => null,
@@ -1335,6 +1348,7 @@ class RouterTest extends TestCase
             ['language' => '[a-z]{3}']
         );
         $result = Router::parseRequest($this->makeRequest('/eng/contact', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'language' => 'eng',
@@ -1353,6 +1367,7 @@ class RouterTest extends TestCase
         );
 
         $result = Router::parseRequest($this->makeRequest('/forestillinger/10/2007/min-forestilling', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['min-forestilling'],
             'plugin' => 'Shows',
@@ -1368,6 +1383,7 @@ class RouterTest extends TestCase
         Router::connect('/{controller}/{action}/*');
         Router::connect('/', ['plugin' => 'pages', 'controller' => 'Pages', 'action' => 'display']);
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'controller' => 'Pages',
@@ -1378,6 +1394,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/Posts/edit/0', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [0],
             'controller' => 'Posts',
@@ -1394,6 +1411,7 @@ class RouterTest extends TestCase
             ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
         );
         $result = Router::parseRequest($this->makeRequest('/Posts/5:sample-post-title', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['5', 'sample-post-title'],
             'id' => '5',
@@ -1412,6 +1430,7 @@ class RouterTest extends TestCase
             ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
         );
         $result = Router::parseRequest($this->makeRequest('/Posts/5:sample-post-title/other/params/4', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['5', 'sample-post-title', 'other', 'params', '4'],
             'id' => 5,
@@ -1426,6 +1445,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/posts/view/*', ['controller' => 'Posts', 'action' => 'view']);
         $result = Router::parseRequest($this->makeRequest('/posts/view/10?id=123&tab=abc', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [10],
             'plugin' => null,
@@ -1443,6 +1463,7 @@ class RouterTest extends TestCase
             ['pass' => ['id', 'url_title'], 'id' => $UUID]
         );
         $result = Router::parseRequest($this->makeRequest('/posts/sample-post-title-(uuid:47fc97a9-019c-41d1-a058-1fa3cbdd56cb)', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['47fc97a9-019c-41d1-a058-1fa3cbdd56cb', 'sample-post-title'],
             'id' => '47fc97a9-019c-41d1-a058-1fa3cbdd56cb',
@@ -1457,6 +1478,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/posts/view/*', ['controller' => 'Posts', 'action' => 'view']);
         $result = Router::parseRequest($this->makeRequest('/posts/view/foo:bar/routing:fun', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['foo:bar', 'routing:fun'],
             'plugin' => null,
@@ -1475,6 +1497,7 @@ class RouterTest extends TestCase
         Router::connect('/articles/{action}/*', ['controller' => 'Articles']);
         $request = new ServerRequest(['url' => '/articles/view/1']);
         $result = Router::parseRequest($request);
+        unset($result['_route']);
         $expected = [
             'pass' => ['1'],
             'plugin' => null,
@@ -1496,6 +1519,7 @@ class RouterTest extends TestCase
             ['category_id' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}']
         );
         $result = Router::parseRequest($this->makeRequest('/subjects/add/4795d601-19c8-49a6-930e-06a8b01d17b7', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'category_id' => '4795d601-19c8-49a6-930e-06a8b01d17b7',
@@ -1519,6 +1543,7 @@ class RouterTest extends TestCase
         );
 
         $result = Router::parseRequest($this->makeRequest('/some_extra/page/this_is_the_slug', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'plugin' => null,
@@ -1531,6 +1556,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/page/this_is_the_slug', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'plugin' => null,
@@ -1683,6 +1709,7 @@ class RouterTest extends TestCase
         $this->_connectDefaultRoutes();
 
         $result = Router::parseRequest($this->makeRequest('/posts.rss', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => null,
             'controller' => 'Posts',
@@ -1694,6 +1721,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/posts/view/1.rss', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => null,
             'controller' => 'Posts',
@@ -1705,6 +1733,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/posts/view/1.rss?query=test', 'GET'));
+        unset($result['_route']);
         $expected['?'] = ['query' => 'test'];
         $this->assertEquals($expected, $result);
 
@@ -1713,6 +1742,7 @@ class RouterTest extends TestCase
         $this->_connectDefaultRoutes();
 
         $result = Router::parseRequest($this->makeRequest('/posts.xml', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => null,
             'controller' => 'Posts',
@@ -1724,6 +1754,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/posts.atom?hello=goodbye', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => null,
             'controller' => 'Posts.atom',
@@ -1737,6 +1768,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
+        unset($result['_route']);
         $expected = [
             'controller' => 'Controller',
             'action' => 'action',
@@ -1750,6 +1782,7 @@ class RouterTest extends TestCase
         Router::reload();
         Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
+        unset($result['_route']);
         $expected = [
             'controller' => 'Controller',
             'action' => 'action',
@@ -1764,6 +1797,7 @@ class RouterTest extends TestCase
         Router::extensions('rss', false);
         Router::connect('/controller/action', ['controller' => 'Controller', 'action' => 'action', '_ext' => 'rss']);
         $result = Router::parseRequest($this->makeRequest('/controller/action', 'GET'));
+        unset($result['_route']);
         $expected = [
             'controller' => 'Controller',
             'action' => 'action',
@@ -2012,6 +2046,7 @@ class RouterTest extends TestCase
         Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
 
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['home'],
             'plugin' => null,
@@ -2022,6 +2057,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/pages/home/', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['home'],
             'plugin' => null,
@@ -2035,6 +2071,7 @@ class RouterTest extends TestCase
         Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
 
         $result = Router::parseRequest($this->makeRequest('/', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => ['home'],
             'plugin' => null,
@@ -2048,6 +2085,7 @@ class RouterTest extends TestCase
         Router::connect('/', ['controller' => 'Posts', 'action' => 'index']);
         Router::connect('/pages/*', ['controller' => 'Pages', 'action' => 'display']);
         $result = Router::parseRequest($this->makeRequest('/pages/contact/', 'GET'));
+        unset($result['_route']);
 
         $expected = [
             'pass' => ['contact'],
@@ -2101,6 +2139,7 @@ class RouterTest extends TestCase
         );
 
         $result = Router::parseRequest($this->makeRequest('/blog/other', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => null,
             'controller' => 'BlogPosts',
@@ -2256,6 +2295,7 @@ class RouterTest extends TestCase
         Router::setRequest($request);
 
         $result = Router::parseRequest($this->makeRequest('/admin/Posts/', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'prefix' => 'Admin',
@@ -2267,6 +2307,7 @@ class RouterTest extends TestCase
         $this->assertEquals($expected, $result);
 
         $result = Router::parseRequest($this->makeRequest('/admin/Posts', 'GET'));
+        unset($result['_route']);
         $this->assertEquals($expected, $result);
 
         $result = Router::url(['prefix' => 'Admin', 'controller' => 'Posts']);
@@ -2288,6 +2329,7 @@ class RouterTest extends TestCase
         Router::setRequest($request);
 
         $result = Router::parseRequest($this->makeRequest('/members/Posts/index', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'prefix' => 'Members',
@@ -2388,6 +2430,7 @@ class RouterTest extends TestCase
         Router::connect('/{locale}/{controller}/{action}/*', [], ['locale' => 'dan|eng']);
 
         $result = Router::parseRequest($this->makeRequest('/eng/Test/testAction', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'locale' => 'eng',
@@ -2439,6 +2482,7 @@ class RouterTest extends TestCase
             ['routeClass' => 'PluginShortRoute', 'slug' => '[a-z_-]+']
         );
         $result = Router::parseRequest($this->makeRequest('/the-best', 'GET'));
+        unset($result['_route']);
         $expected = [
             'plugin' => 'TestPlugin',
             'controller' => 'TestPlugin',
@@ -2784,6 +2828,7 @@ class RouterTest extends TestCase
         $this->assertSame('/blog/actions/', $result);
 
         $result = $route->parseRequest($this->makeRequest('/blog/other', 'GET'));
+        unset($result['_route']);
         $expected = [
             'controller' => 'BlogPosts',
             'action' => 'other',
@@ -3053,6 +3098,7 @@ class RouterTest extends TestCase
     {
         Router::connect('/admin/articles/view', 'Admin/Articles::view');
         $result = Router::parseRequest($this->makeRequest('/admin/articles/view', 'GET'));
+        unset($result['_route']);
         $expected = [
             'pass' => [],
             'prefix' => 'Admin',


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/16155

The route sets `_route` to itself when parsing and RouterMiddleware consumes it while setting the `route` attribute.

This will add `route` to the list of reserved request attributes.