### PR TITLE
4.5 - Error page refresh

### DIFF
--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -30,6 +30,7 @@ foreach ($exceptions as $level => $exc):
             <span class="stack-exception-message"><?= Debugger::formatHtmlMessage($exc->getMessage()) ?></span>
         </div>
     <?php endif; ?>
+    <ul class="stack-frames">
     <?php
     foreach ($stackTrace as $i => $stack):
         $excerpt = $params = [];
@@ -59,7 +60,7 @@ foreach ($exceptions as $level => $exc):
         $frameId = "{$level}-{$i}";
         $activeFrame = $i == 0;
     ?>
-        <div id="stack-frame-<?= $frameId ?>" class="stack-frame">
+        <li id="stack-frame-<?= $frameId ?>" class="stack-frame">
             <div class="stack-frame-header">
                 <div class="stack-frame-header-content">
                     <span class="stack-frame-file">
@@ -116,6 +117,7 @@ foreach ($exceptions as $level => $exc):
                     <?php endforeach; ?>
                 </div>
             </div>
-        </div>
+        </li>
     <?php endforeach; ?>
+    </ul>
 <?php endforeach; ?>

--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -61,9 +61,16 @@ foreach ($exceptions as $level => $exc):
         $activeFrame = $i == 0;
         $vendorFrame = isset($stack['file']) && strpos($stack['file'], APP) === false ? 'vendor-frame' : '';
     ?>
-        <li id="stack-frame-<?= $frameId ?>" class="stack-frame">
+        <li id="stack-frame-<?= $frameId ?>" class="stack-frame <?= $vendorFrame ?>">
             <div class="stack-frame-header">
-                <div class="stack-frame-header-content <?= $vendorFrame ?>">
+                <button
+                    data-frame-id="<?= h($frameId) ?>"
+                    class="stack-frame-toggle <?= $activeFrame ? 'active' : '' ?>"
+                >
+                    &#x25BC;
+                </button>
+
+                <div class="stack-frame-header-content">
                     <span class="stack-frame-file">
                         <?= h(Debugger::trimPath($file)); ?>
                     </span>
@@ -88,13 +95,6 @@ foreach ($exceptions as $level => $exc):
                         <?= $this->Html->link('(edit)', Debugger::editorUrl($file, $line), ['class' => 'stack-frame-edit']); ?>
                     <?php endif; ?>
                 </div>
-
-                <button 
-                    data-frame-id="<?= h($frameId) ?>"
-                    class="stack-frame-toggle <?= $activeFrame ? 'active' : '' ?>"
-                >
-                    &#x25BC;
-                </button>
             </div>
             <div
                 class="stack-frame-contents"

