### PR TITLE
5.x Arrow functions

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -18,7 +18,6 @@ namespace Cake\Collection;
 
 use AppendIterator;
 use ArrayIterator;
-use ArrayObject;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -652,7 +652,7 @@ trait CollectionTrait
         };
 
         return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer))
-            ->map(fn(ArrayObject|ArrayIterator $value) => $isObject ? $value : $value->getArrayCopy());
+            ->map(fn($value) => $isObject ? $value : $value->getArrayCopy());
     }
 
     /**

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -48,9 +48,7 @@ trait ExtractTrait
         $parts = explode('.', $path);
 
         if (str_contains($path, '{*}')) {
-            return function ($element) use ($parts) {
-                return $this->_extract($element, $parts);
-            };
+            return fn($element) => $this->_extract($element, $parts);
         }
 
         return function ($element) use ($parts) {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -141,14 +141,12 @@ abstract class Driver implements DriverInterface
      */
     protected function createPdo(string $dsn, array $config): PDO
     {
-        $action = function () use ($dsn, $config): PDO {
-            return new PDO(
-                $dsn,
-                $config['username'] ?: null,
-                $config['password'] ?: null,
-                $config['flags']
-            );
-        };
+        $action = fn() => new PDO(
+            $dsn,
+            $config['username'] ?: null,
+            $config['password'] ?: null,
+            $config['flags']
+        );
 
         $retry = new CommandRetry(new ErrorCodeWaitStrategy(static::RETRY_ERROR_CODES, 5), 4);
         try {

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -511,7 +511,9 @@ class Sqlserver extends Driver
 
                     return $p;
                 };
-                $manipulator = fn($p, $key) => $params[$key];
+                $manipulator = function($p, $key) use (&$params) {
+                    return $params[$key];
+                };
 
                 $expression
                     ->setName('DATEADD')

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -511,9 +511,7 @@ class Sqlserver extends Driver
 
                     return $p;
                 };
-                $manipulator = function ($p, $key) use (&$params) {
-                    return $params[$key];
-                };
+                $manipulator = fn($p, $key) => $params[$key];
 
                 $expression
                     ->setName('DATEADD')
@@ -533,9 +531,7 @@ class Sqlserver extends Driver
                 if (count($expression) < 4) {
                     $params = [];
                     $expression
-                        ->iterateParts(function ($p) use (&$params) {
-                            return $params[] = $p;
-                        })
+                        ->iterateParts(fn($p) => $params[] = $p)
                         ->add([new FunctionExpression('LEN', [$params[0]]), ['string']]);
                 }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -531,7 +531,9 @@ class Sqlserver extends Driver
                 if (count($expression) < 4) {
                     $params = [];
                     $expression
-                        ->iterateParts(fn($p) => $params[] = $p)
+                        ->iterateParts(function ($p) use (&$params) {
+                            return $params[] = $p;
+                        })
                         ->add([new FunctionExpression('LEN', [$params[0]]), ['string']]);
                 }
 

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -184,9 +184,7 @@ class CommonTableExpression implements ExpressionInterface
     {
         $fields = '';
         if ($this->fields) {
-            $expressions = array_map(function (IdentifierExpression $e) use ($binder) {
-                return $e->sql($binder);
-            }, $this->fields);
+            $expressions = array_map(fn(IdentifierExpression $e) => $e->sql($binder), $this->fields);
             $fields = sprintf('(%s)', implode(', ', $expressions));
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2146,9 +2146,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
         }
 
         if ($expression instanceof ExpressionInterface) {
-            $expression->traverse(function ($exp) use ($callback): void {
-                $this->_expressionsVisitor($exp, $callback);
-            });
+            $expression->traverse(fn($exp) => $this->_expressionsVisitor($exp, $callback));
 
             if (!$expression instanceof self) {
                 $callback($expression);

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1133,9 +1133,7 @@ trait EntityTrait
     public function setAccess(array|string $field, bool $set)
     {
         if ($field === '*') {
-            $this->_accessible = array_map(function ($p) use ($set) {
-                return $set;
-            }, $this->_accessible);
+            $this->_accessible = array_map(fn($p) => $set, $this->_accessible);
             $this->_accessible['*'] = $set;
 
             return $this;

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -287,10 +287,7 @@ class HasMany extends Association
 
         $sourceEntity->set($property, $currentEntities);
 
-        $savedEntity = $this->getConnection()->transactional(function () use ($sourceEntity, $options) {
-            return $this->saveAssociated($sourceEntity, $options);
-        });
-
+        $savedEntity = $this->getConnection()->transactional(fn() => $this->saveAssociated($sourceEntity, $options));
         $ok = ($savedEntity instanceof EntityInterface);
 
         $this->setSaveStrategy($saveStrategy);

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -217,9 +217,7 @@ class EavStrategy implements TranslateStrategyInterface
         }
 
         $query->contain($contain);
-        $query->formatResults(function ($results) use ($locale) {
-            return $this->rowMapper($results, $locale);
-        }, $query::PREPEND);
+        $query->formatResults(fn(CollectionInterface $results) => $this->rowMapper($results, $locale), $query::PREPEND);
     }
 
     /**

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -146,9 +146,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
 
         $query->contain([$config['hasOneAlias']]);
 
-        $query->formatResults(function ($results) use ($locale) {
-            return $this->rowMapper($results, $locale);
-        }, $query::PREPEND);
+        $query->formatResults(fn(CollectionInterface $results) => $this->rowMapper($results, $locale), $query::PREPEND);
     }
 
     /**

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -18,6 +18,7 @@ namespace Cake\ORM\Behavior;
 
 use Cake\Collection\CollectionInterface;
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\EventInterface;
@@ -228,12 +229,9 @@ class TreeBehavior extends Behavior
         if ($diff > 2) {
             $query = $this->_scope($this->_table->query())
                 ->delete()
-                ->where(function ($exp) use ($config, $left, $right) {
-                    /** @var \Cake\Database\Expression\QueryExpression $exp */
-                    return $exp
-                        ->gte($config['leftField'], $left + 1)
-                        ->lte($config['leftField'], $right - 1);
-                });
+                ->where(fn(QueryExpression $exp) => $exp
+                    ->gte($config['leftField'], $left + 1)
+                    ->lte($config['leftField'], $right - 1));
             $statement = $query->execute();
             $statement->closeCursor();
         }
