### PR TITLE
Allow non-underscore $dnsClassMap for StaticConfigTrait

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -25,7 +25,7 @@ use LogicException;
  * for classes that provide an adapter facade or need to have sets of
  * configuration data registered and manipulated.
  *
- * Implementing objects are expected to declare a static `$_dsnClassMap` property.
+ * Implementing objects are expected to declare a static `$dsnClassMap` or `$_dsnClassMap` property.
  */
 trait StaticConfigTrait
 {
@@ -309,7 +309,11 @@ REGEXP;
      */
     public static function setDsnClassMap(array $map): void
     {
-        static::$_dsnClassMap = $map + static::$_dsnClassMap;
+        if (property_exists(static::class, '_dsnClassMap')) {
+            static::$_dsnClassMap = $map + static::$_dsnClassMap;
+        } else {
+            static::$dsnClassMap = $map + static::$dsnClassMap;
+        }
     }
 
     /**
@@ -320,6 +324,6 @@ REGEXP;
      */
     public static function getDsnClassMap(): array
     {
-        return static::$_dsnClassMap;
+        return property_exists(static::class, '_dsnClassMap') ? static::$_dsnClassMap : static::$dsnClassMap;
     }
 }

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use TestApp\Config\TestEmailStaticConfig;
 use TestApp\Config\TestLogStaticConfig;
+use TestApp\Config\TestLogStaticConfigUnderscore;
 use TypeError;
 
 /**
@@ -176,6 +177,7 @@ class StaticConfigTraitTest extends TestCase
             'serialize' => true,
         ];
         $this->assertEquals($expected, TestLogStaticConfig::parseDsn($dsn));
+        $this->assertEquals($expected, TestLogStaticConfigUnderscore::parseDsn($dsn));
     }
 
     /**
@@ -190,5 +192,6 @@ class StaticConfigTraitTest extends TestCase
             'scheme' => 'file',
         ];
         $this->assertEquals($expected, TestLogStaticConfig::parseDsn($dsn));
+        $this->assertEquals($expected, TestLogStaticConfigUnderscore::parseDsn($dsn));
     }
 }

--- a/tests/test_app/TestApp/Config/TestLogStaticConfigUnderscore.php
+++ b/tests/test_app/TestApp/Config/TestLogStaticConfigUnderscore.php
@@ -4,7 +4,7 @@ namespace TestApp\Config;
 
 use Cake\Core\StaticConfigTrait;
 
-class TestLogStaticConfig
+class TestLogStaticConfigUnderscore
 {
     use StaticConfigTrait;
 
@@ -13,7 +13,7 @@ class TestLogStaticConfig
      *
      * @var array
      */
-    protected static $dsnClassMap = [
+    protected static $_dsnClassMap = [
         'console' => 'Cake\Log\Engine\ConsoleLog',
         'file' => 'Cake\Log\Engine\FileLog',
         'syslog' => 'Cake\Log\Engine\SyslogLog',


### PR DESCRIPTION
This is the same change as https://github.com/cakephp/cakephp/pull/16527 but for `StaticConfigTrait`.