--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Prints a stack trace for an exception
+ *
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ * @var array $trace
+ */
+use Cake\Error\Debugger;
+
+foreach ($exceptions as $level => $exc):
+    $stackTrace = Debugger::formatTrace($exc->getTrace(), [
+        'format' => 'array',
+        'args' => true,
+    ]);
+
+    if ($level != 0): ?>
+        <div class="stack-exception-header">
+            <span class="stack-exception-caused">Caused by:</span>
+            <span class="stack-exception-type"><?= h(get_class($exc)); ?></span>
+            <span class="stack-exception-message"><?= Debugger::formatHtmlMessage($exc->getMessage()) ?></span>
+        </div>
+    <?php endif; ?>
+    <?php
+    foreach ($stackTrace as $i => $stack):
+        $excerpt = $params = [];
+
+        $line = null;
+        if (isset($stack['file'], $stack['line']) && is_numeric($stack['line'])):
+            $line = $stack['line'];
+            $excerpt = Debugger::excerpt($stack['file'], $line, 4);
+        endif;
+
+        if (isset($stack['file'])):
+            $file = $stack['file'];
+        else:
+            $file = '[internal function]';
+        endif;
+
+        if (isset($stack['function'])):
+            if (!empty($stack['args'])):
+                foreach ((array)$stack['args'] as $arg):
+                    $params[] = Debugger::exportVar($arg, 4);
+                endforeach;
+            else:
+                $params[] = 'No arguments';
+            endif;
+        endif;
+
+        $frameId = "{$level}-{$i}";
+        $activeFrame = $i == 0;
+    ?>
+        <div id="stack-frame-<?= $frameId ?>" class="stack-frame">
+            <div class="stack-frame-header">
+                <div class="stack-frame-header-content">
+                    <span class="stack-frame-file">
+                        <?= h(Debugger::trimPath($file)); ?>
+                    </span>
+                    <span class="stack-function">
+                        <?php if (isset($stack['class']) || isset($stack['function'])): ?>
+                            <span class="stack-frame-label">in</span>
+                        <?php endif ?>
+                        <?php if (isset($stack['class'])): ?>
+                            <?= h($stack['class'] . $stack['type'] . $stack['function']) ?>
+                        <?php elseif (isset($stack['function'])): ?>
+                            <?= h($stack['function']) ?>
+                        <?php endif; ?>
+                    </span>
+
+                    <?php if ($line !== null): ?>
+                        <span class="stack-frame-line">
+                            <span class="stack-frame-label">at line</span><?= h($line) ?>
+                        </span>
+                    <?php endif ?>
+
+                    <?php if ($line !== null): ?>
+                        <?= $this->Html->link('(open)', Debugger::editorUrl($file, $line), ['class' => 'stack-frame-edit']); ?>
+                    <?php endif; ?>
+                </div>
+
+                <button 
+                    data-frame-id="<?= h($frameId) ?>"
+                    class="stack-frame-toggle <?= $activeFrame ? 'active' : '' ?>"
+                >
+                    &#x25BC;
+                </button>
+            </div>
+            <div
+                class="stack-frame-contents"
+                id="stack-frame-details-<?= $frameId ?>"
+                style="display: <?= $activeFrame ? 'block' : 'none' ?>"
+            >
+                <table class="code-excerpt" cellspacing="0" cellpadding="0">
+                <?php $lineno = isset($stack['line']) && is_numeric($stack['line']) ? $stack['line'] - 4 : 0 ?>
+                <?php foreach ($excerpt as $l => $line): ?>
+                    <tr>
+                        <td class="excerpt-number" data-number="<?= $lineno + $l ?>"></td>
+                        <td class="excerpt-line"><?= $line ?></td>
+                    </tr>
+                <?php endforeach; ?>
+                </table>
+
+                <a href="#" class="stack-frame-args" data-target="stack-args-<?= $frameId ?>">Toggle Arguments</a>
+                <div id="stack-args-<?= $frameId ?>" class="stack-args" style="display: none;">
+                    <?php foreach ($params as $param): ?>
+                        <div class="cake-debug"><?= $param ?></div>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+<?php endforeach; ?>

--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -25,9 +25,9 @@ foreach ($exceptions as $level => $exc):
 
     if ($level != 0): ?>
         <div class="stack-exception-header">
-            <span class="stack-exception-caused">Caused by:</span>
-            <span class="stack-exception-type"><?= h(get_class($exc)); ?></span>
+            <span class="stack-exception-caused">Caused by</span>
             <span class="stack-exception-message"><?= Debugger::formatHtmlMessage($exc->getMessage()) ?></span>
+            <span class="stack-exception-type"><?= h(get_class($exc)); ?></span>
         </div>
     <?php endif; ?>
     <ul class="stack-frames">
@@ -59,10 +59,11 @@ foreach ($exceptions as $level => $exc):
 
         $frameId = "{$level}-{$i}";
         $activeFrame = $i == 0;
+        $vendorFrame = isset($stack['file']) && strpos($stack['file'], APP) === false ? 'vendor-frame' : '';
     ?>
         <li id="stack-frame-<?= $frameId ?>" class="stack-frame">
             <div class="stack-frame-header">
-                <div class="stack-frame-header-content">
+                <div class="stack-frame-header-content <?= $vendorFrame ?>">
                     <span class="stack-frame-file">
                         <?= h(Debugger::trimPath($file)); ?>
                     </span>
@@ -84,7 +85,7 @@ foreach ($exceptions as $level => $exc):
                     <?php endif ?>
 
                     <?php if ($line !== null): ?>
-                        <?= $this->Html->link('(open)', Debugger::editorUrl($file, $line), ['class' => 'stack-frame-edit']); ?>
+                        <?= $this->Html->link('(edit)', Debugger::editorUrl($file, $line), ['class' => 'stack-frame-edit']); ?>
                     <?php endif; ?>
                 </div>
 

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -389,15 +389,6 @@ use Cake\Error\Debugger;
                 event.preventDefault();
             });
 
