### PR TITLE
Add skipLog config to ExceptionTrap

### DIFF
--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -44,6 +44,7 @@ class ExceptionTrap
         'logger' => ErrorLogger::class,
         'stderr' => null,
         'log' => true,
+        'skipLog' => [],
         'trace' => false,
     ];
 
@@ -217,7 +218,17 @@ class ExceptionTrap
         }
         $request = Router::getRequest();
 
-        $this->logException($exception, $request);
+        $shouldLog = true;
+        foreach ($this->_config['skipLog'] as $class) {
+            if ($exception instanceof $class) {
+                $shouldLog = false;
+                break;
+            }
+        }
+
+        if ($shouldLog) {
+            $this->logException($exception, $request);
+        }
 
         try {
             $renderer = $this->renderer($exception);


### PR DESCRIPTION
This used to live in `BaseErrorHandler`, but now it only lives in `ErrorLogger`. I am unable to extend `ExceptionTrap` and use the skipLog config to filter whether to pass exceptions to Sentry.

From a design point of view, this config should really be hoisted to `ExceptionTrap` instead of the dependency classes which it spawns. This config should determine if the logger is called at all not after the call to `logException()`.

With the new `ErrorTrap` and `ExceptionTrap` design, it feels like we're missing a split between Error and Exception for logging. The name `ErrorLogger` isn't consistent now that it handles both error and exception logging.