### PR TITLE
Added count to redis scan

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -47,7 +47,7 @@ class RedisEngine extends CacheEngine
      * - `port` port number to the Redis server.
      * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
-     * - `scan_count` Number of keys to ask for each scan (default: 10)
+     * - `scanCount` Number of keys to ask for each scan (default: 10)
      * - `server` URL or IP to the Redis server host.
      * - `timeout` timeout in seconds (float).
      * - `unix_socket` Path to the unix socket file (default: false)
@@ -66,7 +66,7 @@ class RedisEngine extends CacheEngine
         'server' => '127.0.0.1',
         'timeout' => 0,
         'unix_socket' => false,
-        'scan_count' => 10,
+        'scanCount' => 10,
     ];
 
     /**
@@ -258,7 +258,7 @@ class RedisEngine extends CacheEngine
         $pattern = $this->_config['prefix'] . '*';
 
         while (true) {
-            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scan_count']);
+            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
 
             if ($keys === false) {
                 break;
@@ -289,7 +289,7 @@ class RedisEngine extends CacheEngine
         $pattern = $this->_config['prefix'] . '*';
 
         while (true) {
-            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scan_count']);
+            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scanCount']);
 
             if ($keys === false) {
                 break;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -47,6 +47,7 @@ class RedisEngine extends CacheEngine
      * - `port` port number to the Redis server.
      * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
+     * - `scan_count` Number of keys to ask for each scan (default: 100)
      * - `server` URL or IP to the Redis server host.
      * - `timeout` timeout in seconds (float).
      * - `unix_socket` Path to the unix socket file (default: false)
@@ -65,6 +66,7 @@ class RedisEngine extends CacheEngine
         'server' => '127.0.0.1',
         'timeout' => 0,
         'unix_socket' => false,
+        'scan_count' => 100,
     ];
 
     /**
@@ -256,7 +258,7 @@ class RedisEngine extends CacheEngine
         $pattern = $this->_config['prefix'] . '*';
 
         while (true) {
-            $keys = $this->_Redis->scan($iterator, $pattern);
+            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scan_count']);
 
             if ($keys === false) {
                 break;
@@ -287,7 +289,7 @@ class RedisEngine extends CacheEngine
         $pattern = $this->_config['prefix'] . '*';
 
         while (true) {
-            $keys = $this->_Redis->scan($iterator, $pattern);
+            $keys = $this->_Redis->scan($iterator, $pattern, (int)$this->_config['scan_count']);
 
             if ($keys === false) {
                 break;

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -47,7 +47,7 @@ class RedisEngine extends CacheEngine
      * - `port` port number to the Redis server.
      * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
-     * - `scan_count` Number of keys to ask for each scan (default: 100)
+     * - `scan_count` Number of keys to ask for each scan (default: 10)
      * - `server` URL or IP to the Redis server host.
      * - `timeout` timeout in seconds (float).
      * - `unix_socket` Path to the unix socket file (default: false)
@@ -66,7 +66,7 @@ class RedisEngine extends CacheEngine
         'server' => '127.0.0.1',
         'timeout' => 0,
         'unix_socket' => false,
-        'scan_count' => 100,
+        'scan_count' => 10,
     ];
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -97,7 +97,7 @@ class RedisEngineTest extends TestCase
             'database' => 0,
             'unix_socket' => false,
             'host' => null,
-            'scan_count' => 10,
+            'scanCount' => 10,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -125,7 +125,7 @@ class RedisEngineTest extends TestCase
             'unix_socket' => false,
             'host' => 'localhost',
             'scheme' => 'redis',
-            'scan_count' => 10,
+            'scanCount' => 10,
         ];
         $this->assertEquals($expecting, $config);
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -97,6 +97,7 @@ class RedisEngineTest extends TestCase
             'database' => 0,
             'unix_socket' => false,
             'host' => null,
+            'scan_count' => 100,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -124,6 +125,7 @@ class RedisEngineTest extends TestCase
             'unix_socket' => false,
             'host' => 'localhost',
             'scheme' => 'redis',
+            'scan_count' => 100,
         ];
         $this->assertEquals($expecting, $config);
 

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -97,7 +97,7 @@ class RedisEngineTest extends TestCase
             'database' => 0,
             'unix_socket' => false,
             'host' => null,
-            'scan_count' => 100,
+            'scan_count' => 10,
         ];
         $this->assertEquals($expecting, $config);
     }
@@ -125,7 +125,7 @@ class RedisEngineTest extends TestCase
             'unix_socket' => false,
             'host' => 'localhost',
             'scheme' => 'redis',
-            'scan_count' => 100,
+            'scan_count' => 10,
         ];
         $this->assertEquals($expecting, $config);
 


### PR DESCRIPTION
Allow configuration of scan count when fetching keys. Default to 100.

The scan count is a hint to redis and the server is free to ignore it or trim it.

Relevant ticket: #16554
