### PR TITLE
fix ResultSet index being changed when an exception is thrown inside a loop

### DIFF
--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -576,6 +576,7 @@ class ResultSet implements ResultSetInterface
         // toArray() adjusts the current index, so we have to reset it
         $items = $this->toArray();
         $this->_index = $currentIndex;
+
         return [
             'items' => $items,
         ];

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -572,8 +572,12 @@ class ResultSet implements ResultSetInterface
      */
     public function __debugInfo()
     {
+        $currentIndex = $this->_index;
+        // toArray() adjusts the current index, so we have to reset it
+        $items = $this->toArray();
+        $this->_index = $currentIndex;
         return [
-            'items' => $this->toArray(),
+            'items' => $items,
         ];
     }
 }


### PR DESCRIPTION
fixes #16623

This problem is only reproducable if the xdebug PHP extension is enabled.