### PR TITLE
Simplify FieldTypeConverter

### DIFF
--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -36,7 +36,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      */
     protected function checkNumeric(mixed $value): void
     {
-        if (!is_numeric($value)) {
+        if (!is_numeric($value) && !is_bool($value)) {
             throw new InvalidArgumentException(sprintf(
                 'Cannot convert value of type `%s` to integer',
                 get_debug_type($value)


### PR DESCRIPTION
The code for categorizing converters each type was complicated when a simply map will work.