### PR TITLE
Revert "Add skipLog config to ExceptionTrap"

### DIFF
--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -44,7 +44,6 @@ class ExceptionTrap
         'logger' => ErrorLogger::class,
         'stderr' => null,
         'log' => true,
-        'skipLog' => [],
         'trace' => false,
     ];
 
@@ -222,17 +221,7 @@ class ExceptionTrap
         }
         $request = Router::getRequest();
 
-        $shouldLog = true;
-        foreach ($this->_config['skipLog'] as $class) {
-            if ($exception instanceof $class) {
-                $shouldLog = false;
-                break;
-            }
-        }
-
-        if ($shouldLog) {
-            $this->logException($exception, $request);
-        }
+        $this->logException($exception, $request);
 
         try {
             $renderer = $this->renderer($exception);

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -42,12 +42,13 @@ class ExceptionTrapTest extends TestCase
     {
         parent::setUp();
         $this->memoryLimit = ini_get('memory_limit');
+
+        Log::drop('test_error');
     }
 
     public function tearDown(): void
     {
         parent::tearDown();
-        Log::reset();
         ini_set('memory_limit', $this->memoryLimit);
     }
 
@@ -226,28 +227,6 @@ class ExceptionTrapTest extends TestCase
 
         $logs = Log::engine('test_error')->read();
         $this->assertStringContainsString('nope', $logs[0]);
-    }
-
-    /**
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
-     */
-    public function testSkipLogException(): void
-    {
-        Log::setConfig('test_error', [
-            'className' => 'Array',
-        ]);
-        $trap = new ExceptionTrap([
-            'exceptionRenderer' => WebExceptionRenderer::class,
-            'skipLog' => [InvalidArgumentException::class],
-        ]);
-
-        ob_start();
-        $trap->handleException(new InvalidArgumentException('nope'));
-        ob_get_clean();
-
-        $logs = Log::engine('test_error')->read();
-        $this->assertEmpty($logs);
     }
 
     public function testEventTriggered()


### PR DESCRIPTION
Reverts https://github.com/cakephp/cakephp/pull/16421.

Currently this blocks the `beforeRender` event which is emitted in logException() and logException() can be called externally.