### PR TITLE
Add ResultSetFactory.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -131,6 +131,13 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     protected ?int $_resultsCount = null;
 
     /**
+     * Resultset factory
+     *
+     * @var \Cake\ORM\ResultSetFactory
+     */
+    protected ResultSetFactory $resultSetFactory;
+
+    /**
      * Constructor
      *
      * @param \Cake\Database\Connection $connection The connection object
@@ -1129,7 +1136,21 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         $results = $this->execute()->fetchAll(StatementInterface::FETCH_TYPE_ASSOC);
         $results = $this->getEagerLoader()->loadExternal($this, $results);
 
-        return new ResultSet($this, $results);
+        return $this->resultSetFactory()->createResultSet($this, $results);
+    }
+
+    /**
+     * Get resultset factory.
+     *
+     * @return \Cake\ORM\ResultSetFactory
+     */
+    protected function resultSetFactory(): ResultSetFactory
+    {
+        if (isset($this->resultSetFactory)) {
+            return $this->resultSetFactory;
+        }
+
+        return $this->resultSetFactory = new ResultSetFactory();
     }
 
     /**

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -16,16 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
-use Cake\Collection\Collection;
 use Cake\Collection\CollectionTrait;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetInterface;
 use SplFixedArray;
 
 /**
- * Represents the results obtained after executing a query for a specific table
- * This object is responsible for correctly nesting result keys reported from
- * the query and hydrating entities.
+ * Represents the results obtained after executing a query for a specific table.
  */
 class ResultSet implements ResultSetInterface
 {
@@ -46,48 +43,11 @@ class ResultSet implements ResultSetInterface
     protected EntityInterface|array $_current = [];
 
     /**
-     * Default table instance
+     * Holds the count of records in this result set
      *
-     * @var \Cake\ORM\Table
+     * @var int
      */
-    protected Table $_defaultTable;
-
-    /**
-     * The default table alias
-     *
-     * @var string
-     */
-    protected string $_defaultAlias;
-
-    /**
-     * List of associations that should be placed under the `_matchingData`
-     * result key.
-     *
-     * @var array
-     */
-    protected array $_matchingMap = [];
-
-    /**
-     * List of associations that should be eager loaded.
-     *
-     * @var array
-     */
-    protected array $_containMap = [];
-
-    /**
-     * Map of fields that are fetched with their type and the table they belong to.
-     *
-     * @var array
-     */
-    protected array $_map = [];
-
-    /**
-     * List of matching associations and the column keys to expect
-     * from each of them.
-     *
-     * @var array
-     */
-    protected array $_matchingMapColumns = [];
+    protected int $_count = 0;
 
     /**
      * Results that have been fetched or hydrated into the results.
@@ -97,55 +57,13 @@ class ResultSet implements ResultSetInterface
     protected SplFixedArray $_results;
 
     /**
-     * Whether to hydrate results into entities.
-     *
-     * @var bool
-     */
-    protected bool $_hydrate = true;
-
-    /**
-     * Tracks value of $_autoFields property of $query passed to constructor.
-     *
-     * @var bool|null
-     */
-    protected ?bool $_autoFields = null;
-
-    /**
-     * The fully namespaced name of the class to use for hydrating results.
-     *
-     * @var string
-     */
-    protected string $_entityClass;
-
-    /**
-     * Holds the count of records in this result set
-     *
-     * @var int
-     */
-    protected int $_count = 0;
-
-    /**
      * Constructor
      *
-     * @param \Cake\ORM\Query $query Query from where results came.
      * @param array $results Results array.
      */
-    public function __construct(Query $query, array $results)
+    public function __construct(array $results)
     {
-        $this->_defaultTable = $query->getRepository();
-        $this->_hydrate = $query->isHydrationEnabled();
-        $this->_autoFields = $query->isAutoFieldsEnabled();
-
-        $this->_entityClass = $this->_defaultTable->getEntityClass();
-        $this->_defaultAlias = $this->_defaultTable->getAlias();
-
-        $this->_calculateAssociationMap($query);
-        $this->_calculateColumnMap($query);
-
         $this->__unserialize($results);
-        foreach ($this->_results as $i => $row) {
-            $this->_results[$i] = $this->_groupResult($row);
-        }
     }
 
     /**
@@ -276,173 +194,6 @@ class ResultSet implements ResultSetInterface
     public function isEmpty(): bool
     {
         return !$this->_count;
-    }
-
-    /**
-     * Calculates the list of associations that where eager loaded for this query.
-     *
-     * @param \Cake\ORM\Query $query The query from where to derive the associations.
-     * @return void
-     */
-    protected function _calculateAssociationMap(Query $query): void
-    {
-        $map = $query->getEagerLoader()->associationsMap($this->_defaultTable);
-        $this->_matchingMap = (new Collection($map))
-            ->match(['matching' => true])
-            ->indexBy('alias')
-            ->toArray();
-
-        $this->_containMap = (new Collection(array_reverse($map)))
-            ->match(['matching' => false])
-            ->indexBy('nestKey')
-            ->toArray();
-    }
-
-    /**
-     * Creates a map of row keys out of the query's select clause that can be
-     * used to hydrate nested result sets more quickly.
-     *
-     * @param \Cake\ORM\Query $query The query from where to derive the column map.
-     * @return void
-     */
-    protected function _calculateColumnMap(Query $query): void
-    {
-        $map = [];
-        foreach ($query->clause('select') as $key => $field) {
-            $key = trim($key, '"`[]');
-
-            if (strpos($key, '__') <= 0) {
-                $map[$this->_defaultAlias][$key] = $key;
-                continue;
-            }
-
-            $parts = explode('__', $key, 2);
-            $map[$parts[0]][$key] = $parts[1];
-        }
-
-        foreach ($this->_matchingMap as $alias => $assoc) {
-            if (!isset($map[$alias])) {
-                continue;
-            }
-            $this->_matchingMapColumns[$alias] = $map[$alias];
-            unset($map[$alias]);
-        }
-
-        $this->_map = $map;
-    }
-
-    /**
-     * Correctly nests results keys including those coming from associations.
-     *
-     * Hyrate row array into entity if hydration is enabled.
-     *
-     * @param array $row Array containing columns and values.
-     * @return \Cake\Datasource\EntityInterface|array
-     */
-    protected function _groupResult(array $row): EntityInterface|array
-    {
-        $defaultAlias = $this->_defaultAlias;
-        $results = $presentAliases = [];
-        $options = [
-            'useSetters' => false,
-            'markClean' => true,
-            'markNew' => false,
-            'guard' => false,
-        ];
-
-        foreach ($this->_matchingMapColumns as $alias => $keys) {
-            $matching = $this->_matchingMap[$alias];
-            $results['_matchingData'][$alias] = array_combine(
-                $keys,
-                array_intersect_key($row, $keys)
-            );
-            if ($this->_hydrate) {
-                /** @var \Cake\ORM\Table $table */
-                $table = $matching['instance'];
-                $options['source'] = $table->getRegistryAlias();
-                /** @var \Cake\Datasource\EntityInterface $entity */
-                $entity = new $matching['entityClass']($results['_matchingData'][$alias], $options);
-                $results['_matchingData'][$alias] = $entity;
-            }
-        }
-
-        foreach ($this->_map as $table => $keys) {
-            $results[$table] = array_combine($keys, array_intersect_key($row, $keys));
-            $presentAliases[$table] = true;
-        }
-
-        // If the default table is not in the results, set
-        // it to an empty array so that any contained
-        // associations hydrate correctly.
-        $results[$defaultAlias] = $results[$defaultAlias] ?? [];
-
-        unset($presentAliases[$defaultAlias]);
-
-        foreach ($this->_containMap as $assoc) {
-            $alias = $assoc['nestKey'];
-
-            if ($assoc['canBeJoined'] && empty($this->_map[$alias])) {
-                continue;
-            }
-
-            /** @var \Cake\ORM\Association $instance */
-            $instance = $assoc['instance'];
-
-            if (!$assoc['canBeJoined'] && !isset($row[$alias])) {
-                $results = $instance->defaultRowValue($results, $assoc['canBeJoined']);
-                continue;
-            }
-
-            if (!$assoc['canBeJoined']) {
-                $results[$alias] = $row[$alias];
-            }
-
-            $target = $instance->getTarget();
-            $options['source'] = $target->getRegistryAlias();
-            unset($presentAliases[$alias]);
-
-            if ($assoc['canBeJoined'] && $this->_autoFields !== false) {
-                $hasData = false;
-                foreach ($results[$alias] as $v) {
-                    if ($v !== null && $v !== []) {
-                        $hasData = true;
-                        break;
-                    }
-                }
-
-                if (!$hasData) {
-                    $results[$alias] = null;
-                }
-            }
-
-            if ($this->_hydrate && $results[$alias] !== null && $assoc['canBeJoined']) {
-                $entity = new $assoc['entityClass']($results[$alias], $options);
-                $results[$alias] = $entity;
-            }
-
-            $results = $instance->transformRow($results, $alias, $assoc['canBeJoined'], $assoc['targetProperty']);
-        }
-
-        foreach ($presentAliases as $alias => $present) {
-            if (!isset($results[$alias])) {
-                continue;
-            }
-            $results[$defaultAlias][$alias] = $results[$alias];
-        }
-
-        if (isset($results['_matchingData'])) {
-            $results[$defaultAlias]['_matchingData'] = $results['_matchingData'];
-        }
-
-        $options['source'] = $this->_defaultTable->getRegistryAlias();
-        if (isset($results[$defaultAlias])) {
-            $results = $results[$defaultAlias];
-        }
-        if ($this->_hydrate && !($results instanceof EntityInterface)) {
-            $results = new $this->_entityClass($results, $options);
-        }
-
-        return $results;
     }
 
     /**

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM;
+
+use Cake\Collection\Collection;
+use Cake\Datasource\EntityInterface;
+
+/**
+ * Factory class for generation ResulSet instances.
+ *
+ * It is responsible for correctly nesting result keys reported from the query
+ * and hydrating entities.
+ */
+class ResultSetFactory
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\ORM\Query $query Query from where results came.
+     * @param array $results Results array.
+     */
+    public function createResultSet(Query $query, array $results): ResultSet
+    {
+        $data = $this->collectData($query);
+
+        foreach ($results as $i => $row) {
+            $results[$i] = $this->groupResult($row, $data);
+        }
+
+        return new ResultSet($results);
+    }
+
+    /**
+     * Get repository and it's associations data for nesting results key and
+     * entity hydration.
+     *
+     * @param \Cake\ORM\Query $query The query from where to derive the data.
+     * @return array
+     */
+    protected function collectData(Query $query): array
+    {
+        $primaryTable = $query->getRepository();
+        $data = [
+            'primaryAlias' => $primaryTable->getAlias(),
+            'registryAlias' => $primaryTable->getRegistryAlias(),
+            'entityClass' => $primaryTable->getEntityClass(),
+            'hydrate' => $query->isHydrationEnabled(),
+            'autoFields' => $query->isAutoFieldsEnabled(),
+            'matchingColumns' => [],
+        ];
+
+        $assocMap = $query->getEagerLoader()->associationsMap($primaryTable);
+        $data['matchingAssoc'] = (new Collection($assocMap))
+            ->match(['matching' => true])
+            ->indexBy('alias')
+            ->toArray();
+
+        $data['containAssoc'] = (new Collection(array_reverse($assocMap)))
+            ->match(['matching' => false])
+            ->indexBy('nestKey')
+            ->toArray();
+
+        $fields = [];
+        foreach ($query->clause('select') as $key => $field) {
+            $key = trim($key, '"`[]');
+
+            if (strpos($key, '__') <= 0) {
+                $fields[$data['primaryAlias']][$key] = $key;
+                continue;
+            }
+
+            $parts = explode('__', $key, 2);
+            $fields[$parts[0]][$key] = $parts[1];
+        }
+
+        foreach ($data['matchingAssoc'] as $alias => $assoc) {
+            if (!isset($fields[$alias])) {
+                continue;
+            }
+            $data['matchingColumns'][$alias] = $fields[$alias];
+            unset($fields[$alias]);
+        }
+
+        $data['fields'] = $fields;
+
+        return $data;
+    }
+
+    /**
+     * Correctly nests results keys including those coming from associations.
+     *
+     * Hyrate row array into entity if hydration is enabled.
+     *
+     * @param array $row Array containing columns and values.
+     * @return \Cake\Datasource\EntityInterface|array
+     */
+    protected function groupResult(array $row, array $data): EntityInterface|array
+    {
+        $results = $presentAliases = [];
+        $options = [
+            'useSetters' => false,
+            'markClean' => true,
+            'markNew' => false,
+            'guard' => false,
+        ];
+
+        foreach ($data['matchingColumns'] as $alias => $keys) {
+            $matching = $data['matchingAssoc'][$alias];
+            $results['_matchingData'][$alias] = array_combine(
+                $keys,
+                array_intersect_key($row, $keys)
+            );
+            if ($data['hydrate']) {
+                /** @var \Cake\ORM\Table $table */
+                $table = $matching['instance'];
+                $options['source'] = $table->getRegistryAlias();
+                /** @var \Cake\Datasource\EntityInterface $entity */
+                $entity = new $matching['entityClass']($results['_matchingData'][$alias], $options);
+                $results['_matchingData'][$alias] = $entity;
+            }
+        }
+
+        foreach ($data['fields'] as $table => $keys) {
+            $results[$table] = array_combine($keys, array_intersect_key($row, $keys));
+            $presentAliases[$table] = true;
+        }
+
+        // If the default table is not in the results, set
+        // it to an empty array so that any contained
+        // associations hydrate correctly.
+        $results[$data['primaryAlias']] = $results[$data['primaryAlias']] ?? [];
+
+        unset($presentAliases[$data['primaryAlias']]);
+
+        foreach ($data['containAssoc'] as $assoc) {
+            $alias = $assoc['nestKey'];
+
+            if ($assoc['canBeJoined'] && empty($data['fields'][$alias])) {
+                continue;
+            }
+
+            /** @var \Cake\ORM\Association $instance */
+            $instance = $assoc['instance'];
+
+            if (!$assoc['canBeJoined'] && !isset($row[$alias])) {
+                $results = $instance->defaultRowValue($results, $assoc['canBeJoined']);
+                continue;
+            }
+
+            if (!$assoc['canBeJoined']) {
+                $results[$alias] = $row[$alias];
+            }
+
+            $target = $instance->getTarget();
+            $options['source'] = $target->getRegistryAlias();
+            unset($presentAliases[$alias]);
+
+            if ($assoc['canBeJoined'] && $data['autoFields'] !== false) {
+                $hasData = false;
+                foreach ($results[$alias] as $v) {
+                    if ($v !== null && $v !== []) {
+                        $hasData = true;
+                        break;
+                    }
+                }
+
+                if (!$hasData) {
+                    $results[$alias] = null;
+                }
+            }
+
+            if ($data['hydrate'] && $results[$alias] !== null && $assoc['canBeJoined']) {
+                $entity = new $assoc['entityClass']($results[$alias], $options);
+                $results[$alias] = $entity;
+            }
+
+            $results = $instance->transformRow($results, $alias, $assoc['canBeJoined'], $assoc['targetProperty']);
+        }
+
+        foreach ($presentAliases as $alias => $present) {
+            if (!isset($results[$alias])) {
+                continue;
+            }
+            $results[$data['primaryAlias']][$alias] = $results[$alias];
+        }
+
+        if (isset($results['_matchingData'])) {
+            $results[$data['primaryAlias']]['_matchingData'] = $results['_matchingData'];
+        }
+
+        $options['source'] = $data['registryAlias'];
+        if (isset($results[$data['primaryAlias']])) {
+            $results = $results[$data['primaryAlias']];
+        }
+        if ($data['hydrate'] && !($results instanceof EntityInterface)) {
+            $results = new $data['entityClass']($results, $options);
+        }
+
+        return $results;
+    }
+}

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -461,7 +461,7 @@ class HasManyTest extends TestCase
             ->with('all')
             ->will($this->returnValue($query));
 
