### PR TITLE
Use assert() for asserting valid class types.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
         extensions: mbstring, intl, apcu, memcached, redis, pdo_${{ matrix.db-type }}
-        ini-values: apc.enable_cli = 1
+        ini-values: apc.enable_cli = 1, zend.assertions = 1
         coverage: pcov
 
     - name: Get composer cache directory
@@ -164,7 +164,7 @@ jobs:
       with:
         php-version: ${{ env.PHP_VERSION }}
         extensions: ${{ env.EXTENSIONS }}
-        ini-values: apc.enable_cli = 1, extension = php_fileinfo.dll
+        ini-values: apc.enable_cli = 1, zend.assertions = 1, extension = php_fileinfo.dll
         coverage: none
 
     - name: Setup SQLServer

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -79,11 +79,7 @@ class CacheRegistry extends ObjectRegistry
         }
         unset($config['className']);
 
-        if (!($instance instanceof CacheEngine)) {
-            throw new CakeException(
-                'Cache engines must use Cake\Cache\CacheEngine as a base class.'
-            );
-        }
+        assert($instance instanceof CacheEngine, 'Cache engines must extend Cake\Cache\CacheEngine.');
 
         if (!$instance->init($config)) {
             throw new CakeException(

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -68,7 +68,7 @@ class CacheRegistry extends ObjectRegistry
      * @param string $alias The alias of the object.
      * @param array<string, mixed> $config An array of settings to use for the cache engine.
      * @return \Cake\Cache\CacheEngine The constructed CacheEngine class.
-     * @throws \Cake\Core\Exception\CakeException when an object doesn't implement the correct interface.
+     * @throws \Cake\Core\Exception\CakeException When the cache engine cannot be initialized.
      */
     protected function _create(object|string $class, string $alias, array $config): CacheEngine
     {

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -20,7 +20,6 @@ use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\Exception\CakeException;
 use Cake\Utility\Inflector;
-use InvalidArgumentException;
 
 /**
  * Base class for console commands.
@@ -45,11 +44,10 @@ abstract class BaseCommand implements CommandInterface
      */
     public function setName(string $name)
     {
-        if (!strpos($name, ' ')) {
-            throw new InvalidArgumentException(
-                "The name '{$name}' is missing a space. Names should look like `cake routes`"
-            );
-        }
+        assert(
+            strpos($name, ' '),
+            "The name '{$name}' is missing a space. Names should look like `cake routes`"
+        );
         $this->name = $name;
 
         return $this;
@@ -266,16 +264,12 @@ abstract class BaseCommand implements CommandInterface
     public function executeCommand(CommandInterface|string $command, array $args = [], ?ConsoleIo $io = null): ?int
     {
         if (is_string($command)) {
-            if (!class_exists($command)) {
-                throw new InvalidArgumentException("Command class '{$command}' does not exist.");
-            }
-            $command = new $command();
-        }
-        if (!$command instanceof CommandInterface) {
-            $commandType = get_debug_type($command);
-            throw new InvalidArgumentException(
-                "Command '{$commandType}' is not a subclass of Cake\Console\CommandInterface."
+            assert(
+                is_subclass_of($command, CommandInterface::class),
+                "Command '{$command}' is not a subclass of Cake\Console\CommandInterface."
             );
+
+            $command = new $command();
         }
         $io = $io ?: new ConsoleIo();
 

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -61,13 +61,16 @@ class CommandCollection implements IteratorAggregate, Countable
      */
     public function add(string $name, CommandInterface|string $command)
     {
-        if (is_string($command) && !is_subclass_of($command, CommandInterface::class)) {
-            throw new InvalidArgumentException(sprintf(
-                "Cannot use '%s' for command '%s'. " .
-                "It is not a subclass of Cake\Console\CommandInterface.",
-                $command,
-                $name
-            ));
+        if (is_string($command)) {
+            assert(
+                is_subclass_of($command, CommandInterface::class),
+                sprintf(
+                    "Cannot use '%s' for command '%s'. " .
+                    "It is not a subclass of Cake\Console\CommandInterface.",
+                    $command,
+                    $name
+                )
+            );
         }
         if (!preg_match('/^[^\s]+(?:(?: [^\s]+){1,2})?$/ui', $name)) {
             throw new InvalidArgumentException(

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace Cake\Console;
 
 use Cake\Core\ContainerInterface;
-use InvalidArgumentException;
 
 /**
  * This is a factory for creating Command instances.
@@ -49,11 +48,6 @@ class CommandFactory implements CommandFactoryInterface
             $command = $this->container->get($className);
         } else {
             $command = new $className();
-        }
-
-        if (!$command instanceof CommandInterface) {
-            $message = sprintf('Class `%s` must be an instance of `Cake\Console\CommandInterface`.', $className);
-            throw new InvalidArgumentException($message);
         }
 
         return $command;

--- a/src/Console/CommandInterface.php
+++ b/src/Console/CommandInterface.php
@@ -45,7 +45,6 @@ interface CommandInterface
      *
      * @param string $name The name the command uses in the collection.
      * @return $this
-     * @throws \InvalidArgumentException
      */
     public function setName(string $name);
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -30,7 +30,6 @@ use Cake\Event\EventManagerInterface;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Cake\Utility\Inflector;
-use InvalidArgumentException;
 
 /**
  * Run CLI commands for the provided application.
@@ -125,13 +124,10 @@ class CommandRunner implements EventDispatcherInterface
      * @param array $argv The arguments from the CLI environment.
      * @param \Cake\Console\ConsoleIo|null $io The ConsoleIo instance. Used primarily for testing.
      * @return int The exit code of the command.
-     * @throws \InvalidArgumentException
      */
     public function run(array $argv, ?ConsoleIo $io = null): int
     {
-        if (empty($argv)) {
-            throw new InvalidArgumentException('Cannot run any commands. No arguments received.');
-        }
+        assert(!empty($argv), 'Cannot run any commands. No arguments received.');
 
         $this->bootstrap();
 
@@ -218,13 +214,14 @@ class CommandRunner implements EventDispatcherInterface
      */
     public function setEventManager(EventManagerInterface $eventManager)
     {
-        if ($this->app instanceof PluginApplicationInterface) {
-            $this->app->setEventManager($eventManager);
+        assert(
+            $this->app instanceof PluginApplicationInterface,
+            'Cannot set the event manager, the application does not support events.'
+        );
 
-            return $this;
-        }
+        $this->app->setEventManager($eventManager);
 
-        throw new InvalidArgumentException('Cannot set the event manager, the application does not support events.');
+        return $this;
     }
 
     /**

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -205,12 +205,8 @@ class CommandRunner implements EventDispatcherInterface
     /**
      * Get/set the application's event manager.
      *
-     * If the application does not support events and this method is used as
-     * a setter, an exception will be raised.
-     *
      * @param \Cake\Event\EventManagerInterface $eventManager The event manager to set.
      * @return $this
-     * @throws \InvalidArgumentException
      */
     public function setEventManager(EventManagerInterface $eventManager)
     {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -44,7 +44,6 @@ use Psr\Http\Server\MiddlewareInterface;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionMethod;
-use UnexpectedValueException;
 
 /**
  * Application controller class for organization of business logic.
@@ -477,19 +476,20 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * @param \Closure $action The action closure.
      * @param array $args The arguments to be passed when invoking action.
      * @return void
-     * @throws \UnexpectedValueException If return value of action is not `null` or `ResponseInterface` instance.
      */
     public function invokeAction(Closure $action, array $args): void
     {
         $result = $action(...$args);
-        if ($result !== null && !$result instanceof ResponseInterface) {
-            throw new UnexpectedValueException(sprintf(
-                'Controller actions can only return ResponseInterface instance or null. '
-                . 'Got %s instead.',
-                get_debug_type($result)
-            ));
-        }
-        if ($result === null && $this->isAutoRenderEnabled()) {
+        if ($result !== null) {
+            assert(
+                $result instanceof ResponseInterface,
+                sprintf(
+                    'Controller actions can only return ResponseInterface instance or null. '
+                    . 'Got %s instead.',
+                    get_debug_type($result)
+                )
+            );
+        } elseif ($this->isAutoRenderEnabled()) {
             $result = $this->render();
         }
         if ($result) {

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -97,6 +97,13 @@ class Configure
             if (static::$_hasIniSet) {
                 ini_set('display_errors', $config['debug'] ? '1' : '0');
             }
+
+            if ($config['debug'] && ini_get('zend.assertions') === '-1') {
+                trigger_error(
+                    'You should set `zend.assertions` to `1` in your php.ini for your development environment.',
+                    E_USER_WARNING
+                );
+            }
         }
     }
 

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
-use Cake\Core\Exception\CakeException;
 use League\Container\DefinitionContainerInterface;
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Container\ServiceProvider\BootableServiceProviderInterface;
@@ -48,14 +47,14 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
     {
         $container = parent::getContainer();
 
-        if (!($container instanceof ContainerInterface)) {
-            $message = sprintf(
+        assert(
+            $container instanceof ContainerInterface,
+            sprintf(
                 'Unexpected container type. Expected `%s` got `%s` instead.',
                 ContainerInterface::class,
                 get_debug_type($container)
-            );
-            throw new CakeException($message);
-        }
+            )
+        );
 
         return $container;
     }

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -311,13 +311,11 @@ class WindowExpression implements ExpressionInterface, WindowInterface
             $offset = $offset->sql($binder);
         }
 
-        $sql = sprintf(
+        return sprintf(
             '%s %s',
             $offset ?? 'UNBOUNDED',
             $direction
         );
-
-        return $sql;
     }
 
     /**

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -171,9 +171,11 @@ class NumericPaginator implements PaginatorInterface
             }
         }
 
-        if (!($target instanceof RepositoryInterface)) {
-            throw new CakeException('Pagination targe must be a QueryInterface or ResultSetInterface instance.');
-        }
+        assert(
+            $target instanceof RepositoryInterface,
+            'Pagination target must be an instance of Cake\Datasource\QueryInterface'
+                . ' or Cake\Datasource\RepositoryInterface.'
+        );
 
         $data = $this->extractData($target, $params, $settings);
         $query = $this->getQuery($target, $query, $data);

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -169,6 +169,8 @@ class ExceptionTrap
         set_exception_handler($this->handleException(...));
         register_shutdown_function($this->handleShutdown(...));
         static::$registeredTrap = $this;
+
+        ini_set('assert.exception', '1');
     }
 
     /**

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -202,9 +202,6 @@ class Client implements ClientInterface
             $adapter = new $adapter();
         }
 
-        if (!$adapter instanceof AdapterInterface) {
-            throw new InvalidArgumentException('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
-        }
         $this->_adapter = $adapter;
 
         if (!empty($this->_config['cookieJar'])) {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -181,7 +181,6 @@ class Client implements ClientInterface
      *   to use. Short class names are resolved to the `Http\Client\Auth` namespace.
      *
      * @param array<string, mixed> $config Config options for scoped clients.
-     * @throws \InvalidArgumentException
      */
     public function __construct(array $config = [])
     {

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -86,13 +86,6 @@ abstract class BaseLog extends AbstractLogger
             $formatter = new $class($options);
         }
 
-        if (!$formatter instanceof AbstractFormatter) {
-            throw new InvalidArgumentException(sprintf(
-                'Formatter must extend `%s`, got `%s` instead',
-                AbstractFormatter::class,
-                get_class($formatter)
-            ));
-        }
         $this->formatter = $formatter;
     }
 

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -23,7 +23,6 @@ use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
 use Cake\ORM\Behavior;
 use DateTimeInterface;
-use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -219,9 +218,10 @@ class TimestampBehavior extends Behavior
         /** @var \Cake\Database\Type\DateTimeType $type */
         $type = TypeFactory::build($columnType);
 
-        if (!$type instanceof DateTimeType) {
-            throw new InvalidArgumentException('TimestampBehavior only supports columns of type DateTimeType.');
-        }
+        assert(
+            $type instanceof DateTimeType,
+            'TimestampBehavior only supports columns of type DateTimeType.'
+        );
 
         $class = $type->getDateTimeClassName();
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -29,7 +29,6 @@ use Cake\Datasource\QueryTrait;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Datasource\ResultSetInterface;
 use Closure;
-use InvalidArgumentException;
 use JsonSerializable;
 
 /**
@@ -156,13 +155,13 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      *
      * @param \Cake\ORM\Table $repository The default table object to use.
      * @return $this
-     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function repository(RepositoryInterface $repository)
     {
-        if (!$repository instanceof Table) {
-            throw new InvalidArgumentException('$repository must be an instance of Cake\ORM\Table.');
-        }
+        assert(
+            $repository instanceof Table,
+            '$repository must be an instance of Cake\ORM\Table.'
+        );
 
         $this->_repository = $repository;
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1951,11 +1951,14 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 return false;
             }
 
-            if ($result !== false && !($result instanceof EntityInterface)) {
-                throw new DatabaseException(sprintf(
-                    'The beforeSave callback must return `false` or `EntityInterface` instance. Got `%s` instead.',
-                    get_debug_type($result)
-                ));
+            if ($result !== false) {
+                assert(
+                    $result instanceof EntityInterface,
+                    sprintf(
+                        'The beforeSave callback must return `false` or `EntityInterface` instance. Got `%s` instead.',
+                        get_debug_type($result)
+                    )
+                );
             }
 
             return $result;

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -126,14 +126,15 @@ trait ValidatorAwareTrait
             $this->dispatchEvent($event, compact('validator', 'name'));
         }
 
-        if (!$validator instanceof Validator) {
-            throw new InvalidArgumentException(sprintf(
+        assert(
+            $validator instanceof Validator,
+            sprintf(
                 'The %s::%s() validation method must return an instance of %s.',
                 static::class,
                 $method,
                 Validator::class
-            ));
-        }
+            )
+        );
 
         return $validator;
     }

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\View\Form;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Form\Form;
 use Cake\Utility\Hash;
 
@@ -54,9 +53,10 @@ class FormContext implements ContextInterface
      */
     public function __construct(array $context)
     {
-        if (!isset($context['entity']) || !$context['entity'] instanceof Form) {
-            throw new CakeException('`$context[\'entity\']` must be an instance of Cake\Form\Form');
-        }
+        assert(
+            isset($context['entity']) && $context['entity'] instanceof Form,
+            "`\$context['entity']` must be an instance of Cake\Form\Form"
+        );
 
         $this->_form = $context['entity'];
         $this->_validator = $context['validator'] ?? null;

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -123,12 +123,15 @@ class WidgetLocator
                 continue;
             }
 
-            if (is_object($widget) && !($widget instanceof WidgetInterface)) {
-                throw new InvalidArgumentException(sprintf(
-                    'Widget objects must implement `%s`. Got `%s` instance instead.',
-                    WidgetInterface::class,
-                    get_debug_type($widget)
-                ));
+            if (is_object($widget)) {
+                assert(
+                    $widget instanceof WidgetInterface,
+                    sprintf(
+                        'Widget objects must implement `%s`. Got `%s` instance instead.',
+                        WidgetInterface::class,
+                        get_debug_type($widget)
+                    )
+                );
             }
 
             $this->_widgets[$key] = $widget;

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -111,7 +111,6 @@ class WidgetLocator
      *
      * @param array $widgets Array of widgets to use.
      * @return void
-     * @throws \InvalidArgumentException When class does not implement WidgetInterface.
      */
     public function add(array $widgets): void
     {

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -246,7 +246,7 @@ class CacheTest extends TestCase
         ]);
 
         $this->expectError();
-        $this->expectErrorMessage('Cache engines must use Cake\Cache\CacheEngine');
+        $this->expectErrorMessage('Cache engines must extend Cake\Cache\CacheEngine');
 
         Cache::pool('tests');
     }

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -22,7 +22,6 @@ use Cake\Console\CommandCollection;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use stdClass;
 use TestApp\Command\DemoCommand;
 use TestApp\Command\SampleCommand;
 
@@ -49,18 +48,6 @@ class CommandCollectionTest extends TestCase
         $this->assertTrue($collection->has('routes'));
         $this->assertTrue($collection->has('sample'));
         $this->assertCount(2, $collection);
-    }
-
-    /**
-     * Constructor with invalid class names should blow up
-     */
-    public function testConstructorInvalidClass(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'nope\'. It is not a subclass of Cake\Console\CommandInterface');
-        new CommandCollection([
-            'nope' => stdClass::class,
-        ]);
     }
 
     /**
@@ -140,17 +127,6 @@ class CommandCollectionTest extends TestCase
         $this->expectExceptionMessage("The command name `$name` is invalid.");
         $collection = new CommandCollection();
         $collection->add($name, DemoCommand::class);
-    }
-
-    /**
-     * Class names that are not commands should fail
-     */
-    public function testInvalidCommandClassName(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use \'Cake\TestSuite\TestCase\' for command \'routes\'. It is not a subclass of Cake\Console\CommandInterface');
-        $collection = new CommandCollection();
-        $collection->add('routes', TestCase::class);
     }
 
     /**

--- a/tests/TestCase/Console/CommandFactoryTest.php
+++ b/tests/TestCase/Console/CommandFactoryTest.php
@@ -18,7 +18,6 @@ use Cake\Console\CommandFactory;
 use Cake\Console\CommandInterface;
 use Cake\Core\Container;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use stdClass;
 use TestApp\Command\DemoCommand;
 use TestApp\Command\DependencyCommand;
@@ -45,18 +44,5 @@ class CommandFactoryTest extends TestCase
         $command = $factory->create(DependencyCommand::class);
         $this->assertInstanceOf(DependencyCommand::class, $command);
         $this->assertInstanceOf(stdClass::class, $command->inject);
-    }
-
-    public function testInvalid(): void
-    {
-        $factory = new CommandFactory();
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Class `Cake\Test\TestCase\Console\CommandFactoryTest` must be an instance of ' .
-            '`Cake\Console\CommandInterface`.'
-        );
-
-        $factory->create(static::class);
     }
 }

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -28,7 +28,6 @@ use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use stdClass;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DemoCommand;
@@ -85,35 +84,6 @@ class CommandRunnerTest extends TestCase
 
         $runner = new CommandRunner($app);
         $this->assertSame(EventManager::instance(), $runner->getEventManager());
-    }
-
-    /**
-     * test event manager cannot be set on applications without events.
-     */
-    public function testSetEventManagerNonEventedApplication(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $app = $this->createMock(ConsoleApplicationInterface::class);
-
-        $events = new EventManager();
-        $runner = new CommandRunner($app);
-        $runner->setEventManager($events);
-    }
-
-    /**
-     * Test that running with empty argv fails
-     */
-    public function testRunMissingRootCommand(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot run any commands. No arguments received.');
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
-        $runner = new CommandRunner($app);
-        $runner->run([]);
     }
 
     /**

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
+use AssertionError;
 use Cake\Command\Command;
 use Cake\Console\CommandInterface;
 use Cake\Console\ConsoleIo;
@@ -25,7 +26,6 @@ use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\AutoLoadModelCommand;
 use TestApp\Command\DemoCommand;
@@ -71,7 +71,7 @@ class CommandTest extends TestCase
      */
     public function testSetNameInvalid(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(AssertionError::class);
         $this->expectExceptionMessage('The name \'routes_show\' is missing a space. Names should look like `cake routes`');
 
         $command = new Command();
@@ -83,7 +83,7 @@ class CommandTest extends TestCase
      */
     public function testSetNameInvalidLeadingSpace(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(AssertionError::class);
 
         $command = new Command();
         $command->setName(' routes_show');
@@ -243,18 +243,6 @@ class CommandTest extends TestCase
         $result = $command->executeCommand(DemoCommand::class, [], $this->getMockIo($output));
         $this->assertNull($result);
         $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
-    }
-
-    /**
-     * test executeCommand with an invalid string class
-     */
-    public function testExecuteCommandStringInvalid(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Command class 'Nope' does not exist");
-
-        $command = new Command();
-        $command->executeCommand('Nope', [], $this->getMockIo(new StubConsoleOutput()));
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Controller;
 
+use AssertionError;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\Configure;
@@ -42,7 +43,6 @@ use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\PostsTable;
 use TestPlugin\Controller\Admin\CommentsController;
 use TestPlugin\Controller\TestPluginController;
-use UnexpectedValueException;
 
 /**
  * ControllerTest class
@@ -855,7 +855,7 @@ class ControllerTest extends TestCase
      */
     public function testInvokeActionException(): void
     {
-        $this->expectException(UnexpectedValueException::class);
+        $this->expectException(AssertionError::class);
         $this->expectExceptionMessage(
             'Controller actions can only return ResponseInterface instance or null. '
                 . 'Got string instead.'

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -73,17 +73,6 @@ class ClientTest extends TestCase
     }
 
     /**
-     * testAdapterInstanceCheck
-     */
-    public function testAdapterInstanceCheck(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
-
-        new Client(['adapter' => 'stdClass']);
-    }
-
-    /**
      * Data provider for buildUrl() tests
      *
      * @return array

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -21,10 +21,8 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Http\Response;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
-use InvalidArgumentException;
 use Psr\Log\LogLevel;
 use TestApp\Log\Engine\TestBaseLog;
-use TestApp\Log\Formatter\InvalidFormatter;
 use TestApp\Log\Formatter\ValidFormatter;
 
 class BaseLogTest extends TestCase
@@ -158,14 +156,5 @@ class BaseLogTest extends TestCase
 
         $log = new TestBaseLog(['formatter' => new ValidFormatter()]);
         $this->assertNotNull($log);
-    }
-
-    /**
-     * Test creating log engine with invalid formatter.
-     */
-    public function testInvalidFormatter(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new TestBaseLog(['formatter' => InvalidFormatter::class]);
     }
 }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM\Behavior;
 
+use AssertionError;
 use Cake\Event\Event;
 use Cake\I18n\DateTime;
 use Cake\ORM\Behavior\TimestampBehavior;
@@ -23,7 +24,6 @@ use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
-use InvalidArgumentException;
 use UnexpectedValueException;
 
 /**
@@ -227,7 +227,7 @@ class TimestampBehaviorTest extends TestCase
      */
     public function testNonDateTimeTypeException(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(AssertionError::class);
         $this->expectExceptionMessage('TimestampBehavior only supports columns of type DateTimeType.');
 
         $table = $this->getTableInstance();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use ArrayObject;
+use AssertionError;
 use BadMethodCallException;
 use Cake\Collection\Collection;
 use Cake\Database\Driver\Sqlserver;
@@ -2098,7 +2099,7 @@ class TableTest extends TestCase
      */
     public function testBeforeSaveException(): void
     {
-        $this->expectException(DatabaseException::class);
+        $this->expectException(AssertionError::class);
         $this->expectExceptionMessage('The beforeSave callback must return `false` or `EntityInterface` instance. Got `int` instead.');
 
         $table = $this->getTableLocator()->get('users');
@@ -3348,7 +3349,7 @@ class TableTest extends TestCase
         $table->expects($this->once())
             ->method('validationBad');
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(AssertionError::class);
         $this->expectExceptionMessage(sprintf(
             'The %s::validationBad() validation method must return an instance of Cake\Validation\Validator.',
             get_class($table)

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\View\Form;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Form\Form;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
@@ -33,14 +32,6 @@ class FormContextTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-    }
-
-    public function testConstructor()
-    {
-        $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('`$context[\'entity\']` must be an instance of Cake\Form\Form');
-
-        new FormContext([]);
     }
 
     /**

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -21,7 +21,6 @@ use Cake\View\StringTemplate;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
-use stdClass;
 use TestApp\View\Widget\TestUsingViewWidget;
 
 /**
@@ -128,21 +127,6 @@ class WidgetLocatorTest extends TestCase
         ]);
         $result = $inputs->get('hidden');
         $this->assertInstanceOf('Cake\View\Widget\WidgetInterface', $result);
-    }
-
-    /**
-     * Test adding an instance of an invalid type.
-     */
-    public function testAddInvalidType(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Widget objects must implement `Cake\View\Widget\WidgetInterface`. Got `stdClass` instance instead.'
-        );
-        $inputs = new WidgetLocator($this->templates, $this->view);
-        $inputs->add([
-            'text' => new stdClass(),
-        ]);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -133,6 +133,7 @@ Security::setSalt('a-long-but-not-random-value');
 
 ini_set('intl.default_locale', 'en_US');
 ini_set('session.gc_divisor', '1');
+ini_set('assert.exception', '1');
 
 // Fixate sessionid early on, as php7.2+
 // does not allow the sessionid to be set after stdout


### PR DESCRIPTION
This allows the assertion code to be totally skipped in production
using the zend.assertions ini config.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
