### PR TITLE
Refactor belongs to many link query

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1187,12 +1187,13 @@ class BelongsToMany extends Association
 
                 $prefixedForeignKey = array_map([$junction, 'aliasField'], $foreignKey);
                 $junctionPrimaryKey = (array)$junction->getPrimaryKey();
+                $junctionQueryAlias = $junction->getAlias() . '__matches';
 
                 $keys = $matchesConditions = [];
                 foreach (array_merge($assocForeignKey, $junctionPrimaryKey) as $key) {
                     $aliased = $junction->aliasField($key);
                     $keys[$key] = $aliased;
-                    $matchesConditions[$aliased] = new IdentifierExpression('matches.' . $key);
+                    $matchesConditions[$aliased] = new IdentifierExpression($junctionQueryAlias . '.' . $key);
                 }
 
                 // Use association to create row selection
@@ -1204,7 +1205,7 @@ class BelongsToMany extends Association
                 // Create a subquery join to ensure we get
                 // the correct entity passed to callbacks.
                 $existing = $junction->query()
-                    ->from(['matches' => $matches])
+                    ->from([$junctionQueryAlias => $matches])
                     ->innerJoin(
                         [$junction->getAlias() => $junction->getTable()],
                         $matchesConditions

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -21,7 +21,6 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectWithPivotLoader;
 use Cake\ORM\Query;
@@ -1188,27 +1187,28 @@ class BelongsToMany extends Association
 
                 $prefixedForeignKey = array_map([$junction, 'aliasField'], $foreignKey);
                 $junctionPrimaryKey = (array)$junction->getPrimaryKey();
-                $keys = array_combine($foreignKey, $prefixedForeignKey);
+
+                $keys = $matchesConditions = [];
                 foreach (array_merge($assocForeignKey, $junctionPrimaryKey) as $key) {
-                    $keys[$key] = $junction->aliasField($key);
+                    $aliased = $junction->aliasField($key);
+                    $keys[$key] = $aliased;
+                    $matchesConditions[$aliased] = new IdentifierExpression('matches.' . $key);
                 }
 
-                $existing = $this->_appendJunctionJoin($this->find())
-                    ->select($junction)
-                    ->where(array_combine($prefixedForeignKey, $primaryValue))
-                    ->formatResults(function (ResultSetInterface $results) use ($junction) {
-                        $junctionEntity = $junction->getEntityClass();
-                        $junctionAlias = $junction->getAlias();
+                // Use association to create row selection
+                // with finders & association conditions.
+                $matches = $this->_appendJunctionJoin($this->find())
+                    ->select($keys)
+                    ->where(array_combine($prefixedForeignKey, $primaryValue));
 
-                        // Extract data for the junction entity and map the result
-                        // into junction entity instances so that delete callbacks work correctly.
-                        return $results->map(function ($item) use ($junctionEntity, $junctionAlias) {
-                            return new $junctionEntity(
-                                $item[$junctionAlias],
-                                ['markNew' => false, 'markClean' => true]
-                            );
-                        });
-                    });
+                // Create a subquery join to ensure we get
+                // the correct entity passed to callbacks.
+                $existing = $junction->query()
+                    ->from(['matches' => $matches])
+                    ->innerJoin(
+                        [$junction->getAlias() => $junction->getTable()],
+                        $matchesConditions
+                    );
 
                 $jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);
                 $inserts = $this->_diffLinks($existing, $jointEntities, $targetEntities, $options);


### PR DESCRIPTION
Update the query from #16357 to use a sub-query. This generates more complex SQL but doesn't require using a `formatResults` callback. Thanks to @ndm2 for pointing out that this can be done.

The join conditions are enough to limit the results loaded on the junction table.
