### PR TITLE
add Console.afterRun event

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -172,6 +172,17 @@ class CommandRunner implements EventDispatcherInterface
             $result = $this->runCommand($shell, $argv, $io);
         }
 
+        $event = $this->dispatchEvent('Console.afterRun', [
+            'command' => $shell,
+            'result' => $result,
+        ]);
+        if (is_array($event->getResult())) {
+            foreach ($event->getResult() as $commandData) {
+                $command = $this->createCommand($commandData['command'], $io);
+                $this->runCommand($command, $commandData['arguments'], $io);
+            }
+        }
+
         if ($result === null || $result === true) {
             return CommandInterface::CODE_SUCCESS;
         }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -178,8 +178,13 @@ class CommandRunner implements EventDispatcherInterface
         ]);
         if (is_array($event->getResult())) {
             foreach ($event->getResult() as $commandData) {
-                $command = $this->createCommand($commandData['command'], $io);
-                $this->runCommand($command, $commandData['arguments'], $io);
+                $shell = $this->createCommand($commandData['command'], $io);
+                if ($shell instanceof Shell) {
+                    $this->runShell($shell, $commandData['arguments']);
+                }
+                if ($shell instanceof CommandInterface) {
+                    $this->runCommand($shell, $commandData['arguments'], $io);
+                }
             }
         }
 


### PR DESCRIPTION
This allows users to hook into the command system so they can easily add more commands after another one has executed.

I personally felt the need for this because I wanted to hook into the `bin/cake cache clear_all` command to execute a custom cache warm-up command after it has been done.