### PR TITLE
4.5 - Add SelectQuery

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1206,7 +1206,7 @@ class BelongsToMany extends Association
 
                 // Create a subquery join to ensure we get
                 // the correct entity passed to callbacks.
-                $existing = $junction->query()
+                $existing = $junction->selectQuery()
                     ->from([$junctionQueryAlias => $matches])
                     ->innerJoin(
                         [$junction->getAlias() => $junction->getTable()],

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\Query;
+
+use Cake\ORM\Query;
+
+/**
+ * Select Query forward compatibility shim.
+ */
+class SelectQuery extends Query
+{
+    /**
+     * Type of this query (select, insert, update, delete).
+     *
+     * @var string
+     */
+    protected $_type = 'select';
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(?string $table = null)
+    {
+        $this->_deprecatedMethod('delete()', 'Create your query with deleteQuery() instead.');
+
+        return parent::delete($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insert(array $columns, array $types = [])
+    {
+        $this->_deprecatedMethod('insert()', 'Create your query with insertQuery() instead.');
+
+        return parent::insert($columns, $types);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function into(string $table)
+    {
+        $this->_deprecatedMethod('into()', 'Use from() instead.');
+
+        return parent::into($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function values($data)
+    {
+        $this->_deprecatedMethod('values()');
+
+        return parent::values($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update($table = null)
+    {
+        $this->_deprecatedMethod('update()', 'Create your query with updateQuery() instead.');
+
+        return parent::update($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value = null, $types = [])
+    {
+        $this->_deprecatedMethod('set()');
+
+        return parent::set($key, $value, $types);
+    }
+}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -41,6 +41,7 @@ use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Exception\RolledbackTransactionException;
 use Cake\ORM\Query\DeleteQuery;
 use Cake\ORM\Query\InsertQuery;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Query\UpdateQuery;
 use Cake\ORM\Rule\IsUnique;
 use Cake\Utility\Inflector;
@@ -1268,7 +1269,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function find(string $type = 'all', array $options = []): Query
     {
-        return $this->callFinder($type, $this->query()->select(), $options);
+        return $this->callFinder($type, $this->selectQuery()->select(), $options);
     }
 
     /**
@@ -1713,9 +1714,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function query(): Query
     {
-        // TODO(markstory) Add deprecation here to encourage new methods.
-        // Remember to remind people implementing this method to
-        // implement the new ones instead.
+        deprecationWarning(
+            'As of 4.5.0 using query() is deprecated. Instead use `insertQuery()`, ' .
+            '`deleteQuery()`, `selectQuery()` or `updateQuery()`. The query objects ' .
+            'returned by these methods will emit deprecations that will become fatal errors in 5.0.' .
+            'See https://book.cakephp.org/4/en/appendices/4-5-migration-guide.html for more information.'
+        );
+
         return new Query($this->getConnection(), $this);
     }
 
@@ -1737,6 +1742,16 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function insertQuery(): InsertQuery
     {
         return new InsertQuery($this->getConnection(), $this);
+    }
+
+    /**
+     * Creates a new SelectQuery instance for a table.
+     *
+     * @return \Cake\ORM\Query\SelectQuery
+     */
+    public function selectQuery(): SelectQuery
+    {
+        return new SelectQuery($this->getConnection(), $this);
     }
 
     /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -165,11 +165,11 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -293,11 +293,11 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 10,
         ];
 
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -325,11 +325,11 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 10,
         ];
 
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -688,11 +688,11 @@ class PaginatorComponentTest extends TestCase
      */
     public function testValidateSortInvalid(): void
     {
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -1232,11 +1232,11 @@ class PaginatorComponentTest extends TestCase
             'finder' => 'published',
             'limit' => 2,
         ];
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -1381,7 +1381,7 @@ class PaginatorComponentTest extends TestCase
     protected function _getMockFindQuery(?RepositoryInterface $table = null)
     {
         /** @var \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject $query */
-        $query = $this->getMockBuilder('Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query\SelectQuery')
             ->onlyMethods(['all', 'count', 'applyOptions'])
             ->addMethods(['total'])
             ->disableOriginalConstructor()

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -94,11 +94,11 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -174,11 +174,11 @@ trait PaginatorTestTrait
             'maxLimit' => 10,
         ];
 
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -205,11 +205,11 @@ trait PaginatorTestTrait
             'order' => ['PaginatorPosts.id' => 'DESC', 'PaginatorPosts.title' => 'ASC'],
         ];
 
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -242,11 +242,11 @@ trait PaginatorTestTrait
             'maxLimit' => 10,
         ];
 
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -584,11 +584,11 @@ trait PaginatorTestTrait
      */
     public function testValidateSortInvalid(): void
     {
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -638,11 +638,11 @@ trait PaginatorTestTrait
      */
     public function testValidaSortInitialSortAndDirection(): void
     {
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -677,11 +677,11 @@ trait PaginatorTestTrait
      */
     public function testValidateSortAndDirectionAliased(): void
     {
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -723,11 +723,11 @@ trait PaginatorTestTrait
      */
     public function testValidateSortRetainsOriginalSortValue(): void
     {
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -1176,11 +1176,11 @@ trait PaginatorTestTrait
             'finder' => 'published',
             'limit' => 2,
         ];
-        $table = $this->_getMockPosts(['query']);
+        $table = $this->_getMockPosts(['selectQuery']);
         $query = $this->_getMockFindQuery();
 
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())->method('applyOptions')
@@ -1321,7 +1321,7 @@ trait PaginatorTestTrait
     protected function _getMockFindQuery($table = null)
     {
         /** @var \Cake\ORM\Query|\PHPUnit\Framework\MockObject\MockObject $query */
-        $query = $this->getMockBuilder('Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query\SelectQuery')
             ->onlyMethods(['all', 'count', 'applyOptions'])
             ->addMethods(['total'])
             ->disableOriginalConstructor()

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -160,7 +160,7 @@ class BelongsToTest extends TestCase
             'conditions' => ['Companies.is_active' => true],
         ];
         $association = new BelongsTo('Companies', $config);
-        $query = $this->client->query();
+        $query = $this->client->selectQuery();
         $association->attachTo($query);
 
         $expected = [
@@ -198,7 +198,7 @@ class BelongsToTest extends TestCase
             'targetTable' => $this->company,
             'conditions' => ['Companies.is_active' => true],
         ];
-        $query = $this->client->query();
+        $query = $this->client->selectQuery();
         $association = new BelongsTo('Companies', $config);
 
         $association->attachTo($query, ['includeFields' => false]);
@@ -219,7 +219,7 @@ class BelongsToTest extends TestCase
             'conditions' => ['Companies.is_active' => true],
         ];
         $association = new BelongsTo('Companies', $config);
-        $query = $this->client->query();
+        $query = $this->client->selectQuery();
         $association->attachTo($query);
 
         $expected = [
@@ -253,7 +253,7 @@ class BelongsToTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"');
         $this->company->setPrimaryKey(['id', 'tenant_id']);
-        $query = $this->client->query();
+        $query = $this->client->selectQuery();
         $config = [
             'foreignKey' => 'company_id',
             'sourceTable' => $this->client,
@@ -359,7 +359,7 @@ class BelongsToTest extends TestCase
             $called = true;
         });
         $association = new BelongsTo('Companies', $config);
-        $association->attachTo($this->client->query());
+        $association->attachTo($this->client->selectQuery());
         $this->assertTrue($called, 'Listener should be called.');
     }
 
@@ -380,7 +380,7 @@ class BelongsToTest extends TestCase
             $called = true;
         });
         $association = new BelongsTo('Companies', $config);
-        $query = $this->client->query();
+        $query = $this->client->selectQuery();
         $association->attachTo($query, ['queryBuilder' => function ($q) {
             return $q->applyOptions(['something' => 'more']);
         }]);

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -198,7 +198,7 @@ class HasManyTest extends TestCase
             'strategy' => 'select',
         ];
         $association = new HasMany('Articles', $config);
-        $query = $this->article->query();
+        $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
             ->will($this->returnValue($query));
@@ -241,7 +241,7 @@ class HasManyTest extends TestCase
         $association = new HasMany('Articles', $config);
         $keys = [1, 2, 3, 4];
 
-        $query = $this->article->query();
+        $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
             ->will($this->returnValue($query));
@@ -276,7 +276,7 @@ class HasManyTest extends TestCase
         $keys = [1, 2, 3, 4];
 
         /** @var \Cake\ORM\Query $query */
-        $query = $this->article->query();
+        $query = $this->article->selectQuery();
         $query->addDefaultTypes($this->article->Comments->getSource());
 
         $this->article->method('find')
@@ -328,7 +328,7 @@ class HasManyTest extends TestCase
         ];
         $association = new HasMany('Articles', $config);
         $keys = [1, 2, 3, 4];
-        $query = $this->article->query();
+        $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
             ->will($this->returnValue($query));
@@ -354,7 +354,7 @@ class HasManyTest extends TestCase
         $keys = [1, 2, 3, 4];
 
         /** @var \Cake\ORM\Query $query */
-        $query = $this->article->query();
+        $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
             ->will($this->returnValue($query));
@@ -540,10 +540,10 @@ class HasManyTest extends TestCase
         $author = new Entity(['id' => 1, 'name' => 'mark']);
         $this->assertTrue($association->cascadeDelete($author));
 
-        $query = $articles->query()->where(['author_id' => 1]);
+        $query = $articles->find()->where(['author_id' => 1]);
         $this->assertSame(0, $query->count(), 'Cleared related rows');
 
-        $query = $articles->query()->where(['author_id' => 3]);
+        $query = $articles->find()->where(['author_id' => 3]);
         $this->assertSame(1, $query->count(), 'other records left behind');
     }
 

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -119,7 +119,7 @@ class HasOneTest extends TestCase
             'conditions' => ['Profiles.is_active' => true],
         ];
         $association = new HasOne('Profiles', $config);
