### PR TITLE
Clean up Query::getIterator() and add test

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -266,6 +266,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      */
     public function execute(): StatementInterface
     {
+        $this->_statement = $this->_results = null;
         $this->_statement = $this->_connection->run($this);
         $this->_dirty = false;
 
@@ -2013,8 +2014,11 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
             $results = $this->all();
         }
 
-        /** @var array $results */
-        return new ArrayIterator($results);
+        if (is_array($results)) {
+            return new ArrayIterator($results);
+        }
+
+        return $results;
     }
 
     /**


### PR DESCRIPTION
Currently Databae\Query::all() always executes while getIterator() only executes when dirty. This was an attempt to mimic how users would have called execute() directly. Should we change it to return cached results?