### PR TITLE
Add RETURNING * support to Sqlite driver

### DIFF
--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -109,6 +109,7 @@ class Sqlite extends Driver
      */
     protected $featureVersions = [
         'cte' => '3.8.3',
+        'returning' => '3.35.0',
         'window' => '3.28.0',
     ];
 
@@ -270,6 +271,20 @@ class Sqlite extends Driver
     public function newCompiler(): QueryCompiler
     {
         return new SqliteCompiler();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _insertQueryTranslator(Query $query): Query
+    {
+        if (version_compare($this->version(), $this->featureVersions['returning'], '>=')) {
+            if (!$query->clause('epilog')) {
+                $query->epilog('RETURNING *');
+            }
+        }
+
+        return $query;
     }
 
     /**

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -140,6 +140,31 @@ class SqliteTest extends TestCase
     }
 
     /**
+     * Tests that insert queries get a "RETURNING *" string at the end
+     */
+    public function testInsertReturning(): void
+    {
+        $driver = ConnectionManager::get('test')->getDriver();
+        $this->skipIf(!$driver instanceof Sqlite || version_compare($driver->version(), '3.35.0', '<'));
+
+        $query = ConnectionManager::get('test')->newQuery()
+            ->insert(['id', 'title'])
+            ->into('articles')
+            ->values([1, 'foo']);
+        $translator = $driver->queryTranslator('insert');
+        $query = $translator($query);
+        $this->assertSame('RETURNING *', $query->clause('epilog'));
+
+        $query = ConnectionManager::get('test')->newQuery()
+            ->insert(['id', 'title'])
+            ->into('articles')
+            ->values([1, 'foo'])
+            ->epilog('CUSTOM EPILOG');
+        $query = $translator($query);
+        $this->assertSame('CUSTOM EPILOG', $query->clause('epilog'));
+    }
+
+    /**
      * Data provider for schemaValue()
      *
      * @return array


### PR DESCRIPTION
Closes https://github.com/cakephp/cakephp/issues/16302

Ported implementation and test from Postgres. The test requires a real connection instead of a mock due to version specific feature.
