### PR TITLE
Fixed type hint for accessible

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -107,7 +107,7 @@ trait EntityTrait
      * not defined in the map will take its value. For example, `'*' => true`
      * means that any field not defined in the map will be accessible by default
      *
-     * @var array<bool>
+     * @var array<string, bool>
      */
     protected $_accessible = ['*' => true];
 


### PR DESCRIPTION
Fixes incorrect type hint for $_accessible from array<bool> to array<string,bool>
