### PR TITLE
Fix auto increment detection for tables with non-id primary keys

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -483,19 +483,21 @@ class MysqlSchemaDialect extends SchemaDialect
         if (isset($data['null']) && $data['null'] === false) {
             $out .= ' NOT NULL';
         }
-        $addAutoIncrement = (
-            $schema->getPrimaryKey() === [$name] &&
-            !$schema->hasAutoincrement() &&
-            !isset($data['autoIncrement'])
-        );
+
+        $autoIncrementTypes = [
+            TableSchemaInterface::TYPE_TINYINTEGER,
+            TableSchemaInterface::TYPE_SMALLINTEGER,
+            TableSchemaInterface::TYPE_INTEGER,
+            TableSchemaInterface::TYPE_BIGINTEGER,
+        ];
         if (
-            in_array($data['type'], [TableSchemaInterface::TYPE_INTEGER, TableSchemaInterface::TYPE_BIGINTEGER]) &&
+            in_array($data['type'], $autoIncrementTypes, true) &&
             (
-                $data['autoIncrement'] === true ||
-                $addAutoIncrement
+                ($schema->getPrimaryKey() === [$name] && $name === 'id') || $data['autoIncrement']
             )
         ) {
             $out .= ' AUTO_INCREMENT';
+            unset($data['default']);
         }
 
         $timestampTypes = [

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -463,8 +463,15 @@ class SqliteSchemaDialect extends SchemaDialect
             $out .= ' NOT NULL';
         }
 
