### PR TITLE
Add deprecation for Table::_initializeSchema()

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -515,7 +515,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $method = new ReflectionMethod($this, '_initializeSchema');
             if ($method->getDeclaringClass()->getName() != Table::class) {
                 deprecationWarning(
-                    'Table::_initializeSchema() is deprecated. Implement `getSchema()` with a parent call instead.'
+                    'Table::_initializeSchema() is deprecated. Override `getSchema()` with a parent call instead.'
                 );
                 $this->_schema = $this->_initializeSchema($this->_schema);
             }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -45,6 +45,7 @@ use Cake\Validation\ValidatorAwareInterface;
 use Cake\Validation\ValidatorAwareTrait;
 use Exception;
 use InvalidArgumentException;
+use ReflectionMethod;
 use RuntimeException;
 
 /**
@@ -507,11 +508,17 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getSchema(): TableSchemaInterface
     {
         if ($this->_schema === null) {
-            $this->_schema = $this->_initializeSchema(
-                $this->getConnection()
-                    ->getSchemaCollection()
-                    ->describe($this->getTable())
-            );
+            $this->_schema = $this->getConnection()
+                ->getSchemaCollection()
+                ->describe($this->getTable());
+
+            $method = new ReflectionMethod($this, '_initializeSchema');
+            if ($method->getDeclaringClass()->getName() != Table::class) {
+                deprecationWarning(
+                    'Table::_initializeSchema() is deprecated. Implement `getSchema()` with a parent call instead.'
+                );
+                $this->_schema = $this->_initializeSchema($this->_schema);
+            }
             if (Configure::read('debug')) {
                 $this->checkAliasLengths();
             }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -465,10 +465,12 @@ class TableTest extends TestCase
 
                 return $schema;
             }));
-        $result = $table->getSchema();
-        $schema->setColumnType('username', 'integer');
-        $this->assertEquals($schema, $result);
-        $this->assertEquals($schema, $table->getSchema(), '_initializeSchema should be called once');
+        $this->deprecated(function () use ($schema, $table) {
+            $result = $table->getSchema();
+            $schema->setColumnType('username', 'integer');
+            $this->assertEquals($schema, $result);
+            $this->assertEquals($schema, $table->getSchema(), '_initializeSchema should be called once');
+        });
     }
 
     /**


### PR DESCRIPTION
This method will be removed in 5.x, as we also have `getSchema()` which can be overridden in application code.

Refs #16739
