### PR TITLE
Fix request->is(xml) returning true for HTML requests

### DIFF
--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -553,9 +553,12 @@ class ServerRequest implements ServerRequestInterface
     protected function _acceptHeaderDetector(array $detect): bool
     {
         $content = new ContentTypeNegotiation();
-        $accepted = $content->preferredType($this, $detect['accept']);
+        $options = $detect['accept'];
+        // We add text/html as the browsers often combine xml + html types together.
+        $options[] = 'text/html';
+        $accepted = $content->preferredType($this, $options);
 
-        return $accepted !== null;
+        return $accepted !== null && $accepted != 'text/html';
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -133,7 +133,7 @@ class ServerRequest implements ServerRequestInterface
             'accept' => ['application/xml', 'text/xml'],
             'exclude' => ['text/html'],
             'param' => '_ext',
-            'value' => 'xml'
+            'value' => 'xml',
         ],
     ];
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -563,9 +563,8 @@ class ServerRequest implements ServerRequestInterface
         // Some detectors overlap with the default browser Accept header
         // For these types we use an exclude list to refine our content type
         // detection.
-        $exclude = null;
-        if (!empty($detect['exclude'])) {
-            $exclude = $detect['exclude'];
+        $exclude = $detect['exclude'] ?: null;
+        if ($exclude) {
             $options = array_merge($options, $exclude);
         }
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -563,7 +563,7 @@ class ServerRequest implements ServerRequestInterface
         // Some detectors overlap with the default browser Accept header
         // For these types we use an exclude list to refine our content type
         // detection.
-        $exclude = $detect['exclude'] ?: null;
+        $exclude = $detect['exclude'] ?? null;
         if ($exclude) {
             $options = array_merge($options, $exclude);
         }

--- a/tests/TestCase/Http/ContentTypeNegotiationTest.php
+++ b/tests/TestCase/Http/ContentTypeNegotiationTest.php
@@ -36,7 +36,7 @@ class ContentTypeNegotiationTest extends TestCase
             ],
         ]);
         $this->assertEquals('text/html', $content->preferredType($request));
-        $this->assertEquals('text/html', $content->preferredType($request, ['text/html', 'application/json']));
+        $this->assertEquals('text/html', $content->preferredType($request, ['text/html', 'application/xml']));
         $this->assertEquals('application/xml', $content->preferredType($request, ['application/xml']));
         $this->assertNull($content->preferredType($request, ['application/json']));
     }

--- a/tests/TestCase/Http/ContentTypeNegotiationTest.php
+++ b/tests/TestCase/Http/ContentTypeNegotiationTest.php
@@ -26,6 +26,21 @@ class ContentTypeNegotiationTest extends TestCase
         $this->assertNull($content->preferredType($request));
     }
 
+    public function testPreferredTypeFirefoxHtml()
+    {
+        $content = new ContentTypeNegotiation();
+        $request = new ServerRequest([
+            'url' => '/dashboard',
+            'environment' => [
+                'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+            ],
+        ]);
+        $this->assertEquals('text/html', $content->preferredType($request));
+        $this->assertEquals('text/html', $content->preferredType($request, ['text/html', 'application/json']));
+        $this->assertEquals('application/xml', $content->preferredType($request, ['application/xml']));
+        $this->assertNull($content->preferredType($request, ['application/json']));
+    }
+
     public function testPreferredTypeFirstMatch()
     {
         $content = new ContentTypeNegotiation();

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -92,6 +92,12 @@ class ServerRequestTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withEnv('HTTP_ACCEPT', 'text/plain, */*');
         $this->assertFalse($request->is('json'));
+
+        $request = new ServerRequest();
+        $request = $request->withEnv('HTTP_ACCEPT', 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8');
+        $this->assertFalse($request->is('json'));
+        $this->assertFalse($request->is('xml'));
+        $this->assertFalse($request->is('xml'));
     }
 
     public function testConstructor(): void


### PR DESCRIPTION
Add html/text as an option for all content-type based detectors so that we can differentiate between requests that want HTML but also take xml or json from being confused as a non-html type. Assuming browser based traffic is a safe default in my opinion.

Fixes #16583