-        $query = $this->user->query();
+        $query = $this->user->find();
         $association->attachTo($query, ['includeFields' => false]);
         $this->assertEmpty($query->clause('select'));
     }
@@ -260,7 +260,7 @@ class HasOneTest extends TestCase
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
         ];
-        $query = $this->user->query();
+        $query = $this->user->find();
 
         $this->listenerCalled = false;
         $this->profile->getEventManager()->on('Model.beforeFind', function ($event, $query, $options, $primary): void {
@@ -327,15 +327,15 @@ class HasOneTest extends TestCase
         $entity = new Entity(['id' => 1]);
         $association->cascadeDelete($entity);
 
-        $query = $this->profile->query()->where(['user_id' => 1]);
+        $query = $this->profile->find()->where(['user_id' => 1]);
         $this->assertSame(1, $query->count(), 'Left non-matching row behind');
 
-        $query = $this->profile->query()->where(['user_id' => 3]);
+        $query = $this->profile->find()->where(['user_id' => 3]);
         $this->assertSame(1, $query->count(), 'other records left behind');
 
         $user = new Entity(['id' => 3]);
         $this->assertTrue($association->cascadeDelete($user));
-        $query = $this->profile->query()->where(['user_id' => 3]);
+        $query = $this->profile->find()->where(['user_id' => 3]);
         $this->assertSame(0, $query->count(), 'Matching record was deleted.');
     }
 
@@ -366,7 +366,7 @@ class HasOneTest extends TestCase
         $this->assertNull($entity->article);
         $this->assertTrue($association->cascadeDelete($entity));
 
-        $query = $Articles->query();
+        $query = $Articles->find();
         $this->assertSame(4, $query->count(), 'No articles should be deleted');
     }
 
