### PR TITLE
Remove "experimental" tag from DIC related classes.

### DIFF
--- a/src/Core/Container.php
+++ b/src/Core/Container.php
@@ -22,9 +22,6 @@ use League\Container\Container as LeagueContainer;
  * Dependency Injection container
  *
  * Based on the container out of League\Container
- *
- * @experimental This class' interface is not stable and may change
- *   in future minor releases.
  */
 class Container extends LeagueContainer implements ContainerInterface
 {

--- a/src/Core/ContainerApplicationInterface.php
+++ b/src/Core/ContainerApplicationInterface.php
@@ -18,9 +18,6 @@ namespace Cake\Core;
 
 /**
  * Interface for applications that configure and use a dependency injection container.
- *
- * @experimental This interface is not final and can have additional
- *   methods and parameters added in future minor releases.
  */
 interface ContainerApplicationInterface
 {

--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -26,9 +26,6 @@ use League\Container\DefinitionContainerInterface;
  *
  * The methods defined in this interface use the conventions provided
  * by league/container as that is the library that CakePHP uses.
- *
- * @experimental This interface is not final and can have additional
- *   methods and parameters added in future minor releases.
  */
 interface ContainerInterface extends DefinitionContainerInterface
 {

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -28,9 +28,6 @@ use RuntimeException;
  * to organize your application's dependencies. They also help
  * improve performance of applications with many services by
  * allowing service registration to be deferred until services are needed.
- *
- * @experimental This class' interface is not stable and may change
- *   in future minor releases.
  */
 abstract class ServiceProvider extends AbstractServiceProvider implements BootableServiceProviderInterface
 {


### PR DESCRIPTION
We have already removed the "unstable API" warning from the docs.