### PR TITLE
4.next - pass down finder options to its connected associations

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -770,6 +770,7 @@ abstract class Association
             );
         }
 
+        $dummy->applyOptions($query->getOptions());
         $dummy->where($options['conditions']);
         $this->_dispatchBeforeFind($dummy);
 


### PR DESCRIPTION
This change will pass down finder options to all associated `beforeFind()` listeners.