### PR TITLE
Allow typed finder arguments 

### DIFF
--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -135,10 +135,10 @@ interface QueryInterface
      * a single query.
      *
      * @param string $finder The finder method to use.
-     * @param array<string, mixed> $options The options for the finder.
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return static Returns a modified query.
      */
-    public function find(string $finder, array $options = []): static;
+    public function find(string $finder, mixed ...$args): static;
 
     /**
      * Returns the first result out of executing this query, if the query has not been

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -67,10 +67,10 @@ interface RepositoryInterface
      * type of search that was selected.
      *
      * @param string $type the type of query to perform
-     * @param array<string, mixed> $options An array that will be passed to Query::applyOptions()
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return \Cake\Datasource\QueryInterface
      */
-    public function find(string $type = 'all', array $options = []): QueryInterface;
+    public function find(string $type = 'all', mixed ...$args): QueryInterface;
 
     /**
      * Returns a single record after finding it by its primary key, if no record is

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -832,17 +832,36 @@ abstract class Association
      *
      * @param array<string, mixed>|string|null $type the type of query to perform, if an array is passed,
      *   it will be interpreted as the `$options` parameter
-     * @param array<string, mixed> $options The options to for the find
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @see \Cake\ORM\Table::find()
      * @return \Cake\ORM\Query\SelectQuery
      */
-    public function find(array|string|null $type = null, array $options = []): SelectQuery
+    public function find(array|string|null $type = null, mixed ...$args): SelectQuery
     {
         $type = $type ?: $this->getFinder();
         [$type, $opts] = $this->_extractFinder($type);
 
+        // Find $options in arguments to merge with finder options
+        $options = null;
+        if ($args) {
+            if (array_key_exists(0, $args)) {
+                $options = &$args[0];
+            } elseif (array_key_exists('options', $args)) {
+                $options = &$args['options'];
+            }
+        }
+
+        if ($opts) {
+            if (is_array($options)) {
+                /** @psalm-suppress ReferenceReusedFromConfusingScope */
+                $options = $options + $opts;
+            } else {
+                array_unshift($args, $opts);
+            }
+        }
+
         return $this->getTarget()
-            ->find($type, $options + $opts)
+            ->find($type, ...$args)
             ->where($this->getConditions());
     }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1063,16 +1063,36 @@ class BelongsToMany extends Association
      *
      * @param array<string, mixed>|string|null $type the type of query to perform, if an array is passed,
      *   it will be interpreted as the `$options` parameter
-     * @param array<string, mixed> $options The options to for the find
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @see \Cake\ORM\Table::find()
      * @return \Cake\ORM\Query\SelectQuery
      */
