### PR TITLE
Add psalm-return never-return to the abort functions in console

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -147,8 +147,6 @@ class I18nExtractCommand extends Command
             if (strtoupper($response) === 'Q') {
                 $io->err('Extract Aborted');
                 $this->abort();
-
-                return;
             }
             if (strtoupper($response) === 'D' && count($this->_paths)) {
                 $io->out();

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -243,6 +243,7 @@ abstract class BaseCommand implements CommandInterface
      * @param int $code The exit code to use.
      * @throws \Cake\Console\Exception\StopException
      * @return void
+     * @psalm-return never-return
      */
     public function abort(int $code = self::CODE_ERROR): void
     {

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -298,6 +298,7 @@ class ConsoleIo
      * @param string $message Error message.
      * @param int $code Error code.
      * @return void
+     * @psalm-return never-return
      * @throws \Cake\Console\Exception\StopException
      */
     public function abort($message, $code = CommandInterface::CODE_ERROR): void


### PR DESCRIPTION
Added missing psalm-return never-return to abort in BaseCommand and ConsoleIo. This fixes false positives when doing static analysis with phpstan/psalm and matches the abort in Shell.
