### PR TITLE
Remove invalid @param

### DIFF
--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1390,8 +1390,6 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merge when fields contains an association.
-     *
-     * @param $fields
      */
     public function testMergeWithSingleAssociationAndFields(): void
     {


### PR DESCRIPTION
Attempt to fix Slevomat standard crash with new phpdoc-parser.
