### PR TITLE
4.next - throw exception if string template value is null

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -179,7 +179,7 @@ class StringTemplate
         foreach ($templates as $name) {
             $template = $this->get($name);
             if ($template === null) {
-                throw new InvalidArgumentException("String template '$name' is not valid.");
+                throw new InvalidArgumentException(sprintf('String template `%s` is not valid.', $name));
             }
 
             $template = str_replace('%', '%%', $template);

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Utility\Hash;
+use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -178,7 +179,7 @@ class StringTemplate
         foreach ($templates as $name) {
             $template = $this->get($name);
             if ($template === null) {
-                $this->_compiled[$name] = [null, null];
+                throw new InvalidArgumentException("String template '$name' is not valid.");
             }
 
             $template = str_replace('%', '%%', $template);

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\View;
 use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
+use InvalidArgumentException;
 use RuntimeException;
 use stdClass;
 
@@ -66,6 +67,19 @@ class StringTemplateTest extends TestCase
         );
 
         $this->assertSame($templates['link'], $this->template->get('link'));
+    }
+
+    /**
+     * test adding a template config with a null value
+     */
+    public function testAddWithInvalidTemplate(): void
+    {
+        $templates = [
+            'link' => '<a href="{{url}}">{{text}}</a>',
+            'invalid' => null
+        ];
+        $this->expectException(InvalidArgumentException::class);
+        $this->template->add($templates);
     }
 
     /**

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -76,7 +76,7 @@ class StringTemplateTest extends TestCase
     {
         $templates = [
             'link' => '<a href="{{url}}">{{text}}</a>',
-            'invalid' => null
+            'invalid' => null,
         ];
         $this->expectException(InvalidArgumentException::class);
         $this->template->add($templates);


### PR DESCRIPTION
Since this is a behavior change for template configs I don't think this should directly go into `4.x`

Refs.: https://github.com/cakephp/cakephp/pull/16752