### PR TITLE
Add CheckHttpCache Component

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -206,6 +206,11 @@
       <code>$this-&gt;data</code>
     </ArgumentTypeCoercion>
   </file>
+  <file src="src/Http/Response.php">
+    <DeprecatedMethod occurrences="1">
+      <code>notModified</code>
+    </DeprecatedMethod>
+  </file>
   <file src="src/I18n/DateFormatTrait.php">
     <DeprecatedClass occurrences="5">
       <code>$time-&gt;timezone($timezone)</code>

--- a/src/Controller/Component/CheckHttpCacheComponent.php
+++ b/src/Controller/Component/CheckHttpCacheComponent.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Controller\Component;
+
+use Cake\Controller\Component;
+use Cake\Event\EventInterface;
+
+/**
+ * Use HTTP caching headers to see if rendering can be skipped.
+ *
+ * Checks if the response can be considered different according to the request
+ * headers, and the caching response headers. If it was not modified, then the
+ * controller and view render process is skipped. And the client will get a
+ * empty response with a "304 Not Modified" header.
+ *
+ * To use this component your controller actions must set either the `Last-Modified`
+ * or `Etag` header. Without one of these headers being set this component
+ * will have no effect.
+ */
+class CheckHttpCacheComponent extends Component
+{
+    /**
+     * Before Render hook
+     *
+     * @param \Cake\Event\EventInterface $event The Controller.beforeRender event.
+     * @return void
+     */
+    public function beforeRender(EventInterface $event): void
+    {
+        $controller = $this->getController();
+        $response = $controller->getResponse();
+        $request = $controller->getRequest();
+        if (!$response->isNotModified($request)) {
+            return;
+        }
+
+        $controller->setResponse($response->withNotModified());
+        $event->stopPropagation();
+    }
+}

--- a/src/Controller/Component/CheckHttpCacheComponent.php
+++ b/src/Controller/Component/CheckHttpCacheComponent.php
@@ -23,9 +23,9 @@ use Cake\Event\EventInterface;
  * Use HTTP caching headers to see if rendering can be skipped.
  *
  * Checks if the response can be considered different according to the request
- * headers, and the caching response headers. If it was not modified, then the
- * controller and view render process is skipped. And the client will get a
- * empty response with a "304 Not Modified" header.
+ * headers, and caching headers in the response. If the response was not modified,
+ * then the controller and view render process is skipped. And the client will get a
+ * response with an empty body and a "304 Not Modified" header.
  *
  * To use this component your controller actions must set either the `Last-Modified`
  * or `Etag` header. Without one of these headers being set this component

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -219,14 +219,10 @@ class RequestHandlerComponent extends Component
             $response = $response->withCharset(Configure::read('App.encoding'));
         }
 
