### PR TITLE
Assert that finder options argument is an associative array

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2581,6 +2581,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function callFinder(string $type, Query $query, array $options = []): Query
     {
+        assert(empty($options) || !array_is_list($options), 'Finder options should be an associative array not a list');
+
         $query->applyOptions($options);
         $options = $query->getOptions();
         $finder = 'find' . $type;


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/issues/12690

This is a non-intrusive solution using array_is_list() from php 8.1.
