### PR TITLE
Fix missing use of binding key in BelongsToMany

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -426,6 +426,7 @@ class BelongsToMany extends Association
 
         if (!$junction->hasAssociation($sAlias)) {
             $junction->belongsTo($sAlias, [
+                'bindingKey' => $this->getBindingKey(),
                 'foreignKey' => $this->getForeignKey(),
                 'targetTable' => $source,
             ]);

--- a/tests/Fixture/ArticlesTagsBindingKeysFixture.php
+++ b/tests/Fixture/ArticlesTagsBindingKeysFixture.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.3.7
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Fixture for testing bindingKey in belongstomany associations.
+ */
+class ArticlesTagsBindingKeysFixture extends TestFixture
+{
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['article_id' => 1, 'tagname' => 'tag1'],
+        ['article_id' => 1, 'tagname' => 'tag2'],
+        ['article_id' => 2, 'tagname' => 'tag1'],
+        ['article_id' => 2, 'tagname' => 'tag3'],
+    ];
+}

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1660,7 +1660,7 @@ class BelongsToManyTest extends TestCase
         ]);
         $query = $table->find()
             ->matching('Articles', function ($q) {
-                return $q->where('Articles.id > 0');
+                return $q->where(['Articles.id >' => 0]);
             });
         $results = $query->all();
 

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -50,6 +50,7 @@ class BelongsToManyTest extends TestCase
         'core.Tags',
         'core.SpecialTags',
         'core.ArticlesTags',
+        'core.ArticlesTagsBindingKeys',
         'core.BinaryUuidItems',
         'core.BinaryUuidTags',
         'core.BinaryUuidItemsBinaryUuidTags',
@@ -1643,5 +1644,27 @@ class BelongsToManyTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertCount(3, $results[0]->special_tags);
+    }
+
+    /**
+     * Test custom binding key for target table association
+     */
+    public function testBindingKeyMatching(): void
+    {
+        $table = $this->getTableLocator()->get('Tags');
+        $table->belongsToMany('Articles', [
+            'through' => 'ArticlesTagsBindingKeys',
+            'foreignKey' => 'tagname',
+            'targetForeignKey' => 'article_id',
+            'bindingKey' => 'name',
+        ]);
+        $query = $table->find()
+            ->matching('Articles', function ($q) {
+                return $q->where('Articles.id > 0');
+            });
+        $results = $query->all();
+
+        // 4 records in the junction table.
+        $this->assertCount(4, $results);
     }
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -956,7 +956,7 @@ class TableTest extends TestCase
             ],
         ];
 
-        $table = new Table(['table' => 'dates']);
+        $table = new Table(['table' => 'members']);
         $result = $table->addAssociations($params);
         $this->assertSame($table, $result);
 

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -900,6 +900,28 @@ return [
         ],
     ],
     [
+        'table' => 'articles_tags_binding_keys',
+        'columns' => [
+            'article_id' => [
+                'type' => 'integer',
+                'null' => false,
+            ],
+            'tagname' => [
+                'type' => 'string',
+                'null' => false,
+            ],
+        ],
+        'constraints' => [
+            'unique_tag' => [
+                'type' => 'primary',
+                'columns' => [
+                    'article_id',
+                    'tagname',
+                ],
+            ],
+        ],
+    ],
+    [
         'table' => 'profiles',
         'columns' => [
             'id' => [


### PR DESCRIPTION
Add bindingKey to the generated alias to improve matching query
generation.

Fix #16432
