### PR TITLE
Remove phpstan missing attribute suppression

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,6 @@ parameters:
 		- tests/bootstrap.php
 	paths:
 		- src/
-	ignoreErrors:
-		- '#^Attribute class \w+ does not exist\.$#'
 
 services:
 	-


### PR DESCRIPTION
phpstan won't let us keep this suppression unless without an error.