### PR TITLE
Modify contructors of Controller and ComponentRegistry.

### DIFF
--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -47,7 +47,8 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      */
     public function __construct(Controller $controller)
     {
-        $this->setController($controller);
+        $this->_Controller = $controller;
+        $this->setEventManager($controller->getEventManager());
     }
 
     /**
@@ -58,20 +59,6 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     public function getController(): Controller
     {
         return $this->_Controller;
-    }
-
-    /**
-     * Set the controller associated with the collection.
-     *
-     * @param \Cake\Controller\Controller $controller Controller instance.
-     * @return $this
-     */
-    public function setController(Controller $controller)
-    {
-        $this->_Controller = $controller;
-        $this->setEventManager($controller->getEventManager());
-
-        return $this;
     }
 
     /**

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -18,7 +18,6 @@ namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\App;
-use Cake\Core\Exception\CakeException;
 use Cake\Core\ObjectRegistry;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -35,35 +34,29 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     use EventDispatcherTrait;
 
     /**
-     * The controller that this collection was initialized with.
+     * The controller that this collection is associated with.
      *
-     * @var \Cake\Controller\Controller|null
+     * @var \Cake\Controller\Controller
      */
-    protected ?Controller $_Controller = null;
+    protected Controller $_Controller;
 
     /**
      * Constructor.
      *
-     * @param \Cake\Controller\Controller|null $controller Controller instance.
+     * @param \Cake\Controller\Controller $controller Controller instance.
      */
-    public function __construct(?Controller $controller = null)
+    public function __construct(Controller $controller)
     {
-        if ($controller) {
-            $this->setController($controller);
-        }
+        $this->setController($controller);
     }
 
     /**
      * Get the controller associated with the collection.
      *
-     * @return \Cake\Controller\Controller Controller instance or null if not set.
+     * @return \Cake\Controller\Controller Controller instance.
      */
     public function getController(): Controller
     {
-        if ($this->_Controller === null) {
-            throw new CakeException('Controller not set for ComponentRegistry');
-        }
-
         return $this->_Controller;
     }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -236,19 +236,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     /**
      * Get the component registry for this controller.
      *
-     * If called with the first parameter, it will be set as the controller $this->_components property
-     *
-     * @param \Cake\Controller\ComponentRegistry|null $components Component registry.
      * @return \Cake\Controller\ComponentRegistry
      */
-    public function components(?ComponentRegistry $components = null): ComponentRegistry
+    public function components(): ComponentRegistry
     {
-        if ($components !== null) {
-            $components->setController($this);
-
-            return $this->_components = $components;
-        }
-
         return $this->_components ??= new ComponentRegistry($this);
     }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -179,23 +179,19 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Sets a number of properties based on conventions if they are empty. To override the
      * conventions CakePHP uses you can define properties in your class declaration.
      *
-     * @param \Cake\Http\ServerRequest|null $request Request object for this controller. Can be null for testing,
+     * @param \Cake\Http\ServerRequest $request Request object for this controller.
      *   but expect that features that use the request parameters will not work.
-     * @param \Cake\Http\Response|null $response Response object for this controller.
      * @param string|null $name Override the name useful in testing when using mocks.
      * @param \Cake\Event\EventManagerInterface|null $eventManager The event manager. Defaults to a new instance.
