### PR TITLE
Change return type of CommandInterface::run() and Command::execute().

### DIFF
--- a/src/Command/CacheClearCommand.php
+++ b/src/Command/CacheClearCommand.php
@@ -63,9 +63,9 @@ class CacheClearCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $name = (string)$args->getArgument('engine');
         try {

--- a/src/Command/CacheClearallCommand.php
+++ b/src/Command/CacheClearallCommand.php
@@ -56,9 +56,9 @@ class CacheClearallCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $engines = Cache::configured();
         foreach ($engines as $engine) {

--- a/src/Command/CacheListCommand.php
+++ b/src/Command/CacheListCommand.php
@@ -54,9 +54,9 @@ class CacheListCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $engines = Cache::configured();
         foreach ($engines as $engine) {

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -16,9 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Command;
 
-use Cake\Console\Arguments;
 use Cake\Console\BaseCommand;
-use Cake\Console\ConsoleIo;
 use Cake\Log\LogTrait;
 use Cake\ORM\Locator\LocatorAwareTrait;
 
@@ -29,20 +27,8 @@ use Cake\ORM\Locator\LocatorAwareTrait;
  * Includes traits that integrate logging
  * and ORM models to console commands.
  */
-class Command extends BaseCommand
+abstract class Command extends BaseCommand
 {
     use LocatorAwareTrait;
     use LogTrait;
-
-    /**
-     * Implement this method with your command's logic.
-     *
-     * @param \Cake\Console\Arguments $args The command arguments.
-     * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null|void The exit code or null for success
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     */
-    public function execute(Arguments $args, ConsoleIo $io)
-    {
-    }
 }

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -94,7 +94,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         return match ($args->getArgument('mode')) {
             'commands' => $this->getCommands($args, $io),
@@ -171,7 +171,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
-    protected function getOptions(Arguments $args, ConsoleIo $io): ?int
+    protected function getOptions(Arguments $args, ConsoleIo $io): int
     {
         $name = $args->getArgument('command');
         $subcommand = $args->getArgument('subcommand');

--- a/src/Command/I18nCommand.php
+++ b/src/Command/I18nCommand.php
@@ -30,9 +30,9 @@ class I18nCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('<info>I18n Command</info>');
         $io->hr();

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -170,9 +170,9 @@ class I18nExtractCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $plugin = '';
         if ($args->getOption('exclude')) {

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -43,9 +43,9 @@ class I18nInitCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $language = $args->getArgument('language');
         if (!$language) {

--- a/src/Command/PluginAssetsCopyCommand.php
+++ b/src/Command/PluginAssetsCopyCommand.php
@@ -45,9 +45,9 @@ class PluginAssetsCopyCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $this->io = $io;
         $this->args = $args;

--- a/src/Command/PluginAssetsRemoveCommand.php
+++ b/src/Command/PluginAssetsRemoveCommand.php
@@ -44,9 +44,9 @@ class PluginAssetsRemoveCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $this->io = $io;
         $this->args = $args;

--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -46,9 +46,9 @@ class PluginAssetsSymlinkCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $this->io = $io;
         $this->args = $args;

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -52,9 +52,9 @@ class PluginLoadCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $plugin = (string)$args->getArgument('plugin');
         $options = [];

--- a/src/Command/PluginLoadedCommand.php
+++ b/src/Command/PluginLoadedCommand.php
@@ -39,9 +39,9 @@ class PluginLoadedCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $loaded = Plugin::loaded();
         $io->out($loaded);

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -47,9 +47,9 @@ class PluginUnloadCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $plugin = (string)$args->getArgument('plugin');
 

--- a/src/Command/RoutesCheckCommand.php
+++ b/src/Command/RoutesCheckCommand.php
@@ -42,10 +42,10 @@ class RoutesCheckCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      * @throws \JsonException
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $url = $args->getArgument('url');
         try {

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -31,10 +31,10 @@ class RoutesCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      * @throws \JsonException
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $header = ['Route name', 'URI template', 'Plugin', 'Prefix', 'Controller', 'Action', 'Method(s)'];
         if ($args->getOption('verbose')) {

--- a/src/Command/RoutesGenerateCommand.php
+++ b/src/Command/RoutesGenerateCommand.php
@@ -40,9 +40,9 @@ class RoutesGenerateCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         try {
             $args = $this->_splitArgs($args->getArguments());

--- a/src/Command/SchemacacheBuildCommand.php
+++ b/src/Command/SchemacacheBuildCommand.php
@@ -43,9 +43,9 @@ class SchemacacheBuildCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         try {
             /** @var \Cake\Database\Connection $connection */

--- a/src/Command/SchemacacheClearCommand.php
+++ b/src/Command/SchemacacheClearCommand.php
@@ -43,9 +43,9 @@ class SchemacacheClearCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         try {
             /** @var \Cake\Database\Connection $connection */

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -121,9 +121,9 @@ class ServerCommand extends Command
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null The exit code or null for success
+     * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $this->startup($args, $io);
         $phpBinary = (string)env('PHP', 'php');

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -32,7 +32,7 @@ class VersionCommand extends Command
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out(Configure::version());
 

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -158,7 +158,7 @@ abstract class BaseCommand implements CommandInterface
     /**
      * @inheritDoc
      */
-    public function run(array $argv, ConsoleIo $io): ?int
+    public function run(array $argv, ConsoleIo $io): int
     {
         $this->initialize();
 
@@ -234,10 +234,9 @@ abstract class BaseCommand implements CommandInterface
      *
      * @param \Cake\Console\Arguments $args The command arguments.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null|void The exit code or null for success
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @return int The exit code.
      */
-    abstract public function execute(Arguments $args, ConsoleIo $io);
+    abstract public function execute(Arguments $args, ConsoleIo $io): int;
 
     /**
      * Halt the the current process with a StopException.

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -55,7 +55,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
      * @param \Cake\Console\ConsoleIo $io The console io
      * @return int
      */
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $commands = $this->commands->getIterator();
         if ($commands instanceof ArrayIterator) {

--- a/src/Console/CommandInterface.php
+++ b/src/Console/CommandInterface.php
@@ -54,7 +54,7 @@ interface CommandInterface
      *
      * @param array $argv Arguments from the CLI environment.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null Exit code or null for success.
+     * @return int Exit code.
      */
-    public function run(array $argv, ConsoleIo $io): ?int;
+    public function run(array $argv, ConsoleIo $io): int;
 }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -166,9 +166,6 @@ class CommandRunner implements EventDispatcherInterface
         $command = $this->getCommand($io, $commands, $name);
         $result = $this->runCommand($command, $argv, $io);
 
-        if ($result === null) {
-            return CommandInterface::CODE_SUCCESS;
-        }
         if ($result >= 0 && $result <= 255) {
             return $result;
         }
@@ -317,9 +314,9 @@ class CommandRunner implements EventDispatcherInterface
      * @param \Cake\Console\CommandInterface $command The command to run.
      * @param array $argv The CLI arguments to invoke.
      * @param \Cake\Console\ConsoleIo $io The console io
-     * @return int|null Exit code
+     * @return int Exit code
      */
-    protected function runCommand(CommandInterface $command, array $argv, ConsoleIo $io): ?int
+    protected function runCommand(CommandInterface $command, array $argv, ConsoleIo $io): int
     {
         try {
             return $command->run($argv, $io);

--- a/tests/test_app/Plugin/Company/TestPluginThree/src/Command/CompanyCommand.php
+++ b/tests/test_app/Plugin/Company/TestPluginThree/src/Command/CompanyCommand.php
@@ -9,7 +9,8 @@ use Cake\Console\ConsoleIo;
 
 class CompanyCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Command/ExampleCommand.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Command/ExampleCommand.php
@@ -9,7 +9,8 @@ use Cake\Console\ConsoleIo;
 
 class ExampleCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Command/SampleCommand.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Command/SampleCommand.php
@@ -9,7 +9,8 @@ use Cake\Console\ConsoleIo;
 
 class SampleCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/Command/SampleSubCommand.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Command/SampleSubCommand.php
@@ -32,7 +32,8 @@ class SampleSubCommand extends Command
         return 'sample sub';
     }
 
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Command/ExampleCommand.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Command/ExampleCommand.php
@@ -9,8 +9,10 @@ use Cake\Console\ConsoleIo;
 
 class ExampleCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('This is the main method called from TestPluginTwo.ExampleCommand');
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Command/UniqueCommand.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Command/UniqueCommand.php
@@ -9,8 +9,10 @@ use Cake\Console\ConsoleIo;
 
 class UniqueCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('This is the main method called from TestPluginTwo.UniqueCommand');
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Command/WelcomeCommand.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Command/WelcomeCommand.php
@@ -9,8 +9,10 @@ use Cake\Console\ConsoleIo;
 
 class WelcomeCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('This is the say_hello method called from TestPluginTwo.WelcomeCommand');
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/Plugin/TestPluginTwo/src/Command/WelcomeSayHelloCommand.php
+++ b/tests/test_app/Plugin/TestPluginTwo/src/Command/WelcomeSayHelloCommand.php
@@ -14,7 +14,8 @@ class WelcomeSayHelloCommand extends Command
         return 'welcome say_hello';
     }
 
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/AbortCommand.php
+++ b/tests/test_app/TestApp/Command/AbortCommand.php
@@ -9,11 +9,11 @@ use Cake\Console\ConsoleIo;
 
 class AbortCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->error('Command aborted');
         $this->abort(127);
 
-        return null;
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
+++ b/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 namespace TestApp\Command;
 
 use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
 
 class AutoLoadModelCommand extends Command
 {
     protected ?string $defaultTable = 'Posts';
+
+    public function execute(Arguments $args, ConsoleIo $io): int
+    {
+        return static::CODE_SUCCESS;
+    }
 }

--- a/tests/test_app/TestApp/Command/BridgeCommand.php
+++ b/tests/test_app/TestApp/Command/BridgeCommand.php
@@ -9,7 +9,7 @@ use Cake\Console\ConsoleIo;
 
 class BridgeCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $name = $io->ask('What is your name');
 
@@ -28,5 +28,7 @@ class BridgeCommand extends Command
         }
 
         $io->out('You may pass.');
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -14,7 +14,7 @@ class DemoCommand extends Command
         return 'This is a demo command';
     }
 
-    public function execute(Arguments $args, ConsoleIo $io): ?int
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->quiet('Quiet!');
         $io->out('Demo Command!');
@@ -23,6 +23,6 @@ class DemoCommand extends Command
             $io->out($args->getArgumentAt(0));
         }
 
-        return null;
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/DependencyCommand.php
+++ b/tests/test_app/TestApp/Command/DependencyCommand.php
@@ -17,7 +17,7 @@ class DependencyCommand extends Command
         $this->inject = $inject;
     }
 
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('Dependency Command');
         $io->out('constructor inject: ' . json_encode($this->inject));

--- a/tests/test_app/TestApp/Command/FormatSpecifierCommand.php
+++ b/tests/test_app/TestApp/Command/FormatSpecifierCommand.php
@@ -9,8 +9,10 @@ use Cake\Console\ConsoleIo;
 
 class FormatSpecifierCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('Be careful! %s is a format specifier!');
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/IntegrationCommand.php
+++ b/tests/test_app/TestApp/Command/IntegrationCommand.php
@@ -10,10 +10,12 @@ use Cake\Console\ConsoleOptionParser;
 
 class IntegrationCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('arg: ' . $args->getArgument('arg'));
         $io->out('opt: ' . $args->getOption('opt'));
+
+        return static::CODE_SUCCESS;
     }
 
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser

--- a/tests/test_app/TestApp/Command/NonInteractiveCommand.php
+++ b/tests/test_app/TestApp/Command/NonInteractiveCommand.php
@@ -9,11 +9,11 @@ use Cake\Console\ConsoleIo;
 
 class NonInteractiveCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $result = $io->ask('What?', 'Default!');
         $io->quiet('Result: ' . $result);
 
-        return null;
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/SampleCommand.php
+++ b/tests/test_app/TestApp/Command/SampleCommand.php
@@ -9,8 +9,10 @@ use Cake\Console\ConsoleIo;
 
 class SampleCommand extends Command
 {
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
         $io->out('This is the main method called from SampleCommand');
+
+        return static::CODE_SUCCESS;
     }
 }

--- a/tests/test_app/TestApp/Command/SampleSubCommand.php
+++ b/tests/test_app/TestApp/Command/SampleSubCommand.php
@@ -32,7 +32,8 @@ class SampleSubCommand extends Command
         return 'sample sub';
     }
 
-    public function execute(Arguments $args, ConsoleIo $io)
+    public function execute(Arguments $args, ConsoleIo $io): int
     {
+        return static::CODE_SUCCESS;
     }
 }


### PR DESCRIPTION
Also make Command class abstract.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
