### PR TITLE
Update ORM\Query to not extend Database\Query.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,11 @@ jobs:
 
         if [[ ${{ matrix.php-version }} == '8.1' ]]; then
           export CODECOVERAGE=1
-          vendor/bin/phpunit tests/TestCase/Database --verbose --coverage-clover=coverage.xml
-          CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit tests/TestCase/Database --verbose --testsuite=database
+          vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
+          CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --verbose --testsuite=database
         else
-          vendor/bin/phpunit tests/TestCase/Database
-          CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit tests/TestCase/Database --testsuite=database
+          vendor/bin/phpunit
+          CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --testsuite=database
         fi
 
     - name: Prefer lowest check
@@ -191,14 +191,14 @@ jobs:
       env:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
-          vendor/bin/phpunit tests/TestCase/Database --verbose
+          vendor/bin/phpunit --verbose
 
     - name: Run PHPUnit (autoquote enabled)
       env:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
           set CAKE_TEST_AUTOQUOTE=1
-          vendor/bin/phpunit tests/TestCase/Database --verbose --testsuite=database
+          vendor/bin/phpunit --verbose --testsuite=database
 
   cs-stan:
     name: Coding Standard & Static Analysis
@@ -242,7 +242,7 @@ jobs:
 
     - name: Run phpstan
       if: always()
-      run: vendor/bin/phpstan.phar analyse tests/TestCase/Database --error-format=github
+      run: vendor/bin/phpstan.phar analyse --error-format=github
 
     - name: Run phpstan for tests
       if: always()

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\TypedResultInterface;
 use Cake\Database\TypedResultTrait;
