### PR TITLE
Fix string to int action parameter coercion failing for '0'

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -268,7 +268,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             case 'float':
                 return is_numeric($argument) ? (float)$argument : null;
             case 'int':
-                return filter_var($argument, FILTER_VALIDATE_INT) ? (int)$argument : null;
+                return filter_var($argument, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
             case 'bool':
                 return $argument === '0' ? false : ($argument === '1' ? true : null);
             case 'array':

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -748,14 +748,14 @@ class ControllerFactoryTest extends TestCase
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'requiredTyped',
-                'pass' => ['1.0', '2', '0', ''],
+                'pass' => ['1.0', '0', '0', ''],
             ],
         ]);
         $controller = $this->factory->create($request);
 
         $result = $this->factory->invoke($controller);
         $data = json_decode((string)$result->getBody(), true);
-        $this->assertSame(['one' => 1.0, 'two' => 2, 'three' => false, 'four' => []], $data);
+        $this->assertSame(['one' => 1.0, 'two' => 0, 'three' => false, 'four' => []], $data);
 
         $request = new ServerRequest([
             'url' => 'test_plugin_three/dependencies/requiredTyped',


### PR DESCRIPTION
Fixes bug introduced in https://github.com/cakephp/cakephp/pull/16643