@@ -358,10 +356,7 @@ class TreeBehavior extends Behavior
                     ->eq($config['leftField'], $leftInverse->add($config['leftField']))
                     ->eq($config['rightField'], $rightInverse->add($config['rightField']));
             },
-            function ($exp) use ($config) {
-                /** @var \Cake\Database\Expression\QueryExpression $exp */
-                return $exp->lt($config['leftField'], 0);
-            }
+            fn(QueryExpression $exp) => $exp->lt($config['leftField'], 0)
         );
     }
 
@@ -641,10 +636,7 @@ class TreeBehavior extends Behavior
             $targetNode = $this->_scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
-                ->where(function ($exp) use ($config, $nodeLeft) {
-                    /** @var \Cake\Database\Expression\QueryExpression $exp */
-                    return $exp->lt($config['rightField'], $nodeLeft);
-                })
+                ->where(fn(QueryExpression $exp) => $exp->lt($config['rightField'], $nodeLeft))
                 ->orderDesc($config['leftField'])
                 ->offset($number - 1)
                 ->limit(1)
@@ -655,10 +647,7 @@ class TreeBehavior extends Behavior
             $targetNode = $this->_scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
-                ->where(function ($exp) use ($config, $nodeLeft) {
-                    /** @var \Cake\Database\Expression\QueryExpression $exp */
-                    return $exp->lt($config['rightField'], $nodeLeft);
-                })
+                ->where(fn(QueryExpression $exp) => $exp->lt($config['rightField'], $nodeLeft))
                 ->orderAsc($config['leftField'])
                 ->limit(1)
                 ->first();
@@ -735,10 +724,7 @@ class TreeBehavior extends Behavior
             $targetNode = $this->_scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
-                ->where(function ($exp) use ($config, $nodeRight) {
-                    /** @var \Cake\Database\Expression\QueryExpression $exp */
-                    return $exp->gt($config['leftField'], $nodeRight);
-                })
+                ->where(fn(QueryExpression $exp) => $exp->gt($config['leftField'], $nodeRight))
                 ->orderAsc($config['leftField'])
                 ->offset($number - 1)
                 ->limit(1)
