### PR TITLE
Use random string not bytes for CSRF token salt

### DIFF
--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -190,7 +190,7 @@ class CsrfProtectionMiddleware
      */
     public function createToken()
     {
-        $value = Security::randomBytes(static::TOKEN_VALUE_LENGTH);
+        $value = Security::randomString(static::TOKEN_VALUE_LENGTH);
         if (!$this->_config['verifyTokenSource']) {
             return hash('sha512', $value, false);
         }

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -87,6 +87,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
             $this->assertEquals(0, $cookie['expire'], 'session duration.');
             $this->assertEquals('/dir/', $cookie['path'], 'session path.');
             $this->assertEquals($cookie['value'], $request->getParam('_csrfToken'));
+            $this->assertRegExp('/^[a-z0-9]+$/', $cookie['value']);
         };
 
         $middleware = new CsrfProtectionMiddleware();
@@ -199,6 +200,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
     {
         $middleware = new CsrfProtectionMiddleware(['verifyTokenSource' => true]);
         $token = $middleware->createToken();
+        $this->assertRegexp('/^[a-z0-9]+$/', $token, 'Token should not have unencoded binary data.');
+
         $request = new ServerRequest([
             'environment' => [
                 'REQUEST_METHOD' => $method,


### PR DESCRIPTION
Since https://github.com/cakephp/cakephp/commit/309c8990dcadcf4391967f4b01aa84c58f84b8d8 the CSRF token generated contained a binary part for the salt, when one had the new setting ``verifyTokenSource`` activated.

Like so:
``<input type="hidden" name="_csrfToken" autocomplete="off" value="e�7��T��Ä&quot;\�786952664be900ba7c85f37b215b29da5be37b3f"/>``
Instead of:
``<input type="hidden" name="_csrfToken" autocomplete="off" value="47f3d3fed912070fae3a676b720eceaaa1124b92e21deeb37aa810ebc5193624cd5b13d41523bc500d308ec79722dd2ef8a965548680bfdac669a113de54d308"/>``

This broke the CSRF check completely.

With this change, we use a string representation for it.