### PR TITLE
4.x - Fix regex characters in command names trigger PHP errors.

### DIFF
--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -94,7 +94,7 @@ class MissingOptionException extends ConsoleException
     {
         $bestGuess = null;
         foreach ($haystack as $item) {
-            if (preg_match('/^' . $needle . '/', $item)) {
+            if (strpos($item, $needle) === 0) {
                 return $item;
             }
         }

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -139,6 +139,28 @@ class CommandRunnerTest extends TestCase
     }
 
     /**
+     * Test that using special characters in an unknown command does
+     * not cause a PHP error.
+     */
+    public function testRunInvalidCommandWithSpecialCharacters(): void
+    {
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
+
+        $output = new ConsoleOutput();
+        $runner = new CommandRunner($app);
+        $runner->run(['cake', 's/pec[ial'], $this->getMockIo($output));
+
+        $messages = implode("\n", $output->messages());
+        $this->assertStringContainsString(
+            'Unknown command `cake s/pec[ial`. Run `cake --help` to get the list of commands.',
+            $messages
+        );
+    }
+
+    /**
      * Test that running an unknown command gives suggestions.
      */
     public function testRunInvalidCommandSuggestion(): void


### PR DESCRIPTION
Stumbled over this by accident when I forgot to add the command name, and the first option was treated as the name, it had a `/` in its value, causing a regex pattern compilation failure.
