### PR TITLE
Add HashValidator to validate types in config arrays

### DIFF
--- a/src/Utility/HashValidator.php
+++ b/src/Utility/HashValidator.php
@@ -1,0 +1,276 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         4.3.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Utility;
+
+class HashValidator
+{
+    protected array $schema;
+
+    /**
+     * @param array $schema Hash schema
+     */
+    public function __construct(array $schema)
+    {
+        $this->schema = $schema + ['allowPaths' => true, 'strict' => true, 'required' => false, 'refs' => []];
+    }
+
+    /**
+     * Validates hash against schema.
+     *
+     * @param array $hash Hash to validate
+     * @param array $existing Existing hash that $hash would update.
+     * @return array
+     */
+    public function validate(array $hash, array $existing = []): array
+    {
+        if ($this->schema['allowPaths']) {
+            $hash = Hash::expand($hash);
+        }
+
+         return $this->validateShape(['fields' => $this->schema['fields']], $hash, $existing, '');
+    }
+
+    /**
+     * Validate an array shape.
+     *
+     * @param array $shapeSpec Shape specification
+     * @param array $hash Hash to validate
+     * @param array $existing Existing hash that $hash would update.
+     * @param string $path Shape path
+     * @return array
+     */
+    protected function validateShape(array $shapeSpec, array $hash, array $existing, string $path): array
+    {
+        $errors = [];
+        foreach ($hash as $field => $value) {
+            $fieldPath = $this->appendFieldToPath($path, $field);
+
+            $fieldSpec = $this->getFieldSpec($shapeSpec['fields'], $field);
+            if ($fieldSpec === null) {
+                if ($shapeSpec['strict'] ?? $this->schema['strict']) {
+                    $errors[$fieldPath] = 'Field does not exist in schema.';
+                }
+                continue;
+            }
+
+            $errors += static::validateField($fieldSpec, $value, $existing[$field] ?? [], $fieldPath);
+        }
+
+        $missing = array_diff(array_keys($shapeSpec['fields']), array_keys($hash));
+        foreach ($missing as $field) {
+            $fieldSpec = static::getFieldSpec($shapeSpec['fields'], $field);
+            if (
+                !array_key_exists($field, $existing) &&
+                ($fieldSpec['required'] ?? ($shapeSpec['required'] ?? $this->schema['required']))
+            ) {
+                $errors[$this->appendFieldToPath($path, $field)] = 'Required field missing from hash.';
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Validates an array shape field.
+     *
+     * @param array $fieldSpec Field specification
+     * @param mixed $value Field value
+     * @param array $existing Existing hash that $value would update.
+     * @param string $path Field path
+     * @return array
+     */
+    protected function validateField(array $fieldSpec, $value, array $existing, string $path): array
+    {
+        foreach ((array)$fieldSpec['type'] as $typeId => $typeValue) {
+            if ($typeId === 'array{}') {
+                if (is_array($value)) {
+                    $ref = $typeValue['ref'] ?? null;
+                    if ($ref) {
+                        $typeValue = $this->schema['refs'][$ref];
+                    }
+
+                    return static::validateShape($typeValue, $value, $existing, $path);
+                }
+                continue;
+            }
+
+            if ($this->isUnionType((array)$fieldSpec['type'], $value)) {
+                return [];
+            }
+        }
+
+        return [$path => 'Field value does not match expected type.'];
+    }
+
+    /**
+     * Appends key to dot notation path.
+     *
+     * @param string $path Field path
+     * @param string $field Field name
+     * @return string
+     */
+    protected function appendFieldToPath(string $path, string $field): string
+    {
+        if ($path === '') {
+            return $field;
+        }
+
+        return $path . '.' . $field;
+    }
+
+    /**
+     * Gets normalized field specification or null if not found.
+     *
+     * @param array $specs Field specifications
+     * @param string $field Field name
+     * @return array|null
+     */
+    protected function getFieldSpec(array $specs, string $field): ?array
+    {
+        $spec = $specs[$field] ?? null;
+        if ($spec === null) {
+            return null;
+        }
+
+        if (is_string($spec)) {
+            return ['type' => (array)$spec];
+        }
+
+        return $spec;
+    }
+
+    /**
+     * Checks if $value maches expected $type.
+     *
+     * @param string $type Type name
+     * @param mixed $value Value to check
+     * @return bool
+     */
+    protected function isType(string $type, $value): bool
+    {
+        switch ($type) {
+            case 'array':
+                return is_array($value);
+            case 'list':
+                if (!is_array($value)) {
+                    return false;
+                }
+
+                $e = 0;
+                foreach ($value as $i => $v) {
+                    if ($i !== $e++) {
+                        return false;
+                    }
+                }
+
+                return true;
+            case 'string':
+                return is_string($value);
+            case 'float':
+                return is_float($value);
+            case 'int':
+                return is_int($value);
+            case 'bool':
+                return is_bool($value);
+            case 'null':
+                return $value === null;
+            case 'mixed':
+                return true;
+        }
+
+        return $value instanceof $type;
+    }
+
+    /**
+     * Checks if a value matches expected generic type.
+     *
+     * @param string $typeId Type ID
+     * @param array|string $typeSpec Type specification
+     * @param mixed $value Value to check
+     * @return bool
+     */
+    protected function isGenericType(string $typeId, $typeSpec, $value): bool
+    {
+        switch ($typeId) {
+            case 'array<>':
+                if (!is_array($value)) {
+                    return false;
+                }
+
+                foreach ($value as $i => $v) {
+                    if (!$this->isUnionType((array)$typeSpec, $v)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            case 'list<>':
+                if (!is_array($value)) {
+                    return false;
+                }
+
+                $e = 0;
+                foreach ($value as $i => $v) {
+                    if ($i !== $e++) {
+                        return false;
+                    }
+
+                    if (!$this->isUnionType((array)$typeSpec, $v)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            case 'class-string<>':
+                foreach ((array)$typeSpec as $string) {
+                    /** @var class-string $string */
+                    if (is_a($value, $string, true)) {
+                        return true;
+                    }
+                }
+                break;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if a value is one of the types in a union type.
+     *
+     * Does not check for array shape type: 'array{}'.
+     *
+     * @param array $union Type union
+     * @param mixed $value Value to check
+     * @return bool
+     */
+    protected function isUnionType(array $union, $value): bool
+    {
+        $isType = false;
+        foreach ($union as $typeId => $typeSpec) {
+            if (is_string($typeId)) {
+                if ($this->isGenericType($typeId, $typeSpec, $value)) {
+                    $isType = true;
+                    break;
+                }
+            } elseif ($this->isType($typeSpec, $value)) {
+                $isType = true;
+                break;
+            }
+        }
+
+        return $isType;
+    }
+}

--- a/tests/TestCase/Utility/HashValidatorTest.php
+++ b/tests/TestCase/Utility/HashValidatorTest.php
@@ -1,0 +1,650 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.4.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Utility;
+
+use Cake\TestSuite\TestCase;
+use Cake\Utility\HashValidator;
+use stdClass;
+
+class HashValidatorTest extends TestCase
+{
+    public function testBasicTypes(): void
+    {
+        // all valid basic types
+        $schema = [
+            'fields' => [
+                'array' => 'array',
+                'list' => 'list',
+                'string' => 'string',
+                'float' => 'float',
+                'int' => 'int',
+                'bool' => 'bool',
+                'null' => 'null',
+                'mixed' => 'mixed',
+                'class' => stdClass::class,
+            ],
+        ];
+        $hash = ['array' => [], 'list' => ['value'], 'string' => 'a string', 'float' => 1.23, 'int' => 1, 'bool' => true, 'mixed' => true, 'null' => null, 'class' => new stdClass()];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // all invalid basic types (mixed cannot be invalid)
+        $schema = [
+            'fields' => [
+                'array' => 'array',
+                'list' => 'list',
+                'string' => 'string',
+                'float' => 'float',
+                'int' => 'int',
+                'bool' => 'bool',
+                'null' => 'null',
+                'class' => stdClass::class,
+            ],
+        ];
+        $hash = ['array' => null, 'list' => ['a' => 'value'], 'string' => 1.23, 'float' => 2, 'int' => null, 'bool' => new stdClass(), 'null' => 1, 'class' => true];
+        $this->assertSame(
+            [
+                'array' => 'Field value does not match expected type.',
+                'list' => 'Field value does not match expected type.',
+                'string' => 'Field value does not match expected type.',
+                'float' => 'Field value does not match expected type.',
+                'int' => 'Field value does not match expected type.',
+                'bool' => 'Field value does not match expected type.',
+                'null' => 'Field value does not match expected type.',
+                'class' => 'Field value does not match expected type.',
+            ],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testClassStringType(): void
+    {
+        $schema = [
+            'fields' => [
+                'has_class_string' => [
+                    'type' => ['class-string<>' => stdClass::class],
+                ],
+            ],
+        ];
+        $hash = ['has_class_string' => stdClass::class];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'has_class_string' => [
+                    'type' => ['class-string<>' => [HashValidator::class, stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['has_class_string' => stdClass::class];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'has_class_string' => [
+                    'type' => ['class-string<>' => stdClass::class],
+                ],
+            ],
+        ];
+        $hash = ['has_class_string' => HashValidator::class];
+        $this->assertSame(
+            ['has_class_string' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testArrayType()
+    {
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => ['array<>' => stdClass::class],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['a' => new stdClass(), new stdClass()]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => ['array<>' => [stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['a' => new stdClass(), new stdClass()]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => ['array<>' => ['int', stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => [new stdClass(), 'a' => 1]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => ['array<>' => [stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => new stdClass()];
+        $this->assertSame(
+            ['is_array' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => ['array<>' => [stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => [new stdClass(), 'a' => 1]];
+        $this->assertSame(
+            ['is_array' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testListType()
+    {
+        $schema = [
+            'fields' => [
+                'is_list' => [
+                    'type' => ['list<>' => stdClass::class],
+                ],
+            ],
+        ];
+        $hash = ['is_list' => [new stdClass(), new stdClass()]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_list' => [
+                    'type' => ['list<>' => [stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_list' => [new stdClass(), new stdClass()]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_list' => [
+                    'type' => ['list<>' => ['int', stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_list' => [new stdClass(), 1]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_list' => [
+                    'type' => ['list<>' => [stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_list' => new stdClass()];
+        $this->assertSame(
+            ['is_list' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        $schema = [
+            'fields' => [
+                'is_list' => [
+                    'type' => ['list<>' => [stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_list' => [new stdClass(), 1]];
+        $this->assertSame(
+            ['is_list' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        $schema = [
+            'fields' => [
+                'is_list' => [
+                    'type' => ['list<>' => ['int', stdClass::class]],
+                ],
+            ],
+        ];
+        $hash = ['is_list' => [new stdClass(), 'a' => 1]];
+        $this->assertSame(
+            ['is_list' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testArrayShapes(): void
+    {
+        // single-dimension
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['int' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['int' => 1]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['int' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['int' => 1.13]];
+        $this->assertSame(
+            ['is_array.int' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // test multi-dimension
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => [
+                                'nested' => [
+                                    'type' => [
+                                        'array{}' => [
+                                            'fields' => ['int' => 'int'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['nested' => ['int' => 1]]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => [
+                                'nested' => [
+                                    'type' => [
+                                        'array{}' => [
+                                            'fields' => ['int' => 'int'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['nested' => ['int' => 1.23]]];
+        $this->assertSame(
+            ['is_array.nested.int' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testUnionType(): void
+    {
+        // type is in union
+        $schema = ['fields' => ['string_or_int' => ['type' => ['string', 'int']]]];
+        $hash = ['string_or_int' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // type is not in union
+        $schema = ['fields' => ['string_or_float' => ['type' => ['string', 'float']]]];
+        $hash = ['string_or_float' => 1];
+        $this->assertSame(
+            ['string_or_float' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // test generic in union
+        $schema = ['fields' => ['int_or_array' => ['type' => ['int', 'array<>' => ['class-string<>' => stdClass::class]]]]];
+        $hash = ['int_or_array' => [stdClass::class]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // test shape in union
+        $schema = [
+            'fields' => [
+                'int_or_shape' => [
+                    'type' => [
+                        'int',
+                        'array{}' => [
+                            'fields' => ['int' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['int_or_shape' => ['int' => 1]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'int_or_shape' => [
+                    'type' => [
+                        'int',
+                        'array{}' => [
+                            'fields' => ['int' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['int_or_shape' => ['int' => 1.2]];
+        $this->assertSame(
+            ['int_or_shape.int' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testRequired(): void
+    {
+        // check default is false
+        $schema = [
+            'fields' => [
+                'int' => [
+                    'type' => 'int',
+                ],
+            ],
+        ];
+        $hash = [];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // set default to true
+        $schema = [
+            'required' => true,
+            'fields' => [
+                'int' => [
+                    'type' => 'int',
+                ],
+            ],
+        ];
+        $hash = [];
+        $this->assertSame(
+            ['int' => 'Required field missing from hash.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // override field to true
+        $schema = [
+            'fields' => [
+                'int' => [
+                    'required' => true,
+                    'type' => 'int',
+                ],
+            ],
+        ];
+        $hash = [];
+        $this->assertSame(
+            ['int' => 'Required field missing from hash.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // override field to false
+        $schema = [
+            'required' => true,
+            'fields' => [
+                'int' => [
+                    'required' => false,
+                    'type' => 'int',
+                ],
+            ],
+        ];
+        $hash = [];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // override shape to true
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'required' => true,
+                            'fields' => [
+                                'int' => 'int',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => []];
+        $this->assertSame(
+            ['is_array.int' => 'Required field missing from hash.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testValidateStrict(): void
+    {
+        // check default is true
+        $schema = ['fields' => ['int' => 'int']];
+        $hash = ['extra' => true];
+        $this->assertSame(
+            ['extra' => 'Field does not exist in schema.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // override default to false
+        $schema = ['strict' => false, 'fields' => ['int' => 'int']];
+        $hash = ['extra' => true];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // test shape inherits default
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['int' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['extra' => true]];
+        $this->assertSame(
+            ['is_array.extra' => 'Field does not exist in schema.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // override shape to false
+        $schema = [
+            'strict' => true,
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'strict' => false,
+                            'fields' => ['int' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array' => ['extra' => true]];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // strict and required
+        $schema = ['required' => true, 'fields' => ['int' => 'int']];
+        $hash = ['extra' => true];
+        $this->assertSame(
+            [
+                'extra' => 'Field does not exist in schema.',
+                'int' => 'Required field missing from hash.',
+            ],
+            (new HashValidator($schema))->validate($hash)
+        );
+    }
+
+    public function testAllowPaths(): void
+    {
+        // default to true
+        $schema = [
+            'fields' => [
+                'is_array' => 'array',
+            ],
+        ];
+        $hash = ['is_array.nested.field' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['nested' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array.nested' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['nested' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array.nested.extra' => []];
+        $this->assertSame(
+            ['is_array.nested' => 'Field value does not match expected type.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // disabled
+        $schema = ['allowPaths' => false, 'fields' => ['this.is.an.int' => 'int']];
+        $hash = ['this.is.an.int' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+
+        // partial write with missing required fields
+        $schema = [
+            'fields' => [
+                'int' => [
+                    'required' => true,
+                    'type' => 'int',
+                ],
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['nested' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array.nested' => 1];
+        $this->assertSame(
+            ['int' => 'Required field missing from hash.'],
+            (new HashValidator($schema))->validate($hash)
+        );
+
+        // partial write with required fields in existing hash
+        $schema = [
+            'fields' => [
+                'int' => [
+                    'required' => true,
+                    'type' => 'int',
+                ],
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['nested' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array.nested' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash, ['int' => 1]));
+
+        // partial write with required nested fields in existing hash
+        $schema = [
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['nested' => 'int'],
+                        ],
+                    ],
+                ],
+                'is_array_2' => [
+                    'type' => [
+                        'array{}' => [
+                            'fields' => ['nested' => 'int'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array.nested' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash, ['is_array_2.nested' => 1]));
+    }
+
+    public function testReferences(): void
+    {
+        $schema = [
+            'refs' => [
+                'int_shape_ref' => [
+                    'fields' => ['nested' => 'int'],
+                ],
+            ],
+            'fields' => [
+                'is_array' => [
+                    'type' => [
+                        'array{}' => [
+                            'ref' => 'int_shape_ref',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $hash = ['is_array.nested' => 1];
+        $this->assertEmpty((new HashValidator($schema))->validate($hash));
+    }
+}


### PR DESCRIPTION
Returns an array of errors for each field in the array with the dot notation path to the field as the key. All fields in an array are validated even if one has an error.

## Schema Specification

Example: 

```php
$schema = [
    'strict' => false, // optional, defaults to true
    'required' => true, // optional, defaults to false
    'allowPaths' => false, // optional, defaults to true
    'fields' => [
        'field' => field-specification
    ],
]
```

The `strict` and `required` flags are optional while the fields array must contain at least 1 field.

- `strict`

    The `strict` flag controls whether all of the keys in the data must exist in the schema. Disabling this essentially allows for 
    undocumented pass-through fields.

    This can be overridden for any `array{}` type field 

    Defaults to `true`.

- `required`

    The `required` flag controls whether the field must exist in the data. Enabling essentially means there are no optional fields in the schema.

    This can be overridden for any field.

    Defaults to `false`.

- `allowPaths`

  The `allowPaths` flag controls whether dot notation paths are expanded in in the top-level fields of the hash. Paths are not parsed in nested fields.

  Defaults to true.

## Field Specification

Example: 

```php
$schema = [
    'fields' => [
        'field' => 'int',
        'union_field' => [
           'required' => true,
           'type' => ['int', 'bool'],
        'array_field' => [
            'strict' => false,
            'fields' => [
              ...
           ],
       ],
    ],
]
```

The field specification can be either a string on an array. If a string, that is used as the type for the field.  If an array, then the `type` key is required can be either a string or array.

The `required` flag can be set for each field.

The `type` key can be either a single basic type or an array of basic, generic and array shapes. Generic types and array shapes are arrays with the type name as the key.

```php
[
    type => ['string', 'class-string<>' => stdClass::class, 'array{}' => ['fields' => [...]]
]
```

When the type is an array, it acts as a union type where the field must be one of the types.

Basic Types:

- 'array'
- 'list'
- 'string'
- 'int'
- 'float'
- 'bool'
- 'null'
- 'mixed'

Generic Types:

- ['array<>' => string]
- ['list<>' => string]
- ['class-string<>' => string]

Array Shape:
- ['array{}' => ['fields' => fields]

### Array Shape Specification

Array shapes are represented by the `array{}` type and must be an array that contains a `fields` array the same as the top-level schema.

```php
[
    'type' => [
        'array{}' => [
            'strict' => false,
            'fields' => [
               'array_field' => 'int',
            ],  
        ], 
    ],
]
```

The `strict` flag overrides the schema default for that array only.