### PR TITLE
Fix memory leak in TranslatorRegistry

### DIFF
--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -145,6 +145,7 @@ class TranslatorRegistry extends TranslatorLocator
 
         $key = "translations.$name.$locale";
         $translator = $this->_cacher->read($key);
+        gc_collect_cycles();
         if (!$translator || !$translator->getPackage()) {
             $translator = $this->_getTranslator($name, $locale);
             $this->_cacher->write($key, $translator);


### PR DESCRIPTION
TranslatorRegistry leaks memory due to this PHP bug - https://bugs.php.net/bug.php?id=81142. Some pages in our project with large PO files failed with out-of-memory error due to this. This fixes the memory leak. Tested in PHP 7.4 on Linux. If this fix is acceptable I will also create a pull request to 4.x branch.

![Screenshot from 2022-02-09 12-16-44](https://user-images.githubusercontent.com/3830106/153241906-a69b5329-5acf-4fc7-aff5-54f9c7313104.png)
