### PR TITLE
4.5 - Improve rendering of stack traces

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -373,6 +373,42 @@ class Debugger
     }
 
     /**
+     * Get the frames from $exception that are not present in $parent
+     *
+     * @param \Throwable $exception The exception to get frames from.
+     * @param ?\Throwable $parent The parent exception to compare frames with.
+     * @return array An array of frame structures.
+     */
+    public static function getUniqueFrames(Throwable $exception, ?Throwable $parent): array
+    {
+        if ($parent === null) {
+            return $exception->getTrace();
+        }
+        $parentFrames = $parent->getTrace();
+        $frames = $exception->getTrace();
+
+        $parentCount = count($parentFrames) - 1;
+        $frameCount = count($frames) - 1;
+
+        // Reverse loop through both traces removing frames that
+        // are the same.
+        for ($i = $frameCount, $p = $parentCount; $i >= 0 && $p >= 0; $p--) {
+            $parentTail = $parentFrames[$p];
+            $tail = $frames[$i];
+            $isEqual = (
+                ($tail['file'] ?? '') === ($parentTail['file'] ?? '') &&
+                ($tail['line'] ?? '') === ($parentTail['line'] ?? '')
+            );
+            if ($isEqual) {
+                unset($frames[$i]);
+                $i--;
+            }
+        }
+
+        return $frames;
+    }
+
+    /**
      * Outputs a stack trace based on the supplied options.
      *
      * ### Options
@@ -426,60 +462,50 @@ class Debugger
         ];
         $options = Hash::merge($defaults, $options);
 
-        $count = count($backtrace);
+        $count = count($backtrace) + 1;
         $back = [];
 
-        $_trace = [
-            'line' => '??',
-            'file' => '[internal]',
-            'class' => null,
-            'function' => '[main]',
-        ];
-
         for ($i = $options['start']; $i < $count && $i < $options['depth']; $i++) {
-            $trace = $backtrace[$i] + ['file' => '[internal]', 'line' => '??'];
-            $signature = $reference = '[main]';
+            $frame = ['file' => '[main]', 'line' => ''];
+            if (isset($backtrace[$i])) {
+                $frame = $backtrace[$i] + ['file' => '[internal]', 'line' => '??'];
+            }
 
-            if (isset($backtrace[$i + 1])) {
-                $next = $backtrace[$i + 1] + $_trace;
-                $signature = $reference = $next['function'];
-
-                if (!empty($next['class'])) {
-                    $signature = $next['class'] . '::' . $next['function'];
-                    $reference = $signature . '(';
-                    if ($options['args'] && isset($next['args'])) {
-                        $args = [];
-                        foreach ($next['args'] as $arg) {
-                            $args[] = Debugger::exportVar($arg);
-                        }
-                        $reference .= implode(', ', $args);
+            $signature = $reference = $frame['file'];
+            if (!empty($frame['class'])) {
+                $signature = $frame['class'] . $frame['type'] . $frame['function'];
+                $reference = $signature . '(';
+                if ($options['args'] && isset($frame['args'])) {
+                    $args = [];
+                    foreach ($frame['args'] as $arg) {
+                        $args[] = Debugger::exportVar($arg);
                     }
-                    $reference .= ')';
+                    $reference .= implode(', ', $args);
                 }
+                $reference .= ')';
             }
             if (in_array($signature, $options['exclude'], true)) {
                 continue;
             }
             if ($options['format'] === 'points') {
-                $back[] = ['file' => $trace['file'], 'line' => $trace['line'], 'reference' => $reference];
+                $back[] = ['file' => $frame['file'], 'line' => $frame['line'], 'reference' => $reference];
             } elseif ($options['format'] === 'array') {
                 if (!$options['args']) {
-                    unset($trace['args']);
+                    unset($frame['args']);
                 }
-                $back[] = $trace;
+                $back[] = $frame;
             } else {
-                if (isset($self->_templates[$options['format']]['traceLine'])) {
-                    $tpl = $self->_templates[$options['format']]['traceLine'];
+                $tpl = $self->_templates[$options['format']]['traceLine'] ?? $self->_templates['base']['traceLine'];
+                if ($frame['file'] == '[main]') {
+                    $back[] = '[main]';
                 } else {
-                    $tpl = $self->_templates['base']['traceLine'];
+                    $frame['path'] = static::trimPath($frame['file']);
+                    $frame['reference'] = $reference;
+                    unset($frame['object'], $frame['args']);
+                    $back[] = Text::insert($tpl, $frame, ['before' => '{:', 'after' => '}']);
                 }
-                $trace['path'] = static::trimPath($trace['file']);
-                $trace['reference'] = $reference;
-                unset($trace['object'], $trace['args']);
-                $back[] = Text::insert($tpl, $trace, ['before' => '{:', 'after' => '}']);
             }
         }
-
         if ($options['format'] === 'array' || $options['format'] === 'points') {
             return $back;
         }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -395,9 +395,17 @@ class Debugger
         for ($i = $frameCount, $p = $parentCount; $i >= 0 && $p >= 0; $p--) {
             $parentTail = $parentFrames[$p];
             $tail = $frames[$i];
+
+            // Frames without file/line are never equal to another frame.
             $isEqual = (
-                ($tail['file'] ?? '') === ($parentTail['file'] ?? '') &&
-                ($tail['line'] ?? '') === ($parentTail['line'] ?? '')
+                (
+                    isset($tail['file']) &&
+                    isset($tail['line']) &&
+                    isset($parentTail['file']) &&
+                    isset($parentTail['line'])
+                ) &&
+                ($tail['file'] === $parentTail['file']) &&
+                ($tail['line'] === $parentTail['line'])
             );
             if ($isEqual) {
                 unset($frames[$i]);

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -426,7 +426,11 @@ class Debugger
      */
     public static function trace(array $options = [])
     {
-        return Debugger::formatTrace(debug_backtrace(), $options);
+        // Remove the frame for Debugger::trace()
+        $backtrace = debug_backtrace();
+        array_shift($backtrace);
+
+        return Debugger::formatTrace($backtrace, $options);
     }
 
     /**

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -183,7 +183,11 @@ class PhpError
     {
         $out = [];
         foreach ($this->trace as $frame) {
-            $out[] = "{$frame['reference']} {$frame['file']}, line {$frame['line']}";
+            if (!empty($frame['line'])) {
+                $out[] = "{$frame['reference']} {$frame['file']}, line {$frame['line']}";
+            } else {
+                $out[] = $frame['reference'];
+            }
         }
 
         return implode("\n", $out);

--- a/src/basics.php
+++ b/src/basics.php
@@ -49,12 +49,13 @@ if (!function_exists('debug')) {
 
         $location = [];
         if ($showFrom) {
-            $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
-            /** @psalm-suppress PossiblyInvalidArrayOffset */
-            $location = [
-                'line' => $trace[0]['line'],
-                'file' => $trace[0]['file'],
-            ];
+            $trace = Debugger::trace(['start' => 0, 'depth' => 1, 'format' => 'array']);
+            if (isset($trace[0])) {
+                $location = [
+                    'line' => $trace[0]['line'],
+                    'file' => $trace[0]['file'],
+                ];
+            }
         }
 
         Debugger::printVar($var, $location, $showHtml);

