### PR TITLE
Simplify param types for FactoryLocator.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
             "src/Core/functions.php",
             "src/Collection/functions.php",
             "src/I18n/functions.php",
+            "src/ORM/bootstrap.php",
             "src/Routing/functions.php",
             "src/Utility/bootstrap.php"
         ]

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Datasource\Locator\LocatorInterface;
-use Cake\ORM\Locator\TableLocator;
 use InvalidArgumentException;
 
 /**
@@ -28,7 +27,7 @@ class FactoryLocator
     /**
      * A list of model factory functions.
      *
-     * @var array<callable|\Cake\Datasource\Locator\LocatorInterface>
+     * @var array<string, \Cake\Datasource\Locator\LocatorInterface>
      */
     protected static array $_modelFactories = [];
 
@@ -36,10 +35,10 @@ class FactoryLocator
      * Register a callable to generate repositories of a given type.
      *
      * @param string $type The name of the repository type the factory function is for.
-     * @param \Cake\Datasource\Locator\LocatorInterface|callable $factory The factory function used to create instances.
+     * @param \Cake\Datasource\Locator\LocatorInterface $factory The factory function used to create instances.
      * @return void
      */
-    public static function add(string $type, LocatorInterface|callable $factory): void
+    public static function add(string $type, LocatorInterface $factory): void
     {
         static::$_modelFactories[$type] = $factory;
     }
@@ -60,21 +59,17 @@ class FactoryLocator
      *
      * @param string $type The repository type to get the factory for.
      * @throws \InvalidArgumentException If the specified repository type has no factory.
-     * @return \Cake\Datasource\Locator\LocatorInterface|callable The factory for the repository type.
+     * @return \Cake\Datasource\Locator\LocatorInterface The factory for the repository type.
      */
-    public static function get(string $type): LocatorInterface|callable
+    public static function get(string $type): LocatorInterface
     {
-        if (!isset(static::$_modelFactories['Table'])) {
-            static::$_modelFactories['Table'] = new TableLocator();
+        if (isset(static::$_modelFactories[$type])) {
+            return static::$_modelFactories[$type];
         }
 
-        if (!isset(static::$_modelFactories[$type])) {
-            throw new InvalidArgumentException(sprintf(
-                'Unknown repository type "%s". Make sure you register a type before trying to use it.',
-                $type
-            ));
-        }
-
-        return static::$_modelFactories[$type];
+        throw new InvalidArgumentException(sprintf(
+            'Unknown repository type "%s". Make sure you register a type before trying to use it.',
+            $type
+        ));
     }
 }

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -59,7 +59,10 @@ trait LocatorAwareTrait
      */
     public function getTableLocator(): LocatorInterface
     {
-        /** @var \Cake\ORM\Locator\LocatorInterface */
+        /**
+         * @var \Cake\ORM\Locator\LocatorInterface
+         * @psalm-suppress PropertyTypeCoercion
+         */
         return $this->_tableLocator ??= FactoryLocator::get('Table');
     }
 

--- a/src/ORM/bootstrap.php
+++ b/src/ORM/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Datasource\FactoryLocator;
+use Cake\ORM\Locator\TableLocator;
+
+FactoryLocator::add('Table', new TableLocator());

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -39,6 +39,9 @@
     "autoload": {
         "psr-4": {
             "Cake\\ORM\\": "."
-        }
+        },
+        "files": [
+            "bootstrap.php"
+        ]
     }
 }

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -19,7 +19,6 @@ use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\Locator\LocatorInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use stdClass;
 
 /**
  * FactoryLocatorTest test case
@@ -50,14 +49,6 @@ class FactoryLocatorTest extends TestCase
      */
     public function testAdd(): void
     {
-        FactoryLocator::add('Test', function ($name) {
-            $mock = new stdClass();
-            $mock->name = $name;
-
-            return $mock;
-        });
-        $this->assertIsCallable(FactoryLocator::get('Test'));
-
         $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
         FactoryLocator::add('MyType', $locator);
         $this->assertInstanceOf(LocatorInterface::class, FactoryLocator::get('MyType'));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,8 +17,10 @@ use Cake\Cache\Cache;
 use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\FactoryLocator;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Log\Log;
+use Cake\ORM\Locator\TableLocator;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use Cake\Utility\Security;
 
@@ -107,6 +109,8 @@ ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
 if (env('CAKE_TEST_AUTOQUOTE')) {
     ConnectionManager::get('test')->getDriver()->enableAutoQuoting(true);
 }
+
+FactoryLocator::add('Table', new TableLocator());
 
 Configure::write('Session', [
     'defaults' => 'php',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,10 +17,8 @@ use Cake\Cache\Cache;
 use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
-use Cake\Datasource\FactoryLocator;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Log\Log;
-use Cake\ORM\Locator\TableLocator;
 use Cake\TestSuite\Fixture\SchemaLoader;
 use Cake\Utility\Security;
 
@@ -109,8 +107,6 @@ ConnectionManager::setConfig('test', ['url' => getenv('DB_URL')]);
 if (env('CAKE_TEST_AUTOQUOTE')) {
     ConnectionManager::get('test')->getDriver()->enableAutoQuoting(true);
 }
-
-FactoryLocator::add('Table', new TableLocator());
 
 Configure::write('Session', [
     'defaults' => 'php',


### PR DESCRIPTION
Remove use of TableLocator class of database package from FactoryLocator.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