-        if (
-            $this->_config['checkHttpCache'] &&
-            $response->checkNotModified($controller->getRequest())
-        ) {
-            $controller->setResponse($response);
+        $request = $controller->getRequest();
+        if ($this->_config['checkHttpCache'] && $response->isNotModified($request)) {
+            $response = $response->withNotModified();
             $event->stopPropagation();
-
-            return;
         }
 
         $controller->setResponse($response);

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -989,10 +989,15 @@ class Response implements ResponseInterface
      *
      * *Warning* This method mutates the response in-place and should be avoided.
      *
+     * @deprecated 4.4.0 Use `withNotModified()` instead.
      * @return void
      */
     public function notModified(): void
     {
+        deprecationWarning(
+            'The `notModified()` method is deprecated. ' .
+            'Use `withNotModified() instead, and remember immutability of with* methods.'
+        );
         $this->_createStream();
         $this->_setStatus(304);
 
@@ -1192,19 +1197,16 @@ class Response implements ResponseInterface
     /**
      * Checks whether a response has not been modified according to the 'If-None-Match'
      * (Etags) and 'If-Modified-Since' (last modification date) request
-     * headers. If the response is detected to be not modified, it
-     * is marked as so accordingly so the client can be informed of that.
+     * headers.
      *
-     * In order to mark a response as not modified, you need to set at least
-     * the Last-Modified etag response header before calling this method. Otherwise
-     * a comparison will not be possible.
-     *
-     * *Warning* This method mutates the response in-place and should be avoided.
+     * In order to interact with this method you must mark responses as not modified.
+     * You need to set at least one of the `Last-Modified` or `Etag` response headers
+     * before calling this method. Otherwise a comparison will not be possible.
      *
      * @param \Cake\Http\ServerRequest $request Request object
-     * @return bool Whether the response was marked as not modified or not.
+     * @return bool Whether the response is 'modified' based on cache headers.
      */
-    public function checkNotModified(ServerRequest $request): bool
+    public function isNotModified(ServerRequest $request): bool
     {
         $etags = preg_split('/\s*,\s*/', $request->getHeaderLine('If-None-Match'), 0, PREG_SPLIT_NO_EMPTY);
         $responseTag = $this->getHeaderLine('Etag');
@@ -1221,12 +1223,39 @@ class Response implements ResponseInterface
         if ($etagMatches === null && $timeMatches === null) {
             return false;
         }
-        $notModified = $etagMatches !== false && $timeMatches !== false;
-        if ($notModified) {
+
+        return $etagMatches !== false && $timeMatches !== false;
+    }
+
+    /**
+     * Checks whether a response has not been modified according to the 'If-None-Match'
+     * (Etags) and 'If-Modified-Since' (last modification date) request
+     * headers. If the response is detected to be not modified, it
+     * is marked as so accordingly so the client can be informed of that.
+     *
+     * In order to mark a response as not modified, you need to set at least
+     * the Last-Modified etag response header before calling this method. Otherwise
+     * a comparison will not be possible.
+     *
+     * *Warning* This method mutates the response in-place and should be avoided.
+     *
+     * @param \Cake\Http\ServerRequest $request Request object
+     * @return bool Whether the response was marked as not modified or not.
+     * @deprecated 4.4.0 Use `isNotModified()` and `withNotModified()` instead.
+     */
+    public function checkNotModified(ServerRequest $request): bool
+    {
+        deprecationWarning(
+            'The `checkNotModified()` method is deprecated. ' .
+            'Use `isNotModified() instead and `withNoModified()` instead.'
+        );
+        if ($this->isNotModified($request)) {
             $this->notModified();
+
+            return true;
         }
 
-        return $notModified;
+        return false;
     }
 
     /**

--- a/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
+++ b/tests/TestCase/Controller/Component/CheckHttpCacheComponentTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Controller\Component;
+
+use Cake\Controller\Component\CheckHttpCacheComponent;
+use Cake\Controller\Controller;
+use Cake\Event\Event;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+
+/**
+ * CheckHttpCacheComponentTest class
+ */
+class CheckHttpCacheComponentTest extends TestCase
+{
+    /**
+     * @var \Cake\Controller\Component\CheckHTtpCacheComponent
+     */
+    protected $Component;
+
+    /**
+     * @var \Cake\Controller\Controller
+     */
+    protected $Controller;
+
+    /**
+     * setUp method
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        static::setAppNamespace();
+        $request = (new ServerRequest())
+            ->withHeader('If-Modified-Since', '2012-01-01 00:00:00')
+            ->withHeader('If-None-Match', '*');
+        $this->Controller = new Controller($request);
+        $this->Component = new CheckHttpCacheComponent($this->Controller->components());
+    }
+
+    public function testBeforeRenderSuccess()
+    {
+        $response = $this->Controller->getResponse()
+            ->withEtag('something', true);
+        $this->Controller->setResponse($response);
+
+        $event = new Event('Controller.beforeRender', $this->Controller);
+        $this->Component->beforeRender($event);
+
+        $this->assertTrue($event->isStopped());
+        $response = $this->Controller->getResponse();
+        $this->assertSame(304, $response->getStatusCode());
+    }
+
+    public function testBeforeRenderNoOp()
+    {
+        $event = new Event('Controller.beforeRender', $this->Controller);
+        $this->Component->beforeRender($event);
+
+        $this->assertFalse($event->isStopped());
+        $response = $this->Controller->getResponse();
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -583,8 +583,9 @@ class ResponseTest extends TestCase
             ->withLength(100)
             ->withModified('now');
 
-        $response->notModified();
-
+        $this->deprecated(function () use ($response) {
+            $response->notModified();
+        });
         $this->assertFalse($response->hasHeader('Content-Length'));
         $this->assertFalse($response->hasHeader('Modified'));
         $this->assertEmpty((string)$response->getBody());
@@ -629,8 +630,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $response = $response->withEtag('something')
             ->withHeader('Content-Length', 99);
-        $this->assertTrue($response->checkNotModified($request));
-        $this->assertFalse($response->hasHeader('Content-Type'), 'etags match, should be unmodified');
+        $this->assertTrue($response->isNotModified($request));
+
+        $this->deprecated(function () use ($response, $request) {
+            $this->assertTrue($response->checkNotModified($request));
+            $this->assertFalse($response->hasHeader('Content-Type'), 'etags match, should be unmodified');
+        });
     }
 
     /**
@@ -644,8 +649,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $response = $response->withEtag('something', true)
             ->withHeader('Content-Length', 99);
-        $this->assertTrue($response->checkNotModified($request));
-        $this->assertFalse($response->hasHeader('Content-Type'), 'etags match, should be unmodified');
+        $this->assertTrue($response->isNotModified($request));
+
+        $this->deprecated(function () use ($request, $response) {
+            $this->assertTrue($response->checkNotModified($request));
+            $this->assertFalse($response->hasHeader('Content-Type'), 'etags match, should be unmodified');
+        });
     }
 
     /**
@@ -661,8 +670,12 @@ class ResponseTest extends TestCase
         $response = $response->withModified('2012-01-01 00:00:00')
             ->withEtag('something', true)
             ->withHeader('Content-Length', 99);
-        $this->assertTrue($response->checkNotModified($request));
-        $this->assertFalse($response->hasHeader('Content-Length'), 'etags match, should be unmodified');
+        $this->assertTrue($response->isNotModified($request));
+
+        $this->deprecated(function () use ($request, $response) {
+            $this->assertTrue($response->checkNotModified($request));
+            $this->assertFalse($response->hasHeader('Content-Length'), 'etags match, should be unmodified');
+        });
     }
 
     /**
@@ -678,8 +691,12 @@ class ResponseTest extends TestCase
         $response = $response->withModified('2012-01-01 00:00:01')
             ->withEtag('something', true)
             ->withHeader('Content-Length', 99);
-        $this->assertFalse($response->checkNotModified($request));
-        $this->assertTrue($response->hasHeader('Content-Length'), 'timestamp in response is newer');
+        $this->assertFalse($response->isNotModified($request));
+
+        $this->deprecated(function () use ($request, $response) {
+            $this->assertFalse($response->checkNotModified($request));
+            $this->assertTrue($response->hasHeader('Content-Length'), 'timestamp in response is newer');
+        });
     }
 
     /**
@@ -695,8 +712,11 @@ class ResponseTest extends TestCase
         $response = $response->withModified('2012-01-01 00:00:00')
             ->withEtag('something', true)
             ->withHeader('Content-Length', 99);
-        $this->assertFalse($response->checkNotModified($request));
-        $this->assertTrue($response->hasHeader('Content-Length'), 'etags do not match');
+        $this->assertFalse($response->isNotModified($request));
+        $this->deprecated(function () use ($request, $response) {
+            $this->assertFalse($response->checkNotModified($request));
+            $this->assertTrue($response->hasHeader('Content-Length'), 'etags do not match');
+        });
     }
 
     /**
@@ -710,8 +730,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $response = $response->withModified('2012-01-01 00:00:00')
             ->withHeader('Content-Length', 99);
-        $this->assertTrue($response->checkNotModified($request));
-        $this->assertFalse($response->hasHeader('Content-Length'), 'modified time matches');
+        $this->assertTrue($response->isNotModified($request));
+
+        $this->deprecated(function () use ($request, $response) {
+            $this->assertTrue($response->checkNotModified($request));
+            $this->assertFalse($response->hasHeader('Content-Length'), 'modified time matches');
+        });
     }
 
     /**
@@ -723,8 +747,12 @@ class ResponseTest extends TestCase
         $request = $request->withHeader('If-None-Match', 'W/"something", "other"')
             ->withHeader('If-Modified-Since', '2012-01-01 00:00:00');
         $response = new Response();
-        $this->assertFalse($response->checkNotModified($request));
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertFalse($response->isNotModified($request));
+
+        $this->deprecated(function () use ($request, $response) {
+            $this->assertFalse($response->checkNotModified($request));
+            $this->assertSame(200, $response->getStatusCode());
+        });
     }
 
     /**


### PR DESCRIPTION
This extracts the last bit of RequestHandlerComponent into a separate piece. This is pretty small and I didn't think it fit well on Controller.

Deprecate the mutation based methods for cache headers. Replace `checkNotModified` with `isNotModified` and update tests.