### PR TITLE
Fix deleteMany stopping after the first failure

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -187,7 +187,11 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
     }
 
     /**
-     * Deletes multiple cache items in a single operation.
+     * Deletes multiple cache items as a list
+     *
+     * This is a best effort attempt. If deleting an item would
+     * create an error it will be ignored, and all items will
+     * be attempted.
      *
      * @param iterable $keys A list of string-based keys to be deleted.
      * @return bool True if the items were successfully removed. False if there was an error.

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -198,14 +198,14 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
     {
         $this->ensureValidType($keys);
 
+        $result = true;
         foreach ($keys as $key) {
-            $result = $this->delete($key);
-            if ($result === false) {
-                return false;
+            if (!$this->delete($key)) {
+                $result = false;
             }
         }
 
-        return true;
+        return $result;
     }
 
     /**

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -675,6 +675,25 @@ class CacheTest extends TestCase
     }
 
     /**
+     * testDeleteMany partial failure
+     */
+    public function testDeleteManyPartialFailure(): void
+    {
+        $this->_configCache();
+        $data = [
+            'App.exists' => 'yes',
+            'App.exists2' => 'yes',
+        ];
+        Cache::writeMany($data, 'tests');
+
+        $result = Cache::deleteMany(['App.exists', 'App.noExists', 'App.exists2'], 'tests');
+        $this->assertFalse($result);
+
+        $this->assertNull(Cache::read('App.exists', 'tests'));
+        $this->assertNull(Cache::read('App.exists2', 'tests'));
+    }
+
+    /**
      * Test that failed writes cause errors to be triggered.
      */
     public function testWriteTriggerError(): void


### PR DESCRIPTION
DeleteMany should be more of a best-effort vs stopping at the first missing key.

Fixes #16347
