### PR TITLE
[4.4] add ability to stop default error handler 

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -16,7 +16,7 @@ use InvalidArgumentException;
  *
  * Using the `register()` method you can attach an ErrorTrap to PHP's default error handler.
  *
- * When errors are trapped, errors are logged (if logging is enabled). Then the `Error.handled` event is triggered.
+ * When errors are trapped, errors are logged (if logging is enabled). Then the `Error.beforeRender` event is triggered.
  * Finally, errors are 'rendered' using the defined renderer. If no error renderer is defined in configuration
  * one of the default implementations will be chosen based on the PHP SAPI.
  */
@@ -93,7 +93,7 @@ class ErrorTrap
      * Will use the configured renderer to generate output
      * and output it.
      *
-     * This method will dispatch the `Error.handled` event which can be listened
+     * This method will dispatch the `Error.beforeRender` event which can be listened
      * to on the global event manager.
      *
      * @param int $code Code of error
@@ -126,7 +126,7 @@ class ErrorTrap
         try {
             // Log first incase rendering or event listeners fail
             $logger->logMessage($error->getLabel(), $error->getMessage());
-            $event = $this->dispatchEvent('Error.handled', ['error' => $error]);
+            $event = $this->dispatchEvent('Error.beforeRender', ['error' => $error]);
             if ($event->isStopped()) {
                 return true;
             }

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -126,7 +126,10 @@ class ErrorTrap
         try {
             // Log first incase rendering or event listeners fail
             $logger->logMessage($error->getLabel(), $error->getMessage());
-            $this->dispatchEvent('Error.handled', ['error' => $error]);
+            $event = $this->dispatchEvent('Error.handled', ['error' => $error]);
+            if ($event->isStopped()) {
+                return true;
+            }
             $renderer->write($renderer->render($error, $debug));
         } catch (Exception $e) {
             $logger->logMessage('error', 'Could not render error. Got: ' . $e->getMessage());

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -17,8 +17,12 @@ use Throwable;
  * Using the `register()` method you can attach an ExceptionTrap to PHP's default exception handler and register
  * a shutdown handler to handle fatal errors.
  *
- * When exceptions are trapped the `Exception.handled` event is triggered.
+ * When exceptions are trapped the `Exception.beforeRender` event is triggered.
  * Then exceptions are logged (if enabled) and finally 'rendered' using the defined renderer.
+ *
+ * Stopping the `Exception.beforeRender` event has no effect, as we always need to render
+ * a response to an exception and custom renderers should be used if you want to replace or
+ * skip rendering an exception..
  *
  * If undefined, an ExceptionRenderer will be selected based on the current SAPI (CLI or Web).
  */
@@ -309,7 +313,7 @@ class ExceptionTrap
      * Primarily a public function to ensure consistency between global exception handling
      * and the ErrorHandlerMiddleware.
      *
-     * After logging, the `Exception.handled` event is triggered.
+     * After logging, the `Exception.beforeRender` event is triggered.
      *
      * @param \Throwable $exception The exception to log
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The optional request
@@ -319,7 +323,7 @@ class ExceptionTrap
     {
         $logger = $this->logger();
         $logger->log($exception, $request);
-        $this->dispatchEvent('Exception.handled', ['exception' => $exception]);
+        $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception]);
     }
 
     /**

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -22,7 +22,7 @@ use Throwable;
  *
  * Stopping the `Exception.beforeRender` event has no effect, as we always need to render
  * a response to an exception and custom renderers should be used if you want to replace or
- * skip rendering an exception..
+ * skip rendering an exception.
  *
  * If undefined, an ExceptionRenderer will be selected based on the current SAPI (CLI or Web).
  */

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -219,9 +219,10 @@ class ExceptionTrapTest extends TestCase
     public function testEventTriggered()
     {
         $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
-        $trap->getEventManager()->on('Exception.handled', function ($event, Throwable $error) {
+        $trap->getEventManager()->on('Exception.beforeRender', function ($event, Throwable $error) {
             $this->assertEquals(100, $error->getCode());
             $this->assertStringContainsString('nope', $error->getMessage());
+            $event->stopPropagation();
         });
         $error = new InvalidArgumentException('nope', 100);
 


### PR DESCRIPTION
this helps us to stop event with `$event->stopPropagation();`
in https://github.com/cakephp/debug_kit/pull/856

Refs: #16228