### PR TITLE
Add test for #16779

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -782,7 +782,7 @@ class Debugger
         if ($remaining > 0) {
             if (method_exists($var, '__debugInfo')) {
                 try {
-                    foreach ($var->__debugInfo() as $key => $val) {
+                    foreach ((array)$var->__debugInfo() as $key => $val) {
                         $node->addProperty(new PropertyNode("'{$key}'", null, static::export($val, $context)));
                     }
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -28,6 +28,7 @@ use Cake\Error\Debugger;
 use Cake\Error\Renderer\HtmlErrorRenderer;
 use Cake\Form\Form;
 use Cake\Log\Log;
+use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use MyClass;
@@ -641,6 +642,16 @@ TEXT;
     {
         $result = Debugger::exportVar(new ThrowsDebugInfo());
         $expected = '(unable to export object: from __debugInfo)';
+        $this->assertTextEquals($expected, $result);
+    }
+
+    /**
+     * Test exportVar with a mock
+     */
+    public function testExportVarMockObject(): void
+    {
+        $result = Debugger::exportVar($this->getMockBuilder(Table::class)->getMock());
+        $expected = '(unable to export object: foreach() argument must be of type array|object, null given)';
         $this->assertTextEquals($expected, $result);
     }
 

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -651,8 +651,7 @@ TEXT;
     public function testExportVarMockObject(): void
     {
         $result = Debugger::exportVar($this->getMockBuilder(Table::class)->getMock());
-        $expected = '(unable to export object: foreach() argument must be of type array|object, null given)';
-        $this->assertTextEquals($expected, $result);
+        $this->assertStringContainsString('object(Mock_Table', $result);
     }
 
     /**


### PR DESCRIPTION
Mock objects don't return arrays from their `__debugInfo` methods, so we need to cast.

Fixes #16779

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
