### PR TITLE
Replace RuntimeException with CakeException, DatabaseException or InvalidArgumentException

### DIFF
--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -18,8 +18,8 @@ namespace Cake\Cache;
 
 use BadMethodCallException;
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\ObjectRegistry;
-use RuntimeException;
 
 /**
  * An object registry for cache engines.
@@ -68,7 +68,7 @@ class CacheRegistry extends ObjectRegistry
      * @param string $alias The alias of the object.
      * @param array<string, mixed> $config An array of settings to use for the cache engine.
      * @return \Cake\Cache\CacheEngine The constructed CacheEngine class.
-     * @throws \RuntimeException when an object doesn't implement the correct interface.
+     * @throws \Cake\Core\Exception\CakeException when an object doesn't implement the correct interface.
      */
     protected function _create(object|string $class, string $alias, array $config): CacheEngine
     {
@@ -80,13 +80,13 @@ class CacheRegistry extends ObjectRegistry
         unset($config['className']);
 
         if (!($instance instanceof CacheEngine)) {
-            throw new RuntimeException(
+            throw new CakeException(
                 'Cache engines must use Cake\Cache\CacheEngine as a base class.'
             );
         }
 
         if (!$instance->init($config)) {
-            throw new RuntimeException(
+            throw new CakeException(
                 sprintf(
                     'Cache engine %s is not properly configured. Check error log for additional information.',
                     get_class($instance)

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -18,8 +18,8 @@ namespace Cake\Cache\Engine;
 
 use APCUIterator;
 use Cake\Cache\CacheEngine;
+use Cake\Core\Exception\CakeException;
 use DateInterval;
-use RuntimeException;
 
 /**
  * APCu storage engine for cache
@@ -45,7 +45,7 @@ class ApcuEngine extends CacheEngine
     public function init(array $config = []): bool
     {
         if (!extension_loaded('apcu')) {
-            throw new RuntimeException('The `apcu` extension must be enabled to use ApcuEngine.');
+            throw new CakeException('The `apcu` extension must be enabled to use ApcuEngine.');
         }
 
         return parent::init($config);

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
+use Cake\Core\Exception\CakeException;
 use DateInterval;
 use InvalidArgumentException;
 use Memcached;
-use RuntimeException;
 
 /**
  * Memcached storage engine for cache. Memcached has some limitations in the amount of
@@ -105,7 +105,7 @@ class MemcachedEngine extends CacheEngine
     public function init(array $config = []): bool
     {
         if (!extension_loaded('memcached')) {
-            throw new RuntimeException('The `memcached` extension must be enabled to use MemcachedEngine.');
+            throw new CakeException('The `memcached` extension must be enabled to use MemcachedEngine.');
         }
 
         $this->_serializers = [

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -18,11 +18,11 @@ declare(strict_types=1);
 namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
+use Cake\Core\Exception\CakeException;
 use Cake\Log\Log;
 use DateInterval;
 use Redis;
 use RedisException;
-use RuntimeException;
 
 /**
  * Redis storage engine for cache.
@@ -81,7 +81,7 @@ class RedisEngine extends CacheEngine
     public function init(array $config = []): bool
     {
         if (!extension_loaded('redis')) {
-            throw new RuntimeException('The `redis` extension must be enabled to use RedisEngine.');
+            throw new CakeException('The `redis` extension must be enabled to use RedisEngine.');
         }
 
         if (!empty($config['host'])) {

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -37,7 +37,6 @@ use LimitIterator;
 use LogicException;
 use OuterIterator;
 use RecursiveIteratorIterator;
-use RuntimeException;
 use Traversable;
 use const SORT_ASC;
 use const SORT_DESC;
@@ -750,7 +749,7 @@ trait CollectionTrait
             ];
 
             if (!isset($modes[$order])) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     "Invalid direction `%s` provided. Must be one of: 'desc', 'asc', 'leaves'",
                     $order
                 ));

--- a/src/Command/Helper/ProgressHelper.php
+++ b/src/Command/Helper/ProgressHelper.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Command\Helper;
 
 use Cake\Console\Helper;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Create a progress bar using a supplied callback.
@@ -76,7 +76,7 @@ class ProgressHelper extends Helper
             $args['callback'] = $args[0];
         }
         if (!$args['callback'] || !is_callable($args['callback'])) {
-            throw new RuntimeException('Callback option must be a callable.');
+            throw new InvalidArgumentException('Callback option must be a callable.');
         }
         $this->init($args);
 

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -20,10 +20,10 @@ use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use DirectoryIterator;
-use RuntimeException;
 
 /**
  * Command for interactive I18N management.
@@ -83,7 +83,7 @@ class I18nInitCommand extends Command
 
             $content = file_get_contents($sourceFolder . $filename);
             if ($content === false) {
-                throw new RuntimeException(sprintf('Cannot read file content of %s', $sourceFolder . $filename));
+                throw new CakeException(sprintf('Cannot read file content of %s', $sourceFolder . $filename));
             }
             $io->createFile($targetFolder . $newFilename, $content);
             $count++;

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -18,9 +18,9 @@ namespace Cake\Console;
 
 use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\StopException;
+use Cake\Core\Exception\CakeException;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Base class for console commands.
@@ -112,7 +112,7 @@ abstract class BaseCommand implements CommandInterface
      * You can override buildOptionParser() to define your options & arguments.
      *
      * @return \Cake\Console\ConsoleOptionParser
-     * @throws \RuntimeException When the parser is invalid
+     * @throws \Cake\Core\Exception\CakeException When the parser is invalid
      */
     public function getOptionParser(): ConsoleOptionParser
     {
@@ -123,7 +123,7 @@ abstract class BaseCommand implements CommandInterface
 
         $parser = $this->buildOptionParser($parser);
         if ($parser->subcommands()) {
-            throw new RuntimeException(
+            throw new CakeException(
                 'You cannot add sub-commands to `Command` sub-classes. Instead make a separate command.'
             );
         }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -31,7 +31,6 @@ use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Run CLI commands for the provided application.
@@ -126,10 +125,14 @@ class CommandRunner implements EventDispatcherInterface
      * @param array $argv The arguments from the CLI environment.
      * @param \Cake\Console\ConsoleIo|null $io The ConsoleIo instance. Used primarily for testing.
      * @return int The exit code of the command.
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     public function run(array $argv, ?ConsoleIo $io = null): int
     {
+        if (empty($argv)) {
+            throw new InvalidArgumentException('Cannot run any commands. No arguments received.');
+        }
+
         $this->bootstrap();
 
         $commands = new CommandCollection([
@@ -146,9 +149,6 @@ class CommandRunner implements EventDispatcherInterface
         $this->dispatchEvent('Console.buildCommands', ['commands' => $commands]);
         $this->loadRoutes();
 
-        if (empty($argv)) {
-            throw new RuntimeException('Cannot run any commands. No arguments received.');
-        }
         // Remove the root executable segment
         array_shift($argv);
 

--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -26,7 +26,6 @@ use Cake\Console\TestSuite\Constraint\ContentsNotContain;
 use Cake\Console\TestSuite\Constraint\ContentsRegExp;
 use Cake\Console\TestSuite\Constraint\ExitCode;
 use Cake\Core\TestSuite\ContainerStubTrait;
-use RuntimeException;
 
 /**
  * A bundle of methods that makes testing commands
@@ -73,7 +72,7 @@ trait ConsoleIntegrationTestTrait
      * @param string $command Command to run
      * @param array $input Input values to pass to an interactive shell
      * @throws \Cake\Console\TestSuite\MissingConsoleInputException
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @return void
      */
     public function exec(string $command, array $input = []): void
@@ -89,7 +88,9 @@ trait ConsoleIntegrationTestTrait
         if ($this->_in === null) {
             $this->_in = new StubConsoleInput($input);
         } elseif ($input) {
-            throw new RuntimeException('You can use `$input` only if `$_in` property is null and will be reset.');
+            throw new InvalidArgumentException(
+                'You can use `$input` only if `$_in` property is null and will be reset.'
+            );
         }
 
         $args = $this->commandStringToArgs("cake $command");

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -21,7 +21,6 @@ use Cake\Core\Configure\ConfigEngineInterface;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Exception\CakeException;
 use Cake\Utility\Hash;
-use RuntimeException;
 
 /**
  * Configuration class. Used for managing runtime configuration information.
@@ -156,13 +155,13 @@ class Configure
      *
      * @param string $var Variable to obtain. Use '.' to access array elements.
      * @return mixed Value stored in configure.
-     * @throws \RuntimeException if the requested configuration is not set.
+     * @throws \Cake\Core\Exception\CakeException if the requested configuration is not set.
      * @link https://book.cakephp.org/4/en/development/configuration.html#reading-configuration-data
      */
     public static function readOrFail(string $var): mixed
     {
         if (!static::check($var)) {
-            throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
+            throw new CakeException(sprintf('Expected configuration key "%s" not found.', $var));
         }
 
         return static::read($var);
@@ -196,13 +195,13 @@ class Configure
      *
      * @param string $var Variable to consume. Use '.' to access array elements.
      * @return mixed Value stored in configure.
-     * @throws \RuntimeException if the requested configuration is not set.
+     * @throws \Cake\Core\Exception\CakeException if the requested configuration is not set.
      * @since 3.6.0
      */
     public static function consumeOrFail(string $var): mixed
     {
         if (!static::check($var)) {
-            throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
+            throw new CakeException(sprintf('Expected configuration key "%s" not found.', $var));
         }
 
         return static::consume($var);
@@ -447,14 +446,13 @@ class Configure
      * @param string $cacheConfig The cache configuration to save into. Defaults to 'default'
      * @param array|null $data Either an array of data to store, or leave empty to store all values.
      * @return bool Success
-     * @throws \RuntimeException
      */
     public static function store(string $name, string $cacheConfig = 'default', ?array $data = null): bool
     {
         $data ??= static::$_values;
 
         if (!class_exists(Cache::class)) {
-            throw new RuntimeException('You must install cakephp/cache to use Configure::store()');
+            throw new CakeException('You must install cakephp/cache to use Configure::store()');
         }
 
         return Cache::write($name, $data, $cacheConfig);
@@ -467,12 +465,11 @@ class Configure
      * @param string $name Name of the stored config file to load.
      * @param string $cacheConfig Name of the Cache configuration to read from.
      * @return bool Success.
-     * @throws \RuntimeException
      */
     public static function restore(string $name, string $cacheConfig = 'default'): bool
     {
         if (!class_exists(Cache::class)) {
-            throw new RuntimeException('You must install cakephp/cache to use Configure::restore()');
+            throw new CakeException('You must install cakephp/cache to use Configure::restore()');
         }
         $values = Cache::read($name, $cacheConfig);
         if ($values) {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -17,11 +17,11 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use ArrayIterator;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventListenerInterface;
 use Countable;
 use IteratorAggregate;
-use RuntimeException;
 use Traversable;
 
 /**
@@ -127,7 +127,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @param string $name The name of the alias in the registry.
      * @param array<string, mixed> $config The config data for the new instance.
      * @return void
-     * @throws \RuntimeException When a duplicate is found.
+     * @throws \Cake\Core\Exception\CakeException When a duplicate is found.
      */
     protected function _checkDuplicate(string $name, array $config): void
     {
@@ -135,7 +135,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         $msg = sprintf('The "%s" alias has already been loaded.', $name);
         $hasConfig = method_exists($existing, 'getConfig');
         if (!$hasConfig) {
-            throw new RuntimeException($msg);
+            throw new CakeException($msg);
         }
         if (empty($config)) {
             return;
@@ -160,7 +160,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
             }
         }
         if ($failure) {
-            throw new RuntimeException($msg . $failure);
+            throw new CakeException($msg . $failure);
         }
     }
 
@@ -223,13 +223,13 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      *
      * @param string $name Name of object.
      * @return object Object instance.
-     * @throws \RuntimeException If not loaded or found.
+     * @throws \Cake\Core\Exception\CakeException If not loaded or found.
      * @psalm-return TObject
      */
     public function get(string $name): object
     {
         if (!isset($this->_loaded[$name])) {
-            throw new RuntimeException(sprintf('Unknown object "%s"', $name));
+            throw new CakeException(sprintf('Unknown object "%s"', $name));
         }
 
         return $this->_loaded[$name];

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
+use Cake\Core\Exception\CakeException;
 use League\Container\DefinitionContainerInterface;
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Container\ServiceProvider\BootableServiceProviderInterface;
-use RuntimeException;
 
 /**
  * Container ServiceProvider
@@ -54,7 +54,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
                 ContainerInterface::class,
                 get_debug_type($container)
             );
-            throw new RuntimeException($message);
+            throw new CakeException($message);
         }
 
         return $container;

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -18,6 +18,7 @@ namespace Cake\Database;
 
 use Cake\Cache\Cache;
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Retry\CommandRetry;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\MissingDriverException;
@@ -31,7 +32,6 @@ use Cake\Datasource\ConnectionInterface;
 use Cake\Log\Log;
 use Closure;
 use Psr\SimpleCache\CacheInterface;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -750,7 +750,7 @@ class Connection implements ConnectionInterface
         }
 
         if (!class_exists(Cache::class)) {
-            throw new RuntimeException(
+            throw new CakeException(
                 'To use caching you must either set a cacher using Connection::setCacher()' .
                 ' or require the cakephp/cache package in your composer config.'
             );

--- a/src/Database/Driver/SqlDialectTrait.php
+++ b/src/Database/Driver/SqlDialectTrait.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Driver;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\IdentifierQuoter;
 use Cake\Database\Query;
 use Closure;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Sql dialect trait
@@ -223,13 +223,13 @@ trait SqlDialectTrait
      *
      * @param \Cake\Database\Query $query The query to process.
      * @return \Cake\Database\Query The modified query.
-     * @throws \RuntimeException In case the processed query contains any joins, as removing
+     * @throws \Cake\Database\Exception\DatabaseException In case the processed query contains any joins, as removing
      *  aliases from the conditions can break references to the joined tables.
      */
     protected function _removeAliasesFromConditions(Query $query): Query
     {
         if ($query->clause('join')) {
-            throw new RuntimeException(
+            throw new DatabaseException(
                 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
                 'this can break references to joined tables.'
             );

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -20,7 +20,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\Query;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Provides a translator method for tuple comparisons
@@ -58,7 +58,7 @@ trait TupleComparisonTranslatorTrait
 
         $operator = strtoupper($expression->getOperator());
         if (!in_array($operator, ['IN', '='])) {
-            throw new RuntimeException(
+            throw new InvalidArgumentException(
                 sprintf(
                     'Tuple comparison transform only supports the `IN` and `=` operators, `%s` given.',
                     $operator

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Expression;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 use Closure;
-use RuntimeException;
 
 /**
  * An expression that represents a common table expression definition.
@@ -102,7 +102,7 @@ class CommonTableExpression implements ExpressionInterface
         if ($query instanceof Closure) {
             $query = $query();
             if (!($query instanceof ExpressionInterface)) {
-                throw new RuntimeException(
+                throw new DatabaseException(
                     'You must return an `ExpressionInterface` from a Closure passed to `query()`.'
                 );
             }

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -19,7 +19,7 @@ namespace Cake\Database\Expression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * An expression object for ORDER BY clauses
@@ -75,7 +75,7 @@ class OrderByExpression extends QueryExpression
                 is_string($val) &&
                 !in_array(strtoupper($val), ['ASC', 'DESC'], true)
             ) {
-                throw new RuntimeException(
+                throw new InvalidArgumentException(
                     sprintf(
                         'Passing extra expressions by associative array (`\'%s\' => \'%s\'`) ' .
                         'is not allowed to avoid potential SQL injection. ' .

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database;
 
 use ArrayIterator;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
@@ -28,7 +29,6 @@ use Cake\Database\Expression\WindowExpression;
 use Closure;
 use InvalidArgumentException;
 use IteratorAggregate;
-use RuntimeException;
 use Stringable;
 use Traversable;
 
@@ -279,12 +279,12 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      * The results are cached until the query is modified and marked dirty.
      *
      * @return iterable
-     * @thows \RuntimeException When query is not a SELECT query.
+     * @throws \Cake\Core\Exception\CakeException When query is not a SELECT query.
      */
     public function all(): iterable
     {
         if ($this->_type !== Query::TYPE_SELECT) {
-            throw new RuntimeException(
+            throw new CakeException(
                 '`all()` supports SELECT queries only. Use `execute()` to run all other queries.'
             );
         }
@@ -475,7 +475,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
             $query = $this->getConnection()->newQuery();
             $cte = $cte(new CommonTableExpression(), $query);
             if (!($cte instanceof CommonTableExpression)) {
-                throw new RuntimeException(
+                throw new CakeException(
                     'You must return a `CommonTableExpression` from a Closure passed to `with()`.'
                 );
             }
@@ -1532,7 +1532,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
         if ($window instanceof Closure) {
             $window = $window(new WindowExpression(), $this);
             if (!($window instanceof WindowExpression)) {
-                throw new RuntimeException('You must return a `WindowExpression` from a Closure passed to `window()`.');
+                throw new CakeException('You must return a `WindowExpression` from a Closure passed to `window()`.');
             }
         }
 
@@ -1711,12 +1711,12 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
      * @param array $columns The columns to insert into.
      * @param array<string, string> $types A map between columns & their datatypes.
      * @return $this
-     * @throws \RuntimeException When there are 0 columns.
+     * @throws \InvalidArgumentException When there are 0 columns.
      */
     public function insert(array $columns, array $types = [])
     {
         if (empty($columns)) {
-            throw new RuntimeException('At least 1 column is required to perform an insert.');
+            throw new InvalidArgumentException('At least 1 column is required to perform an insert.');
         }
         $this->_dirty();
         $this->_type = 'insert';
@@ -2402,7 +2402,7 @@ class Query implements ExpressionInterface, IteratorAggregate, Stringable
             set_error_handler(
                 /** @return no-return */
                 function ($errno, $errstr): void {
-                    throw new RuntimeException($errstr, $errno);
+                    throw new CakeException($errstr, $errno);
                 },
                 E_ALL
             );

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Database\DriverInterface;
+use Cake\Database\Exception\DatabaseException;
 use Cake\I18n\DateTime;
 use Cake\I18n\I18nDateTimeInterface;
 use DateTime as NativeDateTime;
@@ -26,7 +27,6 @@ use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
 use PDO;
-use RuntimeException;
 
 /**
  * Datetime type converter.
@@ -402,7 +402,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
 
             return $this;
         }
-        throw new RuntimeException(
+        throw new DatabaseException(
             sprintf('Cannot use locale parsing with the %s class', $this->_className)
         );
     }

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Database\DriverInterface;
+use Cake\Database\Exception\DatabaseException;
 use Cake\I18n\Number;
 use InvalidArgumentException;
 use PDO;
-use RuntimeException;
 use Stringable;
 
 /**
@@ -151,7 +151,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
      *
      * @param bool $enable Whether to enable
      * @return $this
-     * @throws \RuntimeException
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     public function useLocaleParser(bool $enable = true)
     {
@@ -168,7 +168,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
 
             return $this;
         }
-        throw new RuntimeException(
+        throw new DatabaseException(
             sprintf('Cannot use locale parsing with the %s class', static::$numberClass)
         );
     }

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace Cake\Database\Type;
 
 use Cake\Database\DriverInterface;
+use Cake\Database\Exception\DatabaseException;
 use Cake\I18n\Number;
 use PDO;
-use RuntimeException;
 
 /**
  * Float type converter.
@@ -150,7 +150,7 @@ class FloatType extends BaseType implements BatchCastingInterface
 
             return $this;
         }
-        throw new RuntimeException(
+        throw new DatabaseException(
             sprintf('Cannot use locale parsing with the %s class', static::$numberClass)
         );
     }

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Locator;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\RepositoryInterface;
-use RuntimeException;
 
 /**
  * Provides an abstract registry/factory for repository objects.
@@ -44,7 +44,7 @@ abstract class AbstractLocator implements LocatorInterface
      * @param string $alias The alias name you want to get.
      * @param array<string, mixed> $options The options you want to build the table with.
      * @return \Cake\Datasource\RepositoryInterface
-     * @throws \RuntimeException When trying to get alias for which instance
+     * @throws \Cake\Core\Exception\CakeException When trying to get alias for which instance
      *   has already been created with different options.
      */
     public function get(string $alias, array $options = []): RepositoryInterface
@@ -54,7 +54,7 @@ abstract class AbstractLocator implements LocatorInterface
 
         if (isset($this->instances[$alias])) {
             if (!empty($storeOptions) && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
-                throw new RuntimeException(sprintf(
+                throw new CakeException(sprintf(
                     'You cannot configure "%s", it already exists in the registry.',
                     $alias
                 ));

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Cache\Cache;
+use Cake\Core\Exception\CakeException;
 use Closure;
 use Psr\SimpleCache\CacheInterface;
-use RuntimeException;
 use Traversable;
 
 /**
@@ -97,7 +97,7 @@ class QueryCacher
      *
      * @param object $query The query to generate a key for.
      * @return string
-     * @throws \RuntimeException
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _resolveKey(object $query): string
     {
@@ -108,7 +108,7 @@ class QueryCacher
         $key = $func($query);
         if (!is_string($key)) {
             $msg = sprintf('Cache key functions must return a string. Got %s.', var_export($key, true));
-            throw new RuntimeException($msg);
+            throw new CakeException($msg);
         }
 
         return $key;

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Error\Debug;
 
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * A Debugger formatter for generating output with ANSI escape codes
@@ -138,7 +138,7 @@ class ConsoleFormatter implements FormatterInterface
         if ($var instanceof SpecialNode) {
             return $this->style('special', $var->getValue());
         }
-        throw new RuntimeException('Unknown node received ' . get_class($var));
+        throw new InvalidArgumentException('Unknown node received ' . get_class($var));
     }
 
     /**

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Error\Debug;
 
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * A Debugger formatter for generating interactive styled HTML output.
@@ -143,7 +143,7 @@ class HtmlFormatter implements FormatterInterface
         if ($var instanceof SpecialNode) {
             return $this->style('special', $var->getValue());
         }
-        throw new RuntimeException('Unknown node received ' . get_class($var));
+        throw new InvalidArgumentException('Unknown node received ' . get_class($var));
     }
 
     /**

--- a/src/Error/Debug/TextFormatter.php
+++ b/src/Error/Debug/TextFormatter.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Error\Debug;
 
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * A Debugger formatter for generating unstyled plain text output.
@@ -87,7 +87,7 @@ TEXT;
         if ($var instanceof SpecialNode) {
             return $var->getValue();
         }
-        throw new RuntimeException('Unknown node received ' . get_class($var));
+        throw new InvalidArgumentException('Unknown node received ' . get_class($var));
     }
 
     /**

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Error;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Error\Debug\ArrayItemNode;
 use Cake\Error\Debug\ArrayNode;
@@ -39,7 +40,6 @@ use Exception;
 use InvalidArgumentException;
 use ReflectionObject;
 use ReflectionProperty;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -201,7 +201,7 @@ class Debugger
         $instance = static::getInstance();
         if (!isset($instance->editors[$name])) {
             $known = implode(', ', array_keys($instance->editors));
-            throw new RuntimeException("Unknown editor `{$name}`. Known editors are {$known}");
+            throw new InvalidArgumentException("Unknown editor `{$name}`. Known editors are {$known}");
         }
         $instance->setConfig('editor', $name);
     }
@@ -218,7 +218,7 @@ class Debugger
         $instance = static::getInstance();
         $editor = $instance->getConfig('editor');
         if (!isset($instance->editors[$editor])) {
-            throw new RuntimeException("Cannot format editor URL `{$editor}` is not a known editor.");
+            throw new InvalidArgumentException("Cannot format editor URL `{$editor}` is not a known editor.");
         }
 
         $template = $instance->editors[$editor];
@@ -501,7 +501,7 @@ class Debugger
         }
         $instance = new $class();
         if (!$instance instanceof FormatterInterface) {
-            throw new RuntimeException(
+            throw new CakeException(
                 "The `{$class}` formatter does not implement " . FormatterInterface::class
             );
         }

--- a/src/Event/Decorator/ConditionDecorator.php
+++ b/src/Event/Decorator/ConditionDecorator.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Event\Decorator;
 
 use Cake\Event\EventInterface;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Event Condition Decorator
@@ -67,7 +67,7 @@ class ConditionDecorator extends AbstractDecorator
             return $condition !== 'unless';
         }
         if (!is_callable($this->_options[$condition])) {
-            throw new RuntimeException(self::class . ' the `' . $condition . '` condition is not a callable!');
+            throw new InvalidArgumentException(self::class . ' the `' . $condition . '` condition is not a callable!');
         }
 
         return (bool)$this->_options[$condition]($event);

--- a/src/Event/Decorator/SubjectFilterDecorator.php
+++ b/src/Event/Decorator/SubjectFilterDecorator.php
@@ -18,7 +18,6 @@ namespace Cake\Event\Decorator;
 
 use Cake\Core\Exception\CakeException;
 use Cake\Event\EventInterface;
-use RuntimeException;
 
 /**
  * Event Subject Filter Decorator
@@ -53,7 +52,7 @@ class SubjectFilterDecorator extends AbstractDecorator
     public function canTrigger(EventInterface $event): bool
     {
         if (!isset($this->_options['allowedSubject'])) {
-            throw new RuntimeException(self::class . ' Missing subject filter options!');
+            throw new CakeException(self::class . ' Missing subject filter options!');
         }
         if (is_string($this->_options['allowedSubject'])) {
             $this->_options['allowedSubject'] = [$this->_options['allowedSubject']];

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -19,7 +19,6 @@ use Cake\Core\Exception\CakeException;
 use Cake\Http\Client\Request;
 use Cake\Utility\Security;
 use Psr\Http\Message\UriInterface;
-use RuntimeException;
 
 /**
  * Oauth 1 authentication strategy for Cake\Http\Client
@@ -171,12 +170,11 @@ class Oauth
      * @param \Cake\Http\Client\Request $request The request object.
      * @param array $credentials Authentication credentials.
      * @return string
-     * @throws \RuntimeException
      */
     protected function _rsaSha1(Request $request, array $credentials): string
     {
         if (!function_exists('openssl_pkey_get_private')) {
-            throw new RuntimeException('RSA-SHA1 signature method requires the OpenSSL extension.');
+            throw new CakeException('RSA-SHA1 signature method requires the OpenSSL extension.');
         }
 
         $nonce = $credentials['nonce'] ?? bin2hex(Security::randomBytes(16));
@@ -369,9 +367,10 @@ class Oauth
     }
 
     /**
-     * Check for SSL errors and raise if one is encountered.
+     * Check for SSL errors and throw an exception if found.
      *
      * @return void
+     * @throws \Cake\Core\Exception\CakeException When an error is found
      */
     protected function checkSslError(): void
     {
@@ -381,7 +380,7 @@ class Oauth
         }
 
         if (strlen($error) > 0) {
-            throw new RuntimeException('openssl error: ' . $error);
+            throw new CakeException('openssl error: ' . $error);
         }
     }
 }

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -15,11 +15,11 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Client;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Cookie\CookieCollection;
 use Laminas\Diactoros\MessageTrait;
 use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
 use SimpleXMLElement;
 
 /**
@@ -145,12 +145,12 @@ class Response extends Message implements ResponseInterface
      *
      * @param string $body Gzip encoded body.
      * @return string
-     * @throws \RuntimeException When attempting to decode gzip content without gzinflate.
+     * @throws \Cake\Core\Exception\CakeException When attempting to decode gzip content without gzinflate.
      */
     protected function _decodeGzipBody(string $body): string
     {
         if (!function_exists('gzinflate')) {
-            throw new RuntimeException('Cannot decompress gzip response body without gzinflate()');
+            throw new CakeException('Cannot decompress gzip response body without gzinflate()');
         }
         $offset = 0;
         // Look for gzip 'signature'
@@ -162,7 +162,7 @@ class Response extends Message implements ResponseInterface
             return gzinflate(substr($body, $offset + 8));
         }
 
-        throw new RuntimeException('Invalid gzip response');
+        throw new CakeException('Invalid gzip response');
     }
 
     /**

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -17,13 +17,13 @@ declare(strict_types=1);
 
 namespace Cake\Http\Middleware;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use ParagonIE\CSPBuilder\CSPBuilder;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 
 /**
  * Content Security Policy Middleware
@@ -59,12 +59,11 @@ class CspMiddleware implements MiddlewareInterface
      *
      * @param \ParagonIE\CSPBuilder\CSPBuilder|array $csp CSP object or config array
      * @param array<string, mixed> $config Configuration options.
-     * @throws \RuntimeException
      */
     public function __construct(CSPBuilder|array $csp, array $config = [])
     {
         if (!class_exists(CSPBuilder::class)) {
-            throw new RuntimeException('You must install paragonie/csp-builder to use CspMiddleware');
+            throw new CakeException('You must install paragonie/csp-builder to use CspMiddleware');
         }
         $this->setConfig($config);
 

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Http\Middleware;
 
 use ArrayAccess;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
 use Cake\Http\Exception\InvalidCsrfTokenException;
@@ -28,7 +29,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 
 /**
  * Provides CSRF protection & validation.
@@ -133,7 +133,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
         if ($request->getAttribute('csrfToken')) {
-            throw new RuntimeException(
+            throw new CakeException(
                 'A CSRF token is already set in the request.' .
                 "\n" .
                 'Ensure you do not have the CSRF middleware applied more than once. ' .

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Http\Middleware;
 
 use ArrayAccess;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Exception\InvalidCsrfTokenException;
 use Cake\Http\Session;
 use Cake\Utility\Hash;
@@ -25,7 +26,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 
 /**
  * Provides CSRF protection via session based tokens.
@@ -110,7 +110,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
 
         $session = $request->getAttribute('session');
         if (!$session || !($session instanceof Session)) {
-            throw new RuntimeException('You must have a `session` attribute to use session based CSRF tokens');
+            throw new CakeException('You must have a `session` attribute to use session based CSRF tokens');
         }
 
         $token = $session->read($this->_config['key']);

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -20,10 +20,10 @@ use Cake\Core\App;
 use Cake\Http\Middleware\ClosureDecoratorMiddleware;
 use Closure;
 use Countable;
+use InvalidArgumentException;
 use LogicException;
 use OutOfBoundsException;
 use Psr\Http\Server\MiddlewareInterface;
-use RuntimeException;
 use SeekableIterator;
 
 /**
@@ -63,7 +63,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
      *
      * @param \Psr\Http\Server\MiddlewareInterface|\Closure|string $middleware The middleware to resolve.
      * @return \Psr\Http\Server\MiddlewareInterface
-     * @throws \RuntimeException If Middleware not found.
+     * @throws \InvalidArgumentException If Middleware not found.
      */
     protected function resolve(MiddlewareInterface|Closure|string $middleware): MiddlewareInterface
     {
@@ -71,7 +71,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
             /** @psalm-var class-string<\Psr\Http\Server\MiddlewareInterface>|null $className */
             $className = App::className($middleware, 'Middleware', 'Middleware');
             if ($className === null) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'Middleware "%s" was not found.',
                     $middleware
                 ));

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
-use RuntimeException;
 use SessionHandlerInterface;
 use const PHP_SESSION_ACTIVE;
 
@@ -308,7 +308,7 @@ class Session
      *
      * @param array<string, mixed> $options Ini options to set.
      * @return void
-     * @throws \RuntimeException if any directive could not be set
+     * @throws \Cake\Core\Exception\CakeException if any directive could not be set
      */
     public function options(array $options): void
     {
@@ -318,7 +318,7 @@ class Session
 
         foreach ($options as $setting => $value) {
             if (ini_set($setting, (string)$value) === false) {
-                throw new RuntimeException(
+                throw new CakeException(
                     sprintf('Unable to configure the session, setting %s failed.', $setting)
                 );
             }
@@ -329,7 +329,7 @@ class Session
      * Starts the Session.
      *
      * @return bool True if session was started
-     * @throws \RuntimeException if the session was already started
+     * @throws \Cake\Core\Exception\CakeException if the session was already started
      */
     public function start(): bool
     {
@@ -345,7 +345,7 @@ class Session
         }
 
         if (session_status() === PHP_SESSION_ACTIVE) {
-            throw new RuntimeException('Session was already started');
+            throw new CakeException('Session was already started');
         }
 
         if (ini_get('session.use_cookies') && headers_sent()) {
@@ -353,7 +353,7 @@ class Session
         }
 
         if (!session_start()) {
-            throw new RuntimeException('Could not start the session');
+            throw new CakeException('Could not start the session');
         }
 
         $this->_started = true;
@@ -385,7 +385,7 @@ class Session
         }
 
         if (!session_write_close()) {
-            throw new RuntimeException('Could not close the session');
+            throw new CakeException('Could not close the session');
         }
 
         $this->_started = false;
@@ -455,13 +455,13 @@ class Session
      * Returns given session variable, or throws Exception if not found.
      *
      * @param string $name The name of the session variable (or a path as sent to Hash.extract)
-     * @throws \RuntimeException
+     * @throws \Cake\Core\Exception\CakeException
      * @return mixed|null
      */
     public function readOrFail(string $name): mixed
     {
         if (!$this->check($name)) {
-            throw new RuntimeException(sprintf('Expected session key "%s" not found.', $name));
+            throw new CakeException(sprintf('Expected session key "%s" not found.', $name));
         }
 
         return $this->read($name);

--- a/src/I18n/ChainMessagesLoader.php
+++ b/src/I18n/ChainMessagesLoader.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\I18n;
 
-use RuntimeException;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Wraps multiple message loaders calling them one after another until
@@ -47,13 +47,13 @@ class ChainMessagesLoader
      * the chain.
      *
      * @return \Cake\I18n\Package
-     * @throws \RuntimeException if any of the loaders in the chain is not a valid callable
+     * @throws \Cake\Core\Exception\CakeException if any of the loaders in the chain is not a valid callable
      */
     public function __invoke(): Package
     {
         foreach ($this->_loaders as $k => $loader) {
             if (!is_callable($loader)) {
-                throw new RuntimeException(sprintf(
+                throw new CakeException(sprintf(
                     'Loader "%s" in the chain is not a valid callable',
                     $k
                 ));
@@ -65,7 +65,7 @@ class ChainMessagesLoader
             }
 
             if (!($package instanceof Package)) {
-                throw new RuntimeException(sprintf(
+                throw new CakeException(sprintf(
                     'Loader "%s" in the chain did not return a valid Package object',
                     $k
                 ));

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -23,7 +23,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use IntlDateFormatter;
-use RuntimeException;
 
 /**
  * Trait for date formatting methods shared by both Time & Date.
@@ -258,7 +257,7 @@ trait DateFormatTrait
                 $pattern
             );
             if (empty($formatter)) {
-                throw new RuntimeException(
+                throw new CakeException(
                     'Your version of icu does not support creating a date formatter for ' .
                     "`$key`. You should try to upgrade libicu and the intl extension."
                 );

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\I18n;
 
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Plugin;
 use Cake\Utility\Inflector;
 use Locale;
-use RuntimeException;
 
 /**
  * A generic translations package factory that will load translations files
@@ -104,7 +104,7 @@ class MessagesFileLoader
      * package containing the messages loaded from the file.
      *
      * @return \Cake\I18n\Package|false
-     * @throws \RuntimeException if no file parser class could be found for the specified
+     * @throws \Cake\Core\Exception\CakeException if no file parser class could be found for the specified
      * file extension.
      */
     public function __invoke(): Package|false
@@ -119,7 +119,7 @@ class MessagesFileLoader
         $class = App::className($name, 'I18n\Parser', 'FileParser');
 
         if (!$class) {
-            throw new RuntimeException(sprintf('Could not find class %s', "{$name}FileParser"));
+            throw new CakeException(sprintf('Could not find class %s', "{$name}FileParser"));
         }
 
         /** @var \Cake\I18n\Parser\MoFileParser|\Cake\I18n\Parser\PoFileParser $object */

--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\I18n\Parser;
 
-use RuntimeException;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Parses file in MO format
@@ -55,7 +55,7 @@ class MoFileParser
      *
      * @param string $file The file to be parsed.
      * @return array List of messages extracted from the file
-     * @throws \RuntimeException If stream content has an invalid format.
+     * @throws \Cake\Core\Exception\CakeException If stream content has an invalid format.
      */
     public function parse(string $file): array
     {
@@ -64,7 +64,7 @@ class MoFileParser
         $stat = fstat($stream);
 
         if ($stat['size'] < self::MO_HEADER_SIZE) {
-            throw new RuntimeException('Invalid format for MO translations file');
+            throw new CakeException('Invalid format for MO translations file');
         }
         $magic = unpack('V1', fread($stream, 4));
         $magic = hexdec(substr(dechex(current($magic)), -8));
@@ -74,7 +74,7 @@ class MoFileParser
         } elseif ($magic === self::MO_BIG_ENDIAN_MAGIC) {
             $isBigEndian = true;
         } else {
-            throw new RuntimeException('Invalid format for MO translations file');
+            throw new CakeException('Invalid format for MO translations file');
         }
 
         // offset formatRevision

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace Cake\Log;
 
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\ObjectRegistry;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 
 /**
  * Registry of loaded log engines
@@ -50,11 +50,11 @@ class LogEngineRegistry extends ObjectRegistry
      * @param string $class The classname that is missing.
      * @param string|null $plugin The plugin the logger is missing in.
      * @return void
-     * @throws \RuntimeException
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
-        throw new RuntimeException(sprintf('Could not load class %s', $class));
+        throw new CakeException(sprintf('Could not load class %s', $class));
     }
 
     /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -20,6 +20,7 @@ use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Core\App;
 use Cake\Core\ConventionsTrait;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
@@ -29,7 +30,6 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\Utility\Inflector;
 use Closure;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * An Association is a relationship established between two tables and is used
@@ -381,7 +381,7 @@ abstract class Association
                     $errorMessage .= 'You can\'t have an association of the same name with a different target ';
                     $errorMessage .= '"className" option anywhere in your app.';
 
-                    throw new RuntimeException(sprintf(
+                    throw new DatabaseException(sprintf(
                         $errorMessage,
                         isset($this->_sourceTable) ? get_class($this->_sourceTable) : 'null',
                         $this->getName(),
@@ -724,7 +724,7 @@ abstract class Association
         if (!empty($options['queryBuilder'])) {
             $dummy = $options['queryBuilder']($dummy);
             if (!($dummy instanceof Query)) {
-                throw new RuntimeException(sprintf(
+                throw new DatabaseException(sprintf(
                     'Query builder for association "%s" did not return a query',
                     $this->getName()
                 ));
@@ -736,7 +736,7 @@ abstract class Association
             $this->_strategy === static::STRATEGY_JOIN &&
             $dummy->getContain()
         ) {
-            throw new RuntimeException(
+            throw new DatabaseException(
                 "`{$this->getName()}` association cannot contain() associations when using JOIN strategy."
             );
         }
@@ -1060,7 +1060,7 @@ abstract class Association
      *
      * @param array<string, mixed> $options list of options passed to attachTo method
      * @return array
-     * @throws \RuntimeException if the number of columns in the foreignKey do not
+     * @throws \Cake\Database\Exception\DatabaseException if the number of columns in the foreignKey do not
      * match the number of columns in the source table primaryKey
      */
     protected function _joinCondition(array $options): array
@@ -1078,11 +1078,11 @@ abstract class Association
                     $table = $this->getSource()->getTable();
                 }
                 $msg = 'The "%s" table does not define a primary key, and cannot have join conditions generated.';
-                throw new RuntimeException(sprintf($msg, $table));
+                throw new DatabaseException(sprintf($msg, $table));
             }
 
             $msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
-            throw new RuntimeException(sprintf(
+            throw new DatabaseException(sprintf(
                 $msg,
                 $this->_name,
                 implode(', ', $foreignKey),

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
@@ -23,7 +24,6 @@ use Cake\ORM\Association\Loader\SelectLoader;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 use Closure;
-use RuntimeException;
 
 /**
  * Represents an 1 - N relationship where the source side of the relation is
@@ -159,7 +159,7 @@ class BelongsTo extends Association
      *
      * @param array<string, mixed> $options list of options passed to attachTo method
      * @return array<\Cake\Database\Expression\IdentifierExpression>
-     * @throws \RuntimeException if the number of columns in the foreignKey do not
+     * @throws \Cake\Database\Exception\DatabaseException if the number of columns in the foreignKey do not
      * match the number of columns in the target table primaryKey
      */
     protected function _joinCondition(array $options): array
@@ -173,11 +173,11 @@ class BelongsTo extends Association
         if (count($foreignKey) !== count($bindingKey)) {
             if (empty($bindingKey)) {
                 $msg = 'The "%s" table does not define a primary key. Please set one.';
-                throw new RuntimeException(sprintf($msg, $this->getTarget()->getTable()));
+                throw new DatabaseException(sprintf($msg, $this->getTarget()->getTable()));
             }
 
             $msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
-            throw new RuntimeException(sprintf(
+            throw new DatabaseException(sprintf(
                 $msg,
                 $this->_name,
                 implode(', ', $foreignKey),

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association\Loader;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\TupleComparison;
 use Cake\Database\ExpressionInterface;
@@ -24,7 +25,6 @@ use Cake\ORM\Association;
 use Cake\ORM\Query;
 use Closure;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Implements the logic for loading an association using a SELECT query
@@ -370,7 +370,7 @@ class SelectLoader
      *
      * @param array<string, mixed> $options The options for getting the link field.
      * @return array<string>|string
-     * @throws \RuntimeException
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     protected function _linkField(array $options): array|string
     {
@@ -380,7 +380,7 @@ class SelectLoader
         if ($options['foreignKey'] === false && $this->associationType === Association::ONE_TO_MANY) {
             $msg = 'Cannot have foreignKey = false for hasMany associations. ' .
                    'You must provide a foreignKey column.';
-            throw new RuntimeException($msg);
+            throw new DatabaseException($msg);
         }
 
         $keys = in_array($this->associationType, [Association::ONE_TO_ONE, Association::ONE_TO_MANY], true) ?

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Association\Loader;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Query;
 use Closure;
-use RuntimeException;
 
 /**
  * Implements the logic for loading an association using a SELECT query and a pivot table
@@ -170,7 +170,7 @@ class SelectWithPivotLoader extends SelectLoader
      * @param \Cake\ORM\Query $fetchQuery The query to get results from
      * @param array<string, mixed> $options The options passed to the eager loader
      * @return array<string, mixed>
-     * @throws \RuntimeException when the association property is not part of the results set.
+     * @throws \Cake\Database\Exception\DatabaseException when the association property is not part of the results set.
      */
     protected function _buildResultMap(Query $fetchQuery, array $options): array
     {
@@ -179,7 +179,7 @@ class SelectWithPivotLoader extends SelectLoader
 
         foreach ($fetchQuery->all() as $result) {
             if (!isset($result[$this->junctionProperty])) {
-                throw new RuntimeException(sprintf(
+                throw new DatabaseException(sprintf(
                     '"%s" is missing from the belongsToMany results. Results cannot be created.',
                     $this->junctionProperty
                 ));

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -23,7 +23,7 @@ use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
 use Cake\ORM\Behavior;
 use DateTimeInterface;
-use RuntimeException;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -220,7 +220,7 @@ class TimestampBehavior extends Behavior
         $type = TypeFactory::build($columnType);
 
         if (!$type instanceof DateTimeType) {
-            throw new RuntimeException('TimestampBehavior only supports columns of type DateTimeType.');
+            throw new InvalidArgumentException('TimestampBehavior only supports columns of type DateTimeType.');
         }
 
         $class = $type->getDateTimeClassName();

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\ORM\Behavior;
 
 use Cake\Collection\CollectionInterface;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -25,7 +26,6 @@ use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Makes the table to which this is attached to behave like a nested set and
@@ -96,7 +96,7 @@ class TreeBehavior extends Behavior
      * @param \Cake\Event\EventInterface $event The beforeSave event that was fired
      * @param \Cake\Datasource\EntityInterface $entity the entity that is going to be saved
      * @return void
-     * @throws \RuntimeException if the parent to set for the node is invalid
+     * @throws \Cake\Database\Exception\DatabaseException if the parent to set for the node is invalid
      */
     public function beforeSave(EventInterface $event, EntityInterface $entity): void
     {
@@ -108,7 +108,7 @@ class TreeBehavior extends Behavior
         $level = $config['level'];
 
         if ($parent && $entity->get($primaryKey) === $parent) {
-            throw new RuntimeException("Cannot set a node's parent as itself");
+            throw new DatabaseException("Cannot set a node's parent as itself");
         }
 
         if ($isNew) {
@@ -256,7 +256,7 @@ class TreeBehavior extends Behavior
      * @param \Cake\Datasource\EntityInterface $entity The entity to re-parent
      * @param mixed $parent the id of the parent to set
      * @return void
-     * @throws \RuntimeException if the parent to set to the entity is not valid
+     * @throws \Cake\Database\Exception\DatabaseException if the parent to set to the entity is not valid
      */
     protected function _setParent(EntityInterface $entity, mixed $parent): void
     {
@@ -269,7 +269,7 @@ class TreeBehavior extends Behavior
         $left = $entity->get($config['left']);
 
         if ($parentLeft > $left && $parentLeft < $right) {
-            throw new RuntimeException(sprintf(
+            throw new DatabaseException(sprintf(
                 'Cannot use node "%s" as parent for entity "%s"',
                 $parent,
                 $entity->get($this->_getPrimaryKey())

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
-use RuntimeException;
+use Cake\Database\Exception\DatabaseException;
 
 /**
  * Represents a single level in the associations tree to be eagerly loaded
@@ -170,12 +170,12 @@ class EagerLoadable
      * Gets the Association class instance to use for loading the records.
      *
      * @return \Cake\ORM\Association
-     * @throws \RuntimeException
+     * @throws \Cake\Database\Exception\DatabaseException
      */
     public function instance(): Association
     {
         if ($this->_instance === null) {
-            throw new RuntimeException('No instance set.');
+            throw new DatabaseException('No instance set.');
         }
 
         return $this->_instance;

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\ORM\Locator;
 
 use Cake\Core\App;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\Locator\AbstractLocator;
 use Cake\Datasource\RepositoryInterface;
@@ -24,7 +25,6 @@ use Cake\ORM\AssociationCollection;
 use Cake\ORM\Exception\MissingTableClassException;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
-use RuntimeException;
 
 /**
  * Provides a default registry/factory for Table objects.
@@ -141,7 +141,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
         }
 
         if (isset($this->instances[$alias])) {
-            throw new RuntimeException(sprintf(
+            throw new DatabaseException(sprintf(
                 'You cannot configure "%s", it has already been constructed.',
                 $alias
             ));

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -18,6 +18,7 @@ namespace Cake\ORM;
 
 use ArrayObject;
 use Cake\Database\Connection;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\TypedResultInterface;
@@ -30,7 +31,6 @@ use Cake\Datasource\ResultSetInterface;
 use Closure;
 use InvalidArgumentException;
 use JsonSerializable;
-use RuntimeException;
 
 /**
  * Extends the base Query class to provide new methods related to association
@@ -1052,12 +1052,12 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * @param \Cake\Cache\CacheEngine|string $config Either the name of the cache config to use, or
      *   a cache config instance.
      * @return $this
-     * @throws \RuntimeException When you attempt to cache a non-select query.
+     * @throws \Cake\Database\Exception\DatabaseException When you attempt to cache a non-select query.
      */
     public function cache($key, $config = 'default')
     {
         if ($this->_type !== self::TYPE_SELECT) {
-            throw new RuntimeException('You cannot cache the results of non-select queries.');
+            throw new DatabaseException('You cannot cache the results of non-select queries.');
         }
 
         return $this->_cache($key, $config);
@@ -1067,12 +1067,12 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * {@inheritDoc}
      *
      * @return \Cake\Datasource\ResultSetInterface
-     * @throws \RuntimeException if this method is called on a non-select Query.
+     * @throws \Cake\Database\Exception\DatabaseException if this method is called on a non-select Query.
      */
     public function all(): ResultSetInterface
     {
         if ($this->_type !== self::TYPE_SELECT) {
-            throw new RuntimeException(
+            throw new DatabaseException(
                 'You cannot call all() on a non-select query. Use execute() instead.'
             );
         }

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Rule;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
-use RuntimeException;
 
 /**
  * Checks that the value provided in a field exists as the primary key of another
@@ -76,14 +76,14 @@ class ExistsIn
      * @param \Cake\Datasource\EntityInterface $entity The entity from where to extract the fields
      * @param array<string, mixed> $options Options passed to the check,
      * where the `repository` key is required.
-     * @throws \RuntimeException When the rule refers to an undefined association.
+     * @throws \Cake\Database\Exception\DatabaseException When the rule refers to an undefined association.
      * @return bool
      */
     public function __invoke(EntityInterface $entity, array $options): bool
     {
         if (is_string($this->_repository)) {
             if (!$options['repository']->hasAssociation($this->_repository)) {
-                throw new RuntimeException(sprintf(
+                throw new DatabaseException(sprintf(
                     "ExistsIn rule for '%s' is invalid. '%s' is not associated with '%s'.",
                     implode(', ', $this->_fields),
                     $this->_repository,

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Rule;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Checks whether links to a given association exist / do not exist.
@@ -164,7 +164,7 @@ class LinkConstraint
 
         $primaryKey = (array)$source->getPrimaryKey();
         if (!$entity->has($primaryKey)) {
-            throw new RuntimeException(sprintf(
+            throw new DatabaseException(sprintf(
                 'LinkConstraint rule on `%s` requires all primary key values for building the counting ' .
                 'conditions, expected values for `(%s)`, got `(%s)`.',
                 $source->getAlias(),

--- a/src/Routing/Route/EntityRoute.php
+++ b/src/Routing/Route/EntityRoute.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Routing\Route;
 
 use ArrayAccess;
-use RuntimeException;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Matches entities to routes
@@ -71,7 +71,7 @@ class EntityRoute extends Route
     protected function _checkEntity(mixed $entity): void
     {
         if (!$entity instanceof ArrayAccess && !is_array($entity)) {
-            throw new RuntimeException(sprintf(
+            throw new CakeException(sprintf(
                 'Route `%s` expects the URL option `_entity` to be an array or object implementing \ArrayAccess, '
                 . 'but `%s` passed.',
                 $this->template,

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -26,7 +26,6 @@ use Cake\Utility\Inflector;
 use Closure;
 use InvalidArgumentException;
 use Psr\Http\Server\MiddlewareInterface;
-use RuntimeException;
 
 /**
  * Provides features for building routes inside scopes.
@@ -990,7 +989,7 @@ class RouteBuilder
      *
      * @param string ...$names The names of the middleware to apply to the current scope.
      * @return $this
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @see \Cake\Routing\RouteCollection::addMiddlewareToScope()
      */
     public function applyMiddleware(string ...$names)
@@ -999,7 +998,7 @@ class RouteBuilder
             if (!$this->_collection->middlewareExists($name)) {
                 $message = "Cannot apply '$name' middleware or middleware group. " .
                     'Use registerMiddleware() to register middleware.';
-                throw new RuntimeException($message);
+                throw new InvalidArgumentException($message);
             }
         }
         $this->middleware = array_unique(array_merge($this->middleware, $names));

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -20,9 +20,9 @@ use Cake\Routing\Exception\DuplicateNamedRouteException;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
 use Closure;
+use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use RuntimeException;
 
 /**
  * Contains a collection of routes.
@@ -409,19 +409,19 @@ class RouteCollection
      * @param string $name Name of the middleware group
      * @param array<string> $middlewareNames Names of the middleware
      * @return $this
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     public function middlewareGroup(string $name, array $middlewareNames)
     {
         if ($this->hasMiddleware($name)) {
             $message = "Cannot add middleware group '$name'. A middleware by this name has already been registered.";
-            throw new RuntimeException($message);
+            throw new InvalidArgumentException($message);
         }
 
         foreach ($middlewareNames as $middlewareName) {
             if (!$this->hasMiddleware($middlewareName)) {
                 $message = "Cannot add '$middlewareName' middleware to group '$name'. It has not been registered.";
-                throw new RuntimeException($message);
+                throw new InvalidArgumentException($message);
             }
         }
 
@@ -469,7 +469,7 @@ class RouteCollection
      * @param array<string> $names The names of the middleware or groups to fetch
      * @return array An array of middleware. If any of the passed names are groups,
      *   the groups middleware will be flattened into the returned list.
-     * @throws \RuntimeException when a requested middleware does not exist.
+     * @throws \InvalidArgumentException when a requested middleware does not exist.
      */
     public function getMiddleware(array $names): array
     {
@@ -480,7 +480,7 @@ class RouteCollection
                 continue;
             }
             if (!$this->hasMiddleware($name)) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     "The middleware named '%s' has not been registered. Use registerMiddleware() to define it.",
                     $name
                 ));

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Routing;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
@@ -24,7 +25,6 @@ use Closure;
 use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 use ReflectionFunction;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -335,7 +335,7 @@ class Router
                     $ref->getStartLine(),
                     $e->getMessage()
                 );
-                throw new RuntimeException($message, (int)$e->getCode(), $e);
+                throw new CakeException($message, (int)$e->getCode(), $e);
             }
         }
 

--- a/src/TestSuite/Fixture/TransactionFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TransactionFixtureStrategy.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Database\Connection;
-use RuntimeException;
+use Cake\Database\Exception\DatabaseException;
 
 /**
  * Fixture strategy that wraps fixtures in a transaction that is rolled back
@@ -60,7 +60,7 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
                 );
                 $connection->enableSavePoints();
                 if (!$connection->isSavePointsEnabled()) {
-                    throw new RuntimeException(
+                    throw new DatabaseException(
                         "Could not enable save points for the `{$connection->configName()}` connection. " .
                             'Your database needs to support savepoints in order to use ' .
                             'TransactionFixtureStrategy.'

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Database\Connection;
-use RuntimeException;
+use Cake\Database\Exception\DatabaseException;
 
 /**
  * Fixture strategy that wraps fixtures in a transaction that is rolled back
@@ -65,7 +65,7 @@ class TransactionStrategy implements FixtureStrategyInterface
                 );
                 $connection->enableSavePoints();
                 if (!$connection->isSavePointsEnabled()) {
-                    throw new RuntimeException(
+                    throw new DatabaseException(
                         "Could not enable save points for the `{$connection->configName()}` connection. " .
                             'Your database needs to support savepoints in order to use ' .
                             'TransactionStrategy.'

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Cookie Crypt Trait.
@@ -83,7 +83,7 @@ trait CookieCryptTrait
                 'Invalid encryption cipher. Must be one of %s or false.',
                 implode(', ', $this->_validCiphers)
             );
-            throw new RuntimeException($msg);
+            throw new InvalidArgumentException($msg);
         }
     }
 

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -17,7 +17,6 @@ namespace Cake\Utility;
 
 use ArrayAccess;
 use InvalidArgumentException;
-use RuntimeException;
 use const SORT_ASC;
 use const SORT_DESC;
 use const SORT_LOCALE_STRING;
@@ -446,7 +445,7 @@ class Hash
      * @param string|null $groupPath A dot-separated string.
      * @return array Combined array
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::combine
-     * @throws \RuntimeException When keys and values count is unequal.
+     * @throws \InvalidArgumentException When keys and values count is unequal.
      */
     public static function combine(
         array $data,
@@ -486,7 +485,7 @@ class Hash
         }
 
         if (is_array($keys) && count($keys) !== count($vals)) {
-            throw new RuntimeException(
+            throw new InvalidArgumentException(
                 'Hash::combine() needs an equal number of keys + values.'
             );
         }

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Utility\Crypto\OpenSsl;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Security Library contains utility methods related to security
@@ -57,7 +57,7 @@ class Security
      * @param string|bool $salt If true, automatically prepends the value returned by
      *   Security::getSalt() to $string.
      * @return string Hash
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      * @link https://book.cakephp.org/4/en/core-libraries/security.html#hashing-data
      */
     public static function hash(string $string, ?string $algorithm = null, string|bool $salt = false): string
@@ -69,7 +69,7 @@ class Security
 
         $availableAlgorithms = hash_algos();
         if (!in_array($algorithm, $availableAlgorithms, true)) {
-            throw new RuntimeException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'The hash type `%s` was not found. Available algorithms are: %s',
                 $algorithm,
                 implode(', ', $availableAlgorithms)
@@ -283,7 +283,7 @@ class Security
     public static function getSalt(): string
     {
         if (static::$_salt === null) {
-            throw new RuntimeException(
+            throw new CakeException(
                 'Salt not set. Use Security::setSalt() to set one, ideally in `config/bootstrap.php`.'
             );
         }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Validation;
 
+use Cake\Core\Exception\CakeException;
 use Cake\I18n\DateTime;
 use Cake\Utility\Text;
 use Countable;
 use DateTimeInterface;
 use InvalidArgumentException;
-use LogicException;
 use NumberFormatter;
 use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
@@ -1165,8 +1165,7 @@ class Validation
      * @param mixed $check Value to check.
      * @param array|string $mimeTypes Array of mime types or regex pattern to check.
      * @return bool Success
-     * @throws \RuntimeException when mime type can not be determined.
-     * @throws \LogicException when ext/fileinfo is missing
+     * @throws \Cake\Core\Exception\CakeException when mime type can not be determined.
      */
     public static function mimeType(mixed $check, array|string $mimeTypes = []): bool
     {
@@ -1176,18 +1175,18 @@ class Validation
         }
 
         if (!function_exists('finfo_open')) {
-            throw new LogicException('ext/fileinfo is required for validating file mime types');
+            throw new CakeException('ext/fileinfo is required for validating file mime types');
         }
 
         if (!is_file($file)) {
-            throw new RuntimeException('Cannot validate mimetype for a missing file');
+            throw new CakeException('Cannot validate mimetype for a missing file');
         }
 
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $file);
 
         if (!$mime) {
-            throw new RuntimeException('Can not determine the mimetype.');
+            throw new CakeException('Can not determine the mimetype.');
         }
 
         if (is_string($mimeTypes)) {
@@ -1454,7 +1453,7 @@ class Validation
             'type' => 'latLong',
         ];
         if ($options['type'] !== 'latLong') {
-            throw new RuntimeException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Unsupported coordinate type "%s". Use "latLong" instead.',
                 $options['type']
             ));

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Validation;
 
 use Cake\Event\EventDispatcherInterface;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * A trait that provides methods for building and
@@ -107,14 +107,14 @@ trait ValidatorAwareTrait
      *
      * @param string $name The name of the validation set to create.
      * @return \Cake\Validation\Validator
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     protected function createValidator(string $name): Validator
     {
         $method = 'validation' . ucfirst($name);
         if (!$this->validationMethodExists($method)) {
             $message = sprintf('The %s::%s() validation method does not exists.', static::class, $method);
-            throw new RuntimeException($message);
+            throw new InvalidArgumentException($message);
         }
 
         $validator = new $this->_validatorClass();
@@ -127,7 +127,7 @@ trait ValidatorAwareTrait
         }
 
         if (!$validator instanceof Validator) {
-            throw new RuntimeException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'The %s::%s() validation method must return an instance of %s.',
                 static::class,
                 $method,

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\View\Form;
 
 use Cake\Collection\Collection;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\EntityInterface;
 use Cake\Form\Form;
 use Cake\Http\ServerRequest;
-use RuntimeException;
 
 /**
  * Factory for getting form context instance based on provided data.
@@ -136,7 +136,7 @@ class ContextFactory
      * @param \Cake\Http\ServerRequest $request Request instance.
      * @param array<string, mixed> $data The data to get a context provider for.
      * @return \Cake\View\Form\ContextInterface Context provider.
-     * @throws \RuntimeException When a context instance cannot be generated for given entity.
+     * @throws \Cake\Core\Exception\CakeException When a context instance cannot be generated for given entity.
      */
     public function get(ServerRequest $request, array $data = []): ContextInterface
     {
@@ -151,7 +151,7 @@ class ContextFactory
         }
 
         if (!isset($context)) {
-            throw new RuntimeException(sprintf(
+            throw new CakeException(sprintf(
                 'No context provider found for value of type `%s`.'
                 . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.',
                 get_debug_type($data['entity'])

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -18,6 +18,7 @@ namespace Cake\View\Form;
 
 use ArrayAccess;
 use Cake\Collection\Collection;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\InvalidPropertyInterface;
 use Cake\ORM\Entity;
@@ -25,7 +26,7 @@ use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
-use RuntimeException;
+use InvalidArgumentException;
 use Traversable;
 
 /**
@@ -117,7 +118,7 @@ class EntityContext implements ContextInterface
      * like arrays, Collection objects and ResultSets.
      *
      * @return void
-     * @throws \RuntimeException When a table object cannot be located/inferred.
+     * @throws \Cake\Core\Exception\CakeException When a table object cannot be located/inferred.
      */
     protected function _prepare(): void
     {
@@ -153,7 +154,7 @@ class EntityContext implements ContextInterface
         }
 
         if (!($table instanceof Table)) {
-            throw new RuntimeException(
+            throw new CakeException(
                 'Unable to find table class for current entity.'
             );
         }
@@ -331,7 +332,7 @@ class EntityContext implements ContextInterface
      * @param array|null $path Each one of the parts in a path for a field name
      *  or null to get the entity passed in constructor context.
      * @return \Cake\Datasource\EntityInterface|iterable|null
-     * @throws \RuntimeException When properties cannot be read.
+     * @throws \Cake\Core\Exception\CakeException When properties cannot be read.
      */
     public function entity(?array $path = null): EntityInterface|iterable|null
     {
@@ -374,7 +375,7 @@ class EntityContext implements ContextInterface
             }
             $entity = $next;
         }
-        throw new RuntimeException(sprintf(
+        throw new CakeException(sprintf(
             'Unable to fetch property "%s"',
             implode('.', $path)
         ));
@@ -390,7 +391,7 @@ class EntityContext implements ContextInterface
      * @param array|null $path Each one of the parts in a path for a field name
      *  or null to get the entity passed in constructor context.
      * @return array Containing the found entity, and remaining un-matched path.
-     * @throws \RuntimeException When properties cannot be read.
+     * @throws \Cake\Core\Exception\CakeException When properties cannot be read.
      */
     protected function leafEntity(?array $path = null): array
     {
@@ -400,7 +401,7 @@ class EntityContext implements ContextInterface
 
         $oneElement = count($path) === 1;
         if ($oneElement && $this->_isCollection) {
-            throw new RuntimeException(sprintf(
+            throw new CakeException(sprintf(
                 'Unable to fetch property "%s"',
                 implode('.', $path)
             ));
@@ -441,7 +442,7 @@ class EntityContext implements ContextInterface
             }
             $entity = $next;
         }
-        throw new RuntimeException(sprintf(
+        throw new CakeException(sprintf(
             'Unable to fetch property "%s"',
             implode('.', $path)
         ));
@@ -575,7 +576,7 @@ class EntityContext implements ContextInterface
      *
      * @param array $parts Each one of the parts in a path for a field name
      * @return \Cake\Validation\Validator
-     * @throws \RuntimeException If validator cannot be retrieved based on the parts.
+     * @throws \Cake\Core\Exception\CakeException If validator cannot be retrieved based on the parts.
      */
     protected function _getValidator(array $parts): Validator
     {
@@ -595,7 +596,7 @@ class EntityContext implements ContextInterface
 
         $table = $this->_getTable($parts);
         if (!$table) {
-            throw new RuntimeException('Validator not found: ' . $key);
+            throw new InvalidArgumentException('Validator not found: ' . $key);
         }
         $alias = $table->getAlias();
 
@@ -734,7 +735,7 @@ class EntityContext implements ContextInterface
              * @var array<string> $remainingParts
              */
             [$entity, $remainingParts] = $this->leafEntity($parts);
-        } catch (RuntimeException) {
+        } catch (CakeException) {
             return [];
         }
         if ($entity instanceof EntityInterface && count($remainingParts) === 0) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -30,7 +30,6 @@ use Cake\View\View;
 use Cake\View\Widget\WidgetInterface;
 use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Form helper library.
@@ -1209,7 +1208,7 @@ class FormHelper extends Helper
 
                 return $this->{$options['type']}($fieldName, $opts, $options + ['label' => $label]);
             case 'input':
-                throw new RuntimeException("Invalid type 'input' used for field '$fieldName'");
+                throw new InvalidArgumentException("Invalid type 'input' used for field '$fieldName'");
 
             default:
                 return $this->{$options['type']}($fieldName, $options);

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -20,7 +20,7 @@ use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Utility\Hash;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Provides an interface for registering and inserting
@@ -230,12 +230,12 @@ class StringTemplate
      * @param string $name The template name.
      * @param array<string, mixed> $data The data to insert.
      * @return string Formatted string
-     * @throws \RuntimeException If template not found.
+     * @throws \InvalidArgumentException If template not found.
      */
     public function format(string $name, array $data): string
     {
         if (!isset($this->_compiled[$name])) {
-            throw new RuntimeException("Cannot find template named '$name'.");
+            throw new InvalidArgumentException("Cannot find template named '$name'.");
         }
         [$template, $placeholders] = $this->_compiled[$name];
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -18,6 +18,7 @@ namespace Cake\View;
 
 use Cake\Cache\Cache;
 use Cake\Core\App;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Core\Plugin;
 use Cake\Event\EventDispatcherInterface;
@@ -34,7 +35,6 @@ use Cake\View\Exception\MissingTemplateException;
 use Generator;
 use InvalidArgumentException;
 use LogicException;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -704,13 +704,13 @@ class View implements EventDispatcherInterface
      * @param callable $block The block of code that you want to cache the output of.
      * @param array<string, mixed> $options The options defining the cache key etc.
      * @return string The rendered content.
-     * @throws \RuntimeException When $options is lacking a 'key' option.
+     * @throws \InvalidArgumentException When $options is lacking a 'key' option.
      */
     public function cache(callable $block, array $options = []): string
     {
         $options += ['key' => '', 'config' => $this->elementCache];
         if (empty($options['key'])) {
-            throw new RuntimeException('Cannot cache content with an empty key');
+            throw new InvalidArgumentException('Cannot cache content with an empty key');
         }
         $result = Cache::read($options['key'], $options['config']);
         if ($result) {
@@ -794,7 +794,7 @@ class View implements EventDispatcherInterface
 
         if ($this->autoLayout) {
             if (empty($this->layout)) {
-                throw new RuntimeException(
+                throw new CakeException(
                     'View::$layout must be a non-empty string.' .
                     'To disable layout rendering use method View::disableAutoLayout() instead.'
                 );
@@ -877,7 +877,7 @@ class View implements EventDispatcherInterface
      * @param mixed $value Value in case $name is a string (which then works as the key).
      *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
      * @return $this
-     * @throws \RuntimeException If the array combine operation failed.
+     * @throws \Cake\Core\Exception\CakeException If the array combine operation failed.
      */
     public function set(array|string $name, mixed $value = null)
     {
@@ -886,7 +886,7 @@ class View implements EventDispatcherInterface
                 /** @var array|false $data */
                 $data = array_combine($name, $value);
                 if ($data === false) {
-                    throw new RuntimeException(
+                    throw new CakeException(
                         'Invalid data provided for array_combine() to work: Both $name and $value require same count.'
                     );
                 }
@@ -1318,7 +1318,7 @@ class View implements EventDispatcherInterface
      * @param string|null $name Controller action to find template filename for
      * @return string Template filename
      * @throws \Cake\View\Exception\MissingTemplateException when a template file could not be found.
-     * @throws \RuntimeException When template name not provided.
+     * @throws \Cake\Core\Exception\CakeException When template name not provided.
      */
     protected function _getTemplateFileName(?string $name = null): string
     {
@@ -1338,7 +1338,7 @@ class View implements EventDispatcherInterface
         $name ??= $this->template;
 
         if (empty($name)) {
-            throw new RuntimeException('Template name not provided');
+            throw new CakeException('Template name not provided');
         }
 
         [$plugin, $name] = $this->pluginSplit($name);
@@ -1436,13 +1436,13 @@ class View implements EventDispatcherInterface
      * @param string|null $name The name of the layout to find.
      * @return string Filename for layout file.
      * @throws \Cake\View\Exception\MissingLayoutException when a layout cannot be located
-     * @throws \RuntimeException
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _getLayoutFileName(?string $name = null): string
     {
         if ($name === null) {
             if (empty($this->layout)) {
-                throw new RuntimeException(
+                throw new CakeException(
                     'View::$layout must be a non-empty string.' .
                     'To disable layout rendering use method View::disableAutoLayout() instead.'
                 );

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -23,9 +23,9 @@ use Cake\Http\ServerRequest;
 use Cake\View\Exception\MissingViewException;
 use Closure;
 use Exception;
+use InvalidArgumentException;
 use JsonSerializable;
 use PDO;
-use RuntimeException;
 
 /**
  * Provides an API for iteratively building a view up.
@@ -635,7 +635,7 @@ class ViewBuilder implements JsonSerializable
      * @param mixed $item Reference to the view var value.
      * @param string $key View var key.
      * @return void
-     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     protected function _checkViewVars(mixed &$item, string $key): void
     {
@@ -648,7 +648,7 @@ class ViewBuilder implements JsonSerializable
             $item instanceof Closure ||
             $item instanceof PDO
         ) {
-            throw new RuntimeException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Failed serializing the `%s` %s in the `%s` view var',
                 is_resource($item) ? get_resource_type($item) : get_class($item),
                 is_resource($item) ? 'resource' : 'object',

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -20,8 +20,8 @@ use Cake\Core\App;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\View\StringTemplate;
 use Cake\View\View;
+use InvalidArgumentException;
 use ReflectionClass;
-use RuntimeException;
 
 /**
  * A registry/factory for input widgets.
@@ -111,7 +111,7 @@ class WidgetLocator
      *
      * @param array $widgets Array of widgets to use.
      * @return void
-     * @throws \RuntimeException When class does not implement WidgetInterface.
+     * @throws \InvalidArgumentException When class does not implement WidgetInterface.
      */
     public function add(array $widgets): void
     {
@@ -124,7 +124,7 @@ class WidgetLocator
             }
 
             if (is_object($widget) && !($widget instanceof WidgetInterface)) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'Widget objects must implement `%s`. Got `%s` instance instead.',
                     WidgetInterface::class,
                     get_debug_type($widget)
@@ -149,13 +149,13 @@ class WidgetLocator
      *
      * @param string $name The widget name to get.
      * @return \Cake\View\Widget\WidgetInterface WidgetInterface instance.
-     * @throws \RuntimeException when widget is undefined.
+     * @throws \InvalidArgumentException when widget is undefined.
      */
     public function get(string $name): WidgetInterface
     {
         if (!isset($this->_widgets[$name])) {
             if (empty($this->_widgets['_default'])) {
-                throw new RuntimeException(sprintf('Unknown widget `%s`', $name));
+                throw new InvalidArgumentException(sprintf('Unknown widget `%s`', $name));
             }
 
             $name = '_default';
@@ -183,7 +183,7 @@ class WidgetLocator
      *
      * @param array|string $config The widget config.
      * @return \Cake\View\Widget\WidgetInterface Widget instance.
-     * @throws \ReflectionException
+     * @throws \InvalidArgumentException
      */
     protected function _resolveWidget(array|string $config): WidgetInterface
     {
@@ -194,7 +194,7 @@ class WidgetLocator
         $class = array_shift($config);
         $className = App::className($class, 'View/Widget', 'Widget');
         if ($className === null) {
-            throw new RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
+            throw new InvalidArgumentException(sprintf('Unable to locate widget class "%s"', $class));
         }
         if (count($config)) {
             $reflection = new ReflectionClass($className);

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -29,7 +29,6 @@ use Cake\Http\BaseApplication;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 use stdClass;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DemoCommand;
@@ -106,7 +105,7 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunMissingRootCommand(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot run any commands. No arguments received.');
         $app = $this->getMockBuilder(BaseApplication::class)
             ->onlyMethods(['middleware', 'bootstrap', 'routes'])

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -19,10 +19,10 @@ use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingComponentException;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 use TestApp\Controller\Component\AppleComponent;
 use TestApp\Controller\Component\BananaComponent;
 use TestApp\Controller\Component\ConfiguredComponent;
@@ -108,7 +108,7 @@ class ComponentTest extends TestCase
      */
     public function testDuplicateComponentInitialize(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The "Banana" alias has already been loaded. The `property` key');
         $Collection = new ComponentRegistry(new Controller(new ServerRequest()));
         $Collection->load('Banana', ['property' => ['closure' => function (): void {

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -22,7 +22,6 @@ use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Exception;
-use RuntimeException;
 
 /**
  * ConfigureTest
@@ -82,7 +81,7 @@ class ConfigureTest extends TestCase
      */
     public function testReadOrFailThrowingException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
         Configure::readOrFail('This.Key.Does.Not.exist');
     }
@@ -253,7 +252,7 @@ class ConfigureTest extends TestCase
      */
     public function testLoadExceptionOnNonExistentFile(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         Configure::config('test', new PhpConfig());
         Configure::load('nonexistent_configuration_file', 'test');
     }
@@ -263,7 +262,7 @@ class ConfigureTest extends TestCase
      */
     public function testLoadExceptionOnNonExistentEngine(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         Configure::load('nonexistent_configuration_file', 'nonexistent_configuration_engine');
     }
 
@@ -574,7 +573,7 @@ class ConfigureTest extends TestCase
      */
     public function testConsumeOrFailThrowingException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
         Configure::consumeOrFail('This.Key.Does.Not.exist');
     }

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Core;
 
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
-use RuntimeException;
 use TestApp\Config\ReadOnlyTestInstanceConfig;
 use TestApp\Config\TestInstanceConfig;
 
@@ -264,7 +264,7 @@ class InstanceConfigTraitTest extends TestCase
      */
     public function testSetClobber(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Cannot set a.nested.value');
         $this->object->setConfig(['a.nested.value' => 'not possible'], null, false);
         $this->object->getConfig();

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -39,7 +39,6 @@ use DateTime;
 use DateTimeImmutable;
 use InvalidArgumentException;
 use ReflectionProperty;
-use RuntimeException;
 use stdClass;
 use TestApp\Database\Type\BarType;
 
@@ -1786,7 +1785,7 @@ class QueryTest extends TestCase
      */
     public function testSelectOrderByAssociativeArrayContainingExtraExpressions(): void
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'Passing extra expressions by associative array (`\'id\' => \'desc -- Comment\'`) ' .
             'is not allowed to avoid potential SQL injection. ' .
@@ -2864,7 +2863,7 @@ class QueryTest extends TestCase
      */
     public function testDeleteRemovingAliasesCanBreakJoins(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.');
         $query = new Query($this->connection);
 
@@ -3159,7 +3158,7 @@ class QueryTest extends TestCase
      */
     public function testUpdateRemovingAliasesCanBreakJoins(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Aliases are being removed from conditions for UPDATE/DELETE queries, this can break references to joined tables.');
         $query = new Query($this->connection);
 
@@ -3191,7 +3190,7 @@ class QueryTest extends TestCase
      */
     public function testInsertNothing(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('At least 1 column is required to perform an insert.');
         $query = new Query($this->connection);
         $query->insert([]);

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -23,8 +23,8 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Expression\TupleComparison;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use PDOException;
-use RuntimeException;
 
 /**
  * Tuple comparison query tests.
@@ -53,7 +53,7 @@ class TupleComparisonQueryTest extends TestCase
             $driver instanceof Sqlite ||
             $driver instanceof Sqlserver
         ) {
-            $this->expectException(RuntimeException::class);
+            $this->expectException(InvalidArgumentException::class);
             $this->expectExceptionMessage(
                 'Tuple comparison transform only supports the `IN` and `=` operators, `NOT IN` given.'
             );

--- a/tests/TestCase/Database/QueryTests/WindowQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\QueryTests;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
@@ -24,7 +25,6 @@ use Cake\Database\Expression\WindowExpression;
 use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * Tests WindowExpression class
@@ -99,7 +99,7 @@ class WindowQueryTest extends TestCase
 
     public function testMissingWindow(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('You must return a `WindowExpression`');
         (new Query($this->connection))->window('name', function () {
             return new QueryExpression();

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Driver;
 use Cake\Database\Type\DecimalType;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
-use RuntimeException;
 
 /**
  * Test for the Decimal type.
@@ -229,7 +229,7 @@ class DecimalTypeTest extends TestCase
      */
     public function testUseLocaleParsingInvalid(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         DecimalType::$numberClass = 'stdClass';
         $this->type->useLocaleParser();
     }

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Type\FloatType;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use PDO;
-use RuntimeException;
 
 /**
  * Test for the Float type.
@@ -179,7 +179,7 @@ class FloatTypeTest extends TestCase
      */
     public function testUseLocaleParsingInvalid(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         FloatType::$numberClass = 'stdClass';
         $this->type->useLocaleParser();
     }

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -17,9 +17,9 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Cache\Cache;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\QueryCacher;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 use stdClass;
 
 /**
@@ -75,7 +75,7 @@ class QueryCacherTest extends TestCase
      */
     public function testFetchFunctionKeyNoString(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Cache key functions must return a string. Got false.');
         $this->engine->set('my_key', 'A winner');
         $query = new stdClass();

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -29,8 +29,8 @@ use Cake\Form\Form;
 use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
 use MyClass;
-use RuntimeException;
 use SplFixedArray;
 use stdClass;
 use TestApp\Error\TestDebugger;
@@ -749,7 +749,7 @@ EXPECTED;
      */
     public function testSetEditorInvalid(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         Debugger::setEditor('nope');
     }
 

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -21,7 +21,7 @@ use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
+use InvalidArgumentException;
 
 /**
  * Tests the Cake\Event\Event class functionality
@@ -95,7 +95,7 @@ class ConditionDecoratorTest extends TestCase
      */
     public function testCallableRuntimeException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cake\Event\Decorator\ConditionDecorator the `if` condition is not a callable!');
         $callable = function (EventInterface $event) {
             return 'success';

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -19,7 +19,6 @@ use Cake\Core\Exception\CakeException;
 use Cake\Http\Client\Auth\Oauth;
 use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * Oauth test.
@@ -398,7 +397,7 @@ class OauthTest extends TestCase
             'privateKey' => 'not a private key',
         ];
         $auth = new Oauth();
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('openssl error');
         $auth->authentication($request, $options);
     }

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http\Middleware;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Cookie\Cookie;
 use Cake\Http\Cookie\CookieInterface;
 use Cake\Http\Exception\InvalidCsrfTokenException;
@@ -28,7 +29,6 @@ use Laminas\Diactoros\Response as DiactorosResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -216,7 +216,7 @@ class CsrfProtectionMiddlewareTest extends TestCase
         });
 
         $middleware = new CsrfProtectionMiddleware();
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $middleware->process($request, $handler);
     }
 

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 use TestApp\Http\Session\TestAppLibSession;
 use TestApp\Http\Session\TestWebSession;
 
@@ -172,7 +172,7 @@ class SessionTest extends TestCase
     {
         $session = new Session();
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
 
         $session->readOrFail('testing');
     }

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Log;
 
 use BadMethodCallException;
+use Cake\Core\Exception\CakeException;
 use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * LogTest class
@@ -73,7 +73,7 @@ class LogTest extends TestCase
      */
     public function testImportingLoggerFailure(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         Log::setConfig('fail', []);
         Log::engine('fail');
     }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
@@ -34,7 +35,6 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 use TestApp\Model\Entity\ArticlesTag;
 
 /**
@@ -1519,7 +1519,7 @@ class BelongsToManyTest extends TestCase
      */
     public function testEagerLoadingRequiresPrimaryKey(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('The "tags" table does not define a primary key');
         $table = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use ArrayObject;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
@@ -26,7 +27,6 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Tests BelongsTo class
@@ -273,7 +273,7 @@ class BelongsToTest extends TestCase
      */
     public function testAttachToMultiPrimaryKeyMismatch(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"');
         $this->company->setPrimaryKey(['id', 'tenant_id']);
         $query = $this->client->query();

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -17,13 +17,13 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use ArrayObject;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\TypeMap;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * Tests HasOne class
@@ -205,7 +205,7 @@ class HasOneTest extends TestCase
      */
     public function testAttachToMultiPrimaryKeyMismatch(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join', 'select'])

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * Tests the features related to proxying methods from the Association
@@ -54,7 +54,7 @@ class AssociationProxyTest extends TestCase
      */
     public function testGetBadAssociation(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('You have not defined');
         $articles = $this->getTableLocator()->get('articles');
         $articles->posts;

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -17,11 +17,11 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Core\Configure;
+use Cake\Database\Exception\DatabaseException;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 
@@ -170,7 +170,7 @@ class AssociationTest extends TestCase
      */
     public function testInvalidTableFetchedFromRegistry(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
 
         $config = [
             'className' => TestTable::class,

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -23,7 +23,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
-use RuntimeException;
+use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -227,7 +227,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testNonDateTimeTypeException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('TimestampBehavior only supports columns of type DateTimeType.');
 
         $table = $this->getTableInstance();

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 
 /**
  * Translate behavior test case
@@ -862,7 +862,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testReParentSelf(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot set a node\'s parent as itself');
         $entity = $this->table->get(1);
         $entity->parent_id = $entity->id;
@@ -874,7 +874,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testReParentSelfNewEntity(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot set a node\'s parent as itself');
         $entity = $this->table->newEntity(['name' => 'root']);
         $entity->id = 1;
@@ -1089,7 +1089,7 @@ class TreeBehaviorTest extends TestCase
      */
     public function testReparentCycle(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot use node "5" as parent for entity "2"');
         $table = $this->table;
         $entity = $table->get(2);

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\ORM\Entity;
@@ -25,7 +26,6 @@ use Cake\ORM\Marshaller;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 use TestApp\Model\Entity\OpenArticleEntity;
 
 /**
@@ -107,7 +107,7 @@ class CompositeKeysTest extends TestCase
      */
     public function testSaveNewErrorCompositeKeyNoIncrement(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing');
         $articles = $this->getTableLocator()->get('SiteArticles');
         $article = $articles->newEntity(['site_id' => 1, 'author_id' => 1, 'title' => 'testing']);
@@ -422,7 +422,7 @@ class CompositeKeysTest extends TestCase
      */
     public function testSaveNewEntityMissingKey(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing. Got (5, ), expecting (id, site_id)');
         $entity = new Entity([
             'id' => 5,

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -16,13 +16,14 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Locator;
 
+use Cake\Core\Exception\CakeException;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Exception\MissingTableClassException;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
-use RuntimeException;
 use TestApp\Infrastructure\Table\AddressesTable;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\MyUsersTable;
@@ -103,7 +104,7 @@ class TableLocatorTest extends TestCase
         $users = $this->_locator->get('Users');
         $this->assertNotEmpty($users);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('You cannot configure "Users", it has already been constructed.');
 
         $this->_locator->setConfig('Users', ['table' => 'my_users']);
@@ -277,7 +278,7 @@ class TableLocatorTest extends TestCase
         $users = $this->_locator->get('Users');
         $this->assertNotEmpty($users);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('You cannot configure "Users", it already exists in the registry.');
 
         $this->_locator->get('Users', ['table' => 'my_users']);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
@@ -27,7 +28,6 @@ use Cake\ORM\Query;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * Contains regression test for the Query builder
@@ -145,7 +145,7 @@ class QueryRegressionTest extends TestCase
             'finder' => 'list',
         ]);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('"_joinData" is missing from the belongsToMany results');
         $table->find()->contain('Tags')->toArray();
     }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -20,6 +20,7 @@ use Cake\Cache\Engine\FileEngine;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\DriverInterface;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
@@ -37,7 +38,6 @@ use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use ReflectionProperty;
-use RuntimeException;
 
 /**
  * Tests Query class
@@ -1780,7 +1780,7 @@ class QueryTest extends TestCase
      */
     public function testCacheErrorOnNonSelect(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new Query($this->connection, $table);
         $query->insert(['test']);
@@ -1952,7 +1952,7 @@ class QueryTest extends TestCase
      */
     public function testContainWithQueryBuilderHasManyError(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('Articles');
         $query = new Query($this->connection, $table);
@@ -3502,7 +3502,7 @@ class QueryTest extends TestCase
         $articles = $comments->belongsTo('Articles');
         $articles->hasOne('ArticlesTranslations');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('`Articles` association cannot contain() associations when using JOIN strategy');
         $comments->find()
             ->innerJoinWith('Articles', function (Query $q) {

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Rule;
 
 use Cake\Core\Configure;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Event\Event;
@@ -26,7 +27,6 @@ use Cake\ORM\Rule\LinkConstraint;
 use Cake\ORM\RulesChecker;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 use stdClass;
 
 /**
@@ -110,7 +110,7 @@ class LinkConstraintTest extends TestCase
      */
     public function testMissingPrimaryKeyValues(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage(
             'LinkConstraint rule on `Articles` requires all primary key values for building the counting ' .
             'conditions, expected values for `(id, nonexistent)`, got `(1, )`.'

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
 use Cake\Database\Driver\Sqlserver;
+use Cake\Database\Exception\DatabaseException;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
@@ -27,7 +28,6 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Closure;
-use RuntimeException;
 use stdClass;
 
 /**
@@ -576,7 +576,7 @@ class RulesCheckerIntegrationTest extends TestCase
      */
     public function testExistsInInvalidAssociation(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('ExistsIn rule for \'author_id\' is invalid. \'NotValid\' is not associated with \'Cake\ORM\Table\'.');
         $entity = new Entity([
             'title' => 'An Article',

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -436,7 +436,7 @@ class TableTest extends TestCase
         $maxAlias = $this->connection->getDriver()->getMaxAliasLength();
         if ($maxAlias && $maxAlias < 72) {
             $nameLength = $maxAlias - 2;
-            $this->expectException(RuntimeException::class);
+            $this->expectException(DatabaseException::class);
             $this->expectExceptionMessage(
                 'ORM queries generate field aliases using the table name/alias and column name. ' .
                 "The table alias `very_long_alias_name` and column `this_is_invalid_because_it_is_very_very_very_long` create an alias longer than ({$nameLength}). " .
@@ -2098,7 +2098,7 @@ class TableTest extends TestCase
      */
     public function testBeforeSaveException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('The beforeSave callback must return `false` or `EntityInterface` instance. Got `int` instead.');
 
         $table = $this->getTableLocator()->get('users');
@@ -2322,7 +2322,7 @@ class TableTest extends TestCase
      */
     public function testSaveNewErrorOnNoPrimaryKey(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot insert row in "users" table, it has no primary key');
         $entity = new Entity(['username' => 'superuser']);
         $table = $this->getTableLocator()->get('users', [
@@ -3338,7 +3338,7 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests that a RuntimeException is thrown if the custom validator does not return an Validator instance
+     * Tests that a InvalidArgumentException is thrown if the custom validator does not return an Validator instance
      */
     public function testValidationWithBadDefiner(): void
     {
@@ -3348,7 +3348,7 @@ class TableTest extends TestCase
         $table->expects($this->once())
             ->method('validationBad');
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
             'The %s::validationBad() validation method must return an instance of Cake\Validation\Validator.',
             get_class($table)
@@ -3358,11 +3358,11 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests that a RuntimeException is thrown if the custom validator method does not exist.
+     * Tests that a InvalidArgumentException is thrown if the custom validator method does not exist.
      */
     public function testValidatorWithMissingMethod(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The Cake\ORM\Table::validationMissing() validation method does not exists.');
         $table = new Table();
         $table->getValidator('missing');

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -16,9 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Routing\Route;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Routing\Route\EntityRoute;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
 use TestApp\Model\Entity\Article;
 
 /**
@@ -133,7 +133,7 @@ class EntityRouteTest extends TestCase
      */
     public function testInvalidEntityValueException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Route `/` expects the URL option `_entity` to be an array or object implementing \ArrayAccess, but `string` passed.');
 
         $route = new EntityRoute('/', [

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -27,7 +27,6 @@ use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * RouteBuilder test case
@@ -978,7 +977,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testMiddlewareGroupOverlap(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot add middleware group \'test\'. A middleware by this name has already been registered.');
         $func = function (): void {
         };
@@ -992,7 +991,7 @@ class RouteBuilderTest extends TestCase
      */
     public function testApplyMiddlewareInvalidName(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot apply \'bad\' middleware or middleware group. Use registerMiddleware() to register middleware');
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->applyMiddleware('bad');

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -23,7 +23,7 @@ use Cake\Routing\Route\Route;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
-use RuntimeException;
+use InvalidArgumentException;
 
 class RouteCollectionTest extends TestCase
 {
@@ -717,7 +717,7 @@ class RouteCollectionTest extends TestCase
      */
     public function testMiddlewareGroupUnregisteredMiddleware(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot add \'bad\' middleware to group \'group\'. It has not been registered.');
         $this->collection->middlewareGroup('group', ['bad']);
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Routing;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Exception\DuplicateNamedRouteException;
@@ -1104,7 +1105,7 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithUrlFilterFailureClosure(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessageMatches(
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
             ' The filter failed with: nope/'
@@ -1132,7 +1133,7 @@ class RouterTest extends TestCase
      */
     public function testUrlGenerationWithUrlFilterFailureMethod(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessageMatches(
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
             ' The filter failed with: /'

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -22,7 +22,6 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * HashTest
@@ -2234,7 +2233,7 @@ class HashTest extends TestCase
      */
     public function testCombineErrorMissingValue(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $data = [
             ['User' => ['id' => 1, 'name' => 'mark']],
             ['User' => ['name' => 'jose']],
@@ -2247,7 +2246,7 @@ class HashTest extends TestCase
      */
     public function testCombineErrorMissingKey(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $data = [
             ['User' => ['id' => 1, 'name' => 'mark']],
             ['User' => ['id' => 2]],

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -20,7 +20,6 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Crypto\OpenSsl;
 use Cake\Utility\Security;
 use InvalidArgumentException;
-use RuntimeException;
 
 /**
  * SecurityTest class
@@ -88,7 +87,7 @@ class SecurityTest extends TestCase
      */
     public function testInvalidHashTypeException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/The hash type `doesnotexist` was not found. Available algorithms are: \w+/');
 
         Security::hash('test', 'doesnotexist', false);

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Utility;
 
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Exception\XmlException;
@@ -25,7 +26,6 @@ use Cake\Utility\Xml;
 use DateTime;
 use DOMDocument;
 use Exception;
-use RuntimeException;
 use SimpleXMLElement;
 use TypeError;
 
@@ -200,7 +200,7 @@ class XmlTest extends TestCase
      */
     public function testBuildInvalidData($value): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         Xml::build($value);
     }
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Validation;
 
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
@@ -26,7 +27,6 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Locale;
-use RuntimeException;
 use stdClass;
 
 require_once __DIR__ . '/stubs.php';
@@ -2545,7 +2545,7 @@ class ValidationTest extends TestCase
      */
     public function testMimeTypeFalse(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $image = CORE_TESTS . 'invalid-file.png';
         Validation::mimeType($image, ['image/gif']);
     }

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Form;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\ContextFactory;
-use RuntimeException;
 
 /**
  * ContextFactory test case.
@@ -28,7 +28,7 @@ class ContextFactoryTest extends TestCase
 {
     public function testGetException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage(
             'No context provider found for value of type `bool`.'
             . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.'

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -19,11 +19,11 @@ namespace Cake\Test\TestCase\View\Form;
 use ArrayIterator;
 use ArrayObject;
 use Cake\Collection\Collection;
+use Cake\Core\Exception\CakeException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
-use RuntimeException;
 use stdClass;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\ArticlesTag;
@@ -142,7 +142,7 @@ class EntityContextTest extends TestCase
      */
     public function testInvalidTable(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to find table class for current entity');
         $row = new stdClass();
         $context = new EntityContext([
@@ -155,7 +155,7 @@ class EntityContextTest extends TestCase
      */
     public function testDefaultEntityError(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to find table class for current entity');
         $context = new EntityContext([
             'entity' => new Entity(),

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -36,7 +36,6 @@ use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
 use ReflectionProperty;
-use RuntimeException;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
@@ -3775,7 +3774,7 @@ class FormHelperTest extends TestCase
      */
     public function testInvalidControlTypeOption(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid type \'input\' used for field \'text\'');
         $this->Form->control('text', ['type' => 'input']);
     }

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -16,13 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View;
 
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingHelperException;
 use Cake\View\Helper\FormHelper;
 use Cake\View\Helper\HtmlHelper;
 use Cake\View\HelperRegistry;
 use Cake\View\View;
-use RuntimeException;
 use TestApp\View\Helper\HtmlAliasHelper;
 use TestPlugin\View\Helper\OtherHelperHelper;
 
@@ -294,7 +294,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadMultipleTimesDifferentConfigured(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The "Html" alias has already been loaded');
         $this->Helpers->load('Html');
         $this->Helpers->load('Html', ['same' => 'stuff']);
@@ -305,7 +305,7 @@ class HelperRegistryTest extends TestCase
      */
     public function testLoadMultipleTimesDifferentConfigValues(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The "Html" alias has already been loaded');
         $this->Helpers->load('Html', ['key' => 'value']);
         $this->Helpers->load('Html', ['key' => 'new value']);

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -19,7 +19,7 @@ namespace Cake\Test\TestCase\View;
 use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
-use RuntimeException;
+use InvalidArgumentException;
 use stdClass;
 
 class StringTemplateTest extends TestCase
@@ -154,7 +154,7 @@ class StringTemplateTest extends TestCase
      */
     public function testFormatMissingTemplate(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot find template named \'missing\'');
         $templates = [
             'text' => '{{text}}',

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1106,7 +1106,7 @@ class ViewTest extends TestCase
 
     public function testGetTemplateException(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Template name not provided');
         $view = new View();
         $view->render();

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -20,7 +20,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
-use RuntimeException;
+use InvalidArgumentException;
 use stdClass;
 use TestApp\View\Widget\TestUsingViewWidget;
 
@@ -135,7 +135,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testAddInvalidType(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'Widget objects must implement `Cake\View\Widget\WidgetInterface`. Got `stdClass` instance instead.'
         );
@@ -180,7 +180,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testGetNoFallbackError(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown widget `foo`');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->clear();
@@ -207,7 +207,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testGetResolveDependencyMissingClass(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to locate widget class "TestApp\View\DerpWidget"');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add(['test' => ['TestApp\View\DerpWidget']]);
@@ -219,7 +219,7 @@ class WidgetLocatorTest extends TestCase
      */
     public function testGetResolveDependencyMissingDependency(): void
     {
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown widget `label`');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->clear();


### PR DESCRIPTION
The changes in tests are just updating the matching expected exceptions.

All of the changes to InvalidArgumentException have been marked.