### PR TITLE
Fix PHPStan found issues around mixed and object usage.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -339,9 +339,3 @@ parameters:
 			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
 			count: 1
 			path: src/View/Helper/TimeHelper.php
-
-		-
-			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
-			count: 1
-			path: src/View/Widget/DateTimeWidget.php
-

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -839,7 +839,7 @@ trait CollectionTrait
      */
     public function chunk(int $chunkSize): CollectionInterface
     {
-        return $this->map(function ($v, $k, $iterator) use ($chunkSize) {
+        return $this->map(function ($v, $k, Iterator $iterator) use ($chunkSize) {
             $values = [$v];
             for ($i = 1; $i < $chunkSize; $i++) {
                 $iterator->next();
@@ -858,7 +858,7 @@ trait CollectionTrait
      */
     public function chunkWithKeys(int $chunkSize, bool $keepKeys = true): CollectionInterface
     {
-        return $this->map(function ($v, $k, $iterator) use ($chunkSize, $keepKeys) {
+        return $this->map(function ($v, $k, Iterator $iterator) use ($chunkSize, $keepKeys) {
             $key = 0;
             if ($keepKeys) {
                 $key = $k;

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -147,8 +147,6 @@ class I18nExtractCommand extends Command
             if (strtoupper($response) === 'Q') {
                 $io->err('Extract Aborted');
                 $this->abort();
-
-                return;
             }
             if (strtoupper($response) === 'D' && count($this->_paths)) {
                 $io->out();

--- a/src/Database/Driver/SqlDialectTrait.php
+++ b/src/Database/Driver/SqlDialectTrait.php
@@ -229,6 +229,7 @@ trait SqlDialectTrait
             );
         }
 
+        /** @var \Cake\Database\ExpressionInterface|null $conditions */
         $conditions = $query->clause('where');
         if ($conditions) {
             $conditions->traverse(function ($expression) {

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -162,7 +162,7 @@ class QueryCompiler
      * it constructs the CTE definitions list and generates the `RECURSIVE`
      * keyword when required.
      *
-     * @param array $parts List of CTEs to be transformed to string
+     * @param array<\Cake\Database\Expression\CommonTableExpression> $parts List of CTEs to be transformed to string
      * @param \Cake\Database\Query $query The query that is being compiled
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -63,7 +63,7 @@ class SqlserverCompiler extends QueryCompiler
      * it constructs the CTE definitions list without generating the `RECURSIVE`
      * keyword that is neither required nor valid.
      *
-     * @param array $parts List of CTEs to be transformed to string
+     * @param array<\Cake\Database\Expression\CommonTableExpression> $parts List of CTEs to be transformed to string
      * @param \Cake\Database\Query $query The query that is being compiled
      * @param \Cake\Database\ValueBinder $binder Value binder used to generate parameter placeholder
      * @return string

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -468,6 +468,7 @@ class EventManager implements EventManagerInterface
         if ($this->_eventList) {
             $count = count($this->_eventList);
             for ($i = 0; $i < $count; $i++) {
+                /** @var \Cake\Event\Event $event */
                 $event = $this->_eventList[$i];
                 try {
                     $subject = $event->getSubject();

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -166,6 +166,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             $parsedBody = Hash::merge($parsedBody, $files);
         } else {
             // Make a flat map that can be inserted into body for BC.
+            /** @var array<\Laminas\Diactoros\UploadedFile> $fileMap */
             $fileMap = Hash::flatten($files);
             foreach ($fileMap as $key => $file) {
                 $error = $file->getError();

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -200,8 +200,9 @@ class TranslatorRegistry
         // Cache keys cannot contain / if they go to file engine.
         $keyName = str_replace('/', '.', $name);
         $key = "translations.{$keyName}.{$locale}";
+        /** @var \Cake\I18n\Translator|null $translator */
         $translator = $this->_cacher->get($key);
-        if (!$translator || !$translator->getPackage()) {
+        if (!$translator) {
             $translator = $this->_getTranslator($name, $locale);
             $this->_cacher->set($key, $translator);
         }

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -366,6 +366,7 @@ class Log
 
         $registry = static::getRegistry();
         foreach ($registry->loaded() as $streamName) {
+            /** @var \Psr\Log\LoggerInterface $logger */
             $logger = $registry->{$streamName};
             $levels = $scopes = null;
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\ORM;
 
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 use Cake\Core\App;
 use Cake\Core\ConventionsTrait;
 use Cake\Database\Expression\IdentifierExpression;
@@ -974,7 +975,14 @@ abstract class Association
 
         $property = $options['propertyPath'];
         $propertyPath = explode('.', $property);
-        $query->formatResults(function ($results, $query) use ($formatters, $property, $propertyPath) {
+        $query->formatResults(function (
+            CollectionInterface $results,
+            Query $query
+        ) use (
+            $formatters,
+            $property,
+            $propertyPath
+        ) {
             $extracted = [];
             foreach ($results as $result) {
                 foreach ($propertyPath as $propertyPathItem) {
@@ -991,10 +999,9 @@ abstract class Association
                 $extracted = new ResultSetDecorator($callable($extracted, $query));
             }
 
-            /** @var \Cake\Collection\CollectionInterface $results */
             $results = $results->insert($property, $extracted);
             if ($query->isHydrationEnabled()) {
-                $results = $results->map(function ($result) {
+                $results = $results->map(function (EntityInterface $result) {
                     $result->clean();
 
                     return $result;

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1265,6 +1265,7 @@ class BelongsToMany extends Association
         $foreignKey = (array)$this->getForeignKey();
         $assocForeignKey = (array)$belongsTo->getForeignKey();
 
+        /** @var array<string> $keys */
         $keys = array_merge($foreignKey, $assocForeignKey);
         $deletes = $indexed = $present = [];
 
@@ -1275,6 +1276,7 @@ class BelongsToMany extends Association
             $present[$i] = array_values($entity->extract($assocForeignKey));
         }
 
+        /** @var \Cake\Datasource\EntityInterface $result */
         foreach ($existing as $result) {
             $fields = $result->extract($keys);
             $found = false;

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -173,9 +173,10 @@ class EavStrategy implements TranslateStrategyInterface
             return;
         }
 
-        $conditions = function ($field, $locale, $query, $select) {
-            return function ($q) use ($field, $locale, $query, $select) {
-                $q->where([$q->getRepository()->aliasField('locale') => $locale]);
+        $conditions = function (string $field, string $locale, Query $query, array $select) {
+            return function (Query $q) use ($field, $locale, $query, $select) {
+                $table = $q->getRepository();
+                $q->where([$table->aliasField('locale') => $locale]);
 
                 if (
                     $query->isAutoFieldsEnabled() ||
@@ -299,6 +300,7 @@ class EavStrategy implements TranslateStrategyInterface
         }
 
         $modified = [];
+        /** @var \Cake\Datasource\EntityInterface $translation */
         foreach ($preexistent as $field => $translation) {
             $translation->set('content', $values[$field]);
             $modified[$field] = $translation;
@@ -439,6 +441,7 @@ class EavStrategy implements TranslateStrategyInterface
      */
     protected function bundleTranslatedFields(EntityInterface $entity): void
     {
+        /** @var array<string, \Cake\Datasource\EntityInterface> $translations */
         $translations = (array)$entity->get('_translations');
 
         if (empty($translations) && !$entity->isDirty('_translations')) {

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -249,6 +249,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function iterateClause(Query $query, string $name = '', array $config = []): bool
     {
+        /** @var \Cake\Database\Expression\QueryExpression|null $clause */
         $clause = $query->clause($name);
         if (!$clause || !$clause->count()) {
             return false;
@@ -295,6 +296,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function traverseClause(Query $query, string $name = '', array $config = []): bool
     {
+        /** @var \Cake\Database\Expression\QueryExpression|null $clause */
         $clause = $query->clause($name);
         if (!$clause || !$clause->count()) {
             return false;
@@ -537,7 +539,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     {
         return $results->map(function ($row) {
             $translations = (array)$row['_i18n'];
-            if (empty($translations) && $row->get('_translations')) {
+            if (empty($translations) && $row instanceof EntityInterface && $row->get('_translations')) {
                 return $row;
             }
 

--- a/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateStrategyTrait.php
@@ -151,7 +151,7 @@ trait TranslateStrategyTrait
         }
 
         return [
-            '_translations' => function ($value, $entity) use ($marshaller, $options) {
+            '_translations' => function ($value, EntityInterface $entity) use ($marshaller, $options) {
                 if (!is_array($value)) {
                     return null;
                 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -413,6 +413,7 @@ class Marshaller
             $keyFields = array_keys($primaryKey);
 
             $existing = [];
+            /** @var \Cake\Datasource\EntityInterface $row */
             foreach ($query as $row) {
                 $k = implode(';', $row->extract($keyFields));
                 $existing[$k] = $row;
@@ -696,6 +697,7 @@ class Marshaller
         $maybeExistentQuery = $this->_table->find()->where($conditions);
 
         if (!empty($indexed) && count($maybeExistentQuery->clause('where'))) {
+            /** @var \Cake\Datasource\EntityInterface $entity */
             foreach ($maybeExistentQuery as $entity) {
                 $key = implode(';', $entity->extract($primary));
                 if (isset($indexed[$key])) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -955,6 +955,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         }
 
         if (!$complex && $this->_valueBinder !== null) {
+            /** @var \Cake\Database\Expression\QueryExpression|null $order */
             $order = $this->clause('order');
             $complex = $order === null ? false : $order->hasNestedExpression();
         }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2266,6 +2266,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         try {
             $this->getConnection()
                 ->transactional(function () use ($entities, $options, &$isNew, &$failed) {
+                    /**
+                     * @var string $key
+                     * @var \Cake\Datasource\EntityInterface $entity
+                     */
                     foreach ($entities as $key => $entity) {
                         $isNew[$key] = $entity->isNew();
                         if ($this->save($entity, $options) === false) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -611,8 +611,10 @@ class Router
     {
         $route = null;
         if ($params instanceof ServerRequest) {
+            /** @var \Cake\Routing\Route\Route|null $route */
             $route = $params->getAttribute('route');
             $queryString = $params->getQueryParams();
+            /** @var array<string, mixed> $params */
             $params = $params->getAttribute('params');
             $params['?'] = $queryString;
         }

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -276,6 +276,7 @@ class FixtureHelper
      */
     protected function getForeignReferences(Connection $connection, FixtureInterface $fixture): array
     {
+        /** @var array<string, \Cake\Database\Schema\TableSchemaInterface> $schemas */
         static $schemas = [];
 
         // Get and cache off the schema since TestFixture generates a fake schema based on $fields

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Fixture;
 
+use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\ConnectionHelper;
@@ -114,7 +115,7 @@ class SchemaLoader
          * @var \Cake\Database\Connection $connection
          */
         $connection = ConnectionManager::get($connectionName);
-        $connection->disableConstraints(function ($connection) use ($tables): void {
+        $connection->disableConstraints(function (Connection $connection) use ($tables): void {
             foreach ($tables as $table) {
                 $schema = new TableSchema($table['table'], $table['columns']);
                 if (isset($table['indexes'])) {

--- a/src/TestSuite/Fixture/TransactionFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TransactionFixtureStrategy.php
@@ -80,7 +80,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
      */
     public function teardownTest(): void
     {
-        $this->helper->runPerConnection(function ($connection): void {
+        $this->helper->runPerConnection(function (Connection $connection): void {
             if ($connection->inTransaction()) {
                 $connection->rollback(true);
             }

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -85,7 +85,7 @@ class TransactionStrategy implements FixtureStrategyInterface
      */
     public function teardownTest(): void
     {
-        $this->helper->runPerConnection(function ($connection): void {
+        $this->helper->runPerConnection(function (Connection $connection): void {
             if ($connection->inTransaction()) {
                 $connection->rollback(true);
             }

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -387,9 +387,11 @@ class Xml
         ];
 
         $value = $data['value'];
+        /** @var \DOMDocument $dom */
         $dom = $data['dom'];
         $key = $data['key'];
         $format = $data['format'];
+        /** @var \DOMElement $node */
         $node = $data['node'];
 
         $childNS = $childValue = null;

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -729,11 +729,15 @@ class EntityContext implements ContextInterface
     {
         $parts = explode('.', $field);
         try {
+            /**
+             * @var \Cake\Datasource\EntityInterface|null $entity
+             * @var array<string> $remainingParts
+             */
             [$entity, $remainingParts] = $this->leafEntity($parts);
         } catch (RuntimeException) {
             return [];
         }
-        if (count($remainingParts) === 0) {
+        if ($entity instanceof EntityInterface && count($remainingParts) === 0) {
             return $entity->getErrors();
         }
 

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -188,7 +188,7 @@ class DateTimeWidget extends BasicWidget
 
         try {
             if ($value instanceof DateTimeInterface) {
-                /** @var \DateTime $dateTime */
+                /** @var \DateTime|\DateTimeImmutable $dateTime */
                 $dateTime = clone $value;
             } elseif (is_string($value) && !is_numeric($value)) {
                 $dateTime = new DateTime($value);
@@ -207,7 +207,6 @@ class DateTimeWidget extends BasicWidget
                 $timezone = new DateTimeZone($timezone);
             }
 
-            /** @psalm-suppress PossiblyUndefinedMethod */
             $dateTime = $dateTime->setTimezone($timezone);
         }
 

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -188,6 +188,7 @@ class DateTimeWidget extends BasicWidget
 
         try {
             if ($value instanceof DateTimeInterface) {
+                /** @var \DateTime $dateTime */
                 $dateTime = clone $value;
             } elseif (is_string($value) && !is_numeric($value)) {
                 $dateTime = new DateTime($value);


### PR DESCRIPTION
Make more mixed objects visible
As the changes show, we actually found some issues or smells in there now, that can be fixed up.

**Down from 167 errors to 71**

The remaining issues seem almost all also still valid:
```
  Line   Core/StaticConfigTrait.php (in context of class Cake\Mailer\Mailer)  
 ------ --------------------------------------------------------------------- 
  162    Anonymous variable in a `static::$_registry->...()` method call can  
         lead to false dead methods. Make sure the variable type is known     
 ------ --------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   Database/Driver/Sqlserver.php                                          
 ------ ----------------------------------------------------------------------- 
  347    Anonymous variable in a `$original->clause('order')->...()` method     
         call can lead to false dead methods. Make sure the variable type is    
         known                                                                  
  417    Anonymous variable in a `$q->...()` method call can lead to false      
         dead methods. Make sure the variable type is known                     
  417    Anonymous variable in a `$q->newExpr('ROW_NUMBER() OVER')->...()`      
         method call can lead to false dead methods. Make sure the variable     
         type is known                                                          
  417    Anonymous variable in a `$q->newExpr('ROW_NUMBER()                     
         OVER')->add('(PARTITION BY')->...()` method call can lead to false     
         dead methods. Make sure the variable type is known                     
  417    Anonymous variable in a `$q->newExpr('ROW_NUMBER()                     
         OVER')->add('(PARTITION                                                
         BY')->add($q->newExpr()->add($distinct)->setConjunction(','))->...()`  
         method call can lead to false dead methods. Make sure the variable     
         type is known                                                          
  417    Anonymous variable in a `$q->newExpr('ROW_NUMBER()                     
         OVER')->add('(PARTITION                                                
         BY')->add($q->newExpr()->add($distinct)->setConjunction(','))->add($o  
         rder)->...()` method call can lead to false dead methods. Make sure    
         the variable type is known                                             
  417    Anonymous variable in a `$q->newExpr('ROW_NUMBER()                     
         OVER')->add('(PARTITION                                                
         BY')->add($q->newExpr()->add($distinct)->setConjunction(','))->add($o  
         rder)->add(')')->...()` method call can lead to false dead methods.    
         Make sure the variable type is known                                   
  419    Anonymous variable in a `$q->...()` method call can lead to false      
         dead methods. Make sure the variable type is known                     
  419    Anonymous variable in a `$q->newExpr()->...()` method call can lead    
         to false dead methods. Make sure the variable type is known            
  419    Anonymous variable in a `$q->newExpr()->add($distinct)->...()` method  
         call can lead to false dead methods. Make sure the variable type is    
         known                                                                  
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   Database/Query.php                                                     
 ------ ----------------------------------------------------------------------- 
  1377   Anonymous variable in a `$this->_parts['order']->...()` method call    
         can lead to false dead methods. Make sure the variable type is known   
  1411   Anonymous variable in a `$this->_parts['order']->...()` method call    
         can lead to false dead methods. Make sure the variable type is known   
  1717   Anonymous variable in a `$this->_parts['values']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known   
  1791   Anonymous variable in a `$this->_parts['values']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known   
  1855   Anonymous variable in a `$this->_parts['set']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
  1862   Anonymous variable in a `$this->_parts['set']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
  1870   Anonymous variable in a `$this->_parts['set']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
  2324   Anonymous variable in a `$expression->...()` method call can lead to   
         false dead methods. Make sure the variable type is known               
  2325   Anonymous variable in a `$expression->...()` method call can lead to   
         false dead methods. Make sure the variable type is known               
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   Database/QueryCompiler.php                                             
 ------ ----------------------------------------------------------------------- 
  311    Anonymous variable in a `$window['name']->...()` method call can lead  
         to false dead methods. Make sure the variable type is known            
  311    Anonymous variable in a `$window['window']->...()` method call can     
         lead to false dead methods. Make sure the variable type is known       
  354    Anonymous variable in a `$p['query']->...()` method call can lead to   
         false dead methods. Make sure the variable type is known               
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   Database/Type/DateTimeType.php                                         
 ------ ----------------------------------------------------------------------- 
  152    Anonymous variable in a `$value->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  152    Anonymous variable in a `$value->getTimezone()->...()` method call     
         can lead to false dead methods. Make sure the variable type is known   
  157    Anonymous variable in a `$value->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  160    Anonymous variable in a `$value->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
 ------ ----------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   Http/Client/Adapter/Mock.php                                       
 ------ ------------------------------------------------------------------- 
  81     Anonymous variable in a `$mock['request']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known   
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   I18n/RelativeTimeFormatter.php                                     
 ------ ------------------------------------------------------------------- 
  107    Anonymous variable in a `$options['from']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known   
  329    Anonymous variable in a `$options['from']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known   
 ------ ------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------- 
  Line   Mailer/Message.php                                                  
 ------ -------------------------------------------------------------------- 
  1180   Anonymous variable in a `$fileInfo['file']->...()` method call can  
         lead to false dead methods. Make sure the variable type is known    
 ------ -------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Association/BelongsToMany.php                                     
 ------ ---------------------------------------------------------------------- 
  481    Anonymous variable in a `$thisJoin['conditions']->...()` method call  
         can lead to false dead methods. Make sure the variable type is known  
  757    Anonymous variable in a `$original[$k]->...()` method call can lead   
         to false dead methods. Make sure the variable type is known           
 ------ ---------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   ORM/Association/HasMany.php                                          
 ------ --------------------------------------------------------------------- 
  236    Anonymous variable in a `$original[$k]->...()` method call can lead  
         to false dead methods. Make sure the variable type is known          
  238    Anonymous variable in a `$original[$k]->...()` method call can lead  
         to false dead methods. Make sure the variable type is known          
 ------ --------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   ORM/Association/Loader/SelectLoader.php                                
 ------ ----------------------------------------------------------------------- 
  178    Anonymous variable in a `$options['query']->...()` method call can     
         lead to false dead methods. Make sure the variable type is known       
  179    Anonymous variable in a `$options['query']->...()` method call can     
         lead to false dead methods. Make sure the variable type is known       
  451    Anonymous variable in a `$order->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   ORM/Association/Loader/SelectWithPivotLoader.php                       
 ------ ----------------------------------------------------------------------- 
  100    Anonymous variable in a `$query->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  101    Anonymous variable in a `$query->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  101    Anonymous variable in a `$query->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  117    Anonymous variable in a `$query->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  117    Anonymous variable in a                                                
         `$query->where($this->junctionConditions)->...()` method call can      
         lead to false dead methods. Make sure the variable type is known       
  121    Anonymous variable in a `$query->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  121    Anonymous variable in a `$query->getEagerLoader()->...()` method call  
         can lead to false dead methods. Make sure the variable type is known   
  130    Anonymous variable in a `$query->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  130    Anonymous variable in a `$query->getTypeMap()->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
 ------ ----------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Behavior/CounterCacheBehavior.php                                 
 ------ ---------------------------------------------------------------------- 
  143    Anonymous variable in a `$entity->{$entityAlias}->...()` method call  
         can lead to false dead methods. Make sure the variable type is known  
 ------ ---------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------ 
  Line   ORM/LazyEagerLoader.php                                           
 ------ ------------------------------------------------------------------ 
  78     Anonymous variable in a `$entity->...()` method call can lead to  
         false dead methods. Make sure the variable type is known          
  158    Anonymous variable in a `$object->...()` method call can lead to  
         false dead methods. Make sure the variable type is known          
  168    Anonymous variable in a `$object->...()` method call can lead to  
         false dead methods. Make sure the variable type is known          
  169    Anonymous variable in a `$object->...()` method call can lead to  
         false dead methods. Make sure the variable type is known          
 ------ ------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Rule/ExistsIn.php                                                 
 ------ ---------------------------------------------------------------------- 
  85     Anonymous variable in a `$options['repository']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known  
  93     Anonymous variable in a `$options['repository']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known  
  103    Anonymous variable in a `$target->...()` method call can lead to      
         false dead methods. Make sure the variable type is known              
  127    Anonymous variable in a `$source->...()` method call can lead to      
         false dead methods. Make sure the variable type is known              
  129    Anonymous variable in a `$schema->...()` method call can lead to      
         false dead methods. Make sure the variable type is known              
  129    Anonymous variable in a `$schema->...()` method call can lead to      
         false dead methods. Make sure the variable type is known              
  137    Anonymous variable in a `$target->...()` method call can lead to      
         false dead methods. Make sure the variable type is known              
  146    Anonymous variable in a `$target->...()` method call can lead to      
         false dead methods. Make sure the variable type is known              
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   ORM/Rule/IsUnique.php                                                 
 ------ ---------------------------------------------------------------------- 
  78     Anonymous variable in a `$options['repository']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known  
  81     Anonymous variable in a `$options['repository']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known  
  88     Anonymous variable in a `$options['repository']->...()` method call   
         can lead to false dead methods. Make sure the variable type is known  
 ------ ---------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------- 
  Line   ORM/Table.php                                                       
 ------ -------------------------------------------------------------------- 
  323    Anonymous variable in a `$this->_behaviors->...()` method call can  
         lead to false dead methods. Make sure the variable type is known    
 ------ -------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   View/CellTrait.php (in context of class Cake\View\View)                
 ------ ----------------------------------------------------------------------- 
  121    Anonymous variable in a `$this->viewBuilder()->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
  123    Anonymous variable in a `$this->viewBuilder()->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
  124    Anonymous variable in a `$this->viewBuilder()->...()` method call can  
         lead to false dead methods. Make sure the variable type is known       
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------- 
  Line   View/Form/EntityContext.php                                            
 ------ ----------------------------------------------------------------------- 
  650    Anonymous variable in a `$assoc->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  655    Anonymous variable in a `$table->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
  656    Anonymous variable in a `$associationCollection->...()` method call    
         can lead to false dead methods. Make sure the variable type is known   
  667    Anonymous variable in a `$assoc->...()` method call can lead to false  
         dead methods. Make sure the variable type is known                     
 ------ ----------------------------------------------------------------------- 

 [ERROR] Found 71 errors  
```

Also the  176 errors around "mixed callable" could be interesting to look into as per new https://tomasvotruba.com/blog/get-rid-of-mixed-callables-with-phpstan/ post.
But thats probably for another day.