### PR TITLE
Ensure TableLocator returns the same instance when using a table's registry alias.

### DIFF
--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -215,8 +215,6 @@ class TableLocator extends AbstractLocator implements LocatorInterface
             $options = ['alias' => $classAlias] + $options;
         } elseif (!isset($options['alias'])) {
             $options['className'] = $alias;
-            /** @psalm-suppress PossiblyFalseOperand */
-            $alias = substr($alias, strrpos($alias, '\\') + 1, -5);
         }
 
         if (isset($this->_config[$alias])) {

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -178,6 +178,10 @@ class TableLocatorTest extends TestCase
 
         $result = $this->_locator->get(ArticlesTable::class);
         $this->assertSame('Articles', $result->getAlias());
+        $this->assertSame(ArticlesTable::class, $result->getRegistryAlias());
+
+        $result2 = $this->_locator->get($result->getRegistryAlias());
+        $this->assertSame($result, $result2);
     }
 
     /**


### PR DESCRIPTION
Refs #16419

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
