### PR TITLE
Make stacktrace output consistent for console environment

### DIFF
--- a/src/Error/Renderer/ConsoleErrorRenderer.php
+++ b/src/Error/Renderer/ConsoleErrorRenderer.php
@@ -33,13 +33,24 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
     protected $output;
 
     /**
+     * @var bool
+     */
+    protected $trace = false;
+
+    /**
      * Constructor.
+     *
+     * ### Options
+     *
+     * - `stderr` - The ConsoleOutput instance to use. Defaults to `php://stderr`
+     * - `trace` - Whether or not stacktraces should be output.
      *
      * @param array $config Error handling configuration.
      */
     public function __construct(array $config)
     {
         $this->output = $config['stderr'] ?? new ConsoleOutput('php://stderr');
+        $this->trace = (bool)($config['trace'] ?? false);
     }
 
     /**
@@ -55,14 +66,19 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
      */
     public function render(PhpError $error, bool $debug): string
     {
+        $trace = '';
+        if ($this->trace) {
+            $trace = "\n<info>Stack Trace:</info>\n\n" . $error->getTraceAsString();
+        }
+
         return sprintf(
-            "<error>%s: %s :: %s</error> on line %s of %s\n<info>Trace:</info>\n%s",
+            '<error>%s: %s :: %s</error> on line %s of %s%s',
             $error->getLabel(),
             $error->getCode(),
             $error->getMessage(),
             $error->getLine() ?? '',
             $error->getFile() ?? '',
-            $error->getTraceAsString(),
+            $trace
         );
     }
 }

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -27,8 +27,8 @@ use Cake\Error\Renderer\TextErrorRenderer;
 use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Routing\Router;
-use Cake\TestSuite\TestCase;
 use Cake\TestSuite\Stub\ConsoleOutput;
+use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use stdClass;
 use TestApp\Error\LegacyErrorLogger;
@@ -222,7 +222,7 @@ class ErrorTrapTest extends TestCase
         $this->assertStringContainsString('URL=http://localhost/articles/view/1', $logs[0]);
     }
 
-    public function testTraceOptionConsoleRendering()
+    public function testConsoleRenderingNoTrace()
     {
         $stub = new ConsoleOutput();
         $trap = new ErrorTrap([
@@ -240,6 +240,27 @@ class ErrorTrapTest extends TestCase
         $out = $stub->messages();
         $this->assertStringContainsString('Oh no it was bad', $out[0]);
         $this->assertStringNotContainsString('Trace', $out[0]);
+    }
+
+    public function testConsoleRenderingWithTrace()
+    {
+        $stub = new ConsoleOutput();
+        $trap = new ErrorTrap([
+            'errorRenderer' => ConsoleErrorRenderer::class,
+            'trace' => true,
+            'stderr' => $stub,
+        ]);
+        $trap->register();
+
+        ob_start();
+        trigger_error('Oh no it was bad', E_USER_NOTICE);
+        ob_get_clean();
+        restore_error_handler();
+
+        $out = $stub->messages();
+        $this->assertStringContainsString('Oh no it was bad', $out[0]);
+        $this->assertStringContainsString('Trace', $out[0]);
+        $this->assertStringContainsString('ErrorTrapTest::testConsoleRenderingWithTrace', $out[0]);
     }
 
     public function testRegisterNoOutputDebug()

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -28,6 +28,7 @@ use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Cake\TestSuite\Stub\ConsoleOutput;
 use InvalidArgumentException;
 use stdClass;
 use TestApp\Error\LegacyErrorLogger;
@@ -219,6 +220,26 @@ class ErrorTrapTest extends TestCase
         $this->assertStringContainsString('Oh no it was bad', $logs[0]);
         $this->assertStringContainsString('IncludeTrace', $logs[0]);
         $this->assertStringContainsString('URL=http://localhost/articles/view/1', $logs[0]);
+    }
+
+    public function testTraceOptionConsoleRendering()
+    {
+        $stub = new ConsoleOutput();
+        $trap = new ErrorTrap([
+            'errorRenderer' => ConsoleErrorRenderer::class,
+            'trace' => false,
+            'stderr' => $stub,
+        ]);
+        $trap->register();
+
+        ob_start();
+        trigger_error('Oh no it was bad', E_USER_NOTICE);
+        ob_get_clean();
+        restore_error_handler();
+
+        $out = $stub->messages();
+        $this->assertStringContainsString('Oh no it was bad', $out[0]);
+        $this->assertStringNotContainsString('Trace', $out[0]);
     }
 
     public function testRegisterNoOutputDebug()


### PR DESCRIPTION
Make console error rendering use the `trace` option to toggle whether or not stacktraces are shown. This aligns the behavior with exception rendering. I've also used more consistent terms between error and exception rendering.