### PR TITLE
Remove redundancy in regex.

### DIFF
--- a/src/Database/Driver/SqlDialectTrait.php
+++ b/src/Database/Driver/SqlDialectTrait.php
@@ -73,14 +73,14 @@ trait SqlDialectTrait
         }
 
         // string.string with spaces
-        if (preg_match('/^([\w-]+\.[\w][\w\s\-]*[\w])(.*)/u', $identifier, $matches)) {
+        if (preg_match('/^([\w-]+\.[\w][\w\s-]*[\w])(.*)/u', $identifier, $matches)) {
             $items = explode('.', $matches[1]);
             $field = implode($this->_endQuote . '.' . $this->_startQuote, $items);
 
             return $this->_startQuote . $field . $this->_endQuote . $matches[2];
         }
 
-        if (preg_match('/^[\w_\s-]*[\w_-]+/u', $identifier)) {
+        if (preg_match('/^[\w\s-]*[\w-]+/u', $identifier)) {
             return $this->_startQuote . $identifier . $this->_endQuote;
         }
 


### PR DESCRIPTION
"\w" already includes underscore.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
