### PR TITLE
5.x - add enum DB type

### DIFF
--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Type;
+
+use BackedEnum;
+use Cake\Database\Driver;
+use InvalidArgumentException;
+use PDO;
+use TestApp\Model\Enum\AuthorGenderEnum;
+
+/**
+ * Enum type converter.
+ *
+ * Use to convert enum data between PHP and the database types.
+ */
+class EnumType extends BaseType implements BatchCastingInterface
+{
+    /**
+     * Convert enum data into the database format.
+     *
+     * @param mixed $value The value to convert.
+     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @return string|null
+     */
+    public function toDatabase(mixed $value, Driver $driver): ?string
+    {
+        if ($value === null || is_string($value)) {
+            return $value;
+        }
+
+        if ($value instanceof BackedEnum) {
+            return $value->value;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Cannot convert value of type `%s` to string',
+            get_debug_type($value)
+        ));
+    }
+
+    /**
+     * Convert enum value to PHP enumeration.
+     *
+     * @param mixed $value The value to convert.
+     * @param \Cake\Database\Driver $driver The driver instance to convert with.
+     * @return \BackedEnum|null
+     */
+    public function toPHP(mixed $value, Driver $driver): ?BackedEnum
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        // TODO We need a map of database column types to PHP backed enums here
+        return AuthorGenderEnum::MALE;
+    }
+
+    /**
+     * Get the correct PDO binding type for enum data.
+     *
+     * @param mixed $value The value being bound.
+     * @param \Cake\Database\Driver $driver The driver.
+     * @return int
+     */
+    public function toStatement(mixed $value, Driver $driver): int
+    {
+        return PDO::PARAM_STR;
+    }
+
+    /**
+     * Marshals request data into PHP strings.
+     *
+     * @param mixed $value The value to convert.
+     * @return string|null Converted value.
+     */
+    public function marshal(mixed $value): ?string
+    {
+        if ($value === null || is_array($value)) {
+            return null;
+        }
+
+        return (string)$value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function manyToPHP(array $values, array $fields, Driver $driver): array
+    {
+        foreach ($fields as $field) {
+            $value = $values[$field] ?? null;
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_string($value)) {
+                // TODO We need a map of database column types to PHP backed enums here
+                $values[$field] = AuthorGenderEnum::MALE;
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -89,7 +89,7 @@ class EnumType extends BaseType implements BatchCastingInterface
      */
     public function marshal(mixed $value): ?string
     {
-        if ($value === null || is_array($value)) {
+        if ($value === null) {
             return null;
         }
 

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -53,6 +53,7 @@ class TypeFactory
         'timestampfractional' => Type\DateTimeFractionalType::class,
         'timestamptimezone' => Type\DateTimeTimezoneType::class,
         'uuid' => Type\UuidType::class,
+        'enum' => Type\EnumType::class,
     ];
 
     /**

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.1.7
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\TypeFactory;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use PDO;
+use TestApp\Model\Enum\AuthorGenderEnum;
+
+/**
+ * Test for the String type.
+ */
+class EnumTypeTest extends TestCase
+{
+    /**
+     * @var \Cake\Database\TypeInterface
+     */
+    protected $type;
+
+    /**
+     * @var \Cake\Database\Driver|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $driver;
+
+    /**
+     * Setup
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->type = TypeFactory::build('enum');
+        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+    }
+
+    /**
+     * Test toPHP
+     */
+    public function testToPHP(): void
+    {
+        $this->assertNull($this->type->toPHP(null, $this->driver));
+
+        // Doesn't work yet
+        //$this->assertSame(AuthorGenderEnum::FEMALE, $this->type->toPHP('female', $this->driver));
+        //$this->assertSame(AuthorGenderEnum::MALE, $this->type->toPHP('male', $this->driver));
+    }
+
+    /**
+     * Test converting to database format
+     */
+    public function testToDatabase(): void
+    {
+        $this->assertNull($this->type->toDatabase(null, $this->driver));
+        $this->assertSame('female', $this->type->toDatabase(AuthorGenderEnum::FEMALE, $this->driver));
+        $this->assertSame('female', $this->type->toDatabase(AuthorGenderEnum::FEMALE->value, $this->driver));
+        $this->assertSame('male', $this->type->toDatabase(AuthorGenderEnum::MALE, $this->driver));
+        $this->assertSame('male', $this->type->toDatabase(AuthorGenderEnum::MALE->value, $this->driver));
+    }
+
+    /**
+     * Tests that passing an invalid value will throw an exception
+     */
+    public function testToDatabaseInvalidArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->type->toDatabase([1, 2, 3], $this->driver);
+    }
+
+    /**
+     * Test marshalling
+     */
+    public function testMarshal(): void
+    {
+        $this->assertNull($this->type->marshal(null));
+        $this->assertNull($this->type->marshal([1, 2, 3]));
+        $this->assertSame('female', $this->type->marshal('female'));
+    }
+
+    /**
+     * Test that the PDO binding type is correct.
+     */
+    public function testToStatement(): void
+    {
+        $this->assertSame(PDO::PARAM_STR, $this->type->toStatement('male', $this->driver));
+    }
+
+    /**
+     * Test converting string datetimes to PHP values.
+     */
+    public function testManyToPHP(): void
+    {
+        $values = [
+            'a' => null,
+            'b' => 'female',
+        ];
+        $expected = [
+            'a' => null,
+            'b' => AuthorGenderEnum::FEMALE,
+        ];
+
+        // Doesn't work yet
+        //$this->assertEquals(
+        //    $expected,
+        //    $this->type->manyToPHP($values, array_keys($values), $this->driver)
+        //);
+    }
+}

--- a/tests/test_app/TestApp/Model/Enum/AuthorGenderEnum.php
+++ b/tests/test_app/TestApp/Model/Enum/AuthorGenderEnum.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Enum;
+
+enum AuthorGenderEnum: string
+{
+    case MALE = 'male';
+    case FEMALE = 'female';
+    case OTHER = 'other';
+}


### PR DESCRIPTION
This is the first prototype to add a enum DB type.

PHP 8.1 added general support for enums and for this example we are looking at the backed enums which have an associated integer or string value associated to the specific case.

This implementation should provide functionality so database native enums can be mapped to a PHP enum.

## Open questsions

### How do we want to define the mapping between DB column types and PHP enums?

We could for example add an extra static array to `TypeFactory` which holds an associative array mapping column types to enums. So something like
```
TypeFactory::mapEnum([
    'columnType1' => 'App\Model\Enum\MyEnum',
    'columnType2' => 'App\Model\Enum\OtherEnum'
]);
```

### Do we want to support integer enums for integer columns as well?

It would also be nice to do something like this:
```
$entity = new Author();
$entity->name = 'Kevin Pfeifer';
$entity->type = MyEnum::TYPE1;
```

Where `MyEnum` is an integer backed enum which holds all the foreign keys for all the types available.