@@ -749,10 +735,7 @@ class TreeBehavior extends Behavior
             $targetNode = $this->_scope($this->_table->find())
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
-                ->where(function ($exp) use ($config, $nodeRight) {
-                    /** @var \Cake\Database\Expression\QueryExpression $exp */
-                    return $exp->gt($config['leftField'], $nodeRight);
-                })
+                ->where(fn(QueryExpression $exp) => $exp->gt($config['leftField'], $nodeRight))
                 ->orderDesc($config['leftField'])
                 ->limit(1)
                 ->first();

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -370,9 +370,7 @@ class EagerLoader
             if (isset($options['queryBuilder'], $pointer[$table]['queryBuilder'])) {
                 $first = $pointer[$table]['queryBuilder'];
                 $second = $options['queryBuilder'];
-                $options['queryBuilder'] = function ($query) use ($first, $second) {
-                    return $second($first($query));
-                };
+                $options['queryBuilder'] =  fn($query) => $second($first($query));
             }
 
             if (!is_array($options)) {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -370,7 +370,7 @@ class EagerLoader
             if (isset($options['queryBuilder'], $pointer[$table]['queryBuilder'])) {
                 $first = $pointer[$table]['queryBuilder'];
                 $second = $options['queryBuilder'];
-                $options['queryBuilder'] =  fn($query) => $second($first($query));
+                $options['queryBuilder'] = fn($query) => $second($first($query));
             }
 
             if (!is_array($options)) {

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -18,6 +18,7 @@ namespace Cake\ORM;
 
 use ArrayObject;
 use Cake\Collection\Collection;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\EntityInterface;
@@ -75,9 +76,7 @@ class Marshaller
             $prop = (string)$prop;
             $columnType = $schema->getColumnType($prop);
             if ($columnType) {
-                $map[$prop] = function ($value, $entity) use ($columnType) {
-                    return TypeFactory::build($columnType)->marshal($value);
-                };
+                $map[$prop] = fn($value) => TypeFactory::build($columnType)->marshal($value);
             }
         }
 
@@ -405,10 +404,7 @@ class Marshaller
 
         if (!empty($conditions)) {
             $query = $target->find();
-            $query->andWhere(function ($exp) use ($conditions) {
-                /** @var \Cake\Database\Expression\QueryExpression $exp */
-                return $exp->or($conditions);
-            });
+            $query->andWhere(fn(QueryExpression $exp) => $exp->or($conditions));
 
             $keyFields = array_keys($primaryKey);
 
@@ -685,9 +681,7 @@ class Marshaller
             ->map(function ($data, $key) {
                 return explode(';', (string)$key);
             })
-            ->filter(function ($keys) use ($primary) {
-                return count(Hash::filter($keys)) === count($primary);
-            })
+            ->filter(fn ($keys) => count(Hash::filter($keys)) === count($primary))
             ->reduce(function ($conditions, $keys) use ($primary) {
                 $fields = array_map([$this->_table, 'aliasField'], $primary);
                 $conditions['OR'][] = array_combine($fields, $keys);

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -133,9 +133,7 @@ class ExistsIn
         }
 
         $primary = array_map(
-            function ($key) use ($target) {
-                return $target->aliasField($key) . ' IS';
-            },
+            fn($key) => $target->aliasField($key) . ' IS',
             $bindingKey
         );
         $conditions = array_combine(

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1385,14 +1385,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ['keyField', 'valueField', 'groupField']
         );
 
-        return $query->formatResults(function ($results) use ($options) {
+        return $query->formatResults(fn($results) =>
             /** @var \Cake\Collection\CollectionInterface $results */
-            return $results->combine(
+            $results->combine(
                 $options['keyField'],
                 $options['valueField'],
                 $options['groupField']
-            );
-        });
+            ));
     }
 
     /**
@@ -1429,10 +1428,9 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $options = $this->_setFieldMatchers($options, ['keyField', 'parentField']);
 
-        return $query->formatResults(function ($results) use ($options) {
+        return $query->formatResults(fn($results) =>
             /** @var \Cake\Collection\CollectionInterface $results */
-            return $results->nest($options['keyField'], $options['parentField'], $options['nestingKey']);
-        });
+            $results->nest($options['keyField'], $options['parentField'], $options['nestingKey']));
     }
 
     /**
@@ -1551,9 +1549,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected function _executeTransaction(callable $worker, bool $atomic = true): mixed
     {
         if ($atomic) {
-            return $this->getConnection()->transactional(function () use ($worker) {
-                return $worker();
-            });
+            return $this->getConnection()->transactional(fn () => $worker());
         }
 
         return $worker();
@@ -1615,9 +1611,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             'defaults' => true,
         ]);
 
-        $entity = $this->_executeTransaction(function () use ($search, $callback, $options) {
-            return $this->_processFindOrCreate($search, $callback, $options->getArrayCopy());
-        }, $options['atomic']);
+        $entity = $this->_executeTransaction(
+            fn() => $this->_processFindOrCreate($search, $callback, $options->getArrayCopy()),
+            $options['atomic']
+        );
 
         if ($entity && $this->_transactionCommitted($options['atomic'], true)) {
             $this->dispatchEvent('Model.afterSaveCommit', compact('entity', 'options'));
@@ -1882,9 +1879,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             return $entity;
         }
 
-        $success = $this->_executeTransaction(function () use ($entity, $options) {
-            return $this->_processSave($entity, $options);
-        }, $options['atomic']);
+        $success = $this->_executeTransaction(
+            fn() => $this->_processSave($entity, $options),
+            $options['atomic']
+        );
 
         if ($success) {
             if ($this->_transactionCommitted($options['atomic'], $options['_primary'])) {
@@ -2331,9 +2329,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             '_primary' => true,
         ]);
 
-        $success = $this->_executeTransaction(function () use ($entity, $options) {
-            return $this->_processDelete($entity, $options);
-        }, $options['atomic']);
+        $success = $this->_executeTransaction(
+            fn() => $this->_processDelete($entity, $options),
+            $options['atomic']
+        );
 
         if ($success && $this->_transactionCommitted($options['atomic'], $options['_primary'])) {
             $this->dispatchEvent('Model.afterDeleteCommit', [

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -99,9 +99,7 @@ class ConnectionHelper
         }
 
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
-        $schemas = array_map(function ($table) use ($collection) {
-            return $collection->describe($table);
-        }, $tables);
+        $schemas = array_map(fn($table) => $collection->describe($table), $tables);
 
         $dialect = $connection->getDriver()->schemaDialect();
         /** @var \Cake\Database\Schema\TableSchema $schema */
