### PR TITLE
Add ability to get logger instance from db driver.

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -540,9 +540,9 @@ abstract class Driver implements DriverInterface
     /**
      * @inheritDoc
      */
-    public function setLogger(LoggerInterface $logger): void
+    public function getLogger(): ?LoggerInterface
     {
-        $this->logger = $logger;
+        return $this->logger;
     }
 
     /**

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -20,6 +20,7 @@ use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\TableSchemaInterface;
 use Closure;
 use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 use Stringable;
 
 /**
@@ -333,4 +334,11 @@ interface DriverInterface extends LoggerAwareInterface
      * @return bool True if message was logged.
      */
     public function log(Stringable|string $message, array $context = []): bool;
+
+    /**
+     * Get the logger instance.
+     *
+     * @return \Psr\Log\LoggerInterface|null
+     */
+    public function getLogger(): ?LoggerInterface;
 }

--- a/tests/test_app/TestApp/Database/Driver/StubDriver.php
+++ b/tests/test_app/TestApp/Database/Driver/StubDriver.php
@@ -16,17 +16,11 @@ declare(strict_types=1);
 namespace TestApp\Database\Driver;
 
 use Cake\Database\Driver;
-use Psr\Log\LoggerInterface;
 
 abstract class StubDriver extends Driver
 {
     public function connect(): void
     {
         $this->pdo = $this->createPdo('', []);
-    }
-
-    public function getLogger(): ?LoggerInterface
-    {
-        return $this->logger;
     }
 }


### PR DESCRIPTION
The Crud plugin for e.g. has a feature of including query logs in
serialized responses for debugging purposes. This features breaks
without a way to access the custom logger it sets for the drivers.

<!---

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
