### PR TITLE
Improve test suite assertion messages

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1357,10 +1357,26 @@ trait IntegrationTestTrait
      */
     protected function extractExceptionMessage(Exception $exception): string
     {
-        return PHP_EOL .
-            sprintf('Possibly related to %s: "%s" ', get_class($exception), $exception->getMessage()) .
-            PHP_EOL .
-            $exception->getTraceAsString();
+        $exceptions = [$exception];
+        $previous = $exception->getPrevious();
+        while ($previous != null) {
+            $exceptions[] = $previous;
+            $previous = $previous->getPrevious();
+        }
+        $message = PHP_EOL;
+        foreach ($exceptions as $i => $error) {
+            if ($i == 0) {
+                $message .= sprintf('Possibly related to %s: "%s"', get_class($error), $error->getMessage());
+                $message .= PHP_EOL;
+            } else {
+                $message .= sprintf('Caused by %s: "%s"', get_class($error), $error->getMessage());
+                $message .= PHP_EOL;
+            }
+            $message .= $error->getTraceAsString();
+            $message .= PHP_EOL;
+        }
+
+        return $message;
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1492,6 +1492,20 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test for assertion message generation for previous.
+     *
+     * @return void
+     */
+    public function testAssertMessagePrevious()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Caused by RuntimeException');
+
+        $this->get('/posts/throw_chained');
+        $this->assertContentType('test');
+    }
+
+    /**
      * data provider for assertion failure messages
      *
      * @return array

--- a/tests/test_app/TestApp/Controller/PostsController.php
+++ b/tests/test_app/TestApp/Controller/PostsController.php
@@ -19,6 +19,7 @@ namespace TestApp\Controller;
 use Cake\Event\EventInterface;
 use Cake\Http\Cookie\Cookie;
 use OutOfBoundsException;
+use RuntimeException;
 
 /**
  * PostsController class
@@ -208,5 +209,14 @@ class PostsController extends AppController
     {
         $this->Flash->error('Error 1');
         throw new OutOfBoundsException('oh no!');
+    }
+
+    /**
+     * @return \Cake\Http\Response
+     */
+    public function throw_chained()
+    {
+        $inner = new RuntimeException('inner badness');
+        throw new OutOfBoundsException('oh no!', 1, $inner);
     }
 }


### PR DESCRIPTION
I recently was working on a custom view class and had a hard time
figuring out the source of SerializationFailureException as I couldn't
see the wrapped exceptions. With this it would have been much easier.
