### PR TITLE
Store event handlers as closures

### DIFF
--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -22,6 +22,7 @@ use Cake\Event\EventList;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use TestApp\TestCase\Event\CustomTestEventListenerInterface;
 use TestApp\TestCase\Event\EventTestListener;
 
@@ -39,7 +40,7 @@ class EventManagerTest extends TestCase
         $listener = new CustomTestEventListenerInterface();
         $manager->on($listener);
         $expected = [
-            ['callable' => [$listener, 'listenerFunction']],
+            ['callable' => $listener->listenerFunction(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('fake.event'));
     }
@@ -50,10 +51,10 @@ class EventManagerTest extends TestCase
     public function testMatchingListeners(): void
     {
         $manager = new EventManager();
-        $manager->on('fake.event', 'fakeFunction1');
-        $manager->on('real.event', 'fakeFunction2');
-        $manager->on('test.event', 'fakeFunction3');
-        $manager->on('event.test', 'fakeFunction4');
+        $manager->on('fake.event', 'strlen');
+        $manager->on('real.event', 'strlen');
+        $manager->on('test.event', 'strlen');
+        $manager->on('event.test', 'strlen');
 
         $this->assertArrayHasKey('fake.event', $manager->matchingListeners('fake.event'));
         $this->assertArrayHasKey('real.event', $manager->matchingListeners('real.event'));
@@ -120,23 +121,31 @@ class EventManagerTest extends TestCase
         $manager = new EventManager();
         $manager->on('my.event', 'substr');
         $expected = [
-            ['callable' => 'substr'],
+            ['callable' => substr(...)],
         ];
-        $this->assertSame($expected, $manager->listeners('my.event'));
+        $this->assertEquals($expected, $manager->listeners('my.event'));
 
         $manager->on('my.event', ['priority' => 1], 'strpos');
         $expected = [
-            ['callable' => 'strpos'],
-            ['callable' => 'substr'],
+            ['callable' => strpos(...)],
+            ['callable' => substr(...)],
         ];
-        $this->assertSame($expected, $manager->listeners('my.event'));
+        $this->assertEquals($expected, $manager->listeners('my.event'));
 
         $listener = new CustomTestEventListenerInterface();
         $manager->on($listener);
         $expected = [
-            ['callable' => [$listener, 'listenerFunction']],
+            ['callable' => $listener->listenerFunction(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('fake.event'));
+    }
+
+    public function testOnInvalidCall(): void
+    {
+        $manager = new EventManager();
+
+        $this->expectException(InvalidArgumentException::class);
+        $manager->on('my.event');
     }
 
     /**
@@ -145,16 +154,16 @@ class EventManagerTest extends TestCase
     public function testOff(): void
     {
         $manager = new EventManager();
-        $manager->on('fake.event', ['AClass', 'aMethod']);
-        $manager->on('another.event', ['AClass', 'anotherMethod']);
+        $manager->on('fake.event', 'strlen');
+        $manager->on('another.event', strlen(...));
         $manager->on('another.event', ['priority' => 1], 'substr');
 
-        $manager->off('fake.event', ['AClass', 'aMethod']);
+        $manager->off('fake.event', strlen(...));
         $this->assertEquals([], $manager->listeners('fake.event'));
 
-        $manager->off('another.event', ['AClass', 'anotherMethod']);
+        $manager->off('another.event', 'strlen');
         $expected = [
-            ['callable' => 'substr'],
+            ['callable' => substr(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('another.event'));
 
@@ -176,7 +185,7 @@ class EventManagerTest extends TestCase
 
         $manager->off($callable);
         $expected = [
-            ['callable' => 'substr'],
+            ['callable' => substr(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('another.event'));
         $this->assertEquals([], $manager->listeners('fake.event'));
@@ -188,14 +197,14 @@ class EventManagerTest extends TestCase
     public function testRemoveAllListeners(): void
     {
         $manager = new EventManager();
-        $manager->on('fake.event', ['AClass', 'aMethod']);
+        $manager->on('fake.event', 'strlen');
 
         $manager->on('another.event', ['priority' => 1], 'substr');
 
         $manager->off('fake.event');
 
         $expected = [
-            ['callable' => 'substr'],
+            ['callable' => substr(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('another.event'));
         $this->assertEquals([], $manager->listeners('fake.event'));
@@ -368,11 +377,11 @@ class EventManagerTest extends TestCase
             ->getMock();
         $manager->on($listener);
         $expected = [
-            ['callable' => [$listener, 'secondListenerFunction']],
+            ['callable' => $listener->secondListenerFunction(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('another.event'));
         $expected = [
-            ['callable' => [$listener, 'listenerFunction']],
+            ['callable' => $listener->listenerFunction(...)],
         ];
         $this->assertEquals($expected, $manager->listeners('fake.event'));
         $manager->off($listener);

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -107,11 +107,9 @@ class BehaviorRegistryTest extends TestCase
         $result = $this->EventManager->listeners('Model.beforeFind');
         $this->assertCount(0, $result);
 
-        $this->Behaviors->load('Sluggable');
+        $sluggable = $this->Behaviors->load('Sluggable');
         $result = $this->EventManager->listeners('Model.beforeFind');
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf('TestApp\Model\Behavior\SluggableBehavior', $result[0]['callable'][0]);
-        $this->assertSame('beforeFind', $result[0]['callable'][1], 'Method name should match.');
+        $this->assertEquals([['callable' => $sluggable->beforeFind(...)]], $result);
     }
 
     /**


### PR DESCRIPTION
This allows any matching closure to be used with on/off calls and causes the 'callable' key to be validated on assignment.

The parameter type declaration were missing even though they're declared in `EventManagerInterface`.