### PR TITLE
Remove implicit use of PaginatorComponent from controller.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -35,7 +35,7 @@ use UnexpectedValueException;
  *
  * @link https://book.cakephp.org/4/en/controllers/components/pagination.html
  * @mixin \Cake\Datasource\Paging\Paginator
- * @deprecated 4.4.0 Use Cake\Datasource\Paging\Paginator directly. Will be removed in 6.0.
+ * @deprecated 4.4.0 Use Cake\Datasource\Paging\Paginator directly.
  */
 class PaginatorComponent extends Component
 {
@@ -51,6 +51,10 @@ class PaginatorComponent extends Component
      */
     public function __construct(ComponentRegistry $registry, array $config = [])
     {
+        deprecationWarning(
+            'PaginatorComponent is deprecated, use a Cake\Datasource\Pagination\Paginator instance directly.'
+        );
+
         if (!empty($this->_defaultConfig)) {
             throw new UnexpectedValueException('Default configuration must be set using a custom Paginator class.');
         }

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -79,7 +79,9 @@ class PaginatorComponentTest extends TestCase
         $request = new ServerRequest(['url' => 'controller_posts/index']);
         $this->controller = new Controller($request);
         $this->registry = new ComponentRegistry($this->controller);
-        $this->Paginator = new PaginatorComponent($this->registry, []);
+        $this->deprecated(function () {
+            $this->Paginator = new PaginatorComponent($this->registry, []);
+        });
 
         $this->Post = $this->getMockRepository();
     }
@@ -89,24 +91,28 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginatorSetting(): void
     {
-        $paginator = new CustomPaginator();
-        $component = new PaginatorComponent($this->registry, [
-            'paginator' => $paginator,
-        ]);
+        $this->deprecated(function () {
+            $paginator = new CustomPaginator();
+            $component = new PaginatorComponent($this->registry, [
+                'paginator' => $paginator,
+            ]);
 
-        $this->assertSame($paginator, $component->getPaginator());
+            $this->assertSame($paginator, $component->getPaginator());
 
-        $component = new PaginatorComponent($this->registry, []);
-        $this->assertNotSame($paginator, $component->getPaginator());
+            $component = new PaginatorComponent($this->registry, []);
+            $this->assertNotSame($paginator, $component->getPaginator());
 
-        $component->setPaginator($paginator);
-        $this->assertSame($paginator, $component->getPaginator());
+            $component->setPaginator($paginator);
+            $this->assertSame($paginator, $component->getPaginator());
+        });
     }
 
     public function testInvalidDefaultConfig(): void
     {
         $this->expectException(UnexpectedValueException::class);
-        new CustomPaginatorComponent($this->registry);
+        $this->deprecated(function () {
+            new CustomPaginatorComponent($this->registry);
+        });
     }
 
     /**
@@ -116,9 +122,11 @@ class PaginatorComponentTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Paginator must be an instance of Cake\Datasource\Paging\Paginator');
-        new PaginatorComponent($this->registry, [
-            'paginator' => new stdClass(),
-        ]);
+        $this->deprecated(function () {
+            new PaginatorComponent($this->registry, [
+                'paginator' => new stdClass(),
+            ]);
+        });
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -982,12 +982,12 @@ class ControllerTest extends TestCase
         $response = new Response();
 
         $controller = new TestController($request, $response);
-        $result = $controller->loadComponent('Paginator');
-        $this->assertInstanceOf('Cake\Controller\Component\PaginatorComponent', $result);
-        $this->assertSame($result, $controller->Paginator);
+        $result = $controller->loadComponent('FormProtection');
+        $this->assertInstanceOf('Cake\Controller\Component\FormProtectionComponent', $result);
+        $this->assertSame($result, $controller->FormProtection);
 
         $registry = $controller->components();
-        $this->assertTrue(isset($registry->Paginator));
+        $this->assertTrue(isset($registry->FormProtection));
     }
 
     /**
@@ -999,13 +999,13 @@ class ControllerTest extends TestCase
         $response = new Response();
 
         $controller = new TestController($request, $response);
-        $this->assertNotEmpty($controller->loadComponent('Paginator'));
-        $this->assertNotEmpty($controller->loadComponent('Paginator'));
+        $this->assertNotEmpty($controller->loadComponent('FormProtection'));
+        $this->assertNotEmpty($controller->loadComponent('FormProtection'));
         try {
-            $controller->loadComponent('Paginator', ['bad' => 'settings']);
+            $controller->loadComponent('FormProtection', ['bad' => 'settings']);
             $this->fail('No exception');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "Paginator" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The "FormProtection" alias has already been loaded', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
This allows adding explicit deprecation warning to the PaginatorComponent.
PaginatorComponent (or it's subclass) will still be used if explicity loaded.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
