### PR TITLE
Fix mistakes in ErrorTrap HTML rendering

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -460,7 +460,7 @@ class Debugger
             if (in_array($signature, $options['exclude'], true)) {
                 continue;
             }
-            if ($options['format'] === 'points' && $trace['file'] !== '[internal]') {
+            if ($options['format'] === 'points') {
                 $back[] = ['file' => $trace['file'], 'line' => $trace['line'], 'reference' => $reference];
             } elseif ($options['format'] === 'array') {
                 $back[] = $trace;

--- a/src/Error/Renderer/HtmlErrorRenderer.php
+++ b/src/Error/Renderer/HtmlErrorRenderer.php
@@ -68,18 +68,14 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         $code = implode("\n", $excerpt);
 
         $html = <<<HTML
-<pre class="cake-error">
+<div class="cake-error">
     {$toggle}: {$description} [in <b>{$path}</b>, line <b>{$line}</b>]
-    <div id="{:id}-trace" class="cake-stack-trace" style="display: none;">
+    <div id="{$id}-trace" class="cake-stack-trace" style="display: none;">
         {$codeToggle}
-        <pre id="{$id}-code" class="cake-code-dump" style="display: none;">
-            {$code}
-        </pre>
-        <div class="cake-trace">
-            {$trace}
-        </div>
+        <pre id="{$id}-code" class="cake-code-dump" style="display: none;">{$code}</pre>
+        <pre class="cake-trace">{$trace}</pre>
     </div>
-</pre>
+</div>
 HTML;
 
         return $html;
@@ -100,7 +96,7 @@ HTML;
         // phpcs:disable
         return <<<HTML
 <a href="javascript:void(0);"
-  onclick="document.getElementById('{$selector}').style.display = (document.getElementById('{$selector}').style.display == 'none' ? '' : 'none'"
+  onclick="document.getElementById('{$selector}').style.display = (document.getElementById('{$selector}').style.display == 'none' ? '' : 'none')"
 >
     {$text}
 </a>

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -121,7 +121,7 @@ class ErrorHandlerTest extends TestCase
         $wrong = $wrong + 1;
         $result = ob_get_clean();
 
-        $this->assertMatchesRegularExpression('/<pre class="cake-error">/', $result);
+        $this->assertMatchesRegularExpression('/<div class="cake-error">/', $result);
         if (version_compare(PHP_VERSION, '8.0.0-dev', '<')) {
             $this->assertMatchesRegularExpression('/<b>Notice<\/b>/', $result);
             $this->assertMatchesRegularExpression('/variable:\s+wrong/', $result);


### PR DESCRIPTION
* Fix incorrect variable interpolation.
* Switch to a div for the error wrapper as using pre was making the
  templates harder to manage.

Part of #16228