@@ -133,9 +131,7 @@ class ConnectionHelper
 
         $allTables = $collection->listTablesWithoutViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
-        $schemas = array_map(function ($table) use ($collection) {
-            return $collection->describe($table);
-        }, $tables);
+        $schemas = array_map(fn($table) => $collection->describe($table), $tables);
 
         $this->runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
             $dialect = $connection->getDriver()->schemaDialect();
@@ -158,14 +154,10 @@ class ConnectionHelper
     public function runWithoutConstraints(Connection $connection, Closure $callback): void
     {
         if ($connection->getDriver()->supports(DriverInterface::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION)) {
-            $connection->disableConstraints(function (Connection $connection) use ($callback): void {
-                $callback($connection);
-            });
+            $connection->disableConstraints(fn(Connection $connection) => $callback($connection));
         } else {
             $connection->transactional(function (Connection $connection) use ($callback): void {
-                $connection->disableConstraints(function (Connection $connection) use ($callback): void {
-                    $callback($connection);
-                });
+                $connection->disableConstraints(fn(Connection $connection) => $callback($connection));
             });
         }
     }

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -142,9 +142,7 @@ class FixtureHelper
                     $helper = new ConnectionHelper();
                     $helper->runWithoutConstraints(
                         $connection,
-                        function (Connection $connection) use ($groupFixtures): void {
-                            $this->insertConnection($connection, $groupFixtures);
-                        }
+                        fn(Connection $connection) => $this->insertConnection($connection, $groupFixtures)
                     );
                 }
             } else {
@@ -199,9 +197,7 @@ class FixtureHelper
                     $helper = new ConnectionHelper();
                     $helper->runWithoutConstraints(
                         $connection,
-                        function (Connection $connection) use ($groupFixtures): void {
-                            $this->truncateConnection($connection, $groupFixtures);
-                        }
+                        fn(Connection $connection) => $this->truncateConnection($connection, $groupFixtures)
                     );
                 }
             } else {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1052,9 +1052,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return $when === static::WHEN_CREATE ? static::WHEN_UPDATE : static::WHEN_CREATE;
         }
         if ($when instanceof Closure) {
-            return function ($context) use ($when) {
-                return !$when($context);
-            };
+            return fn($context) => !$when($context);
         }
 
         return $when;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2347,9 +2347,10 @@ class FormHelper extends Helper
             }
             // Complex option types
             if (is_array($first)) {
-                $disabled = array_filter($options['options'], function ($i) use ($options) {
-                    return in_array($i['value'], $options['disabled'], true);
-                });
+                $disabled = array_filter(
+                    $options['options'],
+                    fn($i) => in_array($i['value'], $options['disabled'], true)
+                );
 
                 return count($disabled) > 0;
             }


### PR DESCRIPTION
Move as many closures to use the short syntax. There were a few I left alone as going to a short function would change return semantics and I didn't want to break anything.