### PR TITLE
Fix passedParams with non string scalar values.

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -208,7 +208,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             // Use any passed params as positional arguments
             if ($passedParams) {
                 $argument = array_shift($passedParams);
-                if ($type instanceof ReflectionNamedType) {
+                if (is_string($argument) && $type instanceof ReflectionNamedType) {
                     $typedArgument = $this->coerceStringToType($argument, $type);
 
                     if ($typedArgument === null) {

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -490,6 +490,25 @@ class ControllerFactoryTest extends TestCase
         $this->assertEquals($data->dep->id, $inject->id);
     }
 
+    public function testCreateWithNonStringScalarRouteParam(): void
+    {
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/required_typed',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'requiredTyped',
+                'pass' => [1.1, 2, true, ['foo' => 'bar']],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+        $response = $this->factory->invoke($controller);
+
+        $expected = ['one' => 1.1, 'two' => 2, 'three' => true, 'four' => ['foo' => 'bar']];
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertSame($expected, $data);
+    }
+
     /**
      * Ensure that a controllers startup process can emit a response
      */


### PR DESCRIPTION
ControllerFactory no longer tries to coerce type for non string
passed arguments.

Fixes #16307

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
