### PR TITLE
Add sprintf log helper functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
             "src/Core/functions.php",
             "src/Collection/functions.php",
             "src/I18n/functions.php",
+            "src/Log/functions.php",
             "src/Routing/functions.php",
             "src/Utility/bootstrap.php"
         ]

--- a/src/Log/composer.json
+++ b/src/Log/composer.json
@@ -33,6 +33,9 @@
     "autoload": {
         "psr-4": {
             "Cake\\Log\\": "."
-        }
+        },
+        "files": [
+            "functions.php"
+        ]
     }
 }

--- a/src/Log/functions.php
+++ b/src/Log/functions.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Log\Log;
+use Psr\Log\LogLevel;
+
+if (!function_exists('logError')) {
+    /**
+     * Logs an error message using sprintf() style arguments.
+     *
+     * If you need to pass a context such as scope, use `Log::error()`.
+     *
+     * @param string $format The message format string.
+     * @param mixed ...$values The placeholder values.
+     * @return void
+     * @see https://www.php.net/manual/en/function.sprintf.php
+     */
+    function logError(string $format, ...$values): void
+    {
+        Log::write(LogLevel::ERROR, sprintf($format, ...$values));
+    }
+}
+
+if (!function_exists('logWarning')) {
+    /**
+     * Logs an error message using sprintf() style arguments.
+     *
+     * If you need to pass a context such as scope, use `Log::error()`.
+     *
+     * @param string $format The message format string.
+     * @param mixed ...$values The placeholder values.
+     * @return void
+     * @see https://www.php.net/manual/en/function.sprintf.php
+     */
+    function logWarning(string $format, ...$values): void
+    {
+        Log::write(LogLevel::WARNING, sprintf($format, ...$values));
+    }
+}
+
+if (!function_exists('logInfo')) {
+    /**
+     * Logs an info message using sprintf() style arguments.
+     *
+     * If you need to pass a context such as scope, use `Log::error()`.
+     *
+     * @param string $format The message format string.
+     * @param mixed ...$values The placeholder values.
+     * @return void
+     * @see https://www.php.net/manual/en/function.sprintf.php
+     */
+    function logInfo(string $format, ...$values): void
+    {
+        Log::write(LogLevel::INFO, sprintf($format, ...$values));
+    }
+}
+
+if (!function_exists('logDebug')) {
+    /**
+     * Logs a debug message using sprintf() style arguments.
+     *
+     * If you need to pass a context such as scope, use `Log::debug()`.
+     *
+     * @param string $format The message format string.
+     * @param mixed ...$values The placeholder values.
+     * @return void
+     * @see https://www.php.net/manual/en/function.sprintf.php
+     */
+    function logDebug(string $format, ...$values): void
+    {
+        Log::write(LogLevel::DEBUG, sprintf($format, ...$values));
+    }
+}

--- a/tests/TestCase/Log/FunctionsTest.php
+++ b/tests/TestCase/Log/FunctionsTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) <https://book.cakephp.org/4/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Log;
+
+use Cake\Log\Log;
+use Cake\TestSuite\TestCase;
+
+class FunctionsTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Log::reset();
+    }
+
+    public function testLogError(): void
+    {
+        Log::setConfig('test', [
+            'engine' => 'Array',
+            'levels' => ['error'],
+        ]);
+
+        logError('%s %s', 'formatted', 'string');
+        $this->assertSame(['error: formatted string'], Log::engine('test')->read());
+    }
+
+    public function testLogWarning(): void
+    {
+        Log::setConfig('test', [
+            'engine' => 'Array',
+            'levels' => ['warning'],
+        ]);
+
+        logWarning('%s %s', 'formatted', 'string');
+        $this->assertSame(['warning: formatted string'], Log::engine('test')->read());
+    }
+
+    public function testLogInfo(): void
+    {
+        Log::setConfig('test', [
+            'engine' => 'Array',
+            'levels' => ['info'],
+        ]);
+
+        logInfo('%s %s', 'formatted', 'string');
+        $this->assertSame(['info: formatted string'], Log::engine('test')->read());
+    }
+
+    public function testLogDebug(): void
+    {
+        Log::setConfig('test', [
+            'engine' => 'Array',
+            'levels' => ['debug'],
+        ]);
+
+        logDebug('%s %s', 'formatted', 'string');
+        $this->assertSame(['debug: formatted string'], Log::engine('test')->read());
+    }
+}


### PR DESCRIPTION
Provide log helpers that wrap very common sprintf() formatted messages for the most used log levels. This reduces the code needed for almost all the logging I do through LogTrait without accidentally forgetting the log level which defaults to ERROR. This also avoids having to add `use Log` whenever you want to log something and then remove it to avoid phpcs errors.

If these helpers seem useful, will add some simple tests.

This doesn't allow for scoping, but that's the cost of simplifying for the most common use.