-    public function find(array|string|null $type = null, array $options = []): SelectQuery
+    public function find(array|string|null $type = null, mixed ...$args): SelectQuery
     {
         $type = $type ?: $this->getFinder();
         [$type, $opts] = $this->_extractFinder($type);
+
+        // Find $options in arguments to merge with finder options
+        $options = null;
+        if ($args) {
+            if (array_key_exists(0, $args)) {
+                $options = &$args[0];
+            } elseif (array_key_exists('options', $args)) {
+                $options = &$args['options'];
+            }
+        }
+
+        if ($opts) {
+            if (is_array($options)) {
+                /** @psalm-suppress ReferenceReusedFromConfusingScope */
+                $options = $options + $opts;
+            } else {
+                array_unshift($args, $opts);
+            }
+        }
+
         $query = $this->getTarget()
-            ->find($type, $options + $opts)
+            ->find($type, ...$args)
             ->where($this->targetConditions())
             ->addDefaultTypes($this->getTarget());
 

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -24,6 +24,7 @@ use Cake\Event\EventDispatcherTrait;
 use Cake\ORM\Exception\MissingBehaviorException;
 use Cake\ORM\Query\SelectQuery;
 use LogicException;
+use ReflectionFunction;
 
 /**
  * BehaviorRegistry is used as a registry for loaded behaviors and handles loading
@@ -264,20 +265,30 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     /**
      * Invoke a finder on a behavior.
      *
+     * @internal
      * @param string $type The finder type to invoke.
-     * @param array $args The arguments you want to invoke the method with.
+     * @param \Cake\ORM\Query\SelectQuery $query The query object to apply the finder options to.
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return \Cake\ORM\Query\SelectQuery The return value depends on the underlying behavior method.
      * @throws \BadMethodCallException When the method is unknown.
      */
-    public function callFinder(string $type, array $args = []): SelectQuery
+    public function callFinder(string $type, SelectQuery $query, mixed ...$args): SelectQuery
     {
         $type = strtolower($type);
 
         if ($this->hasFinder($type) && $this->has($this->_finderMap[$type][0])) {
             [$behavior, $callMethod] = $this->_finderMap[$type];
-            $callable = [$this->_loaded[$behavior], $callMethod];
+            $callable = $this->_loaded[$behavior]->$callMethod(...);
 
-            return $callable(...$args);
+            if (!$args) {
+                $reflected = new ReflectionFunction($callable);
+                $param = $reflected->getParameters()[1] ?? null;
+                if ($param?->name === 'options' && !$param->isDefaultValueAvailable()) {
+                    $args = [[]];
+                }
+            }
+
+            return $callable($query, ...$args);
         }
 
         throw new BadMethodCallException(

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1665,16 +1665,16 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * {@inheritDoc}
      *
      * @param string $finder The finder method to use.
-     * @param array<string, mixed> $options The options for the finder.
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return static Returns a modified query.
      * @psalm-suppress MoreSpecificReturnType
      */
-    public function find(string $finder, array $options = []): static
+    public function find(string $finder, mixed ...$args): static
     {
         $table = $this->getRepository();
 
         /** @psalm-suppress LessSpecificReturnStatement */
-        return $table->callFinder($finder, $this, $options);
+        return $table->callFinder($finder, $this, ...$args);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -53,6 +53,7 @@ use Cake\Validation\ValidatorAwareTrait;
 use Closure;
 use Exception;
 use InvalidArgumentException;
+use ReflectionMethod;
 
 /**
  * Represents a single database table.
@@ -1219,21 +1220,54 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * ### Calling finders
      *
      * The find() method is the entry point for custom finder methods.
-     * You can invoke a finder by specifying the type:
+     * You can invoke a finder by specifying the type.
+     *
+     * This will invoke the `findPublished` method:
      *
      * ```
      * $query = $articles->find('published');
      * ```
      *
-     * Would invoke the `findPublished` method.
+     * ## Typed finder arguments
+     *
+     * Finders can have typed parameters separate from the `$options` array and the
+     * `$options` parameter can be optional if not needed:
+     *
+     * ```
+     * $query = $articles->find('byCategory', $category);
+     * ```
+     *
+     * Here, the finder "findByCategory" does not have an `$options` parameter:
+     *
+     * ```
+     * function findByCategory(SelectQuery $query, int $category): SelectQuery
+     * {
+     *     return $query;
+     * }
+     * ```
+     *
+     * If you need to pass query options, just add the typed arguments after `$options`:
+     *
+     * ```
+     * $query = $articles->find('byCategory', [...], $category);
+     * ```
+     *
+     * Here, the finder "findByCategory" does have an `$options` parameter:
+     *
+     * ```
+     * function findByCategory(SelectQuery $query, array $options, int $category): SelectQuery
+     * {
+     *     return $query;
+     * }
+     * ```
      *
      * @param string $type the type of query to perform
-     * @param array<string, mixed> $options An array that will be passed to Query::applyOptions()
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return \Cake\ORM\Query\SelectQuery The query builder
      */
-    public function find(string $type = 'all', array $options = []): SelectQuery
+    public function find(string $type = 'all', mixed ...$args): SelectQuery
     {
-        return $this->callFinder($type, $this->selectQuery(), $options);
+        return $this->callFinder($type, $this->selectQuery(), ...$args);
     }
 
     /**
@@ -2557,28 +2591,53 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Calls a finder method and applies it to the passed query.
      *
+     * @internal
      * @param string $type Name of the finder to be called.
      * @param \Cake\ORM\Query\SelectQuery $query The query object to apply the finder options to.
-     * @param array<string, mixed> $options List of options to pass to the finder.
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      * @return \Cake\ORM\Query\SelectQuery
      * @throws \BadMethodCallException
      * @uses findAll()
      * @uses findList()
      * @uses findThreaded()
      */
-    public function callFinder(string $type, SelectQuery $query, array $options = []): SelectQuery
+    public function callFinder(string $type, SelectQuery $query, mixed ...$args): SelectQuery
     {
-        assert(empty($options) || !array_is_list($options), 'Finder options should be an associative array not a list');
+        // Extract and apply $options from arguments
+        if ($args) {
+            $options = [];
+            if (array_key_exists(0, $args)) {
+                // $options is not a named argument
+                $options = &$args[0];
+            } elseif (array_key_exists('options', $args)) {
+                // options is a named argument
+                $options = &$args['options'];
+            }
 
-        $query->applyOptions($options);
-        $options = $query->getOptions();
+            if (is_array($options) && $options) {
+                assert(!array_is_list($options), '`$options` argument should be an associative array.');
+
+                $query->applyOptions($options);
+                /** @psalm-suppress ReferenceReusedFromConfusingScope */
+                $options = $query->getOptions();
+            }
+        }
+
         $finder = 'find' . $type;
         if (method_exists($this, $finder)) {
-            return $this->{$finder}($query, $options);
+            if (!$args) {
+                $reflected = new ReflectionMethod($this, $finder);
+                $param = $reflected->getParameters()[1] ?? null;
+                if ($param?->name === 'options' && !$param->isDefaultValueAvailable()) {
+                    $args = [[]];
+                }
+            }
+
+            return $this->{$finder}($query, ...$args);
         }
 
         if ($this->_behaviors->hasFinder($type)) {
-            return $this->_behaviors->callFinder($type, [$query, $options]);
+            return $this->_behaviors->callFinder($type, $query, ...$args);
         }
 
         throw new BadMethodCallException(sprintf(

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -488,6 +488,42 @@ class AssociationTest extends TestCase
         );
     }
 
+    public function testCustomFinderWithTypedArgs(): void
+    {
+        $this->association->setFinder('published');
+        $this->assertEquals(
+            ['this' => 'custom'],
+            $this->association->find(null, [], 'custom')->getOptions()
+        );
+        $this->assertEquals(
+            ['this' => 'custom'],
+            $this->association->find(null, options: [], what: 'custom')->getOptions()
+        );
+
+        $this->assertEquals(
+            ['other' => true, 'this' => 'custom'],
+            $this->association->find(['published' => ['other' => true]], [], 'custom')->getOptions()
+        );
+        $this->assertEquals(
+            ['other' => true, 'this' => 'custom'],
+            $this->association->find(['published' => ['other' => true]], 'custom')->getOptions()
+        );
+
+        $this->association->setFinder('publishedWithArgOnly');
+        $this->assertEquals(
+            ['this' => 'custom'],
+            $this->association->find(null, 'custom')->getOptions()
+        );
+        $this->assertEquals(
+            ['this' => 'custom'],
+            $this->association->find(null, what: 'custom')->getOptions()
+        );
+        $this->assertEquals(
+            ['this' => 'custom'],
+            $this->association->find(what: 'custom')->getOptions()
+        );
+    }
+
     /**
      * Tests that `locator` is a valid option for the association constructor
      */

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -304,7 +304,7 @@ class BehaviorRegistryTest extends TestCase
             ->method('findNoSlug')
             ->with($query, [])
             ->will($this->returnValue($query));
-        $return = $this->Behaviors->callFinder('noSlug', [$query, []]);
+        $return = $this->Behaviors->callFinder('noSlug', $query, []);
         $this->assertSame($query, $return);
     }
 
@@ -316,7 +316,7 @@ class BehaviorRegistryTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot call finder "nope"');
         $this->Behaviors->load('Sluggable');
-        $this->Behaviors->callFinder('nope');
+        $this->Behaviors->callFinder('nope', new SelectQuery($this->Table));
     }
 
     /**
@@ -342,7 +342,7 @@ class BehaviorRegistryTest extends TestCase
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
 
-        $this->Behaviors->callFinder('noSlug');
+        $this->Behaviors->callFinder('noSlug', new SelectQuery($this->Table));
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1182,6 +1182,18 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that extra arguments are passed to finders.
+     */
+    public function testFindTypedParameters(): void
+    {
+        $author = $this->getTableLocator()->get('Authors')->find('WithIdArgument', 2)->first();
+        $this->assertSame(2, $author->id);
+
+        $author = $this->getTableLocator()->get('Authors')->find('WithIdArgument', id: 2)->first();
+        $this->assertSame(2, $author->id);
+    }
+
+    /**
      * Tests find('list')
      */
     public function testFindListNoHydration(): void
@@ -5255,7 +5267,7 @@ class TableTest extends TestCase
     public function testSimplifiedFind(): void
     {
         $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['callFinder'])
+            ->onlyMethods(['findAll'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => ['id' => ['type' => 'integer']],
@@ -5263,8 +5275,8 @@ class TableTest extends TestCase
             ->getMock();
 
         $query = (new SelectQuery($table))->select();
-        $table->expects($this->once())->method('callFinder')
-            ->with('all', $query, []);
+        $table->expects($this->once())->method('findAll')
+            ->with($query, []);
         $table->find();
     }
 

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -50,6 +50,7 @@ class AuthorsTable extends Table
      *
      * @param \Cake\ORM\Query\SelectQuery $query The query
      * @param array<string, mixed> $options The options
+     * @return \Cake\ORM\Query\SelectQuery
      */
     public function findFormatted(SelectQuery $query, array $options = []): SelectQuery
     {
@@ -60,5 +61,17 @@ class AuthorsTable extends Table
                 return $author;
             });
         });
+    }
+
+    /**
+     * Finder that accepts an option via a typed parameter.
+     *
+     * @param \Cake\ORM\SelectQuery $query The query
+     * @param int $id Author ID
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    public function findWithIdArgument(SelectQuery $query, int $id): SelectQuery
+    {
+        return $query->where(['id' => $id]);
     }
 }

--- a/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
+++ b/tests/test_app/TestApp/Model/Table/GreedyCommentsTable.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace TestApp\Model\Table;
 
-use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 
 /**
@@ -26,10 +26,11 @@ class GreedyCommentsTable extends Table
      * Overload find to cause issues.
      *
      * @param string $type Find type
-     * @param array<string, mixed> $options find options
+     * @param mixed ...$args Arguments that match up to finder-specific parameters
      */
-    public function find(string $type = 'all', array $options = []): Query
+    public function find(string $type = 'all', mixed ...$args): SelectQuery
     {
+        $options = &$args[0];
         if (empty($options['conditions'])) {
             $options['conditions'] = [];
         }

--- a/tests/test_app/TestApp/Model/Table/TestTable.php
+++ b/tests/test_app/TestApp/Model/Table/TestTable.php
@@ -19,8 +19,13 @@ class TestTable extends Table
         $this->setSchema(['id' => ['type' => 'integer']]);
     }
 
-    public function findPublished(SelectQuery $query): SelectQuery
+    public function findPublished(SelectQuery $query, array $options, string $what = 'worked'): SelectQuery
     {
-        return $query->applyOptions(['this' => 'worked']);
+        return $query->applyOptions(['this' => $what]);
+    }
+
+    public function findPublishedWithArgOnly(SelectQuery $query, string $what = 'worked'): SelectQuery
+    {
+        return $query->applyOptions(['this' => $what]);
     }
 }


### PR DESCRIPTION
refs https://github.com/cakephp/cakephp/pull/12787

~This does not remove the `$options` parameter. Users must specify an empty array if they want to by-pass it.~

The `$options` parameter is now optional.