### PR TITLE
Fix Model.afterSaveCommit triggering inconsistency.

### DIFF
--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -692,6 +692,7 @@ class RulesCheckerIntegrationTest extends TestCase
                         'checkRules' => true,
                         'checkExisting' => true,
                         '_primary' => true,
+                        '_cleanOnSuccess' => true,
                     ],
                     $options->getArrayCopy()
                 );
@@ -731,6 +732,7 @@ class RulesCheckerIntegrationTest extends TestCase
                         'checkRules' => true,
                         'checkExisting' => true,
                         '_primary' => true,
+                        '_cleanOnSuccess' => true,
                     ],
                     $options->getArrayCopy()
                 );


### PR DESCRIPTION
When using Table::saveMany() the entities are now cleaned up after
Model.afterSaveCommit event is dispatched, similar to what's done
when saving individual entities with Table::save().

Closes #16499

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