-     * @param \Cake\Controller\ComponentRegistry|null $components The component registry. Defaults to a new instance.
      */
     public function __construct(
-        ?ServerRequest $request = null,
-        ?Response $response = null,
+        ServerRequest $request,
         ?string $name = null,
         ?EventManagerInterface $eventManager = null,
-        ?ComponentRegistry $components = null
     ) {
         if ($name !== null) {
             $this->name = $name;
-        } elseif (!$this->name && $request) {
+        } elseif (!$this->name) {
             $controller = $request->getParam('controller');
             if ($controller) {
                 $this->name = $controller;
@@ -207,8 +203,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $this->name = substr($name, 0, -10);
         }
 
-        $this->setRequest($request ?: new ServerRequest());
-        $this->response = $response ?: new Response();
+        $this->setRequest($request);
+        $this->response = new Response();
 
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);
@@ -218,10 +214,6 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $plugin = $this->request->getParam('plugin');
             $tableAlias = ($plugin ? $plugin . '.' : '') . $this->name;
             $this->defaultTable = $tableAlias;
-        }
-
-        if ($components !== null) {
-            $this->components($components);
         }
 
         $this->initialize();

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -21,7 +21,6 @@ use Cake\Controller\Component\FormProtectionComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingComponentException;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Countable;
@@ -42,7 +41,7 @@ class ComponentRegistryTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $controller = new Controller(new ServerRequest(), new Response());
+        $controller = new Controller(new ServerRequest());
         $this->Components = new ComponentRegistry($controller);
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -85,7 +85,7 @@ class ControllerTest extends TestCase
     public function testTableAutoload(): void
     {
         $request = new ServerRequest(['url' => 'controller/posts/index']);
-        $Controller = new Controller($request, new Response(), 'Articles');
+        $Controller = new Controller($request, 'Articles');
 
         $this->assertInstanceOf(
             'TestApp\Model\Table\ArticlesTable',
@@ -98,7 +98,7 @@ class ControllerTest extends TestCase
      */
     public function testUndefinedPropertyError(): void
     {
-        $controller = new Controller();
+        $controller = new Controller(new ServerRequest());
 
         $this->expectNotice();
         $this->expectNoticeMessage(sprintf(
@@ -115,7 +115,7 @@ class ControllerTest extends TestCase
     public function testGetTable(): void
     {
         $request = new ServerRequest(['url' => 'controller/posts/index']);
-        $Controller = new Controller($request, new Response());
+        $Controller = new Controller($request);
 
         $this->assertFalse(isset($Controller->Articles));
 
@@ -129,7 +129,7 @@ class ControllerTest extends TestCase
     public function testAutoLoadModelUsingDefaultTable()
     {
         Configure::write('App.namespace', 'TestApp');
-        $Controller = new WithDefaultTableController(new ServerRequest(), new Response());
+        $Controller = new WithDefaultTableController(new ServerRequest());
 
         $this->assertInstanceOf(PostsTable::class, $Controller->Posts);
 
@@ -142,7 +142,7 @@ class ControllerTest extends TestCase
     public function testAutoLoadTableUsingFqcn(): void
     {
         Configure::write('App.namespace', 'TestApp');
-        $Controller = new ArticlesController(new ServerRequest(), new Response());
+        $Controller = new ArticlesController(new ServerRequest());
 
         $this->assertInstanceOf(ArticlesTable::class, $Controller->fetchTable());
 
@@ -153,7 +153,7 @@ class ControllerTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
 
-        $Controller = new TestPluginController();
+        $Controller = new TestPluginController(new ServerRequest());
         $Controller->setPlugin('TestPlugin');
 
         $this->assertFalse(isset($Controller->TestPluginComments));
@@ -173,15 +173,14 @@ class ControllerTest extends TestCase
         $this->loadPlugins(['TestPlugin']);
 
         $request = new ServerRequest();
-        $response = new Response();
-        $controller = new PostsController($request, $response);
+        $controller = new PostsController($request);
         $this->assertInstanceOf(PostsTable::class, $controller->fetchTable());
 
-        $controller = new AdminPostsController($request, $response);
+        $controller = new AdminPostsController($request);
         $this->assertInstanceOf(PostsTable::class, $controller->fetchTable());
 
         $request = $request->withParam('plugin', 'TestPlugin');
-        $controller = new CommentsController($request, $response);
+        $controller = new CommentsController($request);
         $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->fetchTable());
     }
 
@@ -192,7 +191,7 @@ class ControllerTest extends TestCase
     {
         $this->loadPlugins(['TestPlugin']);
 
-        $Controller = new TestPluginController(new ServerRequest(), new Response());
+        $Controller = new TestPluginController(new ServerRequest());
         $Controller->loadComponent('TestPlugin.Other');
 
         $this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $Controller->Other);
@@ -212,7 +211,7 @@ class ControllerTest extends TestCase
             ],
         ]);
 
-        $Controller = new Controller($request, new Response());
+        $Controller = new Controller($request);
         $Controller->viewBuilder()->setTemplatePath('Posts');
 
         $result = $Controller->render('index');
@@ -236,7 +235,7 @@ class ControllerTest extends TestCase
             'url' => '/',
             'environment' => ['HTTP_ACCEPT' => 'application/json'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->all();
         $response = $controller->render();
         $this->assertSame('application/json', $response->getHeaderLine('Content-Type'), 'Has correct header');
@@ -253,7 +252,7 @@ class ControllerTest extends TestCase
             'url' => '/',
             'environment' => ['HTTP_ACCEPT' => 'application/xml'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->all();
         $response = $controller->render();
         $this->assertSame(
@@ -271,7 +270,7 @@ class ControllerTest extends TestCase
             'environment' => ['HTTP_ACCEPT' => 'text/plain'],
             'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'all'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->all();
         $response = $controller->render();
         $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'));
@@ -288,7 +287,7 @@ class ControllerTest extends TestCase
             'environment' => ['HTTP_ACCEPT' => 'application/xml'],
             'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'all'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->all();
         $controller->viewBuilder()->setClassName(View::class);
         $response = $controller->render();
@@ -310,7 +309,7 @@ class ControllerTest extends TestCase
             'url' => '/',
             'environment' => ['HTTP_ACCEPT' => 'text/html'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->matchAll();
         $response = $controller->render();
         $this->assertSame('text/html; charset=UTF-8', $response->getHeaderLine('Content-Type'), 'Default response type');
@@ -325,7 +324,7 @@ class ControllerTest extends TestCase
             'environment' => ['HTTP_ACCEPT' => 'text/plain'],
             'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'plain'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->plain();
         $response = $controller->render();
         $this->assertSame('text/plain; charset=UTF-8', $response->getHeaderLine('Content-Type'));
@@ -339,7 +338,7 @@ class ControllerTest extends TestCase
             'environment' => [],
             'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'all', '_ext' => 'json'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->all();
         $response = $controller->render();
         $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
@@ -353,7 +352,7 @@ class ControllerTest extends TestCase
             'environment' => [],
             'params' => ['plugin' => null, 'controller' => 'ContentTypes', 'action' => 'all', '_ext' => 'xml'],
         ]);
-        $controller = new ContentTypesController($request, new Response());
+        $controller = new ContentTypesController($request);
         $controller->all();
         $response = $controller->render();
         $this->assertSame('application/xml; charset=UTF-8', $response->getHeaderLine('Content-Type'));
@@ -372,7 +371,7 @@ class ControllerTest extends TestCase
             ],
         ]);
 
-        $controller = new Controller($request, new Response());
+        $controller = new Controller($request);
         $controller->viewBuilder()->setTemplatePath('Posts');
 
         $result = $controller->render('header');
@@ -386,7 +385,7 @@ class ControllerTest extends TestCase
      */
     public function testBeforeRenderCallbackChangingViewClass(): void
     {
-        $Controller = new Controller(new ServerRequest(), new Response());
+        $Controller = new Controller(new ServerRequest());
 
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
             $controller = $event->getSubject();
@@ -409,7 +408,7 @@ class ControllerTest extends TestCase
      */
     public function testBeforeRenderEventCancelsRender(): void
     {
-        $Controller = new Controller(new ServerRequest(), new Response());
+        $Controller = new Controller(new ServerRequest());
 
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event) {
             return false;
@@ -421,12 +420,12 @@ class ControllerTest extends TestCase
 
     public function testControllerRedirect(): void
     {
-        $Controller = new Controller();
+        $Controller = new Controller(new ServerRequest());
         $uri = new Uri('/foo/bar');
         $response = $Controller->redirect($uri);
         $this->assertSame('http://localhost/foo/bar', $response->getHeaderLine('Location'));
 
-        $Controller = new Controller();
+        $Controller = new Controller(new ServerRequest());
         $uri = new Uri('http://cakephp.org/foo/bar');
         $response = $Controller->redirect($uri);
         $this->assertSame('http://cakephp.org/foo/bar', $response->getHeaderLine('Location'));
@@ -458,7 +457,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectByCode(int $code, string $msg): void
     {
-        $Controller = new Controller(null, new Response());
+        $Controller = new Controller(new ServerRequest());
 
         $response = $Controller->redirect('http://cakephp.org', (int)$code);
         $this->assertSame($response, $Controller->getResponse());
@@ -472,7 +471,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectBeforeRedirectModifyingUrl(): void
     {
-        $Controller = new Controller(null, new Response());
+        $Controller = new Controller(new ServerRequest());
 
         $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response): void {
             $controller = $event->getSubject();
@@ -489,8 +488,7 @@ class ControllerTest extends TestCase
      */
     public function testRedirectBeforeRedirectModifyingStatusCode(): void
     {
-        $response = new Response();
-        $Controller = new Controller(null, $response);
+        $Controller = new Controller(new ServerRequest());
 
         $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response): void {
             $controller = $event->getSubject();
@@ -505,7 +503,7 @@ class ControllerTest extends TestCase
 
     public function testRedirectBeforeRedirectListenerReturnResponse(): void
     {
-        $Controller = new Controller(null, new Response());
+        $Controller = new Controller(new ServerRequest());
 
         $newResponse = new Response();
         $Controller->getEventManager()->on('Controller.beforeRedirect', function (EventInterface $event, $url, Response $response) use ($newResponse) {
@@ -547,7 +545,7 @@ class ControllerTest extends TestCase
         $result = $Controller->referer(null, false);
         $this->assertSame('http://localhost/posts/index', $result);
 
-        $Controller = new Controller(null);
+        $Controller = new Controller(new ServerRequest());
         $result = $Controller->referer('/', false);
         $this->assertSame('http://localhost/', $result);
     }
@@ -578,7 +576,7 @@ class ControllerTest extends TestCase
     public function testStartupProcess(): void
     {
         $eventManager = $this->getMockBuilder('Cake\Event\EventManagerInterface')->getMock();
-        $controller = new Controller(null, null, null, $eventManager);
+        $controller = new Controller(new ServerRequest(), null, $eventManager);
 
         $eventManager
             ->expects($this->exactly(2))
@@ -602,7 +600,7 @@ class ControllerTest extends TestCase
     public function testShutdownProcess(): void
     {
         $eventManager = $this->getMockBuilder('Cake\Event\EventManagerInterface')->getMock();
-        $controller = new Controller(null, null, null, $eventManager);
+        $controller = new Controller(new ServerRequest(), null, $eventManager);
 
         $eventManager->expects($this->once())
             ->method('dispatch')
@@ -620,9 +618,8 @@ class ControllerTest extends TestCase
     public function testPaginate(): void
     {
         $request = new ServerRequest(['url' => 'controller_posts/index']);
-        $response = new Response();
 
-        $Controller = new Controller($request, $response);
+        $Controller = new Controller($request);
         $Controller->setRequest($Controller->getRequest()->withQueryParams([
             'posts' => [
                 'page' => 2,
@@ -679,9 +676,8 @@ class ControllerTest extends TestCase
         $request = new ServerRequest([
             'url' => 'controller_posts/index',
         ]);
-        $response = new Response();
 
-        $Controller = new Controller($request, $response, 'Posts');
+        $Controller = new Controller($request, 'Posts');
         $results = $Controller->paginate();
 
         $this->assertInstanceOf(PaginatedInterface::class, $results);
@@ -692,9 +688,8 @@ class ControllerTest extends TestCase
         $this->expectException(NotFoundException::class);
 
         $request = new ServerRequest(['url' => 'controller_posts/index?page=2&limit=100']);
-        $response = new Response();
 
-        $Controller = new Controller($request, $response, 'Posts');
+        $Controller = new Controller($request, 'Posts');
 
         $Controller->paginate();
     }
@@ -710,9 +705,8 @@ class ControllerTest extends TestCase
             'url' => 'test/missing',
             'params' => ['controller' => 'Test', 'action' => 'missing'],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->getAction();
     }
 
@@ -727,9 +721,8 @@ class ControllerTest extends TestCase
             'url' => 'test/private_m/',
             'params' => ['controller' => 'Test', 'action' => 'private_m'],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->getAction();
     }
 
@@ -744,9 +737,8 @@ class ControllerTest extends TestCase
             'url' => 'test/protected_m/',
             'params' => ['controller' => 'Test', 'action' => 'protected_m'],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->getAction();
     }
 
@@ -761,9 +753,8 @@ class ControllerTest extends TestCase
             'url' => 'test/redirect/',
             'params' => ['controller' => 'Test', 'action' => 'redirect'],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->getAction();
     }
 
@@ -778,9 +769,8 @@ class ControllerTest extends TestCase
             'url' => 'test/RETURNER/',
             'params' => ['controller' => 'Test', 'action' => 'RETURNER'],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->getAction();
     }
 
@@ -794,7 +784,7 @@ class ControllerTest extends TestCase
                 'pass' => ['1'],
             ],
         ]);
-        $controller = new TestController($request, new Response());
+        $controller = new TestController($request);
 
         $closure = $controller->getAction();
         $args = (new ReflectionFunction($closure))->getParameters();
@@ -816,9 +806,8 @@ class ControllerTest extends TestCase
                 'pass' => [],
             ],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->invokeAction($Controller->getAction(), $Controller->getRequest()->getParam('pass'));
 
         $this->assertSame('I am from the controller.', (string)$Controller->getResponse());
@@ -837,7 +826,7 @@ class ControllerTest extends TestCase
                 'pass' => ['param1' => '1', 'param2' => '2'],
             ],
         ]);
-        $controller = new TestController($request, new Response());
+        $controller = new TestController($request);
         $controller->disableAutoRender();
         $controller->invokeAction($controller->getAction(), array_values($controller->getRequest()->getParam('pass')));
 
@@ -866,9 +855,8 @@ class ControllerTest extends TestCase
                 'pass' => [],
             ],
         ]);
-        $response = new Response();
 
-        $Controller = new TestController($url, $response);
+        $Controller = new TestController($url);
         $Controller->invokeAction($Controller->getAction(), $Controller->getRequest()->getParam('pass'));
     }
 
