### PR TITLE
5.x - Allow disabling foreign key on association level.

### DIFF
--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -56,6 +56,20 @@ class BelongsTo extends Association
     }
 
     /**
+     * Sets the name of the field representing the foreign key to the target table.
+     *
+     * @param array<string>|string|false $key the key or keys to be used to link both tables together, if set to `false`
+     *  no join conditions will be generated automatically.
+     * @return $this
+     */
+    public function setForeignKey(array|string|false $key)
+    {
+        $this->_foreignKey = $key;
+
+        return $this;
+    }
+
+    /**
      * Handle cascading deletes.
      *
      * BelongsTo associations are never cleared in a cascading delete scenario.

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -54,6 +54,20 @@ class HasOne extends Association
     }
 
     /**
+     * Sets the name of the field representing the foreign key to the target table.
+     *
+     * @param array<string>|string|false $key the key or keys to be used to link both tables together, if set to `false`
+     *  no join conditions will be generated automatically.
+     * @return $this
+     */
+    public function setForeignKey(array|string|false $key)
+    {
+        $this->_foreignKey = $key;
+
+        return $this;
+    }
+
+    /**
      * Returns default property name based on association name.
      *
      * @return string

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -105,6 +105,29 @@ class BelongsToTest extends TestCase
     }
 
     /**
+     * Tests that the default foreign key condition generation can be disabled.
+     */
+    public function testDisableForeignKey(): void
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $assoc = $table
+            ->belongsTo('Authors')
+            ->setForeignKey('author_id');
+
+        $article = $table->find()->contain(['Authors'])->orderAsc('Articles.id')->first();
+        $this->assertSame('mariano', $article->author->name);
+
+        $assoc
+            ->setForeignKey(false)
+            ->setConditions([
+                'Authors.name' => 'larry',
+            ]);
+
+        $article = $table->find()->contain(['Authors'])->orderAsc('Articles.id')->first();
+        $this->assertSame('larry', $article->author->name);
+    }
+
+    /**
      * Test that foreignKey generation ignores database names in target table.
      */
     public function testForeignKeyIgnoreDatabaseName(): void

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -77,6 +77,29 @@ class HasOneTest extends TestCase
     }
 
     /**
+     * Tests that the default foreign key condition generation can be disabled.
+     */
+    public function testDisableForeignKey(): void
+    {
+        $table = $this->getTableLocator()->get('Users');
+        $assoc = $table
+            ->hasOne('Profiles')
+            ->setForeignKey('user_id');
+
+        $user = $table->find()->contain(['Profiles'])->orderAsc('Users.id')->first();
+        $this->assertSame('mariano', $user->profile->first_name);
+
+        $assoc
+            ->setForeignKey(false)
+            ->setConditions([
+                'Profiles.first_name' => 'larry',
+            ]);
+
+        $user = $table->find()->contain(['Profiles'])->orderAsc('Users.id')->first();
+        $this->assertSame('larry', $user->profile->first_name);
+    }
+
+    /**
      * Tests that the association reports it can be joined
      */
     public function testCanBeJoined(): void


### PR DESCRIPTION
This is already possible on the fly using the `foreignKey` option for
`contain()`, and while not reflected by the method arguments, was
technically already possible before native types were introduced.