@@ -387,15 +387,15 @@ class HasOneTest extends TestCase
         $user = new Entity(['id' => 1]);
         $this->assertTrue($association->cascadeDelete($user));
 
-        $query = $this->profile->query()->where(['user_id' => 1]);
+        $query = $this->profile->find()->where(['user_id' => 1]);
         $this->assertSame(1, $query->count(), 'Left non-matching row behind');
 
-        $query = $this->profile->query()->where(['user_id' => 3]);
+        $query = $this->profile->find()->where(['user_id' => 3]);
         $this->assertSame(1, $query->count(), 'other records left behind');
 
         $user = new Entity(['id' => 3]);
         $this->assertTrue($association->cascadeDelete($user));
-        $query = $this->profile->query()->where(['user_id' => 3]);
+        $query = $this->profile->find()->where(['user_id' => 3]);
         $this->assertSame(0, $query->count(), 'Matching record was deleted.');
     }
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1687,8 +1687,7 @@ class QueryTest extends TestCase
     public function testSelectRandom(): void
     {
         $table = $this->getTableLocator()->get('articles');
-        $query = $table
-            ->query();
+        $query = $table->selectQuery();
 
         $query->select(['s' => $query->func()->rand()]);
         $result = $query
@@ -1707,7 +1706,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('articles');
 
-        $result = $table->query()
+        $result = $table->updateQuery()
             ->update()
             ->set(['title' => 'First'])
             ->execute();
@@ -1724,7 +1723,7 @@ class QueryTest extends TestCase
         $this->skipIf(!$this->connection->getDriver() instanceof Mysql);
         $table = $this->getTableLocator()->get('articles');
 
-        $query = $table->query();
+        $query = $table->updateQuery();
         $result = $query->update($query->newExpr('articles, authors'))
             ->set(['title' => 'First'])
             ->where(['articles.author_id = authors.id'])
@@ -1742,7 +1741,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('articles');
 
-        $result = $table->query()
+        $result = $table->insertQuery()
             ->insert(['title'])
             ->values(['title' => 'First'])
             ->values(['title' => 'Second'])
@@ -1761,8 +1760,7 @@ class QueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('articles');
 
-        $result = $table->query()
-            ->delete()
+        $result = $table->deleteQuery()
             ->where(['id >=' => 1])
             ->execute();
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -42,6 +42,7 @@ use Cake\ORM\Exception\MissingBehaviorException;
 use Cake\ORM\Exception\MissingEntityException;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Query;
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\SaveOptionsBuilder;
 use Cake\ORM\Table;
@@ -202,7 +203,12 @@ class TableTest extends TestCase
     {
         $table = new Table(['table' => 'users']);
 
-        $query = $table->query();
+        $this->deprecated(function () use ($table) {
+            $query = $table->query();
+            $this->assertEquals('users', $query->getRepository()->getTable());
+        });
+
+        $query = $table->selectQuery();
         $this->assertEquals('users', $query->getRepository()->getTable());
 
         $query = $table->subquery();
@@ -1096,14 +1102,14 @@ class TableTest extends TestCase
     public function testFindApplyOptions(): void
     {
         $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['query', 'findAll'])
+            ->onlyMethods(['selectQuery', 'findAll'])
             ->setConstructorArgs([['table' => 'users', 'connection' => $this->connection]])
             ->getMock();
-        $query = $this->getMockBuilder('Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query\SelectQuery')
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
         $table->expects($this->once())
-            ->method('query')
+            ->method('selectQuery')
             ->will($this->returnValue($query));
 
         $options = ['fields' => ['a', 'b'], 'connections' => ['a >' => 1]];
@@ -5226,7 +5232,7 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $query = (new Query($this->connection, $table))->select();
+        $query = (new SelectQuery($this->connection, $table))->select();
         $table->expects($this->once())->method('callFinder')
             ->with('all', $query, []);
         $table->find();
@@ -5250,7 +5256,7 @@ class TableTest extends TestCase
     public function testGet($options): void
     {
         $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['callFinder', 'query'])
+            ->onlyMethods(['callFinder', 'selectQuery'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => [
@@ -5261,13 +5267,13 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $query = $this->getMockBuilder('Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query\SelectQuery')
             ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
 
         $entity = new Entity();
-        $table->expects($this->once())->method('query')
+        $table->expects($this->once())->method('selectQuery')
             ->will($this->returnValue($query));
         $table->expects($this->once())->method('callFinder')
             ->with('all', $query, ['fields' => ['id']])
@@ -5299,7 +5305,7 @@ class TableTest extends TestCase
     public function testGetWithCustomFinder($options): void
     {
         $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['callFinder', 'query'])
+            ->onlyMethods(['callFinder', 'selectQuery'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => [
@@ -5310,13 +5316,13 @@ class TableTest extends TestCase
             ]])
             ->getMock();
 
-        $query = $this->getMockBuilder('Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query\SelectQuery')
             ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
 
         $entity = new Entity();
-        $table->expects($this->once())->method('query')
+        $table->expects($this->once())->method('selectQuery')
             ->will($this->returnValue($query));
         $table->expects($this->once())->method('callFinder')
             ->with('custom', $query, ['fields' => ['id']])
@@ -5366,7 +5372,7 @@ class TableTest extends TestCase
     public function testGetWithCache($options, $cacheKey, $cacheConfig, $primaryKey): void
     {
         $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['callFinder', 'query'])
+            ->onlyMethods(['callFinder', 'selectQuery'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
                 'schema' => [
@@ -5378,13 +5384,13 @@ class TableTest extends TestCase
             ->getMock();
         $table->setTable('table_name');
 
-        $query = $this->getMockBuilder('Cake\ORM\Query')
+        $query = $this->getMockBuilder('Cake\ORM\Query\SelectQuery')
             ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache'])
             ->setConstructorArgs([$this->connection, $table])
             ->getMock();
 
         $entity = new Entity();
-        $table->expects($this->once())->method('query')
+        $table->expects($this->once())->method('selectQuery')
             ->will($this->returnValue($query));
         $table->expects($this->once())->method('callFinder')
             ->with('all', $query, ['fields' => ['id']])


### PR DESCRIPTION
Add SelectQuery and deprecate Table::query(). I needed to update several mocks for queries.
