### PR TITLE
5.x - remove dead code from StringTemplate class

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -178,10 +178,6 @@ class StringTemplate
         }
         foreach ($templates as $name) {
             $template = $this->get($name);
-            if ($template === null) {
-                $this->_compiled[$name] = [null, null];
-            }
-
             $template = str_replace('%', '%%', $template);
             preg_match_all('#\{\{([\w\._]+)\}\}#', $template, $matches);
             $this->_compiled[$name] = [


### PR DESCRIPTION
`$this->_compiled[$name]` will always be overwritten a few lines after, so we can remove that check and initialization part.