### PR TITLE
5.x - use new `str_` methods

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -262,7 +262,7 @@ class MemcachedEngine extends CacheEngine
         if (str_starts_with($server, $socketTransport)) {
             return [substr($server, strlen($socketTransport)), 0];
         }
-        if (substr($server, 0, 1) === '[') {
+        if (str_starts_with($server, '[')) {
             $position = strpos($server, ']:');
             if ($position !== false) {
                 $position++;

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -698,9 +698,9 @@ class ConsoleOptionParser
             if (isset($this->_subcommands[$token])) {
                 continue;
             }
-            if (substr($token, 0, 2) === '--') {
+            if (str_starts_with($token, '--')) {
                 $params = $this->_parseLongOption($token, $params);
-            } elseif (substr($token, 0, 1) === '-') {
+            } elseif (str_starts_with($token, '-')) {
                 $params = $this->_parseShortOption($token, $params);
             } else {
                 $args = $this->_parseArg($token, $args);
@@ -936,7 +936,7 @@ class ConsoleOptionParser
      */
     protected function _optionExists(string $name): bool
     {
-        if (substr($name, 0, 2) === '--') {
+        if (str_starts_with($name, '--')) {
             return isset($this->_options[substr($name, 2)]);
         }
         if ($name[0] === '-' && $name[1] !== '-') {

--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -94,7 +94,7 @@ class MissingOptionException extends ConsoleException
     {
         $bestGuess = null;
         foreach ($haystack as $item) {
-            if (strpos($item, $needle) === 0) {
+            if (str_starts_with($item, $needle)) {
                 return $item;
             }
         }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -157,7 +157,7 @@ class BasePlugin implements PluginInterface
         $path = dirname($reflection->getFileName());
 
         // Trim off src
-        if (substr($path, -3) === 'src') {
+        if (str_ends_with($path, 'src')) {
             $path = substr($path, 0, -3);
         }
         $this->path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -494,7 +494,7 @@ abstract class Driver
             (
                 is_numeric($value) &&
                 !str_contains($value, ',') &&
-                substr($value, 0, 1) !== '0' &&
+                !str_starts_with($value, '0') &&
                 !str_contains($value, 'e')
             )
         ) {

--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -82,7 +82,7 @@ class ReconnectStrategy implements RetryStrategyInterface
         $message = $exception->getMessage();
 
         foreach (static::$causes as $cause) {
-            if (strstr($message, $cause) !== false) {
+            if (str_contains($message, $cause)) {
                 return $this->reconnect();
             }
         }

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -312,7 +312,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
     {
         [, $baseClass] = namespaceSplit(get_class($exception));
 
-        if (substr($baseClass, -9) === 'Exception') {
+        if (str_ends_with($baseClass, 'Exception')) {
             $baseClass = substr($baseClass, 0, -9);
         }
 
@@ -399,7 +399,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             $attributes = $e->getAttributes();
             if (
                 $e instanceof MissingLayoutException ||
-                strpos($attributes['file'], 'error500') !== false
+                str_contains($attributes['file'], 'error500')
             ) {
                 return $this->_outputMessageSafe('error500');
             }

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -154,7 +154,7 @@ class Response extends Message implements ResponseInterface
         }
         $offset = 0;
         // Look for gzip 'signature'
-        if (substr($body, 0, 2) === "\x1f\x8b") {
+        if (str_starts_with($body, "\x1f\x8b")) {
             $offset = 2;
         }
         // Check the format byte
@@ -177,7 +177,7 @@ class Response extends Message implements ResponseInterface
     protected function _parseHeaders(array $headers): void
     {
         foreach ($headers as $value) {
-            if (substr($value, 0, 5) === 'HTTP/') {
+            if (str_starts_with($value, 'HTTP/')) {
                 preg_match('/HTTP\/([\d.]+) ([0-9]+)(.*)/i', $value, $matches);
                 $this->protocol = $matches[1];
                 $this->code = (int)$matches[2];

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -279,7 +279,7 @@ class CookieCollection implements IteratorAggregate, Countable
                 continue;
             }
             $domain = $cookie->getDomain();
-            $leadingDot = substr($domain, 0, 1) === '.';
+            $leadingDot = str_starts_with($domain, '.');
             if ($leadingDot) {
                 $domain = ltrim($domain, '.');
             }

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -91,16 +91,16 @@ class PoFileParser
                 $this->_addMessage($messages, $item);
                 $item = $defaults;
                 $stage = [];
-            } elseif (substr($line, 0, 7) === 'msgid "') {
+            } elseif (str_starts_with($line, 'msgid "')) {
                 // We start a new msg so save previous
                 $this->_addMessage($messages, $item);
                 /** @psalm-suppress InvalidArrayOffset */
                 $item['ids']['singular'] = substr($line, 7, -1);
                 $stage = ['ids', 'singular'];
-            } elseif (substr($line, 0, 8) === 'msgstr "') {
+            } elseif (str_starts_with($line, 'msgstr "')) {
                 $item['translated'] = substr($line, 8, -1);
                 $stage = ['translated'];
-            } elseif (substr($line, 0, 9) === 'msgctxt "') {
+            } elseif (str_starts_with($line, 'msgctxt "')) {
                 $item['context'] = substr($line, 9, -1);
                 $stage = ['context'];
             } elseif ($line[0] === '"') {
@@ -123,11 +123,11 @@ class PoFileParser
                         $item[$stage[0]] .= substr($line, 1, -1);
                         break;
                 }
-            } elseif (substr($line, 0, 14) === 'msgid_plural "') {
+            } elseif (str_starts_with($line, 'msgid_plural "')) {
                 /** @psalm-suppress InvalidArrayOffset */
                 $item['ids']['plural'] = substr($line, 14, -1);
                 $stage = ['ids', 'plural'];
-            } elseif (substr($line, 0, 7) === 'msgstr[') {
+            } elseif (str_starts_with($line, 'msgstr[')) {
                 /** @var int $size */
                 $size = strpos($line, ']');
                 $row = (int)substr($line, 7, 1);

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -96,7 +96,7 @@ class FileLog extends BaseLog
 
         if (!empty($this->_config['file'])) {
             $this->_file = $this->_config['file'];
-            if (substr($this->_file, -4) !== '.log') {
+            if (!str_ends_with($this->_file, '.log')) {
                 $this->_file .= '.log';
             }
         }

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -500,7 +500,7 @@ class SmtpTransport extends AbstractTransport
         while ($checkCode !== false) {
             $response = '';
             $startTime = time();
-            while (substr($response, -2) !== "\r\n" && (time() - $startTime < $timeout)) {
+            while (!str_ends_with($response, "\r\n") && (time() - $startTime < $timeout)) {
                 $bytes = $this->_socket->read();
                 if ($bytes === null) {
                     break;
@@ -508,7 +508,7 @@ class SmtpTransport extends AbstractTransport
                 $response .= $bytes;
             }
             // Catch empty or malformed responses.
-            if (substr($response, -2) !== "\r\n") {
+            if (!str_ends_with($response, "\r\n")) {
                 // Use response message or assume operation timed out.
                 throw new SocketException($response ?: 'SMTP timeout.');
             }

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -236,7 +236,7 @@ class Socket
     protected function _setSslContext(string $host): void
     {
         foreach ($this->_config as $key => $value) {
-            if (substr($key, 0, 4) !== 'ssl_') {
+            if (!str_starts_with($key, 'ssl_')) {
                 continue;
             }
             $contextKey = substr($key, 4);

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -416,7 +416,7 @@ class Behavior implements EventListenerInterface
                 continue;
             }
 
-            if (substr($methodName, 0, 4) === 'find') {
+            if (str_starts_with($methodName, 'find')) {
                 $return['finders'][lcfirst(substr($methodName, 4))] = $methodName;
             } else {
                 $return['methods'][$methodName] = $methodName;

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -91,7 +91,7 @@ class Marshaller
             // If the key is not a special field like _ids or _joinData
             // it is a missing association that we should error on.
             if (!$this->_table->hasAssociation($key)) {
-                if (substr($key, 0, 1) !== '_') {
+                if (!str_starts_with($key, '_')) {
                     throw new InvalidArgumentException(sprintf(
                         'Cannot marshal data for "%s" association. It is not associated with "%s".',
                         (string)$key,

--- a/src/Routing/Asset.php
+++ b/src/Routing/Asset.php
@@ -170,7 +170,7 @@ class Asset
         if (
             !empty($options['ext']) &&
             !str_contains($path, '?') &&
-            substr($path, -strlen($options['ext'])) !== $options['ext']
+            !str_ends_with($path, $options['ext'])
         ) {
             $path .= $options['ext'];
         }

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1025,7 +1025,7 @@ class Text
             return (int)($size * pow(1024, $i + 1));
         }
 
-        if (substr($size, -1) === 'B' && ctype_digit(substr($size, 0, -1))) {
+        if (str_ends_with($size, 'B') && ctype_digit(substr($size, 0, -1))) {
             $size = substr($size, 0, -1);
 
             return (int)$size;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -712,7 +712,7 @@ class FormHelper extends Helper
      */
     public function error(string $field, array|string|null $text = null, array $options = []): string
     {
-        if (substr($field, -5) === '._ids') {
+        if (str_ends_with($field, '._ids')) {
             $field = substr($field, 0, -5);
         }
         $options += ['escape' => true];
@@ -828,14 +828,14 @@ class FormHelper extends Helper
     {
         if ($text === null) {
             $text = $fieldName;
-            if (substr($text, -5) === '._ids') {
+            if (str_ends_with($text, '._ids')) {
                 $text = substr($text, 0, -5);
             }
             if (str_contains($text, '.')) {
                 $fieldElements = explode('.', $text);
                 $text = array_pop($fieldElements);
             }
-            if (substr($text, -3) === '_id') {
+            if (str_ends_with($text, '_id')) {
                 $text = substr($text, 0, -3);
             }
             $text = __(Inflector::humanize(Inflector::underscore($text)));
@@ -1248,7 +1248,7 @@ class FormHelper extends Helper
             return 'hidden';
         }
 
-        if (substr($fieldName, -3) === '_id') {
+        if (str_ends_with($fieldName, '_id')) {
             return 'select';
         }
 
@@ -1295,10 +1295,10 @@ class FormHelper extends Helper
         }
 
         $pluralize = true;
-        if (substr($fieldName, -5) === '._ids') {
+        if (str_ends_with($fieldName, '._ids')) {
             $fieldName = substr($fieldName, 0, -5);
             $pluralize = false;
-        } elseif (substr($fieldName, -3) === '_id') {
+        } elseif (str_ends_with($fieldName, '_id')) {
             $fieldName = substr($fieldName, 0, -3);
         }
         $fieldName = array_slice(explode('.', $fieldName), -1)[0];
@@ -1341,7 +1341,7 @@ class FormHelper extends Helper
             $options = $this->_optionsOptions($fieldName, $options);
         }
 
-        if ($allowOverride && substr($fieldName, -5) === '._ids') {
+        if ($allowOverride && str_ends_with($fieldName, '._ids')) {
             $options['type'] = 'select';
             if (!isset($options['multiple']) || ($options['multiple'] && $options['multiple'] !== 'checkbox')) {
                 $options['multiple'] = true;
@@ -2301,7 +2301,7 @@ class FormHelper extends Helper
 
         if (!isset($options['name'])) {
             $endsWithBrackets = '';
-            if (substr($field, -2) === '[]') {
+            if (str_ends_with($field, '[]')) {
                 $field = substr($field, 0, -2);
                 $endsWithBrackets = '[]';
             }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -388,7 +388,7 @@ class View implements EventDispatcherInterface
         }
         $response = $this->getResponse();
         $responseType = $response->getHeaderLine('Content-Type');
-        if ($responseType === '' || substr($responseType, 0, 9) === 'text/html') {
+        if ($responseType === '' || str_starts_with($responseType, 'text/html')) {
             $response = $response->withType($viewContentType);
         }
         $this->setResponse($response);
@@ -1330,7 +1330,7 @@ class View implements EventDispatcherInterface
         if ($this->subDir !== '') {
             $subDir = $this->subDir . DIRECTORY_SEPARATOR;
             // Check if templatePath already terminates with subDir
-            if ($templatePath != $subDir && substr($templatePath, -strlen($subDir)) === $subDir) {
+            if ($templatePath != $subDir && str_ends_with($templatePath, $subDir)) {
                 $subDir = '';
             }
         }

--- a/templates/Error/missing_cell_template.php
+++ b/templates/Error/missing_cell_template.php
@@ -33,7 +33,7 @@ $this->start('file');
 <ul>
 <?php
     foreach ($paths as $path) :
-        if (strpos($path, CORE_PATH) !== false) {
+        if (str_contains($path, CORE_PATH)) {
             continue;
         }
         echo sprintf('<li>%sCell/%s/%s</li>', h($path), h($name), h($file));

--- a/templates/Error/missing_controller.php
+++ b/templates/Error/missing_controller.php
@@ -21,7 +21,7 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 $namespace = Configure::read('App.namespace');
 $prefixNs = $prefixPath = '';
 
-$incompleteInflection = (strpos($class, '_') !== false || strpos($class, '-'));
+$incompleteInflection = (str_contains($class, '_') || str_contains($class, '-'));
 $originalClass = $class;
 
 $class = Inflector::camelize($class);

--- a/templates/Error/missing_layout.php
+++ b/templates/Error/missing_layout.php
@@ -33,7 +33,7 @@ $this->start('subheading');
 <ul>
 <?php
     foreach ($paths as $path):
-        if (strpos($path, CORE_PATH) !== false) {
+        if (str_contains($path, CORE_PATH)) {
             continue;
         }
         echo sprintf('<li>%s%s</li>', h($path), h($file));

--- a/templates/Error/missing_template.php
+++ b/templates/Error/missing_template.php
@@ -21,7 +21,7 @@ $this->layout = 'dev_error';
 $this->assign('title', 'Missing Template');
 $this->assign('templateName', 'missing_template.php');
 
-$isEmail = strpos($file, 'Email/') === 0;
+$isEmail = str_starts_with($file, 'Email/');
 
 $this->start('subheading');
 ?>
@@ -46,7 +46,7 @@ $this->start('subheading');
 <ul>
 <?php
     foreach ($paths as $path):
-        if (strpos($path, CORE_PATH) !== false) {
+        if (str_contains($path, CORE_PATH)) {
             continue;
         }
         echo sprintf('<li>%s%s</li>', h($path), h($file));

--- a/templates/element/exception_stack_trace_nav.php
+++ b/templates/element/exception_stack_trace_nav.php
@@ -20,7 +20,7 @@ use Cake\Error\Debugger;
 <ul class="stack-trace">
 <?php foreach ($trace as $i => $stack): ?>
     <?php
-    $class = isset($stack['file']) && strpos($stack['file'], APP) === false ? 'vendor-frame' : 'app-frame';
+    $class = isset($stack['file']) && !str_contains($stack['file'], APP) ? 'vendor-frame' : 'app-frame';
     $class .= $i == 0 ? ' active' : '';
     ?>
     <li class="stack-frame <?= $class ?>">


### PR DESCRIPTION
This PR introduces the new `str_` methods which came with PHP 8.0

`str_pos` is cool and all but so many occurrences of this method can be simplified to the more readable versions like
* `str_starts_with`
* `str_ends_with` and
* `str_contains`