### PR TITLE
4.x - Fix required options obstructing the usage of `--help`.

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -705,8 +705,13 @@ class ConsoleOptionParser
                 $args = $this->_parseArg($token, $args);
             }
         }
+
+        if (isset($params['help'])) {
+            return [$params, $args];
+        }
+
         foreach ($this->_args as $i => $arg) {
-            if ($arg->isRequired() && !isset($args[$i]) && empty($params['help'])) {
+            if ($arg->isRequired() && !isset($args[$i])) {
                 throw new ConsoleException(
                     sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
                 );

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -695,13 +695,26 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
-     * test that no exception is triggered when help is being generated
+     * test that no exception is triggered for required arguments when help is being generated
      */
-    public function testHelpNoExceptionWhenGettingHelp(): void
+    public function testHelpNoExceptionForRequiredArgumentsWhenGettingHelp(): void
     {
         $parser = new ConsoleOptionParser('mycommand', false);
         $parser->addOption('test', ['help' => 'A test option.'])
             ->addArgument('model', ['help' => 'The model to make.', 'required' => true]);
+
+        $result = $parser->parse(['--help']);
+        $this->assertTrue($result[0]['help']);
+    }
+
+    /**
+     * test that no exception is triggered for required options when help is being generated
+     */
+    public function testHelpNoExceptionForRequiredOptionsWhenGettingHelp(): void
+    {
+        $parser = new ConsoleOptionParser('mycommand', false);
+        $parser->addOption('test', ['help' => 'A test option.'])
+            ->addOption('model', ['help' => 'The model to make.', 'required' => true]);
 
         $result = $parser->parse(['--help']);
         $this->assertTrue($result[0]['help']);


### PR DESCRIPTION
This allows to invoke help when required options are configured, just
like it's already possible for required arguments.