### PR TITLE
Remove unneeded method calls.

### DIFF
--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -927,7 +927,6 @@ class ConnectionTest extends TestCase
     public function pushNestedTransactionState(): void
     {
         $method = new ReflectionMethod($this->connection, 'wasNestedTransactionRolledback');
-        $method->setAccessible(true);
         $this->nestedTransactionStates[] = $method->invoke($this->connection);
     }
 
@@ -943,7 +942,6 @@ class ConnectionTest extends TestCase
         $statement->closeCursor();
 
         $prop = new ReflectionProperty($conn, '_driver');
-        $prop->setAccessible(true);
         $oldDriver = $prop->getValue($conn);
         $newDriver = $this->getMockBuilder(Driver::class)->getMock();
         $prop->setValue($conn, $newDriver);
@@ -973,7 +971,6 @@ class ConnectionTest extends TestCase
         $conn->begin();
 
         $prop = new ReflectionProperty($conn, '_driver');
-        $prop->setAccessible(true);
         $oldDriver = $prop->getValue($conn);
         $newDriver = $this->getMockBuilder(Driver::class)->getMock();
         $prop->setValue($conn, $newDriver);

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -2297,7 +2297,6 @@ class SelectQueryTest extends TestCase
             ->closeCursor();
 
         $reflect = new ReflectionProperty($query, '_dirty');
-        $reflect->setAccessible(true);
         $this->assertFalse($reflect->getValue($query));
 
         $query->offset(2);

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -683,18 +683,15 @@ class TableLocatorTest extends TestCase
     {
         $articles = $this->_locator->get(ArticlesTable::class);
         $prop1 = new ReflectionProperty($articles, 'queryFactory');
-        $prop1->setAccessible(true);
 
         $users = $this->_locator->get(MyUsersTable::class);
         $prop2 = new ReflectionProperty($users, 'queryFactory');
-        $prop2->setAccessible(true);
 
         $this->assertInstanceOf(QueryFactory::class, $prop1->getValue($articles));
         $this->assertSame($prop1->getValue($articles), $prop2->getValue($users));
 
         $addresses = $this->_locator->get(AddressesTable::class, ['queryFactory' => new QueryFactory()]);
         $prop3 = new ReflectionProperty($addresses, 'queryFactory');
-        $prop3->setAccessible(true);
         $this->assertNotSame($prop1->getValue($articles), $prop3->getValue($addresses));
     }
 }

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -2810,7 +2810,6 @@ class SelectQueryTest extends TestCase
         $this->assertNotSame($copyLoader, $loader, 'should be clones');
 
         $reflect = new ReflectionProperty($loader, '_matching');
-        $reflect->setAccessible(true);
         $this->assertNotSame(
             $reflect->getValue($copyLoader),
             $reflect->getValue($loader),

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -1825,7 +1825,6 @@ HTML;
     public function testStrlen(): void
     {
         $method = new ReflectionMethod('Cake\Utility\Text', '_strlen');
-        $method->setAccessible(true);
         $strlen = function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };
@@ -1849,7 +1848,6 @@ HTML;
     public function testSubstr(): void
     {
         $method = new ReflectionMethod('Cake\Utility\Text', '_substr');
-        $method->setAccessible(true);
         $substr = function () use ($method) {
             return $method->invokeArgs(null, func_get_args());
         };

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6884,7 +6884,6 @@ class FormHelperTest extends TestCase
         $this->assertEquals(['title'], $fields);
         $this->assertStringContainsString($hash, $result, 'Should contain the correct hash.');
         $reflect = new ReflectionProperty($this->Form, '_lastAction');
-        $reflect->setAccessible(true);
         $this->assertSame('/Articles/add', $reflect->getValue($this->Form), 'lastAction was should be restored.');
     }
 


### PR DESCRIPTION
Since PHP 8.1 properties and methods are always considered accessible via Reflection.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
