### PR TITLE
Add deprecation to BaseErrorHandler::register()

### DIFF
--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -23,7 +23,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Throwable;
 
-
 /**
  * Base error handler that provides logic common to the CLI + web
  * error/exception handlers.

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -23,6 +23,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Throwable;
 
+
 /**
  * Base error handler that provides logic common to the CLI + web
  * error/exception handlers.
@@ -88,6 +89,12 @@ abstract class BaseErrorHandler
      */
     public function register(): void
     {
+        deprecationWarning(
+            'Use of `BaseErrorHandler` and subclasses are deprecated. ' .
+            'Upgrade to the new `ErrorTrap` and `ExceptionTrap` subsystem. ' .
+            'See https://book.cakephp.org/4/en/appendices/4-4-migration-guide.html'
+        );
+
         $level = $this->_config['errorLevel'] ?? -1;
         error_reporting($level);
         set_error_handler([$this, 'handleError'], $level);

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -263,17 +263,8 @@ class ErrorHandlerTest extends TestCase
 
         $messages = $this->logger->read();
         $this->assertMatchesRegularExpression('/^(notice|debug|warning)/', $messages[0]);
-        if (version_compare(PHP_VERSION, '8.0.0-dev', '<')) {
-            $this->assertStringContainsString(
-                'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ - 8) . ']',
-                $messages[0]
-            );
-        } else {
-            $this->assertStringContainsString(
-                'Warning (2): Undefined variable $out in [' . __FILE__ . ', line ' . (__LINE__ - 12) . ']',
-                $messages[0]
-            );
-        }
+        $this->assertMatchesRegularExpression('/Undefined variable\:? \$?out in/', $messages[0]);
+        $this->assertStringContainsString('[' . __FILE__ . ', line ' . (__LINE__ - 6) . ']', $messages[0]);
         $this->assertStringContainsString('Trace:', $messages[0]);
         $this->assertStringContainsString(__NAMESPACE__ . '\ErrorHandlerTest::testHandleErrorLoggingTrace()', $messages[0]);
         $this->assertStringContainsString('Request URL:', $messages[0]);


### PR DESCRIPTION
This may be too aggressive of a deprecation. However, the solution is to cut 7 lines from the application bootstrap and replace it with 4 lines.

This upgrade will allow DebugKit to deliver an improved deprecation panel, and makes building custom error handling easier as the renderers provide a simpler interface to implement. The upgrade also enables error rendering, logging and configuration for the entire subsystem from configuration files with no need to inherit code from the framework, hopefully giving more future proof APIs that will break less frequently.

Part of #16228 

