### PR TITLE
4.next - add cascadeCallbacks option to TreeBehavior

### DIFF
--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -235,9 +235,9 @@ class TreeBehavior extends Behavior
                         ->lte($config['leftField'], $right - 1);
                 });
             if ($this->getConfig('useOrmDelete')) {
-                $result = $query->toArray();
-                foreach ($result as $entity) {
-                    $this->_table->delete($entity, ['atomic' => false]);
+                $entities = $query->toArray();
+                foreach ($entities as $entityToDelete) {
+                    $this->_table->delete($entityToDelete, ['atomic' => false]);
                 }
             } else {
                 $query->delete();

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -234,9 +234,9 @@ class TreeBehavior extends Behavior
                         ->gte($config['leftField'], $left + 1)
                         ->lte($config['leftField'], $right - 1);
                 });
-            if($this->getConfig('enableOrmDelete')){
+            if ($this->getConfig('enableOrmDelete')) {
                 $result = $query->toArray();
-                foreach($result as $entity) {
+                foreach ($result as $entity) {
                     $this->_table->delete($entity, ['atomic' => false]);
                 }
             } else {

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -75,7 +75,7 @@ class TreeBehavior extends Behavior
         'scope' => null,
         'level' => null,
         'recoverOrder' => null,
-        'enableOrmDelete' => false,
+        'useOrmDelete' => false,
     ];
 
     /**
@@ -234,7 +234,7 @@ class TreeBehavior extends Behavior
                         ->gte($config['leftField'], $left + 1)
                         ->lte($config['leftField'], $right - 1);
                 });
-            if ($this->getConfig('enableOrmDelete')) {
+            if ($this->getConfig('useOrmDelete')) {
                 $result = $query->toArray();
                 foreach ($result as $entity) {
                     $this->_table->delete($entity, ['atomic' => false]);

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -75,7 +75,7 @@ class TreeBehavior extends Behavior
         'scope' => null,
         'level' => null,
         'recoverOrder' => null,
-        'useOrmDelete' => false,
+        'cascadeCallbacks' => false,
     ];
 
     /**
@@ -234,7 +234,7 @@ class TreeBehavior extends Behavior
                         ->gte($config['leftField'], $left + 1)
                         ->lte($config['leftField'], $right - 1);
                 });
-            if ($this->getConfig('useOrmDelete')) {
+            if ($this->getConfig('cascadeCallbacks')) {
                 $entities = $query->toArray();
                 foreach ($entities as $entityToDelete) {
                     $this->_table->delete($entityToDelete, ['atomic' => false]);

--- a/tests/Fixture/NumberTreesArticlesFixture.php
+++ b/tests/Fixture/NumberTreesArticlesFixture.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         1.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Short description for class.
+ */
+class NumberTreesArticlesFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'number_tree_id' => ['type' => 'integer', 'null' => true],
+        'title' => ['type' => 'string', 'null' => true],
+        'body' => 'text',
+        'published' => ['type' => 'string', 'length' => 1, 'default' => 'N'],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['number_tree_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
+        ['number_tree_id' => 1, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+        ['number_tree_id' => 11, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y'],
+    ];
+}

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1182,6 +1182,14 @@ class TreeBehaviorTest extends TestCase
     public function testDeleteSubTreeWithOrm(): void
     {
         $NumberTreesArticles = $this->getTableLocator()->get('NumberTreesArticles');
+        $newArticle = $NumberTreesArticles->newEntity([
+            'number_tree_id' => 7, // Link to sub-tree item
+            'title' => 'New Article',
+            'body' => 'New Article Body',
+            'published' => 'Y',
+        ]);
+        $NumberTreesArticles->save($newArticle);
+
         $table = $this->table;
         $table->addAssociations([
             'hasMany' => [
@@ -1192,14 +1200,26 @@ class TreeBehaviorTest extends TestCase
             ],
         ]);
         $table->getBehavior('Tree')->setConfig(['useOrmDelete' => true]);
-        $entity = $table->get(1);
+
+        // Delete parent category
+        $entity = $table->get(6);
         $this->assertTrue($table->delete($entity));
 
         $expected = [
-            ' 5: 6 - 11:alien hardware',
+            ' 1:12 -  1:electronics',
+            '_ 2: 9 -  2:televisions',
+            '__ 3: 4 -  3:tube',
+            '__ 5: 6 -  4:lcd',
+            '__ 7: 8 -  5:plasma',
+            '13:14 - 11:alien hardware',
         ];
         $this->assertMpttValues($expected, $this->table);
-        $this->assertSame(1, $NumberTreesArticles->find()->count());
+
+        // Check if new article which was linked to sub-category was deleted
+        $count = $NumberTreesArticles->find()
+            ->where(['number_tree_id' => 7])
+            ->count();
+        $this->assertSame(0, $count);
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1187,9 +1187,9 @@ class TreeBehaviorTest extends TestCase
             'hasMany' => [
                 'NumberTreesArticles' => [
                     'cascadeCallbacks' => true,
-                    'dependent' => true
-                ]
-            ]
+                    'dependent' => true,
+                ],
+            ],
         ]);
         $table->getBehavior('Tree')->setConfig(['enableOrmDelete' => true]);
         $entity = $table->get(1);

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1191,7 +1191,7 @@ class TreeBehaviorTest extends TestCase
                 ],
             ],
         ]);
