### PR TITLE
Remove uneeded constructor args.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -18,7 +18,6 @@ namespace Cake\ORM;
 
 use ArrayObject;
 use Cake\Collection\Iterator\MapReduce;
-use Cake\Database\Connection;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query\SelectQuery as DbSelectQuery;
 use Cake\Database\TypedResultInterface;
@@ -193,12 +192,12 @@ class Query extends DbSelectQuery implements JsonSerializable, QueryInterface
     /**
      * Constructor
      *
-     * @param \Cake\Database\Connection $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
-    public function __construct(Connection $connection, Table $table)
+    public function __construct(Table $table)
     {
-        parent::__construct($connection);
+        parent::__construct($table->getConnection());
+
         $this->setRepository($table);
         $this->addDefaultTypes($table);
     }

--- a/src/ORM/Query/DeleteQuery.php
+++ b/src/ORM/Query/DeleteQuery.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Query;
 
-use Cake\Database\Connection;
 use Cake\Database\Query\DeleteQuery as DbDeleteQuery;
 use Cake\Database\ValueBinder;
 use Cake\ORM\Table;
@@ -31,12 +30,11 @@ class DeleteQuery extends DbDeleteQuery
     /**
      * Constructor
      *
-     * @param \Cake\Database\Connection $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
-    public function __construct(Connection $connection, Table $table)
+    public function __construct(Table $table)
     {
-        parent::__construct($connection);
+        parent::__construct($table->getConnection());
 
         $this->setRepository($table);
         $this->addDefaultTypes($table);

--- a/src/ORM/Query/InsertQuery.php
+++ b/src/ORM/Query/InsertQuery.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Query;
 
-use Cake\Database\Connection;
 use Cake\Database\Query\InsertQuery as DbInsertQuery;
 use Cake\Database\ValueBinder;
 use Cake\ORM\Table;
@@ -31,12 +30,11 @@ class InsertQuery extends DbInsertQuery
     /**
      * Constructor
      *
-     * @param \Cake\Database\Connection $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
-    public function __construct(Connection $connection, Table $table)
+    public function __construct(Table $table)
     {
-        parent::__construct($connection);
+        parent::__construct($table->getConnection());
 
         $this->setRepository($table);
         $this->addDefaultTypes($table);

--- a/src/ORM/Query/QueryFactory.php
+++ b/src/ORM/Query/QueryFactory.php
@@ -32,7 +32,7 @@ class QueryFactory
      */
     public function select(Table $table): Query
     {
-        return new Query($table->getConnection(), $table);
+        return new Query($table);
     }
 
     /**
@@ -43,7 +43,7 @@ class QueryFactory
      */
     public function insert(Table $table): InsertQuery
     {
-        return new InsertQuery($table->getconnection(), $table);
+        return new InsertQuery($table);
     }
 
     /**
@@ -54,7 +54,7 @@ class QueryFactory
      */
     public function update(Table $table): UpdateQuery
     {
-        return new UpdateQuery($table->getconnection(), $table);
+        return new UpdateQuery($table);
     }
 
     /**
@@ -65,6 +65,6 @@ class QueryFactory
      */
     public function delete(Table $table): DeleteQuery
     {
-        return new DeleteQuery($table->getconnection(), $table);
+        return new DeleteQuery($table);
     }
 }

--- a/src/ORM/Query/UpdateQuery.php
+++ b/src/ORM/Query/UpdateQuery.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Query;
 
-use Cake\Database\Connection;
 use Cake\Database\Query\UpdateQuery as DbUpdateQuery;
 use Cake\Database\ValueBinder;
 use Cake\ORM\Table;
@@ -31,12 +30,11 @@ class UpdateQuery extends DbUpdateQuery
     /**
      * Constructor
      *
-     * @param \Cake\Database\Connection $connection The connection object
      * @param \Cake\ORM\Table $table The table this query is starting on
      */
