### PR TITLE
5.x widen types from env()

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -189,10 +189,10 @@ if (!function_exists('env')) {
      *
      * @param string $key Environment variable name.
      * @param string|bool|null $default Specify a default value in case the environment variable is not defined.
-     * @return string|bool|null Environment variable setting.
+     * @return string|int|float|bool|null Environment variable setting.
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#env
      */
-    function env(string $key, string|bool|null $default = null): string|bool|null
+    function env(string $key, string|bool|null $default = null): string|int|float|bool|null
     {
         if ($key === 'HTTPS') {
             if (isset($_SERVER['HTTPS'])) {

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -189,10 +189,10 @@ if (!function_exists('env')) {
      *
      * @param string $key Environment variable name.
      * @param string|bool|null $default Specify a default value in case the environment variable is not defined.
-     * @return string|int|float|bool|null Environment variable setting.
+     * @return string|float|int|bool|null Environment variable setting.
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#env
      */
-    function env(string $key, string|bool|null $default = null): string|int|float|bool|null
+    function env(string $key, string|bool|null $default = null): string|float|int|bool|null
     {
         if ($key === 'HTTPS') {
             if (isset($_SERVER['HTTPS'])) {


### PR DESCRIPTION
The `REQUEST_TIME` env var that debugkit relies on (and likely userland code) is of type int. I'm adding float as well to mitigate future issues being reported.