### PR TITLE
unify exception string building

### DIFF
--- a/src/Auth/ControllerAuthorize.php
+++ b/src/Auth/ControllerAuthorize.php
@@ -87,7 +87,7 @@ class ControllerAuthorize extends BaseAuthorize
     {
         if (!method_exists($this->_Controller, 'isAuthorized')) {
             throw new CakeException(sprintf(
-                '%s does not implement an isAuthorized() method.',
+                '`%s` does not implement an `isAuthorized()` method.',
                 get_class($this->_Controller)
             ));
         }

--- a/src/Auth/PasswordHasherFactory.php
+++ b/src/Auth/PasswordHasherFactory.php
@@ -46,7 +46,7 @@ class PasswordHasherFactory
 
         $className = App::className($class, 'Auth', 'PasswordHasher');
         if ($className === null) {
-            throw new RuntimeException(sprintf('Password hasher class "%s" was not found.', $class));
+            throw new RuntimeException(sprintf('Password hasher class `%s` was not found.', $class));
         }
 
         $hasher = new $className($config);

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -146,7 +146,7 @@ class Cache
 
         if (empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
-                sprintf('The "%s" cache configuration does not exist.', $name)
+                sprintf('The `%s` cache configuration does not exist.', $name)
             );
         }
 
@@ -169,7 +169,7 @@ class Cache
 
             if ($config['fallback'] === $name) {
                 throw new InvalidArgumentException(sprintf(
-                    '"%s" cache configuration cannot fallback to itself.',
+                    '`%s` cache configuration cannot fallback to itself.',
                     $name
                 ), 0, $e);
             }
@@ -520,7 +520,7 @@ class Cache
             return [$group => self::$_groups[$group]];
         }
 
-        throw new InvalidArgumentException(sprintf('Invalid cache group %s', $group));
+        throw new InvalidArgumentException(sprintf('Invalid cache group `%s`', $group));
     }
 
     /**

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -56,7 +56,7 @@ class CacheRegistry extends ObjectRegistry
      */
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
-        throw new BadMethodCallException(sprintf('Cache engine %s is not available.', $class));
+        throw new BadMethodCallException(sprintf('Cache engine `%s` is not available.', $class));
     }
 
     /**
@@ -81,14 +81,14 @@ class CacheRegistry extends ObjectRegistry
 
         if (!($instance instanceof CacheEngine)) {
             throw new RuntimeException(
-                'Cache engines must use Cake\Cache\CacheEngine as a base class.'
+                'Cache engines must use `Cake\Cache\CacheEngine` as a base class.'
             );
         }
 
         if (!$instance->init($config)) {
             throw new RuntimeException(
                 sprintf(
-                    'Cache engine %s is not properly configured. Check error log for additional information.',
+                    'Cache engine `%s` is not properly configured. Check error log for additional information.',
                     get_class($instance)
                 )
             );

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -209,7 +209,7 @@ class MemcachedEngine extends CacheEngine
         $serializer = strtolower($this->_config['serialize']);
         if (!isset($this->_serializers[$serializer])) {
             throw new InvalidArgumentException(
-                sprintf('%s is not a valid serializer engine for Memcached', $serializer)
+                sprintf('`%s` is not a valid serializer engine for Memcached', $serializer)
             );
         }
 
@@ -218,7 +218,7 @@ class MemcachedEngine extends CacheEngine
             !constant('Memcached::HAVE_' . strtoupper($serializer))
         ) {
             throw new InvalidArgumentException(
-                sprintf('Memcached extension is not compiled with %s support', $serializer)
+                sprintf('Memcached extension is not compiled with `%s` support', $serializer)
             );
         }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -751,7 +751,7 @@ trait CollectionTrait
 
             if (!isset($modes[$order])) {
                 throw new RuntimeException(sprintf(
-                    "Invalid direction `%s` provided. Must be one of: 'desc', 'asc', 'leaves'",
+                    'Invalid direction `%s` provided. Must be one of: `desc`, `asc`, `leaves`',
                     $order
                 ));
             }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -46,9 +46,10 @@ abstract class BaseCommand implements CommandInterface
     public function setName(string $name)
     {
         if (strpos($name, ' ') < 1) {
-            throw new InvalidArgumentException(
-                "The name '{$name}' is missing a space. Names should look like `cake routes`"
-            );
+            throw new InvalidArgumentException(sprintf(
+                'The name `%s` is missing a space. Names should look like `cake routes`',
+                $name
+            ));
         }
         $this->name = $name;
 
@@ -266,15 +267,16 @@ abstract class BaseCommand implements CommandInterface
     {
         if (is_string($command)) {
             if (!class_exists($command)) {
-                throw new InvalidArgumentException("Command class '{$command}' does not exist.");
+                throw new InvalidArgumentException(sprintf('Command class `%s` does not exist.', $command));
             }
             $command = new $command();
         }
         if (!$command instanceof CommandInterface) {
             $commandType = getTypeName($command);
-            throw new InvalidArgumentException(
-                "Command '{$commandType}' is not a subclass of Cake\Console\CommandInterface."
-            );
+            throw new InvalidArgumentException(sprintf(
+                'Command `%s` is not a subclass of `Cake\Console\CommandInterface`.',
+                $commandType
+            ));
         }
         $io = $io ?: new ConsoleIo();
 

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -66,16 +66,17 @@ class CommandCollection implements IteratorAggregate, Countable
         if (!is_subclass_of($command, Shell::class) && !is_subclass_of($command, CommandInterface::class)) {
             $class = is_string($command) ? $command : get_class($command);
             throw new InvalidArgumentException(sprintf(
-                "Cannot use '%s' for command '%s'. " .
-                "It is not a subclass of Cake\Console\Shell or Cake\Command\Command.",
+                'Cannot use `%s` for command `%s`. ' .
+                'It is not a subclass of `Cake\Console\Shell` or `Cake\Command\Command`.',
                 $class,
                 $name
             ));
         }
         if (!preg_match('/^[^\s]+(?:(?: [^\s]+){1,2})?$/ui', $name)) {
-            throw new InvalidArgumentException(
-                "The command name `{$name}` is invalid. Names can only be a maximum of three words."
-            );
+            throw new InvalidArgumentException(sprintf(
+                'The command name `%s` is invalid. Names can only be a maximum of three words.',
+                $name
+            ));
         }
 
         $this->commands[$name] = $command;
@@ -134,7 +135,7 @@ class CommandCollection implements IteratorAggregate, Countable
     public function get(string $name)
     {
         if (!$this->has($name)) {
-            throw new InvalidArgumentException("The $name is not a known command name.");
+            throw new InvalidArgumentException(sprintf('The `%s` is not a known command name.', $name));
         }
 
         return $this->commands[$name];

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -309,9 +309,14 @@ class CommandRunner implements EventDispatcherInterface
             $name = Inflector::underscore($name);
         }
         if (!$commands->has($name)) {
+            $msg = sprintf(
+                'Unknown command `%s %s`. Run `%s --help` to get the list of commands.',
+                $this->root,
+                $name,
+                $this->root
+            );
             throw new MissingOptionException(
-                "Unknown command `{$this->root} {$name}`. " .
-                "Run `{$this->root} --help` to get the list of commands.",
+                $msg,
                 $name,
                 $commands->keys()
             );

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -167,7 +167,7 @@ class ConsoleInputArgument
         if (!in_array($value, $this->_choices, true)) {
             throw new ConsoleException(
                 sprintf(
-                    '"%s" is not a valid value for %s. Please use one of "%s"',
+                    '`%s` is not a valid value for `%s`. Please use one of `%s`',
                     $value,
                     $this->_name,
                     implode(', ', $this->_choices)

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -132,7 +132,7 @@ class ConsoleInputOption
 
         if (strlen($this->_short) > 1) {
             throw new ConsoleException(
-                sprintf('Short option "%s" is invalid, short options must be one letter.', $this->_short)
+                sprintf('Short option `%s` is invalid, short options must be one letter.', $this->_short)
             );
         }
         if (isset($this->_default) && $this->prompt) {
@@ -271,7 +271,7 @@ class ConsoleInputOption
         if (!in_array($value, $this->_choices, true)) {
             throw new ConsoleException(
                 sprintf(
-                    '"%s" is not a valid value for --%s. Please use one of "%s"',
+                    '`%s` is not a valid value for `--%s`. Please use one of `%s`',
                     (string)$value,
                     $this->_name,
                     implode(', ', $this->_choices)

--- a/src/Console/ConsoleInputSubcommand.php
+++ b/src/Console/ConsoleInputSubcommand.php
@@ -63,7 +63,7 @@ class ConsoleInputSubcommand
         if (is_array($name)) {
             $data = $name + ['name' => null, 'help' => '', 'parser' => null];
             if (empty($data['name'])) {
-                throw new InvalidArgumentException('"name" not provided for console option parser');
+                throw new InvalidArgumentException('`name` not provided for console option parser');
             }
 
             $name = $data['name'];

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -878,7 +878,7 @@ class ConsoleOptionParser
                 $options[] = "{$short} (short for `--{$long}`)";
             }
             throw new MissingOptionException(
-                "Unknown short option `{$key}`.",
+                sprintf('Unknown short option `%s`.', $key),
                 $key,
                 $options
             );
@@ -900,7 +900,7 @@ class ConsoleOptionParser
     {
         if (!isset($this->_options[$name])) {
             throw new MissingOptionException(
-                "Unknown option `{$name}`.",
+                sprintf('Unknown option `%s`.', $name),
                 $name,
                 array_keys($this->_options)
             );
@@ -965,9 +965,11 @@ class ConsoleOptionParser
         $next = count($args);
         if (!isset($this->_args[$next])) {
             $expected = count($this->_args);
-            throw new ConsoleException(
-                "Received too many arguments. Got {$next} but only {$expected} arguments are defined."
-            );
+            throw new ConsoleException(sprintf(
+                'Received too many arguments. Got `%s` but only `%s` arguments are defined.',
+                $next,
+                $expected
+            ));
         }
 
         $this->_args[$next]->validChoice($argument);

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -339,7 +339,7 @@ class ConsoleOutput
     public function setOutputAs(int $type): void
     {
         if (!in_array($type, [self::RAW, self::PLAIN, self::COLOR], true)) {
-            throw new InvalidArgumentException(sprintf('Invalid output type "%s".', $type));
+            throw new InvalidArgumentException(sprintf('Invalid output type `%s`.', $type));
         }
 
         $this->_outputAs = $type;

--- a/src/Console/Exception/MissingHelperException.php
+++ b/src/Console/Exception/MissingHelperException.php
@@ -22,5 +22,5 @@ class MissingHelperException extends ConsoleException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Helper class %s could not be found.';
+    protected $_messageTemplate = 'Helper class `%s` could not be found.';
 }

--- a/src/Console/Exception/MissingShellException.php
+++ b/src/Console/Exception/MissingShellException.php
@@ -22,7 +22,7 @@ class MissingShellException extends ConsoleException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Shell class for "%s" could not be found.'
+    protected $_messageTemplate = 'Shell class for `%s` could not be found.'
         . ' If you are trying to use a plugin shell, that was loaded via $this->addPlugin(),'
         . ' you may need to update bin/cake.php to match https://github.com/cakephp/app/tree/master/bin/cake.php';
 }

--- a/src/Console/Exception/MissingTaskException.php
+++ b/src/Console/Exception/MissingTaskException.php
@@ -22,5 +22,5 @@ class MissingTaskException extends ConsoleException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Task class %s could not be found.';
+    protected $_messageTemplate = 'Task class `%s` could not be found.';
 }

--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -67,8 +67,13 @@ class StubConsoleInput extends ConsoleInput
             $nth = $formatter->format($this->currentIndex + 1);
 
             $replies = implode(', ', $this->replies);
-            $message = "There are no more input replies available. This is the {$nth} read operation, " .
-                "only {$total} replies were set.\nThe provided replies are: {$replies}";
+            $message = sprintf(
+                'There are no more input replies available. This is the `%s` read operation, ' .
+                "only `%s` replies were set.\nThe provided replies are: `%s`",
+                $nth,
+                $total,
+                $replies
+            );
             throw new MissingConsoleInputException($message);
         }
 

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -536,7 +536,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
             }
             $className = App::className($class, 'Auth', 'Authorize');
             if ($className === null) {
-                throw new CakeException(sprintf('Authorization adapter "%s" was not found.', $class));
+                throw new CakeException(sprintf('Authorization adapter `%s` was not found.', $class));
             }
             if (!method_exists($className, 'authorize')) {
                 throw new CakeException('Authorization objects must implement an authorize() method.');
@@ -831,7 +831,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
             }
             $className = App::className($class, 'Auth', 'Authenticate');
             if ($className === null) {
-                throw new CakeException(sprintf('Authentication adapter "%s" was not found.', $class));
+                throw new CakeException(sprintf('Authentication adapter `%s` was not found.', $class));
             }
             if (!method_exists($className, 'authenticate')) {
                 throw new CakeException('Authentication objects must implement an authenticate() method.');
@@ -873,7 +873,7 @@ class AuthComponent extends Component implements EventDispatcherInterface
         }
         $className = App::className($class, 'Auth/Storage', 'Storage');
         if ($className === null) {
-            throw new CakeException(sprintf('Auth storage adapter "%s" was not found.', $class));
+            throw new CakeException(sprintf('Auth storage adapter `%s` was not found.', $class));
         }
         $request = $this->getController()->getRequest();
         $response = $this->getController()->getResponse();

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -210,7 +210,10 @@ class RequestHandlerComponent extends Component
 
         if ($this->ext && !in_array($this->ext, ['html', 'htm'], true)) {
             if (!$response->getMimeType($this->ext)) {
-                throw new NotFoundException('Invoked extension not recognized/configured: ' . $this->ext);
+                throw new NotFoundException(sprintf(
+                    'Invoked extension not recognized/configured: `%s`',
+                    $this->ext
+                ));
             }
 
             $this->renderAs($controller, $this->ext);

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -99,7 +99,7 @@ class SecurityComponent extends Component
 
             if ($this->_action === $this->_config['blackHoleCallback']) {
                 throw new AuthSecurityException(sprintf(
-                    'Action %s is defined as the blackhole callback.',
+                    'Action `%s` is defined as the blackhole callback.',
                     $this->_action
                 ));
             }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -548,7 +548,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($result !== null && !$result instanceof ResponseInterface) {
             throw new UnexpectedValueException(sprintf(
                 'Controller actions can only return ResponseInterface instance or null. '
-                . 'Got %s instead.',
+                . 'Got `%s` instead.',
                 getTypeName($result)
             ));
         }
@@ -944,12 +944,15 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if (is_string($paginator)) {
             $className = App::className($paginator, 'Datasource/Paging', 'Paginator');
             if ($className === null) {
-                throw new InvalidArgumentException('Invalid paginator: ' . $paginator);
+                throw new InvalidArgumentException(sprintf('Invalid paginator: `%s`', $paginator));
             }
             $paginator = new $className();
         }
         if (!$paginator instanceof PaginatorInterface) {
-            throw new InvalidArgumentException('Paginator must be an instance of ' . PaginatorInterface::class);
+            throw new InvalidArgumentException(sprintf(
+                'Paginator must be an instance of `%s`',
+                PaginatorInterface::class
+            ));
         }
 
         $results = null;

--- a/src/Controller/Exception/InvalidParameterException.php
+++ b/src/Controller/Exception/InvalidParameterException.php
@@ -26,11 +26,11 @@ class InvalidParameterException extends CakeException
      * @var array<string, string>
      */
     protected $templates = [
-        'failed_coercion' => 'Unable to coerce "%s" to `%s` for `%s` in action %s::%s().',
+        'failed_coercion' => 'Unable to coerce `%s` to `%s` for `%s` in action `%s::%s()`.',
         'missing_dependency' => 'Failed to inject dependency from service container for parameter `%s` ' .
-            'with type `%s` in action %s::%s().',
-        'missing_parameter' => 'Missing passed parameter for `%s` in action %s::%s().',
-        'unsupported_type' => 'Type declaration for `%s` in action %s::%s() is unsupported.',
+            'with type `%s` in action `%s::%s()`.',
+        'missing_parameter' => 'Missing passed parameter for `%s` in action `%s::%s()`.',
+        'unsupported_type' => 'Type declaration for `%s` in action `%s::%s()` is unsupported.',
     ];
 
     /**

--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -25,5 +25,5 @@ class MissingActionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Action %s::%s() could not be found, or is not accessible.';
+    protected $_messageTemplate = 'Action `%s::%s()` could not be found, or is not accessible.';
 }

--- a/src/Controller/Exception/MissingComponentException.php
+++ b/src/Controller/Exception/MissingComponentException.php
@@ -24,5 +24,5 @@ class MissingComponentException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Component class %s could not be found.';
+    protected $_messageTemplate = 'Component class `%s` could not be found.';
 }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -246,9 +246,12 @@ class BasePlugin implements PluginInterface
     protected function checkHook(string $hook): void
     {
         if (!in_array($hook, static::VALID_HOOKS, true)) {
-            throw new InvalidArgumentException(
-                "`$hook` is not a valid hook name. Must be one of " . implode(', ', static::VALID_HOOKS)
-            );
+            $hooks = implode(', ', static::VALID_HOOKS);
+            throw new InvalidArgumentException(sprintf(
+                '`%s` is not a valid hook name. Must be one of `%s`',
+                $hook,
+                $hooks
+            ));
         }
     }
 

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -163,7 +163,7 @@ class Configure
     public static function readOrFail(string $var)
     {
         if (!static::check($var)) {
-            throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
+            throw new RuntimeException(sprintf('Expected configuration key `%s` not found.', $var));
         }
 
         return static::read($var);
@@ -203,7 +203,7 @@ class Configure
     public static function consumeOrFail(string $var)
     {
         if (!static::check($var)) {
-            throw new RuntimeException(sprintf('Expected configuration key "%s" not found.', $var));
+            throw new RuntimeException(sprintf('Expected configuration key `%s` not found.', $var));
         }
 
         return static::consume($var);
@@ -331,7 +331,7 @@ class Configure
         if (!$engine) {
             throw new CakeException(
                 sprintf(
-                    'Config %s engine not found when attempting to load %s.',
+                    'Config `%s` engine not found when attempting to load `%s`.',
                     $config,
                     $key
                 )
@@ -382,7 +382,7 @@ class Configure
     {
         $engine = static::_getEngine($config);
         if (!$engine) {
-            throw new CakeException(sprintf('There is no "%s" config engine.', $config));
+            throw new CakeException(sprintf('There is no `%s` config engine.', $config));
         }
         $values = static::$_values;
         if (!empty($keys)) {
@@ -456,7 +456,7 @@ class Configure
             $data = static::$_values;
         }
         if (!class_exists(Cache::class)) {
-            throw new RuntimeException('You must install cakephp/cache to use Configure::store()');
+            throw new RuntimeException('You must install `cakephp/cache` to use `Configure::store()`');
         }
 
         return Cache::write($name, $data, $cacheConfig);
@@ -474,7 +474,7 @@ class Configure
     public static function restore(string $name, string $cacheConfig = 'default'): bool
     {
         if (!class_exists(Cache::class)) {
-            throw new RuntimeException('You must install cakephp/cache to use Configure::restore()');
+            throw new RuntimeException('You must install `cakephp/cache` to use `Configure::restore()`');
         }
         $values = Cache::read($name, $cacheConfig);
         if ($values) {

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -82,7 +82,7 @@ class JsonConfig implements ConfigEngineInterface
         $values = json_decode(file_get_contents($file), true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new CakeException(sprintf(
-                'Error parsing JSON string fetched from config file "%s.json": %s',
+                'Error parsing JSON string fetched from config file "%s.json": `%s`',
                 $key,
                 json_last_error_msg()
             ));

--- a/src/Core/Configure/Engine/PhpConfig.php
+++ b/src/Core/Configure/Engine/PhpConfig.php
@@ -91,7 +91,7 @@ class PhpConfig implements ConfigEngineInterface
             return $return;
         }
 
-        throw new CakeException(sprintf('Config file "%s" did not return an array', $key . '.php'));
+        throw new CakeException(sprintf('Config file `%s.php` did not return an array', $key));
     }
 
     /**

--- a/src/Core/Configure/FileConfigTrait.php
+++ b/src/Core/Configure/FileConfigTrait.php
@@ -66,6 +66,6 @@ trait FileConfigTrait
             return $realPath;
         }
 
-        throw new CakeException(sprintf('Could not load configuration file: %s', $file));
+        throw new CakeException(sprintf('Could not load configuration file: `%s`', $file));
     }
 }

--- a/src/Core/Exception/MissingPluginException.php
+++ b/src/Core/Exception/MissingPluginException.php
@@ -22,5 +22,5 @@ class MissingPluginException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Plugin %s could not be found.';
+    protected $_messageTemplate = 'Plugin `%s` could not be found.';
 }

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -262,7 +262,7 @@ trait InstanceConfigTrait
 
         foreach ($stack as $k) {
             if (!is_array($update)) {
-                throw new CakeException(sprintf('Cannot set %s value', $key));
+                throw new CakeException(sprintf('Cannot set `%s` value', $key));
             }
 
             $update[$k] = $update[$k] ?? [];
@@ -294,7 +294,7 @@ trait InstanceConfigTrait
 
         foreach ($stack as $i => $k) {
             if (!is_array($update)) {
-                throw new CakeException(sprintf('Cannot unset %s value', $key));
+                throw new CakeException(sprintf('Cannot unset `%s` value', $key));
             }
 
             if (!isset($update[$k])) {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -132,7 +132,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     protected function _checkDuplicate(string $name, array $config): void
     {
         $existing = $this->_loaded[$name];
-        $msg = sprintf('The "%s" alias has already been loaded.', $name);
+        $msg = sprintf('The `%s` alias has already been loaded.', $name);
         $hasConfig = method_exists($existing, 'getConfig');
         if (!$hasConfig) {
             throw new RuntimeException($msg);
@@ -146,7 +146,10 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         $failure = null;
         foreach ($config as $key => $value) {
             if (!array_key_exists($key, $existingConfig)) {
-                $failure = " The `{$key}` was not defined in the previous configuration data.";
+                $failure = sprintf(
+                    ' The `%s` was not defined in the previous configuration data.',
+                    $key
+                );
                 break;
             }
             if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
@@ -230,7 +233,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     public function get(string $name)
     {
         if (!isset($this->_loaded[$name])) {
-            throw new RuntimeException(sprintf('Unknown object "%s"', $name));
+            throw new RuntimeException(sprintf('Unknown object `%s`', $name));
         }
 
         return $this->_loaded[$name];

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -345,7 +345,7 @@ class PluginCollection implements Iterator, Countable
     public function with(string $hook): Generator
     {
         if (!in_array($hook, PluginInterface::VALID_HOOKS, true)) {
-            throw new InvalidArgumentException("The `{$hook}` hook is not a known plugin hook.");
+            throw new InvalidArgumentException(sprintf('The `%s` hook is not a known plugin hook.', $hook));
         }
         foreach ($this as $plugin) {
             if ($plugin->isEnabled($hook)) {

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -88,7 +88,7 @@ trait StaticConfigTrait
 
         if (isset(static::$_config[$key])) {
             /** @psalm-suppress PossiblyInvalidArgument */
