### PR TITLE
Disable zend.assertions warning for cli

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -98,7 +98,7 @@ class Configure
                 ini_set('display_errors', $config['debug'] ? '1' : '0');
             }
 
-            if ($config['debug'] && ini_get('zend.assertions') === '-1') {
+            if ($config['debug'] && PHP_SAPI !== 'cli' && ini_get('zend.assertions') === '-1') {
                 trigger_error(
                     'You should set `zend.assertions` to `1` in your php.ini for your development environment.',
                     E_USER_WARNING


### PR DESCRIPTION
psalm executes this before analyzing. We could set the ini option for CS builds. Users would have to do the same, but they already need to set it in their continuous integration builds to avoid the warning.
