### PR TITLE
Make fatal errors into exception & improve console errors

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -111,11 +111,15 @@ class ErrorTrap
         if (!(error_reporting() & $code)) {
             return false;
         }
-        $debug = Configure::read('debug');
+        if ($code === E_USER_ERROR || $code === E_ERROR || $code === E_PARSE) {
+            throw new FatalErrorException($description, $code, $file, $line);
+        }
+
         /** @var array $trace */
         $trace = Debugger::trace(['start' => 1, 'format' => 'points']);
         $error = new PhpError($code, $description, $file, $line, $trace);
 
+        $debug = Configure::read('debug');
         $renderer = $this->renderer();
         $logger = $this->logger();
 

--- a/src/Error/Renderer/ConsoleErrorRenderer.php
+++ b/src/Error/Renderer/ConsoleErrorRenderer.php
@@ -16,23 +16,38 @@ declare(strict_types=1);
  */
 namespace Cake\Error\Renderer;
 
+use Cake\Console\ConsoleOutput;
 use Cake\Error\ErrorRendererInterface;
 use Cake\Error\PhpError;
 
 /**
  * Plain text error rendering with a stack trace.
  *
- * Writes to STDERR for console environments
+ * Writes to STDERR via a Cake\Console\ConsoleOutput instance for console environments
  */
 class ConsoleErrorRenderer implements ErrorRendererInterface
 {
+    /**
+     * @var \Cake\Console\ConsoleOutput
+     */
+    private $output;
+
+    /**
+     * Constructor.
+     *
+     * @param array $config Error handling configuration.
+     */
+    public function __construct(array $config)
+    {
+        $this->output = $config['stderr'] ?? new ConsoleOutput('php://stderr');
+    }
+
     /**
      * @inheritDoc
      */
     public function write(string $out): void
     {
-        // Write to stderr which is useful in console environments.
-        fwrite(STDERR, $out);
+        $this->output->write($out);
     }
 
     /**
@@ -41,7 +56,7 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
     public function render(PhpError $error, bool $debug): string
     {
         return sprintf(
-            "%s: %s :: %s on line %s of %s\nTrace:\n%s",
+            "<error>%s: %s :: %s</error> on line %s of %s\n<info>Trace:</info>\n%s",
             $error->getLabel(),
             $error->getCode(),
             $error->getMessage(),

--- a/src/Error/Renderer/ConsoleErrorRenderer.php
+++ b/src/Error/Renderer/ConsoleErrorRenderer.php
@@ -30,7 +30,7 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
     /**
      * @var \Cake\Console\ConsoleOutput
      */
-    private $output;
+    protected $output;
 
     /**
      * Constructor.

--- a/src/Error/Renderer/ConsoleExceptionRenderer.php
+++ b/src/Error/Renderer/ConsoleExceptionRenderer.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Error\Renderer;
 
+use Cake\Console\ConsoleOutput;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
-use Cake\Console\ConsoleOutput;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
@@ -89,13 +89,13 @@ class ConsoleExceptionRenderer
         }
 
         if ($this->trace) {
-            /** @var array $trace */
             $out[] = '';
             $out[] = '<info>Stack Trace:</info>';
             $out[] = '';
             $out[] = $this->error->getTraceAsString();
             $out[] = '';
         }
+
         return join("\n", $out);
     }
 

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -101,10 +101,8 @@ class ErrorTrapTest extends TestCase
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
         $trap->register();
         try {
-            ob_start();
             trigger_error('Oh no it was bad', E_USER_ERROR);
-            $output = ob_get_clean();
-            $this->assertEmpty($output);
+            $this->fail('Should raise a fatal error');
         } catch (FatalErrorException $e) {
             $this->assertEquals('Oh no it was bad', $e->getMessage());
             $this->assertEquals(E_USER_ERROR, $e->getCode());

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Error;
 use Cake\Core\Configure;
 use Cake\Error\ErrorLogger;
 use Cake\Error\ErrorTrap;
+use Cake\Error\FatalErrorException;
 use Cake\Error\PhpError;
 use Cake\Error\Renderer\ConsoleErrorRenderer;
 use Cake\Error\Renderer\HtmlErrorRenderer;
@@ -93,6 +94,23 @@ class ErrorTrapTest extends TestCase
         restore_error_handler();
 
         $this->assertStringContainsString('Oh no it was bad', $output);
+    }
+
+    public function testRegisterAndHandleFatalUserError()
+    {
+        $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
+        $trap->register();
+        try {
+            ob_start();
+            trigger_error('Oh no it was bad', E_USER_ERROR);
+            $output = ob_get_clean();
+            $this->assertEmpty($output);
+        } catch (FatalErrorException $e) {
+            $this->assertEquals('Oh no it was bad', $e->getMessage());
+            $this->assertEquals(E_USER_ERROR, $e->getCode());
+        } finally {
+            restore_error_handler();
+        }
     }
 
     public function testRegisterAndLogging()


### PR DESCRIPTION
Treat user land and engine fatal errors as halting exceptions. This gives us behavior that is consistent with how fatal errors were handled historically.

Refs #16228 