### PR TITLE
add setSerialized method to ViewVarsTrait

### DIFF
--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -120,7 +120,7 @@ trait ViewVarsTrait
             $data = [$name];
         }
         $currentSerialized = $this->viewBuilder()->getOption('serialize') ?? [];
-        $this->viewBuilder()->setOption('serialize', array_merge($currentSerialized, $data));
+        $this->viewBuilder()->setOption('serialize', array_unique(array_merge($currentSerialized, $data)));
 
         return $this;
     }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -98,4 +98,30 @@ trait ViewVarsTrait
 
         return $this;
     }
+
+    /**
+     * Wrapper function to set variables into the template as well as enabling the serialization of these variables
+     *
+     * @param array|string $name A string or an array of data.
+     * @param mixed|null $value Value in case $name is a string (which then works as the key).
+     *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
+     * @return $this
+     */
+    public function setSerialized(array|string $name, mixed $value = null)
+    {
+        $this->set($name, $value);
+        if (is_array($name)) {
+            if ($value === null) {
+                $data = array_keys($name);
+            } else {
+                $data = $name;
+            }
+        } else {
+            $data = [$name];
+        }
+        $currentSerialized = $this->viewBuilder()->getOption('serialize') ?? [];
+        $this->viewBuilder()->setOption('serialize', array_merge($currentSerialized, $data));
+
+        return $this;
+    }
 }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -103,7 +103,7 @@ trait ViewVarsTrait
      * Wrapper function to set variables into the template as well as enabling the serialization of these variables
      *
      * @param array|string $name A string or an array of data.
-     * @param mixed|null $value Value in case $name is a string (which then works as the key).
+     * @param mixed $value Value in case $name is a string (which then works as the key).
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
      */

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -87,6 +87,53 @@ class ViewVarsTraitTest extends TestCase
     }
 
     /**
+     * test setSerialized() with different keys and values
+     */
+    public function testSetSerializedVars(): void
+    {
+        $keys = ['one', 'key'];
+        $vals = ['two', 'val'];
+        $this->subject->setSerialized($keys, $vals);
+
+        $expected = ['one' => 'two', 'key' => 'val'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getVars());
+
+        $expected = ['one', 'key'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getOption('serialize'));
+    }
+
+    /**
+     * test setSerialized() with chained calls
+     */
+    public function testSetSerializedVarsChained(): void
+    {
+        $this->subject->setSerialized('key1', 'val1')
+            ->setSerialized('key2', 'val2');
+
+        $expected = ['key1' => 'val1', 'key2' => 'val2'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getVars());
+
+        $expected = ['key1', 'key2'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getOption('serialize'));
+    }
+
+    /**
+     * test setSerialized() with compact()
+     */
+    public function testSetSerializedVarsCompact(): void
+    {
+        $key1 = 'val1';
+        $key2 = 'val2';
+        $this->subject->setSerialized(compact('key1', 'key2'));
+
+        $expected = ['key1' => 'val1', 'key2' => 'val2'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getVars());
+
+        $expected = ['key1', 'key2'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getOption('serialize'));
+    }
+
+    /**
      * test that createView() updates viewVars of View instance on each call.
      */
     public function testUptoDateViewVars(): void

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -118,6 +118,22 @@ class ViewVarsTraitTest extends TestCase
     }
 
     /**
+     * test setSerialized() with chained calls which have the same key
+     */
+    public function testSetSerializedVarsChainedSameKeys(): void
+    {
+        $this->subject->setSerialized('key1', 'val1')
+            ->setSerialized('key2', 'val2')
+            ->setSerialized('key1', 'val3');
+
+        $expected = ['key1' => 'val3', 'key2' => 'val2'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getVars());
+
+        $expected = ['key1', 'key2'];
+        $this->assertEquals($expected, $this->subject->viewBuilder()->getOption('serialize'));
+    }
+
+    /**
      * test setSerialized() with compact()
      */
     public function testSetSerializedVarsCompact(): void


### PR DESCRIPTION
This adds a helper method so you can do:
```
$this->setSerialized(compact('data'));
```
instead of having to do this
```
$this->set(compact('data'));
$this->viewBuilder()->setOption('serialize', ['data']);
```