### PR TITLE
Fix content negotiation using extensions with multiple mime types

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -819,9 +819,11 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         // Prefer the _ext route parameter if it is defined.
         $ext = $request->getParam('_ext');
         if ($ext) {
-            $extType = $this->response->getMimeType($ext);
-            if (isset($typeMap[$extType])) {
-                return $typeMap[$extType];
+            $extTypes = (array)($this->response->getMimeType($ext) ?: []);
+            foreach ($extTypes as $extType) {
+                if (isset($typeMap[$extType])) {
+                    return $typeMap[$extType];
+                }
             }
         }
 

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -150,13 +150,13 @@ class AssetMiddleware implements MiddlewareInterface
 
         $response = new Response(['stream' => $stream]);
 
-        $contentType = $response->getMimeType($file->getExtension()) ?: 'application/octet-stream';
+        $contentType = (array)($response->getMimeType($file->getExtension()) ?: 'application/octet-stream');
         $modified = $file->getMTime();
         $expire = strtotime($this->cacheTime);
         $maxAge = $expire - time();
 
         return $response
-            ->withHeader('Content-Type', $contentType)
+            ->withHeader('Content-Type', $contentType[0])
             ->withHeader('Cache-Control', 'public,max-age=' . $maxAge)
             ->withHeader('Date', gmdate(DATE_RFC7231, time()))
             ->withHeader('Last-Modified', gmdate(DATE_RFC7231, $modified))

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -350,7 +350,7 @@ class ControllerTest extends TestCase
         $this->assertStringContainsString('hello world', $response->getBody() . '');
     }
 
-    public function testRenderViewClassesUsesExt()
+    public function testRenderViewClassesUsesSingleMimeExt()
     {
         $request = new ServerRequest([
             'url' => '/',
@@ -362,6 +362,20 @@ class ControllerTest extends TestCase
         $response = $controller->render();
         $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
         $this->assertNotEmpty(json_decode($response->getBody() . ''), 'Body should be json');
+    }
+
+    public function testRenderViewClassesUsesMultiMimeExt()
+    {
+        $request = new ServerRequest([
+            'url' => '/',
+            'environment' => [],
+            'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'all', '_ext' => 'xml'],
+        ]);
+        $controller = new ContentTypesController($request, new Response());
+        $controller->all();
+        $response = $controller->render();
+        $this->assertSame('application/xml; charset=UTF-8', $response->getHeaderLine('Content-Type'));
+        $this->assertTextStartsWith('<?xml', $response->getBody() . '', 'Body should be xml');
     }
 
     /**


### PR DESCRIPTION
This issue also seems to exist in HtmlHelper::media(), but I don't have a fix for it here.