### PR TITLE
Clarify deprecation message when calling ResultSetInterface methods on queries

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -549,9 +549,11 @@ trait QueryTrait
         $resultSetClass = $this->_decoratorClass();
         if (in_array($method, get_class_methods($resultSetClass), true)) {
             deprecationWarning(sprintf(
-                'Calling result set method `%s()` directly on query instance is deprecated. ' .
-                'You must call `all()` to retrieve the results first.',
-                $method
+                'Calling `%s` methods, such as `%s()`, on queries is deprecated. ' .
+                'You must call `all()` first (for example, `all()->%s()`).',
+                ResultSetInterface::class,
+                $method,
+                $method,
             ), 2);
             $results = $this->all();
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1872,7 +1872,7 @@ class QueryTest extends TestCase
     public function testDeprecatedPathCollectionProxy(string $method, $arg, $return): void
     {
         $this->expectDeprecation();
-        $this->expectDeprecationMessage('QueryTest.php');
+        $this->expectDeprecationMessage("Calling `Cake\Datasource\ResultSetInterface` methods, such as `$method()`, on queries is deprecated.");
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['all'])


### PR DESCRIPTION
This should make it easier for users to understand the changes required and what methods we deprecated.