### PR TITLE
5.x driver

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1474,8 +1474,6 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function traverseExpressions(Closure $callback)
     {
-        $callback = $callback(...);
-
         foreach ($this->_parts as $part) {
             $this->_expressionsVisitor($part, $callback);
         }

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -224,7 +224,7 @@ class DriverTest extends TestCase
             ->willReturn('1');
 
         $driver = $this->getMockBuilder(Driver::class)
-            ->onlyMethods(['newCompiler', 'queryTranslator'])
+            ->onlyMethods(['newCompiler', 'transformQuery'])
             ->getMockForAbstractClass();
 
         $driver
@@ -232,17 +232,15 @@ class DriverTest extends TestCase
             ->method('newCompiler')
             ->willReturn($compiler);
 
-        $driver
-            ->expects($this->once())
-            ->method('queryTranslator')
-            ->willReturn(function ($query) {
-                return $query;
-            });
-
         $query = $this->getMockBuilder(Query::class)
             ->disableOriginalConstructor()
             ->getMock();
         $query->method('type')->will($this->returnValue('select'));
+
+        $driver
+            ->expects($this->once())
+            ->method('transformQuery')
+            ->willReturn($query);
 
         $result = $driver->compileQuery($query, new ValueBinder());
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -21,7 +21,6 @@ use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\OrderClauseExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
-use Cake\Database\IdentifierQuoter;
 use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Association;
@@ -758,10 +757,9 @@ class HasManyTest extends TestCase
     protected function assertJoin($expected, $query): void
     {
         if ($this->autoQuote) {
-            $driver = $query->getConnection()->getDriver();
-            $quoter = new IdentifierQuoter($driver);
+            $quoter = $query->getConnection()->getDriver()->quoter();
             foreach ($expected as &$join) {
-                $join['table'] = $driver->quoteIdentifier($join['table']);
+                $join['table'] = $quoter->quoteIdentifier($join['table']);
                 if ($join['conditions']) {
                     $quoter->quoteExpression($join['conditions']);
                 }
@@ -779,8 +777,7 @@ class HasManyTest extends TestCase
     protected function assertWhereClause($expected, $query): void
     {
         if ($this->autoQuote) {
-            $quoter = new IdentifierQuoter($query->getConnection()->getDriver());
-            $expected->traverse($quoter->quoteExpression(...));
+            $expected->traverse($query->getConnection()->getDriver()->quoter()->quoteExpression(...));
         }
         $this->assertEquals($expected, $query->clause('where'));
     }
@@ -794,8 +791,7 @@ class HasManyTest extends TestCase
     protected function assertOrderClause($expected, $query): void
     {
         if ($this->autoQuote) {
-            $quoter = new IdentifierQuoter($query->getConnection()->getDriver());
-            $quoter->quoteExpression($expected);
+            $query->getConnection()->getDriver()->quoter()->quoteExpression($expected);
         }
         $this->assertEquals($expected, $query->clause('order'));
     }


### PR DESCRIPTION
- Removed unnecessary use of closure in `Driver::compileQuery()`.
- Moved all identifier quoting code into `IdentifierQuoter`.