### PR TITLE
5.x Update remaining var annotation to use assert()

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -169,8 +169,9 @@ class Cache
                 ), 0, $e);
             }
 
-            /** @var \Cake\Cache\CacheEngine $fallbackEngine */
             $fallbackEngine = clone static::pool($config['fallback']);
+            assert($fallbackEngine instanceof CacheEngine);
+
             $newConfig = $config + ['groups' => [], 'prefix' => null];
             $fallbackEngine->setConfig('groups', $newConfig['groups'], false);
             if ($newConfig['prefix']) {

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -243,13 +243,13 @@ class FileEngine extends CacheEngine
             $this->_config['path'],
             FilesystemIterator::SKIP_DOTS
         );
+        /** @var \RecursiveDirectoryIterator $contents Coerce for phpstan/psalm */
         $contents = new RecursiveIteratorIterator(
             $directory,
             RecursiveIteratorIterator::SELF_FIRST
         );
         $cleared = [];
         foreach ($contents as $fileInfo) {
-            assert($fileInfo instanceof SplFileInfo);
             if ($fileInfo->isFile()) {
                 unset($fileInfo);
                 continue;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -248,8 +248,8 @@ class FileEngine extends CacheEngine
             RecursiveIteratorIterator::SELF_FIRST
         );
         $cleared = [];
-        /** @var \SplFileInfo $fileInfo */
         foreach ($contents as $fileInfo) {
+            assert($fileInfo instanceof SplFileInfo);
             if ($fileInfo->isFile()) {
                 unset($fileInfo);
                 continue;

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Command;
 
 use Cake\Console\Arguments;
+use Cake\Console\BaseCommand;
 use Cake\Console\CommandCollection;
 use Cake\Console\CommandCollectionAwareInterface;
 use Cake\Console\ConsoleIo;
@@ -185,8 +186,8 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
             // Handle class strings
             if (is_string($value)) {
                 $reflection = new ReflectionClass($value);
-                /** @var \Cake\Console\BaseCommand $value */
                 $value = $reflection->newInstance();
+                assert($value instanceof BaseCommand);
             }
 
             if (method_exists($value, 'getOptionParser')) {

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Command;
 
+use Cake\Command\Helper\ProgressHelper;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
@@ -402,8 +403,8 @@ class I18nExtractCommand extends Command
      */
     protected function _extractTokens(Arguments $args, ConsoleIo $io): void
     {
-        /** @var \Cake\Command\Helper\ProgressHelper $progress */
         $progress = $io->helper('progress');
+        assert($progress instanceof ProgressHelper);
         $progress->init(['total' => count($this->_files)]);
         $isVerbose = $args->getOption('verbose');
 

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -72,7 +72,6 @@ class I18nInitCommand extends Command
 
         $count = 0;
         $iterator = new DirectoryIterator($sourceFolder);
-        /** @var \SplFileInfo $fileInfo */
         foreach ($iterator as $fileInfo) {
             if (!$fileInfo->isFile()) {
                 continue;

--- a/src/Command/SchemacacheBuildCommand.php
+++ b/src/Command/SchemacacheBuildCommand.php
@@ -19,6 +19,7 @@ namespace Cake\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Connection;
 use Cake\Database\SchemaCache;
 use Cake\Datasource\ConnectionManager;
 use RuntimeException;
@@ -48,8 +49,8 @@ class SchemacacheBuildCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         try {
-            /** @var \Cake\Database\Connection $connection */
             $connection = ConnectionManager::get((string)$args->getOption('connection'));
+            assert($connection instanceof Connection);
 
             $cache = new SchemaCache($connection);
         } catch (RuntimeException $e) {

--- a/src/Command/SchemacacheClearCommand.php
+++ b/src/Command/SchemacacheClearCommand.php
@@ -19,6 +19,7 @@ namespace Cake\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
+use Cake\Database\Connection;
 use Cake\Database\SchemaCache;
 use Cake\Datasource\ConnectionManager;
 use RuntimeException;
@@ -48,8 +49,8 @@ class SchemacacheClearCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         try {
-            /** @var \Cake\Database\Connection $connection */
             $connection = ConnectionManager::get((string)$args->getOption('connection'));
+            assert($connection instanceof Connection);
 
             $cache = new SchemaCache($connection);
         } catch (RuntimeException $e) {

--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -25,6 +25,7 @@ use Cake\Console\TestSuite\Constraint\ContentsEmpty;
 use Cake\Console\TestSuite\Constraint\ContentsNotContain;
 use Cake\Console\TestSuite\Constraint\ContentsRegExp;
 use Cake\Console\TestSuite\Constraint\ExitCode;
+use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\TestSuite\ContainerStubTrait;
 
 /**
@@ -259,8 +260,8 @@ trait ConsoleIntegrationTestTrait
      */
     protected function makeRunner(): CommandRunner
     {
-        /** @var \Cake\Core\ConsoleApplicationInterface $app */
         $app = $this->createApp();
+        assert($app instanceof ConsoleApplicationInterface);
 
         return new CommandRunner($app);
     }

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -121,8 +121,8 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        assert($request instanceof ServerRequest);
         $controller = $this->controller;
-        /** @var \Cake\Http\ServerRequest $request */
         $controller->setRequest($request);
 
         $result = $controller->startupProcess();

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -285,8 +285,8 @@ class PluginCollection implements Iterator, Countable
                 throw new InvalidArgumentException(sprintf('Class `%s` does not exist.', $name));
             }
 
-            /** @var \Cake\Core\PluginInterface $plugin */
             $plugin = new $name($config);
+            assert($plugin instanceof PluginInterface);
 
             return $plugin;
         }

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -285,10 +285,8 @@ class PluginCollection implements Iterator, Countable
                 throw new InvalidArgumentException(sprintf('Class `%s` does not exist.', $name));
             }
 
-            $plugin = new $name($config);
-            assert($plugin instanceof PluginInterface);
-
-            return $plugin;
+            /** @var \Cake\Core\PluginInterface */
+            return new $name($config);
         }
 
         $config += ['name' => $name];

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -206,11 +206,10 @@ if (!function_exists('env')) {
             $key = 'SCRIPT_URL';
         }
 
-        /** @var string|null $val */
         $val = $_SERVER[$key] ?? $_ENV[$key] ?? null;
+        assert($val === null || is_scalar($val));
         if ($val == null && getenv($key) !== false) {
-            /** @var string|false $val */
-            $val = getenv($key);
+            $val = (string)getenv($key);
         }
 
         if ($key === 'REMOTE_ADDR' && $val === env('SERVER_ADDR')) {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -606,8 +606,8 @@ abstract class Driver
             );
         }
 
-        /** @var \Cake\Database\ExpressionInterface|null $conditions */
         $conditions = $query->clause('where');
+        assert($conditions === null || $conditions instanceof ExpressionInterface);
         if ($conditions) {
             $conditions->traverse(function ($expression) {
                 if ($expression instanceof ComparisonExpression) {

--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -81,7 +81,6 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
             'to' => $this->_to,
         ];
 
-        /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
         if ($field instanceof ExpressionInterface) {
             $field = $field->sql($binder);
@@ -94,6 +93,7 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
             }
             $parts[$name] = $this->_bindValue($part, $binder, $this->_type);
         }
+        assert(is_string($field));
 
         return sprintf('%s BETWEEN %s AND %s', $field, $parts['from'], $parts['to']);
     }

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -143,7 +143,6 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
 
         if ($field instanceof ExpressionInterface) {
@@ -159,6 +158,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
         } else {
             [$template, $value] = $this->_stringExpression($binder);
         }
+        assert(is_string($field));
 
         return sprintf($template, $field, $this->_operator, $value);
     }
@@ -302,8 +302,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
         $isArray = is_array($values);
 
         if ($isArray) {
-            /** @var array $result */
-            $result = $values;
+            $result = (array)$values;
         }
 
         foreach ($values as $k => $v) {

--- a/src/Database/Expression/OrderClauseExpression.php
+++ b/src/Database/Expression/OrderClauseExpression.php
@@ -52,13 +52,13 @@ class OrderClauseExpression implements ExpressionInterface, FieldInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        /** @var \Cake\Database\ExpressionInterface|string $field */
         $field = $this->_field;
         if ($field instanceof Query) {
             $field = sprintf('(%s)', $field->sql($binder));
         } elseif ($field instanceof ExpressionInterface) {
             $field = $field->sql($binder);
         }
+        assert(is_string($field));
 
         return sprintf('%s %s', $field, $this->_direction);
     }

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -179,8 +179,7 @@ class TupleComparison extends ComparisonExpression
      */
     public function traverse(Closure $callback)
     {
-        /** @var array<string> $fields */
-        $fields = $this->getField();
+        $fields = (array)$this->getField();
         foreach ($fields as $field) {
             $this->_traverseValue($field, $callback);
         }

--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -106,9 +106,7 @@ class SchemaCache
             $connection->cacheMetadata(true);
         }
 
-        $schemaCollection = $connection->getSchemaCollection();
-        assert($schemaCollection instanceof CachedCollection);
-
-        return $schemaCollection;
+        /** @var \Cake\Database\Schema\CachedCollection */
+        return $connection->getSchemaCollection();
     }
 }

--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -106,8 +106,8 @@ class SchemaCache
             $connection->cacheMetadata(true);
         }
 
-        /** @var \Cake\Database\Schema\CachedCollection $schemaCollection */
         $schemaCollection = $connection->getSchemaCollection();
+        assert($schemaCollection instanceof CachedCollection);
 
         return $schemaCollection;
     }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -308,8 +308,8 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             if ($value instanceof NativeDateTime) {
                 $value = clone $value;
             }
