### PR TITLE
Allow php 8.2 tests to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
           vendor/bin/phpunit
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --testsuite=database
         fi
-      continue-on-error: ${{ matrix.php-version == '8.2' }}
 
     - name: Prefer lowest check
       if: matrix.prefer-lowest == 'prefer-lowest'


### PR DESCRIPTION
At this point, we should detect and fix any issues with php 8.2.