### PR TITLE
Add ConnectionManager::aliases()

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -43,7 +43,7 @@ class ConnectionManager
     /**
      * A map of connection aliases.
      *
-     * @var array<string>
+     * @var array<string, string>
      */
     protected static $_aliasMap = [];
 
@@ -184,6 +184,16 @@ class ConnectionManager
     public static function dropAlias(string $alias): void
     {
         unset(static::$_aliasMap[$alias]);
+    }
+
+    /**
+     * Returns the current connection aliases and what they alias.
+     *
+     * @return array<string, string>
+     */
+    public static function aliases(): array
+    {
+        return static::$_aliasMap;
     }
 
     /**

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -39,6 +39,7 @@ class ConnectionManagerTest extends TestCase
         ConnectionManager::drop('missing_write:read');
         ConnectionManager::dropAlias('other_name');
         ConnectionManager::dropAlias('test:read');
+        ConnectionManager::dropAlias('test2');
     }
 
     /**
@@ -185,6 +186,15 @@ class ConnectionManagerTest extends TestCase
         $this->assertNotContains('test_variant', $result);
 
         $this->assertFalse(ConnectionManager::drop('probably_does_not_exist'), 'Should return false on failure.');
+    }
+
+    public function testAliases(): void
+    {
+        $this->assertSame(['default' => 'test'], ConnectionManager::aliases());
+        ConnectionManager::alias('test', 'test2');
+        $this->assertSame(['default' => 'test', 'test2' => 'test'], ConnectionManager::aliases());
+        ConnectionManager::dropAlias('test2');
+        $this->assertSame(['default' => 'test'], ConnectionManager::aliases());
     }
 
     /**


### PR DESCRIPTION
This exposes the current alias map for debugging.