### PR TITLE
Improve type declaration/detection.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property Cake\\\\Collection\\\\Iterator\\\\BufferedIterator\\:\\:\\$_buffer with generic class SplDoublyLinkedList does not specify its types\\: TValue$#"
-			count: 1
-			path: src/Collection/Iterator/BufferedIterator.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Collection/Iterator/NestIterator.php
@@ -19,16 +14,6 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: src/Console/ConsoleOptionParser.php
-
-		-
-			message: "#^Parameter \\#1 \\$request of method Cake\\\\Controller\\\\ControllerFactory\\:\\:getControllerClass\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
-			count: 1
-			path: src/Controller/ControllerFactory.php
-
-		-
-			message: "#^Parameter \\#1 \\$request of method Cake\\\\Controller\\\\ControllerFactory\\:\\:missingController\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
-			count: 2
-			path: src/Controller/ControllerFactory.php
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
@@ -46,11 +31,6 @@ parameters:
 			path: src/Event/EventManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$request of static method Cake\\\\Routing\\\\Router\\:\\:setRequest\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
-			count: 1
-			path: src/Http/BaseApplication.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Http/Client.php
@@ -61,11 +41,6 @@ parameters:
 			path: src/Http/Client/Auth/Digest.php
 
 		-
-			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
-			count: 3
-			path: src/Http/Cookie/Cookie.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Http/Cookie/Cookie.php
@@ -74,11 +49,6 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: src/Http/Cookie/CookieCollection.php
-
-		-
-			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
-			count: 1
-			path: src/Http/Response.php
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
@@ -111,29 +81,9 @@ parameters:
 			path: src/ORM/EagerLoader.php
 
 		-
-			message: "#^Parameter \\#1 \\$assoc of method Cake\\\\ORM\\\\Marshaller\\:\\:_belongsToMany\\(\\) expects Cake\\\\ORM\\\\Association\\\\BelongsToMany, Cake\\\\ORM\\\\Association given\\.$#"
-			count: 1
-			path: src/ORM/Marshaller.php
-
-		-
 			message: "#^Method Cake\\\\ORM\\\\Query\\\\SelectQuery\\:\\:find\\(\\) should return static\\(Cake\\\\ORM\\\\Query\\\\SelectQuery\\) but returns Cake\\\\ORM\\\\Query\\\\SelectQuery\\.$#"
 			count: 1
 			path: src/ORM/Query/SelectQuery.php
-
-		-
-			message: "#^Parameter \\#1 \\$rules of method Cake\\\\ORM\\\\Table\\:\\:buildRules\\(\\) expects Cake\\\\ORM\\\\RulesChecker, Cake\\\\Datasource\\\\RulesChecker given\\.$#"
-			count: 1
-			path: src/ORM/Table.php
-
-		-
-			message: "#^Parameter \\#1 \\$request of static method Cake\\\\Routing\\\\Router\\:\\:parseRequest\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
-			count: 1
-			path: src/Routing/Middleware/RoutingMiddleware.php
-
-		-
-			message: "#^Parameter \\#1 \\$request of static method Cake\\\\Routing\\\\Router\\:\\:setRequest\\(\\) expects Cake\\\\Http\\\\ServerRequest, Psr\\\\Http\\\\Message\\\\ServerRequestInterface given\\.$#"
-			count: 1
-			path: src/Routing/Middleware/RoutingMiddleware.php
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
@@ -161,11 +111,6 @@ parameters:
 			path: src/Utility/Hash.php
 
 		-
-			message: "#^Dead catch \\- Error is never thrown in the try block\\.$#"
-			count: 1
-			path: src/View/Cell.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/View/Form/ContextFactory.php
@@ -174,9 +119,3 @@ parameters:
 			message: "#^Constructor of class Cake\\\\View\\\\Form\\\\NullContext has an unused parameter \\$context\\.$#"
 			count: 1
 			path: src/View/Form/NullContext.php
-
-		-
-			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
-			count: 1
-			path: src/View/Helper/TimeHelper.php
-

