### PR TITLE
Remove support for PHP file arrays.

### DIFF
--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -162,27 +162,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             return $request;
         }
 
-        if (Configure::read('App.uploadedFilesAsObjects', true)) {
-            $parsedBody = Hash::merge($parsedBody, $files);
-        } else {
-            // Make a flat map that can be inserted into body for BC.
-            /** @var array<\Laminas\Diactoros\UploadedFile> $fileMap */
-            $fileMap = Hash::flatten($files);
-            foreach ($fileMap as $key => $file) {
-                $error = $file->getError();
-                $tmpName = '';
-                if ($error === UPLOAD_ERR_OK) {
-                    $tmpName = $file->getStream()->getMetadata('uri');
-                }
-                $parsedBody = Hash::insert($parsedBody, (string)$key, [
-                    'tmp_name' => $tmpName,
-                    'error' => $error,
-                    'name' => $file->getClientFilename(),
-                    'type' => $file->getClientMediaType(),
-                    'size' => $file->getSize(),
-                ]);
-            }
-        }
+        $parsedBody = Hash::merge($parsedBody, $files);
 
         return $request->withParsedBody($parsedBody);
     }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -86,12 +86,8 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * A flag for allowEmptyFor()
      *
-     * When an array is given, if it has at least the `name`, `type`, `tmp_name` and `error` keys,
-     * and the value of `error` is equal to `UPLOAD_ERR_NO_FILE`, the value will be recognized as
-     * empty.
-     *
-     * When an instance of \Psr\Http\Message\UploadedFileInterface is given the
-     * return value of it's getError() method must be equal to `UPLOAD_ERR_NO_FILE`.
+     * The return value of \Psr\Http\Message\UploadedFileInterface::getError()
+     * method must be equal to `UPLOAD_ERR_NO_FILE`.
      *
      * @var int
      */