-            throw new BadMethodCallException(sprintf('Cannot reconfigure existing key "%s"', $key));
+            throw new BadMethodCallException(sprintf('Cannot reconfigure existing key `%s`', $key));
         }
 
         if (is_object($config)) {
@@ -251,7 +251,7 @@ REGEXP;
         preg_match($pattern, $dsn, $parsed);
 
         if (!$parsed) {
-            throw new InvalidArgumentException("The DSN string '{$dsn}' could not be parsed.");
+            throw new InvalidArgumentException(sprintf('The DSN string `%s` could not be parsed.', $dsn));
         }
 
         $exists = [];

--- a/src/Core/TestSuite/ContainerStubTrait.php
+++ b/src/Core/TestSuite/ContainerStubTrait.php
@@ -84,7 +84,10 @@ trait ContainerStubTrait
             $appClass = Configure::read('App.namespace') . '\Application';
         }
         if (!class_exists($appClass)) {
-            throw new LogicException("Cannot load `{$appClass}` for use in integration testing.");
+            throw new LogicException(sprintf(
+                'Cannot load `%s` for use in integration testing.',
+                $appClass
+            ));
         }
         $appArgs = $this->_appArgs ?: [CONFIG];
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -851,8 +851,8 @@ class Connection implements ConnectionInterface
 
         if (!class_exists(Cache::class)) {
             throw new RuntimeException(
-                'To use caching you must either set a cacher using Connection::setCacher()' .
-                ' or require the cakephp/cache package in your composer config.'
+                'To use caching you must either set a cacher using `Connection::setCacher()`' .
+                ' or require the `cakephp/cache` package in your composer config.'
             );
         }
 
@@ -921,8 +921,8 @@ class Connection implements ConnectionInterface
 
         if (!class_exists(QueryLogger::class)) {
             throw new RuntimeException(
-                'For logging you must either set a logger using Connection::setLogger()' .
-                ' or require the cakephp/log package in your composer config.'
+                'For logging you must either set a logger using `Connection::setLogger()`' .
+                ' or require the `cakephp/log` package in your composer config.'
             );
         }
 

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -98,7 +98,7 @@ abstract class Driver implements DriverInterface
     {
         if (empty($config['username']) && !empty($config['login'])) {
             throw new InvalidArgumentException(
-                'Please pass "username" instead of "login" for connecting to the database'
+                'Please pass `username` instead of `login` for connecting to the database'
             );
         }
         $config += $this->_baseConfig;

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -130,9 +130,10 @@ class Sqlite extends Driver
         ];
         if (!is_string($config['database']) || $config['database'] === '') {
             $name = $config['name'] ?? 'unknown';
-            throw new InvalidArgumentException(
-                "The `database` key for the `{$name}` SQLite connection needs to be a non-empty string."
-            );
+            throw new InvalidArgumentException(sprintf(
+                'The `database` key for the `%s` SQLite connection needs to be a non-empty string.',
+                $name
+            ));
         }
 
         $chmodFile = false;

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -120,7 +120,7 @@ class Sqlserver extends Driver
 
         if (isset($config['persistent']) && $config['persistent']) {
             throw new InvalidArgumentException(
-                'Config setting "persistent" cannot be set to true, '
+                'Config setting `persistent` cannot be set to true, '
                 . 'as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT'
             );
         }

--- a/src/Database/Exception/MissingConnectionException.php
+++ b/src/Database/Exception/MissingConnectionException.php
@@ -26,5 +26,5 @@ class MissingConnectionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Connection to %s could not be established: %s';
+    protected $_messageTemplate = 'Connection to `%s` could not be established: `%s`';
 }

--- a/src/Database/Exception/MissingExtensionException.php
+++ b/src/Database/Exception/MissingExtensionException.php
@@ -27,5 +27,5 @@ class MissingExtensionException extends CakeException
      * @inheritDoc
      */
     // phpcs:ignore Generic.Files.LineLength
-    protected $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency. Requested by connection "%s"';
+    protected $_messageTemplate = 'Database driver `%s` cannot be used due to a missing PHP extension or unmet dependency. Requested by connection `%s`';
 }

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -226,9 +226,10 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             if ($value === '') {
                 $field = $this->_field instanceof ExpressionInterface ? $this->_field->sql($binder) : $this->_field;
                 /** @psalm-suppress PossiblyInvalidCast */
-                throw new DatabaseException(
-                    "Impossible to generate condition with empty list of values for field ($field)"
-                );
+                throw new DatabaseException(sprintf(
+                    'Impossible to generate condition with empty list of values for field `%s`',
+                    $field
+                ));
             }
         } else {
             $template .= '%s %s';

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -841,9 +841,10 @@ class QueryExpression implements ExpressionInterface, Countable
         }
 
         if ($value === null && $this->_conjunction !== ',') {
-            throw new InvalidArgumentException(
-                sprintf('Expression `%s` is missing operator (IS, IS NOT) with `null` value.', $expression)
-            );
+            throw new InvalidArgumentException(sprintf(
+                'Expression `%s` is missing operator (IS, IS NOT) with `null` value.',
+                $expression
+            ));
         }
 
         return new ComparisonExpression($expression, $value, $type, $operator);

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -266,7 +266,7 @@ class FunctionsBuilder
             return new FunctionExpression('CURRENT_TIME', [], [], 'time');
         }
 
