### PR TITLE
Rename QueryInterface::repository() to QueryInterface::setRepository().

### DIFF
--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -24,6 +24,7 @@ namespace Cake\Datasource;
  *   provided list using the AND operator. {@see \Cake\Database\Query::andWhere()}
  * @method \Cake\Datasource\EntityInterface|array firstOrFail() Get the first result from the executing query or raise an exception.
  *   {@see \Cake\Database\Query::firstOrFail()}
+ * @method $this setRepository(\Cake\Datasource\RepositoryInterface $repository) Set the default repository object that will be used by this query.
  */
 interface QueryInterface
 {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -89,8 +89,23 @@ trait QueryTrait
      *
      * @param \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table $repository The default table object to use
      * @return $this
+     * @deprecated 4.5.0 Use `setRepository()` instead.
      */
     public function repository(RepositoryInterface $repository)
+    {
+        deprecationWarning('`repository() method is deprecated. Use `setRepository()` instead.');
+
+        return $this->setRepository($repository);
+    }
+
+    /**
+     * Set the default Table object that will be used by this query
+     * and form the `FROM` clause.
+     *
+     * @param \Cake\Datasource\RepositoryInterface|\Cake\ORM\Table $repository The default table object to use
+     * @return $this
+     */
+    public function setRepository(RepositoryInterface $repository)
     {
         $this->_repository = $repository;
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -178,7 +178,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     public function __construct(Connection $connection, Table $table)
     {
         parent::__construct($connection);
-        $this->repository($table);
+        $this->setRepository($table);
 
         if ($this->_repository !== null) {
             $this->addDefaultTypes($this->_repository);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -1403,7 +1403,7 @@ class PaginatorComponentTest extends TestCase
             ->will($this->returnValue(2));
 
         if ($table) {
-            $query->repository($table);
+            $query->setRepository($table);
         }
 
         return $query;

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -1340,7 +1340,7 @@ trait PaginatorTestTrait
             ->will($this->returnValue($results));
 
         if ($table) {
-            $query->repository($table);
+            $query->setRepository($table);
         }
 
         return $query;

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -197,7 +197,7 @@ class CompositeKeysTest extends TestCase
         ];
         $this->assertEquals($expected, $results);
 
-        $results = $query->repository($table)
+        $results = $query->setRepository($table)
             ->select()
             ->contain(['SiteArticles' => ['conditions' => ['SiteArticles.id' => 2]]])
             ->enableHydration(false)

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -285,7 +285,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $results);
 
-        $results = $query->repository($table)
+        $results = $query->setRepository($table)
             ->select()
             ->contain(['articles' => ['conditions' => ['articles.id' => 2]]])
             ->enableHydration(false)
@@ -683,7 +683,7 @@ class QueryTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
 
-        $results = $query->repository($table)
+        $results = $query->setRepository($table)
             ->select()
             ->disableHydration()
             ->matching('Comments', function ($q) {
@@ -722,7 +722,7 @@ class QueryTest extends TestCase
         $query = new Query($this->connection, $table);
         $table->hasMany('Comments');
 
-        $result = $query->repository($table)
+        $result = $query->setRepository($table)
             ->matching('Comments', function ($q) {
                 return $q->where(['Comments.user_id' => 4]);
             })
@@ -748,7 +748,7 @@ class QueryTest extends TestCase
         ]);
         $table->belongsToMany('Tags');
 
-        $results = $query->repository($table)->select()
+        $results = $query->setRepository($table)->select()
             ->matching('Tags', function ($q) {
                 return $q->where(['Tags.id' => 3]);
             })
@@ -813,7 +813,7 @@ class QueryTest extends TestCase
         $table->hasMany('articles');
         $this->getTableLocator()->get('articles')->belongsToMany('tags');
 
-        $results = $query->repository($table)
+        $results = $query->setRepository($table)
             ->select()
             ->enableHydration(false)
             ->matching('articles.tags', function ($q) {
@@ -3210,7 +3210,7 @@ class QueryTest extends TestCase
         $table->hasMany('articles');
         $this->getTableLocator()->get('articles')->belongsToMany('tags');
 
-        $result = $query->repository($table)
+        $result = $query->setRepository($table)
             ->select()
             ->matching('articles.tags', function ($q) {
                 return $q->where(['tags.id' => 2]);


### PR DESCRIPTION
This harmonizes the name as per the naming convention followed throughout the framework
where all getter/setter method pairs have get/set prefix.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
