### PR TITLE
Make Driver::supports() abstract

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -634,20 +634,12 @@ abstract class Driver
     /**
      * Returns whether the driver supports the feature.
      *
-     * Defaults to true for FEATURE_QUOTE and FEATURE_SAVEPOINT.
+     * The FEATURE_* constants represent all features used by cakephp.
      *
      * @param string $feature Driver feature name
      * @return bool
      */
-    public function supports(string $feature): bool
-    {
-        return match ($feature) {
-            static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
-            static::FEATURE_QUOTE,
-            static::FEATURE_SAVEPOINT => true,
-            default => false,
-        };
-    }
+    abstract public function supports(string $feature): bool;
 
     /**
      * Transforms the passed query to this Driver's dialect and returns an instance

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -212,6 +212,12 @@ class Mysql extends Driver
     public function supports(string $feature): bool
     {
         return match ($feature) {
+            static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
+            static::FEATURE_QUOTE,
+            static::FEATURE_SAVEPOINT => true,
+
+            static::FEATURE_TRUNCATE_WITH_CONSTRAINTS => false,
+
             static::FEATURE_CTE,
             static::FEATURE_JSON,
             static::FEATURE_WINDOW => version_compare(
@@ -219,7 +225,8 @@ class Mysql extends Driver
                 $this->featureVersions[$this->serverType][$feature],
                 '>='
             ),
-            default => parent::supports($feature),
+
+            default => false,
         };
     }
 

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -183,10 +183,14 @@ class Postgres extends Driver
         return match ($feature) {
             static::FEATURE_CTE,
             static::FEATURE_JSON,
+            static::FEATURE_QUOTE,
+            static::FEATURE_SAVEPOINT,
             static::FEATURE_TRUNCATE_WITH_CONSTRAINTS,
             static::FEATURE_WINDOW => true,
+
             static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION => false,
-            default => parent::supports($feature),
+
+            default => false,
         };
     }
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -194,14 +194,21 @@ class Sqlite extends Driver
     public function supports(string $feature): bool
     {
         return match ($feature) {
+            static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
+            static::FEATURE_QUOTE,
+            static::FEATURE_SAVEPOINT,
+            static::FEATURE_TRUNCATE_WITH_CONSTRAINTS => true,
+
+            static::FEATURE_JSON => false,
+
             static::FEATURE_CTE,
             static::FEATURE_WINDOW => version_compare(
                 $this->version(),
                 $this->featureVersions[$feature],
                 '>='
             ),
-            static::FEATURE_TRUNCATE_WITH_CONSTRAINTS => true,
-            default => parent::supports($feature),
+
+            default => false,
         };
     }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -270,10 +270,16 @@ class Sqlserver extends Driver
     {
         return match ($feature) {
             static::FEATURE_CTE,
+            static::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION,
+            static::FEATURE_SAVEPOINT,
             static::FEATURE_TRUNCATE_WITH_CONSTRAINTS,
             static::FEATURE_WINDOW => true,
+
+            static::FEATURE_JSON => false,
+
             static::FEATURE_QUOTE => $this->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc',
-            default => parent::supports($feature),
+
+            default => false,
         };
     }
 

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -224,21 +224,18 @@ class MysqlTest extends TestCase
                 'window' => '10.2.0',
             ],
         ];
+        foreach ($featureVersions[$serverType] as $feature => $version) {
+            $this->assertSame(
+                version_compare($driver->version(), $version, '>='),
+                $driver->supports($feature)
+            );
+        }
 
-        $this->assertSame(
-            version_compare($driver->version(), $featureVersions[$serverType]['cte'], '>='),
-            $driver->supports(Driver::FEATURE_CTE)
-        );
-        $this->assertSame(
-            version_compare($driver->version(), $featureVersions[$serverType]['json'], '>='),
-            $driver->supports(Driver::FEATURE_CTE)
-        );
-        $this->assertSame(
-            version_compare($driver->version(), $featureVersions[$serverType]['window'], '>='),
-            $driver->supports(Driver::FEATURE_CTE)
-        );
+        $this->assertTrue($driver->supports(Driver::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
         $this->assertTrue($driver->supports(Driver::FEATURE_SAVEPOINT));
         $this->assertTrue($driver->supports(Driver::FEATURE_QUOTE));
+
+        $this->assertFalse($driver->supports(Driver::FEATURE_TRUNCATE_WITH_CONSTRAINTS));
 
         $this->assertFalse($driver->supports('this-is-fake'));
     }

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -247,11 +247,14 @@ class PostgresTest extends TestCase
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!$driver instanceof Postgres);
 
+        $this->assertTrue($driver->supports(Driver::FEATURE_TRUNCATE_WITH_CONSTRAINTS));
         $this->assertTrue($driver->supports(Driver::FEATURE_CTE));
         $this->assertTrue($driver->supports(Driver::FEATURE_JSON));
         $this->assertTrue($driver->supports(Driver::FEATURE_SAVEPOINT));
         $this->assertTrue($driver->supports(Driver::FEATURE_QUOTE));
         $this->assertTrue($driver->supports(Driver::FEATURE_WINDOW));
+
+        $this->assertFalse($driver->supports(Driver::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
 
         $this->assertFalse($driver->supports('this-is-fake'));
     }

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -201,21 +201,22 @@ class SqliteTest extends TestCase
         $this->skipIf(!$driver instanceof Sqlite);
 
         $featureVersions = [
-            'cte' => '3.8.3',
-            'window' => '3.28.0',
+            Driver::FEATURE_CTE => '3.8.3',
+            Driver::FEATURE_WINDOW => '3.28.0',
         ];
+        foreach ($featureVersions as $feature => $version) {
+            $this->assertSame(
+                version_compare($driver->version(), $version, '>='),
+                $driver->supports($feature)
+            );
+        }
 
-        $this->assertSame(
-            version_compare($driver->version(), $featureVersions['cte'], '>='),
-            $driver->supports(Driver::FEATURE_CTE)
-        );
-        $this->assertSame(
-            version_compare($driver->version(), $featureVersions['window'], '>='),
-            $driver->supports(Driver::FEATURE_WINDOW)
-        );
-        $this->assertFalse($driver->supports(Driver::FEATURE_JSON));
+        $this->assertTrue($driver->supports(Driver::FEATURE_TRUNCATE_WITH_CONSTRAINTS));
+        $this->assertTrue($driver->supports(Driver::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
         $this->assertTrue($driver->supports(Driver::FEATURE_SAVEPOINT));
         $this->assertTrue($driver->supports(Driver::FEATURE_QUOTE));
+
+        $this->assertFalse($driver->supports(Driver::FEATURE_JSON));
 
         $this->assertFalse($driver->supports('this-is-fake'));
     }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -513,11 +513,14 @@ class SqlserverTest extends TestCase
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(!$driver instanceof Sqlserver);
 
+        $this->assertTrue($driver->supports(Driver::FEATURE_DISABLE_CONSTRAINT_WITHOUT_TRANSACTION));
+        $this->assertTrue($driver->supports(Driver::FEATURE_TRUNCATE_WITH_CONSTRAINTS));
         $this->assertTrue($driver->supports(Driver::FEATURE_CTE));
-        $this->assertFalse($driver->supports(Driver::FEATURE_JSON));
         $this->assertTrue($driver->supports(Driver::FEATURE_SAVEPOINT));
         $this->assertTrue($driver->supports(Driver::FEATURE_QUOTE));
         $this->assertTrue($driver->supports(Driver::FEATURE_WINDOW));
+
+        $this->assertFalse($driver->supports(Driver::FEATURE_JSON));
 
         $this->assertFalse($driver->supports('this-is-fake'));
     }

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -109,21 +109,6 @@ class DriverTest extends TestCase
     }
 
     /**
-     * Tests default implementation of feature support check.
-     */
-    public function testSupports(): void
-    {
-        $this->assertTrue($this->driver->supports(Driver::FEATURE_SAVEPOINT));
-        $this->assertTrue($this->driver->supports(Driver::FEATURE_QUOTE));
-
-        $this->assertFalse($this->driver->supports(Driver::FEATURE_CTE));
-        $this->assertFalse($this->driver->supports(Driver::FEATURE_JSON));
-        $this->assertFalse($this->driver->supports(Driver::FEATURE_WINDOW));
-
-        $this->assertFalse($this->driver->supports('this-is-fake'));
-    }
-
-    /**
      * Test schemaValue().
      * Uses a provider for all the different values we can pass to the method.
      *


### PR DESCRIPTION
The default implementation was added so we could support it in a minor release, but we really shouldn't provide default feature checks.

We want drivers (only Oracle really) to create this function.


