### PR TITLE
Fix up assoc docblocks.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,9 +13,9 @@ parameters:
 	earlyTerminatingMethodCalls:
 		Cake\Console\Shell:
 			- abort
-	excludePaths:
-			analyse:
-				- src/Datasource/Paginator.php
+		Cake\Command\BaseCommand:
+			- abort
+
 services:
 	-
 		class: Cake\PHPStan\AssociationTableMixinClassReflectionExtension

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -327,6 +327,14 @@
       <code>ModelAwareTrait</code>
     </DeprecatedTrait>
   </file>
+  <file src="src/Mailer/Transport/SmtpTransport.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;_content</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array{headers: string, message: string}</code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="src/ORM/Locator/LocatorAwareTrait.php">
     <DeprecatedClass occurrences="1">
       <code>$this</code>

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -35,7 +35,7 @@ class ArrayEngine extends CacheEngine
      *
      * Structured as [key => [exp => expiration, val => value]]
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $data = [];
 

--- a/src/Cache/Engine/ArrayEngine.php
+++ b/src/Cache/Engine/ArrayEngine.php
@@ -35,7 +35,7 @@ class ArrayEngine extends CacheEngine
      *
      * Structured as [key => [exp => expiration, val => value]]
      *
-     * @var array<string, mixed>
+     * @var array<string, array>
      */
     protected $data = [];
 

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -37,7 +37,7 @@ class Configure
     /**
      * Array of values currently stored in Configure.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected static $_values = [
         'debug' => false,

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -71,7 +71,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
     /**
      * Options for the table.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_options = [];
 

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -69,7 +69,7 @@ class NumericPaginator implements PaginatorInterface
      * and control other pagination settings.
      *
      * If your settings contain a key with the current table's alias. The data
-     * inside that key will be used. Otherwise the top level configuration will
+     * inside that key will be used. Otherwise, the top level configuration will
      * be used.
      *
      * ```

--- a/src/Datasource/RuleInvoker.php
+++ b/src/Datasource/RuleInvoker.php
@@ -37,7 +37,7 @@ class RuleInvoker
     /**
      * Rule options
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $options = [];
 

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -41,14 +41,14 @@ class Stream implements AdapterInterface
     /**
      * Array of options/content for the HTTP stream context.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_contextOptions = [];
 
     /**
      * Array of options/content for the SSL stream context.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_sslContextOptions = [];
 
@@ -320,7 +320,7 @@ class Stream implements AdapterInterface
             restore_error_handler();
         }
 
-        if (!$this->_stream || !empty($this->_connectionErrors)) {
+        if (!$this->_stream || $this->_connectionErrors) {
             throw new RequestException(implode("\n", $this->_connectionErrors), $request);
         }
     }
@@ -330,7 +330,7 @@ class Stream implements AdapterInterface
      *
      * Useful for debugging and testing context creation.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function contextOptions(): array
     {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -115,7 +115,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Cached decoded JSON data.
      *
-     * @var array<mixed>
+     * @var mixed
      */
     protected $_json;
 
@@ -411,7 +411,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Get the response body as JSON decoded data.
      *
-     * @return array<mixed>
+     * @return mixed
      */
     protected function _getJson()
     {

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -115,7 +115,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Cached decoded JSON data.
      *
-     * @var array
+     * @var array<mixed>
      */
     protected $_json;
 
@@ -411,7 +411,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Get the response body as JSON decoded data.
      *
-     * @return mixed
+     * @return array<mixed>
      */
     protected function _getJson()
     {

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -32,7 +32,7 @@ class HttpException extends CakeException
     protected $_defaultCode = 500;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $headers = [];
 

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -98,7 +98,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
     /**
      * Security related headers to set
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $headers = [];
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -401,7 +401,7 @@ class Response implements ResponseInterface
      * Holds all the cache directives that will be converted
      * into headers when sending the request
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_cacheDirectives = [];
 

--- a/src/Http/Session/CacheSession.php
+++ b/src/Http/Session/CacheSession.php
@@ -32,7 +32,7 @@ class CacheSession implements SessionHandlerInterface
     /**
      * Options for this session engine
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_options = [];
 

--- a/src/I18n/FormatterLocator.php
+++ b/src/I18n/FormatterLocator.php
@@ -29,7 +29,7 @@ class FormatterLocator
     /**
      * A registry to retain formatter objects.
      *
-     * @var array<string, string>
+     * @var array<string, \Cake\I18n\FormatterInterface|class-string<\Cake\I18n\FormatterInterface>>
      */
     protected $registry = [];
 
@@ -44,7 +44,7 @@ class FormatterLocator
     /**
      * Constructor.
      *
-     * @param array<string, string> $registry An array of key-value pairs where the key is the
+     * @param array<string, class-string<\Cake\I18n\FormatterInterface>> $registry An array of key-value pairs where the key is the
      * formatter name the value is a FQCN for the formatter.
      */
     public function __construct(array $registry = [])
@@ -58,7 +58,7 @@ class FormatterLocator
      * Sets a formatter into the registry by name.
      *
      * @param string $name The formatter name.
-     * @param string $className A FQCN for a formatter.
+     * @param class-string<\Cake\I18n\FormatterInterface> $className A FQCN for a formatter.
      * @return void
      */
     public function set(string $name, string $className): void

--- a/src/I18n/FormatterLocator.php
+++ b/src/I18n/FormatterLocator.php
@@ -81,10 +81,13 @@ class FormatterLocator
         }
 
         if (!$this->converted[$name]) {
-            $this->registry[$name] = new $this->registry[$name]();
+            /** @var class-string<\Cake\I18n\FormatterInterface> $formatter */
+            $formatter = $this->registry[$name];
+            $this->registry[$name] = new $formatter();
             $this->converted[$name] = true;
         }
 
+        /** @var \Cake\I18n\FormatterInterface */
         return $this->registry[$name];
     }
 }