-        $table->getBehavior('Tree')->setConfig(['enableOrmDelete' => true]);
+        $table->getBehavior('Tree')->setConfig(['useOrmDelete' => true]);
         $entity = $table->get(1);
         $this->assertTrue($table->delete($entity));
 

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1177,9 +1177,9 @@ class TreeBehaviorTest extends TestCase
     }
 
     /**
-     * Tests deleting a subtree with ORM delete operations
+     * Tests deleting a subtree with ORM delete callbacks
      */
-    public function testDeleteSubTreeWithOrm(): void
+    public function testDeleteSubTreeWithCallbacks(): void
     {
         $NumberTreesArticles = $this->getTableLocator()->get('NumberTreesArticles');
         $newArticle = $NumberTreesArticles->newEntity([
@@ -1199,7 +1199,7 @@ class TreeBehaviorTest extends TestCase
                 ],
             ],
         ]);
-        $table->getBehavior('Tree')->setConfig(['useOrmDelete' => true]);
+        $table->getBehavior('Tree')->setConfig(['cascadeCallbacks' => true]);
 
         // Delete parent category
         $entity = $table->get(6);

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -34,6 +34,7 @@ class TreeBehaviorTest extends TestCase
     protected $fixtures = [
         'core.MenuLinkTrees',
         'core.NumberTrees',
+        'core.NumberTreesArticles',
     ];
 
     /**
@@ -1173,6 +1174,32 @@ class TreeBehaviorTest extends TestCase
             '_18:19 - 18:radios',
         ];
         $this->assertMpttValues($expected, $table);
+    }
+
+    /**
+     * Tests deleting a subtree with ORM delete operations
+     */
+    public function testDeleteSubTreeWithOrm(): void
+    {
+        $NumberTreesArticles = $this->getTableLocator()->get('NumberTreesArticles');
+        $table = $this->table;
+        $table->addAssociations([
+            'hasMany' => [
+                'NumberTreesArticles' => [
+                    'cascadeCallbacks' => true,
+                    'dependent' => true
+                ]
+            ]
+        ]);
+        $table->getBehavior('Tree')->setConfig(['enableOrmDelete' => true]);
+        $entity = $table->get(1);
+        $this->assertTrue($table->delete($entity));
+
+        $expected = [
+            ' 5: 6 - 11:alien hardware',
+        ];
+        $this->assertMpttValues($expected, $this->table);
+        $this->assertSame(1, $NumberTreesArticles->find()->count());
     }
 
     /**

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -1260,6 +1260,36 @@ return [
         ],
     ],
     [
+        'table' => 'number_trees_articles',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'number_tree_id' => [
+                'type' => 'integer',
+                'null' => true,
+            ],
+            'title' => [
+                'type' => 'string',
+                'null' => true,
+            ],
+            'body' => 'text',
+            'published' => [
+                'type' => 'string',
+                'length' => 1,
+                'default' => 'N',
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
+    [
         'table' => 'composite_increments',
         'columns' => [
             'id' => [


### PR DESCRIPTION
fixes #16019

This adds a new `cascadeCallbacks` option to the Tree behavior to optionally enable ORM delete operations instead of direct statement delete operations.

This will then give the user the option to successfully delete dependent entities from sub-categories which are deleted by a parent-category.