### PR TITLE
5.x - replace ssl with https detector

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1324,9 +1324,9 @@ class Response implements ResponseInterface, Stringable
     public function cors(ServerRequest $request): CorsBuilder
     {
         $origin = $request->getHeaderLine('Origin');
-        $ssl = $request->is('ssl');
+        $https = $request->is('https');
 
-        return new CorsBuilder($this, $origin, $ssl);
+        return new CorsBuilder($this, $origin, $https);
     }
 
     /**

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -127,7 +127,7 @@ class ServerRequest implements ServerRequestInterface
         'delete' => ['env' => 'REQUEST_METHOD', 'value' => 'DELETE'],
         'head' => ['env' => 'REQUEST_METHOD', 'value' => 'HEAD'],
         'options' => ['env' => 'REQUEST_METHOD', 'value' => 'OPTIONS'],
-        'ssl' => ['env' => 'HTTPS', 'options' => [1, 'on']],
+        'https' => ['env' => 'HTTPS', 'options' => [1, 'on']],
         'ajax' => ['env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'],
         'json' => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
         'xml' => [

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -716,26 +716,26 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * Test is(ssl)
+     * Test is(https)
      */
-    public function testIsSsl(): void
+    public function testIsHttps(): void
     {
         $request = new ServerRequest();
 
         $request = $request->withEnv('HTTPS', 'on');
-        $this->assertTrue($request->is('ssl'));
+        $this->assertTrue($request->is('https'));
 
         $request = $request->withEnv('HTTPS', '1');
-        $this->assertTrue($request->is('ssl'));
+        $this->assertTrue($request->is('https'));
 
         $request = $request->withEnv('HTTPS', 'I am not empty');
-        $this->assertFalse($request->is('ssl'));
+        $this->assertFalse($request->is('https'));
 
         $request = $request->withEnv('HTTPS', 'off');
-        $this->assertFalse($request->is('ssl'));
+        $this->assertFalse($request->is('https'));
 
         $request = $request->withEnv('HTTPS', '');
-        $this->assertFalse($request->is('ssl'));
+        $this->assertFalse($request->is('https'));
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -621,7 +621,7 @@ class IntegrationTestTraitTest extends TestCase
             '_ssl' => true,
         ]);
         $this->assertResponseOk();
-        $this->assertResponseContains('"isSsl":true');
+        $this->assertResponseContains('"isHttps":true');
         $this->assertResponseContains('"host":"app.example.org"');
     }
 

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -169,7 +169,7 @@ class PostsController extends AppController
     {
         $data = [
             'host' => $this->request->host(),
-            'isSsl' => $this->request->is('ssl'),
+            'isHttps' => $this->request->is('https'),
         ];
 
         return $this->getResponse()->withStringBody(json_encode($data));


### PR DESCRIPTION
SSL is dead, therefore we shouldn't encourage people to still reference it