### PR TITLE
Allow psr/log 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^2.0|^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "psr/http-client": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^3.0",
+        "psr/log": "^2.0|^3.0",
         "psr/simple-cache": "^2.0 || ^3.0"
     },
     "replace": {


### PR DESCRIPTION
composer/composer requires psr/log 2 which prevents us from updating and testing certain plugins.