### PR TITLE
Avoid possible TypeError Exception

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -222,6 +222,10 @@ class FileEngine extends CacheEngine
         /** @psalm-suppress PossiblyNullReference */
         $path = $this->_File->getRealPath();
         $this->_File = null;
+        
+        if ($path === false) {
+            return false;
+        }
 
         // phpcs:disable
         return @unlink($path);

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -222,7 +222,7 @@ class FileEngine extends CacheEngine
         /** @psalm-suppress PossiblyNullReference */
         $path = $this->_File->getRealPath();
         $this->_File = null;
-        
+
         if ($path === false) {
             return false;
         }


### PR DESCRIPTION
Exception: unlink(): Argument #1 ($filename) must be of type string, bool given
In [vendor/cakephp/cakephp/src/Cache/Engine/FileEngine.php, line 227]

2022-03-11 02:32:30 error: [TypeError] unlink(): Argument #1 ($filename) must be of type string, bool given in vendor/cakephp/cakephp/src/Cache/Engine/FileEngine.php on line 227

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
