### PR TITLE
Fix check for skipping test.

### DIFF
--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -643,7 +643,8 @@ class ConnectionTest extends TestCase
      */
     public function testSavePoints(): void
     {
-        $this->skipIf(!$this->connection->enableSavePoints(true));
+        $this->connection->enableSavePoints(true);
+        $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
 
         $this->connection->begin();
         $this->connection->delete('things', ['id' => 1]);
@@ -671,7 +672,9 @@ class ConnectionTest extends TestCase
 
     public function testSavePoints2(): void
     {
-        $this->skipIf(!$this->connection->enableSavePoints(true));
+        $this->connection->enableSavePoints(true);
+        $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
+
         $this->connection->begin();
         $this->connection->delete('things', ['id' => 1]);
 
@@ -726,7 +729,10 @@ class ConnectionTest extends TestCase
             $this->connection->getDriver() instanceof Sqlserver,
             'SQLServer fails when this test is included.'
         );
-        $this->skipIf(!$this->connection->enableSavePoints(true));
+
+        $this->connection->enableSavePoints(true);
+        $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
+
         $this->connection->begin();
         $this->assertTrue($this->connection->inTransaction());
 


### PR DESCRIPTION
`Connection::enableSavePoints()` returns `$this` not a boolean.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