--- a/src/basics.php
+++ b/src/basics.php
@@ -50,7 +50,7 @@ if (!function_exists('debug')) {
         $location = [];
         if ($showFrom) {
             $trace = Debugger::trace(['start' => 0, 'depth' => 1, 'format' => 'array']);
-            if (isset($trace[0])) {
+            if (isset($trace[0]['line']) && isset($trace[0]['file'])) {
                 $location = [
                     'line' => $trace[0]['line'],
                     'file' => $trace[0]['file'],

--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -18,7 +18,9 @@
 use Cake\Error\Debugger;
 
 foreach ($exceptions as $level => $exc):
-    $stackTrace = Debugger::formatTrace($exc->getTrace(), [
+    $parent = $exceptions[$level - 1] ?? null;
+    $stackTrace = Debugger::getUniqueFrames($exc, $parent);
+    $stackTrace = Debugger::formatTrace($stackTrace, [
         'format' => 'array',
         'args' => true,
     ]);

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -128,8 +128,8 @@ class ErrorHandlerTest extends TestCase
             $this->assertMatchesRegularExpression('/<b>Warning<\/b>/', $result);
             $this->assertMatchesRegularExpression('/variable \$wrong/', $result);
         }
-        $this->assertStringContainsString(
-            'ErrorHandlerTest.php, line ' . (__LINE__ - 13),
+        $this->assertMatchesRegularExpression(
+            '/ErrorHandlerTest\.php[^,]+, line[^\d]+' . (__LINE__ - 13) . '/',
             $result,
             'Should contain file and line reference'
         );

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -264,7 +264,7 @@ class ErrorHandlerTest extends TestCase
         $this->assertMatchesRegularExpression('/Undefined variable\:? \$?out in/', $messages[0]);
         $this->assertStringContainsString('[' . __FILE__ . ', line ' . (__LINE__ - 6) . ']', $messages[0]);
         $this->assertStringContainsString('Trace:', $messages[0]);
-        $this->assertStringContainsString(__NAMESPACE__ . '\ErrorHandlerTest::testHandleErrorLoggingTrace()', $messages[0]);
+        $this->assertStringContainsString(__NAMESPACE__ . '\ErrorHandlerTest->testHandleErrorLoggingTrace()', $messages[0]);
         $this->assertStringContainsString('Request URL:', $messages[0]);
         $this->assertStringContainsString('Referer URL:', $messages[0]);
     }

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -160,7 +160,7 @@ class ErrorTrapTest extends TestCase
         $logs = Log::engine('test_error')->read();
         $this->assertStringContainsString('Oh no it was bad', $logs[0]);
         $this->assertStringContainsString('Trace:', $logs[0]);
-        $this->assertStringContainsString('ErrorTrapTest::testHandleErrorLogTrace', $logs[0]);
+        $this->assertStringContainsString('ErrorTrapTest->testHandleErrorLogTrace', $logs[0]);
     }
 
     public function testHandleErrorNoLog()
@@ -252,7 +252,7 @@ class ErrorTrapTest extends TestCase
         $out = $stub->messages();
         $this->assertStringContainsString('Oh no it was bad', $out[0]);
         $this->assertStringContainsString('Trace', $out[0]);
-        $this->assertStringContainsString('ErrorTrapTest::testConsoleRenderingWithTrace', $out[0]);
+        $this->assertStringContainsString('ErrorTrapTest->testConsoleRenderingWithTrace', $out[0]);
     }
 
     public function testRegisterNoOutputDebug()


### PR DESCRIPTION
* De-duplicate stack frames for chained exceptions.
* Align rendering of stacktraces with how PHP natively handles them. Previously we were doing some lookahead logic to get the frame that was called. This lead to the functions being one frame 'off' of where PHP would render the trace. Aligning the trace output could be considered a breaking change but it is very minimal and people who are munging our text outputs know what they've gotten themselves into.
* As part of this trace alignment the method operators were updated to match how the method was called versus always using `::`.