-        throw new InvalidArgumentException('Invalid argument for FunctionsBuilder::now(): ' . $type);
+        throw new InvalidArgumentException(sprintf('Invalid argument for FunctionsBuilder::now(): `%s`', $type));
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1751,7 +1751,7 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function update($table)
     {
         if (!is_string($table) && !($table instanceof ExpressionInterface)) {
-            $text = 'Table must be of type string or "%s", got "%s"';
+            $text = 'Table must be of type string or `%s`, got `%s`';
             $message = sprintf($text, ExpressionInterface::class, gettype($table));
             throw new InvalidArgumentException($message);
         }
@@ -2007,7 +2007,11 @@ class Query implements ExpressionInterface, IteratorAggregate
     {
         if (!array_key_exists($name, $this->_parts)) {
             $clauses = implode(', ', array_keys($this->_parts));
-            throw new InvalidArgumentException("The '$name' clause is not defined. Valid clauses are: $clauses");
+            throw new InvalidArgumentException(sprintf(
+                'The `%s` clause is not defined. Valid clauses are: `%s`',
+                $name,
+                $clauses
+            ));
         }
 
         return $this->_parts[$name];

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -117,7 +117,7 @@ class Collection implements CollectionInterface
 
         $this->_reflect('Column', $name, $config, $table);
         if (count($table->columns()) === 0) {
-            throw new DatabaseException(sprintf('Cannot describe %s. It has 0 columns.', $name));
+            throw new DatabaseException(sprintf('Cannot describe `%s`. It has 0 columns.', $name));
         }
 
         $this->_reflect('Index', $name, $config, $table);

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -108,7 +108,7 @@ class MysqlSchemaDialect extends SchemaDialect
     {
         preg_match('/([a-z]+)(?:\(([0-9,]+)\))?\s*([a-z]+)?/i', $column, $matches);
         if (empty($matches)) {
-            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
         $col = strtolower($matches[1]);

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -102,7 +102,7 @@ class PostgresSchemaDialect extends SchemaDialect
     {
         preg_match('/([a-z\s]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
-            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
         $col = strtolower($matches[1]);

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -58,7 +58,7 @@ class SqliteSchemaDialect extends SchemaDialect
 
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
-            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
         $unsigned = false;

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -469,7 +469,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
         if (!in_array($attrs['type'], static::$_validIndexTypes, true)) {
             throw new DatabaseException(sprintf(
-                'Invalid index type "%s" in index "%s" in table "%s".',
+                'Invalid index type `%s` in index `%s` in table `%s`.',
                 $attrs['type'],
                 $name,
                 $this->_table
@@ -477,7 +477,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
         if (empty($attrs['columns'])) {
             throw new DatabaseException(sprintf(
-                'Index "%s" in table "%s" must have at least one column.',
+                'Index `%s` in table `%s` must have at least one column.',
                 $name,
                 $this->_table
             ));
@@ -486,8 +486,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         foreach ($attrs['columns'] as $field) {
             if (empty($this->_columns[$field])) {
                 $msg = sprintf(
-                    'Columns used in index "%s" in table "%s" must be added to the Table schema first. ' .
-                    'The column "%s" was not found.',
+                    'Columns used in index `%s` in table `%s` must be added to the Table schema first. ' .
+                    'The column `%s` was not found.',
                     $name,
                     $this->_table,
                     $field
@@ -560,14 +560,14 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         $attrs += static::$_indexKeys;
         if (!in_array($attrs['type'], static::$_validConstraintTypes, true)) {
             throw new DatabaseException(sprintf(
-                'Invalid constraint type "%s" in table "%s".',
+                'Invalid constraint type `%s` in table `%s`.',
                 $attrs['type'],
                 $this->_table
             ));
         }
         if (empty($attrs['columns'])) {
             throw new DatabaseException(sprintf(
-                'Constraints in table "%s" must have at least one column.',
+                'Constraints in table `%s` must have at least one column.',
                 $this->_table
             ));
         }
@@ -576,7 +576,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             if (empty($this->_columns[$field])) {
                 $msg = sprintf(
                     'Columns used in constraints must be added to the Table schema first. ' .
-                    'The column "%s" was not found in table "%s".',
+                    'The column `%s` was not found in table `%s`.',
                     $field,
                     $this->_table
                 );
@@ -653,13 +653,13 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
         if (!in_array($attrs['update'], static::$_validForeignKeyActions)) {
             throw new DatabaseException(sprintf(
-                'Update action is invalid. Must be one of %s',
+                'Update action is invalid. Must be one of `%s`',
                 implode(',', static::$_validForeignKeyActions)
             ));
         }
         if (!in_array($attrs['delete'], static::$_validForeignKeyActions)) {
             throw new DatabaseException(sprintf(
-                'Delete action is invalid. Must be one of %s',
+                'Delete action is invalid. Must be one of `%s`',
                 implode(',', static::$_validForeignKeyActions)
             ));
         }

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -61,7 +61,7 @@ class BinaryType extends BaseType
         if (is_resource($value)) {
             return $value;
         }
-        throw new CakeException(sprintf('Unable to convert %s into binary.', gettype($value)));
+        throw new CakeException(sprintf('Unable to convert `%s` into binary.', gettype($value)));
     }
 
     /**

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -82,7 +82,7 @@ class BinaryUuidType extends BaseType
             return $value;
         }
 
-        throw new CakeException(sprintf('Unable to convert %s into binary uuid.', gettype($value)));
+        throw new CakeException(sprintf('Unable to convert `%s` into binary uuid.', gettype($value)));
     }
 
     /**

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -418,7 +418,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new RuntimeException(
-            sprintf('Cannot use locale parsing with the %s class', $this->_className)
+            sprintf('Cannot use locale parsing with the `%s` class', $this->_className)
         );
     }
 

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -168,7 +168,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new RuntimeException(
-            sprintf('Cannot use locale parsing with the %s class', static::$numberClass)
+            sprintf('Cannot use locale parsing with the `%s` class', static::$numberClass)
         );
     }
 

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -151,7 +151,7 @@ class FloatType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new RuntimeException(
-            sprintf('Cannot use locale parsing with the %s class', static::$numberClass)
+            sprintf('Cannot use locale parsing with the `%s` class', static::$numberClass)
         );
     }
 

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -49,7 +49,7 @@ class StringType extends BaseType implements OptionalConvertInterface
         }
 
         throw new InvalidArgumentException(sprintf(
-            'Cannot convert value of type `%s` to string',
+            'Cannot convert value of type `%s` to `string`',
             getTypeName($value)
         ));
     }

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -75,7 +75,7 @@ class TypeFactory
             return static::$_builtTypes[$name];
         }
         if (!isset(static::$_types[$name])) {
-            throw new InvalidArgumentException(sprintf('Unknown type "%s"', $name));
+            throw new InvalidArgumentException(sprintf('Unknown type `%s`', $name));
         }
 
         return static::$_builtTypes[$name] = new static::$_types[$name]($name);

--- a/src/Datasource/Exception/MissingDatasourceConfigException.php
+++ b/src/Datasource/Exception/MissingDatasourceConfigException.php
@@ -24,5 +24,5 @@ class MissingDatasourceConfigException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'The datasource configuration "%s" was not found.';
+    protected $_messageTemplate = 'The datasource configuration `%s` was not found.';
 }

--- a/src/Datasource/Exception/MissingDatasourceException.php
+++ b/src/Datasource/Exception/MissingDatasourceException.php
@@ -24,5 +24,5 @@ class MissingDatasourceException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Datasource class %s could not be found. %s';
+    protected $_messageTemplate = 'Datasource class `%s` could not be found. `%s`';
 }

--- a/src/Datasource/Exception/MissingModelException.php
+++ b/src/Datasource/Exception/MissingModelException.php
@@ -26,5 +26,5 @@ class MissingModelException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Model class "%s" of type "%s" could not be found.';
+    protected $_messageTemplate = 'Model class `%s` of type `%s` could not be found.';
 }

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -59,7 +59,7 @@ class FactoryLocator
         }
 
         throw new InvalidArgumentException(sprintf(
-            '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
+            '`$factory` must be an instance of `Cake\Datasource\Locator\LocatorInterface` or a callable.'
             . ' Got type `%s` instead.',
             getTypeName($factory)
         ));
@@ -91,7 +91,7 @@ class FactoryLocator
 
         if (!isset(static::$_modelFactories[$type])) {
             throw new InvalidArgumentException(sprintf(
-                'Unknown repository type "%s". Make sure you register a type before trying to use it.',
+                'Unknown repository type `%s`. Make sure you register a type before trying to use it.',
                 $type
             ));
         }

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -55,7 +55,7 @@ abstract class AbstractLocator implements LocatorInterface
         if (isset($this->instances[$alias])) {
             if (!empty($storeOptions) && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
                 throw new RuntimeException(sprintf(
-                    'You cannot configure "%s", it already exists in the registry.',
+                    'You cannot configure `%s`, it already exists in the registry.',
                     $alias
                 ));
             }

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -146,7 +146,7 @@ trait ModelAwareTrait
     {
         if (!$factory instanceof LocatorInterface && !is_callable($factory)) {
             throw new InvalidArgumentException(sprintf(
-                '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
+                '`$factory` must be an instance of `Cake\Datasource\Locator\LocatorInterface` or a callable.'
                 . ' Got type `%s` instead.',
                 getTypeName($factory)
             ));

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -114,7 +114,7 @@ class QueryCacher
         $func = $this->_key;
         $key = $func($query);
         if (!is_string($key)) {
-            $msg = sprintf('Cache key functions must return a string. Got %s.', var_export($key, true));
+            $msg = sprintf('Cache key functions must return a string. Got `%s`.', var_export($key, true));
             throw new RuntimeException($msg);
         }
 

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -507,7 +507,7 @@ trait QueryTrait
         if (!$entity) {
             $table = $this->getRepository();
             throw new RecordNotFoundException(sprintf(
-                'Record not found in table "%s"',
+                'Record not found in table `%s`',
                 $table->getTable()
             ));
         }
@@ -560,7 +560,7 @@ trait QueryTrait
             return $results->$method(...$arguments);
         }
         throw new BadMethodCallException(
-            sprintf('Unknown method "%s"', $method)
+            sprintf('Unknown method `%s`', $method)
         );
     }
 

--- a/src/Error/BaseErrorHandler.php
+++ b/src/Error/BaseErrorHandler.php
@@ -362,7 +362,11 @@ abstract class BaseErrorHandler
 
                 $interface = ErrorLoggerInterface::class;
                 $type = getTypeName($logger);
-                throw new RuntimeException("Cannot create logger. `{$type}` does not implement `{$interface}`.");
+                throw new RuntimeException(sprintf(
+                    'Cannot create logger. `%s` does not implement `%s`.',
+                    $type,
+                    $interface
+                ));
             }
             $this->logger = $logger;
         }

--- a/src/Error/Debug/ConsoleFormatter.php
+++ b/src/Error/Debug/ConsoleFormatter.php
@@ -144,7 +144,7 @@ class ConsoleFormatter implements FormatterInterface
         if ($var instanceof SpecialNode) {
             return $this->style('special', $var->getValue());
         }
-        throw new RuntimeException('Unknown node received ' . get_class($var));
+        throw new RuntimeException(sprintf('Unknown node received `%s`', get_class($var)));
     }
 
     /**

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -149,7 +149,7 @@ class HtmlFormatter implements FormatterInterface
         if ($var instanceof SpecialNode) {
             return $this->style('special', $var->getValue());
         }
-        throw new RuntimeException('Unknown node received ' . get_class($var));
+        throw new RuntimeException(sprintf('Unknown node received `%s`', get_class($var)));
     }
 
     /**

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -293,7 +293,7 @@ class Debugger
         $instance = static::getInstance();
         if (!is_string($template) && !($template instanceof Closure)) {
             $type = getTypeName($template);
-            throw new RuntimeException("Invalid editor type of `{$type}`. Expected string or Closure.");
+            throw new RuntimeException(sprintf('Invalid editor type of `%s`. Expected string or Closure.', $type));
         }
         $instance->editors[$name] = $template;
     }
@@ -309,7 +309,7 @@ class Debugger
         $instance = static::getInstance();
         if (!isset($instance->editors[$name])) {
             $known = implode(', ', array_keys($instance->editors));
-            throw new RuntimeException("Unknown editor `{$name}`. Known editors are {$known}");
+            throw new RuntimeException(sprintf('Unknown editor `%s`. Known editors are `%s`', $name, $known));
         }
         $instance->setConfig('editor', $name);
     }
@@ -326,7 +326,7 @@ class Debugger
         $instance = static::getInstance();
         $editor = $instance->getConfig('editor');
         if (!isset($instance->editors[$editor])) {
-            throw new RuntimeException("Cannot format editor URL `{$editor}` is not a known editor.");
+            throw new RuntimeException(sprintf('Cannot format editor URL `%s` is not a known editor.', $editor));
         }
 
         $template = $instance->editors[$editor];
@@ -617,9 +617,11 @@ class Debugger
         }
         $instance = new $class();
         if (!$instance instanceof FormatterInterface) {
-            throw new RuntimeException(
-                "The `{$class}` formatter does not implement " . FormatterInterface::class
-            );
+            throw new RuntimeException(sprintf(
+                'The `%s` formatter does not implement `%s`',
+                $class,
+                FormatterInterface::class
+            ));
         }
 
         return $instance;
@@ -946,9 +948,10 @@ class Debugger
     {
         deprecationWarning('Debugger::addRenderer() is deprecated.');
         if (!in_array(ErrorRendererInterface::class, class_implements($class))) {
-            throw new InvalidArgumentException(
-                'Invalid renderer class. $class must implement ' . ErrorRendererInterface::class
-            );
+            throw new InvalidArgumentException(sprintf(
+                'Invalid renderer class. $class must implement `%s`',
+                ErrorRendererInterface::class
+            ));
         }
         $self = Debugger::getInstance();
         $self->renderers[$name] = $class;

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -161,7 +161,7 @@ class ErrorHandler extends BaseErrorHandler
             $class = App::className($renderer, 'Error');
             if (!$class) {
                 throw new RuntimeException(sprintf(
-                    "The '%s' renderer class could not be found.",
+                    'The `%s` renderer class could not be found.',
                     $renderer
                 ));
             }

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -134,10 +134,11 @@ class ExceptionTrap
         if (is_string($class)) {
             /** @var class-string<\Cake\Error\ExceptionRendererInterface> $class */
             if (!(method_exists($class, 'render') && method_exists($class, 'write'))) {
-                throw new InvalidArgumentException(
-                    "Cannot use {$class} as an `exceptionRenderer`. " .
-                    'It must implement render() and write() methods.'
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot use `%s` as an `exceptionRenderer`. ' .
+                    'It must implement render() and write() methods.',
+                    $class
+                ));
             }
 
             return new $class($exception, $request, $this->_config);

--- a/src/Event/Decorator/ConditionDecorator.php
+++ b/src/Event/Decorator/ConditionDecorator.php
@@ -67,7 +67,7 @@ class ConditionDecorator extends AbstractDecorator
             return $condition !== 'unless';
         }
         if (!is_callable($this->_options[$condition])) {
-            throw new RuntimeException(self::class . ' the `' . $condition . '` condition is not a callable!');
+            throw new RuntimeException(sprintf('`%s` the `%s` condition is not a callable!', self::class, $condition));
         }
 
         return (bool)$this->_options[$condition]($event);

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -185,7 +185,7 @@ class EventManager implements EventManagerInterface
         if (!is_string($eventKey)) {
             if (!is_callable($eventKey)) {
                 throw new CakeException(
-                    'First argument of EventManager::off() must be ' .
+                    'First argument of `EventManager::off()` must be ' .
                     ' string or EventListenerInterface instance or callable.'
                 );
             }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -174,7 +174,7 @@ class Filesystem
         // phpcs:ignore
         if (@mkdir($dir, $mode, true) === false) {
             umask($old);
-            throw new CakeException(sprintf('Failed to create directory "%s"', $dir));
+            throw new CakeException(sprintf('Failed to create directory `%s`', $dir));
         }
 
         umask($old);
@@ -194,7 +194,7 @@ class Filesystem
         }
 
         if (!is_dir($path)) {
-            throw new CakeException(sprintf('"%s" is not a directory', $path));
+            throw new CakeException(sprintf('`%s` is not a directory', $path));
         }
 
         $iterator = new RecursiveIteratorIterator(

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -203,7 +203,7 @@ class Client implements ClientInterface
         }
 
         if (!$adapter instanceof AdapterInterface) {
-            throw new InvalidArgumentException('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
+            throw new InvalidArgumentException('Adapter must be an instance of `Cake\Http\Client\AdapterInterface`');
         }
         $this->_adapter = $adapter;
 
@@ -230,7 +230,7 @@ class Client implements ClientInterface
         $parts = parse_url($url);
 
         if ($parts === false) {
-            throw new InvalidArgumentException('String ' . $url . ' did not parse');
+            throw new InvalidArgumentException(sprintf('String `%s` did not parse', $url));
         }
 
         $config = array_intersect_key($parts, ['scheme' => '', 'port' => '', 'host' => '', 'path' => '']);
@@ -671,7 +671,7 @@ class Client implements ClientInterface
             'xml' => 'application/xml',
         ];
         if (!isset($typeMap[$type])) {
-            throw new CakeException("Unknown type alias '$type'.");
+            throw new CakeException(sprintf('Unknown type alias `%s`.', $type));
         }
 
         return [
@@ -738,7 +738,7 @@ class Client implements ClientInterface
         $class = App::className($name, 'Http/Client/Auth');
         if (!$class) {
             throw new CakeException(
-                sprintf('Invalid authentication type %s', $name)
+                sprintf('Invalid authentication type `%s`', $name)
             );
         }
 

--- a/src/Http/Client/Adapter/Mock.php
+++ b/src/Http/Client/Adapter/Mock.php
@@ -55,7 +55,10 @@ class Mock implements AdapterInterface
     {
         if (isset($options['match']) && !($options['match'] instanceof Closure)) {
             $type = getTypeName($options['match']);
-            throw new InvalidArgumentException("The `match` option must be a `Closure`. Got `{$type}`.");
+            throw new InvalidArgumentException(sprintf(
+                'The `match` option must be a `Closure`. Got `%s`.',
+                $type
+            ));
         }
         $this->responses[] = [
             'request' => $request,

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -85,7 +85,7 @@ class Oauth
                 break;
 
             default:
-                throw new CakeException(sprintf('Unknown Oauth signature method %s', $credentials['method']));
+                throw new CakeException(sprintf('Unknown Oauth signature method `%s`', $credentials['method']));
         }
 
         return $request->withHeader('Authorization', $value);

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -659,9 +659,10 @@ class Cookie implements CookieInterface
     protected static function validateSameSiteValue(string $sameSite)
     {
         if (!in_array($sameSite, CookieInterface::SAMESITE_VALUES, true)) {
-            throw new InvalidArgumentException(
-                'Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES)
-            );
+            throw new InvalidArgumentException(sprintf(
+                'Samesite value must be either of: `%s`',
+                implode(', ', CookieInterface::SAMESITE_VALUES)
+            ));
         }
     }
 

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -140,7 +140,7 @@ class CookieCollection implements IteratorAggregate, Countable
 
         throw new InvalidArgumentException(
             sprintf(
-                'Cookie %s not found. Use has() to check first for existence.',
+                'Cookie `%s` not found. Use `has()` to check first for existence.',
                 $name
             )
         );

--- a/src/Http/Exception/NotImplementedException.php
+++ b/src/Http/Exception/NotImplementedException.php
@@ -22,7 +22,7 @@ class NotImplementedException extends HttpException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = '%s is not implemented.';
+    protected $_messageTemplate = '`%s` is not implemented.';
 
     /**
      * @inheritDoc

--- a/src/Http/Middleware/CspMiddleware.php
+++ b/src/Http/Middleware/CspMiddleware.php
@@ -64,7 +64,7 @@ class CspMiddleware implements MiddlewareInterface
     public function __construct($csp, array $config = [])
     {
         if (!class_exists(CSPBuilder::class)) {
-            throw new RuntimeException('You must install paragonie/csp-builder to use CspMiddleware');
+            throw new RuntimeException('You must install `paragonie/csp-builder` to use CspMiddleware');
         }
         $this->setConfig($config);
 

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -236,7 +236,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
     {
         if (!in_array($value, $allowed, true)) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid arg `%s`, use one of these: %s',
+                'Invalid arg `%s`, use one of these: `%s`',
                 $value,
                 implode(', ', $allowed)
             ));

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -73,7 +73,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
             $className = App::className($middleware, 'Middleware', 'Middleware');
             if ($className === null) {
                 throw new RuntimeException(sprintf(
-                    'Middleware "%s" was not found.',
+                    'Middleware `%s` was not found.',
                     $middleware
                 ));
             }
@@ -192,7 +192,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
         if ($found) {
             return $this->insertAt($i, $middleware);
         }
-        throw new LogicException(sprintf("No middleware matching '%s' could be found.", $class));
+        throw new LogicException(sprintf('No middleware matching `%s` could be found.', $class));
     }
 
     /**
@@ -252,7 +252,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
     public function seek($position): void
     {
         if (!isset($this->queue[$position])) {
-            throw new OutOfBoundsException("Invalid seek position ($position)");
+            throw new OutOfBoundsException(sprintf('Invalid seek position `%s`', $position));
         }
 
         $this->position = $position;
@@ -278,7 +278,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
     public function current(): MiddlewareInterface
     {
         if (!isset($this->queue[$this->position])) {
-            throw new OutOfBoundsException("Invalid current position ($this->position)");
+            throw new OutOfBoundsException(sprintf('Invalid current position `(%s)`', $this->position));
         }
 
         if ($this->queue[$this->position] instanceof MiddlewareInterface) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -633,7 +633,7 @@ class Response implements ResponseInterface
     {
         if ($code < static::STATUS_CODE_MIN || $code > static::STATUS_CODE_MAX) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid status code: %s. Use a valid HTTP status code in range 1xx - 5xx.',
+                'Invalid status code: `%s`. Use a valid HTTP status code in range 1xx - 5xx.',
                 $code
             ));
         }
@@ -731,7 +731,7 @@ class Response implements ResponseInterface
             return is_array($mapped) ? current($mapped) : $mapped;
         }
         if (strpos($contentType, '/') === false) {
-            throw new InvalidArgumentException(sprintf('"%s" is an invalid content type.', $contentType));
+            throw new InvalidArgumentException(sprintf('`%s` is an invalid content type.', $contentType));
         }
 
         return $contentType;
@@ -1492,7 +1492,7 @@ class Response implements ResponseInterface
         $file = new SplFileInfo($path);
         if (!$file->isFile() || !$file->isReadable()) {
             if (Configure::read('debug')) {
-                throw new NotFoundException(sprintf('The requested file %s was not found or not readable', $path));
+                throw new NotFoundException(sprintf('The requested file `%s` was not found or not readable', $path));
             }
             throw new NotFoundException(__d('cake', 'The requested file was not found'));
         }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -470,7 +470,7 @@ class ServerRequest implements ServerRequestInterface
 
             return $this->is(...$params);
         }
-        throw new BadMethodCallException(sprintf('Method "%s()" does not exist', $name));
+        throw new BadMethodCallException(sprintf('Method `%s()` does not exist', $name));
     }
 
     /**
@@ -951,7 +951,7 @@ class ServerRequest implements ServerRequestInterface
             !preg_match('/^[!#$%&\'*+.^_`\|~0-9a-z-]+$/i', $method)
         ) {
             throw new InvalidArgumentException(sprintf(
-                'Unsupported HTTP method "%s" provided',
+                'Unsupported HTTP method `%s` provided',
                 $method
             ));
         }
@@ -1417,7 +1417,7 @@ class ServerRequest implements ServerRequestInterface
     public function withProtocolVersion($version)
     {
         if (!preg_match('/^(1\.[01]|2)$/', $version)) {
-            throw new InvalidArgumentException("Unsupported protocol version '{$version}' provided");
+            throw new InvalidArgumentException(sprintf('Unsupported protocol version `%s` provided', $version));
         }
         $new = clone $this;
         $new->protocol = $version;
@@ -1597,9 +1597,10 @@ class ServerRequest implements ServerRequestInterface
     {
         $new = clone $this;
         if (in_array($name, $this->emulatedAttributes, true)) {
-            throw new InvalidArgumentException(
-                "You cannot unset '$name'. It is a required CakePHP attribute."
-            );
+            throw new InvalidArgumentException(sprintf(
+                'You cannot unset `%s`. It is a required CakePHP attribute.',
+                $name
+            ));
         }
         unset($new->attributes[$name]);
 
@@ -1708,7 +1709,11 @@ class ServerRequest implements ServerRequestInterface
             }
 
             if (!$file instanceof UploadedFileInterface) {
-                throw new InvalidArgumentException("Invalid file at '{$path}{$key}'");
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid file at `%s%s`',
+                    $path,
+                    $key
+                ));
             }
         }
     }

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -267,9 +267,10 @@ class Session
         /** @var class-string<\SessionHandlerInterface>|null $className */
         $className = App::className($class, 'Http/Session');
         if ($className === null) {
-            throw new InvalidArgumentException(
-                sprintf('The class "%s" does not exist and cannot be used as a session engine', $class)
-            );
+            throw new InvalidArgumentException(sprintf(
+                'The class `%s` does not exist and cannot be used as a session engine',
+                $class
+            ));
         }
 
         return $this->setEngine(new $className($options));
@@ -312,9 +313,10 @@ class Session
 
         foreach ($options as $setting => $value) {
             if (ini_set($setting, (string)$value) === false) {
-                throw new RuntimeException(
-                    sprintf('Unable to configure the session, setting %s failed.', $setting)
-                );
+                throw new RuntimeException(sprintf(
+                    'Unable to configure the session, setting `%s` failed.',
+                    $setting
+                ));
             }
         }
     }
@@ -455,7 +457,7 @@ class Session
     public function readOrFail(string $name)
     {
         if (!$this->check($name)) {
-            throw new RuntimeException(sprintf('Expected session key "%s" not found.', $name));
+            throw new RuntimeException(sprintf('Expected session key `%s` not found.', $name));
         }
 
         return $this->read($name);

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -71,7 +71,10 @@ class Uri implements UriInterface
         if ($name === 'base' || $name === 'webroot') {
             return $this->{$name};
         }
-        throw new UnexpectedValueException("Undefined property via __get('{$name}')");
+        throw new UnexpectedValueException(sprintf(
+            "Undefined property via __get('%s')",
+            $name
+        ));
     }
 
     /**

--- a/src/I18n/ChainMessagesLoader.php
+++ b/src/I18n/ChainMessagesLoader.php
@@ -54,7 +54,7 @@ class ChainMessagesLoader
         foreach ($this->_loaders as $k => $loader) {
             if (!is_callable($loader)) {
                 throw new RuntimeException(sprintf(
-                    'Loader "%s" in the chain is not a valid callable',
+                    'Loader `%s` in the chain is not a valid callable',
                     $k
                 ));
             }
@@ -66,7 +66,7 @@ class ChainMessagesLoader
 
             if (!($package instanceof Package)) {
                 throw new RuntimeException(sprintf(
-                    'Loader "%s" in the chain did not return a valid Package object',
+                    'Loader `%s` in the chain did not return a valid Package object',
                     $k
                 ));
             }

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -254,10 +254,11 @@ trait DateFormatTrait
                 $pattern
             );
             if (empty($formatter)) {
-                throw new RuntimeException(
+                throw new RuntimeException(sprintf(
                     'Your version of icu does not support creating a date formatter for ' .
-                    "`$key`. You should try to upgrade libicu and the intl extension."
-                );
+                    '`%s`. You should try to upgrade libicu and the intl extension.',
+                    $key
+                ));
             }
             static::$_formatters[$key] = $formatter;
         }

--- a/src/I18n/FormatterLocator.php
+++ b/src/I18n/FormatterLocator.php
@@ -77,7 +77,7 @@ class FormatterLocator
     public function get(string $name): FormatterInterface
     {
         if (!isset($this->registry[$name])) {
-            throw new I18nException("Formatter named `{$name}` has not been registered");
+            throw new I18nException(sprintf('Formatter named `%s` has not been registered', $name));
         }
 
         if (!$this->converted[$name]) {

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -148,7 +148,7 @@ class I18n
         $translator = $translators->get($name);
         if ($translator === null) {
             throw new I18nException(sprintf(
-                'Translator for domain "%s" could not be found.',
+                'Translator for domain `%s` could not be found.',
                 $name
             ));
         }

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -132,7 +132,7 @@ class MessagesFileLoader
         $class = App::className($name, 'I18n\Parser', 'FileParser');
 
         if (!$class) {
-            throw new RuntimeException(sprintf('Could not find class %s', "{$name}FileParser"));
+            throw new RuntimeException(sprintf('Could not find class `%s`', "{$name}FileParser"));
         }
 
         $messages = (new $class())->parse($file);

--- a/src/I18n/PackageLocator.php
+++ b/src/I18n/PackageLocator.php
@@ -84,7 +84,11 @@ class PackageLocator
     public function get(string $name, string $locale): Package
     {
         if (!isset($this->registry[$name][$locale])) {
-            throw new I18nException("Package '$name' with locale '$locale' is not registered.");
+            throw new I18nException(sprintf(
+                'Package `%s` with locale `%s` is not registered.',
+                $name,
+                $locale
+            ));
         }
 
         if (!$this->converted[$name][$locale]) {

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -54,7 +54,7 @@ class LogEngineRegistry extends ObjectRegistry
      */
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
-        throw new RuntimeException(sprintf('Could not load class %s', $class));
+        throw new RuntimeException(sprintf('Could not load class `%s`', $class));
     }
 
     /**

--- a/src/Mailer/Email.php
+++ b/src/Mailer/Email.php
@@ -247,12 +247,12 @@ class Email implements JsonSerializable, Serializable
             $transport = $name;
         } else {
             throw new InvalidArgumentException(sprintf(
-                'The value passed for the "$name" argument must be either a string, or an object, %s given.',
+                'The value passed for the `$name` argument must be either a string, or an object, `%s` given.',
                 gettype($name)
             ));
         }
         if (!method_exists($transport, 'send')) {
-            throw new LogicException(sprintf('The "%s" do not have send method.', get_class($transport)));
+            throw new LogicException(sprintf('The `%s` do not have send method.', get_class($transport)));
         }
 
         $this->_transport = $transport;
@@ -300,7 +300,7 @@ class Email implements JsonSerializable, Serializable
             $name = $config;
             $config = Mailer::getConfig($name);
             if (empty($config)) {
-                throw new InvalidArgumentException(sprintf('Unknown email configuration "%s".', $name));
+                throw new InvalidArgumentException(sprintf('Unknown email configuration `%s`.', $name));
             }
             unset($name);
         }

--- a/src/Mailer/Exception/MissingActionException.php
+++ b/src/Mailer/Exception/MissingActionException.php
@@ -24,5 +24,5 @@ class MissingActionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Mail %s::%s() could not be found, or is not accessible.';
+    protected $_messageTemplate = 'Mail `%s::%s()` could not be found, or is not accessible.';
 }

--- a/src/Mailer/Exception/MissingMailerException.php
+++ b/src/Mailer/Exception/MissingMailerException.php
@@ -26,5 +26,5 @@ class MissingMailerException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Mailer class "%s" could not be found.';
+    protected $_messageTemplate = 'Mailer class `%s` could not be found.';
 }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -422,7 +422,7 @@ class Mailer implements EventListenerInterface
             $name = $config;
             $config = static::getConfig($name);
             if (empty($config)) {
-                throw new InvalidArgumentException(sprintf('Unknown email configuration "%s".', $name));
+                throw new InvalidArgumentException(sprintf('Unknown email configuration `%s`.', $name));
             }
             unset($name);
         }
@@ -494,11 +494,11 @@ class Mailer implements EventListenerInterface
         } elseif (is_object($name)) {
             $transport = $name;
             if (!$transport instanceof AbstractTransport) {
-                throw new CakeException('Transport class must extend Cake\Mailer\AbstractTransport');
+                throw new CakeException('Transport class must extend `Cake\Mailer\AbstractTransport`');
             }
         } else {
             throw new InvalidArgumentException(sprintf(
-                'The value passed for the "$name" argument must be either a string, or an object, %s given.',
+                'The value passed for the `$name` argument must be either a string, or an object, `%s` given.',
                 gettype($name)
             ));
         }

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -630,7 +630,7 @@ class Message implements JsonSerializable, Serializable
             if (!in_array($encoding, $this->transferEncodingAvailable, true)) {
                 throw new InvalidArgumentException(
                     sprintf(
-                        'Transfer encoding not available. Can be : %s.',
+                        'Transfer encoding not available. Can be: `%s`.',
                         implode(', ', $this->transferEncodingAvailable)
                     )
                 );
@@ -727,9 +727,9 @@ class Message implements JsonSerializable, Serializable
 
         $context = ltrim($context, '_');
         if ($email === '') {
-            throw new InvalidArgumentException(sprintf('The email set for "%s" is empty.', $context));
+            throw new InvalidArgumentException(sprintf('The email set for `%s` is empty.', $context));
         }
-        throw new InvalidArgumentException(sprintf('Invalid email set for "%s". You passed "%s".', $context, $email));
+        throw new InvalidArgumentException(sprintf('Invalid email set for `%s`. You passed `%s`.', $context, $email));
     }
 
     /**
@@ -1185,7 +1185,7 @@ class Message implements JsonSerializable, Serializable
                 $fileName = $fileInfo['file'];
                 $fileInfo['file'] = realpath($fileInfo['file']);
                 if ($fileInfo['file'] === false || !file_exists($fileInfo['file'])) {
-                    throw new InvalidArgumentException(sprintf('File not found: "%s"', $fileName));
+                    throw new InvalidArgumentException(sprintf('File not found: `%s`', $fileName));
                 }
                 if (is_int($name)) {
                     $name = basename($fileInfo['file']);
@@ -1513,7 +1513,7 @@ class Message implements JsonSerializable, Serializable
         foreach ($content as $type => $text) {
             if (!in_array($type, $this->emailFormatAvailable, true)) {
                 throw new InvalidArgumentException(sprintf(
-                    'Invalid message type: "%s". Valid types are: "text", "html".',
+                    'Invalid message type: `%s`. Valid types are: `text`, `html`.',
                     $type
                 ));
             }

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -83,13 +83,13 @@ class TransportFactory
     {
         if (!isset(static::$_config[$name])) {
             throw new InvalidArgumentException(
-                sprintf('The "%s" transport configuration does not exist', $name)
+                sprintf('The `%s` transport configuration does not exist', $name)
             );
         }
 
         if (is_array(static::$_config[$name]) && empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
-                sprintf('Transport config "%s" is invalid, the required `className` option is missing', $name)
+                sprintf('Transport config `%s` is invalid, the required `className` option is missing', $name)
             );
         }
 

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -54,7 +54,7 @@ class TransportRegistry extends ObjectRegistry
      */
     protected function _throwMissingClassError(string $class, ?string $plugin): void
     {
-        throw new BadMethodCallException(sprintf('Mailer transport %s is not available.', $class));
+        throw new BadMethodCallException(sprintf('Mailer transport `%s` is not available.', $class));
     }
 
     /**
@@ -81,7 +81,7 @@ class TransportRegistry extends ObjectRegistry
         }
 
         throw new RuntimeException(
-            'Mailer transports must use Cake\Mailer\AbstractTransport as a base class.'
+            'Mailer transports must use `Cake\Mailer\AbstractTransport` as a base class.'
         );
     }
 

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -484,7 +484,7 @@ class Socket
 
         try {
             if ($this->connection === null) {
-                throw new CakeException('You must call connect() first.');
+                throw new CakeException('You must call `connect()` first.');
             }
             $enableCryptoResult = stream_socket_enable_crypto($this->connection, $enable, $method);
         } catch (Exception $e) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -260,7 +260,7 @@ abstract class Association
             $alias = $this->_targetTable->getAlias();
             if ($alias !== $name) {
                 throw new InvalidArgumentException(sprintf(
-                    'Association name "%s" does not match target table alias "%s".',
+                    'Association name `%s` does not match target table alias `%s`.',
                     $name,
                     $alias
                 ));
@@ -321,7 +321,7 @@ abstract class Association
             get_class($this->_targetTable) !== App::className($className, 'Model/Table', 'Table')
         ) {
             throw new InvalidArgumentException(sprintf(
-                'The class name "%s" doesn\'t match the target table class name of "%s".',
+                'The class name `%s` doesn\'t match the target table class name of `%s`.',
                 $className,
                 get_class($this->_targetTable)
             ));
@@ -406,12 +406,12 @@ abstract class Association
                 $className = App::className($this->_className, 'Model/Table', 'Table') ?: Table::class;
 
                 if (!$this->_targetTable instanceof $className) {
-                    $errorMessage = '%s association "%s" of type "%s" to "%s" doesn\'t match the expected class "%s". ';
-                    $errorMessage .= 'You can\'t have an association of the same name with a different target ';
-                    $errorMessage .= '"className" option anywhere in your app.';
+                    $msg = '`%s` association `%s` of type `%s` to `%s` doesn\'t match the expected class `%s`.';
+                    $msg .= ' You can\'t have an association of the same name with a different target ';
+                    $msg .= '"className" option anywhere in your app.';
 
                     throw new RuntimeException(sprintf(
-                        $errorMessage,
+                        $msg,
                         $this->_sourceTable === null ? 'null' : get_class($this->_sourceTable),
                         $this->getName(),
                         $this->type(),
@@ -635,7 +635,7 @@ abstract class Association
     {
         if (!in_array($name, $this->_validStrategies, true)) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid strategy "%s" was provided. Valid options are (%s).',
+                'Invalid strategy `%s` was provided. Valid options are `(%s)`.',
                 $name,
                 implode(', ', $this->_validStrategies)
             ));
@@ -754,7 +754,7 @@ abstract class Association
             $dummy = $options['queryBuilder']($dummy);
             if (!($dummy instanceof Query)) {
                 throw new RuntimeException(sprintf(
-                    'Query builder for association "%s" did not return a query',
+                    'Query builder for association `%s` did not return a query',
                     $this->getName()
                 ));
             }
@@ -765,9 +765,10 @@ abstract class Association
             $this->_strategy === static::STRATEGY_JOIN &&
             $dummy->getContain()
         ) {
-            throw new RuntimeException(
-                "`{$this->getName()}` association cannot contain() associations when using JOIN strategy."
-            );
+            throw new RuntimeException(sprintf(
+                '`%s` association cannot contain() associations when using JOIN strategy.',
+                $this->getName()
+            ));
         }
 
         $dummy->where($options['conditions']);
@@ -1099,11 +1100,11 @@ abstract class Association
                 if ($this->isOwningSide($this->getSource())) {
                     $table = $this->getSource()->getTable();
                 }
-                $msg = 'The "%s" table does not define a primary key, and cannot have join conditions generated.';
+                $msg = 'The `%s` table does not define a primary key, and cannot have join conditions generated.';
                 throw new RuntimeException(sprintf($msg, $table));
             }
 
-            $msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
+            $msg = 'Cannot match provided foreignKey for `%s`, got `(%s)` but expected foreign key for `(%s)`';
             throw new RuntimeException(sprintf(
                 $msg,
                 $this->_name,

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -159,11 +159,11 @@ class BelongsTo extends Association
 
         if (count($foreignKey) !== count($bindingKey)) {
             if (empty($bindingKey)) {
-                $msg = 'The "%s" table does not define a primary key. Please set one.';
+                $msg = 'The `%s` table does not define a primary key. Please set one.';
                 throw new RuntimeException(sprintf($msg, $this->getTarget()->getTable()));
             }
 
-            $msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
+            $msg = 'Cannot match provided foreignKey for `%s`, got `(%s)` but expected foreign key for `(%s)`';
             throw new RuntimeException(sprintf(
                 $msg,
                 $this->_name,

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -418,10 +418,14 @@ class BelongsToMany extends Association
                 $this->getTargetForeignKey() !== $belongsTo->getForeignKey() ||
                 $target !== $belongsTo->getTarget()
             ) {
-                throw new InvalidArgumentException(
-                    "The existing `{$tAlias}` association on `{$junction->getAlias()}` " .
-                    "is incompatible with the `{$this->getName()}` association on `{$source->getAlias()}`"
-                );
+                throw new InvalidArgumentException(sprintf(
+                    'The existing `%s` association on `%s` ' .
+                    'is incompatible with the `%s` association on `%s`',
+                    $tAlias,
+                    $junction->getAlias(),
+                    $this->getName(),
+                    $source->getAlias()
+                ));
             }
         }
 
@@ -639,7 +643,7 @@ class BelongsToMany extends Association
     public function setSaveStrategy(string $strategy)
     {
         if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
-            $msg = sprintf('Invalid save strategy "%s"', $strategy);
+            $msg = sprintf('Invalid save strategy `%s`', $strategy);
             throw new InvalidArgumentException($msg);
         }
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -111,7 +111,7 @@ class HasMany extends Association
     public function setSaveStrategy(string $strategy)
     {
         if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
-            $msg = sprintf('Invalid save strategy "%s"', $strategy);
+            $msg = sprintf('Invalid save strategy `%s`', $strategy);
             throw new InvalidArgumentException($msg);
         }
 
@@ -161,7 +161,7 @@ class HasMany extends Association
 
         if (!is_iterable($targetEntities)) {
             $name = $this->getProperty();
-            $message = sprintf('Could not save %s, it cannot be traversed', $name);
+            $message = sprintf('Could not save `%s`, it cannot be traversed', $name);
             throw new InvalidArgumentException($message);
         }
 

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -272,7 +272,7 @@ class SelectLoader
         if ($missingFields) {
             throw new InvalidArgumentException(
                 sprintf(
-                    'You are required to select the "%s" field(s)',
+                    'You are required to select the `%s` field(s)',
                     implode(', ', $key)
                 )
             );
@@ -373,7 +373,7 @@ class SelectLoader
         $name = $this->alias;
 
         if ($options['foreignKey'] === false && $this->associationType === Association::ONE_TO_MANY) {
-            $msg = 'Cannot have foreignKey = false for hasMany associations. ' .
+            $msg = 'Cannot have `foreignKey = false` for hasMany associations. ' .
                    'You must provide a foreignKey column.';
             throw new RuntimeException($msg);
         }

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -177,7 +177,7 @@ class SelectWithPivotLoader extends SelectLoader
         foreach ($fetchQuery->all() as $result) {
             if (!isset($result[$this->junctionProperty])) {
                 throw new RuntimeException(sprintf(
-                    '"%s" is missing from the belongsToMany results. Results cannot be created.',
+                    '`%s` is missing from the belongsToMany results. Results cannot be created.',
                     $this->junctionProperty
                 ));
             }

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -264,7 +264,7 @@ class AssociationCollection implements IteratorAggregate
             $relation = $this->get($alias);
             if (!$relation) {
                 $msg = sprintf(
-                    'Cannot save %s, it is not associated to %s',
+                    'Cannot save `%s`, it is not associated to `%s`',
                     $alias,
                     $table->getAlias()
                 );

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -255,7 +255,7 @@ class Behavior implements EventListenerInterface
             foreach ($this->_config[$key] as $method) {
                 if (!is_callable([$this, $method])) {
                     throw new CakeException(sprintf(
-                        'The method %s is not callable on class %s',
+                        'The method `%s` is not callable on class `%s`',
                         $method,
                         static::class
                     ));

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -104,7 +104,7 @@ class TimestampBehavior extends Behavior
         foreach ($events[$eventName] as $field => $when) {
             if (!in_array($when, ['always', 'new', 'existing'], true)) {
                 throw new UnexpectedValueException(sprintf(
-                    'When should be one of "always", "new" or "existing". The passed value "%s" is invalid',
+                    'When should be one of `always`, `new` or `existing`. The passed value `%s` is invalid',
                     $when
                 ));
             }

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -271,7 +271,7 @@ class TreeBehavior extends Behavior
 
         if ($parentLeft > $left && $parentLeft < $right) {
             throw new RuntimeException(sprintf(
-                'Cannot use node "%s" as parent for entity "%s"',
+                'Cannot use node `%s` as parent for entity `%s`',
                 $parent,
                 $entity->get($this->_getPrimaryKey())
             ));
@@ -386,7 +386,7 @@ class TreeBehavior extends Behavior
     public function findPath(Query $query, array $options): Query
     {
         if (empty($options['for'])) {
-            throw new InvalidArgumentException("The 'for' key is required for find('path')");
+            throw new InvalidArgumentException("The `for` key is required for `find('path')`");
         }
 
         $config = $this->getConfig();
@@ -461,7 +461,7 @@ class TreeBehavior extends Behavior
         [$for, $direct] = [$options['for'], $options['direct']];
 
         if (empty($for)) {
-            throw new InvalidArgumentException("The 'for' key is required for find('children')");
+            throw new InvalidArgumentException("The `for` key is required for `find('children')`");
         }
 
         if ($query->clause('order') === null) {
@@ -813,7 +813,10 @@ class TreeBehavior extends Behavior
             ->first();
 
         if (!$node) {
-            throw new RecordNotFoundException("Node \"{$id}\" was not found in the tree.");
+            throw new RecordNotFoundException(sprintf(
+                'Node `%s` was not found in the tree.',
+                $id
+            ));
         }
 
         /** @psalm-suppress InvalidReturnStatement */

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -176,7 +176,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
             if (isset($this->_finderMap[$finder]) && $this->has($this->_finderMap[$finder][0])) {
                 $duplicate = $this->_finderMap[$finder];
                 $error = sprintf(
-                    '%s contains duplicate finder "%s" which is already provided by "%s"',
+                    '`%s` contains duplicate finder `%s` which is already provided by `%s`',
                     $class,
                     $finder,
                     $duplicate[0]
@@ -190,7 +190,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
             if (isset($this->_methodMap[$method]) && $this->has($this->_methodMap[$method][0])) {
                 $duplicate = $this->_methodMap[$method];
                 $error = sprintf(
-                    '%s contains duplicate method "%s" which is already provided by "%s"',
+                    '`%s` contains duplicate method `%s` which is already provided by `%s`',
                     $class,
                     $method,
                     $duplicate[0]
@@ -253,7 +253,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call "%s" it does not belong to any attached behavior.', $method)
+            sprintf('Cannot call `%s` it does not belong to any attached behavior.', $method)
         );
     }
 
@@ -277,7 +277,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call finder "%s" it does not belong to any attached behavior.', $type)
+            sprintf('Cannot call finder `%s` it does not belong to any attached behavior.', $type)
         );
     }
 }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -654,7 +654,11 @@ class EagerLoader
                     strpos($path, '.') === false &&
                     (!array_key_exists($path, $collected) || !array_key_exists($alias, $collected[$path]))
                 ) {
-                    $message = "Unable to load `{$path}` association. Ensure foreign key in `{$alias}` is selected.";
+                    $message = sprintf(
+                        'Unable to load `%s` association. Ensure foreign key in `%s` is selected.',
+                        $path,
+                        $alias
+                    );
                     throw new InvalidArgumentException($message);
                 }
 

--- a/src/ORM/Exception/MissingBehaviorException.php
+++ b/src/ORM/Exception/MissingBehaviorException.php
@@ -24,5 +24,5 @@ class MissingBehaviorException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Behavior class %s could not be found.';
+    protected $_messageTemplate = 'Behavior class `%s` could not be found.';
 }

--- a/src/ORM/Exception/MissingEntityException.php
+++ b/src/ORM/Exception/MissingEntityException.php
@@ -28,5 +28,5 @@ class MissingEntityException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'Entity class %s could not be found.';
+    protected $_messageTemplate = 'Entity class `%s` could not be found.';
 }

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -55,7 +55,7 @@ class PersistenceFailedException extends CakeException
             }
             if ($errors) {
                 $message[] = implode(', ', $errors);
-                $this->_messageTemplate = 'Entity %s failure. Found the following errors (%s).';
+                $this->_messageTemplate = 'Entity %s failure. Found the following errors `%s`.';
             }
         }
         parent::__construct($message, $code, $previous);

--- a/src/ORM/Exception/RolledbackTransactionException.php
+++ b/src/ORM/Exception/RolledbackTransactionException.php
@@ -24,6 +24,6 @@ class RolledbackTransactionException extends CakeException
     /**
      * @var string
      */
-    protected $_messageTemplate = 'The afterSave event in "%s" is aborting the transaction'
+    protected $_messageTemplate = 'The afterSave event in `%s` is aborting the transaction'
         . ' before the save process is done.';
 }

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -141,7 +141,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
 
         if (isset($this->instances[$alias])) {
             throw new RuntimeException(sprintf(
-                'You cannot configure "%s", it has already been constructed.',
+                'You cannot configure `%s`, it has already been constructed.',
                 $alias
             ));
         }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -95,7 +95,7 @@ class Marshaller
             if (!$this->_table->hasAssociation($key)) {
                 if (substr($key, 0, 1) !== '_') {
                     throw new InvalidArgumentException(sprintf(
-                        'Cannot marshal data for "%s" association. It is not associated with "%s".',
+                        'Cannot marshal data for `%s` association. It is not associated with `%s`.',
                         (string)$key,
                         $this->_table->getAlias()
                     ));
@@ -267,9 +267,10 @@ class Marshaller
         }
 
         if ($validator === null) {
-            throw new RuntimeException(
-                sprintf('validate must be a boolean, a string or an object. Got %s.', getTypeName($options['validate']))
-            );
+            throw new RuntimeException(sprintf(
+                'validate must be a boolean, a string or an object. Got `%s`.',
+                getTypeName($options['validate'])
+            ));
         }
 
         return $validator->validate($data, $isNew);

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1347,7 +1347,7 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call method "%s" on a "%s" query', $method, $this->type())
+            sprintf('Cannot call method `%s` on a `%s` query', $method, $this->type())
         );
     }
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -230,7 +230,7 @@ class ResultSet implements ResultSetInterface
 
         if (!$this->_useBuffering) {
             $msg = 'You cannot rewind an un-buffered ResultSet. '
-                . 'Use Query::bufferResults() to get a buffered ResultSet.';
+                . 'Use `Query::bufferResults()` to get a buffered ResultSet.';
             throw new DatabaseException($msg);
         }
 
@@ -312,7 +312,7 @@ class ResultSet implements ResultSetInterface
     {
         if (!$this->_useBuffering) {
             $msg = 'You cannot serialize an un-buffered ResultSet. '
-                . 'Use Query::bufferResults() to get a buffered ResultSet.';
+                . 'Use `Query::bufferResults()` to get a buffered ResultSet.';
             throw new DatabaseException($msg);
         }
 

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -84,7 +84,7 @@ class ExistsIn
         if (is_string($this->_repository)) {
             if (!$options['repository']->hasAssociation($this->_repository)) {
                 throw new RuntimeException(sprintf(
-                    "ExistsIn rule for '%s' is invalid. '%s' is not associated with '%s'.",
+                    'ExistsIn rule for `%s` is invalid. `%s` is not associated with `%s`.',
                     implode(', ', $this->_fields),
                     $this->_repository,
                     get_class($options['repository'])

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -564,7 +564,10 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected function checkAliasLengths(): void
     {
         if ($this->_schema === null) {
-            throw new RuntimeException("Unable to check max alias lengths for  `{$this->getAlias()}` without schema.");
+            throw new RuntimeException(sprintf(
+                'Unable to check max alias lengths for `%s` without schema.',
+                $this->getAlias()
+            ));
         }
 
         $maxLength = null;
@@ -579,12 +582,15 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         foreach ($this->_schema->columns() as $name) {
             if (strlen($table . '__' . $name) > $maxLength) {
                 $nameLength = $maxLength - 2;
-                throw new RuntimeException(
+                throw new RuntimeException(sprintf(
                     'ORM queries generate field aliases using the table name/alias and column name. ' .
-                    "The table alias `{$table}` and column `{$name}` create an alias longer than ({$nameLength}). " .
+                    'The table alias `%s` and column `%s` create an alias longer than `%s`. ' .
                     'You must change the table schema in the database and shorten either the table or column ' .
-                    'identifier so they fit within the database alias limits.'
-                );
+                    'identifier so they fit within the database alias limits.',
+                    $table,
+                    $name,
+                    $nameLength
+                ));
             }
         }
     }
@@ -853,7 +859,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if (!$this->_behaviors->has($name)) {
             throw new InvalidArgumentException(sprintf(
-                'The %s behavior is not defined on %s.',
+                'The `%s` behavior is not defined on `%s`.',
                 $name,
                 static::class
             ));
@@ -896,7 +902,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (!$association) {
             $assocations = $this->associations()->keys();
 
-            $message = "The `{$name}` association is not defined on `{$this->getAlias()}`.";
+            $message = sprintf(
+                'The `%s` association is not defined on `%s`.',
+                $name,
+                $this->getAlias()
+            );
             if ($assocations) {
                 $message .= "\nValid associations are: " . implode(', ', $assocations);
             }
@@ -1498,7 +1508,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if ($primaryKey === null) {
             throw new InvalidPrimaryKeyException(sprintf(
-                'Record not found in table "%s" with primary key [NULL]',
+                'Record not found in table `%s` with primary key `[NULL]`',
                 $this->getTable()
             ));
         }
@@ -1518,7 +1528,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }, $primaryKey);
 
             throw new InvalidPrimaryKeyException(sprintf(
-                'Record not found in table "%s" with primary key [%s]',
+                'Record not found in table `%s` with primary key `[%s]`',
                 $this->getTable(),
                 implode(', ', $primaryKey)
             ));
@@ -1688,7 +1698,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $query = $search;
         } else {
             throw new InvalidArgumentException(sprintf(
-                'Search criteria must be an array, callable or Query. Got "%s"',
+                'Search criteria must be an array, callable or Query. Got `%s`',
                 getTypeName($search)
             ));
         }
@@ -2042,7 +2052,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $primary = (array)$this->getPrimaryKey();
         if (empty($primary)) {
             $msg = sprintf(
-                'Cannot insert row in "%s" table, it has no primary key.',
+                'Cannot insert row in `%s` table, it has no primary key.',
                 $this->getTable()
             );
             throw new RuntimeException($msg);
@@ -2065,7 +2075,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 if (!isset($data[$k]) && empty($schema->getColumn($k)['autoIncrement'])) {
                     $msg = 'Cannot insert row, some of the primary key values are missing. ';
                     $msg .= sprintf(
-                        'Got (%s), expecting (%s)',
+                        'Got `(%s)`, expecting `(%s)`',
                         implode(', ', $filteredKeys + $entity->extract(array_keys($primary))),
                         implode(', ', array_keys($primary))
                     );
@@ -2149,7 +2159,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (count($primaryColumns) === 0) {
             $entityClass = get_class($entity);
             $table = $this->getTable();
-            $message = "Cannot update `$entityClass`. The `$table` has no primary key.";
+            $message = sprintf(
+                'Cannot update `%s`. The `%s` has no primary key.',
+                $entityClass,
+                $table
+            );
             throw new InvalidArgumentException($message);
         }
 
@@ -2556,7 +2570,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         throw new BadMethodCallException(sprintf(
-            'Unknown finder method "%s" on %s.',
+            'Unknown finder method `%s` on `%s`.',
             $type,
             static::class
         ));
@@ -2590,7 +2604,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $conditions = [];
             if (count($args) < count($fields)) {
                 throw new BadMethodCallException(sprintf(
-                    'Not enough arguments for magic finder. Got %s required %s',
+                    'Not enough arguments for magic finder. Got `%s` required `%s`',
                     count($args),
                     count($fields)
                 ));
@@ -2646,7 +2660,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         throw new BadMethodCallException(
-            sprintf('Unknown method "%s" called on %s', $method, static::class)
+            sprintf('Unknown method `%s"` called on `%s`', $method, static::class)
         );
     }
 

--- a/src/Routing/Exception/DuplicateNamedRouteException.php
+++ b/src/Routing/Exception/DuplicateNamedRouteException.php
@@ -25,7 +25,7 @@ class DuplicateNamedRouteException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'A route named "%s" has already been connected to "%s".';
+    protected $_messageTemplate = 'A route named `%s` has already been connected to `%s`.';
 
     /**
      * Constructor.

--- a/src/Routing/Exception/MissingDispatcherFilterException.php
+++ b/src/Routing/Exception/MissingDispatcherFilterException.php
@@ -24,5 +24,5 @@ class MissingDispatcherFilterException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Dispatcher filter %s could not be found.';
+    protected $_messageTemplate = 'Dispatcher filter `%s` could not be found.';
 }

--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -26,14 +26,14 @@ class MissingRouteException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'A route matching "%s" could not be found.';
+    protected $_messageTemplate = 'A route matching `%s` could not be found.';
 
     /**
      * Message template to use when the requested method is included.
      *
      * @var string
      */
-    protected $_messageTemplateWithMethod = 'A "%s" route matching "%s" could not be found.';
+    protected $_messageTemplateWithMethod = 'A `%s` route matching `%s` could not be found.';
 
     /**
      * Constructor.

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -824,7 +824,7 @@ class Route
         $search = $replace = [];
         foreach ($this->keys as $key) {
             if (!array_key_exists($key, $params)) {
-                throw new InvalidArgumentException("Missing required route key `{$key}`");
+                throw new InvalidArgumentException(sprintf('Missing required route key `%s`', $key));
             }
             $string = $params[$key];
             if ($this->braceKeys) {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -724,7 +724,7 @@ class RouteBuilder
             $routeClass = App::className($options['routeClass'], 'Routing/Route');
             if ($routeClass === null) {
                 throw new InvalidArgumentException(sprintf(
-                    'Cannot find route class %s',
+                    'Cannot find route class `%s`',
                     $options['routeClass']
                 ));
             }
@@ -737,7 +737,7 @@ class RouteBuilder
             foreach ($this->_params as $param => $val) {
                 if (isset($defaults[$param]) && $param !== 'prefix' && $defaults[$param] !== $val) {
                     $msg = 'You cannot define routes that conflict with the scope. ' .
-                        'Scope had %s = %s, while route had %s = %s';
+                        'Scope had `%s = %s`, while route had `%s = %s`';
                     throw new BadMethodCallException(sprintf(
                         $msg,
                         $param,
@@ -998,9 +998,9 @@ class RouteBuilder
     {
         foreach ($names as $name) {
             if (!$this->_collection->middlewareExists($name)) {
-                $message = "Cannot apply '$name' middleware or middleware group. " .
-                    'Use registerMiddleware() to register middleware.';
-                throw new RuntimeException($message);
+                $message = 'Cannot apply `%s` middleware or middleware group. ' .
+                    'Use `registerMiddleware()` to register middleware.';
+                throw new RuntimeException(sprintf($message, $name));
             }
         }
         $this->middleware = array_unique(array_merge($this->middleware, $names));

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -306,7 +306,7 @@ class RouteCollection
                 throw new MissingRouteException([
                     'url' => $name,
                     'context' => $context,
-                    'message' => "A named route was found for `{$name}`, but matching failed.",
+                    'message' => sprintf('A named route was found for `%s`, but matching failed.', $name),
                 ]);
             }
             throw new MissingRouteException(['url' => $name, 'context' => $context]);
@@ -412,13 +412,20 @@ class RouteCollection
     public function middlewareGroup(string $name, array $middlewareNames)
     {
         if ($this->hasMiddleware($name)) {
-            $message = "Cannot add middleware group '$name'. A middleware by this name has already been registered.";
+            $message = sprintf(
+                'Cannot add middleware group `%s`. A middleware by this name has already been registered.',
+                $name
+            );
             throw new RuntimeException($message);
         }
 
         foreach ($middlewareNames as $middlewareName) {
             if (!$this->hasMiddleware($middlewareName)) {
-                $message = "Cannot add '$middlewareName' middleware to group '$name'. It has not been registered.";
+                $message = sprintf(
+                    'Cannot add `%s` middleware to group `%s`. It has not been registered.',
+                    $middlewareName,
+                    $name
+                );
                 throw new RuntimeException($message);
             }
         }
@@ -479,7 +486,7 @@ class RouteCollection
             }
             if (!$this->hasMiddleware($name)) {
                 throw new RuntimeException(sprintf(
-                    "The middleware named '%s' has not been registered. Use registerMiddleware() to define it.",
+                    'The middleware named `%s` has not been registered. Use `registerMiddleware()` to define it.',
                     $name
                 ));
             }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -364,7 +364,7 @@ class Router
                     $ref = new ReflectionFunction($filter);
                 }
                 $message = sprintf(
-                    'URL filter defined in %s on line %s could not be applied. The filter failed with: %s',
+                    'URL filter defined in `%s` on line %s could not be applied. The filter failed with: `%s`',
                     $ref->getFileName(),
                     $ref->getStartLine(),
                     $e->getMessage()
@@ -970,9 +970,10 @@ class Router
     {
         foreach (['plugin', 'prefix', 'controller', 'action'] as $key) {
             if (array_key_exists($key, $url)) {
-                throw new InvalidArgumentException(
-                    "`$key` cannot be used when defining route targets with a string route path."
-                );
+                throw new InvalidArgumentException(sprintf(
+                    '`%s` cannot be used when defining route targets with a string route path.',
+                    $key
+                ));
             }
         }
         $url += static::parseRoutePath($url['_path']);
@@ -1012,7 +1013,7 @@ class Router
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {
-            throw new InvalidArgumentException("Could not parse a string route path `{$url}`.");
+            throw new InvalidArgumentException(sprintf('Could not parse a string route path `%s`.', $url));
         }
 
         $defaults = [];

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -89,7 +89,7 @@ class EventFiredWith extends Constraint
 
         if (count($events) > 1) {
             throw new AssertionFailedError(sprintf(
-                'Event "%s" was fired %d times, cannot make data assertion',
+                'Event `%s` was fired %d times, cannot make data assertion',
                 $other,
                 count($events)
             ));

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -83,11 +83,11 @@ class FixtureHelper
             }
 
             if (isset($fixtures[$className])) {
-                throw new UnexpectedValueException("Found duplicate fixture `$fixtureName`.");
+                throw new UnexpectedValueException(sprintf('Found duplicate fixture `%s`.', $fixtureName));
             }
 
             if (!class_exists($className)) {
-                throw new UnexpectedValueException("Could not find fixture `$fixtureName`.");
+                throw new UnexpectedValueException(sprintf('Could not find fixture `%s`.', $fixtureName));
             }
 
             if (!isset($cachedFixtures[$className])) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -232,7 +232,7 @@ class FixtureManager
                 $this->_fixtureMap[$name] = $this->_loaded[$fixture];
             } else {
                 $msg = sprintf(
-                    'Referenced fixture class "%s" not found. Fixture "%s" was referenced in test case "%s".',
+                    'Referenced fixture class `%s` not found. Fixture `%s` was referenced in test case `%s`.',
                     $className,
                     $fixture,
                     get_class($test)
@@ -309,7 +309,7 @@ class FixtureManager
                             $fixture->dropConstraints($db);
                         } catch (PDOException $e) {
                             $msg = sprintf(
-                                'Unable to drop constraints for fixture "%s" in "%s" test case: ' . "\n" . '%s',
+                                'Unable to drop constraints for fixture `%s` in `%s` test case: ' . "\n" . '`%s`',
                                 get_class($fixture),
                                 get_class($test),
                                 $e->getMessage()
@@ -336,7 +336,7 @@ class FixtureManager
                         $fixture->createConstraints($db);
                     } catch (PDOException $e) {
                         $msg = sprintf(
-                            'Unable to create constraints for fixture "%s" in "%s" test case: ' . "\n" . '%s',
+                            'Unable to create constraints for fixture `%s` in `%s` test case: ' . "\n" . '`%s`',
                             get_class($fixture),
                             get_class($test),
                             $e->getMessage()
@@ -354,7 +354,7 @@ class FixtureManager
                         $fixture->insert($db);
                     } catch (PDOException $e) {
                         $msg = sprintf(
-                            'Unable to insert fixture "%s" in "%s" test case: ' . "\n" . '%s',
+                            'Unable to insert fixture `%s` in `%s` test case: ' . "\n" . '`%s`',
                             get_class($fixture),
                             get_class($test),
                             $e->getMessage()
@@ -366,7 +366,7 @@ class FixtureManager
             $this->_runOperation($fixtures, $insert);
         } catch (PDOException $e) {
             $msg = sprintf(
-                'Unable to insert fixtures for "%s" test case. %s',
+                'Unable to insert fixtures for `%s` test case. `%s`',
                 get_class($test),
                 $e->getMessage()
             );
@@ -458,7 +458,7 @@ class FixtureManager
     public function loadSingle(string $name, ?ConnectionInterface $connection = null, bool $dropTables = true): void
     {
         if (!isset($this->_fixtureMap[$name])) {
-            throw new UnexpectedValueException(sprintf('Referenced fixture class %s not found', $name));
+            throw new UnexpectedValueException(sprintf('Referenced fixture class `%s` not found', $name));
         }
 
         $fixture = $this->_fixtureMap[$name];

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -76,7 +76,7 @@ class SchemaLoader
         $connection = ConnectionManager::get($connectionName);
         foreach ($files as $file) {
             if (!file_exists($file)) {
-                throw new InvalidArgumentException("Unable to load SQL file `$file`.");
+                throw new InvalidArgumentException(sprintf('Unable to load SQL file `%s`.', $file));
             }
             $sql = file_get_contents($file);
 

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -105,7 +105,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             $connection = $this->connection;
             if (strpos($connection, 'test') !== 0) {
                 $message = sprintf(
-                    'Invalid datasource name "%s" for "%s" fixture. Fixture datasource names must begin with "test".',
+                    'Invalid datasource name `%s` for `%s` fixture. Fixture datasource names must begin with `test`.',
                     $connection,
                     static::class
                 );
@@ -288,7 +288,7 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
             }
         } catch (Exception $e) {
             $msg = sprintf(
-                'Fixture creation for "%s" failed "%s"',
+                'Fixture creation for `%s` failed `%s`',
                 $this->table,
                 $e->getMessage()
             );

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -65,11 +65,12 @@ class TransactionStrategy implements FixtureStrategyInterface
                 );
                 $connection->enableSavePoints();
                 if (!$connection->isSavePointsEnabled()) {
-                    throw new RuntimeException(
-                        "Could not enable save points for the `{$connection->configName()}` connection. " .
+                    throw new RuntimeException(sprintf(
+                        'Could not enable save points for the `%s` connection. ' .
                             'Your database needs to support savepoints in order to use ' .
-                            'TransactionStrategy.'
-                    );
+                            'TransactionStrategy.',
+                        $connection->configName()
+                    ));
                 }
 
                 $connection->begin();

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -379,7 +379,7 @@ abstract class TestCase extends BaseTestCase
             /** @var \Cake\Routing\RoutingApplicationInterface $app */
             $app = $reflect->newInstanceArgs($appArgs);
         } catch (ReflectionException $e) {
-            throw new LogicException(sprintf('Cannot load "%s" to load routes from.', $className), 0, $e);
+            throw new LogicException(sprintf('Cannot load `%s` to load routes from.', $className), 0, $e);
         }
         $builder = Router::createRouteBuilder('/');
         $app->routes($builder);

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -82,7 +82,7 @@ trait CookieCryptTrait
     {
         if (!in_array($encrypt, $this->_validCiphers, true)) {
             $msg = sprintf(
-                'Invalid encryption cipher. Must be one of %s or false.',
+                'Invalid encryption cipher. Must be one of `%s` or false.',
                 implode(', ', $this->_validCiphers)
             );
             throw new RuntimeException($msg);

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -63,7 +63,7 @@ class Hash
         } else {
             if (!is_array($path)) {
                 throw new InvalidArgumentException(sprintf(
-                    'Invalid Parameter %s, should be dot separated path or array.',
+                    'Invalid Parameter `%s`, should be dot separated path or array.',
                     $path
                 ));
             }
@@ -498,7 +498,7 @@ class Hash
 
         if (is_array($keys) && count($keys) !== count($vals)) {
             throw new RuntimeException(
-                'Hash::combine() needs an equal number of keys + values.'
+                '`Hash::combine()` needs an equal number of keys + values.'
             );
         }
 

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -70,7 +70,7 @@ class Security
         $availableAlgorithms = hash_algos();
         if (!in_array($algorithm, $availableAlgorithms, true)) {
             throw new RuntimeException(sprintf(
-                'The hash type `%s` was not found. Available algorithms are: %s',
+                'The hash type `%s` was not found. Available algorithms are: `%s`',
                 $algorithm,
                 implode(', ', $availableAlgorithms)
             ));
@@ -221,9 +221,10 @@ class Security
     protected static function _checkKey(string $key, string $method): void
     {
         if (mb_strlen($key, '8bit') < 32) {
-            throw new InvalidArgumentException(
-                sprintf('Invalid key for %s, key must be at least 256 bits (32 bytes) long.', $method)
-            );
+            throw new InvalidArgumentException(sprintf(
+                'Invalid key for `%s`, key must be at least 256 bits (32 bytes) long.',
+                $method
+            ));
         }
     }
 
@@ -288,7 +289,7 @@ class Security
     {
         if (static::$_salt === null) {
             throw new RuntimeException(
-                'Salt not set. Use Security::setSalt() to set one, ideally in `config/bootstrap.php`.'
+                'Salt not set. Use `Security::setSalt()` to set one, ideally in `config/bootstrap.php`.'
             );
         }
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -1125,7 +1125,7 @@ class Text
 
         $return = transliterator_transliterate($transliterator, $string);
         if ($return === false) {
-            throw new CakeException(sprintf('Unable to transliterate string: %s', $string));
+            throw new CakeException(sprintf('Unable to transliterate string: `%s`', $string));
         }
 
         return $return;

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -122,7 +122,7 @@ class Xml
 
         if (!is_string($input)) {
             $type = gettype($input);
-            throw new XmlException("Invalid input. {$type} cannot be parsed as XML.");
+            throw new XmlException(sprintf('Invalid input. `%s` cannot be parsed as XML.', $type));
         }
 
         if (strpos($input, '<') !== false) {
@@ -359,14 +359,14 @@ class Xml
                         throw new XmlException('Invalid array');
                     }
                     if (is_numeric(implode('', array_keys($value)))) {
-// List
+                        // List
                         foreach ($value as $item) {
                             $itemData = compact('dom', 'node', 'key', 'format');
                             $itemData['value'] = $item;
                             static::_createChild($itemData);
                         }
                     } else {
-// Struct
+                        // Struct
                         static::_createChild(compact('dom', 'node', 'key', 'value', 'format'));
                     }
                 }

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1235,7 +1235,7 @@ class Validation
         }
 
         if (!function_exists('finfo_open')) {
-            throw new LogicException('ext/fileinfo is required for validating file mime types');
+            throw new LogicException('`ext/fileinfo` is required for validating file mime types');
         }
 
         if (!is_file($file)) {
@@ -1524,7 +1524,7 @@ class Validation
         ];
         if ($options['type'] !== 'latLong') {
             throw new RuntimeException(sprintf(
-                'Unsupported coordinate type "%s". Use "latLong" instead.',
+                'Unsupported coordinate type `%s`. Use `latLong` instead.',
                 $options['type']
             ));
         }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -130,7 +130,7 @@ class ValidationRule
         if (!$isCallable) {
             /** @psalm-suppress PossiblyInvalidArgument */
             $message = sprintf(
-                'Unable to call method "%s" in "%s" provider for field "%s"',
+                'Unable to call method `%s` in `%s` provider for field `%s`',
                 $this->_rule,
                 $this->_provider,
                 $context['field']

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -529,7 +529,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 }
 
                 if ($validationSet->offsetExists($name)) {
-                    $message = 'You cannot add a rule without a unique name, already existing rule found: ' . $name;
+                    $message = sprintf(
+                        'You cannot add a rule without a unique name, already existing rule found: `%s`',
+                        $name
+                    );
                     throw new InvalidArgumentException($message);
                 }
 
@@ -1156,7 +1159,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
         if (!is_array($settings)) {
             throw new InvalidArgumentException(
-                sprintf('Invalid settings for "%s". Settings must be an array.', $fieldName)
+                sprintf('Invalid settings for `%s`. Settings must be an array.', $fieldName)
             );
         }
         $settings += $defaults;

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -113,7 +113,7 @@ trait ValidatorAwareTrait
     {
         $method = 'validation' . ucfirst($name);
         if (!$this->validationMethodExists($method)) {
-            $message = sprintf('The %s::%s() validation method does not exists.', static::class, $method);
+            $message = sprintf('The `%s::%s()` validation method does not exists.', static::class, $method);
             throw new RuntimeException($message);
         }
 
@@ -128,7 +128,7 @@ trait ValidatorAwareTrait
 
         if (!$validator instanceof Validator) {
             throw new RuntimeException(sprintf(
-                'The %s::%s() validation method must return an instance of %s.',
+                'The `%s::%s()` validation method must return an instance of `%s`.',
                 static::class,
                 $method,
                 Validator::class

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -174,7 +174,7 @@ abstract class Cell implements EventDispatcherInterface
                 $reflect->invokeArgs($this, $this->args);
             } catch (ReflectionException $e) {
                 throw new BadMethodCallException(sprintf(
-                    'Class %s does not have a "%s" method.',
+                    'Class `%s` does not have a `%s` method.',
                     static::class,
                     $this->action
                 ));

--- a/src/View/Exception/MissingCellException.php
+++ b/src/View/Exception/MissingCellException.php
@@ -26,5 +26,5 @@ class MissingCellException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Cell class %s is missing.';
+    protected $_messageTemplate = 'Cell class `%s` is missing.';
 }

--- a/src/View/Exception/MissingHelperException.php
+++ b/src/View/Exception/MissingHelperException.php
@@ -24,5 +24,5 @@ class MissingHelperException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'Helper class %s could not be found.';
+    protected $_messageTemplate = 'Helper class `%s` could not be found.';
 }

--- a/src/View/Exception/MissingViewException.php
+++ b/src/View/Exception/MissingViewException.php
@@ -26,5 +26,5 @@ class MissingViewException extends CakeException
     /**
      * @inheritDoc
      */
-    protected $_messageTemplate = 'View class "%s" is missing.';
+    protected $_messageTemplate = 'View class `%s` is missing.';
 }

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -153,7 +153,7 @@ class ContextFactory
         if (!isset($context)) {
             throw new RuntimeException(sprintf(
                 'No context provider found for value of type `%s`.'
-                . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.',
+                . ' Use `null` as 1st argument of `FormHelper::create()` to create a context-less form.',
                 getTypeName($data['entity'])
             ));
         }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -390,7 +390,7 @@ class EntityContext implements ContextInterface
             $entity = $next;
         }
         throw new RuntimeException(sprintf(
-            'Unable to fetch property "%s"',
+            'Unable to fetch property `%s`',
             implode('.', $path)
         ));
     }
@@ -416,7 +416,7 @@ class EntityContext implements ContextInterface
         $oneElement = count($path) === 1;
         if ($oneElement && $this->_isCollection) {
             throw new RuntimeException(sprintf(
-                'Unable to fetch property "%s"',
+                'Unable to fetch property `%s`',
                 implode('.', $path)
             ));
         }
@@ -457,7 +457,7 @@ class EntityContext implements ContextInterface
             $entity = $next;
         }
         throw new RuntimeException(sprintf(
-            'Unable to fetch property "%s"',
+            'Unable to fetch property `%s`',
             implode('.', $path)
         ));
     }
@@ -610,7 +610,7 @@ class EntityContext implements ContextInterface
 
         $table = $this->_getTable($parts);
         if (!$table) {
-            throw new RuntimeException('Validator not found: ' . $key);
+            throw new RuntimeException(sprintf('Validator not found: `%s`', $key));
         }
         $alias = $table->getAlias();
 

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -55,7 +55,7 @@ class FormContext implements ContextInterface
     public function __construct(array $context)
     {
         if (!isset($context['entity']) || !$context['entity'] instanceof Form) {
-            throw new CakeException('`$context[\'entity\']` must be an instance of Cake\Form\Form');
+            throw new CakeException('`$context[\'entity\']` must be an instance of `Cake\Form\Form`');
         }
 
         $this->_form = $context['entity'];

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -157,7 +157,7 @@ class BreadcrumbsHelper extends Helper
     public function insertAt(int $index, string $title, $url = null, array $options = [])
     {
         if (!isset($this->crumbs[$index]) && $index !== count($this->crumbs)) {
-            throw new LogicException(sprintf("No crumb could be found at index '%s'", $index));
+            throw new LogicException(sprintf('No crumb could be found at index `%s`', $index));
         }
 
         array_splice($this->crumbs, $index, 0, [compact('title', 'url', 'options')]);
@@ -189,7 +189,7 @@ class BreadcrumbsHelper extends Helper
         $key = $this->findCrumb($matchingTitle);
 
         if ($key === null) {
-            throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
+            throw new LogicException(sprintf('No crumb matching `%s` could be found.', $matchingTitle));
         }
 
         return $this->insertAt($key, $title, $url, $options);
@@ -219,7 +219,7 @@ class BreadcrumbsHelper extends Helper
         $key = $this->findCrumb($matchingTitle);
 
         if ($key === null) {
-            throw new LogicException(sprintf("No crumb matching '%s' could be found.", $matchingTitle));
+            throw new LogicException(sprintf('No crumb matching `%s` could be found.', $matchingTitle));
         }
 
         return $this->insertAt($key + 1, $title, $url, $options);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1210,7 +1210,7 @@ class FormHelper extends Helper
 
                 return $this->{$options['type']}($fieldName, $opts, $options + ['label' => $label]);
             case 'input':
-                throw new RuntimeException("Invalid type 'input' used for field '$fieldName'");
+                throw new RuntimeException(sprintf('Invalid type `input` used for field `%s`', $fieldName));
 
             default:
                 return $this->{$options['type']}($fieldName, $options);
@@ -1606,7 +1606,7 @@ class FormHelper extends Helper
     public function __call(string $method, array $params)
     {
         if (empty($params)) {
-            throw new CakeException(sprintf('Missing field name for FormHelper::%s', $method));
+            throw new CakeException(sprintf('Missing field name for `FormHelper::%s`', $method));
         }
         $options = $params[1] ?? [];
         $options['type'] = $options['type'] ?? $method;
@@ -2541,7 +2541,7 @@ class FormHelper extends Helper
 
         if ($diff) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid value source(s): %s. Valid values are: %s',
+                'Invalid value source(s): `%s`. Valid values are: `%s`',
                 implode(', ', $diff),
                 implode(', ', $this->supportedValueSources)
             ));

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -69,7 +69,7 @@ class NumberHelper extends Helper
         /** @psalm-var class-string<\Cake\I18n\Number>|null $engineClass */
         $engineClass = App::className($config['engine'], 'Utility');
         if ($engineClass === null) {
-            throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
+            throw new CakeException(sprintf('Class for `%s` could not be found', $config['engine']));
         }
 
         $this->_engine = new $engineClass($config);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -86,7 +86,7 @@ class TextHelper extends Helper
         /** @psalm-var class-string<\Cake\Utility\Text>|null $engineClass */
         $engineClass = App::className($config['engine'], 'Utility');
         if ($engineClass === null) {
-            throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
+            throw new CakeException(sprintf('Class for `%s` could not be found', $config['engine']));
         }
 
         $this->_engine = new $engineClass($config);

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -58,7 +58,7 @@ class UrlHelper extends Helper
         /** @psalm-var class-string<\Cake\Routing\Asset>|null $engineClass */
         $engineClass = App::className($engineClassConfig, 'Routing');
         if ($engineClass === null) {
-            throw new CakeException(sprintf('Class for %s could not be found', $engineClassConfig));
+            throw new CakeException(sprintf('Class for `%s` could not be found', $engineClassConfig));
         }
 
         $this->_assetUrlClassName = $engineClass;

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -234,7 +234,7 @@ class StringTemplate
     public function format(string $name, array $data): string
     {
         if (!isset($this->_compiled[$name])) {
-            throw new RuntimeException("Cannot find template named '$name'.");
+            throw new RuntimeException(sprintf('Cannot find template named `%s`.', $name));
         }
         [$template, $placeholders] = $this->_compiled[$name];
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -812,7 +812,7 @@ class View implements EventDispatcherInterface
             if (empty($this->layout)) {
                 throw new RuntimeException(
                     'View::$layout must be a non-empty string.' .
-                    'To disable layout rendering use method View::disableAutoLayout() instead.'
+                    'To disable layout rendering use method `View::disableAutoLayout()` instead.'
                 );
             }
 
@@ -1085,7 +1085,7 @@ class View implements EventDispatcherInterface
                     $paths = $this->_paths($plugin);
                     $defaultPath = $paths[0] . static::TYPE_ELEMENT . DIRECTORY_SEPARATOR;
                     throw new LogicException(sprintf(
-                        'You cannot extend an element which does not exist (%s).',
+                        'You cannot extend an element which does not exist `%s`.',
                         $defaultPath . $name . $this->_ext
                     ));
                 }
@@ -1193,7 +1193,7 @@ class View implements EventDispatcherInterface
 
         if ($initialBlocks !== $remainingBlocks) {
             throw new LogicException(sprintf(
-                'The "%s" block was left open. Blocks are not allowed to cross files.',
+                'The `%s` block was left open. Blocks are not allowed to cross files.',
                 (string)$this->Blocks->active()
             ));
         }
@@ -1428,7 +1428,7 @@ class View implements EventDispatcherInterface
         $absolute = realpath($file);
         if (strpos($absolute, $path) !== 0) {
             throw new InvalidArgumentException(sprintf(
-                'Cannot use "%s" as a template, it is not within any view template path.',
+                'Cannot use `%s` as a template, it is not within any view template path.',
                 $file
             ));
         }
@@ -1475,7 +1475,7 @@ class View implements EventDispatcherInterface
             if (empty($this->layout)) {
                 throw new RuntimeException(
                     'View::$layout must be a non-empty string.' .
-                    'To disable layout rendering use method View::disableAutoLayout() instead.'
+                    'To disable layout rendering use method `View::disableAutoLayout()` instead.'
                 );
             }
             $name = $this->layout;

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -88,7 +88,7 @@ class ViewBlock
     public function start(string $name, string $mode = ViewBlock::OVERRIDE): void
     {
         if (array_key_exists($name, $this->_active)) {
-            throw new CakeException(sprintf("A view block with the name '%s' is already/still open.", $name));
+            throw new CakeException(sprintf('A view block with the name `%s` is already/still open.', $name));
         }
         $this->_active[$name] = $mode;
         ob_start();

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -111,7 +111,7 @@ class DateTimeWidget extends BasicWidget
 
         if (!isset($this->formatMap[$data['type']])) {
             throw new InvalidArgumentException(sprintf(
-                'Invalid type `%s` for input tag, expected datetime-local, date, time, month or week',
+                'Invalid type `%s` for input tag, expected `datetime-local`, `date`, `time`, `month` or `week`',
                 $data['type']
             ));
         }

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -198,7 +198,7 @@ class WidgetLocator
         $class = array_shift($config);
         $className = App::className($class, 'View/Widget', 'Widget');
         if ($className === null) {
-            throw new RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
+            throw new RuntimeException(sprintf('Unable to locate widget class `%s`', $class));
         }
         if (count($config)) {
             $reflection = new ReflectionClass($className);

--- a/tests/TestCase/Auth/PasswordHasherFactoryTest.php
+++ b/tests/TestCase/Auth/PasswordHasherFactoryTest.php
@@ -51,7 +51,7 @@ class PasswordHasherFactoryTest extends TestCase
     public function testBuildException(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Password hasher class "FooBar" was not found.');
+        $this->expectExceptionMessage('Password hasher class `FooBar` was not found.');
         $hasher = PasswordHasherFactory::build('FooBar');
     }
 }

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -246,7 +246,7 @@ class CacheTest extends TestCase
         ]);
 
         $this->expectError();
-        $this->expectErrorMessage('Cache engines must use Cake\Cache\CacheEngine');
+        $this->expectErrorMessage('Cache engines must use `Cake\Cache\CacheEngine`');
 
         Cache::pool('tests');
     }

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -154,7 +154,7 @@ class MemcachedEngineTest extends TestCase
     public function testInvalidSerializerSetting(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('invalid_serializer is not a valid serializer engine for Memcached');
+        $this->expectExceptionMessage('`invalid_serializer` is not a valid serializer engine for Memcached');
         $Memcached = new MemcachedEngine();
         $config = [
             'className' => 'Memcached',

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -101,7 +101,7 @@ class CacheCommandsTest extends TestCase
     {
         $this->exec('cache clear foo');
         $this->assertExitCode(Shell::CODE_ERROR);
-        $this->assertErrorContains('The "foo" cache configuration does not exist');
+        $this->assertErrorContains('The `foo` cache configuration does not exist');
     }
 
     /**

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -89,7 +89,7 @@ class PluginLoadCommandTest extends TestCase
     {
         $this->exec('plugin load NopeNotThere');
         $this->assertExitCode(Command::CODE_ERROR);
-        $this->assertErrorContains('Plugin NopeNotThere could not be found');
+        $this->assertErrorContains('Plugin `NopeNotThere` could not be found');
 
         $contents = file_get_contents($this->app);
         $this->assertStringNotContainsString("\$this->addPlugin('NopeNotThere');", $contents);

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -57,7 +57,7 @@ class CommandCollectionTest extends TestCase
     public function testConstructorInvalidClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'nope\'. It is not a subclass of Cake\Console\Shell');
+        $this->expectExceptionMessage('Cannot use `stdClass` for command `nope`. It is not a subclass of `Cake\Console\Shell`');
         new CommandCollection([
             'sample' => SampleShell::class,
             'nope' => stdClass::class,
@@ -117,7 +117,7 @@ class CommandCollectionTest extends TestCase
     public function testAddInvalidInstance(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'routes\'. It is not a subclass of Cake\Console\Shell');
+        $this->expectExceptionMessage('Cannot use `stdClass` for command `routes`. It is not a subclass of `Cake\Console\Shell`');
         $collection = new CommandCollection();
         $shell = new stdClass();
         $collection->add('routes', $shell);
@@ -161,7 +161,7 @@ class CommandCollectionTest extends TestCase
     public function testInvalidShellClassName(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use \'stdClass\' for command \'routes\'. It is not a subclass of Cake\Console\Shell');
+        $this->expectExceptionMessage('Cannot use `stdClass` for command `routes`. It is not a subclass of `Cake\Console\Shell`');
         $collection = new CommandCollection();
         $collection->add('routes', stdClass::class);
     }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -81,7 +81,7 @@ class CommandTest extends TestCase
     public function testSetNameInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The name \'routes_show\' is missing a space. Names should look like `cake routes`');
+        $this->expectExceptionMessage('The name `routes_show` is missing a space. Names should look like `cake routes`');
 
         $command = new Command();
         $command->setName('routes_show');
@@ -260,7 +260,7 @@ class CommandTest extends TestCase
     public function testExecuteCommandStringInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Command class 'Nope' does not exist");
+        $this->expectExceptionMessage('Command class `Nope` does not exist');
 
         $command = new Command();
         $command->executeCommand('Nope', [], $this->getMockIo(new StubConsoleOutput()));
@@ -318,7 +318,7 @@ class CommandTest extends TestCase
     public function testExecuteCommandInstanceInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Command 'stdClass' is not a subclass");
+        $this->expectExceptionMessage('Command `stdClass` is not a subclass');
 
         $command = new Command();
         $command->executeCommand(new \stdClass(), [], $this->getMockIo(new StubConsoleOutput()));

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -506,7 +506,7 @@ class RequestHandlerComponentTest extends TestCase
     public function testUnrecognizedExtensionFailure(): void
     {
         $this->expectException(NotFoundException::class);
-        $this->expectExceptionMessage('Invoked extension not recognized/configured: foo');
+        $this->expectExceptionMessage('Invoked extension not recognized/configured: `foo`');
 
         Router::extensions(['json', 'foo'], false);
         $this->Controller->setRequest($this->Controller->getRequest()->withParam('_ext', 'foo'));

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -211,7 +211,7 @@ class ComponentRegistryTest extends TestCase
     public function testUnloadUnknown(): void
     {
         $this->expectException(MissingComponentException::class);
-        $this->expectExceptionMessage('Component class FooComponent could not be found.');
+        $this->expectExceptionMessage('Component class `FooComponent` could not be found.');
         $this->Components->unload('Foo');
     }
 

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -110,7 +110,7 @@ class ComponentTest extends TestCase
     public function testDuplicateComponentInitialize(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The "Banana" alias has already been loaded. The `property` key');
+        $this->expectExceptionMessage('The `Banana` alias has already been loaded. The `property` key');
         $Collection = new ComponentRegistry();
         $Collection->load('Banana', ['property' => ['closure' => function (): void {
         }]]);
@@ -196,7 +196,7 @@ class ComponentTest extends TestCase
     public function testLazyLoadingDoesNotExists(): void
     {
         $this->expectException(MissingComponentException::class);
-        $this->expectExceptionMessage('Component class YouHaveNoBananasComponent could not be found.');
+        $this->expectExceptionMessage('Component class `YouHaveNoBananasComponent` could not be found.');
         $Component = new ConfiguredComponent(new ComponentRegistry(), [], ['YouHaveNoBananas']);
         $bananas = $Component->YouHaveNoBananas;
     }

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -551,7 +551,7 @@ class ControllerFactoryTest extends TestCase
 
         $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage(
-            'Failed to inject dependency from service container for parameter `dep` with type `stdClass` in action Dependencies::requiredDep()'
+            'Failed to inject dependency from service container for parameter `dep` with type `stdClass` in action `Dependencies::requiredDep()`'
         );
         $this->factory->invoke($controller);
     }
@@ -569,7 +569,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Missing passed parameter for `one` in action Dependencies::requiredParam()');
+        $this->expectExceptionMessage('Missing passed parameter for `one` in action `Dependencies::requiredParam()`');
         $this->factory->invoke($controller);
     }
 
@@ -718,7 +718,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Missing passed parameter for `str` in action Dependencies::requiredString()');
+        $this->expectExceptionMessage('Missing passed parameter for `str` in action `Dependencies::requiredString()`');
         $this->factory->invoke($controller);
     }
 
@@ -812,7 +812,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "true" to `float` for `one` in action Dependencies::requiredTyped()');
+        $this->expectExceptionMessage('Unable to coerce `true` to `float` for `one` in action `Dependencies::requiredTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -833,7 +833,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "2.0" to `int` for `two` in action Dependencies::requiredTyped()');
+        $this->expectExceptionMessage('Unable to coerce `2.0` to `int` for `two` in action `Dependencies::requiredTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -854,7 +854,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "true" to `bool` for `three` in action Dependencies::requiredTyped()');
+        $this->expectExceptionMessage('Unable to coerce `true` to `bool` for `three` in action `Dependencies::requiredTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -875,7 +875,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "test" to `iterable` for `one` in action Dependencies::unsupportedTyped()');
+        $this->expectExceptionMessage('Unable to coerce `test` to `iterable` for `one` in action `Dependencies::unsupportedTyped()`');
         $this->factory->invoke($controller);
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -764,7 +764,7 @@ class ControllerTest extends TestCase
     public function testGetActionMissingAction(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::missing() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::missing()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/missing',
             'params' => ['controller' => 'Test', 'action' => 'missing'],
@@ -781,7 +781,7 @@ class ControllerTest extends TestCase
     public function testGetActionPrivate(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::private_m() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::private_m()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/private_m/',
             'params' => ['controller' => 'Test', 'action' => 'private_m'],
@@ -798,7 +798,7 @@ class ControllerTest extends TestCase
     public function testGetActionProtected(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::protected_m() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::protected_m()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/protected_m/',
             'params' => ['controller' => 'Test', 'action' => 'protected_m'],
@@ -815,7 +815,7 @@ class ControllerTest extends TestCase
     public function testGetActionBaseMethods(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::redirect() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::redirect()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/redirect/',
             'params' => ['controller' => 'Test', 'action' => 'redirect'],
@@ -832,7 +832,7 @@ class ControllerTest extends TestCase
     public function testGetActionMethodCasing(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::RETURNER() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::RETURNER()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/RETURNER/',
             'params' => ['controller' => 'Test', 'action' => 'RETURNER'],
@@ -914,7 +914,7 @@ class ControllerTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage(
             'Controller actions can only return ResponseInterface instance or null. '
-                . 'Got string instead.'
+                . 'Got `string` instead.'
         );
 
         $url = new ServerRequest([
@@ -1062,7 +1062,7 @@ class ControllerTest extends TestCase
             $controller->loadComponent('FormProtection', ['bad' => 'settings']);
             $this->fail('No exception');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "FormProtection" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The `FormProtection` alias has already been loaded', $e->getMessage());
         }
     }
 

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -83,7 +83,7 @@ class ConfigureTest extends TestCase
     public function testReadOrFailThrowingException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
+        $this->expectExceptionMessage('Expected configuration key `This.Key.Does.Not.exist` not found');
         Configure::readOrFail('This.Key.Does.Not.exist');
     }
 
@@ -575,7 +575,7 @@ class ConfigureTest extends TestCase
     public function testConsumeOrFailThrowingException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Expected configuration key "This.Key.Does.Not.exist" not found');
+        $this->expectExceptionMessage('Expected configuration key `This.Key.Does.Not.exist` not found');
         Configure::consumeOrFail('This.Key.Does.Not.exist');
     }
 }

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -265,7 +265,7 @@ class InstanceConfigTraitTest extends TestCase
     public function testSetClobber(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot set a.nested.value');
+        $this->expectExceptionMessage('Cannot set `a.nested.value`');
         $this->object->setConfig(['a.nested.value' => 'not possible'], null, false);
         $this->object->getConfig();
     }
@@ -507,7 +507,7 @@ class InstanceConfigTraitTest extends TestCase
     public function testDeleteClobber(): void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Cannot unset a.nested.value.whoops');
+        $this->expectExceptionMessage('Cannot unset `a.nested.value.whoops`');
         $this->object->setConfig('a.nested.value.whoops', null);
     }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -166,8 +166,8 @@ class ConnectionTest extends TestCase
     {
         $this->expectException(MissingExtensionException::class);
         $this->expectExceptionMessage(
-            'Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency. ' .
-            'Requested by connection "custom_connection_name"'
+            'Database driver `DriverMock` cannot be used due to a missing PHP extension or unmet dependency. ' .
+            'Requested by connection `custom_connection_name`'
         );
         $mock = $this->getMockBuilder(Mysql::class)
             ->onlyMethods(['enabled'])
@@ -210,7 +210,7 @@ class ConnectionTest extends TestCase
         $this->assertNotNull($e);
         $this->assertStringStartsWith(
             sprintf(
-                'Connection to %s could not be established:',
+                'Connection to `%s` could not be established:',
                 App::shortName(get_class($connection->getDriver()), 'Database/Driver')
             ),
             $e->getMessage()

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -226,7 +226,7 @@ class SqlserverTest extends TestCase
         ]);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Config setting "persistent" cannot be set to true, as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT');
+        $this->expectExceptionMessage('Config setting `persistent` cannot be set to true, as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT');
         $driver->connect();
     }
 

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -60,7 +60,7 @@ class DriverTest extends TestCase
             $this->getMockForAbstractClass(Driver::class, [$arg]);
         } catch (Exception $e) {
             $this->assertStringContainsString(
-                'Please pass "username" instead of "login" for connecting to the database',
+                'Please pass `username` instead of `login` for connecting to the database',
                 $e->getMessage()
             );
         }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -811,7 +811,7 @@ class QueryTest extends TestCase
     public function testSelectWhereArrayTypeEmptyWithExpression(): void
     {
         $this->expectException(DatabaseException::class);
-        $this->expectExceptionMessage('with empty list of values for field (SELECT 1)');
+        $this->expectExceptionMessage('with empty list of values for field `SELECT 1`');
         $query = new Query($this->connection);
         $result = $query
             ->select(['id'])
@@ -4936,7 +4936,7 @@ class QueryTest extends TestCase
     public function testClauseUndefined(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The \'nope\' clause is not defined. Valid clauses are: delete, update');
+        $this->expectExceptionMessage('The `nope` clause is not defined. Valid clauses are: `delete, update');
         $query = new Query($this->connection);
         $this->assertEmpty($query->clause('where'));
         $query->clause('nope');

--- a/tests/TestCase/Database/Type/BinaryTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryTypeTest.php
@@ -68,7 +68,7 @@ class BinaryTypeTest extends TestCase
     public function testToPHPFailure(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Unable to convert array into binary.');
+        $this->expectExceptionMessage('Unable to convert `array` into binary.');
         $this->type->toPHP([], $this->driver);
     }
 

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -78,7 +78,7 @@ class BinaryUuidTypeTest extends TestCase
     public function testToPHPFailure(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Unable to convert array into binary uuid.');
+        $this->expectExceptionMessage('Unable to convert `array` into binary uuid.');
 
         $this->type->toPHP([], $this->driver);
     }

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -88,7 +88,7 @@ class ConnectionManagerTest extends TestCase
     public function testConfigDuplicateConfig(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot reconfigure existing key "test_variant"');
+        $this->expectExceptionMessage('Cannot reconfigure existing key `test_variant`');
         $settings = [
             'className' => FakeConnection::class,
             'database' => ':memory:',
@@ -103,7 +103,7 @@ class ConnectionManagerTest extends TestCase
     public function testGetFailOnMissingConfig(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The datasource configuration "test_variant" was not found.');
+        $this->expectExceptionMessage('The datasource configuration `test_variant` was not found.');
         ConnectionManager::get('test_variant');
     }
 
@@ -127,7 +127,7 @@ class ConnectionManagerTest extends TestCase
     public function testGetNoAlias(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The datasource configuration "other_name" was not found.');
+        $this->expectExceptionMessage('The datasource configuration `other_name` was not found.');
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');
 
@@ -385,7 +385,7 @@ class ConnectionManagerTest extends TestCase
     public function testParseDsnInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The DSN string \'bagof:nope\' could not be parsed.');
+        $this->expectExceptionMessage('The DSN string `bagof:nope` could not be parsed.');
         $result = ConnectionManager::parseDsn('bagof:nope');
     }
 

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -41,7 +41,7 @@ class FactoryLocatorTest extends TestCase
     public function testGetNonExistent(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
+        $this->expectExceptionMessage('Unknown repository type `Test`. Make sure you register a type before trying to use it.');
         FactoryLocator::get('Test');
     }
 
@@ -69,7 +69,7 @@ class FactoryLocatorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
+            '`$factory` must be an instance of `Cake\Datasource\Locator\LocatorInterface` or a callable.'
             . ' Got type `string` instead.'
         );
 
@@ -82,7 +82,7 @@ class FactoryLocatorTest extends TestCase
     public function testDrop(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
+        $this->expectExceptionMessage('Unknown repository type `Test`. Make sure you register a type before trying to use it.');
         FactoryLocator::drop('Test');
 
         FactoryLocator::get('Test');

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -144,7 +144,7 @@ class ModelAwareTraitTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            '`$factory` must be an instance of Cake\Datasource\Locator\LocatorInterface or a callable.'
+            '`$factory` must be an instance of `Cake\Datasource\Locator\LocatorInterface` or a callable.'
             . ' Got type `string` instead.'
         );
 
@@ -178,7 +178,7 @@ class ModelAwareTraitTest extends TestCase
     public function testMissingModelException(): void
     {
         $this->expectException(MissingModelException::class);
-        $this->expectExceptionMessage('Model class "Magic" of type "Test" could not be found.');
+        $this->expectExceptionMessage('Model class `Magic` of type `Test` could not be found.');
         $stub = new Stub();
 
         $this->deprecated(function () {

--- a/tests/TestCase/Datasource/QueryCacherTest.php
+++ b/tests/TestCase/Datasource/QueryCacherTest.php
@@ -76,7 +76,7 @@ class QueryCacherTest extends TestCase
     public function testFetchFunctionKeyNoString(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cache key functions must return a string. Got false.');
+        $this->expectExceptionMessage('Cache key functions must return a string. Got `false`.');
         $this->engine->set('my_key', 'A winner');
         $query = new stdClass();
 

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -96,7 +96,7 @@ class ErrorHandlerTest extends TestCase
     public function testInvalidRenderer(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The \'TotallyInvalid\' renderer class could not be found');
+        $this->expectExceptionMessage('The `TotallyInvalid` renderer class could not be found');
 
         $errorHandler = new ErrorHandler(['exceptionRenderer' => 'TotallyInvalid']);
         $errorHandler->getRenderer(new Exception('Something bad'));

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -703,7 +703,7 @@ class ExceptionRendererTest extends TestCase
         $helpers = $controller->viewBuilder()->getHelpers();
         sort($helpers);
         $this->assertEquals([], $helpers);
-        $this->assertStringContainsString('Helper class Fail', (string)$response->getBody());
+        $this->assertStringContainsString('Helper class `Fail`', (string)$response->getBody());
     }
 
     /**

--- a/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
+++ b/tests/TestCase/Event/Decorator/ConditionDecoratorTest.php
@@ -96,7 +96,7 @@ class ConditionDecoratorTest extends TestCase
     public function testCallableRuntimeException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cake\Event\Decorator\ConditionDecorator the `if` condition is not a callable!');
+        $this->expectExceptionMessage('`Cake\Event\Decorator\ConditionDecorator` the `if` condition is not a callable!');
         $callable = function (EventInterface $event) {
             return 'success';
         };

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -78,7 +78,7 @@ class ClientTest extends TestCase
     public function testAdapterInstanceCheck(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Adapter must be an instance of Cake\Http\Client\AdapterInterface');
+        $this->expectExceptionMessage('Adapter must be an instance of `Cake\Http\Client\AdapterInterface`');
 
         new Client(['adapter' => 'stdClass']);
     }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -173,7 +173,7 @@ class CookieTest extends TestCase
     public function testWithSameSiteException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
+        $this->expectExceptionMessage('Samesite value must be either of: `' . implode(', ', CookieInterface::SAMESITE_VALUES) . '`');
 
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $cookie->withSameSite('invalid');
@@ -486,7 +486,7 @@ class CookieTest extends TestCase
     public function testInvalidSameSiteForDefaults(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Samesite value must be either of: ' . implode(', ', CookieInterface::SAMESITE_VALUES));
+        $this->expectExceptionMessage('Samesite value must be either of: `' . implode(', ', CookieInterface::SAMESITE_VALUES) . '`');
 
         Cookie::setDefaults(['samesite' => 'ompalompa']);
         $cookie = new Cookie('cakephp', 'cakephp-rocks');

--- a/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SecurityHeadersMiddlewareTest.php
@@ -80,7 +80,7 @@ class SecurityHeadersMiddlewareTest extends TestCase
     public function testCheckValues(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid arg `INVALID-VALUE!`, use one of these: all, none, master-only, by-content-type, by-ftp-filename');
+        $this->expectExceptionMessage('Invalid arg `INVALID-VALUE!`, use one of these: `all, none, master-only, by-content-type, by-ftp-filename`');
         $middleware = new SecurityHeadersMiddleware();
         $middleware->setCrossDomainPolicy('INVALID-VALUE!');
     }

--- a/tests/TestCase/Http/MiddlewareQueueTest.php
+++ b/tests/TestCase/Http/MiddlewareQueueTest.php
@@ -79,7 +79,7 @@ class MiddlewareQueueTest extends TestCase
     public function testGetException(): void
     {
         $this->expectException(OutOfBoundsException::class);
-        $this->expectExceptionMessage('Invalid current position (0)');
+        $this->expectExceptionMessage('Invalid current position `(0)`');
 
         $queue = new MiddlewareQueue();
         $queue->current();
@@ -303,7 +303,7 @@ class MiddlewareQueueTest extends TestCase
     public function testInsertBeforeInvalid(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('No middleware matching \'InvalidClassName\' could be found.');
+        $this->expectExceptionMessage('No middleware matching `InvalidClassName` could be found.');
         $one = function (): void {
         };
         $two = new SampleMiddleware();

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -201,7 +201,7 @@ class ResponseTest extends TestCase
     public function testWithTypeInvalidType(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('"beans" is an invalid content type');
+        $this->expectExceptionMessage('`beans` is an invalid content type');
         $response = new Response();
         $response->withType('beans');
     }
@@ -1020,7 +1020,7 @@ class ResponseTest extends TestCase
     public function testWithFileNotFound(): void
     {
         $this->expectException(NotFoundException::class);
-        $this->expectExceptionMessage('The requested file /some/missing/folder/file.jpg was not found');
+        $this->expectExceptionMessage('The requested file `/some/missing/folder/file.jpg` was not found');
 
         $response = new Response();
         $response->withFile('/some/missing/folder/file.jpg');
@@ -1049,8 +1049,8 @@ class ResponseTest extends TestCase
         return [
             ['my/../cat.gif', 'The requested file contains `..` and will not be read.'],
             ['my\..\cat.gif', 'The requested file contains `..` and will not be read.'],
-            ['my/ca..t.gif', 'my/ca..t.gif was not found or not readable'],
-            ['my/ca..t/image.gif', 'my/ca..t/image.gif was not found or not readable'],
+            ['my/ca..t.gif', '`my/ca..t.gif` was not found or not readable'],
+            ['my/ca..t/image.gif', '`my/ca..t/image.gif` was not found or not readable'],
         ];
     }
 
@@ -1392,7 +1392,7 @@ class ResponseTest extends TestCase
     public function testWithStatusInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid status code: 1001. Use a valid HTTP status code in range 1xx - 5xx.');
+        $this->expectExceptionMessage('Invalid status code: `1001`. Use a valid HTTP status code in range 1xx - 5xx.');
         $response = new Response();
         $response->withStatus(1001);
     }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -334,7 +334,7 @@ class ServerRequestTest extends TestCase
     public function testWithUploadedFilesInvalidFile(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid file at \'avatar\'');
+        $this->expectExceptionMessage('Invalid file at `avatar`');
         $request = new ServerRequest();
         $request->withUploadedFiles(['avatar' => 'not a file']);
     }
@@ -345,7 +345,7 @@ class ServerRequestTest extends TestCase
     public function testWithUploadedFilesInvalidFileNested(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid file at \'user.avatar\'');
+        $this->expectExceptionMessage('Invalid file at `user.avatar`');
         $request = new ServerRequest();
         $request->withUploadedFiles(['user' => ['avatar' => 'not a file']]);
     }
@@ -579,7 +579,7 @@ class ServerRequestTest extends TestCase
     public function testWithMethodInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported HTTP method "no good" provided');
+        $this->expectExceptionMessage('Unsupported HTTP method `no good` provided');
         $request = new ServerRequest([
             'environment' => ['REQUEST_METHOD' => 'delete'],
         ]);
@@ -619,7 +619,7 @@ class ServerRequestTest extends TestCase
     public function testWithProtocolVersionInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported protocol version \'no good\' provided');
+        $this->expectExceptionMessage('Unsupported protocol version `no good` provided');
         $request = new ServerRequest();
         $request->withProtocolVersion('no good');
     }

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -497,7 +497,7 @@ class SessionTest extends TestCase
     public function testBadEngine(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The class "Derp" does not exist and cannot be used as a session engine');
+        $this->expectExceptionMessage('The class `Derp` does not exist and cannot be used as a session engine');
         $session = new Session();
         $session->engine('Derp');
     }

--- a/tests/TestCase/Mailer/EmailTest.php
+++ b/tests/TestCase/Mailer/EmailTest.php
@@ -315,7 +315,7 @@ class EmailTest extends TestCase
     public function testClassNameException(): void
     {
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Mailer transport TestFalse is not available.');
+        $this->expectExceptionMessage('Mailer transport `TestFalse` is not available.');
         $email = new Email();
         $email->setTransport('badClassName');
     }
@@ -326,7 +326,7 @@ class EmailTest extends TestCase
     public function testUnsetEmailPattern(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
+        $this->expectExceptionMessage('Invalid email set for `to`. You passed `fail.@example.com`.');
         $email = new Email();
         $this->assertSame(Email::EMAIL_PATTERN, $email->getEmailPattern());
 
@@ -343,7 +343,7 @@ class EmailTest extends TestCase
     public function testEmptyTo(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The email set for "to" is empty.');
+        $this->expectExceptionMessage('The email set for `to` is empty.');
         $email = new Email();
         $email->setTo('');
     }
@@ -821,7 +821,7 @@ class EmailTest extends TestCase
     public function testTransportInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "Invalid" transport configuration does not exist');
+        $this->expectExceptionMessage('The `Invalid` transport configuration does not exist');
         $this->Email->setTransport('Invalid');
     }
 
@@ -840,7 +840,7 @@ class EmailTest extends TestCase
     public function testTransportTypeInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value passed for the "$name" argument must be either a string, or an object, integer given.');
+        $this->expectExceptionMessage('The value passed for the `$name` argument must be either a string, or an object, `integer` given.');
         $this->Email->setTransport(123);
     }
 
@@ -909,7 +909,7 @@ class EmailTest extends TestCase
     public function testProfileInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown email configuration "derp".');
+        $this->expectExceptionMessage('Unknown email configuration `derp`.');
         $email = new Email();
         $email->setProfile('derp');
     }

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -50,7 +50,7 @@ class MailerAwareTraitTest extends TestCase
     public function testGetMailerThrowsException(): void
     {
         $this->expectException(MissingMailerException::class);
-        $this->expectExceptionMessage('Mailer class "Test" could not be found.');
+        $this->expectExceptionMessage('Mailer class `Test` could not be found.');
         $stub = new Stub();
         $stub->getMailer('Test');
     }

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -101,7 +101,7 @@ class MailerTest extends TestCase
     public function testTransportInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "Invalid" transport configuration does not exist');
+        $this->expectExceptionMessage('The `Invalid` transport configuration does not exist');
         $this->mailer->setTransport('Invalid');
     }
 
@@ -120,7 +120,7 @@ class MailerTest extends TestCase
     public function testTransportTypeInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value passed for the "$name" argument must be either a string, or an object, integer given.');
+        $this->expectExceptionMessage('The value passed for the `$name` argument must be either a string, or an object, `integer` given.');
         $this->mailer->setTransport(123);
     }
 
@@ -286,7 +286,7 @@ class MailerTest extends TestCase
     public function testProfileInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown email configuration "derp".');
+        $this->expectExceptionMessage('Unknown email configuration `derp`.');
         $mailer = new Mailer();
         $mailer->setProfile('derp');
     }
@@ -1311,7 +1311,7 @@ class MailerTest extends TestCase
     public function testMissingActionThrowsException(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Mail Cake\Mailer\Mailer::test() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Mail `Cake\Mailer\Mailer::test()` could not be found, or is not accessible.');
         (new Mailer())->send('test');
     }
 

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -570,7 +570,7 @@ HTML;
     public function testUnsetEmailPattern(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
+        $this->expectExceptionMessage('Invalid email set for `to`. You passed `fail.@example.com`');
         $email = new Message();
         $this->assertSame(Message::EMAIL_PATTERN, $email->getEmailPattern());
 
@@ -587,7 +587,7 @@ HTML;
     public function testEmptyTo(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The email set for "to" is empty.');
+        $this->expectExceptionMessage('The email set for `to` is empty.');
         $email = new Message();
         $email->setTo('');
     }

--- a/tests/TestCase/Mailer/TransportFactoryTest.php
+++ b/tests/TestCase/Mailer/TransportFactoryTest.php
@@ -63,7 +63,7 @@ class TransportFactoryTest extends TestCase
     public function testGetMissingClassName(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Transport config "debug" is invalid, the required `className` option is missing');
+        $this->expectExceptionMessage('Transport config `debug` is invalid, the required `className` option is missing');
 
         TransportFactory::drop('debug');
         TransportFactory::setConfig('debug', []);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -154,7 +154,7 @@ class BelongsToManyTest extends TestCase
     public function testStrategyFailure(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid strategy "join" was provided');
+        $this->expectExceptionMessage('Invalid strategy `join` was provided');
         $assoc = new BelongsToMany('Test');
         $assoc->setStrategy(BelongsToMany::STRATEGY_JOIN);
     }
@@ -330,7 +330,7 @@ class BelongsToManyTest extends TestCase
     public function testSaveStrategyInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid save strategy "depsert"');
+        $this->expectExceptionMessage('Invalid save strategy `depsert`');
         new BelongsToMany('Test', ['saveStrategy' => 'depsert']);
     }
 
@@ -1472,7 +1472,7 @@ class BelongsToManyTest extends TestCase
     public function testEagerLoadingRequiresPrimaryKey(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The "tags" table does not define a primary key');
+        $this->expectExceptionMessage('The `tags` table does not define a primary key');
         $table = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
         $tags->getSchema()->dropConstraint('primary');

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -251,7 +251,7 @@ class BelongsToTest extends TestCase
     public function testAttachToMultiPrimaryKeyMismatch(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"');
+        $this->expectExceptionMessage('Cannot match provided foreignKey for `Companies`, got `(company_id)` but expected foreign key for `(id, tenant_id)`');
         $this->company->setPrimaryKey(['id', 'tenant_id']);
         $query = $this->client->query();
         $config = [

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -182,7 +182,7 @@ class HasManyTest extends TestCase
     public function testStrategyFailure(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid strategy "join" was provided');
+        $this->expectExceptionMessage('Invalid strategy `join` was provided');
         $assoc = new HasMany('Test');
         $assoc->setStrategy(HasMany::STRATEGY_JOIN);
     }
@@ -320,7 +320,7 @@ class HasManyTest extends TestCase
     public function testEagerLoaderFieldsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('You are required to select the "Articles.author_id"');
+        $this->expectExceptionMessage('You are required to select the `Articles.author_id`');
         $config = [
             'sourceTable' => $this->author,
             'targetTable' => $this->article,
@@ -859,7 +859,7 @@ class HasManyTest extends TestCase
     public function testSaveAssociatedNotEmptyNotIterable(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Could not save comments, it cannot be traversed');
+        $this->expectExceptionMessage('Could not save `comments`, it cannot be traversed');
         $articles = $this->getTableLocator()->get('Articles');
         $association = $articles->hasMany('Comments', [
             'saveStrategy' => HasMany::SAVE_APPEND,

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -183,7 +183,7 @@ class HasOneTest extends TestCase
     public function testAttachToMultiPrimaryKeyMismatch(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"');
+        $this->expectExceptionMessage('Cannot match provided foreignKey for `Profiles`, got `(user_id)` but expected foreign key for `(id, site_id)`');
         $query = $this->getMockBuilder('Cake\ORM\Query')
             ->onlyMethods(['join', 'select'])
             ->disableOriginalConstructor()

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -390,7 +390,7 @@ class AssociationCollectionTest extends TestCase
     public function testErrorOnUnknownAlias(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot save Profiles, it is not associated to Users');
+        $this->expectExceptionMessage('Cannot save `Profiles`, it is not associated to `Users`');
         $table = $this->getMockBuilder('Cake\ORM\Table')
             ->onlyMethods(['save'])
             ->setConstructorArgs([['alias' => 'Users']])

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -110,7 +110,7 @@ class AssociationTest extends TestCase
     public function testSetNameAfterTarget(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Association name "Bar" does not match target table alias');
+        $this->expectExceptionMessage('Association name `Bar` does not match target table alias');
         $this->deprecated(function () {
             $this->association->getTarget();
             $this->association->setName('Bar');
@@ -161,7 +161,7 @@ class AssociationTest extends TestCase
     public function testSetClassNameAfterTarget(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The class name "' . AuthorsTable::class . '" doesn\'t match the target table class name of');
+        $this->expectExceptionMessage('The class name `' . AuthorsTable::class . '` doesn\'t match the target table class name of');
         $this->association->getTarget();
         $this->association->setClassName(AuthorsTable::class);
     }
@@ -172,7 +172,7 @@ class AssociationTest extends TestCase
     public function testSetClassNameWithShortSyntaxAfterTarget(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The class name "Authors" doesn\'t match the target table class name of');
+        $this->expectExceptionMessage('The class name `Authors` doesn\'t match the target table class name of');
         $this->association->getTarget();
         $this->association->setClassName('Authors');
     }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -264,7 +264,7 @@ class TimestampBehaviorTest extends TestCase
     public function testInvalidEventConfig(): void
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid');
+        $this->expectExceptionMessage('When should be one of `always`, `new` or `existing`. The passed value `fat fingers` is invalid');
         $table = $this->getTableInstance();
         $settings = ['events' => ['Model.beforeSave' => ['created' => 'fat fingers']]];
         $this->Behavior = new TimestampBehavior($table, $settings);

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -1090,7 +1090,7 @@ class TreeBehaviorTest extends TestCase
     public function testReparentCycle(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot use node "5" as parent for entity "2"');
+        $this->expectExceptionMessage('Cannot use node `5` as parent for entity `2`');
         $table = $this->table;
         $entity = $table->get(2);
         $entity->parent_id = 5;

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -161,7 +161,7 @@ class BehaviorRegistryTest extends TestCase
     public function testLoadDuplicateMethodError(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"');
+        $this->expectExceptionMessage('`TestApp\Model\Behavior\DuplicateBehavior` contains duplicate method `slugify`');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->load('Duplicate');
     }
@@ -189,7 +189,7 @@ class BehaviorRegistryTest extends TestCase
     public function testLoadDuplicateFinderError(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('TestApp\Model\Behavior\DuplicateBehavior contains duplicate finder "children"');
+        $this->expectExceptionMessage('`TestApp\Model\Behavior\DuplicateBehavior` contains duplicate finder `children`');
         $this->Behaviors->load('Tree');
         $this->Behaviors->load('Duplicate');
     }
@@ -278,7 +278,7 @@ class BehaviorRegistryTest extends TestCase
     public function testCallError(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call "nope"');
+        $this->expectExceptionMessage('Cannot call `nope`');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->call('nope');
     }
@@ -314,7 +314,7 @@ class BehaviorRegistryTest extends TestCase
     public function testCallFinderError(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call finder "nope"');
+        $this->expectExceptionMessage('Cannot call finder `nope`');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->callFinder('nope');
     }
@@ -325,7 +325,7 @@ class BehaviorRegistryTest extends TestCase
     public function testUnloadBehaviorThenCall(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call "slugify" it does not belong to any attached behavior.');
+        $this->expectExceptionMessage('Cannot call `slugify` it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
 
@@ -338,7 +338,7 @@ class BehaviorRegistryTest extends TestCase
     public function testUnloadBehaviorThenCallFinder(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call finder "noslug" it does not belong to any attached behavior.');
+        $this->expectExceptionMessage('Cannot call finder `noslug` it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
 
@@ -378,7 +378,7 @@ class BehaviorRegistryTest extends TestCase
     public function testUnloadUnknown(): void
     {
         $this->expectException(MissingBehaviorException::class);
-        $this->expectExceptionMessage('Behavior class FooBehavior could not be found.');
+        $this->expectExceptionMessage('Behavior class `FooBehavior` could not be found.');
         $this->Behaviors->unload('Foo');
     }
 

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -241,7 +241,7 @@ class BehaviorTest extends TestCase
     public function testVerifyImplementedFindersInvalid(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The method findNotDefined is not callable on class ' . Test2Behavior::class);
+        $this->expectExceptionMessage('The method `findNotDefined` is not callable on class `' . Test2Behavior::class . '`');
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedFinders' => [
@@ -275,7 +275,7 @@ class BehaviorTest extends TestCase
     public function testVerifyImplementedMethodsInvalid(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The method iDoNotExist is not callable on class ' . Test2Behavior::class);
+        $this->expectExceptionMessage('The method `iDoNotExist` is not callable on class `' . Test2Behavior::class . '`');
         $table = $this->getMockBuilder(Table::class)->getMock();
         $behavior = new Test2Behavior($table, [
             'implementedMethods' => [

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -424,7 +424,7 @@ class CompositeKeysTest extends TestCase
     public function testSaveNewEntityMissingKey(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing. Got (5, ), expecting (id, site_id)');
+        $this->expectExceptionMessage('Cannot insert row, some of the primary key values are missing. Got `(5, )`, expecting `(id, site_id)`');
         $entity = new Entity([
             'id' => 5,
             'title' => 'Fifth Article',

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -104,7 +104,7 @@ class TableLocatorTest extends TestCase
         $this->assertNotEmpty($users);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('You cannot configure "Users", it has already been constructed.');
+        $this->expectExceptionMessage('You cannot configure `Users`, it has already been constructed.');
 
         $this->_locator->setConfig('Users', ['table' => 'my_users']);
     }
@@ -282,7 +282,7 @@ class TableLocatorTest extends TestCase
         $this->assertNotEmpty($users);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('You cannot configure "Users", it already exists in the registry.');
+        $this->expectExceptionMessage('You cannot configure `Users`, it already exists in the registry.');
 
         $this->_locator->get('Users', ['table' => 'my_users']);
     }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -297,7 +297,7 @@ class MarshallerTest extends TestCase
     public function testOneInvalidAssociation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot marshal data for "Derp" association. It is not associated with "Articles".');
+        $this->expectExceptionMessage('Cannot marshal data for `Derp` association. It is not associated with `Articles`.');
         $data = [
             'title' => 'My title',
             'body' => 'My content',
@@ -1369,7 +1369,7 @@ class MarshallerTest extends TestCase
     public function testMergeInvalidAssociation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot marshal data for "Derp" association. It is not associated with "Articles".');
+        $this->expectExceptionMessage('Cannot marshal data for `Derp` association. It is not associated with `Articles`.');
         $data = [
             'title' => 'My title',
             'body' => 'My content',

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -146,7 +146,7 @@ class QueryRegressionTest extends TestCase
         ]);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('"_joinData" is missing from the belongsToMany results');
+        $this->expectExceptionMessage('`_joinData` is missing from the belongsToMany results');
         $table->find()->contain('Tags')->toArray();
     }
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1890,7 +1890,7 @@ class QueryTest extends TestCase
     public function testCollectionProxyBadMethod(): void
     {
         $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Unknown method "derpFilter"');
+        $this->expectExceptionMessage('Unknown method `derpFilter`');
         $this->getTableLocator()->get('articles')->find('all')->derpFilter();
     }
 

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -577,7 +577,7 @@ class RulesCheckerIntegrationTest extends TestCase
     public function testExistsInInvalidAssociation(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('ExistsIn rule for \'author_id\' is invalid. \'NotValid\' is not associated with \'Cake\ORM\Table\'.');
+        $this->expectExceptionMessage('ExistsIn rule for `author_id` is invalid. `NotValid` is not associated with `Cake\ORM\Table`.');
         $entity = new Entity([
             'title' => 'An Article',
             'author_id' => 500,

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1527,7 +1527,7 @@ class TableTest extends TestCase
     public function testTableClassNonExistent(): void
     {
         $this->expectException(MissingEntityException::class);
-        $this->expectExceptionMessage('Entity class FooUser could not be found.');
+        $this->expectExceptionMessage('Entity class `FooUser` could not be found.');
         $table = new Table();
         $table->setEntityClass('FooUser');
     }
@@ -1687,7 +1687,7 @@ class TableTest extends TestCase
             $table->addBehavior('Sluggable', ['thing' => 'thing']);
             $this->fail('No exception raised');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "Sluggable" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The `Sluggable` alias has already been loaded', $e->getMessage());
         }
     }
 
@@ -1767,7 +1767,7 @@ class TableTest extends TestCase
         $table = new Table(['table' => 'comments']);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The Sluggable behavior is not defined on ' . get_class($table) . '.');
+        $this->expectExceptionMessage('The `Sluggable` behavior is not defined on `' . get_class($table) . '`.');
 
         $this->assertFalse($table->hasBehavior('Sluggable'));
         $table->getBehavior('Sluggable');
@@ -2320,7 +2320,7 @@ class TableTest extends TestCase
     public function testSaveNewErrorOnNoPrimaryKey(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot insert row in "users" table, it has no primary key');
+        $this->expectExceptionMessage('Cannot insert row in `users` table, it has no primary key');
         $entity = new Entity(['username' => 'superuser']);
         $table = $this->getTableLocator()->get('users', [
             'schema' => [
@@ -3348,7 +3348,7 @@ class TableTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(sprintf(
-            'The %s::validationBad() validation method must return an instance of Cake\Validation\Validator.',
+            'The `%s::validationBad()` validation method must return an instance of `Cake\Validation\Validator`.',
             get_class($table)
         ));
 
@@ -3361,7 +3361,7 @@ class TableTest extends TestCase
     public function testValidatorWithMissingMethod(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The Cake\ORM\Table::validationMissing() validation method does not exists.');
+        $this->expectExceptionMessage('The `Cake\ORM\Table::validationMissing()` validation method does not exists.');
         $table = new Table();
         $table->getValidator('missing');
     }
@@ -3452,7 +3452,7 @@ class TableTest extends TestCase
     public function testMagicFindError(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Not enough arguments for magic finder. Got 0 required 1');
+        $this->expectExceptionMessage('Not enough arguments for magic finder. Got `0` required `1`');
         $table = $this->getTableLocator()->get('Users');
 
         $table->findByUsername();
@@ -3464,7 +3464,7 @@ class TableTest extends TestCase
     public function testMagicFindErrorMissingField(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Not enough arguments for magic finder. Got 1 required 2');
+        $this->expectExceptionMessage('Not enough arguments for magic finder. Got `1` required `2`');
         $table = $this->getTableLocator()->get('Users');
 
         $table->findByUsernameAndId('garrett');
@@ -5451,7 +5451,7 @@ class TableTest extends TestCase
     public function testGetNotFoundException(): void
     {
         $this->expectException(RecordNotFoundException::class);
-        $this->expectExceptionMessage('Record not found in table "articles"');
+        $this->expectExceptionMessage('Record not found in table `articles`');
         $table = new Table([
             'name' => 'Articles',
             'connection' => $this->connection,
@@ -5466,7 +5466,7 @@ class TableTest extends TestCase
     public function testGetExceptionOnNoData(): void
     {
         $this->expectException(InvalidPrimaryKeyException::class);
-        $this->expectExceptionMessage('Record not found in table "articles" with primary key [NULL]');
+        $this->expectExceptionMessage('Record not found in table `articles` with primary key `[NULL]`');
         $table = new Table([
             'name' => 'Articles',
             'connection' => $this->connection,
@@ -5481,7 +5481,7 @@ class TableTest extends TestCase
     public function testGetExceptionOnTooMuchData(): void
     {
         $this->expectException(InvalidPrimaryKeyException::class);
-        $this->expectExceptionMessage('Record not found in table "articles" with primary key [1, \'two\']');
+        $this->expectExceptionMessage('Record not found in table `articles` with primary key `[1, \'two\']`');
         $table = new Table([
             'name' => 'Articles',
             'connection' => $this->connection,
@@ -5796,7 +5796,7 @@ class TableTest extends TestCase
         $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage(
             'Entity findOrCreate failure. ' .
-            'Found the following errors (title._empty: "This field cannot be left empty").'
+            'Found the following errors `title._empty: "This field cannot be left empty"`.'
         );
 
         $articles = $this->getTableLocator()->get('Articles');
@@ -5838,7 +5838,7 @@ class TableTest extends TestCase
         $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage(
             'Entity findOrCreate failure. ' .
-            'Found the following errors (title._required: "This field is required").'
+            'Found the following errors `title._required: "This field is required"`.'
         );
 
         $articles->findOrCreate(['body' => 'test']);
@@ -6363,7 +6363,7 @@ class TableTest extends TestCase
     public function testSaveOrFailErrorDisplay(): void
     {
         $this->expectException(PersistenceFailedException::class);
-        $this->expectExceptionMessage('Entity save failure. Found the following errors (field.0: "Some message", multiple.one: "One", multiple.two: "Two")');
+        $this->expectExceptionMessage('Entity save failure. Found the following errors `field.0: "Some message", multiple.one: "One", multiple.two: "Two"`');
 
         $entity = new Entity([
             'foo' => 'bar',
@@ -6381,7 +6381,7 @@ class TableTest extends TestCase
     public function testSaveOrFailNestedError(): void
     {
         $this->expectException(PersistenceFailedException::class);
-        $this->expectExceptionMessage('Entity save failure. Found the following errors (articles.0.title.0: "Bad value")');
+        $this->expectExceptionMessage('Entity save failure. Found the following errors `articles.0.title.0: "Bad value"`');
 
         $entity = new Entity([
             'username' => 'bad',

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -519,7 +519,7 @@ class RoutingMiddlewareTest extends TestCase
             'tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php',
         ]);
         $this->expectException(CacheInvalidArgumentException::class);
-        $this->expectExceptionMessage('The "notfound" cache configuration does not exist.');
+        $this->expectExceptionMessage('The `notfound` cache configuration does not exist.');
 
         Cache::setConfig('_cake_router_', [
             'engine' => 'File',

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -979,7 +979,7 @@ class RouteBuilderTest extends TestCase
     public function testMiddlewareGroupOverlap(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot add middleware group \'test\'. A middleware by this name has already been registered.');
+        $this->expectExceptionMessage('Cannot add middleware group `test`. A middleware by this name has already been registered.');
         $func = function (): void {
         };
         $routes = new RouteBuilder($this->collection, '/api');
@@ -993,7 +993,7 @@ class RouteBuilderTest extends TestCase
     public function testApplyMiddlewareInvalidName(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot apply \'bad\' middleware or middleware group. Use registerMiddleware() to register middleware');
+        $this->expectExceptionMessage('Cannot apply `bad` middleware or middleware group. Use `registerMiddleware()` to register middleware');
         $routes = new RouteBuilder($this->collection, '/api');
         $routes->applyMiddleware('bad');
     }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -47,7 +47,7 @@ class RouteCollectionTest extends TestCase
     public function testParseMissingRoute(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/" could not be found');
+        $this->expectExceptionMessage('A route matching `/` could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
@@ -62,7 +62,7 @@ class RouteCollectionTest extends TestCase
     public function testParseMissingRouteMethod(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A "POST" route matching "/b" could not be found');
+        $this->expectExceptionMessage('A `POST` route matching `/b` could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles', '_method' => ['GET']]);
 
@@ -255,7 +255,7 @@ class RouteCollectionTest extends TestCase
     public function testParseRequestMissingRoute(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/" could not be found');
+        $this->expectExceptionMessage('A route matching `/` could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
@@ -340,7 +340,7 @@ class RouteCollectionTest extends TestCase
     public function testParseRequestCheckHostConditionFail(string $host): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/fallback" could not be found');
+        $this->expectExceptionMessage('A route matching `/fallback` could not be found');
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect(
             '/fallback',
@@ -454,7 +454,7 @@ class RouteCollectionTest extends TestCase
     public function testMatchError(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "array (');
+        $this->expectExceptionMessage('A route matching `array (');
         $context = [
             '_base' => '/',
             '_scheme' => 'http',
@@ -720,7 +720,7 @@ class RouteCollectionTest extends TestCase
     public function testMiddlewareGroupUnregisteredMiddleware(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot add \'bad\' middleware to group \'group\'. It has not been registered.');
+        $this->expectExceptionMessage('Cannot add `bad` middleware to group `group`. It has not been registered.');
         $this->collection->middlewareGroup('group', ['bad']);
     }
 }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1087,8 +1087,8 @@ class RouterTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches(
-            '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
-            ' The filter failed with: nope/'
+            '/URL filter defined in `.*RouterTest\.php` on line \d+ could not be applied\.' .
+            ' The filter failed with: `nope`/'
         );
         Router::connect('/{lang}/{controller}/{action}/*');
         $request = new ServerRequest([
@@ -1114,7 +1114,7 @@ class RouterTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches(
-            '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
+            '/URL filter defined in `.*RouterTest\.php` on line \d+ could not be applied\.' .
             ' The filter failed with: /'
         );
         Router::connect('/{lang}/{controller}/{action}/*');

--- a/tests/TestCase/TestSuite/FixtureManagerTest.php
+++ b/tests/TestCase/TestSuite/FixtureManagerTest.php
@@ -273,7 +273,7 @@ class FixtureManagerTest extends TestCase
     public function testFixturizeInvalidType(): void
     {
         $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Referenced fixture class "Test\Fixture\Derp.DerpFixture" not found. Fixture "Derp.Derp" was referenced');
+        $this->expectExceptionMessage('Referenced fixture class `Test\Fixture\Derp.DerpFixture` not found. Fixture `Derp.Derp` was referenced');
         $test = $this->getMockBuilder('Cake\TestSuite\TestCase')->getMock();
         $test->expects($this->any())
             ->method('getFixtures')
@@ -401,7 +401,7 @@ class FixtureManagerTest extends TestCase
         }
 
         $this->assertNotNull($e);
-        $this->assertMatchesRegularExpression('/^Unable to insert fixtures for "Mock_TestCase_\w+" test case. message$/D', $e->getMessage());
+        $this->assertMatchesRegularExpression('/^Unable to insert fixtures for `Mock_TestCase_\w+` test case. `message`$/D', $e->getMessage());
         $this->assertInstanceOf('PDOException', $e->getPrevious());
     }
 
@@ -462,15 +462,15 @@ class FixtureManagerTest extends TestCase
         return [
             [
                 'createConstraints',
-                '/^Unable to create constraints for fixture "Mock_ProductsFixture_\w+" in "Mock_TestCase_\w+" test case: \nmessage$/D',
+                '/^Unable to create constraints for fixture `Mock_ProductsFixture_\w+` in `Mock_TestCase_\w+` test case: \n`message`$/D',
             ],
             [
                 'dropConstraints',
-                '/^Unable to drop constraints for fixture "Mock_ProductsFixture_\w+" in "Mock_TestCase_\w+" test case: \nmessage$/D',
+                '/^Unable to drop constraints for fixture `Mock_ProductsFixture_\w+` in `Mock_TestCase_\w+` test case: \n`message`$/D',
             ],
             [
                 'insert',
-                '/^Unable to insert fixture "Mock_ProductsFixture_\w+" in "Mock_TestCase_\w+" test case: \nmessage$/D',
+                '/^Unable to insert fixture `Mock_ProductsFixture_\w+` in `Mock_TestCase_\w+` test case: \n`message`$/D',
             ],
         ];
     }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1516,49 +1516,49 @@ class IntegrationTestTraitTest extends TestCase
 
         return [
             'assertContentType' => ['assertContentType', 'Failed asserting that \'test\' is set as the Content-Type (`text/html`).', '/posts/index', 'test'],
-            'assertContentTypeVerbose' => ['assertContentType', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test'],
+            'assertContentTypeVerbose' => ['assertContentType', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertCookie' => ['assertCookie', 'Failed asserting that \'test\' is in cookie \'remember_me\'.', '/posts/index', 'test', 'remember_me'],
-            'assertCookieVerbose' => ['assertCookie', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test', 'remember_me'],
+            'assertCookieVerbose' => ['assertCookie', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'remember_me'],
             'assertCookieEncrypted' => ['assertCookieEncrypted', 'Failed asserting that \'test\' is encrypted in cookie \'secrets\'.', '/posts/secretCookie', 'test', 'secrets'],
-            'assertCookieEncryptedVerbose' => ['assertCookieEncrypted', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test', 'NameOfCookie'],
+            'assertCookieEncryptedVerbose' => ['assertCookieEncrypted', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'NameOfCookie'],
             'assertCookieNotSet' => ['assertCookieNotSet', 'Failed asserting that \'remember_me\' cookie is not set.', '/posts/index', 'remember_me'],
             'assertFileResponse' => ['assertFileResponse', 'Failed asserting that \'test\' file was sent.', '/posts/file', 'test'],
-            'assertFileResponseVerbose' => ['assertFileResponse', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test'],
+            'assertFileResponseVerbose' => ['assertFileResponse', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertHeader' => ['assertHeader', 'Failed asserting that \'test\' equals content in header \'X-Cake\' (`custom header`).', '/posts/header', 'X-Cake', 'test'],
             'assertHeaderContains' => ['assertHeaderContains', 'Failed asserting that \'test\' is in header \'X-Cake\' (`custom header`)', '/posts/header', 'X-Cake', 'test'],
             'assertHeaderNotContains' => ['assertHeaderNotContains', 'Failed asserting that \'custom header\' is not in header \'X-Cake\' (`custom header`)', '/posts/header', 'X-Cake', 'custom header'],
-            'assertHeaderContainsVerbose' => ['assertHeaderContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'X-Cake', 'test'],
-            'assertHeaderNotContainsVerbose' => ['assertHeaderNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'X-Cake', 'test'],
+            'assertHeaderContainsVerbose' => ['assertHeaderContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
+            'assertHeaderNotContainsVerbose' => ['assertHeaderNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
             'assertLayout' => ['assertLayout', 'Failed asserting that \'custom_layout\' equals layout file `' . $templateDir . 'layout' . DS . 'default.php`.', '/posts/index', 'custom_layout'],
-            'assertLayoutVerbose' => ['assertLayout', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'custom_layout'],
+            'assertLayoutVerbose' => ['assertLayout', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'custom_layout'],
             'assertRedirect' => ['assertRedirect', 'Failed asserting that \'http://localhost/\' equals content in header \'Location\' (`http://localhost/posts`).', '/posts/flashNoRender', '/'],
-            'assertRedirectVerbose' => ['assertRedirect', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/'],
+            'assertRedirectVerbose' => ['assertRedirect', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/'],
             'assertRedirectContains' => ['assertRedirectContains', 'Failed asserting that \'/posts/somewhere-else\' is in header \'Location\' (`http://localhost/posts`).', '/posts/flashNoRender', '/posts/somewhere-else'],
-            'assertRedirectContainsVerbose' => ['assertRedirectContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/posts/somewhere-else'],
-            'assertRedirectNotContainsVerbose' => ['assertRedirectNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/posts/somewhere-else'],
+            'assertRedirectContainsVerbose' => ['assertRedirectContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
+            'assertRedirectNotContainsVerbose' => ['assertRedirectNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
             'assertResponseCode' => ['assertResponseCode', 'Failed asserting that `302` matches response status code `200`.', '/posts/index', 302],
             'assertResponseContains' => ['assertResponseContains', 'Failed asserting that \'test\' is in response body.', '/posts/index', 'test'],
             'assertResponseEmpty' => ['assertResponseEmpty', 'Failed asserting that response body is empty.', '/posts/index'],
             'assertResponseEquals' => ['assertResponseEquals', 'Failed asserting that \'test\' matches response body.', '/posts/index', 'test'],
-            'assertResponseEqualsVerbose' => ['assertResponseEquals', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test'],
+            'assertResponseEqualsVerbose' => ['assertResponseEquals', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertResponseError' => ['assertResponseError', 'Failed asserting that 200 is between 400 and 429.', '/posts/index'],
             'assertResponseFailure' => ['assertResponseFailure', 'Failed asserting that 200 is between 500 and 505.', '/posts/index'],
             'assertResponseNotContains' => ['assertResponseNotContains', 'Failed asserting that \'index\' is not in response body.', '/posts/index', 'index'],
             'assertResponseNotEmpty' => ['assertResponseNotEmpty', 'Failed asserting that response body is not empty.', '/posts/empty_response'],
             'assertResponseNotEquals' => ['assertResponseNotEquals', 'Failed asserting that \'posts index\' does not match response body.', '/posts/index/error', 'posts index'],
             'assertResponseNotRegExp' => ['assertResponseNotRegExp', 'Failed asserting that `/index/` PCRE pattern not found in response body.', '/posts/index/error', '/index/'],
-            'assertResponseNotRegExpVerbose' => ['assertResponseNotRegExp', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/index/'],
+            'assertResponseNotRegExpVerbose' => ['assertResponseNotRegExp', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/index/'],
             'assertResponseOk' => ['assertResponseOk', 'Failed asserting that 404 is between 200 and 204.', '/posts/missing', '/index/'],
             'assertResponseRegExp' => ['assertResponseRegExp', 'Failed asserting that `/test/` PCRE pattern found in response body.', '/posts/index/error', '/test/'],
             'assertResponseSuccess' => ['assertResponseSuccess', 'Failed asserting that 404 is between 200 and 308.', '/posts/missing'],
-            'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to Cake\Controller\Exception\MissingActionException: "Action PostsController::missing() could not be found, or is not accessible."', '/posts/missing'],
+            'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to Cake\Controller\Exception\MissingActionException: "Action `PostsController::missing()` could not be found, or is not accessible."', '/posts/missing'],
 
             'assertSession' => ['assertSession', 'Failed asserting that \'test\' is in session path \'Missing.path\'.', '/posts/index', 'test', 'Missing.path'],
             'assertSessionHasKey' => ['assertSessionHasKey', 'Failed asserting that \'Missing.path\' is a path present in the session.', '/posts/index', 'Missing.path'],
             'assertSessionNotHasKey' => ['assertSessionNotHasKey', 'Failed asserting that \'Flash.flash\' is not a path present in the session.', '/posts/index', 'Flash.flash'],
 
             'assertTemplate' => ['assertTemplate', 'Failed asserting that \'custom_template\' equals template file `' . $templateDir . 'Posts' . DS . 'index.php`.', '/posts/index', 'custom_template'],
-            'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'custom_template'],
+            'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'custom_template'],
             'assertFlashMessage' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'flash\' message.', '/posts/index', 'missing'],
             'assertFlashMessageWithKey' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'auth\' message.', '/posts/index', 'missing', 'auth'],
             'assertFlashMessageAt' => ['assertFlashMessageAt', 'Failed asserting that \'missing\' is in \'flash\' message #0.', '/posts/index', 0, 'missing'],
@@ -1592,7 +1592,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertCookieNotSetVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withCookie(new Cookie('cookie', 'value'));
         $this->assertCookieNotSet('cookie');
@@ -1604,7 +1604,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertNoRedirectVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withHeader('Location', '/redirect');
         $this->assertNoRedirect();
@@ -1616,7 +1616,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertHeaderVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->assertHeader('Etag', 'abc123');
     }
@@ -1627,7 +1627,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertResponseNotEqualsVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withStringBody('body');
         $this->assertResponseNotEquals('body');
@@ -1639,7 +1639,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertResponseRegExpVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withStringBody('body');
         $this->assertResponseRegExp('/patternNotFound/');

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -89,7 +89,7 @@ class SecurityTest extends TestCase
     public function testInvalidHashTypeException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageMatches('/The hash type `doesnotexist` was not found. Available algorithms are: \w+/');
+        $this->expectExceptionMessageMatches('/The hash type `doesnotexist` was not found. Available algorithms are: `\w+/');
 
         Security::hash('test', 'doesnotexist', false);
     }
@@ -155,7 +155,7 @@ class SecurityTest extends TestCase
     public function testEncryptInvalidKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.');
+        $this->expectExceptionMessage('Invalid key for `encrypt()`, key must be at least 256 bits (32 bytes) long.');
         $txt = 'The quick brown fox jumped over the lazy dog.';
         $key = 'this is too short';
         Security::encrypt($txt, $key);
@@ -181,7 +181,7 @@ class SecurityTest extends TestCase
     public function testDecryptInvalidKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.');
+        $this->expectExceptionMessage('Invalid key for `decrypt()`, key must be at least 256 bits (32 bytes) long.');
         $txt = 'The quick brown fox jumped over the lazy dog.';
         $key = 'this is too short';
         Security::decrypt($txt, $key);

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -92,7 +92,7 @@ class ValidationRuleTest extends TestCase
     public function testCustomMethodMissingError(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to call method "totallyMissing" in "default" provider for field "test"');
+        $this->expectExceptionMessage('Unable to call method `totallyMissing` in `default` provider for field `test`');
         $def = ['rule' => ['totallyMissing']];
         $data = 'some data';
         $providers = ['default' => $this];

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1941,7 +1941,7 @@ class ValidatorTest extends TestCase
         $validator->add('title', 'notBlank', ['rule' => 'notBlank']);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('You cannot add a rule without a unique name, already existing rule found: notBlank');
+        $this->expectExceptionMessage('You cannot add a rule without a unique name, already existing rule found: `notBlank`');
 
         $validator->add('title', [
             [

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -295,7 +295,7 @@ class CellTest extends TestCase
     public function testCellMissingMethod(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Class TestApp\View\Cell\ArticlesCell does not have a "nope" method.');
+        $this->expectExceptionMessage('Class `TestApp\View\Cell\ArticlesCell` does not have a `nope` method.');
         $cell = $this->View->cell('Articles::nope');
         $cell->render();
     }

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -31,7 +31,7 @@ class ContextFactoryTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'No context provider found for value of type `boolean`.'
-            . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.'
+            . ' Use `null` as 1st argument of `FormHelper::create()` to create a context-less form.'
         );
 
         $factory = new ContextFactory();

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -38,7 +38,7 @@ class FormContextTest extends TestCase
     public function testConstructor()
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('`$context[\'entity\']` must be an instance of Cake\Form\Form');
+        $this->expectExceptionMessage('`$context[\'entity\']` must be an instance of `Cake\Form\Form`');
 
         new FormContext([]);
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3813,7 +3813,7 @@ class FormHelperTest extends TestCase
     public function testInvalidControlTypeOption(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Invalid type \'input\' used for field \'text\'');
+        $this->expectExceptionMessage('Invalid type `input` used for field `text`');
         $this->Form->control('text', ['type' => 'input']);
     }
 
@@ -8140,7 +8140,7 @@ class FormHelperTest extends TestCase
     public function testValueSourcesValidation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid value source(s): invalid, foo. Valid values are: context, data, query');
+        $this->expectExceptionMessage('Invalid value source(s): `invalid, foo`. Valid values are: `context, data, query`');
 
         $this->Form->setValueSources(['query', 'data', 'invalid', 'context', 'foo']);
     }

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -249,7 +249,7 @@ class HelperRegistryTest extends TestCase
     public function testUnloadUnknown(): void
     {
         $this->expectException(MissingHelperException::class);
-        $this->expectExceptionMessage('Helper class FooHelper could not be found.');
+        $this->expectExceptionMessage('Helper class `FooHelper` could not be found.');
         $this->Helpers->unload('Foo');
     }
 
@@ -295,7 +295,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadMultipleTimesDifferentConfigured(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The "Html" alias has already been loaded');
+        $this->expectExceptionMessage('The `Html` alias has already been loaded');
         $this->Helpers->load('Html');
         $this->Helpers->load('Html', ['same' => 'stuff']);
     }
@@ -306,7 +306,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadMultipleTimesDifferentConfigValues(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The "Html" alias has already been loaded');
+        $this->expectExceptionMessage('The `Html` alias has already been loaded');
         $this->Helpers->load('Html', ['key' => 'value']);
         $this->Helpers->load('Html', ['key' => 'new value']);
     }

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -155,7 +155,7 @@ class StringTemplateTest extends TestCase
     public function testFormatMissingTemplate(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot find template named \'missing\'');
+        $this->expectExceptionMessage('Cannot find template named `missing`');
         $templates = [
             'text' => '{{text}}',
         ];

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -291,7 +291,7 @@ class ViewBuilderTest extends TestCase
     public function testBuildMissingViewClass(): void
     {
         $this->expectException(MissingViewException::class);
-        $this->expectExceptionMessage('View class "Foo" is missing.');
+        $this->expectExceptionMessage('View class `Foo` is missing.');
         $builder = new ViewBuilder();
         $builder->setClassName('Foo');
         $builder->build();

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -858,7 +858,7 @@ class ViewTest extends TestCase
             $View->loadHelper('Html', ['test' => 'value']);
             $this->fail('No exception');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "Html" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The `Html` alias has already been loaded', $e->getMessage());
         }
     }
 
@@ -1465,7 +1465,7 @@ class ViewTest extends TestCase
             $this->fail('No exception');
         } catch (LogicException $e) {
             ob_end_clean();
-            $this->assertStringContainsString('The "no_close" block was left open', $e->getMessage());
+            $this->assertStringContainsString('The `no_close` block was left open', $e->getMessage());
         }
     }
 

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -116,7 +116,7 @@ class ViewVarsTraitTest extends TestCase
     public function testCreateViewException(): void
     {
         $this->expectException(MissingViewException::class);
-        $this->expectExceptionMessage('View class "Foo" is missing.');
+        $this->expectExceptionMessage('View class `Foo` is missing.');
         $this->subject->createView('Foo');
     }
 }

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -256,7 +256,7 @@ class DateTimeWidgetTest extends TestCase
     public function testRenderInvalidTypeException(): void
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid type `foo` for input tag, expected datetime-local, date, time, month or week');
+        $this->expectExceptionMessage('Invalid type `foo` for input tag, expected `datetime-local`, `date`, `time`, `month` or `week`');
         $result = $this->DateTime->render(['type' => 'foo', 'val' => new DateTime()], $this->context);
     }
 

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -208,7 +208,7 @@ class WidgetLocatorTest extends TestCase
     public function testGetResolveDependencyMissingClass(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unable to locate widget class "TestApp\View\DerpWidget"');
+        $this->expectExceptionMessage('Unable to locate widget class `TestApp\View\DerpWidget`');
         $inputs = new WidgetLocator($this->templates, $this->view);
         $inputs->add(['test' => ['TestApp\View\DerpWidget']]);
         $inputs->get('test');


### PR DESCRIPTION
As discussed in discord we currently have a lot of different ways to build strings for e.g. exception messages.
Some examples

- `'String ' . $url . ' did not parse'`
- `"Unknown type alias '$type'."`
- `sprintf('String template %s is not valid.', $name)`

This is not ideal and inconsistent. I therefore asked the team what the default/recommended way of building such string should be - and the conclusion was:

* Use back ticks for all variables / special names
* Use sprintf() for adding placeholders into human text
* Don't use `"` and use `'` instead

Therefore these examples above should look like
```
sprintf('String `%s` did not parse', $url);
sprintf('Unknown type alias `%s`.', $type);
sprintf('String template `%s` is not valid.', $name);
```

For exception messages which are being rendered with `debug => true` this would look like so:
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/9105243/190424115-82f4b482-cd58-4e14-beb9-7ab7c05524dd.png">

This PR tries to catch as many exception strings as possible which fall inside this new string building schema.