### PR TITLE
Remove redundant class type checks.

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -10,7 +10,6 @@ use Cake\Error\Renderer\HtmlErrorRenderer;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Routing\Router;
 use Exception;
-use InvalidArgumentException;
 
 /**
  * Entry point to CakePHP's error handling.
@@ -184,11 +183,6 @@ class ErrorTrap
     {
         /** @var class-string<\Cake\Error\ErrorRendererInterface> $class */
         $class = $this->getConfig('errorRenderer') ?: $this->chooseErrorRenderer();
-        if (!in_array(ErrorRendererInterface::class, class_implements($class))) {
-            throw new InvalidArgumentException(
-                "Cannot use {$class} as an error renderer. It must implement \Cake\Error\ErrorRendererInterface."
-            );
-        }
 
         return new $class($this->_config);
     }
@@ -208,11 +202,6 @@ class ErrorTrap
 
         /** @var class-string<\Cake\Error\ErrorLoggerInterface> $class */
         $class = $this->getConfig('logger', $this->_defaultConfig['logger']);
-        if (!in_array(ErrorLoggerInterface::class, class_implements($class))) {
-            throw new InvalidArgumentException(
-                "Cannot use {$class} as an error logger. It must implement \Cake\Error\ErrorLoggerInterface."
-            );
-        }
 
         return new $class($this->_config);
     }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -166,12 +166,6 @@ class ExceptionTrap
     {
         /** @var class-string<\Cake\Error\ErrorLoggerInterface> $class */
         $class = $this->getConfig('logger', $this->_defaultConfig['logger']);
-        if (!in_array(ErrorLoggerInterface::class, class_implements($class))) {
-            throw new InvalidArgumentException(
-                "Cannot use {$class} as an exception logger. " .
-                "It must implement \Cake\Error\ErrorLoggerInterface."
-            );
-        }
 
         return new $class($this->_config);
     }

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -263,22 +263,16 @@ class Session
         if ($class instanceof SessionHandlerInterface) {
             return $this->setEngine($class);
         }
-        $className = App::className($class, 'Http/Session');
 
-        if (!$className) {
+        /** @var class-string<\SessionHandlerInterface>|null $className */
+        $className = App::className($class, 'Http/Session');
+        if ($className === null) {
             throw new InvalidArgumentException(
                 sprintf('The class "%s" does not exist and cannot be used as a session engine', $class)
             );
         }
 
-        $handler = new $className($options);
-        if (!($handler instanceof SessionHandlerInterface)) {
-            throw new InvalidArgumentException(
-                'The chosen SessionHandler does not implement SessionHandlerInterface, it cannot be used as an engine.'
-            );
-        }
-
-        return $this->setEngine($handler);
+        return $this->setEngine(new $className($options));
     }
 
     /**

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -82,6 +82,7 @@ class AssociationCollection implements IteratorAggregate
      * @param array<string, mixed> $options List of options to configure the association definition.
      * @return \Cake\ORM\Association
      * @throws \InvalidArgumentException
+     * @psalm-param class-string<\Cake\ORM\Association> $className
      */
     public function load(string $className, string $associated, array $options = []): Association
     {
@@ -90,14 +91,6 @@ class AssociationCollection implements IteratorAggregate
         ];
 
         $association = new $className($associated, $options);
-        if (!$association instanceof Association) {
-            $message = sprintf(
-                'The association must extend `%s` class, `%s` given.',
-                Association::class,
-                get_class($association)
-            );
-            throw new InvalidArgumentException($message);
-        }
 
         return $this->add($association->getName(), $association);
     }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -859,9 +859,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ));
         }
 
