### PR TITLE
Fix crash when you have a field which has the same name as your table

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -287,7 +287,7 @@ class Marshaller
         $options += ['validate' => true];
 
         $tableName = $this->_table->getAlias();
-        if (isset($data[$tableName])) {
+        if (isset($data[$tableName]) && is_array($data[$tableName])) {
             $data += $data[$tableName];
             unset($data[$tableName]);
         }


### PR DESCRIPTION
If you have a column that has the same name as your table, the original version of this code crashes because you're trying to use the "+" operator to perform a merge of a string to an array. 

Example: 
Table "AccountName"
Fields: 
  - ID
  - AccountNumber
  - AccountName

In this case, the "isset($data[$tableName])" check is true and the code then tries to use the "+" operator to merge a string to the data array. 

This change fixes this since it will only perform the "+" based merge if "$data[$tableName]" is an array.