-            bindEvent('.toggle-vendor-frames', 'click', function(event) {
-                each(frames, function(el) {
-                    if (el.classList.contains('vendor-frame')) {
-                        toggleElement(el);
-                    }
-                });
-                event.preventDefault();
-            });
-
             bindEvent('.header-title a', 'click', function(event) {
                 event.preventDefault();
                 var text = '';

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -245,6 +245,7 @@ use Cake\Error\Debugger;
         margin: 0 5px 0 0;
     }
     .stack-frame-toggle {
+        cursor: pointer;
         color: #525252;
         border: 1px solid #d2d2d2;
         border-radius: var(--border-radius);

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -36,7 +36,7 @@ use Cake\Error\Debugger;
         --layout-padding: 30px;
         --layout-vertical-gap: 20px;
 
-        --color-vendor-frame: #8c8c8c;
+        --color-vendor-frame: #7c7c7c;
 
         --breakpoint-tablet: 810px;
     }
@@ -168,12 +168,14 @@ use Cake\Error\Debugger;
         border-radius: var(--border-radius);
     }
     .stack-frame {
-        background: #e5e5e5;
         padding: 10px;
-        background: #ececec;
+        background: #eaeaea;
         padding: 10px;
         border-bottom: 2px solid #f5f7fa;
         overflow: hidden;
+    }
+    .vendor-frame {
+        background: #f1f1f1;
     }
     .stack-frame:first-child {
         border-radius: var(--border-radius) var(--border-radius) 0 0;
@@ -197,14 +199,15 @@ use Cake\Error\Debugger;
     /* Stack frame headers */
     .stack-frame-header {
         display: flex;
-        justify-content: space-between;
+        align-items: center;
+        gap: 10px;
     }
     .stack-frame-header-content {
         display: flex;
         gap: 8px;
     }
-    .stack-frame-header-content.vendor-frame ,
-    .stack-frame-header-content.vendor-frame a {
+    .vendor-frame .stack-frame-header-content,
+    .vendor-frame .stack-frame-header-content  a {
         color: var(--color-vendor-frame);
     }
     @media (max-width: 810px) {
@@ -252,6 +255,9 @@ use Cake\Error\Debugger;
     }
     .stack-frame-toggle.active {
         transform: rotate(180deg);
+    }
+    .stack-frame-header .stack-frame-toggle {
+        opacity: 0.7;
     }
 
     .stack-frame-args {
@@ -333,9 +339,9 @@ use Cake\Error\Debugger;
             </p>
             <?php endif; ?>
 
-            <div class="error-suggestion">
-                <?= $this->fetch('file') ?>
-            </div>
+<div class="error-suggestion">
+<?= $this->fetch('file') ?>
+</div>
 
             <?= $this->element('dev_error_stacktrace'); ?>
 

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -43,7 +43,7 @@ use Cake\Error\Debugger;
         flex: 1;
         background-color: #D33C47;
         color: #ffffff;
-        padding: 10px;
+        padding: 30px;
     }
     .header-title {
         display: flex;
@@ -73,21 +73,8 @@ use Cake\Error\Debugger;
     .header-help a {
         color: #fff;
     }
-
     .error-content {
-        display: flex;
-    }
-    .col-left,
-    .col-right {
-        overflow-y: auto;
-        padding: 10px;
-    }
-    .col-left {
-        background: #ececec;
-        flex: 0 0 30%;
-    }
-    .col-right {
-        flex: 1;
+        padding: 30px;
     }
 
     .toggle-vendor-frames {
@@ -146,11 +133,28 @@ use Cake\Error\Debugger;
         margin: 0;
         padding: 0;
     }
-    .stack-previous {
-        margin: 24px 0 12px 8px;
+
+    /* Previous exception blocks */
+    .stack-exception-header {
+        margin: 36px 0 12px 8px;
     }
+    .stack-exception-caused {
+        font-size: 1.4em;
+        display: block;
+    }
+    .stack-exception-type {
+        font-family: consolas, monospace;
+    }
+    .stack-exception-message {
+        margin-top: 12px;
+    }
+
     .stack-frame {
         background: #e5e5e5;
+        padding: 10px;
+        margin-bottom: 10px;
+        background: #ececec;
+        border-radius: 4px;
         padding: 10px;
         margin-bottom: 10px;
     }
@@ -159,7 +163,6 @@ use Cake\Error\Debugger;
         margin-bottom: 0;
     }
     .stack-frame a {
-        display: block;
         color: #212121;
         text-decoration: none;
     }
@@ -169,47 +172,21 @@ use Cake\Error\Debugger;
     .stack-frame a:hover {
         text-decoration: underline;
     }
+
+    /* Stack frame headers */
     .stack-frame-header {
         display: flex;
-        align-items: center;
+        justify-content: space-between;
     }
-    .stack-frame-file a {
-        color: #212121;
+    .stack-frame-header-content {
+        display: flex;
+        gap: 8px;
     }
-
-    .stack-frame-args {
-        flex: 0 0 150px;
-        display: block;
-        padding: 8px 14px;
-        text-decoration: none;
-        background-color: #606c76;
-        border-radius: 4px;
-        cursor: pointer;
-        color: #fff;
-        text-align: center;
-        margin-bottom: 10px;
-    }
-    .stack-frame-args:hover {
-        background-color: #D33C47;
-    }
-
-    .stack-frame-file {
-        flex: 1;
-        word-break:break-all;
-        margin-right: 10px;
-        font-size: 16px;
-    }
-    .stack-file,
-    .stack-function {
-        display: block;
-    }
-
+    .stack-function,
     .stack-frame-file,
+    .stack-frame-line,
     .stack-file {
         font-family: consolas, monospace;
-    }
-    .stack-function {
-        font-weight: bold;
     }
     .stack-file {
         font-size: 0.9em;
@@ -218,14 +195,42 @@ use Cake\Error\Debugger;
         overflow: hidden;
         direction: rtl;
     }
-
-    .stack-details {
-        background: #ececec;
-        border-radius: 4px;
-        padding: 10px;
-        margin-bottom: 18px;
+    .stack-frame-file {
+        word-break: break-all;
+    }
+    .stack-frame-label {
+        font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+        font-weight: normal;
+        margin: 0 5px 0 0;
+        font-size: 0.9em;
+    }
+    .stack-frame-edit {
+        margin: 0 5px 0 0;
+    }
+    .stack-frame-toggle {
+        border: 1px solid #7a7a7a;
+        border-radius: 5px;
+        height: 28px;
+        width: 28px;
+        background: #F5F7FA;
+        line-height: 1.5;
+    }
+    .stack-frame-toggle.active {
+        transform: rotate(180deg);
     }
 
+    .stack-frame-args {
+        display: block;
+        margin: 10px 0 0 0;
+    }
+    .stack-frame-args:hover {
+        color: #D33C47;
+    }
+    .stack-args h4 {
+        margin-top: 0;
+    }
+
+    /* Code excerpts */
     .code-excerpt {
         width: 100%;
         margin: 10px 0 0 0;
@@ -249,10 +254,6 @@ use Cake\Error\Debugger;
     .excerpt-number:after {
         content: attr(data-number);
     }
-    .cake-debug {
-        margin-top: 10px;
-    }
-
     table {
         text-align: left;
     }
@@ -261,6 +262,10 @@ use Cake\Error\Debugger;
     }
     th {
         border-bottom: 1px solid #ccc;
+    }
+
+    .cake-debug {
+        margin-top: 10px;
     }
     </style>
     <?php require CAKE . 'Error/Debug/dumpHeader.html'; ?>
@@ -282,21 +287,17 @@ use Cake\Error\Debugger;
         <span class="header-type"><?= get_class($error) ?></span>
     </header>
     <div class="error-content">
-        <div class="col-left">
-            <?= $this->element('exception_stack_trace_nav') ?>
-        </div>
-        <div class="col-right">
             <?php if ($this->fetch('subheading')): ?>
             <p class="error-subheading">
                 <?= $this->fetch('subheading') ?>
             </p>
             <?php endif; ?>
 
-            <?= $this->element('exception_stack_trace'); ?>
-
             <div class="error-suggestion">
                 <?= $this->fetch('file') ?>
             </div>
+
+            <?= $this->element('dev_error_stacktrace'); ?>
 
             <?php if ($this->fetch('templateName')): ?>
             <p class="customize">
@@ -304,7 +305,6 @@ use Cake\Error\Debugger;
                 <em><?= 'templates' . DIRECTORY_SEPARATOR . 'Error' . DIRECTORY_SEPARATOR . $this->fetch('templateName') ?></em>
             </p>
             <?php endif; ?>
-        </div>
     </div>
 
     <script type="text/javascript">
@@ -340,18 +340,12 @@ use Cake\Error\Debugger;
 
             var details = document.querySelectorAll('.stack-details');
             var frames = document.querySelectorAll('.stack-frame');
-            bindEvent('.stack-frame a', 'click', function(event) {
-                each(frames, function(el) {
-                    el.classList.remove('active');
-                });
-                this.parentNode.classList.add('active');
+            bindEvent('.stack-frame-toggle', 'click', function(event) {
+                this.classList.toggle('active');
 
-                each(details, function(el) {
-                    el.style.display = 'none';
-                });
-
-                var target = document.getElementById(this.dataset['target']);
-                toggleElement(target);
+                var frameId = this.dataset.frameId;
+                var frame = document.getElementById('stack-frame-details-' + frameId);
+                toggleElement(frame);
                 event.preventDefault();
             });
 

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -28,8 +28,23 @@ use Cake\Error\Debugger;
     * {
         box-sizing: border-box;
     }
+    :root {
+        --typeface: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+        --typeface-mono: consolas, monospace;
+        --layout-padding: 30px;
+
+        --breakpoint-tablet: 810px;
+    }
+
+    /* Smaller viewport variations */
+    @media (max-width: 810px) {
+        :root {
+            --layout-padding: 20px;
+        }
+    }
+
     body {
-        font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+        font-family: var(--typeface);
         color: #404041;
         background: #F5F7FA;
         font-size: 14px;
@@ -43,7 +58,7 @@ use Cake\Error\Debugger;
         flex: 1;
         background-color: #D33C47;
         color: #ffffff;
-        padding: 30px;
+        padding: var(--layout-padding);
     }
     .header-title {
         display: flex;
@@ -74,7 +89,7 @@ use Cake\Error\Debugger;
         color: #fff;
     }
     .error-content {
-        padding: 30px;
+        padding: var(--layout-padding);
     }
 
     .toggle-vendor-frames {
@@ -143,22 +158,31 @@ use Cake\Error\Debugger;
         display: block;
     }
     .stack-exception-type {
-        font-family: consolas, monospace;
+        font-family: var(--typeface-mono);
     }
     .stack-exception-message {
         margin-top: 12px;
     }
 
+    .stack-frames {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        border-radius: 4px;
+    }
     .stack-frame {
         background: #e5e5e5;
         padding: 10px;
-        margin-bottom: 10px;
         background: #ececec;
-        border-radius: 4px;
         padding: 10px;
-        margin-bottom: 10px;
+        border-bottom: 2px solid #f5f7fa;
+        overflow: hidden;
+    }
+    .stack-frame:first-child {
+        border-radius: 5px 5px 0 0;
     }
     .stack-frame:last-child {
+        border-radius: 0 0 5px 5px;
         border-bottom: none;
         margin-bottom: 0;
     }
@@ -182,11 +206,16 @@ use Cake\Error\Debugger;
         display: flex;
         gap: 8px;
     }
+    @media (max-width: 810px) {
+        .stack-frame-header-content {
+            flex-direction: column;
+        }
+    }
     .stack-function,
     .stack-frame-file,
     .stack-frame-line,
     .stack-file {
-        font-family: consolas, monospace;
+        font-family: var(--typeface-mono);
     }
     .stack-file {
         font-size: 0.9em;
@@ -199,16 +228,21 @@ use Cake\Error\Debugger;
         word-break: break-all;
     }
     .stack-frame-label {
-        font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+        font-family: var(--typeface);
         font-weight: normal;
         margin: 0 5px 0 0;
         font-size: 0.9em;
     }
+    .stack-function .stack-frame-label {
+        margin: 0;
+    }
+
     .stack-frame-edit {
         margin: 0 5px 0 0;
     }
     .stack-frame-toggle {
-        border: 1px solid #7a7a7a;
+        color: #525252;
+        border: 1px solid #d2d2d2;
         border-radius: 5px;
         height: 28px;
         width: 28px;

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -31,7 +31,12 @@ use Cake\Error\Debugger;
     :root {
         --typeface: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
         --typeface-mono: consolas, monospace;
+
+        --border-radius: 5px;
         --layout-padding: 30px;
+        --layout-vertical-gap: 20px;
+
+        --color-vendor-frame: #8c8c8c;
 
         --breakpoint-tablet: 810px;
     }
@@ -79,7 +84,7 @@ use Cake\Error\Debugger;
         display: block;
         font-size: 18px;
         line-height: 1.2;
-        margin-bottom: 16px;
+        margin-bottom: var(--layout-vertical-gap);
     }
     .header-type {
         display: block;
@@ -92,23 +97,10 @@ use Cake\Error\Debugger;
         padding: var(--layout-padding);
     }
 
-    .toggle-vendor-frames {
-        color: #404041;
-        display: block;
-        padding: 5px;
-        margin-bottom: 10px;
-        text-align: center;
-        text-decoration: none;
-    }
-    .toggle-vendor-frames:hover,
-    .toggle-vendor-frames:active {
-        background: #e5e5e5;
-    }
-
     .code-dump,
     pre {
         background: #fff;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
         padding: 5px;
         white-space: pre-wrap;
         margin: 0;
@@ -116,9 +108,10 @@ use Cake\Error\Debugger;
 
     .error,
     .error-subheading {
+        border-radius: var(--border-radius);
         font-size: 18px;
         margin-top: 0;
-        padding: 20px 16px;
+        padding: var(--layout-vertical-gap) 16px;
     }
     .error-subheading {
         color: #fff;
@@ -154,21 +147,25 @@ use Cake\Error\Debugger;
         margin: 36px 0 12px 8px;
     }
     .stack-exception-caused {
-        font-size: 1.4em;
+        font-size: 1.6em;
         display: block;
+        margin-bottom: var(--layout-vertical-gap);
     }
     .stack-exception-type {
+        display: block;
         font-family: var(--typeface-mono);
     }
     .stack-exception-message {
-        margin-top: 12px;
+        margin-bottom: 10px;
+        font-size: 1.2em;
+        font-weight: bold;
     }
 
     .stack-frames {
         list-style: none;
         padding: 0;
         margin: 0;
-        border-radius: 4px;
+        border-radius: var(--border-radius);
     }
     .stack-frame {
         background: #e5e5e5;
@@ -179,10 +176,10 @@ use Cake\Error\Debugger;
         overflow: hidden;
     }
     .stack-frame:first-child {
-        border-radius: 5px 5px 0 0;
+        border-radius: var(--border-radius) var(--border-radius) 0 0;
     }
     .stack-frame:last-child {
-        border-radius: 0 0 5px 5px;
+        border-radius: 0 0 var(--border-radius) var(--border-radius);
         border-bottom: none;
         margin-bottom: 0;
     }
@@ -205,6 +202,10 @@ use Cake\Error\Debugger;
     .stack-frame-header-content {
         display: flex;
         gap: 8px;
+    }
+    .stack-frame-header-content.vendor-frame ,
+    .stack-frame-header-content.vendor-frame a {
+        color: var(--color-vendor-frame);
     }
     @media (max-width: 810px) {
         .stack-frame-header-content {
@@ -243,7 +244,7 @@ use Cake\Error\Debugger;
     .stack-frame-toggle {
         color: #525252;
         border: 1px solid #d2d2d2;
-        border-radius: 5px;
+        border-radius: var(--border-radius);
         height: 28px;
         width: 28px;
         background: #F5F7FA;
@@ -262,6 +263,11 @@ use Cake\Error\Debugger;
     }
     .stack-args h4 {
         margin-top: 0;
+    }
+
+    /* Suggestion and help context */
+    .error-suggestion {
+        margin-bottom: var(--layout-vertical-gap);
     }
 
     /* Code excerpts */


### PR DESCRIPTION
Refresh the design of the development error pages. I find the current design pretty busy and hard to navigate, as you can only look at a single frame at a time. The new design has a few improvements:

* Responsive design. The new layout renders reasonably well on tablets and ok on phones. The previous design was a mess on small viewports.
* Focus on the stack trace. The stack trace navigation and context for each frame are now together.
* You can view multiple frames at a time. Because each frame can be collapsed individually you can now look at multiple frames at the same time.
* Chained exceptions are rendered!
* Vendor frames are dimmed. I've removed the 'toggle vendor frames' behavior as I don't think it is that useful.

### Next steps

Next, I'd like to de-duplicate the stack frame rendering so that chained exceptions are easier to read.

### Backwards compatibility

I've changed a good amount of the CSS in an incompatible way. This could cause userland custom error pages to render poorly, but I'm not overly concerned about that. My thinking is that if a user has modified the templates for error pages they hopefully have duplicated and modified the existing error CSS.

I've left the elements used in the previous implementation behind so that if userland code is using them those error pages will continue to work as they always have.

### Screenshots

Please ignore the cake icon on the right side as it is from debug kit.

**Missing Controller** an example of a 'helpful' error message from the framework.

![Screenshot 2022-09-18 at 13-27-21 Error Missing Controller](https://user-images.githubusercontent.com/24086/190920631-31962f18-b8b7-4ea2-8028-ef73e8ae7d8b.png)

**Chained exception rendering**

![Screenshot 2022-09-18 at 13-27-39 Error Page is missing](https://user-images.githubusercontent.com/24086/190920632-b39e7996-f579-4aad-8bb0-cbd279d74b1f.png)
