### PR TITLE
Update api-docs.yml

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -12,9 +12,6 @@ permissions: {}
 
 jobs:
   trigger-api:
-    permissions:
-      metadata: read
-
     runs-on: ubuntu-latest
     steps:
       - name: Get Cakebot App Token


### PR DESCRIPTION
I don't know how I missed that by while `metadata` is listed [in permission types](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) it is actually unsupported by workflows schema.
