### PR TITLE
Fix PHPStan found issues around mixed and object usage.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -465,6 +465,7 @@ class FileEngine extends CacheEngine
             $directoryIterator,
             RecursiveIteratorIterator::CHILD_FIRST
         );
+        /** @var array<SplFileInfo> $filtered */
         $filtered = new CallbackFilterIterator(
             $contents,
             function (SplFileInfo $current) use ($group, $prefix) {

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -465,7 +465,7 @@ class FileEngine extends CacheEngine
             $directoryIterator,
             RecursiveIteratorIterator::CHILD_FIRST
         );
-        /** @var array<SplFileInfo> $filtered */
+        /** @var array<\SplFileInfo> $filtered */
         $filtered = new CallbackFilterIterator(
             $contents,
             function (SplFileInfo $current) use ($group, $prefix) {

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -567,7 +567,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function bundleTranslatedFields(EntityInterface $entity): void
     {
-        /** @var array<string, \Cake\Datasource\EntityInterface> $translations */
+        /** @var array<string, \Cake\ORM\Entity> $translations */
         $translations = (array)$entity->get('_translations');
 
         if (empty($translations) && !$entity->isDirty('_translations')) {

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -567,6 +567,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function bundleTranslatedFields(EntityInterface $entity): void
     {
+        /** @var array<string, \Cake\Datasource\EntityInterface> $translations */
         $translations = (array)$entity->get('_translations');
 
         if (empty($translations) && !$entity->isDirty('_translations')) {


### PR DESCRIPTION
I was looking into https://tomasvotruba.com/blog/not-all-mixed-types-are-equally-useless/#How-detect-Object-mixed-with-PHPStan
and found 175 issues after I fixed the first it found (correctly).
Some might be false positives or not a big deal, but usually all 175 remaining issues indicate that phpstan cannot find the object type here.

Here the list of remaining issues:

```
 ------ --------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Collection)  
 ------ --------------------------------------------------------------------------------- 
  845    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `next()`.                    
  846    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `valid()`.                   
  849    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `current()`.                 
  868    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `next()`.                    
  869    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `valid()`.                   
  873    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `current()`.                 
  873    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `key()`.                     
  875    Anonymous variables in a method call can lead to false dead methods.             
         Make sure the variable type is known in method name `current()`.                 
 ------ --------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Iterator\TreeIterator)  
 ------ -------------------------------------------------------------------------------------------- 
  845    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `next()`.                               
  846    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `valid()`.                              
  849    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `current()`.                            
  868    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `next()`.                               
  869    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `valid()`.                              
  873    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `current()`.                            
  873    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `key()`.                                
  875    Anonymous variables in a method call can lead to false dead methods.                        
         Make sure the variable type is known in method name `current()`.                            
 ------ -------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Iterator\TreePrinter)  
 ------ ------------------------------------------------------------------------------------------- 
  845    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `next()`.                              
  846    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `valid()`.                             
  849    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `current()`.                           
  868    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `next()`.                              
  869    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `valid()`.                             
  873    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `current()`.                           
  873    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `key()`.                               
  875    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `current()`.                           
 ------ ------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Iterator\ZipIterator)  
 ------ ------------------------------------------------------------------------------------------- 
  845    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `next()`.                              
  846    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `valid()`.                             
  849    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `current()`.                           
  868    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `next()`.                              
  869    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `valid()`.                             
  873    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `current()`.                           
  873    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `key()`.                               
  875    Anonymous variables in a method call can lead to false dead methods.                       
         Make sure the variable type is known in method name `current()`.                           
 ------ ------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\ORM\ResultSet)  
 ------ ------------------------------------------------------------------------- 
  845    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `next()`.            
  846    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `valid()`.           
  849    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `current()`.         
  868    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `next()`.            
  869    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `valid()`.           
  873    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `current()`.         
  873    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `key()`.             
  875    Anonymous variables in a method call can lead to false dead methods.     
         Make sure the variable type is known in method name `current()`.         
 ------ ------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Command/CompletionCommand.php                                         
 ------ ---------------------------------------------------------------------- 
  209    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `options()`.      
  211    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `short()`.        
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Core/StaticConfigTrait.php (in context of class Cake\Mailer\Mailer)   
 ------ ---------------------------------------------------------------------- 
  159    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `unload()`.       
 ------ ---------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------- 
  Line   Database/Driver/SqlDialectTrait.php (in context of class Cake\Database\Driver\Mysql)  
 ------ -------------------------------------------------------------------------------------- 
  234    Anonymous variables in a method call can lead to false dead methods.                  
         Make sure the variable type is known in method name `traverse()`.                     
 ------ -------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------- 
  Line   Database/Driver/SqlDialectTrait.php (in context of class Cake\Database\Driver\Postgres)  
 ------ ----------------------------------------------------------------------------------------- 
  234    Anonymous variables in a method call can lead to false dead methods.                     
         Make sure the variable type is known in method name `traverse()`.                        
 ------ ----------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   Database/Driver/SqlDialectTrait.php (in context of class Cake\Database\Driver\Sqlite)  
 ------ --------------------------------------------------------------------------------------- 
  234    Anonymous variables in a method call can lead to false dead methods.                   
         Make sure the variable type is known in method name `traverse()`.                      
 ------ --------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------ 
  Line   Database/Driver/SqlDialectTrait.php (in context of class Cake\Database\Driver\Sqlserver)  
 ------ ------------------------------------------------------------------------------------------ 
  234    Anonymous variables in a method call can lead to false dead methods.                      
         Make sure the variable type is known in method name `traverse()`.                         
 ------ ------------------------------------------------------------------------------------------ 

 ------ ----------------------------------------------------------------------- 
  Line   Database/Driver/Sqlserver.php                                          
 ------ ----------------------------------------------------------------------- 
  346    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `iterateParts()`.  
  416    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `add()`.           
  416    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `add()`.           
  416    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `add()`.           
  416    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `add()`.           
  416    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `newExpr()`.       
  416    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `setConjunction()`.                                                    
  418    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `add()`.           
  418    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `newExpr()`.       
  418    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `setConjunction()`.                                                    
 ------ ----------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Database/Query.php                                                    
 ------ ---------------------------------------------------------------------- 
  1326   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
  1360   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
  1666   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setColumns()`.   
  1740   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
  1804   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
  1811   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
  1819   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `eq()`.           
  2291   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getConjunction()`.                                                   
  2292   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Database/QueryCompiler.php                                            
 ------ ---------------------------------------------------------------------- 
  176    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `isRecursive()`.  
  177    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `sql()`.          
  312    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `sql()`.          
  312    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `sql()`.          
  355    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `sql()`.          
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Database/SqlserverCompiler.php                                        
 ------ ---------------------------------------------------------------------- 
  75     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `sql()`.          
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Database/Type/DateTimeType.php                                        
 ------ ---------------------------------------------------------------------- 
  152    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getName()`.      
  152    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getTimezone()`.  
  157    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setTimezone()`.  
  160    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `format()`.       
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Event/EventManager.php                                                
 ------ ---------------------------------------------------------------------- 
  473    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getSubject()`.   
  474    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getName()`.      
  476    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getName()`.      
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Http/Client/Adapter/Mock.php                                          
 ------ ---------------------------------------------------------------------- 
  81     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getMethod()`.    
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Http/ServerRequestFactory.php                                         
 ------ ---------------------------------------------------------------------- 
  171    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getError()`.     
  174    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getMetadata()`.  
  174    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getStream()`.    
  179    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getClientFilename()`.                                                
  180    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getClientMediaType()`.                                               
  181    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getSize()`.      
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   I18n/RelativeTimeFormatter.php                                        
 ------ ---------------------------------------------------------------------- 
  107    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `format()`.       
  329    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `format()`.       
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   I18n/TranslatorRegistry.php                                           
 ------ ---------------------------------------------------------------------- 
  204    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getPackage()`.   
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Log/Log.php                                                           
 ------ ---------------------------------------------------------------------- 
  382    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `log()`.          
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Mailer/Message.php                                                    
 ------ ---------------------------------------------------------------------- 
  1180   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getClientFilename()`.                                                
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Association.php                                                   
 ------ ---------------------------------------------------------------------- 
  995    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `insert()`.       
  996    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `isHydrationEnabled()`.                                               
  998    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `clean()`.        
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Association/BelongsToMany.php                                     
 ------ ---------------------------------------------------------------------- 
  481    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `add()`.          
  757    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setErrors()`.    
  1279   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `extract()`.      
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Association/HasMany.php                                           
 ------ ---------------------------------------------------------------------- 
  236    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setErrors()`.    
  238    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setInvalid()`.   
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   ORM/Association/Loader/SelectLoader.php                                
 ------ ----------------------------------------------------------------------- 
  178    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `isHydrationEnabled()`.                                                
  179    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `isResultsCastingEnabled()`.                                           
  451    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `iterateParts()`.  
 ------ ----------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Association/Loader/SelectWithPivotLoader.php                      
 ------ ---------------------------------------------------------------------- 
  100    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `isAutoFieldsEnabled()`.                                              
  101    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `clause()`.       
  101    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `enableAutoFields()`.                                                 
  117    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `select()`.       
  117    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `where()`.        
  121    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `addToJoinsMap()`.                                                    
  121    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getEagerLoader()`.                                                   
  130    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `addDefaults()`.  
  130    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getTypeMap()`.   
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Behavior/CounterCacheBehavior.php                                 
 ------ ---------------------------------------------------------------------- 
  143    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `isDirty()`.      
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Behavior/Translate/EavStrategy.php                                
 ------ ---------------------------------------------------------------------- 
  178    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `aliasField()`.   
  178    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getRepository()`.                                                    
  178    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `where()`.        
  181    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `isAutoFieldsEnabled()`.                                              
  185    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `select()`.       
  303    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `set()`.          
  456    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `isDirty()`.      
  460    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `get()`.          
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   ORM/Behavior/Translate/ShadowTableStrategy.php                         
 ------ ----------------------------------------------------------------------- 
  253    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `count()`.         
  263    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `iterateParts()`.  
  299    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `count()`.         
  309    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `traverse()`.      
  540    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `get()`.           
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Behavior/Translate/TranslateStrategyTrait.php (in context of class Cake\ORM\Behavior\Translate\EavStrategy)  
 ------ ----------------------------------------------------------------------------------------------------------------- 
  160    Anonymous variables in a method call can lead to false dead methods.                                             
         Make sure the variable type is known in method name `get()`.                                                     
  181    Anonymous variables in a method call can lead to false dead methods.                                             
         Make sure the variable type is known in method name `setErrors()`.                                               
 ------ ----------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/LazyEagerLoader.php                                               
 ------ ---------------------------------------------------------------------- 
  78     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `method()`.       
  158    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `extract()`.      
  168    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `set()`.          
  169    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setDirty()`.     
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Marshaller.php                                                    
 ------ ---------------------------------------------------------------------- 
  417    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `extract()`.      
  700    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `extract()`.      
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Query.php                                                         
 ------ ---------------------------------------------------------------------- 
  953    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `hasNestedExpression()`.                                              
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Rule/ExistsIn.php                                                 
 ------ ---------------------------------------------------------------------- 
  85     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `hasAssociation()`.                                                   
  93     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getAssociation()`.                                                   
  103    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getPrimaryKey()`.                                                    
  127    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getSchema()`.    
  129    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getColumn()`.    
  129    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `isNullable()`.   
  137    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `aliasField()`.   
  146    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `exists()`.       
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Rule/IsUnique.php                                                 
 ------ ---------------------------------------------------------------------- 
  78     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getAlias()`.     
  81     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getPrimaryKey()`.                                                    
  88     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `exists()`.       
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Table.php                                                         
 ------ ---------------------------------------------------------------------- 
  323    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `setTable()`.     
  2269   Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `isNew()`.        
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   TestSuite/Fixture/FixtureHelper.php                                   
 ------ ---------------------------------------------------------------------- 
  289    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `constraints()`.  
  290    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `getConstraint()`.                                                    
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   TestSuite/Fixture/SchemaLoader.php                                    
 ------ ---------------------------------------------------------------------- 
  133    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `execute()`.      
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   TestSuite/Fixture/TransactionFixtureStrategy.php                      
 ------ ---------------------------------------------------------------------- 
  84     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `inTransaction()`.                                                    
  85     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `rollback()`.     
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   TestSuite/Fixture/TransactionStrategy.php                             
 ------ ---------------------------------------------------------------------- 
  89     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name                   
         `inTransaction()`.                                                    
  90     Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `rollback()`.     
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   Utility/Filesystem.php                                                
 ------ ---------------------------------------------------------------------- 
  208    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getType()`.      
  209    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getType()`.      
  211    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getPathname()`.  
  217    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `getPathname()`.  
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   Utility/Xml.php                                                        
 ------ ----------------------------------------------------------------------- 
  412    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `createElement()`.                                                     
  414    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `appendChild()`.   
  414    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `createTextNode()`.                                                    
  417    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `setAttribute()`.  
  421    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `appendChild()`.   
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   View/CellTrait.php (in context of class Cake\View\View)                
 ------ ----------------------------------------------------------------------- 
  121    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `getTheme()`.      
  123    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `getClassName()`.  
  124    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `getClassName()`.  
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   View/Form/EntityContext.php                                            
 ------ ----------------------------------------------------------------------- 
  650    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `junction()`.      
  655    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `associations()`.  
  656    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name                    
         `getByProperty()`.                                                     
  667    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `getTarget()`.     
  737    Anonymous variables in a method call can lead to false dead methods.   
         Make sure the variable type is known in method name `getErrors()`.     
 ------ ----------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   View/Widget/DateTimeWidget.php                                        
 ------ ---------------------------------------------------------------------- 
  227    Anonymous variables in a method call can lead to false dead methods.  
         Make sure the variable type is known in method name `format()`.       
 ------ ---------------------------------------------------------------------- 

```



### Reproduce
```patch
Index: phpstan.neon
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/phpstan.neon b/phpstan.neon
--- a/phpstan.neon	(revision 3dec5ef7bc8e36ea21b05b284dece8fa24b6e8a4)
+++ b/phpstan.neon	(date 1643985994126)
@@ -19,3 +19,10 @@
 		tags:
 			- phpstan.broker.methodsClassReflectionExtension
 			- phpstan.broker.propertiesClassReflectionExtension
+	-
+		class: Symplify\PHPStanRules\Rules\Explicit\NoMixedPropertyFetcherRule
+		tags: [phpstan.rules.rule]
+
+	-
+		class: Symplify\PHPStanRules\Rules\Explicit\NoMixedMethodCallerRule
+		tags: [phpstan.rules.rule]
Index: composer.json
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/composer.json b/composer.json
--- a/composer.json	(revision 3dec5ef7bc8e36ea21b05b284dece8fa24b6e8a4)
+++ b/composer.json	(date 1643985845429)
@@ -21,6 +21,7 @@
             "homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
         }
     ],
+    "minimum-stability": "dev",
     "require": {
         "php": ">=8.0",
         "ext-intl": "*",
@@ -57,7 +58,8 @@
         "cakephp/cakephp-codesniffer": "5.x-dev",
         "mikey179/vfsstream": "^1.6.10",
         "paragonie/csp-builder": "^2.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "symplify/phpstan-rules": "dev-main"
     },
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",
```