### PR TITLE
4.4 - Improve error logging

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -209,6 +209,15 @@
       <code>$this-&gt;modelClass</code>
     </DeprecatedProperty>
   </file>
+  <file src="src/Error/BaseErrorHandler.php">
+    <DeprecatedMethod occurrences="1">
+      <code>log</code>
+    </DeprecatedMethod>
+    <DeprecatedMethod occurrences="2">
+      <code>logMessage</code>
+    </DeprecatedMethod>
+  </file>
+
   <file src="src/Error/ErrorHandler.php">
     <DeprecatedClass occurrences="1">
       <code>ExceptionRenderer::class</code>
@@ -217,10 +226,18 @@
       <code>outputError</code>
     </DeprecatedMethod>
   </file>
+  <file src="src/Error/ErrorTrap.php">
+    <DeprecatedMethod occurrences="2">
+      <code>logMessage</code>
+    </DeprecatedMethod>
+  </file>
   <file src="src/Error/ExceptionTrap.php">
     <DeprecatedClass occurrences="2">
       <code>\Cake\Error\ExceptionRenderer</code>
     </DeprecatedClass>
+    <DeprecatedMethod occurrences="1">
+      <code>log</code>
+    </DeprecatedMethod>
   </file>
   <file src="src/Http/BaseApplication.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -336,6 +336,11 @@ abstract class BaseErrorHandler
         if (empty($this->_config['log'])) {
             return false;
         }
+        foreach ($this->_config['skipLog'] as $class) {
+            if ($exception instanceof $class) {
+                return false;
+            }
+        }
 
         return $this->getLogger()->log($exception, $request ?? Router::getRequest());
     }

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -33,14 +33,11 @@ class ErrorLogger implements ErrorLoggerInterface
     /**
      * Default configuration values.
      *
-     * - `skipLog` List of exceptions to skip logging. Exceptions that
-     *   extend one of the listed exceptions will also not be logged.
      * - `trace` Should error logs include stack traces?
      *
      * @var array<string, mixed>
      */
     protected $_defaultConfig = [
-        'skipLog' => [],
         'trace' => false,
     ];
 
