### PR TITLE
Correcting documentation for Xml::build

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -51,7 +51,7 @@ class Xml
      * Building XML from a file path:
      *
      * ```
-     * $xml = Xml::build('/path/to/an/xml/file.xml');
+     * $xml = Xml::build('/path/to/an/xml/file.xml', ['readFile' => true]);
      * ```
      *
      * Building XML from a remote URL:


### PR DESCRIPTION
The Xml::build from local file requires readFile to be true, but is not stated in the PHP Docblock example.
