### PR TITLE
Minor typo in notEmptyString() PHPDoc

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -906,7 +906,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     }
 
     /**
-     * Requires a field to be not be an empty string.
+     * Requires a field to not be an empty string.
      *
      * Opposite to allowEmptyString()
      *


### PR DESCRIPTION
I believe a "be" is redundant in phrase "Requires a field to be not be an empty string."
