### PR TITLE
5.x - expand default value type on env()

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -192,7 +192,7 @@ if (!function_exists('env')) {
      * @return string|float|int|bool|null Environment variable setting.
      * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#env
      */
-    function env(string $key, string|bool|null $default = null): string|float|int|bool|null
+    function env(string $key, string|float|int|bool|null $default = null): string|float|int|bool|null
     {
         if ($key === 'HTTPS') {
             if (isset($_SERVER['HTTPS'])) {

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -48,6 +48,14 @@ class FunctionsTest extends TestCase
         $this->assertSame('0', env('ZERO'));
         $this->assertSame('0', env('ZERO', '1'));
 
+        $_ENV['ZERO'] = 0;
+        $this->assertSame(0, env('ZERO'));
+        $this->assertSame(0, env('ZERO', 1));
+
+        $_ENV['ZERO'] = 0.0;
+        $this->assertSame(0.0, env('ZERO'));
+        $this->assertSame(0.0, env('ZERO', 1));
+
         $this->assertSame('', env('DOCUMENT_ROOT'));
         $this->assertStringContainsString('phpunit', env('PHP_SELF'));
     }


### PR DESCRIPTION
To match with the output type as changed in #16591
