### PR TITLE
Improve casting of integer routing parameters

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -268,7 +268,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             case 'float':
                 return is_numeric($argument) ? (float)$argument : null;
             case 'int':
-                return ctype_digit($argument) || filter_var($argument, FILTER_VALIDATE_INT) ? (int)$argument : null;
+                return filter_var($argument, FILTER_VALIDATE_INT) ? (int)$argument : null;
             case 'bool':
                 return $argument === '0' ? false : ($argument === '1' ? true : null);
             case 'array':

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -268,7 +268,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             case 'float':
                 return is_numeric($argument) ? (float)$argument : null;
             case 'int':
-                return ctype_digit($argument) ? (int)$argument : null;
+                return ctype_digit($argument) || filter_var($argument, FILTER_VALIDATE_INT) ? (int)$argument : null;
             case 'bool':
                 return $argument === '0' ? false : ($argument === '1' ? true : null);
             case 'array':

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -733,7 +733,7 @@ class ControllerFactoryTest extends TestCase
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'requiredTyped',
-                'pass' => ['1.0', '02', '0', '8,9'],
+                'pass' => ['1.0', '2', '0', '8,9'],
             ],
         ]);
         $controller = $this->factory->create($request);
@@ -748,7 +748,7 @@ class ControllerFactoryTest extends TestCase
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'requiredTyped',
-                'pass' => ['1.0', '02', '0', ''],
+                'pass' => ['1.0', '2', '0', ''],
             ],
         ]);
         $controller = $this->factory->create($request);

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -740,8 +740,6 @@ class ControllerFactoryTest extends TestCase
 
         $result = $this->factory->invoke($controller);
         $data = json_decode((string)$result->getBody(), true);
-
-        $this->assertNotNull($data);
         $this->assertSame(['one' => 1.0, 'two' => 2, 'three' => false, 'four' => ['8', '9']], $data);
 
         $request = new ServerRequest([
@@ -757,9 +755,22 @@ class ControllerFactoryTest extends TestCase
 
         $result = $this->factory->invoke($controller);
         $data = json_decode((string)$result->getBody(), true);
-
-        $this->assertNotNull($data);
         $this->assertSame(['one' => 1.0, 'two' => 2, 'three' => false, 'four' => []], $data);
+
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/requiredTyped',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'requiredTyped',
+                'pass' => ['1.0', '-1', '0', ''],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+
+        $result = $this->factory->invoke($controller);
+        $data = json_decode((string)$result->getBody(), true);
+        $this->assertSame(['one' => 1.0, 'two' => -1, 'three' => false, 'four' => []], $data);
     }
 
     /**
@@ -781,7 +792,6 @@ class ControllerFactoryTest extends TestCase
         $result = $this->factory->invoke($controller);
         $data = json_decode((string)$result->getBody(), true);
 
-        $this->assertNotNull($data);
         $this->assertSame(['one' => 1.0, 'two' => 2, 'three' => true], $data);
     }
 


### PR DESCRIPTION
Allow negative numbers to be cast to integers for typed routing parameters.

Fixes #16640