-        $behavior = $this->_behaviors->get($name);
-
-        return $behavior;
+        return $this->_behaviors->get($name);
     }
 
     /**

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -720,6 +720,7 @@ class RouteBuilder
     protected function _makeRoute($route, $defaults, $options): Route
     {
         if (is_string($route)) {
+            /** @var class-string<\Cake\Routing\Route\Route>|null $routeClass */
             $routeClass = App::className($options['routeClass'], 'Routing/Route');
             if ($routeClass === null) {
                 throw new InvalidArgumentException(sprintf(
@@ -754,12 +755,7 @@ class RouteBuilder
             $route = new $routeClass($route, $defaults, $options);
         }
 
-        if ($route instanceof Route) {
-            return $route;
-        }
-        throw new InvalidArgumentException(
-            'Route class not found, or route class is not a subclass of Cake\Routing\Route\Route'
-        );
+        return $route;
     }
 
     /**

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -29,8 +29,6 @@ use Cake\Http\ServerRequest;
 use Cake\Log\Log;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
-use stdClass;
 use TestApp\Error\LegacyErrorLogger;
 
 class ErrorTrapTest extends TestCase
@@ -41,13 +39,6 @@ class ErrorTrapTest extends TestCase
 
         Log::drop('test_error');
         Router::reload();
-    }
-
-    public function testConfigRendererInvalid()
-    {
-        $trap = new ErrorTrap(['errorRenderer' => stdClass::class]);
-        $this->expectException(InvalidArgumentException::class);
-        $trap->renderer();
     }
 
     public function testConfigErrorRendererFallback()
@@ -67,13 +58,6 @@ class ErrorTrapTest extends TestCase
         $trap = new ErrorTrap();
         $trap->setConfig('errorRenderer', null);
         $this->assertInstanceOf(ConsoleErrorRenderer::class, $trap->renderer());
-    }
-
-    public function testLoggerConfigInvalid()
-    {
-        $trap = new ErrorTrap(['logger' => stdClass::class]);
-        $this->expectException(InvalidArgumentException::class);
-        $trap->logger();
     }
 
     public function testLoggerConfig()

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -29,7 +29,6 @@ use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 use InvalidArgumentException;
-use stdClass;
 use TestApp\Error\LegacyErrorLogger;
 use Throwable;
 
@@ -53,14 +52,6 @@ class ExceptionTrapTest extends TestCase
         parent::tearDown();
         Log::reset();
         ini_set('memory_limit', $this->memoryLimit);
-    }
-
-    public function testConfigRendererInvalid()
-    {
-        $trap = new ExceptionTrap(['exceptionRenderer' => stdClass::class]);
-        $this->expectException(InvalidArgumentException::class);
-        $error = new InvalidArgumentException('nope');
-        $trap->renderer($error);
     }
 
     public function testConfigExceptionRendererFallbackInCli()
@@ -106,13 +97,6 @@ class ExceptionTrapTest extends TestCase
         $trap->setConfig('exceptionRenderer', null);
         $error = new InvalidArgumentException('nope');
         $this->assertInstanceOf(ConsoleExceptionRenderer::class, $trap->renderer($error));
-    }
-
-    public function testLoggerConfigInvalid()
-    {
-        $trap = new ExceptionTrap(['logger' => stdClass::class]);
-        $this->expectException(InvalidArgumentException::class);
-        $trap->logger();
     }
 
     public function testLoggerConfig()

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -105,17 +105,6 @@ class AssociationCollectionTest extends TestCase
     }
 
     /**
-     * Test load invalid class.
-     */
-    public function testLoadInvalid(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The association must extend `Cake\ORM\Association` class, `stdClass` given.');
-
-        $this->associations->load('stdClass', 'Users');
-    }
-
-    /**
      * Test removeAll method
      */
     public function testRemoveAll(): void

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -364,22 +364,6 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
-     * Test error on invalid route class
-     */
-    public function testConnectErrorInvalidRouteClass(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Route class not found, or route class is not a subclass of');
-        $routes = new RouteBuilder(
-            $this->collection,
-            '/l',
-            [],
-            ['extensions' => ['json']]
-        );
-        $routes->connect('/{controller}', [], ['routeClass' => '\stdClass']);
-    }
-
-    /**
      * Test conflicting parameters raises an exception.
      */
     public function testConnectConflictingParameters(): void


### PR DESCRIPTION
The return type declarations for the methods already ensure a TypeError
is thrown with appropriate message in case of type mismatch.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