@@ -881,8 +869,7 @@ class ControllerTest extends TestCase
             'url' => 'admin/posts',
             'params' => ['prefix' => 'Admin'],
         ]);
-        $response = new Response();
-        $Controller = new AdminPostsController($request, $response);
+        $Controller = new AdminPostsController($request);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
@@ -890,8 +877,7 @@ class ControllerTest extends TestCase
         $this->assertSame('Admin' . DS . 'Posts', $Controller->viewBuilder()->getTemplatePath());
 
         $request = $request->withParam('prefix', 'admin/super');
-        $response = new Response();
-        $Controller = new AdminPostsController($request, $response);
+        $Controller = new AdminPostsController($request);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
@@ -904,7 +890,7 @@ class ControllerTest extends TestCase
                 'prefix' => false,
             ],
         ]);
-        $Controller = new PagesController($request, $response);
+        $Controller = new PagesController($request);
         $Controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $e) {
             return $e->getSubject()->getResponse();
         });
@@ -918,9 +904,8 @@ class ControllerTest extends TestCase
     public function testComponents(): void
     {
         $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
 
-        $controller = new TestController($request, $response);
+        $controller = new TestController($request);
         $this->assertInstanceOf('Cake\Controller\ComponentRegistry', $controller->components());
 
         $result = $controller->components();
@@ -933,12 +918,13 @@ class ControllerTest extends TestCase
     public function testComponentsWithCustomRegistry(): void
     {
         $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
         $componentRegistry = $this->getMockBuilder('Cake\Controller\ComponentRegistry')
             ->addMethods(['offsetGet'])
+            ->disableOriginalConstructor()
             ->getMock();
 
-        $controller = new TestController($request, $response, null, null, $componentRegistry);
+        $controller = new TestController($request);
+        $controller->components($componentRegistry);
         $this->assertInstanceOf(get_class($componentRegistry), $controller->components());
 
         $result = $controller->components();
@@ -951,9 +937,8 @@ class ControllerTest extends TestCase
     public function testLoadComponent(): void
     {
         $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
 
-        $controller = new TestController($request, $response);
+        $controller = new TestController($request);
         $result = $controller->loadComponent('FormProtection');
         $this->assertInstanceOf('Cake\Controller\Component\FormProtectionComponent', $result);
         $this->assertSame($result, $controller->FormProtection);
@@ -968,9 +953,8 @@ class ControllerTest extends TestCase
     public function testLoadComponentDuplicate(): void
     {
         $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
 
-        $controller = new TestController($request, $response);
+        $controller = new TestController($request);
         $this->assertNotEmpty($controller->loadComponent('FormProtection'));
         $this->assertNotEmpty($controller->loadComponent('FormProtection'));
         try {
@@ -987,8 +971,7 @@ class ControllerTest extends TestCase
     public function testIsAction(): void
     {
         $request = new ServerRequest(['url' => '/']);
-        $response = new Response();
-        $controller = new TestController($request, $response);
+        $controller = new TestController($request);
 
         $this->assertFalse($controller->isAction('redirect'));
         $this->assertFalse($controller->isAction('beforeFilter'));
@@ -1000,7 +983,7 @@ class ControllerTest extends TestCase
      */
     public function testBeforeRenderViewVariables(): void
     {
-        $controller = new AdminPostsController();
+        $controller = new AdminPostsController(new ServerRequest());
 
         $controller->getEventManager()->on('Controller.beforeRender', function (EventInterface $event): void {
             /** @var \Cake\Controller\Controller $controller */
@@ -1020,7 +1003,7 @@ class ControllerTest extends TestCase
      */
     public function testBeforeRenderTemplateAndLayout(): void
     {
-        $Controller = new Controller(new ServerRequest(), new Response());
+        $Controller = new Controller(new ServerRequest());
         $Controller->getEventManager()->on('Controller.beforeRender', function ($event): void {
             $this->assertSame(
                 '/Element/test_element',
@@ -1045,7 +1028,7 @@ class ControllerTest extends TestCase
      */
     public function testName(): void
     {
-        $controller = new AdminPostsController();
+        $controller = new AdminPostsController(new ServerRequest());
         $this->assertSame('Posts', $controller->getName());
 
         $this->assertSame($controller, $controller->setName('Articles'));
@@ -1057,7 +1040,7 @@ class ControllerTest extends TestCase
      */
     public function testPlugin(): void
     {
-        $controller = new AdminPostsController();
+        $controller = new AdminPostsController(new ServerRequest());
         $this->assertNull($controller->getPlugin());
 
         $this->assertSame($controller, $controller->setPlugin('Articles'));
@@ -1069,7 +1052,7 @@ class ControllerTest extends TestCase
      */
     public function testRequest(): void
     {
-        $controller = new AdminPostsController();
+        $controller = new AdminPostsController(new ServerRequest());
         $this->assertInstanceOf(ServerRequest::class, $controller->getRequest());
 
         $request = new ServerRequest([
@@ -1093,7 +1076,7 @@ class ControllerTest extends TestCase
      */
     public function testResponse(): void
     {
-        $controller = new AdminPostsController();
+        $controller = new AdminPostsController(new ServerRequest());
         $this->assertInstanceOf(Response::class, $controller->getResponse());
 
         $response = new Response();
@@ -1106,7 +1089,7 @@ class ControllerTest extends TestCase
      */
     public function testAutoRender(): void
     {
-        $controller = new AdminPostsController();
+        $controller = new AdminPostsController(new ServerRequest());
         $this->assertTrue($controller->isAutoRenderEnabled());
 
         $this->assertSame($controller, $controller->disableAutoRender());

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -913,25 +913,6 @@ class ControllerTest extends TestCase
     }
 
     /**
-     * Test the components() method with the custom ObjectRegistry.
-     */
-    public function testComponentsWithCustomRegistry(): void
-    {
-        $request = new ServerRequest(['url' => '/']);
-        $componentRegistry = $this->getMockBuilder('Cake\Controller\ComponentRegistry')
-            ->addMethods(['offsetGet'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $controller = new TestController($request);
-        $controller->components($componentRegistry);
-        $this->assertInstanceOf(get_class($componentRegistry), $controller->components());
-
-        $result = $controller->components();
-        $this->assertSame($result, $controller->components());
-    }
-
-    /**
      * Test adding a component
      */
     public function testLoadComponent(): void

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -26,6 +26,7 @@ use Cake\Error\Debug\SpecialNode;
 use Cake\Error\Debug\TextFormatter;
 use Cake\Error\Debugger;
 use Cake\Form\Form;
+use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use MyClass;
@@ -158,7 +159,7 @@ object(stdClass) id:0 {
 TEXT;
         $this->assertTextEquals($expected, $result);
 
-        $Controller = new Controller();
+        $Controller = new Controller(new ServerRequest());
         $Controller->viewBuilder()->setHelpers(['Html', 'Form']);
         $View = $Controller->createView();
 

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -672,6 +672,7 @@ class WebExceptionRendererTest extends TestCase
         /** @var \Cake\Controller\Controller|\PHPUnit\Framework\MockObject\MockObject $controller */
         $controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->onlyMethods(['render'])
+            ->setConstructorArgs([new ServerRequest()])
             ->getMock();
         $controller->viewBuilder()->setHelpers(['Fail', 'Boom']);
         $controller->setRequest(new ServerRequest());
@@ -700,6 +701,7 @@ class WebExceptionRendererTest extends TestCase
         /** @var \Cake\Controller\Controller|\PHPUnit\Framework\MockObject\MockObject $controller */
         $controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->onlyMethods(['beforeRender'])
+            ->setConstructorArgs([new ServerRequest()])
             ->getMock();
         $controller->setRequest(new ServerRequest());
         $controller->expects($this->any())
@@ -721,7 +723,7 @@ class WebExceptionRendererTest extends TestCase
         $exception = new NotFoundException();
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
 
-        $controller = new Controller();
+        $controller = new Controller(new ServerRequest());
         $controller->viewBuilder()->setHelpers(['Fail', 'Boom']);
         $controller->getEventManager()->on(
             'Controller.beforeRender',
@@ -750,7 +752,7 @@ class WebExceptionRendererTest extends TestCase
         $exception = new NotFoundException();
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception);
 
-        $controller = new Controller();
+        $controller = new Controller(new ServerRequest());
         $controller->getEventManager()->on(
             'Controller.beforeRender',
             function (EventInterface $event): void {
@@ -781,6 +783,7 @@ class WebExceptionRendererTest extends TestCase
         /** @var \Cake\Controller\Controller|\PHPUnit\Framework\MockObject\MockObject $controller */
         $controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->onlyMethods(['render'])
+            ->setConstructorArgs([new ServerRequest()])
             ->getMock();
         $controller->setPlugin('TestPlugin');
         $controller->setRequest(new ServerRequest());
@@ -811,6 +814,7 @@ class WebExceptionRendererTest extends TestCase
         /** @var \Cake\Controller\Controller|\PHPUnit\Framework\MockObject\MockObject $controller */
         $controller = $this->getMockBuilder('Cake\Controller\Controller')
             ->onlyMethods(['render'])
+            ->setConstructorArgs([new ServerRequest()])
             ->getMock();
         $controller->setPlugin('TestPlugin');
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -24,6 +24,7 @@ use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Http\Middleware\EncryptedCookieMiddleware;
 use Cake\Http\Middleware\SessionCsrfProtectionMiddleware;
 use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\Http\Session;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\RouteBuilder;
@@ -1635,7 +1636,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testViewVariableNotFoundShouldReturnNull(): void
     {
-        $this->_controller = new Controller();
+        $this->_controller = new Controller(new ServerRequest());
         $this->assertNull($this->viewVariable('notFound'));
     }
 

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -346,8 +346,7 @@ class CellTest extends TestCase
     public function testCellInheritsController(): void
     {
         $request = new ServerRequest();
-        $response = new Response();
-        $controller = new CellTraitTestController($request, $response);
+        $controller = new CellTraitTestController($request);
         $controller->viewBuilder()->setTheme('Pretty');
         $controller->viewBuilder()->setClassName('Json');
         $cell = $controller->cell('Articles');

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -20,7 +20,6 @@ namespace Cake\Test\TestCase\View;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\SerializationFailureException;
@@ -220,8 +219,7 @@ class JsonViewTest extends TestCase
     public function testRenderWithoutView($data, $serialize, $jsonOptions, $expected): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
 
         $Controller->set($data);
         $Controller->viewBuilder()
@@ -239,8 +237,7 @@ class JsonViewTest extends TestCase
     public function testRenderSerializeNoHelpers(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
 
         $Controller->set([
             'tags' => ['cakephp', 'framework'],
@@ -260,8 +257,7 @@ class JsonViewTest extends TestCase
     public function testJsonpResponse(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
 
         $data = ['user' => 'fake', 'list' => ['item1', 'item2']];
         $Controller->set([
@@ -296,8 +292,7 @@ class JsonViewTest extends TestCase
     public function testRenderWithView(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $Controller->setName('Posts');
 
         $data = [
@@ -326,8 +321,7 @@ class JsonViewTest extends TestCase
         $this->expectExceptionMessage('Serialization of View data failed.');
 
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
 
         $data = "\xB1\x31";
         $Controller->set('data', $data);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -709,7 +709,7 @@ class ViewTest extends TestCase
      */
     public function testElementParamsDontOverwriteHelpers(): void
     {
-        $Controller = new ViewPostsController();
+        $Controller = new ViewPostsController(new ServerRequest());
 
         $View = $Controller->createView();
         $result = $View->element('type_check', ['form' => 'string'], ['callbacks' => true]);
@@ -725,7 +725,7 @@ class ViewTest extends TestCase
      */
     public function testElementCacheHelperNoCache(): void
     {
-        $Controller = new ViewPostsController();
+        $Controller = new ViewPostsController(new ServerRequest());
         $View = $Controller->createView();
         $result = $View->element('test_element', ['ram' => 'val', 'test' => ['foo', 'bar']]);
         $this->assertSame('this is the test element', $result);
@@ -1118,7 +1118,7 @@ class ViewTest extends TestCase
      */
     public function testViewVarOverwritingLocalHelperVar(): void
     {
-        $Controller = new ViewPostsController();
+        $Controller = new ViewPostsController(new ServerRequest());
         $Controller->set('html', 'I am some test html');
         $View = $Controller->createView();
         $View->setTemplatePath($Controller->getName());

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\View;
 
 use Cake\Controller\Controller;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingViewException;
 
@@ -36,7 +37,7 @@ class ViewVarsTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = new Controller();
+        $this->subject = new Controller(new ServerRequest());
     }
 
     /**

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -20,7 +20,6 @@ namespace Cake\Test\TestCase\View;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Xml;
@@ -44,8 +43,7 @@ class XmlViewTest extends TestCase
     public function testRenderWithoutView(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $data = ['users' => ['user' => ['user1', 'user2']]];
         $Controller->set(['users' => $data]);
         $Controller->viewBuilder()
@@ -95,8 +93,7 @@ class XmlViewTest extends TestCase
     public function testRenderSerializeNoHelpers(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $Controller->set([
             'tags' => ['cakephp', 'framework'],
         ]);
@@ -114,8 +111,7 @@ class XmlViewTest extends TestCase
     public function testRenderSerializeWithOptions(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $data = [
             'tags' => [
                     'tag' => [
@@ -150,8 +146,7 @@ class XmlViewTest extends TestCase
     public function testRenderSerializeWithString(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $data = [
             'tags' => [
                 'tags' => [
@@ -188,8 +183,7 @@ class XmlViewTest extends TestCase
     public function testRenderWithoutViewMultiple(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $data = ['no' => 'nope', 'user' => 'fake', 'list' => ['item1', 'item2']];
         $Controller->set($data);
         $Controller->viewBuilder()
@@ -220,8 +214,7 @@ class XmlViewTest extends TestCase
     public function testRenderWithoutViewMultipleAndAlias(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $data = ['original_name' => 'my epic name', 'user' => 'fake', 'list' => ['item1', 'item2']];
         $Controller->set($data);
         $Controller->viewBuilder()
@@ -252,8 +245,7 @@ class XmlViewTest extends TestCase
     public function testRenderWithSerializeTrue(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $data = ['users' => ['user' => ['user1', 'user2']]];
         $Controller->set(['users' => $data]);
         $Controller->viewBuilder()
@@ -266,7 +258,7 @@ class XmlViewTest extends TestCase
         $this->assertSame('application/xml', $View->getResponse()->getType());
 
         $data = ['no' => 'nope', 'user' => 'fake', 'list' => ['item1', 'item2']];
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $Controller->viewBuilder()
             ->setClassName('Xml')
             ->setOption('serialize', true);
@@ -285,8 +277,7 @@ class XmlViewTest extends TestCase
     public function testRenderWithView(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
         $Controller->setName('Posts');
 
         $data = [
@@ -319,8 +310,7 @@ class XmlViewTest extends TestCase
     public function testSerializingResultSet(): void
     {
         $Request = new ServerRequest();
-        $Response = new Response();
-        $Controller = new Controller($Request, $Response);
+        $Controller = new Controller($Request);
 
         $data = $this->getTableLocator()->get('Authors')
             ->find('all')

--- a/tests/test_app/TestApp/Error/Renderer/TestAppsExceptionRenderer.php
+++ b/tests/test_app/TestApp/Error/Renderer/TestAppsExceptionRenderer.php
@@ -5,7 +5,6 @@ namespace TestApp\Error\Renderer;
 
 use Cake\Controller\Controller;
 use Cake\Error\Renderer\WebExceptionRenderer;
-use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Exception;
@@ -22,12 +21,11 @@ class TestAppsExceptionRenderer extends WebExceptionRenderer
         if ($request === null) {
             $request = new ServerRequest();
         }
-        $response = new Response();
         try {
-            $controller = new TestAppsErrorController($request, $response);
+            $controller = new TestAppsErrorController($request);
             $controller->viewBuilder()->setLayout('banana');
         } catch (Exception $e) {
-            $controller = new Controller($request, $response);
+            $controller = new Controller($request);
             $controller->viewBuilder()->setTemplatePath('Error');
         }
 


### PR DESCRIPTION
The new signatures better reflected the actual usage rather than testing scenarios.
It also removes the cyclic dependency between Controller and ComponentRegistry
which trips auto-wiring containers.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
