### PR TITLE
Allow naming plugin classes matching the plugin name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
             "TestPluginTwo\\": "tests/test_app/Plugin/TestPluginTwo/src/",
             "Company\\TestPluginThree\\": "tests/test_app/Plugin/Company/TestPluginThree/src/",
             "Company\\TestPluginThree\\Test\\": "tests/test_app/Plugin/Company/TestPluginThree/tests/",
-            "ParentPlugin\\": "tests/test_app/Plugin/ParentPlugin/src/"
+            "Named\\": "tests/test_app/Plugin/Named/src/"
         }
     },
     "scripts": {

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -238,15 +238,28 @@ class PluginCollection implements Iterator, Countable
         }
 
         $config += ['name' => $name];
-        /** @var class-string<\Cake\Core\PluginInterface> $className */
-        $className = str_replace('/', '\\', $name) . '\\' . 'Plugin';
+        $namespace = str_replace('/', '\\', $name);
+
+        $className = $namespace . '\\' . 'Plugin';
+        // Check for [Vendor/]Foo/Plugin class
         if (!class_exists($className)) {
-            $className = BasePlugin::class;
-            if (empty($config['path'])) {
-                $config['path'] = $this->findPath($name);
+            $pos = strpos($name, '/');
+            if ($pos === false) {
+                $className = $namespace . '\\' . $name . 'Plugin';
+            } else {
+                $className = $namespace . '\\' . substr($name, $pos + 1) . 'Plugin';
+            }
+
+            // Check for [Vendor/]Foo/FooPlugin
+            if (!class_exists($className)) {
+                $className = BasePlugin::class;
+                if (empty($config['path'])) {
+                    $config['path'] = $this->findPath($name);
+                }
             }
         }
 
+        /** @var class-string<\Cake\Core\PluginInterface> $className */
         return new $className($config);
     }
 

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -25,7 +25,7 @@ use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
-use Company\TestPluginThree\Plugin as TestPluginThree;
+use Company\TestPluginThree\TestPluginThreePlugin;
 use TestPlugin\Plugin as TestPlugin;
 
 /**
@@ -64,7 +64,7 @@ class BasePluginTest extends TestCase
         $plugin = new TestPlugin();
         $this->assertSame('TestPlugin', $plugin->getName());
 
-        $plugin = new TestPluginThree();
+        $plugin = new TestPluginThreePlugin();
         $this->assertSame('Company/TestPluginThree', $plugin->getName());
     }
 

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -21,9 +21,9 @@ use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\PluginCollection;
 use Cake\Core\PluginInterface;
 use Cake\TestSuite\TestCase;
-use Company\TestPluginThree\Plugin as TestPluginThree;
+use Company\TestPluginThree\TestPluginThreePlugin;
 use InvalidArgumentException;
-use ParentPlugin\Plugin;
+use Named\NamedPlugin;
 use TestPlugin\Plugin as TestPlugin;
 
 /**
@@ -65,7 +65,7 @@ class PluginCollectionTest extends TestCase
     public function testAddVendoredPlugin(): void
     {
         $plugins = new PluginCollection();
-        $plugins->add(new TestPluginThree());
+        $plugins->add(new TestPluginThreePlugin());
 
         $this->assertTrue($plugins->has('Company/TestPluginThree'));
         $this->assertFalse($plugins->has('TestPluginThree'));
@@ -95,8 +95,8 @@ class PluginCollectionTest extends TestCase
     public function testGetAutoload(): void
     {
         $plugins = new PluginCollection();
-        $plugin = $plugins->get('ParentPlugin');
-        $this->assertInstanceOf(Plugin::class, $plugin);
+        $plugin = $plugins->get('Named');
+        $this->assertInstanceOf(NamedPlugin::class, $plugin);
     }
 
     public function testGetInvalid(): void
@@ -111,15 +111,18 @@ class PluginCollectionTest extends TestCase
     {
         $plugins = new PluginCollection();
 
-        $plugin = $plugins->create('ParentPlugin');
-        $this->assertInstanceOf(Plugin::class, $plugin);
+        $plugin = $plugins->create('Named');
+        $this->assertInstanceOf(NamedPlugin::class, $plugin);
 
-        $plugin = $plugins->create('ParentPlugin', ['name' => 'Granpa']);
-        $this->assertInstanceOf(Plugin::class, $plugin);
+        $plugin = $plugins->create('Named', ['name' => 'Granpa']);
+        $this->assertInstanceOf(NamedPlugin::class, $plugin);
         $this->assertSame('Granpa', $plugin->getName());
 
-        $plugin = $plugins->create(Plugin::class);
-        $this->assertInstanceOf(Plugin::class, $plugin);
+        $plugin = $plugins->create(NamedPlugin::class);
+        $this->assertInstanceOf(NamedPlugin::class, $plugin);
+
+        $plugin = $plugins->create('Company/TestPluginThree');
+        $this->assertInstanceOf(TestPluginThreePlugin::class, $plugin);
 
         $plugin = $plugins->create('TestTheme');
         $this->assertInstanceOf(BasePlugin::class, $plugin);
@@ -130,7 +133,7 @@ class PluginCollectionTest extends TestCase
     {
         $data = [
             new TestPlugin(),
-            new TestPluginThree(),
+            new TestPluginThreePlugin(),
         ];
         $plugins = new PluginCollection($data);
         $out = [];
@@ -147,7 +150,7 @@ class PluginCollectionTest extends TestCase
         $plugin = new TestPlugin();
         $plugin->disable('routes');
 
-        $pluginThree = new TestPluginThree();
+        $pluginThree = new TestPluginThreePlugin();
 
         $plugins->add($plugin);
         $plugins->add($pluginThree);
@@ -171,7 +174,7 @@ class PluginCollectionTest extends TestCase
     {
         $plugins = new PluginCollection();
         $plugin = new TestPlugin();
-        $pluginThree = new TestPluginThree();
+        $pluginThree = new TestPluginThreePlugin();
 
         $plugins->add($plugin);
         $plugins->add($pluginThree);

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -183,10 +183,10 @@ class BaseApplicationTest extends TestCase
             BaseApplication::class,
             [$this->path]
         );
-        $app->addPlugin('ParentPlugin');
+        $app->addPlugin('Named');
         $app->pluginBootstrap();
         $this->assertTrue(
-            Configure::check('ParentPlugin.bootstrap'),
+            Configure::check('Named.bootstrap'),
             'Plugin bootstrap should be run'
         );
         $this->assertTrue(

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/TestPluginThreePlugin.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/TestPluginThreePlugin.php
@@ -17,6 +17,6 @@ namespace Company\TestPluginThree;
 
 use Cake\Core\BasePlugin;
 
-class Plugin extends BasePlugin
+class TestPluginThreePlugin extends BasePlugin
 {
 }

--- a/tests/test_app/Plugin/Named/src/NamedPlugin.php
+++ b/tests/test_app/Plugin/Named/src/NamedPlugin.php
@@ -1,17 +1,17 @@
 <?php
 declare(strict_types=1);
 
-namespace ParentPlugin;
+namespace Named;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\PluginApplicationInterface;
 
-class Plugin extends BasePlugin
+class NamedPlugin extends BasePlugin
 {
     public function bootstrap(PluginApplicationInterface $app): void
     {
-        Configure::write('ParentPlugin.bootstrap', true);
+        Configure::write('Named.bootstrap', true);
 
         $app->addPlugin('TestPluginTwo', ['bootstrap' => true]);
         $app->addPlugin('TestPlugin', ['bootstrap' => true]);


### PR DESCRIPTION
This avoids having numerous classes named "Plugin" in your app. You can now name the class the same as the plugin name with a "Plugin" suffix. For e.g. `ADmad\I18n\I18nPlugin` instead of `ADmad\I18n\Plugin`.