-    public function __construct(Connection $connection, Table $table)
+    public function __construct(Table $table)
     {
-        parent::__construct($connection);
+        parent::__construct($table->getConnection());
 
         $this->setRepository($table);
         $this->addDefaultTypes($table);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -452,7 +452,7 @@ class HasManyTest extends TestCase
         $keys = [[1, 10], [2, 20], [3, 30], [4, 40]];
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['all', 'andWhere', 'getRepository'])
-            ->setConstructorArgs([ConnectionManager::get('test'), $this->article])
+            ->setConstructorArgs([$this->article])
             ->getMock();
         $query->method('getRepository')
             ->will($this->returnValue($this->article));

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -209,7 +209,7 @@ class HasOneTest extends TestCase
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join', 'select'])
-            ->setConstructorArgs([$this->user->getConnection(), $this->user])
+            ->setConstructorArgs([$this->user])
             ->getMock();
         $config = [
             'sourceTable' => $this->user,

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -296,7 +296,7 @@ class BehaviorRegistryTest extends TestCase
             ->getMock();
         $this->Behaviors->set('Sluggable', $mockedBehavior);
 
-        $query = new Query($this->Table->getConnection(), $this->Table);
+        $query = new Query($this->Table);
         $mockedBehavior
             ->expects($this->once())
             ->method('findNoSlug')

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -146,7 +146,7 @@ class CompositeKeysTest extends TestCase
             'sort' => ['SiteArticles.id' => 'asc'],
             'foreignKey' => ['author_id', 'site_id'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query->select()
             ->contain('SiteArticles')
@@ -226,7 +226,7 @@ class CompositeKeysTest extends TestCase
             'foreignKey' => ['article_id', 'site_id'],
             'targetForeignKey' => ['tag_id', 'site_id'],
         ]);
-        $query = new Query($this->connection, $articles);
+        $query = new Query($articles);
 
         $results = $query->select()->contain('SiteTags')->enableHydration(false)->toArray();
         $expected = [
@@ -307,7 +307,7 @@ class CompositeKeysTest extends TestCase
             'strategy' => $strategy,
             'foreignKey' => ['author_id', 'site_id'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->where(['SiteArticles.id IN' => [1, 2]])
             ->contain('SiteAuthors')
@@ -355,7 +355,7 @@ class CompositeKeysTest extends TestCase
             'strategy' => $strategy,
             'foreignKey' => ['author_id', 'site_id'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->where(['SiteAuthors.id IN' => [1, 3]])
             ->contain('SiteArticles')
@@ -569,7 +569,7 @@ class CompositeKeysTest extends TestCase
         $table = $this->getTableLocator()->get('SiteAuthors');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['_addDefaultFields', 'execute'])
-            ->setConstructorArgs([$table->getConnection(), $table])
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $items = new ResultSetDecorator([

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -191,7 +191,7 @@ class EagerLoaderTest extends TestCase
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join'])
-            ->setConstructorArgs([$this->connection, $this->table])
+            ->setConstructorArgs([$this->table])
             ->getMock();
 
         $query->setTypeMap($this->clientsTypeMap);
@@ -410,7 +410,7 @@ class EagerLoaderTest extends TestCase
         ]);
         $builder = $loader->getContain()['clients']['queryBuilder'];
         $table = $this->getTableLocator()->get('foo');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query = $builder($query);
         $this->assertEquals(['a', 'b'], $query->clause('select'));
     }
@@ -430,7 +430,7 @@ class EagerLoaderTest extends TestCase
         ];
 
         $table = $this->getTableLocator()->get('foo');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $loader = new EagerLoader();
         $loader->contain($contains);
         $query->select('foo.id');
