### PR TITLE
Add read/write connection configurations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -201,11 +201,6 @@ parameters:
 			path: src/Database/Statement/PDOStatement.php
 
 		-
-			message: "#^Static property Cake\\\\Datasource\\\\ConnectionManager\\:\\:\\$_registry \\(Cake\\\\Datasource\\\\ConnectionRegistry\\) in isset\\(\\) is not nullable\\.$#"
-			count: 2
-			path: src/Datasource/ConnectionManager.php
-
-		-
 			message: "#^Constructor of class Cake\\\\Error\\\\Renderer\\\\ConsoleExceptionRenderer has an unused parameter \\$request\\.$#"
 			count: 1
 			path: src/Error/Renderer/ConsoleExceptionRenderer.php

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -178,6 +178,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Returns the connection role: read or write.
+     *
+     * @return string
+     */
+    public function role(): string
+    {
+        return preg_match('/:read$/', $this->configName()) === 1 ? static::ROLE_READ : static::ROLE_WRITE;
+    }
+
+    /**
      * Sets the driver instance. If a string is passed it will be treated
      * as a class name and will be instantiated.
      *
@@ -978,6 +988,7 @@ class Connection implements ConnectionInterface
         return [
             'config' => $config,
             'driver' => $this->_driver,
+            'role' => $this->role(),
             'transactionLevel' => $this->_transactionLevel,
             'transactionStarted' => $this->_transactionStarted,
             'useSavePoints' => $this->_useSavePoints,

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -25,6 +25,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\ValuesExpression;
 use Cake\Database\Expression\WindowExpression;
 use Cake\Database\Statement\CallbackStatement;
+use Cake\Datasource\ConnectionManager;
 use Closure;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -227,6 +228,53 @@ class Query implements ExpressionInterface, IteratorAggregate
     public function getConnection(): Connection
     {
         return $this->_connection;
+    }
+
+    /**
+     * Sets the connection for this query to the read-only role for the current connection.
+     *
+     * @return $this
+     */
+    public function useReadRole()
+    {
+        if ($this->_connection->role() !== Connection::ROLE_READ) {
+            /** @var \Cake\Database\Connection $read */
+            $read = ConnectionManager::get($this->_connection->configName(), true, Connection::ROLE_READ);
+            $this->setConnection($read);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the connection for this query to the write role for the current connection.
+     *
+     * @return $this
+     */
+    public function useWriteRole()
+    {
+        if ($this->_connection->role() !== Connection::ROLE_WRITE) {
+            /** @var \Cake\Database\Connection $write */
+            $write = ConnectionManager::get($this->_connection->configName(), true, Connection::ROLE_WRITE);
+            $this->setConnection($write);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the connection for this query to the specified role for the current connection.
+     *
+     * @param string $role Connection role - read or write
+     * @return $this
+     */
+    public function useRole(string $role)
+    {
+        if ($role === Connection::ROLE_READ) {
+            return $this->useReadRole();
+        }
+
+        return $this->useWriteRole();
     }
 
     /**

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -43,6 +43,16 @@ use Psr\SimpleCache\CacheInterface;
 interface ConnectionInterface extends LoggerAwareInterface
 {
     /**
+     * @var string
+     */
+    public const ROLE_WRITE = 'write';
+
+    /**
+     * @var string
+     */
+    public const ROLE_READ = 'read';
+
+    /**
      * Gets the current logger object.
      *
      * @return \Psr\Log\LoggerInterface logger instance


### PR DESCRIPTION
closes https://github.com/cakephp/cakephp/issues/16579

This uses a connection naming convention to switch between read and write connections. 

Read connections have a `:read` suffix. A `:read` connection  must have a matching write connection.

Calling `useReadRole()` or `useWriteRole()` on a query switches the connection instances at that point.