### PR TITLE
added ability to set a command description

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -41,6 +41,13 @@ abstract class BaseCommand implements CommandInterface
     protected $name = 'cake unknown';
 
     /**
+     * The description of this command
+     *
+     * @var string
+     */
+    protected $description = '';
+
+    /**
      * @inheritDoc
      */
     public function setName(string $name)
@@ -63,6 +70,26 @@ abstract class BaseCommand implements CommandInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setDescription(string $description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Get the command description.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
     }
 
     /**

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -45,7 +45,7 @@ abstract class BaseCommand implements CommandInterface
      *
      * @var string
      */
-    protected $description = '';
+    protected static $description = '';
 
     /**
      * @inheritDoc
@@ -77,9 +77,9 @@ abstract class BaseCommand implements CommandInterface
      *
      * @return string
      */
-    public function getDescription(): string
+    public static function getDescription(): string
     {
-        return $this->description;
+        return static::$description;
     }
 
     /**

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -73,16 +73,6 @@ abstract class BaseCommand implements CommandInterface
     }
 
     /**
-     * @inheritDoc
-     */
-    public function setDescription(string $description)
-    {
-        $this->description = $description;
-
-        return $this;
-    }
-
-    /**
      * Get the command description.
      *
      * @return string

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -41,13 +41,6 @@ abstract class BaseCommand implements CommandInterface
     protected $name = 'cake unknown';
 
     /**
-     * The description of this command
-     *
-     * @var string
-     */
-    protected static $description = '';
-
-    /**
      * @inheritDoc
      */
     public function setName(string $name)
@@ -79,7 +72,7 @@ abstract class BaseCommand implements CommandInterface
      */
     public static function getDescription(): string
     {
-        return static::$description;
+        return '';
     }
 
     /**

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -138,7 +138,7 @@ abstract class BaseCommand implements CommandInterface
      */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
