### PR TITLE
Fix diffForHumans() not generating translated strings.

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\I18n;
 
+use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\DifferenceFormatterInterface;
 use Cake\Core\Exception\CakeException;
 use Closure;
@@ -481,6 +482,34 @@ trait DateFormatTrait
     public static function setDiffFormatter(DifferenceFormatterInterface $formatter): void
     {
         static::$diffFormatter = $formatter;
+    }
+
+    /**
+     * Get the difference in a human readable format.
+     *
+     * When comparing a value in the past to default now:
+     * 1 hour ago
+     * 5 months ago
+     *
+     * When comparing a value in the future to default now:
+     * 1 hour from now
+     * 5 months from now
+     *
+     * When comparing a value in the past to another value:
+     * 1 hour before
+     * 5 months before
+     *
+     * When comparing a value in the future to another value:
+     * 1 hour after
+     * 5 months after
+     *
+     * @param \Cake\Chronos\ChronosInterface|null $other The datetime to compare with.
+     * @param bool $absolute removes time difference modifiers ago, after, etc
+     * @return string
+     */
+    public function diffForHumans(?ChronosInterface $other = null, bool $absolute = false): string
+    {
+        return static::getDiffFormatter()->diffForHumans($this, $other, $absolute);
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -16,9 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\I18n;
 
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\I18n\Date;
 use Cake\I18n\FrozenDate;
+use Cake\I18n\I18n;
+use Cake\I18n\Package;
 use Cake\TestSuite\TestCase;
 use DateTimeZone;
 use IntlDateFormatter;
@@ -38,6 +41,16 @@ class DateTest extends TestCase
         Configure::write('Error.ignoredDeprecationPaths', [
             'src/I18n/Date.php',
         ]);
+
+        Cache::clear('_cake_core_');
+        I18n::setTranslator('cake', function () {
+            $package = new Package();
+            $package->setMessages([
+                '{0} ago' => '{0} ago (translated)',
+            ]);
+
+            return $package;
+        }, 'fr_FR');
     }
 
     /**
@@ -112,6 +125,17 @@ class DateTest extends TestCase
         $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'en-US');
         $expected = 'Wednesday, January 1, 2014 at 12:00:00 AM';
         $this->assertStringStartsWith($expected, $result);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     */
+    public function testDiffForHumans(string $class): void
+    {
+        I18n::setLocale('fr_FR');
+        $time = new $class('yesterday');
+        $this->assertSame('1 day ago (translated)', $time->diffForHumans());
+        I18n::setLocale(I18n::getDefaultLocale());
     }
 
     /**


### PR DESCRIPTION
Closes #16691.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
