### PR TITLE
Clear TableRegistry after reflecting schema in fixtures

### DIFF
--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -252,6 +252,8 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             /** @var \Cake\Database\Schema\TableSchema $schema */
             $schema = $ormTable->getSchema();
             $this->_schema = $schema;
+
+            $this->getTableLocator()->clear();
         } catch (CakeException $e) {
             $message = sprintf(
                 'Cannot describe schema for table `%s` for fixture `%s`. The table does not exist.',

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -21,9 +21,11 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
+use Cake\Test\Fixture\PostsFixture;
 use Cake\TestSuite\TestCase;
 use Exception;
 use TestApp\Test\Fixture\ArticlesFixture;
+use TestApp\Test\Fixture\FeaturedTagsFixture;
 use TestApp\Test\Fixture\ImportsFixture;
 use TestApp\Test\Fixture\LettersFixture;
 use TestApp\Test\Fixture\StringsTestsFixture;
@@ -141,7 +143,6 @@ class TestFixtureTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Cannot describe schema for table `letters` for fixture `' . LettersFixture::class . '`. The table does not exist.');
         $fixture = new LettersFixture();
-        $fixture->init();
     }
 
     /**
@@ -162,7 +163,6 @@ class TestFixtureTest extends TestCase
         }
 
         $fixture = new LettersFixture();
-        $fixture->init();
         $this->assertSame(['id', 'letter'], $fixture->getTableSchema()->columns());
     }
 
@@ -188,10 +188,29 @@ class TestFixtureTest extends TestCase
         $table->getSchema()->setColumnType('complex_field', 'json');
 
         $fixture = new LettersFixture();
-        $fixture->init();
         $fixtureSchema = $fixture->getTableSchema();
         $this->assertSame(['id', 'letter', 'complex_field'], $fixtureSchema->columns());
         $this->assertSame('json', $fixtureSchema->getColumnType('complex_field'));
+    }
+
+    /**
+     * test init with other tables used in initialize()
+     *
+     * The FeaturedTagsTable uses PostsTable, then when PostsFixture
+     * reflects schema it should not raise an error.
+     */
+    public function testInitInitializeUsesRegistry(): void
+    {
+        $this->setAppNamespace();
+
+        $fixture = new FeaturedTagsFixture();
+
+        $posts = new PostsFixture();
+        $posts->fields = [];
+        $posts->init();
+
+        $expected = ['tag_id', 'priority'];
+        $this->assertSame($expected, $fixture->getTableSchema()->columns());
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/FeaturedTagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/FeaturedTagsTable.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.7
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Table;
+
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
+/**
+ * FeaturedTags table class
+ */
+class FeaturedTagsTable extends Table
+{
+    public function initialize(array $config): void
+    {
+        // Used to reproduce https://github.com/cakephp/cakephp/issues/16373
+        $this->Posts = TableRegistry::getTableLocator()->get('Posts');
+    }
+}

--- a/tests/test_app/TestApp/tests/Fixture/FeaturedTagsFixture.php
+++ b/tests/test_app/TestApp/tests/Fixture/FeaturedTagsFixture.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class FeaturedTagsFixture extends TestFixture
+{
+    /**
+     * Table property
+     *
+     * @var string
+     */
+    public $table = 'featured_tags';
+
+    /**
+     * Records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['tag_id' => 1, 'priority' => 1.0],
+        ['tag_id' => 2, 'priority' => 0.7],
+    ];
+}


### PR DESCRIPTION
User-land code can use TableRegistry in Table::initialize() hooks We need to clear the table registry to resolve errors caused by differing configuration.

Fixes #16373