### PR TITLE
Fix type error.

### DIFF
--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -55,7 +55,7 @@ trait StringCompareTrait
             $path = $this->_compareBasePath . $path;
         }
 
-        $this->_updateComparisons ??= env('UPDATE_TEST_COMPARISON_FILES');
+        $this->_updateComparisons ??= env('UPDATE_TEST_COMPARISON_FILES') ?: false;
 
         if ($this->_updateComparisons) {
             file_put_contents($path, $result);


### PR DESCRIPTION
The property type is `bool` and `env()` would return null if the var is unset.
<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
