### PR TITLE
Deprecate associating multiple methods with the same event

### DIFF
--- a/src/Event/EventListenerInterface.php
+++ b/src/Event/EventListenerInterface.php
@@ -34,7 +34,7 @@ interface EventListenerInterface
      *      return [
      *          'Order.complete' => 'sendEmail',
      *          'Article.afterBuy' => 'decrementInventory',
-     *          'User.onRegister' => ['callable' => 'logRegistration', 'priority' => 20, 'passParams' => true]
+     *          'User.onRegister' => ['callable' => 'logRegistration', 'priority' => 20]
      *      ];
      *  }
      * ```

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -136,6 +136,10 @@ class EventManager implements EventManagerInterface
             if (is_array($function) && isset($function['callable'])) {
                 [$method, $options] = $this->_extractCallable($function, $subscriber);
             } elseif (is_array($function) && is_numeric(key($function))) {
+                deprecationWarning(
+                    'Registering multiple methods with an event is deprecated. ' .
+                    'Assign a single method and call others from it.'
+                );
                 foreach ($function as $f) {
                     [$method, $options] = $this->_extractCallable($f, $subscriber);
                     $this->on($eventKey, $options, $method);
@@ -244,6 +248,10 @@ class EventManager implements EventManagerInterface
         foreach ($events as $key => $function) {
             if (is_array($function)) {
                 if (is_numeric(key($function))) {
+                    deprecationWarning(
+                        'Registering multiple methods with an event is deprecated. ' .
+                        'Assign a single method and call others from it.'
+                    );
                     foreach ($function as $handler) {
                         $handler = $handler['callable'] ?? $handler;
                         $this->off($key, [$subscriber, $handler]);

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -24,6 +24,7 @@ use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use TestApp\TestCase\Event\CustomTestEventListenerInterface;
 use TestApp\TestCase\Event\EventTestListener;
+use TestApp\TestCase\Event\MultiMethodEventListenerInterface;
 
 /**
  * Tests the Cake\Event\EventManager class functionality
@@ -343,16 +344,16 @@ class EventManagerTest extends TestCase
     public function testOnSubscriberMultiple(): void
     {
         $manager = new EventManager();
-        $listener = $this->getMockBuilder(CustomTestEventListenerInterface::class)
-            ->onlyMethods(['listenerFunction', 'thirdListenerFunction'])
+        $listener = $this->getMockBuilder(MultiMethodEventListenerInterface::class)
+            ->onlyMethods(['listenerFunction', 'secondListenerFunction'])
             ->getMock();
-        $manager->on($listener);
+        $this->deprecated(fn () => $manager->on($listener));
         $event = new Event('multiple.handlers');
         $listener->expects($this->once())
             ->method('listenerFunction')
             ->with($event);
         $listener->expects($this->once())
-            ->method('thirdListenerFunction')
+            ->method('secondListenerFunction')
             ->with($event);
         $manager->dispatch($event);
     }
@@ -378,6 +379,22 @@ class EventManagerTest extends TestCase
         $manager->off($listener);
         $this->assertEquals([], $manager->listeners('fake.event'));
         $this->assertEquals([], $manager->listeners('another.event'));
+    }
+
+    public function testDetachSubscriberMultiple(): void
+    {
+        $manager = new EventManager();
+        $listener = $this->getMockBuilder(MultiMethodEventListenerInterface::class)
+            ->onlyMethods(['listenerFunction', 'secondListenerFunction'])
+            ->getMock();
+        $this->deprecated(fn () => $manager->on($listener));
+        $expected = [
+            ['callable' => [$listener, 'listenerFunction']],
+            ['callable' => [$listener, 'secondListenerFunction']],
+        ];
+        $this->assertEquals($expected, $manager->listeners('multiple.handlers'));
+        $this->deprecated(fn () => $manager->off($listener));
+        $this->assertEquals([], $manager->listeners('multiple.handlers'));
     }
 
     /**

--- a/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
+++ b/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
@@ -18,10 +18,6 @@ class CustomTestEventListenerInterface extends EventTestListener implements Even
         return [
             'fake.event' => 'listenerFunction',
             'another.event' => ['callable' => 'secondListenerFunction'],
-            'multiple.handlers' => [
-                ['callable' => 'listenerFunction'],
-                ['callable' => 'thirdListenerFunction'],
-            ],
         ];
     }
 

--- a/tests/test_app/TestApp/TestCase/Event/MultiMethodEventListenerInterface.php
+++ b/tests/test_app/TestApp/TestCase/Event/MultiMethodEventListenerInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\TestCase\Event;
+
+use Cake\Event\EventListenerInterface;
+
+/**
+ * Mock used for testing the subscriber objects
+ */
+class MultiMethodEventListenerInterface extends EventTestListener implements EventListenerInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function implementedEvents(): array
+    {
+        return [
+            'multiple.handlers' => [
+                ['callable' => 'listenerFunction'],
+                ['callable' => 'secondListenerFunction'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This simplifies the expected array shape detection when attaching a listener. 