-        if ($data['type'] === TableSchemaInterface::TYPE_INTEGER && $schema->getPrimaryKey() === [$name]) {
-            $out .= ' PRIMARY KEY AUTOINCREMENT';
+        if ($data['type'] === TableSchemaInterface::TYPE_INTEGER) {
+            if ($schema->getPrimaryKey() === [$name]) {
+                $out .= ' PRIMARY KEY';
+
+                if (($name === 'id' || $data['autoIncrement']) && $data['autoIncrement'] !== false) {
+                    $out .= ' AUTOINCREMENT';
+                    unset($data['default']);
+                }
+            }
         }
 
         $timestampTypes = [

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -436,15 +436,20 @@ class SqlserverSchemaDialect extends SchemaDialect
             $out .= $typeMap[$data['type']];
         }
 
-        $isInt = [
+        $autoIncrementTypes = [
+            TableSchemaInterface::TYPE_TINYINTEGER,
+            TableSchemaInterface::TYPE_SMALLINTEGER,
             TableSchemaInterface::TYPE_INTEGER,
             TableSchemaInterface::TYPE_BIGINTEGER,
         ];
-        if (in_array($data['type'], $isInt, true)) {
-            if ($schema->getPrimaryKey() === [$name] || $data['autoIncrement'] === true) {
-                unset($data['null'], $data['default']);
-                $out .= ' IDENTITY(1, 1)';
-            }
+        if (
+            in_array($data['type'], $autoIncrementTypes, true) &&
+            (
+                ($schema->getPrimaryKey() === [$name] && $name === 'id') || $data['autoIncrement']
+            )
+        ) {
+            $out .= ' IDENTITY(1, 1)';
+            unset($data['default']);
         }
 
         if ($data['type'] === TableSchemaInterface::TYPE_TEXT && $data['length'] !== TableSchema::LENGTH_TINY) {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -147,9 +147,11 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         ],
         'tinyinteger' => [
             'unsigned' => null,
+            'autoIncrement' => null,
         ],
         'smallinteger' => [
             'unsigned' => null,
+            'autoIncrement' => null,
         ],
         'integer' => [
             'unsigned' => null,

--- a/tests/Fixture/FeaturedTagsFixture.php
+++ b/tests/Fixture/FeaturedTagsFixture.php
@@ -27,8 +27,8 @@ class FeaturedTagsFixture extends TestFixture
      * @var array
      */
     public array $records = [
-        ['priority' => 1],
-        ['priority' => 2],
-        ['priority' => 3],
+        ['tag_id' => 1, 'priority' => 1],
+        ['tag_id' => 2, 'priority' => 2],
+        ['tag_id' => 3, 'priority' => 3],
     ];
 }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -520,17 +520,8 @@ SQL;
         $table = $schema->describe('odd_primary_key');
         $connection->execute('DROP TABLE odd_primary_key');
 
-        $column = $table->getColumn('id');
-        $this->assertNull($column['autoIncrement'], 'should not autoincrement');
-        $this->assertTrue($column['unsigned'], 'should be unsigned');
-
         $column = $table->getColumn('other_field');
-        $this->assertTrue($column['autoIncrement'], 'should not autoincrement');
-        $this->assertFalse($column['unsigned'], 'should not be unsigned');
-
-        $output = $table->createSql($connection);
-        $this->assertStringContainsString('`id` BIGINT UNSIGNED NOT NULL,', $output[0]);
-        $this->assertStringContainsString('`other_field` INTEGER NOT NULL AUTO_INCREMENT,', $output[0]);
+        $this->assertTrue($column['autoIncrement']);
     }
 
     /**
@@ -1080,7 +1071,7 @@ SQL;
                 'columns' => ['id'],
             ]);
         $result = $schema->columnSql($table, 'id');
-        $this->assertSame($result, '`id` INTEGER NOT NULL AUTO_INCREMENT');
+        $this->assertSame('`id` INTEGER NOT NULL AUTO_INCREMENT', $result);
 
         $table = new TableSchema('articles');
         $table->addColumn('id', [
@@ -1092,7 +1083,7 @@ SQL;
                 'columns' => ['id'],
             ]);
         $result = $schema->columnSql($table, 'id');
-        $this->assertSame($result, '`id` BIGINT NOT NULL AUTO_INCREMENT');
+        $this->assertSame('`id` BIGINT NOT NULL AUTO_INCREMENT', $result);
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -384,6 +384,7 @@ SQL;
                 'precision' => null,
                 'unsigned' => null,
                 'comment' => null,
+                'autoIncrement' => null,
             ],
             'readingtime' => [
                 'type' => 'time',
@@ -804,7 +805,7 @@ SQL;
             [
                 'post_id',
                 ['type' => 'integer', 'length' => 11],
-                '"post_id" INTEGER',
+                '"post_id" INT',
             ],
             [
                 'post_id',
@@ -985,7 +986,7 @@ SQL;
             ]);
 
         $result = $schema->columnSql($table, 'id');
-        $this->assertSame($result, '"id" SERIAL');
+        $this->assertSame('"id" SERIAL NOT NULL', $result);
     }
 
     /**
@@ -1201,7 +1202,7 @@ SQL;
 
         $expected = <<<SQL
 CREATE TABLE "schema_articles" (
-"id" SERIAL,
+"id" SERIAL NOT NULL,
 "title" VARCHAR NOT NULL,
 "body" TEXT,
 "data" JSONB,
@@ -1275,8 +1276,8 @@ SQL;
 
         $expected = <<<SQL
 CREATE TABLE "articles_tags" (
-"article_id" INTEGER NOT NULL,
-"tag_id" INTEGER NOT NULL,
+"article_id" INT NOT NULL,
+"tag_id" INT NOT NULL,
 PRIMARY KEY ("article_id", "tag_id")
 )
 SQL;
@@ -1301,8 +1302,8 @@ SQL;
 
         $expected = <<<SQL
 CREATE TABLE "composite_key" (
-"id" SERIAL,
-"account_id" INTEGER NOT NULL,
+"id" SERIAL NOT NULL,
+"account_id" INT NOT NULL,
 PRIMARY KEY ("id", "account_id")
 )
 SQL;

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -736,7 +736,7 @@ SQL;
                 'columns' => ['id'],
             ]);
         $result = $schema->columnSql($table, 'id');
-        $this->assertSame($result, '"id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT');
+        $this->assertSame('"id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT', $result);
 
         $result = $schema->constraintSql($table, 'primary');
         $this->assertSame('', $result, 'Integer primary keys are special in sqlite.');

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -420,6 +420,7 @@ SQL;
                 'precision' => null,
                 'unsigned' => null,
                 'comment' => null,
+                'autoIncrement' => null,
             ],
             'created' => [
                 'type' => 'datetime',
@@ -1053,7 +1054,7 @@ SQL;
 
         $expected = <<<SQL
 CREATE TABLE [schema_articles] (
-[id] INTEGER IDENTITY(1, 1),
+[id] INTEGER IDENTITY(1, 1) NOT NULL,
 [title] NVARCHAR(255) NOT NULL,
 [body] NVARCHAR(MAX),
 [data] NVARCHAR(MAX),

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -256,6 +256,7 @@ class EnumTypeTest extends TestCase
     {
         /** @var \Cake\Datasource\EntityInterface $entity */
         $entity = $this->FeaturedTags->newEntity([
+            'tag_id' => 4,
             'priority' => Priority::MEDIUM,
         ]);
         $saved = $this->FeaturedTags->save($entity);
@@ -272,6 +273,7 @@ class EnumTypeTest extends TestCase
     {
         /** @var \Cake\Datasource\EntityInterface $entity */
         $entity = $this->FeaturedTags->newEntity([
+            'tag_id' => 4,
             'priority' => 2,
         ]);
         $saved = $this->FeaturedTags->save($entity);
@@ -288,6 +290,7 @@ class EnumTypeTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->FeaturedTags->newEntity([
+            'tag_id' => 4,
             'priority' => -1,
         ]);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -514,7 +514,7 @@ class TableTest extends TestCase
 
     public function testSchemaTypeOverrideInInitialize(): void
     {
-        $table = new class (['table' => 'users', 'connection' => $this->connection]) extends Table {
+        $table = new class (['alias' => 'Users', 'table' => 'users', 'connection' => $this->connection]) extends Table {
             public function initialize(array $config): void
             {
                 $this->getSchema()->setColumnType('username', 'foobar');


### PR DESCRIPTION
This aligns and cleans up the auto-increment column detection with an exception for SQLite's primary key requirement.

We should add auto-increment only for primary keys that are named `id` unless auto-increment is disabled.

Since MySQL behavior changes with NOT NULL, I thought it cleaner to just leave NOT NULL in for all schemas to keep the code the same.