--- a/src/I18n/FormatterLocator.php
+++ b/src/I18n/FormatterLocator.php
@@ -29,7 +29,7 @@ class FormatterLocator
     /**
      * A registry to retain formatter objects.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $registry = [];
 
@@ -44,7 +44,7 @@ class FormatterLocator
     /**
      * Constructor.
      *
-     * @param array $registry An array of key-value pairs where the key is the
+     * @param array<string, string> $registry An array of key-value pairs where the key is the
      * formatter name the value is a FQCN for the formatter.
      */
     public function __construct(array $registry = [])

--- a/src/I18n/PackageLocator.php
+++ b/src/I18n/PackageLocator.php
@@ -48,7 +48,7 @@ class PackageLocator
     /**
      * Constructor.
      *
-     * @param array<string, array<string, mixed>> $registry A registry of packages.
+     * @param array<string, array<string, \Cake\I18n\Package|callable>> $registry A registry of packages.
      * @see PackageLocator::$registry
      */
     public function __construct(array $registry = [])

--- a/src/I18n/PackageLocator.php
+++ b/src/I18n/PackageLocator.php
@@ -88,11 +88,13 @@ class PackageLocator
         }
 
         if (!$this->converted[$name][$locale]) {
+            /** @var callable $func */
             $func = $this->registry[$name][$locale];
             $this->registry[$name][$locale] = $func();
             $this->converted[$name][$locale] = true;
         }
 
+        /** @var \Cake\I18n\Package */
         return $this->registry[$name][$locale];
     }
 

--- a/src/I18n/PackageLocator.php
+++ b/src/I18n/PackageLocator.php
@@ -33,7 +33,7 @@ class PackageLocator
      * key is a package name, the second key is a locale code, and the value
      * is a callable that returns a Package object for that name and locale.
      *
-     * @var array<string, array<string, mixed>>
+     * @var array<string, array<string, \Cake\I18n\Package|callable>>
      */
     protected $registry = [];
 

--- a/src/I18n/PackageLocator.php
+++ b/src/I18n/PackageLocator.php
@@ -33,7 +33,7 @@ class PackageLocator
      * key is a package name, the second key is a locale code, and the value
      * is a callable that returns a Package object for that name and locale.
      *
-     * @var array
+     * @var array<string, array<string, mixed>>
      */
     protected $registry = [];
 
@@ -41,14 +41,14 @@ class PackageLocator
      * Tracks whether a registry entry has been converted from a
      * callable to a Package object.
      *
-     * @var array
+     * @var array<string, array<string, bool>>
      */
     protected $converted = [];
 
     /**
      * Constructor.
      *
-     * @param array $registry A registry of packages.
+     * @param array<string, array<string, mixed>> $registry A registry of packages.
      * @see PackageLocator::$registry
      */
     public function __construct(array $registry = [])

