### PR TITLE
Drop unneeded method.

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -67,16 +67,6 @@ class Collection extends IteratorIterator implements CollectionInterface
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @return int
-     */
-    public function countKeys(): int
-    {
-        return count($this->toArray());
-    }
-
-    /**
      * Returns an array that can be used to describe the internal state of this
      * object.
      *

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -185,6 +185,7 @@ class ResultSet implements ResultSetInterface
      */
     public function countKeys(): int
     {
+        // This is an optimization over the implementation provided by CollectionTrait::countKeys()
         return $this->_count;
     }
 


### PR DESCRIPTION
ResultSet::count() returns the same value.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