-        $results = new ResultSet($query, []);
+        $results = new ResultSet([]);
 
         $results->__unserialize([
             ['id' => 1, 'title' => 'article 1', 'author_id' => 2, 'site_id' => 10],

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -853,7 +853,7 @@ class QueryTest extends TestCase
     {
         $query = new Query($this->connection, $this->table);
 
-        $results = new ResultSet($query, []);
+        $results = new ResultSet([]);
         $query->setResult($results);
         $this->assertSame($results, $query->all());
 
@@ -1795,7 +1795,7 @@ class QueryTest extends TestCase
             ->onlyMethods(['execute'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
-        $resultSet = new ResultSet($query, []);
+        $resultSet = new ResultSet([]);
 
         $query->expects($this->never())
             ->method('execute');

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -1,0 +1,243 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Database\Log\QueryLogger;
+use Cake\Datasource\ConnectionManager;
+use Cake\Log\Log;
+use Cake\ORM\ResultSetFactory;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ResultSetFactory test case.
+ */
+class ResultSetFactoryTest extends TestCase
+{
+    /**
+     * @var array<string>
+     */
+    protected array $fixtures = ['core.Articles', 'core.Authors', 'core.Comments'];
+
+    /**
+     * @var \Cake\ORM\Table
+     */
+    protected $table;
+
+    /**
+     * @var array
+     */
+    protected $fixtureData;
+
+    /**
+     * @var \Cake\Datasource\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * @var \Cake\ORM\ResultSetFactory
+     */
+    protected $factory;
+
+    /**
+     * setup
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+        $this->table = new Table([
+            'table' => 'articles',
+            'connection' => $this->connection,
+        ]);
+        $this->factory = new ResultSetFactory();
+
+        $this->fixtureData = [
+            ['id' => 1, 'author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
+            ['id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+            ['id' => 3, 'author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y'],
+        ];
+    }
+
+    /**
+     * Tests __debugInfo
+     */
+    public function testDebugInfo(): void
+    {
+        $query = $this->table->find('all');
+        $results = $query->all();
+        $expected = [
+            'items' => $results->toArray(),
+        ];
+        $this->assertSame($expected, $results->__debugInfo());
+    }
+
+    /**
+     * Test that eagerLoader leaves empty associations unpopulated.
+     */
+    public function testBelongsToEagerLoaderLeavesEmptyAssociation(): void
+    {
+        $comments = $this->getTableLocator()->get('Comments');
+        $comments->belongsTo('Articles');
+
+        // Clear the articles table so we can trigger an empty belongsTo
+        $this->table->deleteAll([]);
+
+        $comment = $comments->find()->where(['Comments.id' => 1])
+            ->contain(['Articles'])
+            ->enableHydration(false)
+            ->first();
+        $this->assertSame(1, $comment['id']);
+        $this->assertNotEmpty($comment['comment']);
+        $this->assertNull($comment['article']);
+
+        $comment = $comments->get(1, ['contain' => ['Articles']]);
+        $this->assertNull($comment->article);
+        $this->assertSame(1, $comment->id);
+        $this->assertNotEmpty($comment->comment);
+    }
+
+    /**
+     * Test showing associated record is preserved when selecting only field with
+     * null value if auto fields is disabled.
+     */
+    public function testBelongsToEagerLoaderWithAutoFieldsFalse(): void
+    {
+        $authors = $this->getTableLocator()->get('Authors');
+
+        $author = $authors->newEntity(['name' => null]);
+        $authors->save($author);
+
+        $articles = $this->getTableLocator()->get('Articles');
+        $articles->belongsTo('Authors');
+
+        $article = $articles->newEntity([
+            'author_id' => $author->id,
+            'title' => 'article with author with null name',
+        ]);
+        $articles->save($article);
+
+        $result = $articles->find()
+            ->select(['Articles.id', 'Articles.title', 'Authors.name'])
+            ->contain(['Authors'])
+            ->where(['Articles.id' => $article->id])
+            ->disableAutoFields()
+            ->enableHydration(false)
+            ->first();
+
+        $this->assertNotNull($result['author']);
+    }
+
+    /**
+     * Test that eagerLoader leaves empty associations unpopulated.
+     */
+    public function testHasOneEagerLoaderLeavesEmptyAssociation(): void
+    {
+        $this->table->hasOne('Comments');
+
+        // Clear the comments table so we can trigger an empty hasOne.
+        $comments = $this->getTableLocator()->get('Comments');
+        $comments->deleteAll([]);
+
+        $article = $this->table->get(1, ['contain' => ['Comments']]);
+        $this->assertNull($article->comment);
+        $this->assertSame(1, $article->id);
+        $this->assertNotEmpty($article->title);
+
+        $article = $this->table->find()->where(['articles.id' => 1])
+            ->contain(['Comments'])
+            ->enableHydration(false)
+            ->first();
+        $this->assertNull($article['comment']);
+        $this->assertSame(1, $article['id']);
+        $this->assertNotEmpty($article['title']);
+    }
+
+    /**
+     * Test that fetching rows does not fail when no fields were selected
+     * on the default alias.
+     */
+    public function testFetchMissingDefaultAlias(): void
+    {
+        $comments = $this->getTableLocator()->get('Comments');
+        $query = $comments->find()->select(['Other__field' => 'test']);
+        $query->disableAutoFields();
+
+        $row = ['Other__field' => 'test'];
+        $statement = $this->getMockBuilder('Cake\Database\StatementInterface')->getMock();
+        $statement->method('fetchAll')
+            ->will($this->returnValue([$row]));
+
+        $results = $this->factory->createResultSet($query, $statement->fetchAll());
+        $this->assertNotEmpty($results);
+    }
+
+    /**
+     * Test that associations have source() correctly set.
+     */
+    public function testSourceOnContainAssociations(): void
+    {
+        $this->loadPlugins(['TestPlugin']);
+        $comments = $this->getTableLocator()->get('TestPlugin.Comments');
+        $comments->belongsTo('Authors', [
+            'className' => 'TestPlugin.Authors',
+            'foreignKey' => 'user_id',
+        ]);
+        $result = $comments->find()->contain(['Authors'])->first();
+        $this->assertSame('TestPlugin.Comments', $result->getSource());
+        $this->assertSame('TestPlugin.Authors', $result->author->getSource());
+
+        $result = $comments->find()->matching('Authors', function ($q) {
+            return $q->where(['Authors.id' => 1]);
+        })->first();
+        $this->assertSame('TestPlugin.Comments', $result->getSource());
+        $this->assertSame('TestPlugin.Authors', $result->_matchingData['Authors']->getSource());
+        $this->clearPlugins();
+    }
+
+    /**
+     * @see https://github.com/cakephp/cakephp/issues/14676
+     */
+    public function testQueryLoggingForSelectsWithZeroRows(): void
+    {
+        Log::setConfig('queries', ['className' => 'Array']);
+
+        $defaultLogger = $this->connection->getLogger();
+        $queryLogging = $this->connection->isQueryLoggingEnabled();
+
+        $logger = new QueryLogger();
+        $this->connection->setLogger($logger);
+        $this->connection->enableQueryLogging(true);
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(0, $messages);
+
+        $results = $this->table->find('all')
+            ->where(['id' => 0])
+            ->all();
+
+        $this->assertCount(0, $results);
+
+        $messages = Log::engine('queries')->read();
+        $message = array_pop($messages);
+        $this->assertStringContainsString('SELECT', $message);
+
+        $this->connection->setLogger($defaultLogger);
+        $this->connection->enableQueryLogging($queryLogging);
+        Log::reset();
+    }
+}


### PR DESCRIPTION
The code for keys nesting and entities hydration has been extracted
from ResultSet into ResultFactory.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
