### PR TITLE
Allow typed finder arguments after the $options array

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -260,12 +260,13 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     /**
      * Invoke a finder on a behavior.
      *
+     * @internal
      * @param string $type The finder type to invoke.
-     * @param array $args The arguments you want to invoke the method with.
+     * @param mixed ...$args The arguments you want to invoke the method with.
      * @return \Cake\ORM\Query The return value depends on the underlying behavior method.
      * @throws \BadMethodCallException When the method is unknown.
      */
-    public function callFinder(string $type, array $args = []): Query
+    public function callFinder(string $type, ...$args): Query
     {
         $type = strtolower($type);
 

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -304,7 +304,7 @@ class BehaviorRegistryTest extends TestCase
             ->method('findNoSlug')
             ->with($query, [])
             ->will($this->returnValue($query));
-        $return = $this->Behaviors->callFinder('noSlug', [$query, []]);
+        $return = $this->Behaviors->callFinder('noSlug', $query, []);
         $this->assertSame($query, $return);
     }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1127,6 +1127,15 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that extra arguments are passed to finders.
+     */
+    public function testFindTypedParameters(): void
+    {
+        $author = $this->getTableLocator()->get('Authors')->find('WithIdArgument', [], 2)->first();
+        $this->assertSame(2, $author->id);
+    }
+
+    /**
      * Tests find('list')
      */
     public function testFindListNoHydration(): void

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -61,4 +61,16 @@ class AuthorsTable extends Table
             });
         });
     }
+
+    /**
+     * Finder that accepts an option via a typed parameter.
+     *
+     * @param \Cake\ORM\Query $query The query
+     * @param array<string, mixed> $options The options
+     * @param int $id Author ID
+     */
+    public function findWithIdArgument(Query $query, array $options, int $id): Query
+    {
+        return $query->where(['id' => $id]);
+    }
 }

--- a/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
+++ b/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
@@ -27,8 +27,9 @@ class GreedyCommentsTable extends Table
      *
      * @param string $type Find type
      * @param array<string, mixed> $options find options
+     * @param mixed ...$args Finder arguments
      */
-    public function find(string $type = 'all', array $options = []): Query
+    public function find(string $type = 'all', array $options = [], ...$args): Query
     {
         if (empty($options['conditions'])) {
             $options['conditions'] = [];


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/pull/12787

This does not try to make `$options` optional.