### PR TITLE
Prevent exception in debugInfo from causing fatal error

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Collection;
 
 use ArrayIterator;
+use Exception;
 use IteratorIterator;
 use Serializable;
 
@@ -120,8 +121,14 @@ class Collection extends IteratorIterator implements CollectionInterface, Serial
      */
     public function __debugInfo(): array
     {
+        try {
+            $count = $this->count();
+        } catch (Exception $e) {
+            $count = 'An exception occurred while getting count';
+        }
+
         return [
-            'count' => $this->count(),
+            'count' => $count,
         ];
     }
 }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -22,9 +22,11 @@ use Cake\Collection\Collection;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use CallbackFilterIterator;
 use DateInterval;
 use DatePeriod;
 use DateTime;
+use Exception;
 use Generator;
 use InvalidArgumentException;
 use LogicException;
@@ -1870,6 +1872,18 @@ class CollectionTest extends TestCase
         $result = $collection->__debugInfo();
         $expected = [
             'count' => 0,
+        ];
+        $this->assertSame($expected, $result);
+
+        $filter = function ($value) {
+            throw new Exception('filter exception');
+        };
+        $iterator = new CallbackFilterIterator(new ArrayIterator($items), $filter);
+        $collection = new Collection($iterator);
+
+        $result = $collection->__debugInfo();
+        $expected = [
+            'count' => 'An exception occurred while getting count',
         ];
         $this->assertSame($expected, $result);
     }


### PR DESCRIPTION
If an exception occurs in `__debugInfo()` it causes a fatal error "__debuginfo() must return an array". Depending on usage the `count()` method might throw an exception.

Closes #16526