### PR TITLE
Fix description of has() to match __isset()

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -216,7 +216,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable
 
     /**
      * Returns whether this entity contains a field named $field
-     * regardless of if it is empty.
+     * and is not set to null.
      *
      * @param array<string>|string $field The field to check.
      * @return bool


### PR DESCRIPTION
This should match the description of `__isset()` which was fixed in https://github.com/cakephp/cakephp/pull/16354.

I don't know how both of these were incorrectly described.