@@ -2480,14 +2476,6 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         if (is_array($data)) {
-            if (
-                ($flags & self::EMPTY_FILE)
-                && isset($data['name'], $data['type'], $data['tmp_name'], $data['error'])
-                && (int)$data['error'] === UPLOAD_ERR_NO_FILE
-            ) {
-                return true;
-            }
-
             $allFieldsAreEmpty = true;
             foreach ($data as $field) {
                 if ($field !== null && $field !== '') {

--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\View\Widget;
 
-use Cake\Core\Configure;
 use Cake\View\Form\ContextInterface;
 
 /**
@@ -68,24 +67,5 @@ class FileWidget extends BasicWidget
                 ['name']
             ),
         ]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function secureFields(array $data): array
-    {
-        // PSR7 UploadedFileInterface objects are used.
-        if (Configure::read('App.uploadedFilesAsObjects', true)) {
-            return [$data['name']];
-        }
-
-        // Backwards compatibility for array files.
-        $fields = [];
-        foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $suffix) {
-            $fields[] = $data['name'] . '[' . $suffix . ']';
-        }
-
-        return $fields;
     }
 }

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -1021,7 +1021,7 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Tests the default file upload merging behavior.
      */
-    public function testFromGlobalsWithFilesAsObjectsDefault(): void
+    public function testFromGlobalsWithFiles(): void
     {
         $this->assertNull(Configure::read('App.uploadedFilesAsObjects'));
 
@@ -1042,66 +1042,6 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame($files['file']['error'], $expected->getError());
         $this->assertSame($files['file']['name'], $expected->getClientFilename());
         $this->assertSame($files['file']['type'], $expected->getClientMediaType());
-    }
-
-    /**
-     * Tests the "as arrays" file upload merging behavior.
-     */
-    public function testFromGlobalsWithFilesAsObjectsDisabled(): void
-    {
-        Configure::write('App.uploadedFilesAsObjects', false);
-
-        $files = [
-            'file' => [
-                'name' => 'file.txt',
-                'type' => 'text/plain',
-                'tmp_name' => __FILE__,
-                'error' => 0,
-                'size' => 1234,
-            ],
-        ];
-        $request = ServerRequestFactory::fromGlobals(null, null, null, null, $files);
-
-        $expected = [
-            'file' => [
-                'tmp_name' => __FILE__,
-                'error' => 0,
-                'name' => 'file.txt',
-                'type' => 'text/plain',
-                'size' => 1234,
-            ],
-        ];
-        $this->assertEquals($expected, $request->getData());
-    }
-
-    /**
-     * Tests the "as objects" file upload merging behavior.
-     */
-    public function testFromGlobalsWithFilesAsObjectsEnabled(): void
-    {
-        Configure::write('App.uploadedFilesAsObjects', true);
-
-        $files = [
-            'file' => [
-                'name' => 'file.txt',
-                'type' => 'text/plain',
-                'tmp_name' => __FILE__,
-                'error' => 0,
-                'size' => 1234,
-            ],
-        ];
-        $request = ServerRequestFactory::fromGlobals(null, null, null, null, $files);
-
-        $expected = [
-            'file' => new UploadedFile(
-                __FILE__,
-                1234,
-                0,
-                'file.txt',
-                'text/plain'
-            ),
-        ];
-        $this->assertEquals($expected, $request->getData());
     }
 
     /**
@@ -1232,10 +1172,8 @@ class ServerRequestFactoryTest extends TestCase
             ],
         ];
 
-        Configure::write('App.uploadedFilesAsObjects', false);
         $request = ServerRequestFactory::fromGlobals([], [], [], [], $files);
-        $this->assertEquals($files, $request->getData());
-        Configure::write('App.uploadedFilesAsObjects', true);
+        $this->assertInstanceOf(UploadedFileInterface::class, $request->getData()['birth_cert']);
 
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);
@@ -1261,10 +1199,8 @@ class ServerRequestFactoryTest extends TestCase
             ],
         ];
 
-        Configure::write('App.uploadedFilesAsObjects', false);
         $request = ServerRequestFactory::fromGlobals([], [], [], [], $files);
-        $this->assertEquals($files, $request->getData());
-        Configure::write('App.uploadedFilesAsObjects', true);
+        $this->assertInstanceOf(UploadedFileInterface::class, $request->getData()[0]);
 
         $uploads = $request->getUploadedFiles();
         $this->assertCount(1, $uploads);

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -653,17 +653,6 @@ class ValidatorTest extends TestCase
             ->add('picture', 'file', ['rule' => 'uploadedFile']);
 
         $data = [
-            'picture' => [
-                'name' => '',
-                'type' => '',
-                'tmp_name' => '',
-                'error' => UPLOAD_ERR_NO_FILE,
-            ],
-        ];
-        $result = $validator->validate($data);
-        $this->assertEmpty($result, 'No errors on empty file');
-
-        $data = [
             'picture' => new UploadedFile(
                 '',
                 0,
@@ -672,17 +661,6 @@ class ValidatorTest extends TestCase
         ];
         $result = $validator->validate($data);
         $this->assertEmpty($result, 'No errors on empty file');
-
-        $data = [
-            'picture' => [
-                'name' => 'fake.png',
-                'type' => '',
-                'tmp_name' => '',
-                'error' => UPLOAD_ERR_OK,
-            ],
-        ];
-        $result = $validator->validate($data);
-        $this->assertNotEmpty($result, 'Invalid file should be caught still.');
     }
 
     /**
@@ -799,29 +777,13 @@ class ValidatorTest extends TestCase
         $this->assertTrue($validator->field('photo')->isEmptyAllowed());
 
         $data = [
-            'photo' => [
-                'name' => '',
-                'type' => '',
-                'tmp_name' => '',
-                'error' => UPLOAD_ERR_NO_FILE,
-            ],
-        ];
-        $result = $validator->validate($data);
-        $this->assertEmpty($result);
-
-        $data = [
             'photo' => null,
         ];
         $result = $validator->validate($data);
         $this->assertEmpty($result);
 
         $data = [
-            'photo' => [
-                'name' => '',
-                'type' => '',
-                'tmp_name' => '',
-                'error' => UPLOAD_ERR_FORM_SIZE,
-            ],
+            'photo' => [],
         ];
         $expected = [
             'photo' => [
@@ -833,11 +795,6 @@ class ValidatorTest extends TestCase
 
         $data = [
             'photo' => '',
-        ];
-        $expected = [
-            'photo' => [
-                'uploadedFile' => 'The provided value is invalid',
-            ],
         ];
         $result = $validator->validate($data);
         $this->assertSame($expected, $result);
@@ -872,17 +829,7 @@ class ValidatorTest extends TestCase
         $this->assertFalse($validator->isEmptyAllowed('photo', true));
         $this->assertFalse($validator->isEmptyAllowed('photo', false));
 
-        $data = [
-            'photo' => [
-                'name' => '',
-                'type' => '',
-                'tmp_name' => '',
-                'error' => UPLOAD_ERR_NO_FILE,
-            ],
-        ];
         $error = ['photo' => ['_empty' => 'required field']];
-        $this->assertSame($error, $validator->validate($data));
-
         $data = ['photo' => null];
         $this->assertSame($error, $validator->validate($data));
 

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Widget;
 
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
@@ -111,9 +110,8 @@ class FileWidgetTest extends TestCase
         $data = ['name' => 'image', 'required' => true, 'val' => 'nope'];
         $this->assertEquals(['image'], $input->secureFields($data));
 
-        Configure::write('App.uploadedFilesAsObjects', false);
         $this->assertEquals(
-            ['image[name]', 'image[type]', 'image[tmp_name]', 'image[error]', 'image[size]'],
+            ['image'],
             $input->secureFields($data)
         );
     }


### PR DESCRIPTION
Only UploadedFileInterface instances are now used across the framework.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