--- a/src/Log/Engine/ArrayLog.php
+++ b/src/Log/Engine/ArrayLog.php
@@ -44,7 +44,7 @@ class ArrayLog extends BaseLog
     /**
      * Captured messages
      *
-     * @var array
+     * @var array<string>
      */
     protected $content = [];
 

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -443,7 +443,7 @@ class Email implements JsonSerializable, Serializable
     /**
      * Log the email message delivery.
      *
-     * @param array $contents The content with 'headers' and 'message' keys.
+     * @param array<string, string> $contents The content with 'headers' and 'message' keys.
      * @return void
      */
     protected function _logDelivery(array $contents): void

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -93,7 +93,7 @@ class Email implements JsonSerializable, Serializable
      * A copy of the configuration profile for this
      * instance. This copy can be modified with Email::profile().
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_profile = [];
 
@@ -305,7 +305,7 @@ class Email implements JsonSerializable, Serializable
             unset($name);
         }
 
-        $this->_profile = array_merge($this->_profile, $config);
+        $this->_profile = $config + $this->_profile;
 
         $simpleMethods = [
             'transport',

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -169,7 +169,7 @@ class SmtpTransport extends AbstractTransport
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance
-     * @return array
+     * @return array<string, mixed>
      * @throws \Cake\Network\Exception\SocketException
      * @psalm-return array{headers: string, message: string}
      */

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -54,7 +54,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Content of email to return
      *
-     * @var array<string, mixed>
+     * @var array<string, string>
      */
     protected $_content = [];
 
@@ -169,7 +169,7 @@ class SmtpTransport extends AbstractTransport
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance
-     * @return array<string, mixed>
+     * @return array<string, string>
      * @throws \Cake\Network\Exception\SocketException
      * @psalm-return array{headers: string, message: string}
      */

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -54,7 +54,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Content of email to return
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_content = [];
 

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -169,9 +169,8 @@ class SmtpTransport extends AbstractTransport
      * Send mail
      *
      * @param \Cake\Mailer\Message $message Message instance
-     * @return array<string, string>
+     * @return array{headers: string, message: string}
      * @throws \Cake\Network\Exception\SocketException
-     * @psalm-return array{headers: string, message: string}
      */
     public function send(Message $message): array
     {
@@ -415,7 +414,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Send emails
      *
-     * @param \Cake\Mailer\Message $message Message message
+     * @param \Cake\Mailer\Message $message Message instance
      * @throws \Cake\Network\Exception\SocketException
      * @return void
      */
@@ -433,7 +432,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Send Data
      *
-     * @param \Cake\Mailer\Message $message Message message
+     * @param \Cake\Mailer\Message $message Message instance
      * @return void
      * @throws \Cake\Network\Exception\SocketException
      */

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -63,7 +63,7 @@ class Socket
     /**
      * This variable contains an array with the last error number (num) and string (str)
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $lastError = [];
 
@@ -96,7 +96,7 @@ class Socket
      * Used to capture connection warnings which can happen when there are
      * SSL errors for example.
      *
-     * @var array
+     * @var array<string>
      */
     protected $_connectionErrors = [];
 

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -46,7 +46,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     /**
      * Method mappings.
      *
-     * @var array<string, mixed>
+     * @var array<string, array>
      */
     protected $_methodMap = [];
 

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -53,7 +53,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     /**
      * Finder method mappings.
      *
-     * @var array<string, mixed>
+     * @var array<string, array>
      */
     protected $_finderMap = [];
 

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -46,14 +46,14 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     /**
      * Method mappings.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_methodMap = [];
 
     /**
      * Finder method mappings.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_finderMap = [];
 

--- a/src/ORM/EagerLoadable.php
+++ b/src/ORM/EagerLoadable.php
@@ -51,7 +51,7 @@ class EagerLoadable
      * A list of options to pass to the association object for loading
      * the records.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_config = [];
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -91,7 +91,7 @@ class EagerLoader
      * A map of table aliases pointing to the association objects they represent
      * for the query.
      *
-     * @var array
+     * @var array<string, \Cake\ORM\EagerLoadable>
      */
     protected $_joinsMap = [];
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -73,7 +73,7 @@ class ResultSet implements ResultSetInterface
      * List of associations that should be placed under the `_matchingData`
      * result key.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_matchingMap = [];
 
@@ -88,7 +88,7 @@ class ResultSet implements ResultSetInterface
      * Map of fields that are fetched from the statement with
      * their type and the table they belong to
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_map = [];
 
@@ -96,7 +96,7 @@ class ResultSet implements ResultSetInterface
      * List of matching associations and the column keys to expect
      * from each of them.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_matchingMapColumns = [];
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -107,7 +107,7 @@ class Router
     /**
      * A hash of request context data.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected static $_requestContext = [];
 
@@ -159,7 +159,7 @@ class Router
     /**
      * Cache of parsed route paths
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected static $_routePaths = [];
 

--- a/src/TestSuite/TestEmailTransport.php
+++ b/src/TestSuite/TestEmailTransport.php
@@ -38,8 +38,7 @@ class TestEmailTransport extends DebugTransport
      * Stores email for later assertions
      *
      * @param \Cake\Mailer\Message $message Message
-     * @return array
-     * @psalm-return array{headers: string, message: string}
+     * @return array{headers: string, message: string}
      */
     public function send(Message $message): array
     {

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -166,7 +166,7 @@ class Inflector
     /**
      * Method cache array.
      *
-     * @var array
+     * @var array<string, array<string, mixed>>
      */
     protected static $_cache = [];
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -166,7 +166,7 @@ class Inflector
     /**
      * Method cache array.
      *
-     * @var array<string, array<string, mixed>>
+     * @var array<string, mixed>
      */
     protected static $_cache = [];
 

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -453,7 +453,7 @@ class Xml
      * Recursive method to toArray
      *
      * @param \SimpleXMLElement $xml SimpleXMLElement object
-     * @param array $parentData Parent array with data
+     * @param array<string, mixed> $parentData Parent array with data
      * @param string $ns Namespace of current child
      * @param array<string> $namespaces List of namespaces in XML
      * @return void

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -696,7 +696,7 @@ class Validation
      * The list of what is considered to be boolean values, may be set via $booleanValues.
      *
      * @param string|int|bool $check Value to check.
-     * @param array $booleanValues List of valid boolean values, defaults to `[true, false, 0, 1, '0', '1']`.
+     * @param array<string|int|bool> $booleanValues List of valid boolean values, defaults to `[true, false, 0, 1, '0', '1']`.
      * @return bool Success.
      */
     public static function boolean($check, array $booleanValues = []): bool
@@ -714,7 +714,7 @@ class Validation
      * The list of what is considered to be truthy values, may be set via $truthyValues.
      *
      * @param string|int|bool $check Value to check.
-     * @param array $truthyValues List of valid truthy values, defaults to `[true, 1, '1']`.
+     * @param array<string|int|bool> $truthyValues List of valid truthy values, defaults to `[true, 1, '1']`.
      * @return bool Success.
      */
     public static function truthy($check, array $truthyValues = []): bool
@@ -732,7 +732,7 @@ class Validation
      * The list of what is considered to be falsey values, may be set via $falseyValues.
      *
      * @param string|int|bool $check Value to check.
-     * @param array $falseyValues List of valid falsey values, defaults to `[false, 0, '0']`.
+     * @param array<string|int|bool> $falseyValues List of valid falsey values, defaults to `[false, 0, '0']`.
      * @return bool Success.
      */
     public static function falsey($check, array $falseyValues = []): bool

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -74,7 +74,7 @@ class ValidationRule
     /**
      * Constructor
      *
-     * @param array $validator [optional] The validator properties
+     * @param array<string, mixed> $validator [optional] The validator properties
      */
     public function __construct(array $validator = [])
     {
@@ -184,7 +184,7 @@ class ValidationRule
     /**
      * Sets the rule properties from the rule entry in validate
      *
-     * @param array $validator [optional]
+     * @param array<string, mixed> $validator [optional]
      * @return void
      */
     protected function _addValidatorProps(array $validator = []): void

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -155,7 +155,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Contains the validation messages associated with checking the presence
      * for each corresponding field.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $_presenceMessages = [];
 
@@ -170,14 +170,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Contains the validation messages associated with checking the emptiness
      * for each corresponding field.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $_allowEmptyMessages = [];
 
     /**
      * Contains the flags which specify what is empty for each corresponding field.
      *
-     * @var array
+     * @var array<string, int>
      */
     protected $_allowEmptyFlags = [];
 

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -73,7 +73,7 @@ class ArrayContext implements ContextInterface
     /**
      * Context data for this object.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_context;
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -55,7 +55,7 @@ class EntityContext implements ContextInterface
     /**
      * Context data for this object.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_context;
 
@@ -91,7 +91,7 @@ class EntityContext implements ContextInterface
     /**
      * Constructor.
      *
-     * @param array $context Context info.
+     * @param array<string, mixed> $context Context info.
      */
     public function __construct(array $context)
     {


### PR DESCRIPTION
I am wondering if we can already use `list<Type>` for non assoc arrays that are clearly not using the key.
This would be nice to clarify for some of those arrays that there isnt a key missing, but on purpose not set.