### PR TITLE
Fix array types in docblock.

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -428,7 +428,7 @@ class Connection implements ConnectionInterface
      *
      * @param string $table the table to insert values in
      * @param array $values values to be inserted
-     * @param array<string, string> $types list of associative array containing the types to be used for casting
+     * @param array<int|string, string> $types Array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
     public function insert(string $table, array $values, array $types = []): StatementInterface
@@ -449,7 +449,7 @@ class Connection implements ConnectionInterface
      * @param string $table the table to update rows from
      * @param array $values values to be updated
      * @param array $conditions conditions to be set for update statement
-     * @param array $types list of associative array containing the types to be used for casting
+     * @param array<string> $types list of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
     public function update(string $table, array $values, array $conditions = [], array $types = []): StatementInterface
@@ -467,7 +467,7 @@ class Connection implements ConnectionInterface
      *
      * @param string $table the table to delete rows from
      * @param array $conditions conditions to be set for delete statement
-     * @param array $types list of associative array containing the types to be used for casting
+     * @param array<string> $types list of associative array containing the types to be used for casting
      * @return \Cake\Database\StatementInterface
      */
     public function delete(string $table, array $conditions = [], array $types = []): StatementInterface

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -111,7 +111,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * be added. When using an array and the key is 'OR' or 'AND' a new expression
      * object will be created with that conjunction and internal array value passed
      * as conditions.
-     * @param array<string, string> $types Associative array of fields pointing to the type of the
+     * @param array<int|string, string> $types Associative array of fields pointing to the type of the
      * values that are being passed. Used for correctly binding values to statements.
      * @see \Cake\Database\Query::where() for examples on conditions
      * @return $this
@@ -702,7 +702,7 @@ class QueryExpression implements ExpressionInterface, Countable
      * representation is wrapped around an adequate instance or of this class.
      *
      * @param array $conditions list of conditions to be stored in this object
-     * @param array<string, string> $types list of types associated on fields referenced in $conditions
+     * @param array<int|string, string> $types list of types associated on fields referenced in $conditions
      * @return void
      */
     protected function _addConditions(array $conditions, array $types): void

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1646,7 +1646,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * with Query::values().
      *
      * @param array $columns The columns to insert into.
-     * @param array<string, string> $types A map between columns & their datatypes.
+     * @param array<int|string, string> $types A map between columns & their datatypes.
      * @return $this
      * @throws \RuntimeException When there are 0 columns.
      */

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -22,29 +22,29 @@ namespace Cake\Database;
 class TypeMap
 {
     /**
-     * Associative array with the default fields and the related types this query might contain.
+     * Array with the default fields and the related types this query might contain.
      *
      * Used to avoid repetition when calling multiple functions inside this class that
      * may require a custom type for a specific field.
      *
-     * @var array<string, string>
+     * @var array<int|string, string>
      */
     protected $_defaults = [];
 
     /**
-     * Associative array with the fields and the related types that override defaults this query might contain
+     * Array with the fields and the related types that override defaults this query might contain
      *
      * Used to avoid repetition when calling multiple functions inside this class that
      * may require a custom type for a specific field.
      *
-     * @var array<string, string>
+     * @var array<int|string, string>
      */
     protected $_types = [];
 
     /**
      * Creates an instance with the given defaults
      *
-     * @param array<string, string> $defaults The defaults to use.
+     * @param array<int|string, string> $defaults The defaults to use.
      */
     public function __construct(array $defaults = [])
     {
@@ -69,7 +69,7 @@ class TypeMap
      * This method will replace all the existing default mappings with the ones provided.
      * To add into the mappings use `addDefaults()`.
      *
-     * @param array<string, string> $defaults Associative array where keys are field names and values
+     * @param array<int|string, string> $defaults Array where keys are field names / positions and values
      * are the correspondent type.
      * @return $this
      */
@@ -83,7 +83,7 @@ class TypeMap
     /**
      * Returns the currently configured types.
      *
-     * @return array<string, string>
+     * @return array<int|string, string>
      */
     public function getDefaults(): array
     {
@@ -95,7 +95,7 @@ class TypeMap
      *
      * If a key already exists it will not be overwritten.
      *
-     * @param array<string, string> $types The additional types to add.
+     * @param array<int|string, string> $types The additional types to add.
      * @return void
      */
     public function addDefaults(array $types): void
@@ -114,7 +114,7 @@ class TypeMap
      *
      * This method will replace all the existing type maps with the ones provided.
      *
-     * @param array<string, string> $types Associative array where keys are field names and values
+     * @param array<int|string, string> $types Array where keys are field names / positions and values
      * are the correspondent type.
      * @return $this
      */
@@ -128,7 +128,7 @@ class TypeMap
     /**
      * Gets a map of fields and their associated types for single-use.
      *
-     * @return array<string, string>
+     * @return array<int|string, string>
      */
     public function getTypes(): array
     {
@@ -151,7 +151,7 @@ class TypeMap
     /**
      * Returns an array of all types mapped types
      *
-     * @return array<string, string>
+     * @return array<int|string, string>
      */
     public function toArray(): array
     {

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -66,7 +66,7 @@ trait TypeMapTrait
      * To add a default without overwriting existing ones
      * use `getTypeMap()->addDefaults()`
      *
-     * @param array<string, string> $types The array of types to set.
+     * @param array<int|string, string> $types The array of types to set.
      * @return $this
      * @see \Cake\Database\TypeMap::setDefaults()
      */
@@ -80,7 +80,7 @@ trait TypeMapTrait
     /**
      * Gets default types of current type map.
      *
-     * @return array<string, string>
+     * @return array<int|string, string>
      */
     public function getDefaultTypes(): array
     {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1306,7 +1306,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
      * Can be combined with the where() method to create delete queries.
      *
      * @param array $columns The columns to insert into.
-     * @param array<string, string> $types A map between columns & their datatypes.
+     * @param array<string> $types A map between columns & their datatypes.
      * @return $this
      */
     public function insert(array $columns, array $types = [])


### PR DESCRIPTION
We have tests with non associative array for `$types`.

https://github.com/cakephp/cakephp/blob/45c91d7ed8a8804d20daf2e001e8e2b292aed77d/tests/TestCase/Database/ConnectionTest.php#L365-L369

Also `TypeMap::type()` takes `int|string` as argument.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
