### PR TITLE
Add primary and replica connection roles

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -63,6 +63,13 @@ class Query implements ExpressionInterface, IteratorAggregate
     protected $_connection;
 
     /**
+     * Connection role.
+     *
+     * @var string|null
+     */
+    protected $connectionRole;
+
+    /**
      * Type of this query (select, insert, update, delete).
      *
      * @var string
@@ -227,6 +234,40 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function getConnection(): Connection
     {
         return $this->_connection;
+    }
+
+    /**
+     * Overrides the default connection role.
+     *
+     * @param string $role Connection role
+     * @return $this
+     */
+    public function setConnectionRole(string $role)
+    {
+        $this->connectionRole = $role;
+
+        return $this;
+    }
+
+    /**
+     * Returns the connection role for the query.
+     *
+     * Defaults to Connection::ROLE_REPLICA for select queries.
+     * You can override the default using setConnectionRole().
+     *
+     * @return string
+     */
+    public function getConnectionRole(): string
+    {
+        if ($this->connectionRole !== null) {
+            return $this->connectionRole;
+        }
+
+        if ($this->_type === 'select') {
+            return Connection::ROLE_REPLICA;
+        }
+
+        return Connection::ROLE_PRIMARY;
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1306,11 +1306,10 @@ class ConnectionTest extends TestCase
         $statement->execute();
         $statement->closeCursor();
 
-        $prop = new ReflectionProperty($conn, '_driver');
+        $prop = new ReflectionProperty($conn, 'roles');
         $prop->setAccessible(true);
-        $oldDriver = $prop->getValue($conn);
         $newDriver = $this->getMockBuilder(Driver::class)->getMock();
-        $prop->setValue($conn, $newDriver);
+        $prop->setValue($conn, ['primary' => $newDriver,'replica' => $newDriver]);
 
         $newDriver->expects($this->exactly(2))
             ->method('prepare')


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/issues/16095

This changes the config layout for `Connection` to move all driver configurations into separate arrays for primary and replica roles.

```php
[
  'className' => Connection::class,
  'drivers' => [
    'primary' => [
      'className' => Sqlite::class,
    ],
    'replica' => [],
],
```

The `driver` key is moved into the roles as `className`.

Select queries default to replica while all others use primary. All non-query operations in `Connection` use the primary role including transactions.