### PR TITLE
Fix errors on invalid cookies

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -26,6 +26,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Traversable;
+use TypeError;
 
 /**
  * Cookie Collection
@@ -68,7 +69,7 @@ class CookieCollection implements IteratorAggregate, Countable
         foreach ($header as $value) {
             try {
                 $cookies[] = Cookie::createFromHeaderString($value, $defaults);
-            } catch (Exception $e) {
+            } catch (Exception | TypeError $e) {
                 // Don't blow up on invalid cookies
             }
         }

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -456,6 +456,7 @@ class CookieCollectionTest extends TestCase
             'http=name; HttpOnly; Secure;',
             'expires=expiring; Expires=Wed, 15-Jun-2022 10:22:22; Path=/api; HttpOnly; Secure;',
             'expired=expired; version=1; Expires=Wed, 15-Jun-2015 10:22:22;',
+            'invalid=invalid-secure; Expires=Tue, 17 May 2022 22:19:06 GMT; Secure=true; SameSite=none',
         ];
         $cookies = CookieCollection::createFromHeader($header);
         $this->assertCount(3, $cookies);
@@ -463,6 +464,7 @@ class CookieCollectionTest extends TestCase
         $this->assertTrue($cookies->has('expires'));
         $this->assertFalse($cookies->has('version'));
         $this->assertTrue($cookies->has('expired'), 'Expired cookies should be present');
+        $this->assertFalse($cookies->has('invalid'), 'Invalid cookies should not be present');
     }
 
     /**


### PR DESCRIPTION
When cookies contain invalid attributes we should gracefully ignore
those cookies.

Fixes #16449
