### PR TITLE
Ensure Query::__debugInfo() always returns an array.

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2396,6 +2396,8 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      */
     public function __debugInfo(): array
     {
+        $sql = 'SQL could not be generated for this query as it is incomplete.';
+        $params = [];
         try {
             set_error_handler(
                 /** @return no-return */
@@ -2406,20 +2408,17 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
             );
             $sql = $this->sql();
             $params = $this->getValueBinder()->bindings();
-        } catch (RuntimeException) {
-            $sql = 'SQL could not be generated for this query as it is incomplete.';
-            $params = [];
         } finally {
             restore_error_handler();
-        }
 
-        return [
-            '(help)' => 'This is a Query object, to get the results execute or iterate it.',
-            'sql' => $sql,
-            'params' => $params,
-            'defaultTypes' => $this->getDefaultTypes(),
-            'decorators' => count($this->_resultDecorators),
-            'executed' => $this->_statement ? true : false,
-        ];
+            return [
+                '(help)' => 'This is a Query object, to get the results execute or iterate it.',
+                'sql' => $sql,
+                'params' => $params,
+                'defaultTypes' => $this->getDefaultTypes(),
+                'decorators' => count($this->_resultDecorators),
+                'executed' => $this->_statement ? true : false,
+            ];
+        }
     }
 }

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -209,7 +209,7 @@ class HasOneTest extends TestCase
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join', 'select'])
-            ->disableOriginalConstructor()
+            ->setConstructorArgs([$this->user->getConnection(), $this->user])
             ->getMock();
         $config = [
             'sourceTable' => $this->user,


### PR DESCRIPTION
~~Before this fix ORM\Query::__debugInfo() could generate a "Typed property accessed before initialization.."
error due to `_repository` not being initilized in mocked objects.~~
Updated the test case to fix this.

Database\Query::__debugInfo() did not retrun an array if the `try` block failed.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
