### PR TITLE
Fix description of Entity::__isset()

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -143,7 +143,7 @@ trait EntityTrait
 
     /**
      * Returns whether this entity contains a field named $field
-     * regardless of if it is empty.
+     * and is not set to null.
      *
      * @param string $field The field to check.
      * @return bool


### PR DESCRIPTION
Checking isset() on an entity field does not return true if it's set to null.
