### PR TITLE
Fix missing arguments in development errors

### DIFF
--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -260,7 +260,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
         if ($isDebug) {
             $trace = (array)Debugger::formatTrace($exception->getTrace(), [
                 'format' => 'array',
-                'args' => false,
+                'args' => true,
             ]);
             $origin = [
                 'file' => $exception->getFile() ?: 'null',

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -260,6 +260,7 @@ use Cake\Error\Debugger;
         border-bottom: 1px solid #ccc;
     }
     </style>
+    <?php require CAKE . 'Error/Debug/dumpHeader.html'; ?>
 </head>
 <body>
     <header>


### PR DESCRIPTION
Enable argument output for HTML development errors. Because of how Debugger prepares method signatures, the object dump CSS needs to be manually required.

Fixes #16683