@@ -147,7 +147,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
     {
         $parts = [];
         foreach ($this->_conditions as $condition) {
-            if ($condition instanceof Query) {
+            if ($condition instanceof QueryInterface) {
                 $condition = sprintf('(%s)', $condition->sql($binder));
             } elseif ($condition instanceof ExpressionInterface) {
                 $condition = $condition->sql($binder);

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use Cake\Database\ValueBinder;
 use Closure;
 
@@ -54,7 +54,7 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
     {
         /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
-        if ($field instanceof Query) {
+        if ($field instanceof QueryInterface) {
             $field = sprintf('(%s)', $field->sql($binder));
         } elseif ($field instanceof ExpressionInterface) {
             $field = $field->sql($binder);

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use Cake\Database\TypeMap;
 use Cake\Database\TypeMapTrait;
 use Cake\Database\ValueBinder;
@@ -529,7 +529,7 @@ class QueryExpression implements ExpressionInterface, Countable
         $template = $len === 1 ? '%s' : '(%s)';
         $parts = [];
         foreach ($this->_conditions as $part) {
-            if ($part instanceof Query) {
+            if ($part instanceof QueryInterface) {
                 $part = '(' . $part->sql($binder) . ')';
             } elseif ($part instanceof ExpressionInterface) {
                 $part = $part->sql($binder);

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -18,7 +18,7 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\TypeMap;
 use Cake\Database\TypeMapTrait;
@@ -51,11 +51,11 @@ class ValuesExpression implements ExpressionInterface
     protected array $_columns = [];
 
     /**
-     * The Query object to use as a values expression
+     * The QueryInterface object to use as a values expression
      *
-     * @var \Cake\Database\Query|null
+     * @var \Cake\Database\QueryInterface|null
      */
-    protected ?Query $_query = null;
+    protected ?QueryInterface $_query = null;
 
     /**
      * Whether values have been casted to expressions
@@ -80,17 +80,17 @@ class ValuesExpression implements ExpressionInterface
     /**
      * Add a row of data to be inserted.
      *
-     * @param \Cake\Database\Query|array $values Array of data to append into the insert, or
+     * @param \Cake\Database\QueryInterface|array $values Array of data to append into the insert, or
      *   a query for doing INSERT INTO .. SELECT style commands
      * @return void
-     * @throws \Cake\Database\Exception\DatabaseException When mixing array + Query data types.
+     * @throws \Cake\Database\Exception\DatabaseException When mixing array + QueryInterface data types.
      */
-    public function add(Query|array $values): void
+    public function add(QueryInterface|array $values): void
     {
         if (
             (
                 count($this->_values) &&
-                $values instanceof Query
+                $values instanceof QueryInterface
             ) ||
             (
                 $this->_query &&
@@ -101,7 +101,7 @@ class ValuesExpression implements ExpressionInterface
                 'You cannot mix subqueries and array values in inserts.'
             );
         }
-        if ($values instanceof Query) {
+        if ($values instanceof QueryInterface) {
             $this->setQuery($values);
 
             return;
@@ -187,10 +187,10 @@ class ValuesExpression implements ExpressionInterface
      * Sets the query object to be used as the values expression to be evaluated
      * to insert records in the table.
      *
-     * @param \Cake\Database\Query $query The query to set
+     * @param \Cake\Database\QueryInterface $query The query to set
      * @return $this
      */
-    public function setQuery(Query $query)
+    public function setQuery(QueryInterface $query)
     {
         $this->_query = $query;
 
@@ -201,9 +201,9 @@ class ValuesExpression implements ExpressionInterface
      * Gets the query object to be used as the values expression to be evaluated
      * to insert records in the table.
      *
-     * @return \Cake\Database\Query|null
+     * @return \Cake\Database\QueryInterface|null
      */
-    public function getQuery(): ?Query
+    public function getQuery(): ?QueryInterface
     {
         return $this->_query;
     }

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
-use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use Cake\Database\Type\ExpressionTypeCasterTrait;
 use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
@@ -277,7 +277,7 @@ class WhenThenExpression implements ExpressionInterface
         ) {
             $when = $this->_castToExpression($when, $this->whenType);
         }
-        if ($when instanceof Query) {
+        if ($when instanceof QueryInterface) {
             $when = sprintf('(%s)', $when->sql($binder));
         } elseif ($when instanceof ExpressionInterface) {
             $when = $when->sql($binder);

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -32,7 +32,7 @@ use Stringable;
  * for dynamically constructing each query part, execute it and transform it
  * to a specific SQL dialect.
  */
-abstract class Query implements ExpressionInterface, Stringable
+abstract class Query implements QueryInterface, Stringable
 {
     use TypeMapTrait;
 

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -19,6 +19,7 @@ namespace Cake\Database\Query;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\ValuesExpression;
 use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use InvalidArgumentException;
 
 /**
@@ -94,12 +95,12 @@ class InsertQuery extends Query
      * or by providing an array of value sets. Additionally $data can be a Query
      * instance to insert data from another SELECT statement.
      *
-     * @param \Cake\Database\Expression\ValuesExpression|\Cake\Database\Query|array $data The data to insert.
+     * @param \Cake\Database\Expression\ValuesExpression|\Cake\Database\QueryInterface|array $data The data to insert.
      * @return $this
      * @throws \Cake\Database\Exception\DatabaseException if you try to set values before declaring columns.
      *   Or if you try to set values on non-insert queries.
      */
-    public function values(ValuesExpression|Query|array $data)
+    public function values(ValuesExpression|QueryInterface|array $data)
     {
         if (empty($this->_parts['insert'])) {
             throw new DatabaseException(

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -22,6 +22,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
+use Cake\Database\QueryInterface;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
 use Closure;
@@ -670,11 +671,11 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * `SELECT id, name FROM things d UNION SELECT id, title FROM articles a`
      *
-     * @param \Cake\Database\Query|string $query full SQL query to be used in UNION operator
+     * @param \Cake\Database\QueryInterface|string $query full SQL query to be used in UNION operator
      * @param bool $overwrite whether to reset the list of queries to be operated or not
      * @return $this
      */
-    public function union(Query|string $query, bool $overwrite = false)
+    public function union(QueryInterface|string $query, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['union'] = [];
@@ -705,11 +706,11 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * `SELECT id, name FROM things d UNION ALL SELECT id, title FROM articles a`
      *
-     * @param \Cake\Database\Query|string $query full SQL query to be used in UNION operator
+     * @param \Cake\Database\QueryInterface|string $query full SQL query to be used in UNION operator
      * @param bool $overwrite whether to reset the list of queries to be operated or not
      * @return $this
      */
-    public function unionAll(Query|string $query, bool $overwrite = false)
+    public function unionAll(QueryInterface|string $query, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['union'] = [];

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -351,7 +351,9 @@ class QueryCompiler
     protected function _buildUnionPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $parts = array_map(function ($p) use ($binder) {
-            $p['query'] = $p['query']->sql($binder);
+            if (!is_string($p['query'])) {
+                $p['query'] = $p['query']->sql($binder);
+            }
             $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
             $prefix = $p['all'] ? 'ALL ' : '';
             if ($this->_orderedUnion) {

--- a/src/Database/QueryInterface.php
+++ b/src/Database/QueryInterface.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database;
+
+interface QueryInterface extends ExpressionInterface
+{
+    /**
+     * Sets the connection instance to be used for executing and transforming this query.
+     *
+     * @param \Cake\Database\Connection $connection Connection instance
+     * @return $this
+     */
+    public function setConnection(Connection $connection);
+
+    /**
+     * Gets the connection instance to be used for executing and transforming this query.
+     *
+     * @return \Cake\Database\Connection
+     */
+    public function getConnection(): Connection;
+}

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -287,7 +287,7 @@ trait QueryTrait
             $results = $this->_cache->fetch($this);
         }
         if ($results === null) {
-            $results = $this->_decorateResults($this->_execute());
+            $results = $this->_decorateResults($this->executeSelect());
             if ($this->_cache) {
                 $this->_cache->store($this, $results);
             }
@@ -552,7 +552,7 @@ trait QueryTrait
      *
      * @return iterable
      */
-    abstract protected function _execute(): iterable;
+    abstract protected function executeSelect(): iterable;
 
     /**
      * Decorates the results iterator with MapReduce routines and formatters

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -24,6 +24,7 @@ use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Query as DatabaseQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -163,7 +164,7 @@ abstract class Association
      *
      * @var string
      */
-    protected string $_joinType = Query::JOIN_TYPE_LEFT;
+    protected string $_joinType = DatabaseQuery::JOIN_TYPE_LEFT;
 
     /**
      * The property name that should be filled with data from the target table

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -20,6 +20,7 @@ use Cake\Core\App;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Query as DatabaseQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectWithPivotLoader;
@@ -59,7 +60,7 @@ class BelongsToMany extends Association
      *
      * @var string
      */
-    protected string $_joinType = Query::JOIN_TYPE_INNER;
+    protected string $_joinType = DatabaseQuery::JOIN_TYPE_INNER;
 
     /**
      * The strategy name to be used to fetch associated records.
@@ -1108,7 +1109,7 @@ class BelongsToMany extends Association
             $name => [
                 'table' => $junctionTable->getTable(),
                 'conditions' => $conditions,
-                'type' => Query::JOIN_TYPE_INNER,
+                'type' => DatabaseQuery::JOIN_TYPE_INNER,
             ],
         ];
 
@@ -1278,7 +1279,7 @@ class BelongsToMany extends Association
             $present[$i] = array_values($entity->extract($assocForeignKey));
         }
 
-        foreach ($existing as $existingLink) {
+        foreach ($existing->all() as $existingLink) {
             $existingKeys = $existingLink->extract($keys);
             $found = false;
             foreach ($unmatchedEntityKeys as $i => $unmatchedKeys) {

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -20,11 +20,11 @@ use Cake\Collection\Collection;
 use Cake\Database\Expression\FieldInterface;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Query as DatabaseQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\InvalidPropertyInterface;
 use Cake\ORM\Association;
 use Cake\ORM\Association\Loader\SelectLoader;
-use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Closure;
 use InvalidArgumentException;
@@ -49,7 +49,7 @@ class HasMany extends Association
      *
      * @var string
      */
-    protected string $_joinType = Query::JOIN_TYPE_INNER;
+    protected string $_joinType = DatabaseQuery::JOIN_TYPE_INNER;
 
     /**
      * The strategy name to be used to fetch associated records.
@@ -524,7 +524,7 @@ class HasMany extends Association
                 });
                 $query = $this->find()->where($conditions);
                 $ok = true;
-                foreach ($query as $assoc) {
+                foreach ($query->all() as $assoc) {
                     $ok = $ok && $target->delete($assoc, $options);
                 }
 

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -20,6 +20,7 @@ use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Core\InstanceConfigTrait;
+use Cake\Database\Query as DatabaseQuery;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Entity;
@@ -134,7 +135,7 @@ class EavStrategy implements TranslateStrategyInterface
             $this->table->hasOne($name, [
                 'targetTable' => $fieldTable,
                 'foreignKey' => 'foreign_key',
-                'joinType' => $filter ? Query::JOIN_TYPE_INNER : Query::JOIN_TYPE_LEFT,
+                'joinType' => $filter ? DatabaseQuery::JOIN_TYPE_INNER : DatabaseQuery::JOIN_TYPE_LEFT,
                 'conditions' => $conditions,
                 'propertyName' => $field . '_translation',
             ]);
@@ -210,8 +211,8 @@ class EavStrategy implements TranslateStrategyInterface
 
             if ($changeFilter) {
                 $filter = $options['filterByCurrentLocale']
-                    ? Query::JOIN_TYPE_INNER
-                    : Query::JOIN_TYPE_LEFT;
+                    ? DatabaseQuery::JOIN_TYPE_INNER
+                    : DatabaseQuery::JOIN_TYPE_LEFT;
                 $contain[$name]['joinType'] = $filter;
             }
         }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
+use Cake\Database\Query as DatabaseQuery;
 use Closure;
 use InvalidArgumentException;
 
@@ -240,7 +241,7 @@ class EagerLoader
     {
         $this->_matching ??= new static();
 
-        $options += ['joinType' => Query::JOIN_TYPE_INNER];
+        $options += ['joinType' => DatabaseQuery::JOIN_TYPE_INNER];
         $sharedOptions = ['negateMatch' => false, 'matching' => true] + $options;
 
         $contains = [];

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -80,7 +80,7 @@ class LazyEagerLoader
         $query = $source
             ->find()
             ->select((array)$primaryKey)
-            ->where(function (QueryExpression $exp, Query $q) use ($primaryKey, $keys, $source) {
+            ->where(function (QueryExpression $exp, $q) use ($primaryKey, $keys, $source) {
                 if (is_array($primaryKey) && count($primaryKey) === 1) {
                     $primaryKey = current($primaryKey);
                 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -410,7 +410,7 @@ class Marshaller
 
             $existing = [];
             /** @var \Cake\Datasource\EntityInterface $row */
-            foreach ($query as $row) {
+            foreach ($query->all() as $row) {
                 $k = implode(';', $row->extract($keyFields));
                 $existing[$k] = $row;
             }
@@ -692,7 +692,7 @@ class Marshaller
 
         if (!empty($indexed) && count($maybeExistentQuery->clause('where'))) {
             /** @var \Cake\Datasource\EntityInterface $entity */
-            foreach ($maybeExistentQuery as $entity) {
+            foreach ($maybeExistentQuery->all() as $entity) {
                 $key = implode(';', $entity->extract($primary));
                 if (isset($indexed[$key])) {
                     $output[] = $this->merge($entity, $indexed[$key], $options);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -23,6 +23,7 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
@@ -1753,7 +1754,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * @inheritDoc
      */
-    public function exists(QueryExpression|Closure|array|string|null $conditions): bool
+    public function exists(ExpressionInterface|Closure|array|string|null $conditions): bool
     {
         return (bool)count(
             $this->find('all')

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -159,6 +159,24 @@ class UpdateQueryTest extends TestCase
     }
 
     /**
+     * Test update with table expression.
+     */
+    public function testUpdateWithTableExpression(): void
+    {
+        $this->skipIf(!$this->connection->getDriver() instanceof Mysql);
+
+        $query = $this->connection->newUpdateQuery();
+        $result = $query->update($query->newExpr('articles, authors'))
+            ->set(['title' => 'First'])
+            ->where(['articles.author_id = authors.id'])
+            ->andWhere(['authors.name' => 'mariano'])
+            ->execute();
+
+        $this->assertInstanceOf(StatementInterface::class, $result);
+        $this->assertGreaterThan(0, $result->rowCount());
+    }
+
+    /**
      * Tests update with subquery that references itself
      */
     public function testUpdateSubquery(): void

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -1273,7 +1273,7 @@ trait PaginatorTestTrait
     {
         /** @var \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject $query */
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['all', 'count', 'applyOptions'])
+            ->onlyMethods(['all', 'count', 'applyOptions', 'getConnection', 'getRepository'])
             ->addMethods(['total'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -1283,6 +1283,10 @@ trait PaginatorTestTrait
             ->getMock();
 
         $query->expects($this->any())
+            ->method('getConnection')
+            ->willReturn(ConnectionManager::get('test'));
+
+        $query->expects($this->any())
             ->method('count')
             ->will($this->returnValue(2));
 
@@ -1290,9 +1294,9 @@ trait PaginatorTestTrait
             ->method('all')
             ->will($this->returnValue($results));
 
-        if ($table) {
-            $query->repository($table);
-        }
+        $query->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($table ?: $this->_getMockPosts(['query']));
 
         return $query;
     }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -1196,13 +1196,19 @@ class HasManyTest extends TestCase
 
         $entity = $authors->save($entity, ['associated' => ['Articles']]);
         $sizeArticles = count($entity->articles);
-        $this->assertCount($sizeArticles, $authors->Articles->find('all')->where(['author_id' => $entity['id']]));
+        $this->assertCount(
+            $sizeArticles,
+            $authors->Articles->find('all')->where(['author_id' => $entity['id']])->all()
+        );
 
         $entity->set('articles', []);
 
         $entity = $authors->save($entity, ['associated' => ['Articles']]);
 
-        $this->assertCount(0, $authors->Articles->find('all')->where(['author_id' => $entity['id']]));
+        $this->assertCount(
+            0,
+            $authors->Articles->find('all')->where(['author_id' => $entity['id']])->all()
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -181,8 +181,8 @@ class HasOneTest extends TestCase
         $association = new HasOne('Profiles', $config);
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['join'])
-            ->disableOriginalConstructor()
+            ->addMethods(['join'])
+            ->setConstructorArgs([$this->profile->getConnection(), $this->profile])
             ->getMock();
         $field1 = new IdentifierExpression('Profiles.user_id');
         $field2 = new IdentifierExpression('Profiles.user_site_id');
@@ -208,7 +208,8 @@ class HasOneTest extends TestCase
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['join', 'select'])
+            ->onlyMethods(['select'])
+            ->addMethods(['join'])
             ->setConstructorArgs([$this->user->getConnection(), $this->user])
             ->getMock();
         $config = [

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -60,7 +60,7 @@ class BehaviorRegressionTest extends TestCase
         $table->setEntityClass(NumberTree::class);
 
         /** @var \TestApp\Model\Entity\NumberTree[] $all */
-        $all = $table->find('threaded')->find('translations');
+        $all = $table->find('threaded')->find('translations')->all();
         $results = [];
         foreach ($all as $node) {
             $results[] = $node->translation('dan')->name;

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Behavior;
 
 use Cake\Database\Driver\Sqlserver;
-use Cake\Database\Query;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
@@ -444,9 +443,7 @@ class CounterCacheBehaviorTest extends TestCase
         $this->post->addBehavior('CounterCache', [
             'Users' => [
                 'posts_published' => function (EventInterface $event, EntityInterface $entity, Table $table) {
-                    $query = new Query($this->connection);
-
-                    return $query->select(4);
+                    return $table->getConnection()->newSelectQuery([4]);
                 },
             ],
         ]);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -465,7 +465,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $results = $table->find('translations');
+        $results = $table->find('translations')->all();
         $expected = [
             [
                 'eng' => ['title' => 'Title #1', 'body' => 'Content #1', 'description' => 'Description #1', 'locale' => 'eng'],
@@ -493,7 +493,7 @@ class TranslateBehaviorEavTest extends TestCase
             3 => ['Third Article' => 'Third Article Body'],
         ];
 
-        $grouped = $results->all()->combine('title', 'body', 'id');
+        $grouped = $results->combine('title', 'body', 'id');
         $this->assertEquals($expected, $grouped->toArray());
     }
 
@@ -504,7 +504,7 @@ class TranslateBehaviorEavTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-        $results = $table->find('translations', ['locales' => ['deu', 'cze']]);
+        $results = $table->find('translations', ['locales' => ['deu', 'cze']])->all();
         $expected = [
             [
                 'deu' => ['title' => 'Titel #1', 'body' => 'Inhalt #1', 'locale' => 'deu'],
@@ -529,7 +529,7 @@ class TranslateBehaviorEavTest extends TestCase
             3 => ['Third Article' => 'Third Article Body'],
         ];
 
-        $grouped = $results->all()->combine('title', 'body', 'id');
+        $grouped = $results->combine('title', 'body', 'id');
         $this->assertEquals($expected, $grouped->toArray());
     }
 
@@ -546,7 +546,8 @@ class TranslateBehaviorEavTest extends TestCase
                 'valueField' => '_translations.deu.title',
                 'groupField' => 'id',
             ])
-            ->find('translations', ['locales' => ['deu']]);
+            ->find('translations', ['locales' => ['deu']])
+            ->all();
 
         $expected = [
             1 => ['First Article' => 'Titel #1'],
@@ -564,7 +565,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->setLocale('cze');
-        $results = $table->find('translations', ['locales' => ['deu', 'cze']]);
+        $results = $table->find('translations', ['locales' => ['deu', 'cze']])->all();
         $expected = [
             [
                 'deu' => ['title' => 'Titel #1', 'body' => 'Inhalt #1', 'locale' => 'deu'],
@@ -589,7 +590,7 @@ class TranslateBehaviorEavTest extends TestCase
             3 => ['Titulek #3' => 'Obsah #3'],
         ];
 
-        $grouped = $results->all()->combine('title', 'body', 'id');
+        $grouped = $results->combine('title', 'body', 'id');
         $this->assertEquals($expected, $grouped->toArray());
     }
 
@@ -1447,7 +1448,7 @@ class TranslateBehaviorEavTest extends TestCase
                 ],
             ],
         ];
-        $result = $table->find('translations')->where(['id' => $result->id]);
+        $result = $table->find('translations')->where(['id' => $result->id])->all();
         $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
     }
 
@@ -1482,7 +1483,7 @@ class TranslateBehaviorEavTest extends TestCase
                 ],
             ],
         ];
-        $result = $table->find('translations')->where(['id' => $result->id]);
+        $result = $table->find('translations')->where(['id' => $result->id])->all();
         $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
     }
 
@@ -1510,7 +1511,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertNotFalse($table->save($article));
 
         $results = $this->_extractTranslations(
-            $table->find('translations')->where(['id' => 1])
+            $table->find('translations')->where(['id' => 1])->all()
         )->first();
 
         $this->assertArrayHasKey('es', $results, 'New translation added');
@@ -1548,7 +1549,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertNotFalse($table->save($article));
 
         $results = $this->_extractTranslations(
-            $table->find('translations')->where(['id' => 1])
+            $table->find('translations')->where(['id' => 1])->all()
         )->first();
 
         $this->assertSame('Mi nuevo titulo', $results['spa']['title']);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -836,7 +836,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertNotFalse($table->save($article));
 
         $results = $this->_extractTranslations(
-            $table->find('translations')->where(['id' => 1])
+            $table->find('translations')->where(['id' => 1])->all()
         )->first();
 
         $this->assertSame('Mi nuevo titulo', $results['spa']['title']);
@@ -890,7 +890,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
                 ],
             ],
         ];
-        $result = $table->find('translations')->where(['id' => $result->id]);
+        $result = $table->find('translations')->where(['id' => $result->id])->all();
         $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
     }
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -190,7 +190,7 @@ class EagerLoaderTest extends TestCase
         ];
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['join'])
+            ->addMethods(['join'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
 
@@ -508,7 +508,7 @@ class EagerLoaderTest extends TestCase
         ];
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['join'])
+            ->addMethods(['join'])
             ->setConstructorArgs([$this->connection, $this->table])
             ->getMock();
 

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1585,8 +1585,7 @@ class QueryRegressionTest extends TestCase
                         ->ABS([
                             $table
                                 ->getConnection()
-                                ->newQuery()
-                                ->select(-1),
+                                ->newSelectQuery(-1),
                         ])
                         ->setReturnType('integer'),
                 ];
@@ -1641,8 +1640,7 @@ class QueryRegressionTest extends TestCase
                             [
                                 $table
                                     ->getConnection()
-                                    ->newQuery()
-                                    ->select(1.23456),
+                                    ->newSelectQuery(1.23456),
                                 2,
                             ],
                             [null, 'integer']

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -606,9 +606,7 @@ class LinkConstraintTest extends TestCase
             'conditions' => function (QueryExpression $exp, Query $query) {
                 $connection = $query->getConnection();
                 $subQuery = $connection
-                    ->newQuery()
-                    ->select(['RecentComments.id'])
-                    ->from(['RecentComments' => 'comments'])
+                    ->newSelectQuery(['RecentComments.id'], ['RecentComments' => 'comments'])
                     ->where(function (QueryExpression $exp) {
                         return $exp->eq(
                             new IdentifierExpression('Articles.id'),
@@ -643,9 +641,7 @@ class LinkConstraintTest extends TestCase
             'conditions' => function (QueryExpression $exp, Query $query) {
                 $connection = $query->getConnection();
                 $subQuery = $connection
-                    ->newQuery()
-                    ->select(['RecentComments.id'])
-                    ->from(['RecentComments' => 'comments'])
+                    ->newSelectQuery(['RecentComments.id'], ['RecentComments' => 'comments'])
                     ->where(function (QueryExpression $exp) {
                         return $exp->eq(
                             new IdentifierExpression('Articles.id'),

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -30,7 +30,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\Exception\RecordNotFoundException;
-use Cake\Datasource\ResultSetDecorator;
+use Cake\Datasource\ResultSetInterface;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\I18n\DateTime;
@@ -619,7 +619,7 @@ class TableTest extends TestCase
         );
 
         $query = $table->find('all')
-            ->formatResults(function (ResultSetDecorator $results) {
+            ->formatResults(function (ResultSetInterface $results) {
                 return $results;
             });
         $query->limit(1);
@@ -2605,7 +2605,8 @@ class TableTest extends TestCase
             ->getMock();
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->onlyMethods(['execute', 'addDefaultTypes', 'set'])
+            ->onlyMethods(['execute', 'addDefaultTypes'])
+            ->addMethods(['set'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
 
@@ -4228,7 +4229,7 @@ class TableTest extends TestCase
 
         $this->assertTrue($authors->Articles->link($author, $newArticles));
 
-        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id)->all());
         $this->assertCount($sizeArticles, $author->articles);
         $this->assertFalse($author->isDirty('articles'));
     }
@@ -4278,7 +4279,7 @@ class TableTest extends TestCase
 
         $sizeArticles++;
 
-        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id)->all());
         $this->assertCount($sizeArticles, $author->articles);
         $this->assertFalse($author->isDirty('articles'));
     }
@@ -4331,7 +4332,7 @@ class TableTest extends TestCase
 
         $sizeArticles++;
 
-        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id)->all());
         $this->assertCount($sizeArticles, $author->articles);
         $this->assertFalse($author->isDirty('articles'));
     }
@@ -4377,7 +4378,7 @@ class TableTest extends TestCase
 
         $authors->Articles->unlink($author, $articlesToUnlink);
 
-        $this->assertCount($sizeArticles - count($articlesToUnlink), $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles - count($articlesToUnlink), $authors->Articles->findAllByAuthorId($author->id)->all());
         $this->assertCount($sizeArticles - count($articlesToUnlink), $author->articles);
         $this->assertFalse($author->isDirty('articles'));
     }
@@ -4423,7 +4424,7 @@ class TableTest extends TestCase
 
         $authors->Articles->unlink($author, $articlesToUnlink, ['cleanProperty' => false]);
 
-        $this->assertCount($sizeArticles - count($articlesToUnlink), $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles - count($articlesToUnlink), $authors->Articles->findAllByAuthorId($author->id)->all());
         $this->assertCount($sizeArticles, $author->articles);
         $this->assertFalse($author->isDirty('articles'));
     }
@@ -4528,7 +4529,7 @@ class TableTest extends TestCase
         unset($newArticles[0]);
 
         $this->assertFalse($authors->Articles->replace($author, $newArticles));
-        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id)->all());
     }
 
     /**
@@ -4568,7 +4569,7 @@ class TableTest extends TestCase
         $newArticles = [];
 
         $this->assertTrue($authors->Articles->replace($author, $newArticles));
-        $this->assertCount(0, $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount(0, $authors->Articles->findAllByAuthorId($author->id)->all());
     }
 
     /**
@@ -4608,7 +4609,7 @@ class TableTest extends TestCase
         $this->assertEquals($authors->Articles->findAllByAuthorId($author->id)->count(), $sizeArticles);
         $this->assertCount($sizeArticles, $author->articles);
         $this->assertTrue($authors->Articles->replace($author, $newArticles));
-        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id));
+        $this->assertCount($sizeArticles, $authors->Articles->findAllByAuthorId($author->id)->all());
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/PublishedPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PublishedPostsTable.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Table;
 
-use Cake\Database\Query;
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 
 /**


### PR DESCRIPTION
While this isn't complete (query conversion and fixing few failing tests is pending) I wanted to show what I have till now.

I don't really like the changes required to `ORM\Query` to retain it as a single query class at the ORM level. Lot of non-DRY and hackish code.

Based on the discussion on #16648, one of the main reason for retaining the API of `ORM\Query` was to be able to continue having usage like `$table->find('someType')->delete();`.

Would we be okay instead having to specify the query type before hand (for non select queries)? For e.g. by using a special option like `$table->find('someType', ['_type' => 'delete'])->delete()->execute();`. That would avoid the whole query conversion conundrum. This would make static analyzers unhappy though and the return type for `find()` can't be typed to specific query types. So another option would be `$table->deleteQuery('someType')->execute()`.

IMHO usage of finders for non select queries is an abuse of the feature. One could instead add custom delete methods to the table to have clean/DRY code.
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
