### PR TITLE
Fix cache key generation.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1498,12 +1498,21 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function get($primaryKey, array $options = []): EntityInterface
     {
+        if ($primaryKey === null) {
+            throw new InvalidPrimaryKeyException(sprintf(
+                'Record not found in table "%s" with primary key [NULL]',
+                $this->getTable()
+            ));
+        }
+
         $key = (array)$this->getPrimaryKey();
         $alias = $this->getAlias();
         foreach ($key as $index => $keyname) {
             $key[$index] = $alias . '.' . $keyname;
         }
-        $primaryKey = (array)$primaryKey;
+        if (!is_array($primaryKey)) {
+            $primaryKey = [$primaryKey];
+        }
         if (count($key) !== count($primaryKey)) {
             $primaryKey = $primaryKey ?: [null];
             $primaryKey = array_map(function ($key) {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5380,11 +5380,19 @@ class TableTest extends TestCase
         return [
             [
                 ['fields' => ['id'], 'cache' => 'default'],
-                'get-test-table_name-[10]', 'default',
+                'get-test-table_name-[10]', 'default', 10,
+            ],
+            [
+                ['fields' => ['id'], 'cache' => 'default'],
+                'get-test-table_name-["uuid"]', 'default', 'uuid',
+            ],
+            [
+                ['fields' => ['id'], 'cache' => 'default'],
+                'get-test-table_name-["2020-07-08T00:00:00+00:00"]', 'default', new FrozenTime('2020-07-08'),
             ],
             [
                 ['fields' => ['id'], 'cache' => 'default', 'key' => 'custom_key'],
-                'custom_key', 'default',
+                'custom_key', 'default', 10,
             ],
         ];
     }
@@ -5396,8 +5404,9 @@ class TableTest extends TestCase
      * @param array $options
      * @param string $cacheKey
      * @param string $cacheConfig
+     * @param mixed $primaryKey
      */
-    public function testGetWithCache($options, $cacheKey, $cacheConfig): void
+    public function testGetWithCache($options, $cacheKey, $cacheConfig, $primaryKey): void
     {
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['callFinder', 'query'])
@@ -5425,14 +5434,14 @@ class TableTest extends TestCase
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('where')
-            ->with([$table->getAlias() . '.bar' => 10])
+            ->with([$table->getAlias() . '.bar' => $primaryKey])
             ->will($this->returnSelf());
         $query->expects($this->once())->method('cache')
             ->with($cacheKey, $cacheConfig)
             ->will($this->returnSelf());
         $query->expects($this->once())->method('firstOrFail')
             ->will($this->returnValue($entity));
-        $result = $table->get(10, $options);
+        $result = $table->get($primaryKey, $options);
         $this->assertSame($entity, $result);
     }
 


### PR DESCRIPTION
Double quotes are not allowed in cache key. Closes #16610

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