-        return $parser;
+        return $parser->setDescription(static::getDescription());
     }
 
     /**

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -119,6 +119,7 @@ abstract class BaseCommand implements CommandInterface
         [$root, $name] = explode(' ', $this->name, 2);
         $parser = new ConsoleOptionParser($name);
         $parser->setRootName($root);
+        $parser->setDescription(static::getDescription());
 
         $parser = $this->buildOptionParser($parser);
         if ($parser->subcommands()) {
@@ -138,7 +139,7 @@ abstract class BaseCommand implements CommandInterface
      */
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
-        return $parser->setDescription(static::getDescription());
+        return $parser;
     }
 
     /**

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -113,15 +113,8 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             }
 
             $description = '';
-            try {
-                $reflectionClass = (new \ReflectionClass($class));
-                if (!$reflectionClass->isAbstract()) {
-                    $instance = $reflectionClass->newInstanceWithoutConstructor();
-                    if (is_subclass_of($instance, BaseCommand::class)) {
-                        $description = $instance->getDescription();
-                    }
-                }
-            } catch (\ReflectionException $e) {
+            if (method_exists($class, 'getDescription')) {
+                $description = $class::getDescription();
             }
             $grouped[$prefix][] = [
                 'name' => $shortestName,

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -128,7 +128,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             foreach ($names as $data) {
                 $io->out(' - ' . $data['name']);
                 if ($data['description']) {
-                    $io->info(str_pad(' \u{2514}', 15, '\u{2500}') . ' ' . $data['description']);
+                    $io->info(str_pad(" \u{2514}", 13, "\u{2500}") . ' ' . $data['description']);
                 }
             }
             $io->out('');

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -128,7 +128,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             foreach ($names as $data) {
                 $io->out(' - ' . $data['name']);
                 if ($data['description']) {
-                    $io->info(str_pad(' \'', 5, '-') . ' ' . $data['description']);
+                    $io->info(str_pad(' \u{2514}', 15, '\u{2500}') . ' ' . $data['description']);
                 }
             }
             $io->out('');

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -130,7 +130,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             $io->out("<info>{$prefix}</info>:");
             sort($names);
             foreach ($names as $data) {
-                if ($data['description'] !== '') {
+                if ($data['description']) {
                     $io->out(' - ' . str_pad($data['name'], 50) . ' | ' . $data['description']);
                 } else {
                     $io->out(' - ' . $data['name']);

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -112,13 +112,9 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
                 [, $shortestName] = explode('.', $shortestName, 2);
             }
 
-            $description = '';
-            if (method_exists($class, 'getDescription')) {
-                $description = $class::getDescription();
-            }
             $grouped[$prefix][] = [
                 'name' => $shortestName,
-                'description' => $description,
+                'description' => is_subclass_of($class, BaseCommand::class) ? $class::getDescription() : '',
             ];
         }
         ksort($grouped);

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -126,10 +126,9 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
             $io->out("<info>{$prefix}</info>:");
             sort($names);
             foreach ($names as $data) {
+                $io->out(' - ' . $data['name']);
                 if ($data['description']) {
-                    $io->out(' - ' . str_pad($data['name'], 50) . ' | ' . $data['description']);
-                } else {
-                    $io->out(' - ' . $data['name']);
+                    $io->info(str_pad(' \'', 5, '-') . ' ' . $data['description']);
                 }
             }
             $io->out('');

--- a/src/Console/CommandInterface.php
+++ b/src/Console/CommandInterface.php
@@ -50,14 +50,6 @@ interface CommandInterface
     public function setName(string $name);
 
     /**
-     * Set the description of this command
-     *
-     * @param string $description The description for the command
-     * @return mixed
-     */
-    public function setDescription(string $description);
-
-    /**
      * Run the command.
      *
      * @param array $argv Arguments from the CLI environment.

--- a/src/Console/CommandInterface.php
+++ b/src/Console/CommandInterface.php
@@ -50,6 +50,14 @@ interface CommandInterface
     public function setName(string $name);
 
     /**
+     * Set the description of this command
+     *
+     * @param string $description The description for the command
+     * @return mixed
+     */
+    public function setDescription(string $description);
+
+    /**
      * Run the command.
      *
      * @param array $argv Arguments from the CLI environment.

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -95,6 +95,7 @@ class HelpCommandTest extends TestCase
         $this->assertOutputContains('- abort', 'command object');
         $this->assertOutputContains('To run a command', 'more info present');
         $this->assertOutputContains('To get help', 'more info present');
+        $this->assertOutputContains('This is a demo command', 'command description missing');
     }
 
     /**

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -9,7 +9,10 @@ use Cake\Console\ConsoleIo;
 
 class DemoCommand extends Command
 {
-    protected static $description = 'This is a demo command';
+    public static function getDescription(): string
+    {
+        return 'This is a demo command';
+    }
 
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -9,7 +9,7 @@ use Cake\Console\ConsoleIo;
 
 class DemoCommand extends Command
 {
-    protected $description = 'This is a demo command';
+    protected static $description = 'This is a demo command';
 
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -9,6 +9,8 @@ use Cake\Console\ConsoleIo;
 
 class DemoCommand extends Command
 {
+    protected $description = 'This is a demo command';
+
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $io->quiet('Quiet!');


### PR DESCRIPTION
<img width="602" alt="image" src="https://user-images.githubusercontent.com/9105243/157096268-81855f2e-3198-4807-bb59-c4b0818176a9.png">

With this PR it is possible to set a description inside a command like so

```
class BirthdayNotificationCommand extends Command
{
    protected $description = "This is a test";

    ... rest of the command ...
}
```

Currently the description is only printed when using the HelpCommand `bin/cake` aka `bin/cake help`

But `bin/cake birthday_notification --help` doesn't print the description.

I don't know if the usage of Reflection - especially the usage of `->newInstanceWithoutConstructor();` - is OK with you but I didn't find another way how to access protected property values without having an instance present in there.

Also I can't just create a new instance of that command on the fly at that moment because - especially since the introduction of the DI Container - we can't instanciate objects in there (as far as I know at least 😅 )