+            assert($value instanceof DateTime || $value instanceof DateTimeImmutable);
 
-            /** @var \Datetime|\DateTimeImmutable $value */
             return $value->setTimezone($this->defaultTimezone);
         }
 
@@ -323,6 +323,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             if (is_int($value) || (is_string($value) && ctype_digit($value))) {
                 /** @var \DateTime|\DateTimeImmutable $dateTime */
                 $dateTime = new $class('@' . $value);
+                assert($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable);
 
                 return $dateTime->setTimezone($this->defaultTimezone);
             }
@@ -334,8 +335,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
                     $dateTime = $this->_parseValue($value);
                 }
 
-                /** @var \DateTime|\DateTimeImmutable|null $dateTime */
-                if ($dateTime !== null) {
+                if ($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable) {
                     $dateTime = $dateTime->setTimezone($this->defaultTimezone);
                 }
 
@@ -377,8 +377,8 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             $value['microsecond']
         );
 
-        /** @var \DateTime|\DateTimeImmutable $dateTime */
         $dateTime = new $class($format, $value['timezone'] ?? $this->userTimezone);
+        assert($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable);
 
         return $dateTime->setTimezone($this->defaultTimezone);
     }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -261,8 +261,7 @@ class Debugger
      */
     public static function log(mixed $var, string|int $level = 'debug', int $maxDepth = 3): void
     {
-        /** @var string $source */
-        $source = static::trace(['start' => 1]);
+        $source = (string)static::trace(['start' => 1]);
         $source .= "\n";
 
         Log::write(

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -118,8 +118,8 @@ class ErrorLogger implements ErrorLoggerInterface
         }
 
         if ($includeTrace) {
-            /** @var array $trace */
             $trace = Debugger::formatTrace($exception, ['format' => 'points']);
+            assert(is_array($trace));
             $message .= "\nStack Trace:\n";
             foreach ($trace as $line) {
                 if (is_string($line)) {

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -118,8 +118,7 @@ class ErrorTrap
             throw new FatalErrorException($description, $code, $file, $line);
         }
 
-        /** @var array $trace */
-        $trace = Debugger::trace(['start' => 1, 'format' => 'points']);
+        $trace = (array)Debugger::trace(['start' => 1, 'format' => 'points']);
         $error = new PhpError($code, $description, $file, $line, $trace);
 
         $debug = Configure::read('debug');

--- a/src/Error/Renderer/TextExceptionRenderer.php
+++ b/src/Error/Renderer/TextExceptionRenderer.php
@@ -67,7 +67,7 @@ class TextExceptionRenderer implements ExceptionRendererInterface
      */
     public function write(ResponseInterface|string $output): void
     {
-        /** @var string $output */
+        assert(is_string($output));
         echo $output;
     }
 }

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -172,8 +172,8 @@ class WebExceptionRenderer implements ExceptionRendererInterface
                 $class = App::className('Error', 'Controller', 'Controller');
             }
 
-            /** @var \Cake\Controller\Controller $controller */
             $controller = new $class($request);
+            assert($controller instanceof Controller);
             $controller->startupProcess();
         } catch (Throwable $e) {
         }

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -81,8 +81,8 @@ trait EventDispatcherTrait
     {
         $subject ??= $this;
 
+        /** @var \Cake\Event\EventInterface $event Coerce for psalm/phpstan */
         $event = new $this->_eventClass($name, $subject, $data);
-        assert($event instanceof EventInterface);
         $this->getEventManager()->dispatch($event);
 
         return $event;

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -81,8 +81,8 @@ trait EventDispatcherTrait
     {
         $subject ??= $this;
 
-        /** @var \Cake\Event\EventInterface $event */
         $event = new $this->_eventClass($name, $subject, $data);
+        assert($event instanceof EventInterface);
         $this->getEventManager()->dispatch($event);
 
         return $event;

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -483,8 +483,8 @@ class EventManager implements EventManagerInterface
         if ($this->_eventList) {
             $count = count($this->_eventList);
             for ($i = 0; $i < $count; $i++) {
-                /** @var \Cake\Event\Event $event */
                 $event = $this->_eventList[$i];
+                assert($event instanceof EventInterface);
                 try {
                     $subject = $event->getSubject();
                     $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . $subject::class;

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -49,8 +49,8 @@ class Curl implements AdapterInterface
         $options = $this->buildOptions($request, $options);
         curl_setopt_array($ch, $options);
 
-        /** @var string|false $body */
         $body = $this->exec($ch);
+        assert($body === false || is_string($body));
         if ($body === false) {
             $errorCode = curl_errno($ch);
             $error = curl_error($ch);

--- a/src/Http/Client/Auth/Basic.php
+++ b/src/Http/Client/Auth/Basic.php
@@ -37,7 +37,6 @@ class Basic
     {
         if (isset($credentials['username'], $credentials['password'])) {
             $value = $this->_generateHeader($credentials['username'], $credentials['password']);
-            /** @var \Cake\Http\Client\Request $request */
             $request = $request->withHeader('Authorization', $value);
         }
 
@@ -56,7 +55,6 @@ class Basic
     {
         if (isset($credentials['username'], $credentials['password'])) {
             $value = $this->_generateHeader($credentials['username'], $credentials['password']);
-            /** @var \Cake\Http\Client\Request $request */
             $request = $request->withHeader('Proxy-Authorization', $value);
         }
 

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -374,9 +374,9 @@ class Response extends Message implements ResponseInterface
     protected function _getCookies(): array
     {
         $cookies = $this->buildCookieCollection();
+        assert($cookies !== null);
 
         $out = [];
-        /** @var array<\Cake\Http\Cookie\Cookie> $cookies */
         foreach ($cookies as $cookie) {
             $out[$cookie->getName()] = $cookie->toArray();
         }

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -373,11 +373,8 @@ class Response extends Message implements ResponseInterface
      */
     protected function _getCookies(): array
     {
-        $cookies = $this->buildCookieCollection();
-        assert($cookies !== null);
-
         $out = [];
-        foreach ($cookies as $cookie) {
+        foreach ($this->buildCookieCollection() as $cookie) {
             $out[$cookie->getName()] = $cookie->toArray();
         }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -307,10 +307,9 @@ class Cookie implements CookieInterface
             }
         }
 
-        /** @var string $name */
         $name = $data['name'];
-        /** @var string $value */
         $value = $data['value'];
+        assert(is_string($name) && is_string($value));
         unset($data['name'], $data['value']);
 
         return Cookie::create(

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -155,7 +155,6 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
         if ($method === 'GET' && $cookieData === null) {
             $token = $this->createToken();
             $request = $request->withAttribute('csrfToken', $this->saltToken($token));
-            /** @var mixed $response */
             $response = $handler->handle($request);
 
             return $this->_addTokenCookie($token, $request, $response);

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -139,9 +139,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      */
     protected function encodeCookies(Response $response): Response
     {
-        /** @var array<\Cake\Http\Cookie\CookieInterface> $cookies */
-        $cookies = $response->getCookieCollection();
-        foreach ($cookies as $cookie) {
+        foreach ($response->getCookieCollection() as $cookie) {
             if (in_array($cookie->getName(), $this->cookieNames, true)) {
                 $value = $this->_encrypt($cookie->getValue(), $this->cipherType);
                 $response = $response->withCookie($cookie->withValue($value));
@@ -159,7 +157,6 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
      */
     protected function encodeSetCookieHeader(ResponseInterface $response): ResponseInterface
     {
-        /** @var array<\Cake\Http\Cookie\CookieInterface> $cookies */
         $cookies = CookieCollection::createFromHeader($response->getHeader('Set-Cookie'));
         $header = [];
         foreach ($cookies as $cookie) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1281,9 +1281,8 @@ class Response implements ResponseInterface, Stringable
     public function getCookies(): array
     {
         $out = [];
-        /** @var array<\Cake\Http\Cookie\Cookie> $cookies */
-        $cookies = $this->_cookies;
-        foreach ($cookies as $cookie) {
+        foreach ($this->_cookies as $cookie) {
+            assert($cookie instanceof CookieInterface);
             $out[$cookie->getName()] = $cookie->toArray();
         }
 

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -112,8 +112,8 @@ class DatabaseSession implements SessionHandlerInterface
      */
     public function read(string $id): string|false
     {
-        /** @var string $pkField */
         $pkField = $this->_table->getPrimaryKey();
+        assert(is_string($pkField));
         $result = $this->_table
             ->find('all')
             ->select(['data'])

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -345,8 +345,8 @@ class Number
             static::$_formatters[$locale][$type] = new NumberFormatter($locale, $type);
         }
 
+        /** @var \NumberFormatter $formatter */
         $formatter = static::$_formatters[$locale][$type];
-        assert($formatter instanceof NumberFormatter);
         $formatter = clone $formatter;
 
         return static::_setAttributes($formatter, $options);

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -345,8 +345,8 @@ class Number
             static::$_formatters[$locale][$type] = new NumberFormatter($locale, $type);
         }
 
-        /** @var \NumberFormatter $formatter */
         $formatter = static::$_formatters[$locale][$type];
+        assert($formatter instanceof NumberFormatter);
         $formatter = clone $formatter;
 
         return static::_setAttributes($formatter, $options);

--- a/src/I18n/PackageLocator.php
+++ b/src/I18n/PackageLocator.php
@@ -88,8 +88,8 @@ class PackageLocator
         }
 
         if (!$this->converted[$name][$locale]) {
-            /** @var callable $func */
             $func = $this->registry[$name][$locale];
+            assert(is_callable($func));
             $this->registry[$name][$locale] = $func();
             $this->converted[$name][$locale] = true;
         }

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -126,8 +126,9 @@ class PoFileParser
                 $item['ids']['plural'] = substr($line, 14, -1);
                 $stage = ['ids', 'plural'];
             } elseif (str_starts_with($line, 'msgstr[')) {
-                /** @var int $size */
                 $size = strpos($line, ']');
+                assert(is_int($size));
+
                 $row = (int)substr($line, 7, 1);
                 $item['translated'][$row] = substr($line, $size + 3, -1);
                 $stage = ['translated', $row];

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -344,8 +344,8 @@ class TranslatorRegistry
         }
 
         return function () use ($loader, $fallbackDomain) {
+            /** @var \Cake\I18n\Package $package */
             $package = $loader();
-            assert($package instanceof Package);
             if (!$package->getFallback()) {
                 $package->setFallback($fallbackDomain);
             }

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -344,8 +344,8 @@ class TranslatorRegistry
         }
 
         return function () use ($loader, $fallbackDomain) {
-            /** @var \Cake\I18n\Package $package */
             $package = $loader();
+            assert($package instanceof Package);
             if (!$package->getFallback()) {
                 $package->setFallback($fallbackDomain);
             }

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -364,8 +364,8 @@ class Log
 
         $registry = static::getRegistry();
         foreach ($registry->loaded() as $streamName) {
+            /** @var \Psr\Log\LoggerInterface $logger */
             $logger = $registry->{$streamName};
-            assert($logger instanceof LoggerInterface);
             $levels = $scopes = null;
 
             if ($logger instanceof BaseLog) {

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -364,8 +364,8 @@ class Log
 
         $registry = static::getRegistry();
         foreach ($registry->loaded() as $streamName) {
-            /** @var \Psr\Log\LoggerInterface $logger */
             $logger = $registry->{$streamName};
+            assert($logger instanceof LoggerInterface);
             $levels = $scopes = null;
 
             if ($logger instanceof BaseLog) {

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1174,8 +1174,8 @@ class Message implements JsonSerializable
             } elseif ($fileInfo['file'] instanceof UploadedFileInterface) {
                 $fileInfo['mimetype'] = $fileInfo['file']->getClientMediaType();
                 if (is_int($name)) {
-                    /** @var string $name */
                     $name = $fileInfo['file']->getClientFilename();
+                    assert(is_string($name));
                 }
             } elseif (is_string($fileInfo['file'])) {
                 $fileName = $fileInfo['file'];
@@ -1299,8 +1299,7 @@ class Message implements JsonSerializable
         $hasMultipleTypes = $this->emailFormat === static::MESSAGE_BOTH;
         $multiPart = ($hasAttachments || $hasMultipleTypes);
 
-        /** @var string $boundary */
-        $boundary = $this->boundary;
+        $boundary = $this->boundary ?? '';
         $relBoundary = $textBoundary = $boundary;
 
         if ($hasInlineAttachments) {

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -275,9 +275,8 @@ class SmtpTransport extends AbstractTransport
             }
             $host = $config['client'];
         } else {
-            /** @var string $httpHost */
             $httpHost = env('HTTP_HOST');
-            if ($httpHost) {
+            if (is_string($httpHost) && strlen($httpHost)) {
                 [$host] = explode(':', $httpHost);
             }
         }

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -69,7 +69,8 @@ class TransportRegistry extends ObjectRegistry
     protected function _create(object|string $class, string $alias, array $config): AbstractTransport
     {
         if (is_object($class)) {
-            /** @var \Cake\Mailer\AbstractTransport */
+            assert($class instanceof AbstractTransport);
+
             return $class;
         }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1102,8 +1102,8 @@ class BelongsToMany extends Association
         }
 
         $name = $this->_junctionAssociationName();
-        /** @var array $joins */
         $joins = $query->clause('join');
+        assert(is_array($joins));
         $matching = [
             $name => [
                 'table' => $junctionTable->getTable(),

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -360,9 +360,7 @@ class HasMany extends Association
 
         $conditions = [
             'OR' => (new Collection($targetEntities))
-                ->map(function ($entity) use ($targetPrimaryKey) {
-                    /** @var \Cake\Datasource\EntityInterface $entity */
-                    /** @psalm-suppress InvalidArgument,UnusedPsalmSuppress */
+                ->map(function (EntityInterface $entity) use ($targetPrimaryKey) {
                     return $entity->extract($targetPrimaryKey);
                 })
                 ->toList(),
@@ -469,8 +467,7 @@ class HasMany extends Association
         $primaryKey = (array)$target->getPrimaryKey();
         $exclusions = new Collection($remainingEntities);
         $exclusions = $exclusions->map(
-            function ($ent) use ($primaryKey) {
-                /** @var \Cake\Datasource\EntityInterface $ent */
+            function (EntityInterface $ent) use ($primaryKey) {
                 return $ent->extract($primaryKey);
             }
         )

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -361,6 +361,8 @@ class HasMany extends Association
         $conditions = [
             'OR' => (new Collection($targetEntities))
                 ->map(function (EntityInterface $entity) use ($targetPrimaryKey) {
+                    /** @psalm-suppress InvalidArgument,UnusedPsalmSuppress */
+                    /** @var array<string> $targetPrimaryKey */
                     return $entity->extract($targetPrimaryKey);
                 })
                 ->toList(),

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -164,8 +164,8 @@ class SelectLoader
         $finder = $this->finder;
         $options['fields'] = $options['fields'] ?? [];
 
-        /** @var \Cake\ORM\Query\SelectQuery $query */
         $query = $finder();
+        assert($query instanceof SelectQuery);
         if (isset($options['finder'])) {
             [$finderName, $opts] = $this->_extractFinder($options['finder']);
             $query = $query->find($finderName, $opts);

--- a/src/ORM/AssociationsNormalizerTrait.php
+++ b/src/ORM/AssociationsNormalizerTrait.php
@@ -47,8 +47,9 @@ trait AssociationsNormalizerTrait
 
             $path = explode('.', $table);
             $table = array_pop($path);
-            /** @var string $first */
             $first = array_shift($path);
+            assert(is_string($first));
+
             $pointer += [$first => []];
             $pointer = &$pointer[$first];
             $pointer += ['associated' => []];

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -385,8 +385,8 @@ class Behavior implements EventListenerInterface
         $eventMethods = [];
         foreach ($events as $binding) {
             if (is_array($binding) && isset($binding['callable'])) {
-                /** @var string $callable */
                 $callable = $binding['callable'];
+                assert(is_string($callable));
                 $binding = $callable;
             }
             $eventMethods[$binding] = true;

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -216,9 +216,7 @@ class TimestampBehavior extends Behavior
             return;
         }
 
-        /** @var \Cake\Database\Type\DateTimeType $type */
         $type = TypeFactory::build($columnType);
-
         assert(
             $type instanceof DateTimeType,
             'TimestampBehavior only supports columns of type DateTimeType.'

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -298,8 +298,9 @@ class EavStrategy implements TranslateStrategyInterface
         }
 
         $modified = [];
-        /** @var \Cake\Datasource\EntityInterface $translation */
         foreach ($preexistent as $field => $translation) {
+            assert($translation instanceof EntityInterface);
+
             $translation->set('content', $values[$field]);
             $modified[$field] = $translation;
         }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -20,6 +20,7 @@ use ArrayObject;
 use Cake\Collection\CollectionInterface;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Database\Expression\FieldInterface;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -247,11 +248,11 @@ class ShadowTableStrategy implements TranslateStrategyInterface
      */
     protected function iterateClause(SelectQuery $query, string $name = '', array $config = []): bool
     {
-        /** @var \Cake\Database\Expression\QueryExpression|null $clause */
         $clause = $query->clause($name);
         if (!$clause || !$clause->count()) {
             return false;
         }
+        assert($clause instanceof QueryExpression);
 
         $alias = $config['hasOneAlias'];
         $fields = $this->translatedFields();
@@ -397,7 +398,6 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         if ($id) {
             $where['id'] = $id;
 
-            /** @var \Cake\Datasource\EntityInterface|null $translation */
             $translation = $this->translationTable->find()
                 ->select(array_merge(['id', 'locale'], $fields))
                 ->where($where)
@@ -415,6 +415,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 ]
             );
         }
+        assert($translation instanceof EntityInterface);
 
         $entity->set('_i18n', array_merge($bundled, [$translation]));
         $entity->set('_locale', $locale, ['setter' => false]);

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\ORM\Behavior;
 
 use Cake\I18n\I18n;
+use Cake\Datasource\QueryInterface;
 use Cake\ORM\Behavior;
 use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
 use Cake\ORM\Behavior\Translate\TranslateStrategyInterface;
@@ -316,8 +317,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
         $targetAlias = $this->getStrategy()->getTranslationTable()->getAlias();
 
         return $query
-            ->contain([$targetAlias => function ($query) use ($locales, $targetAlias) {
-                /** @var \Cake\Datasource\QueryInterface $query */
+            ->contain([$targetAlias => function (QueryInterface $query) use ($locales, $targetAlias) {
                 if ($locales) {
                     $query->where(["$targetAlias.locale IN" => $locales]);
                 }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -16,8 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Behavior;
 
-use Cake\I18n\I18n;
 use Cake\Datasource\QueryInterface;
+use Cake\I18n\I18n;
 use Cake\ORM\Behavior;
 use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
 use Cake\ORM\Behavior\Translate\TranslateStrategyInterface;

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -145,8 +145,8 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
             return $class;
         }
 
+        /** @var \Cake\ORM\Behavior $instance */
         $instance = new $class($this->_table, $config);
-        assert($instance instanceof Behavior);
 
         $enable = $config['enabled'] ?? true;
         if ($enable) {

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -145,8 +145,9 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
             return $class;
         }
 
-        /** @var \Cake\ORM\Behavior $instance */
         $instance = new $class($this->_table, $config);
+        assert($instance instanceof Behavior);
+
         $enable = $config['enabled'] ?? true;
         if ($enable) {
             $this->getEventManager()->on($instance);

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -537,8 +537,8 @@ class EagerLoader
                 if (count($configs) < 2) {
                     continue;
                 }
-                /** @var \Cake\ORM\EagerLoadable $loadable */
                 foreach ($configs as $loadable) {
+                    assert($loadable instanceof EagerLoadable);
                     if (str_contains($loadable->aliasPath(), '.')) {
                         $this->_correctStrategy($loadable);
                     }

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -158,8 +158,8 @@ class LazyEagerLoader
                 continue;
             }
 
-            /** @var \Cake\Datasource\EntityInterface $loaded */
             $loaded = $results[$key];
+            assert($loaded instanceof EntityInterface);
             foreach ($associations as $assoc) {
                 $property = $properties[$assoc];
                 $object->set($property, $loaded->get($property), ['useSetters' => false]);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -106,8 +106,7 @@ class Marshaller
                 $nested['forceNew'] = $options['forceNew'];
             }
             if (isset($options['isMerge'])) {
-                $callback = function ($value, $entity) use ($assoc, $nested) {
-                    /** @var \Cake\Datasource\EntityInterface $entity */
+                $callback = function ($value, EntityInterface $entity) use ($assoc, $nested) {
                     $options = $nested + ['associated' => [], 'association' => $assoc];
 
                     return $this->_mergeAssociation($entity->get($assoc->getProperty()), $assoc, $value, $options);
@@ -409,8 +408,8 @@ class Marshaller
             $keyFields = array_keys($primaryKey);
 
             $existing = [];
-            /** @var \Cake\Datasource\EntityInterface $row */
             foreach ($query as $row) {
+                assert($row instanceof EntityInterface);
                 $k = implode(';', $row->extract($keyFields));
                 $existing[$k] = $row;
             }
@@ -595,7 +594,7 @@ class Marshaller
         }
 
         foreach ((array)$options['fields'] as $field) {
-            /** @var string $field */
+            assert(is_string($field));
             if (!array_key_exists($field, $properties)) {
                 continue;
             }
@@ -690,8 +689,8 @@ class Marshaller
         $maybeExistentQuery = $this->_table->find()->where($conditions);
 
         if (!empty($indexed) && count($maybeExistentQuery->clause('where'))) {
-            /** @var \Cake\Datasource\EntityInterface $entity */
             foreach ($maybeExistentQuery as $entity) {
+                assert($entity instanceof EntityInterface);
                 $key = implode(';', $entity->extract($primary));
                 if (isset($indexed[$key])) {
                     $output[] = $this->merge($entity, $indexed[$key], $options);

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -18,8 +18,8 @@ namespace Cake\ORM\Query;
 
 use ArrayObject;
 use Cake\Collection\Iterator\MapReduce;
-use Cake\Database\ExpressionInterface;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\ExpressionInterface;
 use Cake\Database\Query\SelectQuery as DbSelectQuery;
 use Cake\Database\TypedResultInterface;
 use Cake\Database\TypeMap;

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -19,6 +19,7 @@ namespace Cake\ORM\Query;
 use ArrayObject;
 use Cake\Collection\Iterator\MapReduce;
 use Cake\Database\ExpressionInterface;
+use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Query\SelectQuery as DbSelectQuery;
 use Cake\Database\TypedResultInterface;
 use Cake\Database\TypeMap;
@@ -1417,8 +1418,8 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         }
 
         if (!$complex && $this->_valueBinder !== null) {
-            /** @var \Cake\Database\Expression\QueryExpression|null $order */
             $order = $this->clause('order');
+            assert($order === null || $order instanceof QueryExpression);
             $complex = $order === null ? false : $order->hasNestedExpression();
         }
 

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -128,11 +128,13 @@ class ResultSetFactory
                 array_intersect_key($row, $keys)
             );
             if ($data['hydrate']) {
-                /** @var \Cake\ORM\Table $table */
                 $table = $matching['instance'];
+                assert($table instanceof Table || $table instanceof Association);
+
                 $options['source'] = $table->getRegistryAlias();
-                /** @var \Cake\Datasource\EntityInterface $entity */
                 $entity = new $matching['entityClass']($results['_matchingData'][$alias], $options);
+                assert($entity instanceof EntityInterface);
+
                 $results['_matchingData'][$alias] = $entity;
             }
         }
@@ -156,8 +158,8 @@ class ResultSetFactory
                 continue;
             }
 
-            /** @var \Cake\ORM\Association $instance */
             $instance = $assoc['instance'];
+            assert($instance instanceof Association);
 
             if (!$assoc['canBeJoined'] && !isset($row[$alias])) {
                 $results = $instance->defaultRowValue($results, $assoc['canBeJoined']);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -18,6 +18,7 @@ namespace Cake\ORM;
 
 use ArrayObject;
 use BadMethodCallException;
+use Cake\Collection\CollectionInterface;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
@@ -500,8 +501,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getConnection(): Connection
     {
         if (!$this->_connection) {
-            /** @var \Cake\Database\Connection $connection */
             $connection = ConnectionManager::get(static::defaultConnectionName());
+            assert($connection instanceof Connection);
             $this->_connection = $connection;
         }
 
@@ -1358,8 +1359,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ['keyField', 'valueField', 'groupField']
         );
 
-        return $query->formatResults(fn($results) =>
-            /** @var \Cake\Collection\CollectionInterface $results */
+        return $query->formatResults(fn(CollectionInterface $results) =>
             $results->combine(
                 $options['keyField'],
                 $options['valueField'],
@@ -1401,8 +1401,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $options = $this->_setFieldMatchers($options, ['keyField', 'parentField']);
 
-        return $query->formatResults(fn($results) =>
-            /** @var \Cake\Collection\CollectionInterface $results */
+        return $query->formatResults(fn(CollectionInterface $results) =>
             $results->nest($options['keyField'], $options['parentField'], $options['nestingKey']));
     }
 

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -20,6 +20,7 @@ use Cake\Core\PluginApplicationInterface;
 use Cake\Http\Exception\RedirectException;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Runner;
+use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Laminas\Diactoros\Response\RedirectResponse;
@@ -98,8 +99,9 @@ class RoutingMiddleware implements MiddlewareInterface
                 unset($params['_middleware'], $params['_route']);
 
                 $request = $request->withAttribute('route', $route);
-                /** @var \Cake\Http\ServerRequest $request */
                 $request = $request->withAttribute('params', $params);
+
+                assert($request instanceof ServerRequest);
                 Router::setRequest($request);
             }
         } catch (RedirectException $e) {

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -294,8 +294,8 @@ class Route
         if ($this->_compiledRoute === null) {
             $this->_writeRoute();
         }
+        assert($this->_compiledRoute !== null);
 
-        /** @var string */
         return $this->_compiledRoute;
     }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -611,11 +611,12 @@ class Router
     {
         $route = null;
         if ($params instanceof ServerRequest) {
-            /** @var \Cake\Routing\Route\Route|null $route */
             $route = $params->getAttribute('route');
+            assert($route === null || $route instanceof Route);
+
             $queryString = $params->getQueryParams();
-            /** @var array<string, mixed> $params */
             $params = $params->getAttribute('params');
+            assert(is_array($params));
             $params['?'] = $queryString;
         }
         $pass = $params['pass'] ?? [];

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -18,7 +18,6 @@ namespace Cake\TestSuite;
 use Cake\Database\Connection;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Log\QueryLogger;
-use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Closure;
 
@@ -95,17 +94,16 @@ class ConnectionHelper
         $allTables = $collection->listTablesWithoutViews();
 
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
+        /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
         $schemas = array_map(fn($table) => $collection->describe($table), $tables);
 
         $dialect = $connection->getDriver()->schemaDialect();
         foreach ($schemas as $schema) {
-            assert($schema instanceof TableSchema);
             foreach ($dialect->dropConstraintSql($schema) as $statement) {
                 $connection->execute($statement);
             }
         }
         foreach ($schemas as $schema) {
-            assert($schema instanceof TableSchema);
             foreach ($dialect->dropTableSql($schema) as $statement) {
                 $connection->execute($statement);
             }
@@ -127,11 +125,11 @@ class ConnectionHelper
 
         $allTables = $collection->listTablesWithoutViews();
         $tables = $tables !== null ? array_intersect($tables, $allTables) : $allTables;
+        /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
         $schemas = array_map(fn($table) => $collection->describe($table), $tables);
 
         $this->runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
             $dialect = $connection->getDriver()->schemaDialect();
-            /** @var \Cake\Database\Schema\TableSchema $schema */
             foreach ($schemas as $schema) {
                 foreach ($dialect->truncateTableSql($schema) as $statement) {
                     $connection->execute($statement);

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -18,6 +18,7 @@ namespace Cake\TestSuite;
 use Cake\Database\Connection;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Database\Log\QueryLogger;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Closure;
 
@@ -88,8 +89,8 @@ class ConnectionHelper
      */
     public function dropTables(string $connectionName, ?array $tables = null): void
     {
-        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($connectionName);
+        assert($connection instanceof Connection);
         $collection = $connection->getSchemaCollection();
         $allTables = $collection->listTablesWithoutViews();
 
@@ -97,14 +98,14 @@ class ConnectionHelper
         $schemas = array_map(fn($table) => $collection->describe($table), $tables);
 
         $dialect = $connection->getDriver()->schemaDialect();
-        /** @var \Cake\Database\Schema\TableSchema $schema */
         foreach ($schemas as $schema) {
+            assert($schema instanceof TableSchema);
             foreach ($dialect->dropConstraintSql($schema) as $statement) {
                 $connection->execute($statement);
             }
         }
-        /** @var \Cake\Database\Schema\TableSchema $schema */
         foreach ($schemas as $schema) {
+            assert($schema instanceof TableSchema);
             foreach ($dialect->dropTableSql($schema) as $statement) {
                 $connection->execute($statement);
             }
@@ -120,8 +121,8 @@ class ConnectionHelper
      */
     public function truncateTables(string $connectionName, ?array $tables = null): void
     {
-        /** @var \Cake\Database\Connection $connection */
         $connection = ConnectionManager::get($connectionName);
+        assert($connection instanceof Connection);
         $collection = $connection->getSchemaCollection();
 
         $allTables = $collection->listTablesWithoutViews();

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite\Fixture;
 
 use Cake\Core\Exception\CakeException;
+use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionInterface;
@@ -135,8 +136,8 @@ class TestFixture implements FixtureInterface
      */
     protected function _schemaFromReflection(): void
     {
-        /** @var \Cake\Database\Connection $db */
         $db = ConnectionManager::get($this->connection());
+        assert($db instanceof Connection);
         try {
             $name = Inflector::camelize($this->table);
             $ormTable = $this->fetchTable($name, ['connection' => $db]);
@@ -145,8 +146,8 @@ class TestFixture implements FixtureInterface
             // with test cases that need to (re)configure the alias.
             $this->getTableLocator()->remove($name);
 
-            /** @var \Cake\Database\Schema\TableSchema $schema */
             $schema = $ormTable->getSchema();
+            assert($schema instanceof TableSchemaInterface);
             $this->_schema = $schema;
 
             $this->getTableLocator()->clear();
@@ -165,9 +166,9 @@ class TestFixture implements FixtureInterface
      */
     public function insert(ConnectionInterface $connection): bool
     {
+        assert($connection instanceof Connection);
         if (!empty($this->records)) {
             [$fields, $values, $types] = $this->_getRecords();
-            /** @var \Cake\Database\Connection $connection */
             $query = $connection->insertQuery()
                 ->insert($fields, $types)
                 ->into($this->sourceName());
@@ -196,8 +197,8 @@ class TestFixture implements FixtureInterface
         /** @var array<string> $fields */
         $fields = array_values(array_unique($fields));
         foreach ($fields as $field) {
-            /** @var array $column */
             $column = $this->_schema->getColumn($field);
+            assert($column !== null);
             $types[$field] = $column['type'];
         }
         $default = array_fill_keys($fields, null);
@@ -213,7 +214,7 @@ class TestFixture implements FixtureInterface
      */
     public function truncate(ConnectionInterface $connection): bool
     {
-        /** @var \Cake\Database\Connection $connection */
+        assert($connection instanceof Connection);
         $sql = $this->_schema->truncateSql($connection);
         foreach ($sql as $stmt) {
             $connection->execute($stmt);

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -18,6 +18,7 @@ namespace Cake\TestSuite\Fixture;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Schema\SqlGeneratorInterface;
+use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
@@ -147,7 +148,7 @@ class TestFixture implements FixtureInterface
             $this->getTableLocator()->remove($name);
 
             $schema = $ormTable->getSchema();
-            assert($schema instanceof TableSchemaInterface);
+            assert($schema instanceof TableSchema);
             $this->_schema = $schema;
 
             $this->getTableLocator()->clear();

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -17,6 +17,7 @@ namespace Cake\TestSuite;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Core\HttpApplicationInterface;
 use Cake\Core\TestSuite\ContainerStubTrait;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Error\Renderer\WebExceptionRenderer;
@@ -503,8 +504,8 @@ trait IntegrationTestTrait
     protected function _makeDispatcher(): MiddlewareDispatcher
     {
         EventManager::instance()->on('Controller.initialize', $this->controllerSpy(...));
-        /** @var \Cake\Core\HttpApplicationInterface $app */
         $app = $this->createApp();
+        assert($app instanceof HttpApplicationInterface);
 
         return new MiddlewareDispatcher($app);
     }
@@ -519,8 +520,8 @@ trait IntegrationTestTrait
     public function controllerSpy(EventInterface $event, ?Controller $controller = null): void
     {
         if (!$controller) {
-            /** @var \Cake\Controller\Controller $controller */
             $controller = $event->getSubject();
+            assert($controller instanceof Controller);
         }
         $this->_controller = $controller;
         $events = $controller->getEventManager();

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -179,6 +179,7 @@ abstract class TestCase extends BaseTestCase
     {
         $duplicate = Configure::read('Error.allowDuplicateDeprecations');
         Configure::write('Error.allowDuplicateDeprecations', true);
+        /** @var bool $deprecation Expand type for psalm */
         $deprecation = false;
 
         $previousHandler = set_error_handler(

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -26,6 +26,7 @@ use Cake\ORM\Exception\MissingTableClassException;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Table;
 use Cake\Routing\Router;
+use Cake\Routing\RoutingApplicationInterface;
 use Cake\TestSuite\Constraint\EventFired;
 use Cake\TestSuite\Constraint\EventFiredWith;
 use Cake\TestSuite\Fixture\FixtureStrategyInterface;
@@ -178,7 +179,6 @@ abstract class TestCase extends BaseTestCase
     {
         $duplicate = Configure::read('Error.allowDuplicateDeprecations');
         Configure::write('Error.allowDuplicateDeprecations', true);
-        /** @var bool $deprecation */
         $deprecation = false;
 
         $previousHandler = set_error_handler(
@@ -302,8 +302,8 @@ abstract class TestCase extends BaseTestCase
         $className = Configure::read('App.namespace') . '\\Application';
         try {
             $reflect = new ReflectionClass($className);
-            /** @var \Cake\Routing\RoutingApplicationInterface $app */
             $app = $reflect->newInstanceArgs($appArgs);
+            assert($app instanceof RoutingApplicationInterface);
         } catch (ReflectionException $e) {
             throw new LogicException(sprintf('Cannot load `%s` to load routes from.', $className), 0, $e);
         }

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -201,6 +201,7 @@ class Filesystem
             throw new CakeException(sprintf('"%s" is not a directory', $path));
         }
 
+        /** @var \RecursiveDirectoryIterator $iterator Replace type for psalm */
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
             RecursiveIteratorIterator::CHILD_FIRST
@@ -208,7 +209,6 @@ class Filesystem
 
         $result = true;
         foreach ($iterator as $fileInfo) {
-            assert($fileInfo instanceof SplFileInfo);
             $isWindowsLink = DIRECTORY_SEPARATOR === '\\' && $fileInfo->getType() === 'link';
             if ($fileInfo->getType() === self::TYPE_DIR || $isWindowsLink) {
                 // phpcs:ignore
@@ -250,7 +250,6 @@ class Filesystem
 
         $result = true;
         foreach ($iterator as $fileInfo) {
-            assert($fileInfo instanceof SplFileInfo);
             if ($fileInfo->isDir()) {
                 $result = $result && $this->copyDir(
                     $fileInfo->getPathname(),

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -207,8 +207,8 @@ class Filesystem
         );
 
         $result = true;
-        /** @var \SplFileInfo $fileInfo */
         foreach ($iterator as $fileInfo) {
+            assert($fileInfo instanceof SplFileInfo);
             $isWindowsLink = DIRECTORY_SEPARATOR === '\\' && $fileInfo->getType() === 'link';
             if ($fileInfo->getType() === self::TYPE_DIR || $isWindowsLink) {
                 // phpcs:ignore
@@ -249,8 +249,8 @@ class Filesystem
         $iterator = new FilesystemIterator($source);
 
         $result = true;
-        /** @var \SplFileInfo $fileInfo */
         foreach ($iterator as $fileInfo) {
+            assert($fileInfo instanceof SplFileInfo);
             if ($fileInfo->isDir()) {
                 $result = $result && $this->copyDir(
                     $fileInfo->getPathname(),

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -459,13 +459,13 @@ class Hash
 
         if (is_array($keyPath)) {
             $format = array_shift($keyPath);
-            /** @var array $keys */
             $keys = static::format($data, $keyPath, $format);
+            assert(is_array($keys));
         } elseif ($keyPath === null) {
             $keys = $keyPath;
         } else {
-            /** @var array $keys */
             $keys = static::extract($data, $keyPath);
+            assert(is_array($keys));
         }
         if ($keyPath !== null && empty($keys)) {
             return [];
@@ -474,11 +474,11 @@ class Hash
         $vals = null;
         if (!empty($valuePath) && is_array($valuePath)) {
             $format = array_shift($valuePath);
-            /** @var array $vals */
             $vals = static::format($data, $valuePath, $format);
+            assert(is_array($vals));
         } elseif (!empty($valuePath)) {
-            /** @var array $vals */
             $vals = static::extract($data, $valuePath);
+            assert(is_array($vals));
         }
         if (empty($vals)) {
             $vals = array_fill(0, $keys === null ? count($data) : count($keys), null);
@@ -986,8 +986,8 @@ class Hash
         if ($numeric) {
             $data = array_values($data);
         }
-        /** @var array $sortValues */
         $sortValues = static::extract($data, $path);
+        assert(is_array($sortValues));
         $dataCount = count($data);
 
         // Make sortValues match the data length, as some keys could be missing
@@ -1003,10 +1003,11 @@ class Hash
             $sortValues = array_pad($sortValues, $dataCount, null);
         }
         $result = static::_squash($sortValues);
-        /** @var array $keys */
         $keys = static::extract($result, '{n}.id');
-        /** @var array $values */
+        assert(is_array($keys));
+
         $values = static::extract($result, '{n}.value');
+        assert(is_array($values));
 
         if (is_string($dir)) {
             $dir = strtolower($dir);
@@ -1213,8 +1214,8 @@ class Hash
         ];
 
         $return = $idMap = [];
-        /** @var array $ids */
         $ids = static::extract($data, $options['idPath']);
+        assert(is_array($ids));
 
         $idKeys = explode('.', $options['idPath']);
         array_shift($idKeys);

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -386,13 +386,14 @@ class Xml
             'format' => null,
         ];
 
-        $value = $data['value'];
-        /** @var \DOMDocument $dom */
-        $dom = $data['dom'];
         $key = $data['key'];
         $format = $data['format'];
-        /** @var \DOMElement $node */
+        $value = $data['value'];
+        $dom = $data['dom'];
+        assert($dom instanceof DOMDocument);
+
         $node = $data['node'];
+        assert($node instanceof DOMElement || $node instanceof DOMDocument);
 
         $childNS = $childValue = null;
         if (is_object($value) && method_exists($value, 'toArray') && is_callable([$value, 'toArray'])) {
@@ -435,8 +436,8 @@ class Xml
         if ($obj instanceof DOMNode) {
             $obj = simplexml_import_dom($obj);
         }
+        assert($obj instanceof SimpleXMLElement);
         $result = [];
-        /** @var \SimpleXMLElement $obj */
         $namespaces = array_merge(['' => ''], $obj->getNamespaces(true));
         static::_toArray($obj, $result, '', array_keys($namespaces));
 

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -91,8 +91,8 @@ trait CellTrait
      */
     protected function _createCell(string $className, string $action, ?string $plugin, array $options): Cell
     {
+        /** @var \Cake\View\Cell $instance */
         $instance = new $className($this->request, $this->response, $this->getEventManager(), $options);
-        assert($instance instanceof Cell);
 
         $builder = $instance->viewBuilder();
         $builder->setTemplate(Inflector::underscore($action));

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -91,8 +91,8 @@ trait CellTrait
      */
     protected function _createCell(string $className, string $action, ?string $plugin, array $options): Cell
     {
-        /** @var \Cake\View\Cell $instance */
         $instance = new $className($this->request, $this->response, $this->getEventManager(), $options);
+        assert($instance instanceof Cell);
 
         $builder = $instance->viewBuilder();
         $builder->setTemplate(Inflector::underscore($action));

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -122,11 +122,10 @@ class EntityContext implements ContextInterface
      */
     protected function _prepare(): void
     {
-        /** @var \Cake\ORM\Table|null $table */
         $table = $this->_context['table'];
+
         /** @var \Cake\Datasource\EntityInterface|iterable<\Cake\Datasource\EntityInterface|array> $entity */
         $entity = $this->_context['entity'];
-
         $this->_isCollection = is_iterable($entity);
 
         if (empty($table)) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1036,6 +1036,7 @@ class HtmlHelper extends Helper
             } else {
                 /** @var string $mimeType */
                 $mimeType = $this->_View->getResponse()->getMimeType(pathinfo($path, PATHINFO_EXTENSION));
+                assert(is_string($mimeType));
             }
             if (preg_match('#^video/#', $mimeType)) {
                 $tag = 'video';

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -1150,8 +1150,8 @@ class PaginatorHelper extends Helper
             '100' => '100',
         ];
         $default = $default ?? $this->paginated()->perPage();
-        /** @var string|null $scope */
         $scope = $this->param('scope');
+        assert($scope === null || is_string($scope));
         if ($scope) {
             $scope .= '.';
         }

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -89,8 +89,7 @@ class UrlHelper extends Helper
 
         $url = Router::url($url, $options['fullBase']);
         if ($options['escape']) {
-            /** @var string $url */
-            $url = h($url);
+            $url = (string)h($url);
         }
 
         return $url;

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -150,8 +150,8 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
             return $class;
         }
 
+        /** @var \Cake\View\Helper $instance */
         $instance = new $class($this->_View, $config);
-        assert($instance instanceof Helper);
 
         $enable = $config['enabled'] ?? true;
         if ($enable) {

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -150,8 +150,8 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
             return $class;
         }
 
-        /** @var \Cake\View\Helper $instance */
         $instance = new $class($this->_View, $config);
+        assert($instance instanceof Helper);
 
         $enable = $config['enabled'] ?? true;
         if ($enable) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -883,7 +883,6 @@ class View implements EventDispatcherInterface
     {
         if (is_array($name)) {
             if (is_array($value)) {
-                /** @var array|false $data */
                 $data = array_combine($name, $value);
                 if ($data === false) {
                     throw new CakeException(

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -883,6 +883,7 @@ class View implements EventDispatcherInterface
     {
         if (is_array($name)) {
             if (is_array($value)) {
+                /** @var array|false $data Coerce phpstan to accept failure case */
                 $data = array_combine($name, $value);
                 if ($data === false) {
                     throw new CakeException(

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -590,10 +590,8 @@ class ViewBuilder implements JsonSerializable
         ];
         $data += $this->_options;
 
-        $view = new $className($request, $response, $events, $data);
-        assert($view instanceof View);
-
-        return $view;
+        /** @var \Cake\View\View */
+        return new $className($request, $response, $events, $data);
     }
 
     /**

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -590,8 +590,8 @@ class ViewBuilder implements JsonSerializable
         ];
         $data += $this->_options;
 
-        /** @var \Cake\View\View $view */
         $view = new $className($request, $response, $events, $data);
+        assert($view instanceof View);
 
         return $view;
     }

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -188,8 +188,8 @@ class DateTimeWidget extends BasicWidget
 
         try {
             if ($value instanceof DateTimeInterface) {
-                /** @var \DateTime|\DateTimeImmutable $dateTime */
                 $dateTime = clone $value;
+                assert($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable);
             } elseif (is_string($value) && !is_numeric($value)) {
                 $dateTime = new DateTime($value);
             } elseif (is_numeric($value)) {

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -188,8 +188,8 @@ class DateTimeWidget extends BasicWidget
 
         try {
             if ($value instanceof DateTimeInterface) {
+                /** @var \DateTime|\DateTimeImmutable $dateTime Expand type for phpstan */
                 $dateTime = clone $value;
-                assert($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable);
             } elseif (is_string($value) && !is_numeric($value)) {
                 $dateTime = new DateTime($value);
             } elseif (is_numeric($value)) {

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -212,8 +212,8 @@ class WidgetLocator
         } else {
             $instance = new $className($this->_templates);
         }
-        assert($instance instanceof WidgetInterface);
 
+        /** @var \Cake\View\Widget\WidgetInterface */
         return $instance;
     }
 }

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -208,12 +208,11 @@ class WidgetLocator
                     $arguments[] = $this->get($requirement);
                 }
             }
-            /** @var \Cake\View\Widget\WidgetInterface $instance */
             $instance = $reflection->newInstanceArgs($arguments);
         } else {
-            /** @var \Cake\View\Widget\WidgetInterface $instance */
             $instance = new $className($this->_templates);
         }
+        assert($instance instanceof WidgetInterface);
 
         return $instance;
     }

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -147,13 +147,13 @@ class XmlView extends SerializedView
             $options['pretty'] = true;
         }
 
-        /** @var string|false $result */
         $result = Xml::fromArray($data, $options)->saveXML();
         if ($result === false) {
             throw new SerializationFailureException(
                 'XML serialization of View data failed.'
             );
         }
+        assert(is_string($result));
 
         return $result;
     }

--- a/src/basics.php
+++ b/src/basics.php
@@ -87,8 +87,8 @@ if (!function_exists('stackTrace')) {
         $options += ['start' => 0];
         $options['start']++;
 
-        /** @var string $trace */
         $trace = Debugger::trace($options);
+        assert(is_string($trace));
         echo $trace;
     }
 


### PR DESCRIPTION
There are still a bunch of `@var` annotations left, but they are for types more complex than PHP's typesystem can currently handle or were inline hints for factory methods.
