### PR TITLE
Update QueryExpression.php to handle between expression

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -725,6 +725,11 @@ class QueryExpression implements ExpressionInterface, Countable
 
             $isArray = is_array($c);
             $isOperator = $isNot = false;
+            if($isArray && !$numericKey && count($c) === 2 && strpos(strtolower($k),' between ') !== false){
+                $parts = explode(' ',$k);
+                $this->_conditions[] = new BetweenExpression($parts[0],$c[0],$c[1]);
+                continue;
+            }
             if (!$numericKey) {
                 $normalizedKey = strtolower($k);
                 $isOperator = in_array($normalizedKey, $operators);


### PR DESCRIPTION
Having '<field> BETWEEN ? AND ?' => array('val1','val2') in a condition key for find options would fail. This patch implements BETWEEN.

When using condition options, having 'BETWEEN ? and ?' would fail with error "Cannot convert value of type array to string"

```php
$this->fetchTable('Goals')->find('all', array(
                'conditions' => array(
                    'Goal.account_id' => $goal_id,
                    'created BETWEEN ? and ?' => array(
                        $this->timeframe['from_date'],
                        $this->timeframe['to_date']
                    )
                )
            ))->toArray();
```

The following proposed change allows usage of BETWEEN within the conditions array.