### PR TITLE
Initialize property.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -131,7 +131,7 @@ class Router
      *
      * @var \Cake\Http\ServerRequest|null
      */
-    protected static ?ServerRequest $_request;
+    protected static ?ServerRequest $_request = null;
 
     /**
      * Initial state is populated the first time reload() is called which is at the bottom


### PR DESCRIPTION
This avoid Router::getRequest() from throwing property not initialized error.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
