### PR TITLE
Detect Auth Plain or Login for SMTP

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -28,6 +28,9 @@ use RuntimeException;
  */
 class SmtpTransport extends AbstractTransport
 {
+    protected const AUTH_PLAN = 'PLAIN';
+    protected const AUTH_LOGIN = 'LOGIN';
+
     /**
      * Default config for this class
      *
@@ -232,20 +235,20 @@ class SmtpTransport extends AbstractTransport
 
         $auth = '';
         foreach ($this->_lastResponse as $line) {
-            if (strlen($line['message']) == 0 || substr($line['message'], 0, 5) === 'AUTH ') {
+            if (strlen($line['message']) === 0 || substr($line['message'], 0, 5) === 'AUTH ') {
                 $auth = $line['message'];
                 break;
             }
         }
 
-        if (strpos($auth, 'PLAIN') !== false) {
-            $this->authType = 'PLAIN';
+        if (strpos($auth, self::AUTH_PLAN) !== false) {
+            $this->authType = self::AUTH_PLAN;
 
             return;
         }
 
-        if (strpos($auth, 'LOGIN') !== false) {
-            $this->authType = 'LOGIN';
+        if (strpos($auth, self::AUTH_LOGIN) !== false) {
+            $this->authType = self::AUTH_LOGIN;
 
             return;
         }
@@ -331,13 +334,13 @@ class SmtpTransport extends AbstractTransport
             return;
         }
 
-        if ($this->authType === 'PLAIN') {
+        if ($this->authType === self::AUTH_PLAN) {
             $this->_authPlain($username, $password);
 
             return;
         }
 
-        if ($this->authType === 'LOGIN') {
+        if ($this->authType === self::AUTH_LOGIN) {
             $this->_authLogin($username, $password);
 
             return;

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -28,7 +28,7 @@ use RuntimeException;
  */
 class SmtpTransport extends AbstractTransport
 {
-    protected const AUTH_PLAN = 'PLAIN';
+    protected const AUTH_PLAIN = 'PLAIN';
     protected const AUTH_LOGIN = 'LOGIN';
 
     /**
@@ -241,8 +241,8 @@ class SmtpTransport extends AbstractTransport
             }
         }
 
-        if (strpos($auth, self::AUTH_PLAN) !== false) {
-            $this->authType = self::AUTH_PLAN;
+        if (strpos($auth, self::AUTH_PLAIN) !== false) {
+            $this->authType = self::AUTH_PLAIN;
 
             return;
         }
@@ -334,7 +334,7 @@ class SmtpTransport extends AbstractTransport
             return;
         }
 
-        if ($this->authType === self::AUTH_PLAN) {
+        if ($this->authType === self::AUTH_PLAIN) {
             $this->_authPlain($username, $password);
 
             return;

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -173,6 +173,16 @@ class SmtpTransport extends AbstractTransport
     }
 
     /**
+     * Returns the authentication type detected and used to connect to the SMTP server.
+     * If no authentication was detected, null is returned.
+     * @return string|null
+     */
+    public function getAuthType(): ?string
+    {
+        return $this->authType;
+    }
+
+    /**
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -173,16 +173,6 @@ class SmtpTransport extends AbstractTransport
     }
 
     /**
-     * Returns the authentication type detected and used to connect to the SMTP server.
-     * If no authentication was detected, null is returned.
-     * @return string|null
-     */
-    public function getAuthType(): ?string
-    {
-        return $this->authType;
-    }
-
-    /**
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -68,7 +68,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Detected authentication type.
      *
-     * @var string
+     * @var string|null
      */
     protected $authType = null;
 

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -232,7 +232,7 @@ class SmtpTransport extends AbstractTransport
 
         $auth = '';
         foreach ($this->_lastResponse as $line) {
-            if (empty($line['message']) || substr($line['message'], 0, 5) === 'AUTH ') {
+            if (strlen($line['message']) == 0 || substr($line['message'], 0, 5) === 'AUTH ') {
                 $auth = $line['message'];
                 break;
             }

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -179,7 +179,7 @@ class SmtpTransportTest extends TestCase
     {
         $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
 
-        $this->socket->expects($this->any())
+        $this->socket->expects($this->exactly(3))
             ->method('read')
             ->will($this->onConsecutiveCalls(
                 "220 Welcome message\r\n",
@@ -195,7 +195,7 @@ class SmtpTransportTest extends TestCase
 
         $this->SmtpTransport->setConfig($this->credentials);
         $this->SmtpTransport->connect();
-        $this->assertEquals($this->SmtpTransport->getConfig('authType'), 'PLAIN');
+        $this->assertEquals($this->SmtpTransport->getAuthType(), 'PLAIN');
     }
 
     public function testConnectEhloWithAuthLogin(): void
@@ -207,9 +207,11 @@ class SmtpTransportTest extends TestCase
             ->will($this->onConsecutiveCalls(
                 "220 Welcome message\r\n",
                 "250 Accepted\r\n250 AUTH LOGIN\r\n",
-                "235 OK\r\n",
+                "334 Login\r\n",
+                "334 Pass\r\n",
+                "235 OK\r\n"
             ));
-        $this->socket->expects($this->exactly(2))
+        $this->socket->expects($this->exactly(4))
             ->method('write')
             ->withConsecutive(
                 ["EHLO localhost\r\n"],
@@ -220,7 +222,7 @@ class SmtpTransportTest extends TestCase
 
         $this->SmtpTransport->setConfig($this->credentials);
         $this->SmtpTransport->connect();
-        $this->assertEquals($this->SmtpTransport->getConfig('authType'), 'LOGIN');
+        $this->assertEquals($this->SmtpTransport->getAuthType(), 'LOGIN');
     }
 
     /**

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -175,6 +175,54 @@ class SmtpTransportTest extends TestCase
         $this->SmtpTransport->connect();
     }
 
+    public function testConnectEhloWithAuthPlain(): void
+    {
+        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+
+        $this->socket->expects($this->any())
+            ->method('read')
+            ->will($this->onConsecutiveCalls(
+                "220 Welcome message\r\n",
+                "250 Accepted\r\n250 AUTH PLAIN LOGIN\r\n",
+                "235 OK\r\n",
+            ));
+        $this->socket->expects($this->exactly(2))
+            ->method('write')
+            ->withConsecutive(
+                ["EHLO localhost\r\n"],
+                ["AUTH PLAIN {$this->credentialsEncoded}\r\n"]
+            );
+
+        $this->SmtpTransport->setConfig($this->credentials);
+        $this->SmtpTransport->connect();
+        $this->assertEquals($this->SmtpTransport->getConfig('authType'), 'PLAIN');
+    }
+
+    public function testConnectEhloWithAuthLogin(): void
+    {
+        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+
+        $this->socket->expects($this->any())
+            ->method('read')
+            ->will($this->onConsecutiveCalls(
+                "220 Welcome message\r\n",
+                "250 Accepted\r\n250 AUTH LOGIN\r\n",
+                "235 OK\r\n",
+            ));
+        $this->socket->expects($this->exactly(2))
+            ->method('write')
+            ->withConsecutive(
+                ["EHLO localhost\r\n"],
+                ["AUTH LOGIN\r\n"],
+                ["bWFyaw==\r\n"],
+                ["c3Rvcnk=\r\n"]
+            );
+
+        $this->SmtpTransport->setConfig($this->credentials);
+        $this->SmtpTransport->connect();
+        $this->assertEquals($this->SmtpTransport->getConfig('authType'), 'LOGIN');
+    }
+
     /**
      * testConnectHelo method
      */

--- a/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
+++ b/tests/test_app/TestApp/Mailer/Transport/SmtpTestTransport.php
@@ -39,4 +39,15 @@ class SmtpTestTransport extends SmtpTransport
 
         return call_user_func_array([$this, $method], $args);
     }
+
+    /**
+     * Returns the authentication type detected and used to connect to the SMTP server.
+     * If no authentication was detected, null is returned.
+     *
+     * @return string|null
+     */
+    public function getAuthType(): ?string
+    {
+        return $this->authType;
+    }
 }


### PR DESCRIPTION
With this PR, the SMTP authentication method is detected right after the reply to HELO/EHLO is received. 

Hence, `AUTH PLAIN` will be attempted only and only if is listed as supported. Similarly  for `AUTH LOGIN`.

If for some reason no authentication method was detected, the implementation fallbacks to trying both `AUTH PLAIN` and `AUTH LOGIN`