### PR TITLE
Allow the 'P1D' notation for DateInterval cache ttl.

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -18,6 +18,7 @@ namespace Cake\Cache;
 
 use Cake\Core\InstanceConfigTrait;
 use DateInterval;
+use DateTime;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -383,7 +384,9 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
             return $ttl;
         }
         if ($ttl instanceof DateInterval) {
-            return (int)$ttl->format('%s');
+            return (int)DateTime::createFromFormat('U', '0')
+                ->add($ttl)
+                ->format('U');
         }
 
         throw new InvalidArgumentException('TTL values must be one of null, int, \DateInterval');

--- a/tests/TestCase/Cache/Engine/CacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/CacheEngineTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Cache\Engine;
+
+use Cake\Cache\InvalidArgumentException;
+use Cake\TestSuite\TestCase;
+use TestApp\Cache\Engine\TestAppCacheEngine;
+
+class CacheEngineTest extends TestCase
+{
+    public function durationProvider(): array
+    {
+        return [
+            [null, 10],
+            [2, 2],
+            [new \DateInterval('PT1S'), 1],
+            [new \DateInterval('P1D'), 86400],
+        ];
+    }
+
+    /**
+     * Test duration with null, int and DateInterval multiple format.
+     *
+     * @dataProvider durationProvider
+     */
+    public function testDuration($ttl, $expected): void
+    {
+        $engine = new TestAppCacheEngine();
+        $engine->setConfig(['duration' => 10]);
+
+        $result = $engine->getDuration($ttl);
+
+        $this->assertSame($result, $expected);
+    }
+
+    /**
+     * Test duration value should be \DateInterval, int or null.
+     */
+    public function testDurationException(): void
+    {
+        $engine = new TestAppCacheEngine();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('TTL values must be one of null, int, \DateInterval');
+        $engine->getDuration('ttl');
+    }
+}

--- a/tests/test_app/TestApp/Cache/Engine/TestAppCacheEngine.php
+++ b/tests/test_app/TestApp/Cache/Engine/TestAppCacheEngine.php
@@ -79,4 +79,15 @@ class TestAppCacheEngine extends CacheEngine
     public function clearGroup(string $group): bool
     {
     }
+
+    /**
+     * Return duration method result.
+     *
+     * @param mixed $ttl
+     * @return int
+     */
+    public function getDuration($ttl): int
+    {
+        return $this->duration($ttl);
+    }
 }


### PR DESCRIPTION
Allow Cache ttl with DateInterval set in day/month/year, not only seconds.
example: `P1D` will return 86400.