### PR TITLE
skip test if xdebug is loaded

### DIFF
--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -371,6 +371,7 @@ TEXT;
      */
     public function testExportVarInvalidDebugInfo(): void
     {
+        $this->skipIf(extension_loaded('xdebug'), 'Throwing exceptions inside __debugInfo breaks with xDebug');
         $result = Debugger::exportVar(new ThrowsDebugInfo());
         $expected = '(unable to export object: from __debugInfo)';
         $this->assertTextEquals($expected, $result);


### PR DESCRIPTION
This skips a specific test where we throw a exception inside a `__debugInfo()` method.
[We asked the xdebug DEVs](https://bugs.xdebug.org/view.php?id=2116#c6373) but their answer was, that we shouldn't throw a exception inside a `__debugInfo`.
With this PR one can at least run the whole testsuite without having the need to disable the xdebug extension inside their PHP settings.