### PR TITLE
Fix belongsToMany with finder & contain

### DIFF
--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -973,6 +973,34 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
+     * Test that replace links use loads junction records with a concrete
+     * target table so that finders with contain will work.
+     */
+    public function testReplaceLinksFinderContain(): void
+    {
+        $this->setAppNamespace('TestApp');
+
+        $joint = $this->getTableLocator()->get('ArticlesTags');
+        $articles = $this->getTableLocator()->get('Articles');
+        $tags = $this->getTableLocator()->get('Tags');
+
+        $assoc = $tags->belongsToMany('Articles', [
+            'sourceTable' => $tags,
+            'targetTable' => $articles,
+            'through' => $joint,
+            'joinTable' => 'articles_tags',
+            'finder' => 'withAuthors',
+        ]);
+        $tag = $tags->get(1);
+        $article = $articles->get(1);
+
+        $assoc->replaceLinks($tag, [$article]);
+
+        $fresh = $tags->get(1, ['contain' => 'Articles']);
+        $this->assertCount(1, $fresh->articles);
+    }
+
+    /**
      * Tests replaceLinks with failing domain rules and new link targets.
      */
     public function testReplaceLinkFailingDomainRules(): void

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -47,6 +47,17 @@ class ArticlesTable extends Table
     }
 
     /**
+     * Find articles and eager load authors.
+     *
+     * @param \Cake\ORM\Query $query The query
+     * @param array<string, mixed> $options The options
+     */
+    public function findWithAuthors($query, array $options = []): Query
+    {
+        return $query->contain('Authors');
+    }
+
+    /**
      * Example public method
      */
     public function doSomething(): void


### PR DESCRIPTION
When a belongsToMany association uses a finder, and that finder applies a contain() the query will fail as the query is rooted in the junction table and not the association target table. This was caused by the
changes done in #15977 to fix the wrong entity type being passed to delete callbacks.

Restoring the old query fixes this issue, but would break entity delete callbacks. To solve that I've selected all the fields on the junction table and then created the correct entity. This is a bit gross, but trying to use `contain()` on the junction association doesn't work as the table has already been `innerJoinWith()` onto the query. I also attempted to use subqueries and `where exists` but abandoned that as it caused other problems in type mapping parameters.

Fixes #16252