@@ -79,12 +76,6 @@ class ErrorLogger implements ErrorLoggerInterface
      */
     public function log(Throwable $exception, ?ServerRequestInterface $request = null): bool
     {
-        foreach ($this->getConfig('skipLog') as $class) {
-            if ($exception instanceof $class) {
-                return false;
-            }
-        }
-
         $message = $this->getMessage($exception);
 
         if ($request !== null) {

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -55,11 +55,11 @@ class ErrorLogger implements ErrorLoggerInterface
      * Log an error to Cake's Log subsystem
      *
      * @param \Cake\Error\PhpError $error The error to log
-     * @param bool $includeTrace Should the log message include a stacktrace
      * @param ?\Psr\Http\Message\ServerRequestInterface $request The request if in an HTTP context.
-     * @return bool Logging success
+     * @param bool $includeTrace Should the log message include a stacktrace
+     * @return void
      */
-    public function logError(PhpError $error, bool $includeTrace = false, ?ServerRequestInterface $request = null): bool
+    public function logError(PhpError $error, ?ServerRequestInterface $request = null, bool $includeTrace = false): void
     {
         $message = $error->getMessage();
         if ($request) {
@@ -75,31 +75,28 @@ class ErrorLogger implements ErrorLoggerInterface
         $level = $error->getLabel();
         $level = $logMap[$level] ?? $level;
 
-        return Log::write($level, $message);
+        Log::write($level, $message);
     }
 
     /**
      * Log an exception to Cake's Log subsystem
      *
      * @param \Throwable $exception The exception to log a message for.
-     * @param bool $includeTrace Whether or not a stack trace should be logged.
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request if available.
-     * @return bool
+     * @param bool $includeTrace Whether or not a stack trace should be logged.
+     * @return void
      */
     public function logException(
         Throwable $exception,
-        bool $includeTrace = false,
-        ?ServerRequestInterface $request = null
-    ): bool {
+        ?ServerRequestInterface $request = null,
+        bool $includeTrace = false
+    ): void {
         $message = $this->getMessage($exception, false, $includeTrace);
 
         if ($request !== null) {
             $message .= $this->getRequestContext($request);
         }
-
-        $message .= "\n\n";
-
-        return Log::error($message);
+        Log::error($message);
     }
 
     /**

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -25,9 +25,9 @@ use Throwable;
  * Used by the ErrorHandlerMiddleware and global
  * error handlers to log exceptions and errors.
  *
- * @method bool logException(\Throwable $exception, bool $includeTrace = false, ?\Psr\Http\Message\ServerRequestInterface $request = null)
+ * @method void logException(\Throwable $exception, ?\Psr\Http\Message\ServerRequestInterface $request = null, bool $includeTrace = false)
  *   Log an exception with an optional HTTP request.
- * @method bool logError(\Cake\Error\PhpError $error, bool $includeTrace = false, ?\Psr\Http\Message\ServerRequestInterface $request = null)
+ * @method void logError(\Cake\Error\PhpError $error, ?\Psr\Http\Message\ServerRequestInterface $request = null, bool $includeTrace = false)
  *   Log an error with an optional HTTP request.
  */
 interface ErrorLoggerInterface

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -24,6 +24,11 @@ use Throwable;
  *
  * Used by the ErrorHandlerMiddleware and global
  * error handlers to log exceptions and errors.
+ *
+ * @method bool logException(\Throwable $exception, bool $includeTrace = false, ?\Psr\Http\Message\ServerRequestInterface $request = null)
+ *   Log an exception with an optional HTTP request.
+ * @method bool logError(\Cake\Error\PhpError $error, bool $includeTrace = false, ?\Psr\Http\Message\ServerRequestInterface $request = null)
+ *   Log an error with an optional HTTP request.
  */
 interface ErrorLoggerInterface
 {

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -38,6 +38,7 @@ interface ErrorLoggerInterface
      * @param \Throwable $exception The exception to log a message for.
      * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request if available.
      * @return bool
+     * @deprecated 4.4.0 Implement `logException` instead.
      */
     public function log(
         Throwable $exception,
@@ -51,6 +52,7 @@ interface ErrorLoggerInterface
      * @param string $message The message to be logged.
      * @param array $context Context.
      * @return bool
+     * @deprecated 4.4.0 Implement `logError` instead.
      */
     public function logMessage($level, string $message, array $context = []): bool;
 }

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -8,6 +8,7 @@ use Cake\Core\InstanceConfigTrait;
 use Cake\Error\Renderer\ConsoleErrorRenderer;
 use Cake\Error\Renderer\HtmlErrorRenderer;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Routing\Router;
 use Exception;
 use InvalidArgumentException;
 
@@ -123,10 +124,18 @@ class ErrorTrap
         $renderer = $this->renderer();
         $logger = $this->logger();
 
+        $context = [];
+        if ($this->_config['trace']) {
+            $context = [
+                'trace' => $error->getTraceAsString(),
+                'request' => Router::getRequest(),
+            ];
+        }
+
         try {
             // Log first incase rendering or event listeners fail
             if ($this->_config['log']) {
-                $logger->logMessage($error->getLabel(), $error->getMessage());
+                $logger->logMessage($error->getLabel(), $error->getMessage(), $context);
             }
             $event = $this->dispatchEvent('Error.beforeRender', ['error' => $error]);
             if ($event->isStopped()) {

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -122,17 +122,17 @@ class ErrorTrap
         $renderer = $this->renderer();
         $logger = $this->logger();
 
-        $context = [];
-        if ($this->_config['trace']) {
-            $context = [
-                'trace' => $error->getTraceAsString(),
-                'request' => Router::getRequest(),
-            ];
-        }
 
         try {
             // Log first incase rendering or event listeners fail
             if ($this->_config['log']) {
+                $context = [];
+                if ($this->_config['trace']) {
+                    $context = [
+                        'trace' => $error->getTraceAsString(),
+                        'request' => Router::getRequest(),
+                    ];
+                }
                 $logger->logMessage($error->getLabel(), $error->getMessage(), $context);
             }
             $event = $this->dispatchEvent('Error.beforeRender', ['error' => $error]);

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -125,13 +125,16 @@ class ErrorTrap
 
         try {
             // Log first incase rendering or event listeners fail
-            $logger->logMessage($error->getLabel(), $error->getMessage());
+            if ($this->_config['log']) {
+                $logger->logMessage($error->getLabel(), $error->getMessage());
+            }
             $event = $this->dispatchEvent('Error.beforeRender', ['error' => $error]);
             if ($event->isStopped()) {
                 return true;
             }
             $renderer->write($renderer->render($error, $debug));
         } catch (Exception $e) {
+            // Fatal errors always log.
             $logger->logMessage('error', 'Could not render error. Got: ' . $e->getMessage());
 
             return false;

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -29,16 +29,23 @@ class ErrorTrap
     }
 
     /**
-     * See the `Error` key in you `config/app.php`
-     * for details on the keys and their values.
+     * Configuration options. Generally these are defined in config/app.php
+     *
+     * - `errorLevel` - int - The level of errors you are interested in capturing.
+     * - `errorRenderer` - string - The class name of render errors with. Defaults
+     *   to choosing between Html and Console based on the SAPI.
+     * - `log` - boolean - Whether or not you want errors logged.
+     * - `logger` - string - The class name of the error logger to use.
+     * - `trace` - boolean - Whether or not backtraces should be included in
+     *   logged errors.
      *
      * @var array<string, mixed>
      */
     protected $_defaultConfig = [
         'errorLevel' => E_ALL,
+        'errorRenderer' => null,
         'log' => true,
         'logger' => ErrorLogger::class,
-        'errorRenderer' => null,
         'trace' => false,
     ];
 

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -36,11 +36,9 @@ class ErrorTrap
      */
     protected $_defaultConfig = [
         'errorLevel' => E_ALL,
-        'ignoredDeprecationPaths' => [],
         'log' => true,
         'logger' => ErrorLogger::class,
         'errorRenderer' => null,
-        'extraFatalErrorMemory' => 4 * 1024,
         'trace' => false,
     ];
 

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -129,7 +129,6 @@ class ErrorTrap
         $renderer = $this->renderer();
         $logger = $this->logger();
 
-
         try {
             // Log first incase rendering or event listeners fail
             if ($this->_config['log']) {

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -159,11 +159,11 @@ class ErrorTrap
         }
         $logger = $this->logger();
         if (method_exists($logger, 'logError')) {
-            $logger->logError($error, $this->_config['trace'], Router::getRequest());
+            $logger->logError($error, Router::getRequest(), $this->_config['trace']);
         } else {
             $loggerClass = get_class($logger);
             deprecationWarning(
-                "The configured logger `{$loggerClass}` does not implement `logError` " .
+                "The configured logger `{$loggerClass}` does not implement `logError()` " .
                 'which will be required in future versions of CakePHP.'
             );
             $context = [];

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -36,20 +36,24 @@ class ExceptionTrap
     /**
      * Configuration options. Generally these will be defined in your config/app.php
      *
-     * - `trace` - boolean - Whether or not backtraces should be included in
-     *   logged exceptions.
-     * - `logger` - string - The class name of the error logger to use.
      * - `exceptionRenderer` - string - The class responsible for rendering uncaught exceptions.
      *   The chosen class will be used for for both CLI and web environments. If  you want different
      *   classes used in CLI and web environments you'll need to write that conditional logic as well.
      *   The conventional location for custom renderers is in `src/Error`. Your exception renderer needs to
      *   implement the `render()` method and return either a string or Http\Response.
+     * - `log` Set to false to disable logging.
+     * - `logger` - string - The class name of the error logger to use.
+     * - `trace` - boolean - Whether or not backtraces should be included in
+     *   logged exceptions.
      * - `skipLog` - array - List of exceptions to skip for logging. Exceptions that
-     *   extend one of the listed exceptions will also be skipped for logging.
-     *   E.g.: `'skipLog' => ['Cake\Http\Exception\NotFoundException', 'Cake\Http\Exception\UnauthorizedException']`
-     * - `extraFatalErrorMemory` - int - The number of megabytes to increase the memory limit by
-     *   when a fatal error is encountered. This allows
-     *   breathing room to complete logging or error handling.
+     *   extend one of the listed exceptions will also not be logged. E.g.:
+     *   ```
+     *   'skipLog' => ['Cake\Http\Exception\NotFoundException', 'Cake\Http\Exception\UnauthorizedException']
+     *   ```
+     *   This option is forwarded to the configured `logger`
+     * - `extraFatalErrorMemory` - int - The number of megabytes to increase the memory limit by when a fatal error is
+     *   encountered. This allows breathing room to complete logging or error handling.
+     * - `stderr` Used in console environments so that renderers have access to the current console output stream.
      *
      * @var array<string, mixed>
      */
@@ -341,14 +345,7 @@ class ExceptionTrap
      */
     public function logException(Throwable $exception, ?ServerRequestInterface $request = null): void
     {
-        $shouldLog = true;
-        foreach ($this->_config['skipLog'] as $class) {
-            if ($exception instanceof $class) {
-                $shouldLog = false;
-                break;
-            }
-        }
-        if ($shouldLog && $this->_config['log']) {
+        if ($this->_config['log']) {
             $this->logger()->log($exception, $request);
         }
         $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception]);

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -64,6 +64,7 @@ class ExceptionTrap
         'log' => true,
         'skipLog' => [],
         'trace' => false,
+        'extraFatalErrorMemory' => 4,
     ];
 
     /**

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -346,7 +346,15 @@ class ExceptionTrap
      */
     public function logException(Throwable $exception, ?ServerRequestInterface $request = null): void
     {
-        if ($this->_config['log']) {
+        $shouldLog = $this->_config['log'];
+        if ($shouldLog) {
+            foreach ($this->getConfig('skipLog') as $class) {
+                if ($exception instanceof $class) {
+                    $shouldLog = false;
+                }
+            }
+        }
+        if ($shouldLog) {
             $this->logger()->log($exception, $request);
         }
         $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception]);

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -364,12 +364,11 @@ class ExceptionTrap
     public function logInternalError(Throwable $exception): void
     {
         $message = sprintf(
-            "[%s] %s (%s:%s)\n%s", // Keeping same message format
+            "[%s] %s (%s:%s)", // Keeping same message format
             get_class($exception),
             $exception->getMessage(),
             $exception->getFile(),
             $exception->getLine(),
-            $exception->getTraceAsString()
         );
         trigger_error($message, E_USER_ERROR);
     }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -357,7 +357,7 @@ class ExceptionTrap
         if ($shouldLog) {
             $logger = $this->logger();
             if (method_exists($logger, 'logException')) {
-                $logger->logException($exception, $this->_config['trace'], $request);
+                $logger->logException($exception, $request, $this->_config['trace']);
             } else {
                 $loggerClass = get_class($logger);
                 deprecationWarning(

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -373,7 +373,7 @@ class ExceptionTrap
     public function logInternalError(Throwable $exception): void
     {
         $message = sprintf(
-            "[%s] %s (%s:%s)", // Keeping same message format
+            '[%s] %s (%s:%s)', // Keeping same message format
             get_class($exception),
             $exception->getMessage(),
             $exception->getFile(),

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -348,7 +348,7 @@ class ExceptionTrap
                 break;
             }
         }
-        if ($shouldLog) {
+        if ($shouldLog && $this->_config['log']) {
             $this->logger()->log($exception, $request);
         }
         $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception]);
@@ -366,8 +366,6 @@ class ExceptionTrap
      */
     public function logInternalError(Throwable $exception): void
     {
-        // Disable trace for internal errors.
-        $this->_config['trace'] = false;
         $message = sprintf(
             "[%s] %s (%s:%s)\n%s", // Keeping same message format
             get_class($exception),

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -355,7 +355,17 @@ class ExceptionTrap
             }
         }
         if ($shouldLog) {
-            $this->logger()->log($exception, $request);
+            $logger = $this->logger();
+            if (method_exists($logger, 'logException')) {
+                $logger->logException($exception, $this->_config['trace'], $request);
+            } else {
+                $loggerClass = get_class($logger);
+                deprecationWarning(
+                    "The configured logger `{$loggerClass}` should implement `logException()` " .
+                    'to be compatible with future versions of CakePHP.'
+                );
+                $this->logger()->log($exception, $request);
+            }
         }
         $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception]);
     }

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -144,6 +144,28 @@ class ErrorTrapTest extends TestCase
         $this->assertStringContainsString($logLevel, $logs[0]);
     }
 
+    public function testHandleErrorLogTrace()
+    {
+        Log::setConfig('test_error', [
+            'className' => 'Array',
+        ]);
+        $trap = new ErrorTrap([
+            'errorRenderer' => TextErrorRenderer::class,
+            'trace' => true,
+        ]);
+        $trap->register();
+
+        ob_start();
+        trigger_error('Oh no it was bad', E_USER_WARNING);
+        ob_get_clean();
+        restore_error_handler();
+
+        $logs = Log::engine('test_error')->read();
+        $this->assertStringContainsString('Oh no it was bad', $logs[0]);
+        $this->assertStringContainsString('Trace:', $logs[0]);
+        $this->assertStringContainsString('ErrorTrapTest::testHandleErrorLogTrace', $logs[0]);
+    }
+
     public function testHandleErrorNoLog()
     {
         Log::setConfig('test_error', [

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -230,6 +230,19 @@ class ExceptionTrapTest extends TestCase
         $this->assertStringContainsString('nope', $logs[0]);
     }
 
+    public function testLogExceptionConfigOff()
+    {
+        Log::setConfig('test_error', [
+            'className' => 'Array',
+        ]);
+        $trap = new ExceptionTrap(['log' => false]);
+        $error = new InvalidArgumentException('nope');
+        $trap->logException($error);
+
+        $logs = Log::engine('test_error')->read();
+        $this->assertEmpty($logs);
+    }
+
     /**
      * @preserveGlobalState disabled
      * @runInSeparateProcess

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -23,12 +23,14 @@ use Cake\Error\Renderer\ConsoleExceptionRenderer;
 use Cake\Error\Renderer\TextExceptionRenderer;
 use Cake\Error\Renderer\WebExceptionRenderer;
 use Cake\Http\Exception\MissingControllerException;
+use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\TestSuite\Stub\ConsoleOutput;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 use InvalidArgumentException;
 use stdClass;
+use TestApp\Error\LegacyErrorLogger;
 use Throwable;
 
 class ExceptionTrapTest extends TestCase
@@ -241,6 +243,28 @@ class ExceptionTrapTest extends TestCase
 
         $logs = Log::engine('test_error')->read();
         $this->assertEmpty($logs);
+    }
+
+    public function testLogExceptionDeprecatedLoggerMethods()
+    {
+        Log::setConfig('test_error', [
+            'className' => 'Array',
+        ]);
+        $trap = new ExceptionTrap([
+            'log' => true,
+            'logger' => LegacyErrorLogger::class,
+            'trace' => true,
+        ]);
+        $error = new InvalidArgumentException('nope');
+        $request = new ServerRequest(['url' => '/articles/view/1']);
+        $this->deprecated(function () use ($trap, $error, $request) {
+            $trap->logException($error, $request);
+        });
+
+        $logs = Log::engine('test_error')->read();
+        $this->assertStringContainsString('nope', $logs[0]);
+        $this->assertStringContainsString('IncludeTrace', $logs[0]);
+        $this->assertStringContainsString('URL=http://localhost/articles/view/1', $logs[0]);
     }
 
     /**

--- a/tests/test_app/TestApp/Error/LegacyErrorLogger.php
+++ b/tests/test_app/TestApp/Error/LegacyErrorLogger.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Error;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\Error\ErrorLoggerInterface;
+use Cake\Log\Log;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Test stub that only implements the interface as declared.
+ * Necessary to test the deprecated logging paths in ErrorTrap and ExceptionTrap
+ */
+class LegacyErrorLogger implements ErrorLoggerInterface
+{
+    use InstanceConfigTrait;
+
+    /**
+     * Default configuration values.
+     *
+     * - `trace` Should error logs include stack traces?
+     *
+     * @var array<string, mixed>
+     */
+    protected $_defaultConfig = [
+        'trace' => false,
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param array<string, mixed> $config Config array.
+     */
+    public function __construct(array $config = [])
+    {
+        $this->setConfig($config);
+    }
+
+    /**
+     * @param string|int $level The logging level
+     * @param string $message The message to be logged.
+     * @param array $context Context.
+     * @return bool
+     */
+    public function logMessage($level, string $message, array $context = []): bool
+    {
+        if (!empty($context['request'])) {
+            $message .= ' URL=' . $context['request']->getUri();
+        }
+        if (!empty($context['trace'])) {
+            $message .= ' IncludeTrace';
+        }
+        $logMap = [
+            'strict' => LOG_NOTICE,
+            'deprecated' => LOG_NOTICE,
+        ];
+        $level = $logMap[$level] ?? $level;
+
+        return Log::write($level, $message);
+    }
+
+    /**
+     * @param \Throwable $exception The exception to log a message for.
+     * @param \Psr\Http\Message\ServerRequestInterface|null $request The current request if available.
+     * @return bool
+     */
+    public function log(Throwable $exception, ?ServerRequestInterface $request = null): bool
+    {
+        $message = $exception->getMessage();
+        if ($request !== null) {
+            $message .= 'URL=' . $request->getUri();
+        }
+        if ($this->getConfig('trace')) {
+            $message .= 'IncludeTrace';
+        }
+
+        return Log::error($message);
+    }
+}


### PR DESCRIPTION
Fix several error logging related issues that @ADmad identified.

* The `log` option now works in `ErrorTrap`
* Improved documentation for what `stderr` does.
* The `trace` option now works with `ErrorTrap`.
* Removed a redundant copy of the `skipLog` logic.
* Removed the configuration mutation when handling fatal errors. Instead the `trace` option is applied consistently.