--- a/src/Collection/Iterator/BufferedIterator.php
+++ b/src/Collection/Iterator/BufferedIterator.php
@@ -29,7 +29,8 @@ class BufferedIterator extends Collection implements Countable
     /**
      * The in-memory cache containing results from previous iterators
      *
-     * @var \SplDoublyLinkedList
+     * @var \SplDoublyLinkedList<mixed>
+     * @psalm-suppress MissingTemplateParam
      */
     protected SplDoublyLinkedList $_buffer;
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -211,7 +211,7 @@ class CommandRunner implements EventDispatcherInterface
     public function setEventManager(EventManagerInterface $eventManager)
     {
         assert(
-            $this->app instanceof PluginApplicationInterface,
+            $this->app instanceof EventDispatcherInterface,
             'Cannot set the event manager, the application does not support events.'
         );
 

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -68,6 +68,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
      */
     public function create(ServerRequestInterface $request): Controller
     {
+        assert($request instanceof ServerRequest);
         $className = $this->getControllerClass($request);
         if ($className === null) {
             throw $this->missingController($request);

--- a/src/Datasource/Paging/PaginatedInterface.php
+++ b/src/Datasource/Paging/PaginatedInterface.php
@@ -22,7 +22,6 @@ use Traversable;
 /**
  * This interface describes the methods for pagination instance.
  *
- * @method int count() Item count for current page.
  * @template-extends \Traversable<mixed>
  */
 interface PaginatedInterface extends Countable, Traversable

--- a/src/Datasource/RulesAwareTrait.php
+++ b/src/Datasource/RulesAwareTrait.php
@@ -100,7 +100,10 @@ trait RulesAwareTrait
         }
         /** @psalm-var class-string<\Cake\Datasource\RulesChecker> $class */
         $class = defined('static::RULES_CLASS') ? static::RULES_CLASS : RulesChecker::class;
-        /** @psalm-suppress ArgumentTypeCoercion */
+        /**
+         * @psalm-suppress ArgumentTypeCoercion
+         * @phpstan-ignore-next-line
+         */
         $this->_rulesChecker = $this->buildRules(new $class(['repository' => $this]));
         $this->dispatchEvent('Model.buildRules', ['rules' => $this->_rulesChecker]);
 

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -172,8 +172,8 @@ class WebExceptionRenderer implements ExceptionRendererInterface
                 $class = App::className('Error', 'Controller', 'Controller');
             }
 
+            assert(is_subclass_of($class, Controller::class));
             $controller = new $class($request);
-            assert($controller instanceof Controller);
             $controller->startupProcess();
         } catch (Throwable $e) {
         }

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -484,7 +484,6 @@ class EventManager implements EventManagerInterface
             $count = count($this->_eventList);
             for ($i = 0; $i < $count; $i++) {
                 $event = $this->_eventList[$i];
-                assert($event instanceof EventInterface);
                 try {
                     $subject = $event->getSubject();
                     $properties['_dispatchedEvents'][] = $event->getName() . ' with subject ' . $subject::class;

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -317,6 +317,7 @@ abstract class BaseApplication implements
         $this->controllerFactory ??= new ControllerFactory($container);
 
         if (Router::getRequest() !== $request) {
+            assert($request instanceof ServerRequest);
             Router::setRequest($request);
         }
 

--- a/src/Http/Client/Adapter/Curl.php
+++ b/src/Http/Client/Adapter/Curl.php
@@ -50,7 +50,7 @@ class Curl implements AdapterInterface
         curl_setopt_array($ch, $options);
 
         $body = $this->exec($ch);
-        assert($body === false || is_string($body));
+        assert($body !== true);
         if ($body === false) {
             $errorCode = curl_errno($ch);
             $error = curl_error($ch);

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -167,7 +167,10 @@ class Cookie implements CookieInterface
         $this->sameSite = static::resolveSameSiteEnum($sameSite ?? static::$defaults['samesite']);
 
         if ($expiresAt) {
-            /** @psalm-suppress UndefinedInterfaceMethod */
+            /**
+             * @psalm-suppress UndefinedInterfaceMethod
+             * @phpstan-ignore-next-line
+             */
             $expiresAt = $expiresAt->setTimezone(new DateTimeZone('GMT'));
         } else {
             $expiresAt = static::$defaults['expires'];
@@ -242,7 +245,10 @@ class Cookie implements CookieInterface
         }
 
         if ($expires instanceof DateTimeInterface) {
-            /** @psalm-suppress UndefinedInterfaceMethod */
+            /**
+             * @psalm-suppress UndefinedInterfaceMethod
+             * @phpstan-ignore-next-line
+             */
             return $expires->setTimezone(new DateTimeZone('GMT'));
         }
 
@@ -533,7 +539,10 @@ class Cookie implements CookieInterface
     public function withExpiry(DateTimeInterface $dateTime): static
     {
         $new = clone $this;
-        /** @psalm-suppress UndefinedInterfaceMethod */
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         * @phpstan-ignore-next-line
+         */
         $new->expiresAt = $dateTime->setTimezone(new DateTimeZone('GMT'));
 
         return $new;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1074,7 +1074,10 @@ class Response implements ResponseInterface, Stringable
             $result = new DateTime($time ?? 'now');
         }
 
-        /** @psalm-suppress UndefinedInterfaceMethod */
+        /**
+         * @psalm-suppress UndefinedInterfaceMethod
+         * @phpstan-ignore-next-line
+         */
         return $result->setTimezone(new DateTimeZone('UTC'));
     }
 
@@ -1282,7 +1285,6 @@ class Response implements ResponseInterface, Stringable
     {
         $out = [];
         foreach ($this->_cookies as $cookie) {
-            assert($cookie instanceof CookieInterface);
             $out[$cookie->getName()] = $cookie->toArray();
         }
 

--- a/src/Mailer/TransportRegistry.php
+++ b/src/Mailer/TransportRegistry.php
@@ -69,8 +69,6 @@ class TransportRegistry extends ObjectRegistry
     protected function _create(object|string $class, string $alias, array $config): AbstractTransport
     {
         if (is_object($class)) {
-            assert($class instanceof AbstractTransport);
-
             return $class;
         }
 

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -285,6 +285,7 @@ class EavStrategy implements TranslateStrategyInterface
 
         $preexistent = [];
         if ($key) {
+            /** @var \Traversable<string, \Cake\Datasource\EntityInterface> $preexistent */
             $preexistent = $this->translationTable->find()
                 ->select(['id', 'field'])
                 ->where([
@@ -299,8 +300,6 @@ class EavStrategy implements TranslateStrategyInterface
 
         $modified = [];
         foreach ($preexistent as $field => $translation) {
-            assert($translation instanceof EntityInterface);
-
             $translation->set('content', $values[$field]);
             $modified[$field] = $translation;
         }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -249,10 +249,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     protected function iterateClause(SelectQuery $query, string $name = '', array $config = []): bool
     {
         $clause = $query->clause($name);
+        assert($clause === null || $clause instanceof QueryExpression);
         if (!$clause || !$clause->count()) {
             return false;
         }
-        assert($clause instanceof QueryExpression);
 
         $alias = $config['hasOneAlias'];
         $fields = $this->translatedFields();
@@ -415,7 +415,6 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 ]
             );
         }
-        assert($translation instanceof EntityInterface);
 
         $entity->set('_i18n', array_merge($bundled, [$translation]));
         $entity->set('_locale', $locale, ['setter' => false]);

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -146,6 +146,7 @@ class LazyEagerLoader
         $injected = [];
         $properties = $this->_getPropertyMap($source, $associations);
         $primaryKey = (array)$source->getPrimaryKey();
+        /** @var array<string, \Cake\Datasource\EntityInterface> $results */
         $results = $results
             ->all()
             ->indexBy(fn(EntityInterface $e) => implode(';', $e->extract($primaryKey)))
@@ -159,7 +160,6 @@ class LazyEagerLoader
             }
 
             $loaded = $results[$key];
-            assert($loaded instanceof EntityInterface);
             foreach ($associations as $assoc) {
                 $property = $properties[$assoc];
                 $object->set($property, $loaded->get($property), ['useSetters' => false]);

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -87,6 +87,7 @@ class RoutingMiddleware implements MiddlewareInterface
     {
         $this->loadRoutes();
         try {
+            assert($request instanceof ServerRequest);
             Router::setRequest($request);
             $params = (array)$request->getAttribute('params', []);
             $middleware = [];

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -114,6 +114,7 @@ class Hash
      * @return \ArrayAccess|array An array of the extracted values. Returns an empty array
      *   if there are no matches.
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::extract
+     * @psalm-return ($path is non-empty-string ? array : \ArrayAccess|array)
      */
     public static function extract(ArrayAccess|array $data, string $path): ArrayAccess|array
     {
@@ -534,13 +535,14 @@ class Hash
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::format
      * @see sprintf()
      * @see \Cake\Utility\Hash::extract()
+     * @psalm-return ($paths is non-empty-array ? array : null)
      */
     public static function format(array $data, array $paths, string $format): ?array
     {
         $extracted = [];
         $count = count($paths);
 
-        if (!$count) {
+        if ($count === 0) {
             return null;
         }
 
@@ -1004,10 +1006,8 @@ class Hash
         }
         $result = static::_squash($sortValues);
         $keys = static::extract($result, '{n}.id');
-        assert(is_array($keys));
 
         $values = static::extract($result, '{n}.value');
-        assert(is_array($values));
 
         if (is_string($dir)) {
             $dir = strtolower($dir);
@@ -1192,11 +1192,12 @@ class Hash
      * - `root` The id of the desired top-most result.
      *
      * @param array $data The data to nest.
-     * @param array<string, mixed> $options Options are:
+     * @param array<string, string|null> $options Options.
      * @return array<array> of results, nested
      * @see \Cake\Utility\Hash::extract()
      * @throws \InvalidArgumentException When providing invalid data.
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::nest
+     * @psalm-param array{idPath?: string, parentPath?: string, children?: string, root?: string|null} $options
      * @psalm-return list<array>
      */
     public static function nest(array $data, array $options = []): array
@@ -1230,10 +1231,8 @@ class Hash
             $parentId = static::get($result, $parentKeys);
 
             if (isset($idMap[$id][$options['children']])) {
-                /** @psalm-suppress PossiblyInvalidArgument psalm thinks $result could be ArrayAccess */
                 $idMap[$id] = array_merge($result, $idMap[$id]);
             } else {
-                /** @psalm-suppress PossiblyInvalidArgument psalm thinks $result could be ArrayAccess */
                 $idMap[$id] = array_merge($result, [$options['children'] => []]);
             }
             if (!$parentId || !in_array($parentId, $ids)) {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -267,6 +267,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
             ), E_USER_WARNING);
 
             return '';
+        /** @phpstan-ignore-next-line */
         } catch (Error $e) {
             throw new Error(sprintf(
                 'Could not render cell - %s [%s, line %d]',

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1034,7 +1034,6 @@ class HtmlHelper extends Helper
             if (is_array($path)) {
                 $mimeType = $path[0]['type'];
             } else {
-                /** @var string $mimeType */
                 $mimeType = $this->_View->getResponse()->getMimeType(pathinfo($path, PATHINFO_EXTENSION));
                 assert(is_string($mimeType));
             }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -284,8 +284,11 @@ class TimeHelper extends Helper
             'timezone' => null,
         ];
         $options['timezone'] = $this->_getTimezone($options['timezone']);
-        /** @psalm-suppress UndefinedInterfaceMethod */
         if ($options['timezone'] && $dateTime instanceof DateTimeInterface) {
+            /**
+             * @psalm-suppress UndefinedInterfaceMethod
+             * @phpstan-ignore-next-line
+             */
             $dateTime = $dateTime->setTimezone($options['timezone']);
             unset($options['timezone']);
         }

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -153,7 +153,6 @@ class XmlView extends SerializedView
                 'XML serialization of View data failed.'
             );
         }
-        assert(is_string($result));
 
         return $result;
     }


### PR DESCRIPTION
Removed assert() calls just before returning a value. It provides no practical benefit other than throwing an AssertionError instead of TypeError, when the method already has a typed return.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
