### PR TITLE
Fix _assertFieldsPresent when auto fields is enabled

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -244,6 +244,10 @@ class SelectLoader
      */
     protected function _assertFieldsPresent(Query $fetchQuery, array $key): void
     {
+        if ($fetchQuery->isAutoFieldsEnabled()) {
+            return;
+        }
+
         $select = $fetchQuery->aliasFields($fetchQuery->clause('select'));
         if (empty($select)) {
             return;

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -2032,7 +2032,7 @@ class QueryTest extends TestCase
      * Integration test that uses the contain signature that is the same as the
      * matching signature
      */
-    public function testContainSecondSignature(): void
+    public function testContainClosureSignature(): void
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
@@ -2050,6 +2050,21 @@ class QueryTest extends TestCase
             }
         }
         $this->assertEquals([1], array_unique($ids));
+    }
+
+    public function testContainAutoFields(): void
+    {
+        $table = $this->getTableLocator()->get('authors');
+        $table->hasMany('articles');
+        $query = new Query($this->connection, $table);
+        $query
+            ->select()
+            ->contain('articles', function ($q) {
+                return $q->select(['test' => '(SELECT 20)'])
+                    ->enableAutoFields(true);
+            });
+        $results = $query->toArray();
+        $this->assertNotEmpty($results);
     }
 
     /**


### PR DESCRIPTION
Contain query callback was throwing an exception if a select was used, even if enableAutoFields was set in the query.

```php
$Table->find('all')
    ->contain('Relationship', fn(Query $q) => $q
          ->select([
                'test' => 'NOW()'
          ])
          ->enableAutoFields(true)
    );
```