### PR TITLE
Remove StatementInterface from FixtureInterface::insert() return type

### DIFF
--- a/src/Datasource/FixtureInterface.php
+++ b/src/Datasource/FixtureInterface.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
-use Cake\Database\StatementInterface;
-
 /**
  * Defines the interface that testing fixtures use.
  */
@@ -30,10 +28,9 @@ interface FixtureInterface
      *
      * @param \Cake\Datasource\ConnectionInterface $connection An instance of the connection
      *   into which the records will be inserted.
-     * @return \Cake\Database\StatementInterface|bool on success or if there are no records to insert,
-     *  or false on failure.
+     * @return bool
      */
-    public function insert(ConnectionInterface $connection): StatementInterface|bool;
+    public function insert(ConnectionInterface $connection): bool;
 
     /**
      * Truncates the current fixture.

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
-use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\FixtureInterface;
@@ -160,7 +159,7 @@ class TestFixture implements FixtureInterface
     /**
      * @inheritDoc
      */
-    public function insert(ConnectionInterface $connection): StatementInterface|bool
+    public function insert(ConnectionInterface $connection): bool
     {
         if (!empty($this->records)) {
             [$fields, $values, $types] = $this->_getRecords();
@@ -174,8 +173,6 @@ class TestFixture implements FixtureInterface
             }
             $statement = $query->execute();
             $statement->closeCursor();
-
-            return $statement;
         }
 
         return true;

--- a/tests/Fixture/OtherArticlesFixture.php
+++ b/tests/Fixture/OtherArticlesFixture.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\Test\Fixture;
 
-use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\FixtureInterface;
 
@@ -37,7 +36,7 @@ class OtherArticlesFixture implements FixtureInterface
         return true;
     }
 
-    public function insert(ConnectionInterface $connection): StatementInterface|bool
+    public function insert(ConnectionInterface $connection): bool
     {
         return true;
     }

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -185,7 +185,7 @@ class TestFixtureTest extends TestCase
             ->method('execute')
             ->will($this->returnValue($statement));
 
-        $this->assertSame($statement, $fixture->insert($db));
+        $this->assertSame(true, $fixture->insert($db));
     }
 
     /**


### PR DESCRIPTION
This is preventing non-pdo fixtures from implementing `FixtureInterface`. We have no need to use the statement after inserting. Error will throw an exception.

Blocking https://github.com/cakephp/elastic-search/pull/277