### PR TITLE
Mimic the exception thrown by ModelAwareTrait::loadModel().

### DIFF
--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Locator;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Datasource\FactoryLocator;
 use Cake\ORM\Table;
+use UnexpectedValueException;
 
 /**
  * Contains method for setting and accessing LocatorInterface instance
@@ -83,8 +83,10 @@ trait LocatorAwareTrait
     public function fetchTable(?string $alias = null, array $options = []): Table
     {
         $alias = $alias ?? $this->defaultTable;
-        if ($alias === null) {
-            throw new CakeException('You must provide an `$alias` or set the `$defaultTable` property.');
+        if (empty($alias)) {
+            throw new UnexpectedValueException(
+                'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
+            );
         }
 
         return $this->getTableLocator()->get($alias, $options);

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
 
 namespace Cake\Test\TestCase\ORM\Locator;
 
-use Cake\Core\Exception\CakeException;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Locator\LocatorInterface;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use TestApp\Model\Table\PaginatorPostsTable;
 use TestApp\Stub\LocatorAwareStub;
+use UnexpectedValueException;
 
 /**
  * LocatorAwareTrait test case
@@ -81,10 +81,23 @@ class LocatorAwareTraitTest extends TestCase
 
     public function testfetchTableException()
     {
-        $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('You must provide an `$alias` or set the `$defaultTable` property.');
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
+        );
 
         $stub = new LocatorAwareStub();
+        $stub->fetchTable();
+    }
+
+    public function testfetchTableExceptionForEmptyString()
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
+        );
+
+        $stub = new LocatorAwareStub('');
         $stub->fetchTable();
     }
 }


### PR DESCRIPTION
Bake has a feature which specifically checks for the UnexpectedValueException.
This accounts for the default table set to an empty string too.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
