### PR TITLE
5.x - update phpstan and psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         ],
         "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
         "stan-baseline": "phpstan.phar --generate-baseline",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.6.0 psalm/phar:~4.22.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.7.0 psalm/phar:~4.23.0 && mv composer.backup composer.json",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -78,7 +78,7 @@ class View implements EventDispatcherInterface
     }
     use EventDispatcherTrait;
     use InstanceConfigTrait {
-        getConfig as private _getConfig;
+        getConfig as protected;
     }
     use LogTrait;
 


### PR DESCRIPTION
I changed the visibility of the `getConfig()` method inside the View class because it is only used in classes which extend the view class.

Don't know why it was private in the first place...