### PR TITLE
Create data provider for valid action parameter coercion test

### DIFF
--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -43,11 +43,10 @@ class DependenciesController extends Controller
         return $this->response->withStringBody(json_encode(compact('str')));
     }
 
-    public function requiredTyped(float $one, int $two, bool $three, array $four)
+    public function requiredTyped(float $float, int $int, bool $bool, array $array)
     {
-        return $this->response->withStringBody(json_encode(
-            compact('one', 'two', 'three', 'four'),
-            JSON_PRESERVE_ZERO_FRACTION
+        return $this->response->withStringBody(serialize(
+            compact('float', 'int', 'bool', 'array'),
         ));
     }
 


### PR DESCRIPTION
The ini setting change is required for PHP_FLOAT_MAX.

Currently, values larger than PHP_FLOAT_MAX will be converted to something like INF instead of null.