### PR TITLE
Allow negative numbers for typed int action parameters

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -268,7 +268,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             case 'float':
                 return is_numeric($argument) ? (float)$argument : null;
             case 'int':
-                return ctype_digit($argument) ? (int)$argument : null;
+                return preg_match('/^\-?[0-9]+$/', $argument) === 1 ? (int)$argument : null;
             case 'bool':
                 return $argument === '0' ? false : ($argument === '1' ? true : null);
             case 'array':

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -733,7 +733,7 @@ class ControllerFactoryTest extends TestCase
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'requiredTyped',
-                'pass' => ['1.0', '02', '0', '8,9'],
+                'pass' => ['1.0', '-0123456789', '0', '8,9'],
             ],
         ]);
         $controller = $this->factory->create($request);
@@ -742,7 +742,7 @@ class ControllerFactoryTest extends TestCase
         $data = json_decode((string)$result->getBody(), true);
 
         $this->assertNotNull($data);
-        $this->assertSame(['one' => 1.0, 'two' => 2, 'three' => false, 'four' => ['8', '9']], $data);
+        $this->assertSame(['one' => 1.0, 'two' => -123456789, 'three' => false, 'four' => ['8', '9']], $data);
 
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/requiredTyped',
@@ -809,7 +809,7 @@ class ControllerFactoryTest extends TestCase
     /**
      * Test using invalid value for supported type
      */
-    public function testInvokePassedParametersUnsupportedIntCoercion(): void
+    public function testInvokePassedParametersUnsupportedIntCoercionFloat(): void
     {
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/requiredTyped',
@@ -824,6 +824,48 @@ class ControllerFactoryTest extends TestCase
 
         $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage('Unable to coerce "2.0" to `int` for `two` in action Dependencies::requiredTyped()');
+        $this->factory->invoke($controller);
+    }
+
+    /**
+     * Test using invalid value for supported type
+     */
+    public function testInvokePassedParametersUnsupportedIntCoercionEmpty(): void
+    {
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/requiredTyped',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'requiredTyped',
+                'pass' => ['1', '', '1'],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Unable to coerce "" to `int` for `two` in action Dependencies::requiredTyped()');
+        $this->factory->invoke($controller);
+    }
+
+    /**
+     * Test using invalid value for supported type
+     */
+    public function testInvokePassedParametersUnsupportedIntCoercionPartial(): void
+    {
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/dependencies/requiredTyped',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'Dependencies',
+                'action' => 'requiredTyped',
+                'pass' => ['1', '-', '1'],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Unable to coerce "-" to `int` for `two` in action Dependencies::requiredTyped()');
         $this->factory->invoke($controller);
     }
 


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/16640

We are already supporting a leading 0 so switch to regex to validate integer strings with negative numbers since filter_var() will fail.