### PR TITLE
Add default parameter to groupBy() and indexBy()

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -430,9 +430,10 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @param callable|string $path The column name to use for grouping or callback that returns the value.
      * or a function returning the grouping key out of the provided element
+     * @param mixed $default The default value to use if the path does not exist or is null.
      * @return self
      */
-    public function groupBy(callable|string $path): CollectionInterface;
+    public function groupBy(callable|string $path, mixed $default = null): CollectionInterface;
 
     /**
      * Given a list and a callback function that returns a key for each element
@@ -469,9 +470,10 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      *
      * @param callable|string $path The column name to use for indexing or callback that returns the value.
      * or a function returning the indexing key out of the provided element
+     * @param mixed $default The default value to use if the path does not exist or is null.
      * @return self
      */
-    public function indexBy(callable|string $path): CollectionInterface;
+    public function indexBy(callable|string $path, mixed $default = null): CollectionInterface;
 
     /**
      * Sorts a list into groups and returns a count for the number of elements

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -262,12 +262,12 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function groupBy(callable|string $path): CollectionInterface
+    public function groupBy(callable|string $path, mixed $default = null): CollectionInterface
     {
         $callback = $this->_propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
-            $pathValue = $callback($value);
+            $pathValue = $callback($value) ?? $default;
             if ($pathValue === null) {
                 throw new InvalidArgumentException(
                     'Cannot group by path that does not exist or contains a null value. ' .
@@ -283,12 +283,12 @@ trait CollectionTrait
     /**
      * @inheritDoc
      */
-    public function indexBy(callable|string $path): CollectionInterface
+    public function indexBy(callable|string $path, mixed $default = null): CollectionInterface
     {
         $callback = $this->_propertyExtractor($path);
         $group = [];
         foreach ($this->optimizeUnwrap() as $value) {
-            $pathValue = $callback($value);
+            $pathValue = $callback($value) ?? $default;
             if ($pathValue === null) {
                 throw new InvalidArgumentException(
                     'Cannot index by path that does not exist or contains a null value. ' .

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -691,6 +691,27 @@ class CollectionTest extends TestCase
         $collection->groupBy('missing');
     }
 
+    public function testGroupByDefault(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+            ['id' => 3, 'name' => 'baz', 'missing' => 'not default'],
+        ];
+        $collection = new Collection($items);
+
+        $expected = [
+            'default' => [
+                ['id' => 1, 'name' => 'foo'],
+                ['id' => 2, 'name' => 'bar'],
+            ],
+            'not default' => [
+                ['id' => 3, 'name' => 'baz', 'missing' => 'not default'],
+            ],
+        ];
+        $this->assertSame($expected, $collection->groupBy('missing', 'default')->toArray());
+    }
+
     /**
      * Provider for some indexBy tests
      *
@@ -781,6 +802,22 @@ class CollectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
         $collection->indexBy('missing');
+    }
+
+    public function testIndexByDefault(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo'],
+            ['id' => 2, 'name' => 'bar'],
+            ['id' => 3, 'name' => 'baz', 'missing' => 'not default'],
+        ];
+        $collection = new Collection($items);
+
+        $expected = [
+            'default' => ['id' => 2, 'name' => 'bar'],
+            'not default' => ['id' => 3, 'name' => 'baz', 'missing' => 'not default'],
+        ];
+        $this->assertSame($expected, $collection->indexBy('missing', 'default')->toArray());
     }
 
     /**


### PR DESCRIPTION
After adding the exception on missing or null path, users have to pass a callback to set default values. This makes it much easier to handle just the default scenario.
