### PR TITLE
Add compatibility shim for `errorLogger`

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -203,7 +203,7 @@ class ErrorTrap
         $oldConfig = $this->getConfig('errorLogger');
         if ($oldConfig !== null) {
             deprecationWarning('The `errorLogger` configuration key is deprecated. Use `logger` instead.');
-            $this->setConfig('logger', $oldConfig);
+            $this->setConfig(['logger' => $oldConfig, 'errorLogger' => null]);
         }
 
         /** @var class-string<\Cake\Error\ErrorLoggerInterface> $class */

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -200,6 +200,12 @@ class ErrorTrap
      */
     public function logger(): ErrorLoggerInterface
     {
+        $oldConfig = $this->getConfig('errorLogger');
+        if ($oldConfig !== null) {
+            deprecationWarning('The `errorLogger` configuration key is deprecated. Use `logger` instead.');
+            $this->setConfig('logger', $oldConfig);
+        }
+
         /** @var class-string<\Cake\Error\ErrorLoggerInterface> $class */
         $class = $this->getConfig('logger', $this->_defaultConfig['logger']);
         if (!in_array(ErrorLoggerInterface::class, class_implements($class))) {

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -82,6 +82,14 @@ class ErrorTrapTest extends TestCase
         $this->assertInstanceOf(ErrorLogger::class, $trap->logger());
     }
 
+    public function testLoggerConfigCompatibility()
+    {
+        $this->deprecated(function () {
+            $trap = new ErrorTrap(['errorLogger' => ErrorLogger::class]);
+            $this->assertInstanceOf(ErrorLogger::class, $trap->logger());
+        });
+    }
+
     public function testLoggerHandleUnsafeOverwrite()
     {
         $trap = new ErrorTrap();


### PR DESCRIPTION
Users with custom error logging will be using the `errorLogger` key. In order for them to complete their upgrade to `ErrorTrap` they need to use the `logger` key instead.