### PR TITLE
Add ORM\Query::selectAlso() which does not disable auto-selecting fields

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -243,6 +243,24 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
     }
 
     /**
+     * Behaves the exact same as `select()` except adds the field to the list of fields selected and
+     * does not disable auto-selecting fields for Associations.
+     *
+     * Use this instead of calling `select()` then `enableAutoFields()` to re-enable auto-fields.
+     *
+     * @param \Cake\Database\ExpressionInterface|\Cake\ORM\Table|\Cake\ORM\Association|callable|array|string $fields Fields
+     * to be added to the list.
+     * @return $this
+     */
+    public function selectAlso($fields)
+    {
+        $this->select($fields);
+        $this->_autoFields = true;
+
+        return $this;
+    }
+
+    /**
      * All the fields associated with the passed table except the excluded
      * fields will be added to the select clause of the query. Passed excluded fields should not be aliased.
      * After the first call to this method, a second call cannot be used to remove fields that have already

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -160,6 +160,48 @@ class QueryTest extends TestCase
         $this->assertSame($this->table, $result);
     }
 
+    public function testSelectAlso(): void
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $query = new Query($this->connection, $table);
+        $results = $query
+            ->selectAlso(['extra' => 'id'])
+            ->where(['author_id' => 3])
+            ->disableHydration()
+            ->first();
+
+        $this->assertSame(
+            ['extra' => 2, 'id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+            $results
+        );
+
+        $query = new Query($this->connection, $table);
+        $results = $query
+            ->select('id')
+            ->selectAlso(['extra' => 'id'])
+            ->where(['author_id' => 3])
+            ->disableHydration()
+            ->first();
+
+        $this->assertSame(
+            ['id' => 2, 'extra' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+            $results
+        );
+
+        $query = new Query($this->connection, $table);
+        $results = $query
+            ->selectAlso(['extra' => 'id'])
+            ->select('id')
+            ->where(['author_id' => 3])
+            ->disableHydration()
+            ->first();
+
+        $this->assertSame(
+            ['extra' => 2, 'id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+            $results
+        );
+    }
+
     /**
      * Tests that results are grouped correctly when using contain()
      * and results are not hydrated


### PR DESCRIPTION
I thought about adding another parameter to `select()` but I thought this is easier to read and doesn't require setting `$override` each time.

I am constantly trying to add an aggregate calculation when selecting entities from a table.