@@ -454,7 +454,7 @@ class EagerLoaderTest extends TestCase
     {
         $contains = ['clients' => ['orders']];
 
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $query->select()->contain($contains)->sql();
         $select = $query->clause('select');
         $expected = [
@@ -467,7 +467,7 @@ class EagerLoaderTest extends TestCase
         $this->assertEquals($expected, $select);
 
         $contains['clients']['fields'] = ['name'];
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $query->select('foo.id')->contain($contains)->sql();
         $select = $query->clause('select');
         $expected = ['foo__id' => 'foo.id', 'clients__name' => 'clients.name'];
@@ -476,7 +476,7 @@ class EagerLoaderTest extends TestCase
 
         $contains['clients']['fields'] = [];
         $contains['clients']['orders']['fields'] = false;
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $query->select()->contain($contains)->sql();
         $select = $query->clause('select');
         $expected = [
@@ -509,7 +509,7 @@ class EagerLoaderTest extends TestCase
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join'])
-            ->setConstructorArgs([$this->connection, $this->table])
+            ->setConstructorArgs([$this->table])
             ->getMock();
 
         $loader = new EagerLoader();

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -154,7 +154,7 @@ class QueryTest extends TestCase
      */
     public function testGetRepository(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
 
         $result = $query->getRepository();
         $this->assertSame($this->table, $result);
@@ -171,7 +171,7 @@ class QueryTest extends TestCase
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $table->belongsTo('authors', ['strategy' => $strategy]);
 
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->contain('authors')
             ->enableHydration(false)
@@ -232,7 +232,7 @@ class QueryTest extends TestCase
             'strategy' => $strategy,
             'sort' => ['articles.id' => 'asc'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query->select()
             ->contain('articles')
@@ -310,7 +310,7 @@ class QueryTest extends TestCase
             'strategy' => $strategy,
             'sort' => ['articles.id' => 'asc'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $query = $query->select()
             ->contain('articles');
@@ -337,7 +337,7 @@ class QueryTest extends TestCase
         $this->getTableLocator()->get('articles');
         $table->hasMany('articles', ['propertyName' => 'articles'] + compact('strategy'));
 
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->contain([
                 'articles' => [
@@ -392,7 +392,7 @@ class QueryTest extends TestCase
             'sort' => ['articles.id' => 'asc'],
         ]);
         $article->belongsTo('authors');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query->select()
             ->contain(['articles' => ['authors']])
@@ -467,7 +467,7 @@ class QueryTest extends TestCase
         ]);
         $article->belongsTo('authors');
 
-        $query = new Query($this->connection, $article);
+        $query = new Query($article);
 
         $results = $query->select()
             ->contain(['authors' => ['posts']])
@@ -571,7 +571,7 @@ class QueryTest extends TestCase
             'strategy' => $strategy,
             'sort' => 'tag_id',
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query->select()->contain('Tags')->disableHydration()->toArray();
         $expected = [
@@ -679,7 +679,7 @@ class QueryTest extends TestCase
      */
     public function testFilteringByHasManyNoHydration(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments');
 
@@ -719,7 +719,7 @@ class QueryTest extends TestCase
     public function testFilteringByHasManyHydration(): void
     {
         $table = $this->getTableLocator()->get('Articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $table->hasMany('Comments');
 
         $result = $query->setRepository($table)
@@ -740,7 +740,7 @@ class QueryTest extends TestCase
      */
     public function testFilteringByBelongsToManyNoHydration(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $table = $this->getTableLocator()->get('Articles');
         $this->getTableLocator()->get('Tags');
         $this->getTableLocator()->get('ArticlesTags', [
@@ -774,7 +774,7 @@ class QueryTest extends TestCase
         ];
         $this->assertEquals($expected, $results);
 
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->matching('Tags', function ($q) {
                 return $q->where(['Tags.name' => 'tag2']);
@@ -807,7 +807,7 @@ class QueryTest extends TestCase
      */
     public function testMatchingDotNotation(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $table = $this->getTableLocator()->get('authors');
         $this->getTableLocator()->get('articles');
         $table->hasMany('articles');
@@ -853,7 +853,7 @@ class QueryTest extends TestCase
      */
     public function testSetResult(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
 
         $results = new ResultSet([]);
         $query->setResult($results);
@@ -869,7 +869,7 @@ class QueryTest extends TestCase
     public function testClearResult(): void
     {
         $article = $this->getTableLocator()->get('articles');
-        $query = new Query($this->connection, $article);
+        $query = new Query($article);
 
         $firstCount = $query->count();
         $firstResults = $query->toArray();
@@ -927,7 +927,7 @@ class QueryTest extends TestCase
             'contain' => ['articles'],
             'join' => ['table_a' => ['conditions' => ['a > b']]],
         ];
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $query->applyOptions($options);
 
         $this->assertEquals(['field_a', 'field_b'], $query->clause('select'));
@@ -962,7 +962,7 @@ class QueryTest extends TestCase
      */
     public function testApplyOptionsPageIsLast(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $opts = [
             'page' => 3,
             'limit' => 5,
@@ -980,7 +980,7 @@ class QueryTest extends TestCase
         $options = [
             'fields' => null,
         ];
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $query->applyOptions($options);
         $this->assertEquals([], $query->clause('select'));
     }
@@ -991,7 +991,7 @@ class QueryTest extends TestCase
     public function testGetOptions(): void
     {
         $options = ['doABarrelRoll' => true, 'fields' => ['id', 'name']];
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $query->applyOptions($options);
         $expected = ['doABarrelRoll' => true];
         $this->assertEquals($expected, $query->getOptions());
@@ -1010,7 +1010,7 @@ class QueryTest extends TestCase
         };
         $mapper2 = function (): void {
         };
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $this->assertSame($query, $query->mapReduce($mapper1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => null]],
@@ -1041,7 +1041,7 @@ class QueryTest extends TestCase
         };
         $reducer2 = function (): void {
         };
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $this->assertSame($query, $query->mapReduce($mapper1, $reducer1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => $reducer1]],
@@ -1071,7 +1071,7 @@ class QueryTest extends TestCase
         };
         $reducer2 = function (): void {
         };
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $this->assertEquals($query, $query->mapReduce($mapper1, $reducer1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => $reducer1]],
@@ -1091,7 +1091,7 @@ class QueryTest extends TestCase
     public function testResultsAreWrappedInMapReduce(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select(['a' => 'id'])->limit(2)->order(['id' => 'ASC']);
         $query->mapReduce(function ($v, $k, $mr): void {
             $mr->emit($v['a']);
@@ -1114,7 +1114,7 @@ class QueryTest extends TestCase
     public function testFirstDirtyQuery(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $result = $query->select(['id'])->enableHydration(false)->first();
         $this->assertEquals(['id' => 1], $result);
         $this->assertEquals(1, $query->clause('limit'));
@@ -1128,7 +1128,7 @@ class QueryTest extends TestCase
     public function testFirstCleanQuery(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select(['id'])->toArray();
 
         $first = $query->enableHydration(false)->first();
@@ -1142,7 +1142,7 @@ class QueryTest extends TestCase
     public function testFirstSameResult(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select(['id'])->toArray();
 
         $first = $query->enableHydration(false)->first();
@@ -1164,7 +1164,7 @@ class QueryTest extends TestCase
         };
 
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select(['id'])
             ->enableHydration(false)
             ->mapReduce($map, $reduce);
@@ -1179,7 +1179,7 @@ class QueryTest extends TestCase
     public function testFirstUnbuffered(): void
     {
         $table = $this->getTableLocator()->get('Articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select(['id']);
 
         $first = $query->enableHydration(false)->first();
@@ -1193,7 +1193,7 @@ class QueryTest extends TestCase
     public function testHydrateSimple(): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()->toArray();
 
         $this->assertCount(3, $results);
@@ -1220,7 +1220,7 @@ class QueryTest extends TestCase
             'propertyName' => 'articles',
             'sort' => ['articles.id' => 'asc'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->contain('articles')
             ->toArray();
@@ -1260,7 +1260,7 @@ class QueryTest extends TestCase
             'table' => 'articles_tags',
         ]);
         $table->belongsToMany('Tags');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query
             ->select()
@@ -1318,7 +1318,7 @@ class QueryTest extends TestCase
                 });
             });
 
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query
             ->select()
@@ -1371,7 +1371,7 @@ class QueryTest extends TestCase
         $this->getTableLocator()->get('authors');
         $table->belongsTo('authors', ['strategy' => $strategy]);
 
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->contain('authors')
             ->order(['articles.id' => 'asc'])
@@ -1398,7 +1398,7 @@ class QueryTest extends TestCase
             'sort' => ['articles.id' => 'asc'],
         ]);
         $article->belongsTo('authors', ['strategy' => $strategy]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $results = $query->select()
             ->contain(['articles' => ['authors']])
@@ -1422,7 +1422,7 @@ class QueryTest extends TestCase
             'table' => 'articles',
             'entityClass' => '\\' . $class,
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()->toArray();
 
         $this->assertCount(3, $results);
@@ -1456,7 +1456,7 @@ class QueryTest extends TestCase
             'propertyName' => 'articles',
             'sort' => ['articles.id' => 'asc'],
         ]);
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->contain('articles')
             ->toArray();
@@ -1490,7 +1490,7 @@ class QueryTest extends TestCase
         ]);
         $table->belongsTo('authors');
 
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->select()
             ->contain('authors')
             ->order(['articles.id' => 'asc'])
@@ -1755,7 +1755,7 @@ class QueryTest extends TestCase
         /** @var \Cake\ORM\Query $query */
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['all'])
-            ->setConstructorArgs([$this->connection, $this->table])
+            ->setConstructorArgs([$this->table])
             ->getMock();
 
         $query->contain([
@@ -1781,7 +1781,7 @@ class QueryTest extends TestCase
     {
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['execute'])
-            ->setConstructorArgs([$this->connection, $this->table])
+            ->setConstructorArgs([$this->table])
             ->getMock();
         $resultSet = new ResultSet([]);
 
@@ -1807,7 +1807,7 @@ class QueryTest extends TestCase
     public function testCacheWriteIntegration(): void
     {
         $table = $this->getTableLocator()->get('Articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
 
         $query->select(['id', 'title']);
 
@@ -1832,7 +1832,7 @@ class QueryTest extends TestCase
     public function testCacheIntegrationWithFormatResults(): void
     {
         $table = $this->getTableLocator()->get('Articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $cacher = new FileEngine();
         $cacher->init();
 
@@ -1844,7 +1844,7 @@ class QueryTest extends TestCase
             ->cache('my_key', $cacher);
 
         $expected = $query->toArray();
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $results = $query->cache('my_key', $cacher)->toArray();
         $this->assertSame($expected, $results);
     }
@@ -1876,7 +1876,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query
             ->select()
             ->contain([
@@ -1902,7 +1902,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query
             ->select()
             ->contain('articles', function ($q) {
@@ -1922,7 +1922,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query
             ->select()
             ->contain('articles', function ($q) {
@@ -1942,7 +1942,7 @@ class QueryTest extends TestCase
         $this->expectException(DatabaseException::class);
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany('Articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select()
             ->contain([
                 'Articles' => [
@@ -1963,7 +1963,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Authors');
         $table->hasOne('Articles');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select()
             ->contain([
                 'Articles' => [
@@ -1979,7 +1979,7 @@ class QueryTest extends TestCase
 
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsTo('Authors');
-        $query = new Query($this->connection, $articles);
+        $query = new Query($articles);
         $query->select()
             ->contain([
                 'Authors' => [
@@ -2019,7 +2019,7 @@ class QueryTest extends TestCase
         $callback2 = function (): void {
         };
         $table = $this->getTableLocator()->get('authors');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $this->assertSame($query, $query->formatResults($callback1));
         $this->assertSame([$callback1], $query->getResultFormatters());
         $this->assertSame($query, $query->formatResults($callback2));
@@ -2203,7 +2203,7 @@ class QueryTest extends TestCase
     public function testQueryWithFormatter(): void
     {
         $table = $this->getTableLocator()->get('authors');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select()->formatResults(function ($results) {
             $this->assertInstanceOf('Cake\ORM\ResultSet', $results);
 
@@ -2218,7 +2218,7 @@ class QueryTest extends TestCase
     public function testQueryWithStackedFormatters(): void
     {
         $table = $this->getTableLocator()->get('authors');
-        $query = new Query($this->connection, $table);
+        $query = new Query($table);
         $query->select()->formatResults(function ($results) {
             $this->assertInstanceOf('Cake\ORM\ResultSet', $results);
 
@@ -3069,7 +3069,7 @@ class QueryTest extends TestCase
      */
     public function testMatchingWithContain(): void
     {
-        $query = new Query($this->connection, $this->table);
+        $query = new Query($this->table);
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles');
         $this->getTableLocator()->get('articles')->belongsToMany('tags');
@@ -3735,7 +3735,7 @@ class QueryTest extends TestCase
     {
         $post = $this->getTableLocator()->get('posts');
 
-        $query = new Query($this->connection, $post);
+        $query = new Query($post);
 
         $results = $query
             ->select([

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1083,11 +1083,11 @@ class TableTest extends TestCase
         $this->expectException(DatabaseException::class);
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['updateQuery'])
-            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->setConstructorArgs([['table' => 'users']])
             ->getMock();
         $query = $this->getMockBuilder(UpdateQuery::class)
             ->onlyMethods(['execute'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
         $table->expects($this->once())
             ->method('updateQuery')
@@ -1143,11 +1143,11 @@ class TableTest extends TestCase
         $this->expectException(DatabaseException::class);
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['deleteQuery'])
-            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->setConstructorArgs([['table' => 'users']])
             ->getMock();
         $query = $this->getMockBuilder(DeleteQuery::class)
             ->onlyMethods(['execute'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
         $table->expects($this->once())
             ->method('deleteQuery')
@@ -1170,7 +1170,7 @@ class TableTest extends TestCase
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
             ->getMock();
         $query = $this->getMockBuilder('Cake\ORM\Query')
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
         $table->expects($this->once())
             ->method('query')
@@ -1321,10 +1321,9 @@ class TableTest extends TestCase
             ->onlyMethods(['find', 'findList'])
             ->disableOriginalConstructor()
             ->getMock();
-        $params = [$this->connection, $table];
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['addDefaultTypes'])
-            ->setConstructorArgs($params)
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $table->expects($this->once())
@@ -2304,11 +2303,11 @@ class TableTest extends TestCase
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['insertQuery'])
-            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->setConstructorArgs([['table' => 'users']])
             ->getMock();
         $query = $this->getMockBuilder(InsertQuery::class)
             ->onlyMethods(['execute', 'addDefaultTypes'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
         $statement = $this->createMock(StatementInterface::class);
         $data = new Entity([
@@ -2446,7 +2445,7 @@ class TableTest extends TestCase
             ->getMock();
         $query = $this->getMockBuilder(InsertQuery::class)
             ->onlyMethods(['execute', 'addDefaultTypes'])
-            ->setConstructorArgs([$connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
         $table->expects($this->any())->method('getConnection')
             ->will($this->returnValue($connection));
@@ -2486,7 +2485,7 @@ class TableTest extends TestCase
             ->getMock();
         $query = $this->getMockBuilder(InsertQuery::class)
             ->onlyMethods(['execute', 'addDefaultTypes'])
-            ->setConstructorArgs([$connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $table->expects($this->any())->method('getConnection')
@@ -2659,12 +2658,12 @@ class TableTest extends TestCase
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
             ->onlyMethods(['updateQuery'])
-            ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
+            ->setConstructorArgs([['table' => 'users']])
             ->getMock();
 
         $query = $this->getMockBuilder(UpdateQuery::class)
             ->onlyMethods(['execute', 'addDefaultTypes', 'set'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $table->expects($this->once())->method('updateQuery')
@@ -5274,7 +5273,7 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $query = (new Query($this->connection, $table))->select();
+        $query = (new Query($table))->select();
         $table->expects($this->once())->method('callFinder')
             ->with('all', $query, []);
         $table->find();
@@ -5311,7 +5310,7 @@ class TableTest extends TestCase
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $entity = new Entity();
@@ -5360,7 +5359,7 @@ class TableTest extends TestCase
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $entity = new Entity();
@@ -5428,7 +5427,7 @@ class TableTest extends TestCase
 
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
-            ->setConstructorArgs([$this->connection, $table])
+            ->setConstructorArgs([$table])
             ->getMock();
 
         $entity = new Entity();


### PR DESCRIPTION
The ORM queries can get the connection from the table.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
