### PR TITLE
Fix logging deprecated warnings

### DIFF
--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -65,6 +65,11 @@ class ErrorLogger implements ErrorLoggerInterface
         if (!empty($context['trace'])) {
             $message .= "\nTrace:\n" . $context['trace'] . "\n";
         }
+        $logMap = [
+            'strict' => LOG_NOTICE,
+            'deprecated' => LOG_NOTICE,
+        ];
+        $level = $logMap[$level] ?? $level;
 
         return Log::write($level, $message);
     }

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -111,7 +111,21 @@ class ErrorTrapTest extends TestCase
         }
     }
 
-    public function testRegisterAndLogging()
+    public function logLevelProvider(): array
+    {
+        return [
+            // PHP error level, expected log level
+            [E_USER_ERROR, 'error'],
+            [E_USER_WARNING, 'warning'],
+            [E_USER_NOTICE, 'info'],
+            [E_USER_DEPRECATED, 'info'],
+        ];
+    }
+
+    /**
+     * @dataProvider logLevelProvider
+     */
+    public function testLoggingLevel($level, $logLevel)
     {
         Log::setConfig('test_error', [
             'className' => 'Array',


### PR DESCRIPTION
Convert PhpError levels to logging levels. This fix an exception being raised while we are logging an error.

Thanks @saeideng for finding this.
