### PR TITLE
fix TableLocator::get() with options throw exception if model mocked.

### DIFF
--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -53,7 +53,7 @@ abstract class AbstractLocator implements LocatorInterface
         unset($storeOptions['allowFallbackClass']);
 
         if (isset($this->instances[$alias])) {
-            if (!empty($storeOptions) && $this->options[$alias] !== $storeOptions) {
+            if (!empty($storeOptions) && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
                 throw new RuntimeException(sprintf(
                     'You cannot configure "%s", it already exists in the registry.',
                     $alias

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -665,7 +665,7 @@ class TableLocatorTest extends TestCase
     /**
      * testInstanceSetButNotOptions
      *
-     * Tests that mock model will not thrown an exception if model fetched with options.
+     * Tests that mock model will not throw an exception if model fetched with options.
      */
     public function testInstanceSetButNotOptions(): void
     {

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -661,4 +661,18 @@ class TableLocatorTest extends TestCase
         $table = $this->_locator->get('FooBar');
         $this->assertInstanceOf(ArticlesTable::class, $table);
     }
+
+    /**
+     * testInstanceSetButNotOptions
+     *
+     * Tests that mock model will not thrown an exception if model fetched with options.
+     */
+    public function testInstanceSetButNotOptions(): void
+    {
+        $this->setTableLocator($this->_locator);
+        $mock = $this->getMockForModel('Articles', ['findPublished']);
+        $table = $this->_locator->get('Articles', ['className' => ArticlesTable::class]);
+
+        $this->assertSame($table, $mock);
+    }
 }


### PR DESCRIPTION
fix #16603