### PR TITLE
Fix null $pass parameters in _writeUrl method in Route

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -815,7 +815,7 @@ class Route
      */
     protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $pass = array_filter($pass, fn(mixed $value): bool => $value !== null);
+        $pass = array_filter($pass, fn($value): bool => $value !== null);
         $pass = implode('/', array_map('rawurlencode', $pass));
         $out = $this->template;
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -815,8 +815,7 @@ class Route
      */
     protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $pass = array_filter($pass, fn($value): bool => $value !== null);
-        $pass = implode('/', array_map('rawurlencode', $pass));
+        $pass = implode('/', array_map(fn($value): string => rawurlencode((string) $value), $pass));
         $out = $this->template;
 
         $search = $replace = [];

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -815,6 +815,7 @@ class Route
      */
     protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
+        $pass = array_filter($pass, fn(mixed $value): bool => $value !== null);
         $pass = implode('/', array_map('rawurlencode', $pass));
         $out = $this->template;
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -815,7 +815,7 @@ class Route
      */
     protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $pass = implode('/', array_map(fn($value): string => rawurlencode((string) $value), $pass));
+        $pass = implode('/', array_map(fn($value): string => rawurlencode((string)$value), $pass));
         $out = $this->template;
 
         $search = $replace = [];


### PR DESCRIPTION
This fixes following deprecation notice:

```
[Deprecated (8192) ](javascript:void(0);): rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated
```