### PR TITLE
Add orderBy() and groupBy() to match sql

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -530,7 +530,7 @@ abstract class Driver
     protected function _transformDistinct(SelectQuery $query): SelectQuery
     {
         if (is_array($query->clause('distinct'))) {
-            $query->group($query->clause('distinct'), true);
+            $query->groupBy($query->clause('distinct'), true);
             $query->distinct(false);
         }
 

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -317,7 +317,7 @@ class Sqlserver extends Driver
         }
 
         if ($offset !== null && !$query->clause('order')) {
-            $query->order($query->newExpr()->add('(SELECT NULL)'));
+            $query->orderBy($query->newExpr()->add('(SELECT NULL)'));
         }
 
         if ($this->version() < 11 && $offset !== null) {
@@ -374,7 +374,7 @@ class Sqlserver extends Driver
                 '_cake_page_rownum_' => new UnaryExpression('ROW_NUMBER() OVER', $order),
             ])->limit(null)
             ->offset(null)
-            ->order([], true);
+            ->orderBy([], true);
 
         $outer = $query->getConnection()->selectQuery();
         $outer->select('*')
@@ -432,7 +432,7 @@ class Sqlserver extends Driver
             })
             ->limit(null)
             ->offset(null)
-            ->order([], true);
+            ->orderBy([], true);
 
         $outer = new SelectQuery($query->getConnection());
         $outer->select('*')

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -92,7 +92,15 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
      */
     public function order(ExpressionInterface|Closure|array|string $fields)
     {
-        $this->getWindow()->order($fields);
+        return $this->orderBy($fields);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function orderBy(ExpressionInterface|Closure|array|string $fields)
+    {
+        $this->getWindow()->orderBy($fields);
 
         return $this;
     }

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -117,6 +117,14 @@ class WindowExpression implements ExpressionInterface, WindowInterface
      */
     public function order(ExpressionInterface|Closure|array|string $fields)
     {
+        return $this->orderBy($fields);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function orderBy(ExpressionInterface|Closure|array|string $fields)
+    {
         if (!$fields) {
             return $this;
         }

--- a/src/Database/Expression/WindowInterface.php
+++ b/src/Database/Expression/WindowInterface.php
@@ -58,12 +58,21 @@ interface WindowInterface
     public function partition(ExpressionInterface|Closure|array|string $partitions);
 
     /**
-     * Adds one or more order clauses to the window.
+     * Adds one or more order by clauses to the window.
+     *
+     * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $fields Order expressions
+     * @return $this
+     * @deprecated 5.0.0 Use orderBy() instead.
+     */
+    public function order(ExpressionInterface|Closure|array|string $fields);
+
+    /**
+     * Adds one or more order by clauses to the window.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array<\Cake\Database\ExpressionInterface|string>|string $fields Order expressions
      * @return $this
      */
-    public function order(ExpressionInterface|Closure|array|string $fields);
+    public function orderBy(ExpressionInterface|Closure|array|string $fields);
 
     /**
      * Adds a simple range frame to the window.

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1087,7 +1087,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * ### Examples:
      *
      * ```
-     * $query->order(['title' => 'DESC', 'author_id' => 'ASC']);
+     * $query->orderBy(['title' => 'DESC', 'author_id' => 'ASC']);
      * ```
      *
      * Produces:
@@ -1096,8 +1096,8 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * ```
      * $query
-     *     ->order(['title' => $query->newExpr('DESC NULLS FIRST')])
-     *     ->order('author_id');
+     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy('author_id');
      * ```
      *
      * Will generate:
@@ -1106,13 +1106,13 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * ```
      * $expression = $query->newExpr()->add(['id % 2 = 0']);
-     * $query->order($expression)->order(['title' => 'ASC']);
+     * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
      * ```
      *
      * and
      *
      * ```
-     * $query->order(function ($exp, $query) {
+     * $query->orderBy(function ($exp, $query) {
      *     return [$exp->add(['id % 2 = 0']), 'title' => 'ASC'];
      * });
      * ```
@@ -1126,13 +1126,80 @@ abstract class Query implements ExpressionInterface, Stringable
      * in user-supplied data to `order()`.
      *
      * If you need to set complex expressions as order conditions, you
-     * should use `orderAsc()` or `orderDesc()`.
+     * should use `orderByAsc()` or `orderByDesc()`.
+     *
+     * @param \Cake\Database\ExpressionInterface|\Closure|array|string $fields fields to be added to the list
+     * @param bool $overwrite whether to reset order with field list or not
+     * @return $this
+     * @deprecated 5.0.0 Use orderBy() instead now that CollectionInterface methods are no longer proxied.
+     */
+    public function order(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false)
+    {
+        return $this->orderBy($fields, $overwrite);
+    }
+
+    /**
+     * Adds a single or multiple fields to be used in the ORDER clause for this query.
+     * Fields can be passed as an array of strings, array of expression
+     * objects, a single expression or a single string.
+     *
+     * If an array is passed, keys will be used as the field itself and the value will
+     * represent the order in which such field should be ordered. When called multiple
+     * times with the same fields as key, the last order definition will prevail over
+     * the others.
+     *
+     * By default this function will append any passed argument to the list of fields
+     * to be selected, unless the second argument is set to true.
+     *
+     * ### Examples:
+     *
+     * ```
+     * $query->orderBy(['title' => 'DESC', 'author_id' => 'ASC']);
+     * ```
+     *
+     * Produces:
+     *
+     * `ORDER BY title DESC, author_id ASC`
+     *
+     * ```
+     * $query
+     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy('author_id');
+     * ```
+     *
+     * Will generate:
+     *
+     * `ORDER BY title DESC NULLS FIRST, author_id`
+     *
+     * ```
+     * $expression = $query->newExpr()->add(['id % 2 = 0']);
+     * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
+     * ```
+     *
+     * and
+     *
+     * ```
+     * $query->orderBy(function ($exp, $query) {
+     *     return [$exp->add(['id % 2 = 0']), 'title' => 'ASC'];
+     * });
+     * ```
+     *
+     * Will both become:
+     *
+     * `ORDER BY (id %2 = 0), title ASC`
+     *
+     * Order fields/directions are not sanitized by the query builder.
+     * You should use an allowed list of fields/directions when passing
+     * in user-supplied data to `order()`.
+     *
+     * If you need to set complex expressions as order conditions, you
+     * should use `orderByAsc()` or `orderByDesc()`.
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
      * @return $this
      */
-    public function order(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false)
+    public function orderBy(ExpressionInterface|Closure|array|string $fields, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['order'] = null;
@@ -1162,8 +1229,27 @@ abstract class Query implements ExpressionInterface, Stringable
      * @param \Cake\Database\ExpressionInterface|\Closure|string $field The field to order on.
      * @param bool $overwrite Whether to reset the order clauses.
      * @return $this
+     * @deprecated 5.0.0 Use orderByAsc() instead now that CollectionInterface methods are no longer proxied.
      */
     public function orderAsc(ExpressionInterface|Closure|string $field, bool $overwrite = false)
+    {
+        return $this->orderByAsc($field, $overwrite);
+    }
+
+    /**
+     * Add an ORDER BY clause with an ASC direction.
+     *
+     * This method allows you to set complex expressions
+     * as order conditions unlike order()
+     *
+     * Order fields are not suitable for use with user supplied data as they are
+     * not sanitized by the query builder.
+     *
+     * @param \Cake\Database\ExpressionInterface|\Closure|string $field The field to order on.
+     * @param bool $overwrite Whether to reset the order clauses.
+     * @return $this
+     */
+    public function orderByAsc(ExpressionInterface|Closure|string $field, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['order'] = null;
@@ -1196,8 +1282,27 @@ abstract class Query implements ExpressionInterface, Stringable
      * @param \Cake\Database\ExpressionInterface|\Closure|string $field The field to order on.
      * @param bool $overwrite Whether to reset the order clauses.
      * @return $this
+     * @deprecated 5.0.0 Use orderByDesc() instead now that CollectionInterface methods are no longer proxied.
      */
     public function orderDesc(ExpressionInterface|Closure|string $field, bool $overwrite = false)
+    {
+        return $this->orderByDesc($field, $overwrite);
+    }
+
+    /**
+     * Add an ORDER BY clause with a DESC direction.
+     *
+     * This method allows you to set complex expressions
+     * as order conditions unlike order()
+     *
+     * Order fields are not suitable for use with user supplied data as they are
+     * not sanitized by the query builder.
+     *
+     * @param \Cake\Database\ExpressionInterface|\Closure|string $field The field to order on.
+     * @param bool $overwrite Whether to reset the order clauses.
+     * @return $this
+     */
+    public function orderByDesc(ExpressionInterface|Closure|string $field, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['order'] = null;

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -506,10 +506,41 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * ```
      * // Produces GROUP BY id, title
-     * $query->group(['id', 'title']);
+     * $query->groupBy(['id', 'title']);
      *
      * // Produces GROUP BY title
-     * $query->group('title');
+     * $query->groupBy('title');
+     * ```
+     *
+     * Group fields are not suitable for use with user supplied data as they are
+     * not sanitized by the query builder.
+     *
+     * @param \Cake\Database\ExpressionInterface|array|string $fields fields to be added to the list
+     * @param bool $overwrite whether to reset fields with passed list or not
+     * @return $this
+     * @deprecated 5.0.0 Use groupBy() instead now that CollectionInterface methods are no longer proxied.
+     */
+    public function group(ExpressionInterface|array|string $fields, bool $overwrite = false)
+    {
+        return $this->groupBy($fields, $overwrite);
+    }
+
+    /**
+     * Adds a single or multiple fields to be used in the GROUP BY clause for this query.
+     * Fields can be passed as an array of strings, array of expression
+     * objects, a single expression or a single string.
+     *
+     * By default this function will append any passed argument to the list of fields
+     * to be grouped, unless the second argument is set to true.
+     *
+     * ### Examples:
+     *
+     * ```
+     * // Produces GROUP BY id, title
+     * $query->groupBy(['id', 'title']);
+     *
+     * // Produces GROUP BY title
+     * $query->groupBy('title');
      * ```
      *
      * Group fields are not suitable for use with user supplied data as they are
@@ -519,7 +550,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * @param bool $overwrite whether to reset fields with passed list or not
      * @return $this
      */
-    public function group(ExpressionInterface|array|string $fields, bool $overwrite = false)
+    public function groupBy(ExpressionInterface|array|string $fields, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['group'] = [];

--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -215,7 +215,7 @@ interface QueryInterface
      * ### Examples:
      *
      * ```
-     * $query->order(['title' => 'DESC', 'author_id' => 'ASC']);
+     * $query->orderBy(['title' => 'DESC', 'author_id' => 'ASC']);
      * ```
      *
      * Produces:
@@ -224,8 +224,8 @@ interface QueryInterface
      *
      * ```
      * $query
-     *     ->order(['title' => $query->newExpr('DESC NULLS FIRST')])
-     *     ->order('author_id');
+     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy('author_id');
      * ```
      *
      * Will generate:
@@ -234,7 +234,7 @@ interface QueryInterface
      *
      * ```
      * $expression = $query->newExpr()->add(['id % 2 = 0']);
-     * $query->order($expression)->order(['title' => 'ASC']);
+     * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
      * ```
      *
      * Will become:
@@ -242,13 +242,65 @@ interface QueryInterface
      * `ORDER BY (id %2 = 0), title ASC`
      *
      * If you need to set complex expressions as order conditions, you
-     * should use `orderAsc()` or `orderDesc()`.
+     * should use `orderByAsc()` or `orderByDesc()`.
+     *
+     * @param \Closure|array|string $fields fields to be added to the list
+     * @param bool $overwrite whether to reset order with field list or not
+     * @return $this
+     * @deprecated 5.0.0 Use orderBy() instead now that CollectionInterface methods are no longer proxied.
+     */
+    public function order(Closure|array|string $fields, bool $overwrite = false);
+
+    /**
+     * Adds a single or multiple fields to be used in the ORDER clause for this query.
+     * Fields can be passed as an array of strings, array of expression
+     * objects, a single expression or a single string.
+     *
+     * If an array is passed, keys will be used as the field itself and the value will
+     * represent the order in which such field should be ordered. When called multiple
+     * times with the same fields as key, the last order definition will prevail over
+     * the others.
+     *
+     * By default this function will append any passed argument to the list of fields
+     * to be selected, unless the second argument is set to true.
+     *
+     * ### Examples:
+     *
+     * ```
+     * $query->orderBy(['title' => 'DESC', 'author_id' => 'ASC']);
+     * ```
+     *
+     * Produces:
+     *
+     * `ORDER BY title DESC, author_id ASC`
+     *
+     * ```
+     * $query
+     *     ->orderBy(['title' => $query->newExpr('DESC NULLS FIRST')])
+     *     ->orderBy('author_id');
+     * ```
+     *
+     * Will generate:
+     *
+     * `ORDER BY title DESC NULLS FIRST, author_id`
+     *
+     * ```
+     * $expression = $query->newExpr()->add(['id % 2 = 0']);
+     * $query->orderBy($expression)->orderBy(['title' => 'ASC']);
+     * ```
+     *
+     * Will become:
+     *
+     * `ORDER BY (id %2 = 0), title ASC`
+     *
+     * If you need to set complex expressions as order conditions, you
+     * should use `orderByAsc()` or `orderByDesc()`.
      *
      * @param \Closure|array|string $fields fields to be added to the list
      * @param bool $overwrite whether to reset order with field list or not
      * @return $this
      */
-    public function order(Closure|array|string $fields, bool $overwrite = false);
+    public function orderBy(Closure|array|string $fields, bool $overwrite = false);
 
     /**
      * Set the page of results you want.

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -190,7 +190,7 @@ class SelectLoader
         }
 
         if (!empty($options['sort'])) {
-            $fetchQuery->order($options['sort']);
+            $fetchQuery->orderBy($options['sort']);
         }
 
         if (!empty($options['contain'])) {
@@ -418,12 +418,12 @@ class SelectLoader
         // Ignore limit if there is no order since we need all rows to find matches
         if (!$filterQuery->clause('limit') || !$filterQuery->clause('order')) {
             $filterQuery->limit(null);
-            $filterQuery->order([], true);
+            $filterQuery->orderBy([], true);
             $filterQuery->offset(null);
         }
 
         $fields = $this->_subqueryFields($query);
-        $filterQuery->select($fields['select'], true)->group($fields['group']);
+        $filterQuery->select($fields['select'], true)->groupBy($fields['group']);
 
         return $filterQuery;
     }

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -409,7 +409,7 @@ class TreeBehavior extends Behavior
                 "$left <=" => $node->get($config['left']),
                 "$right >=" => $node->get($config['right']),
             ])
-            ->order([$left => 'ASC']);
+            ->orderBy([$left => 'ASC']);
     }
 
     /**
@@ -470,7 +470,7 @@ class TreeBehavior extends Behavior
         }
 
         if ($query->clause('order') === null) {
-            $query->order([$left => 'ASC']);
+            $query->orderBy([$left => 'ASC']);
         }
 
         if ($direct) {
@@ -655,7 +655,7 @@ class TreeBehavior extends Behavior
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
                 ->where(fn (QueryExpression $exp) => $exp->lt($config['rightField'], $nodeLeft))
-                ->orderDesc($config['leftField'])
+                ->orderByDesc($config['leftField'])
                 ->offset($number - 1)
                 ->limit(1)
                 ->first();
@@ -666,7 +666,7 @@ class TreeBehavior extends Behavior
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
                 ->where(fn (QueryExpression $exp) => $exp->lt($config['rightField'], $nodeLeft))
-                ->orderAsc($config['leftField'])
+                ->orderByAsc($config['leftField'])
                 ->limit(1)
                 ->first();
 
@@ -744,7 +744,7 @@ class TreeBehavior extends Behavior
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
                 ->where(fn (QueryExpression $exp) => $exp->gt($config['leftField'], $nodeRight))
-                ->orderAsc($config['leftField'])
+                ->orderByAsc($config['leftField'])
                 ->offset($number - 1)
                 ->limit(1)
                 ->first();
@@ -755,7 +755,7 @@ class TreeBehavior extends Behavior
                 ->select([$left, $right])
                 ->where(["$parent IS" => $nodeParent])
                 ->where(fn (QueryExpression $exp) => $exp->gt($config['leftField'], $nodeRight))
-                ->orderDesc($config['leftField'])
+                ->orderByDesc($config['leftField'])
                 ->limit(1)
                 ->first();
 
@@ -845,7 +845,7 @@ class TreeBehavior extends Behavior
         $nodes = $this->_scope($this->_table->query())
             ->select($primaryKey)
             ->where([$parent . ' IS' => $parentId])
-            ->order($order)
+            ->orderBy($order)
             ->disableHydration()
             ->all();
 
@@ -878,7 +878,7 @@ class TreeBehavior extends Behavior
         $rightField = $this->_config['rightField'];
         $edge = $this->_scope($this->_table->find())
             ->select([$field])
-            ->orderDesc($rightField)
+            ->orderByDesc($rightField)
             ->first();
 
         if ($edge === null || empty($edge[$field])) {

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1135,7 +1135,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * $usersQuery
      *     ->select(['total_articles' => $query->func()->count('Articles.id')])
      *     ->leftJoinWith('Articles')
-     *     ->group(['Users.id'])
+     *     ->groupBy(['Users.id'])
      *     ->enableAutoFields();
      * ```
      *
@@ -1148,7 +1148,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *     ->leftJoinWith('Articles', function ($q) {
      *         return $q->where(['Articles.votes >=' => 5]);
      *     })
-     *     ->group(['Users.id'])
+     *     ->groupBy(['Users.id'])
      *     ->enableAutoFields();
      * ```
      *
@@ -1172,7 +1172,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *     ->leftJoinWith('Comments.Users', function ($q) {
      *         return $q->where(['username' => 'markstory']);
      *     })
-     *    ->group(['Users.id']);
+     *    ->groupBy(['Users.id']);
      * ```
      *
      * Please note that the query passed to the closure will only accept calling
@@ -1335,7 +1335,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         $clone->triggerBeforeFind();
         $clone->disableAutoFields();
         $clone->limit(null);
-        $clone->order([], true);
+        $clone->orderBy([], true);
         $clone->offset(null);
         $clone->mapReduce(null, null, true);
         $clone->formatResults(null, self::OVERWRITE);

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -186,7 +186,7 @@ class PostgresTest extends TestCase
                 'posts.author_id',
                 'post_count' => $query->func()->count('posts.id'),
             ])
-            ->group(['posts.author_id'])
+            ->groupBy(['posts.author_id'])
             ->having([$query->newExpr()->gte('post_count', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS "post_count" ' .
@@ -214,7 +214,7 @@ class PostgresTest extends TestCase
                 'posts.author_id',
                 'post_count' => $query->func()->count('posts.id'),
             ])
-            ->group(['posts.author_id'])
+            ->groupBy(['posts.author_id'])
             ->having([$query->newExpr()->gte('posts.author_id', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS "post_count" ' .

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -246,14 +246,14 @@ class SqlserverTest extends TestCase
         $query = new SelectQuery($connection);
         $query->select(['id', 'title'])
             ->from('articles')
-            ->order(['id'])
+            ->orderBy(['id'])
             ->offset(10);
         $this->assertSame('SELECT id, title FROM articles ORDER BY id OFFSET 10 ROWS', $query->sql());
 
         $query = new SelectQuery($connection);
         $query->select(['id', 'title'])
             ->from('articles')
-            ->order(['id'])
+            ->orderBy(['id'])
             ->limit(10)
             ->offset(50);
         $this->assertSame('SELECT id, title FROM articles ORDER BY id OFFSET 50 ROWS FETCH FIRST 10 ROWS ONLY', $query->sql());
@@ -311,7 +311,7 @@ class SqlserverTest extends TestCase
         $query = new SelectQuery($connection);
         $query->select(['id', 'title'])
             ->from('articles')
-            ->order(['id'])
+            ->orderBy(['id'])
             ->offset(10);
         $expected = 'SELECT * FROM (SELECT id, title, (ROW_NUMBER() OVER (ORDER BY id)) AS ' . $identifier . ' ' .
             'FROM articles) _cake_paging_ ' .
@@ -321,7 +321,7 @@ class SqlserverTest extends TestCase
         $query = new SelectQuery($connection);
         $query->select(['id', 'title'])
             ->from('articles')
-            ->order(['id'])
+            ->orderBy(['id'])
             ->where(['title' => 'Something'])
             ->limit(10)
             ->offset(50);
@@ -339,7 +339,7 @@ class SqlserverTest extends TestCase
                 'computed' => $subquery,
             ])
             ->from('articles')
-            ->order([
+            ->orderBy([
                 'computed' => 'ASC',
             ])
             ->offset(10);
@@ -377,7 +377,7 @@ class SqlserverTest extends TestCase
                 'computedB' => $subqueryB,
             ])
             ->from('articles')
-            ->order([
+            ->orderBy([
                 'computedA' => 'ASC',
             ])
             ->offset(10);
@@ -437,7 +437,7 @@ class SqlserverTest extends TestCase
                 'posts.author_id',
                 'post_count' => $query->func()->count('posts.id'),
             ])
-            ->group(['posts.author_id'])
+            ->groupBy(['posts.author_id'])
             ->having([$query->newExpr()->gte('post_count', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS post_count ' .
@@ -468,7 +468,7 @@ class SqlserverTest extends TestCase
                 'posts.author_id',
                 'post_count' => $query->func()->count('posts.id'),
             ])
-            ->group(['posts.author_id'])
+            ->groupBy(['posts.author_id'])
             ->having([$query->newExpr()->gte('posts.author_id', 2, 'integer')]);
 
         $expected = 'SELECT posts.author_id, (COUNT(posts.id)) AS post_count ' .

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -83,7 +83,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
             $f->sql(new ValueBinder())
         );
 
-        $f = (new AggregateExpression('MyFunction'))->order('test');
+        $f = (new AggregateExpression('MyFunction'))->orderBy('test');
         $this->assertEqualsSql(
             'MyFunction() OVER (ORDER BY test)',
             $f->sql(new ValueBinder())

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -37,7 +37,7 @@ class WindowExpressionTest extends TestCase
         $w = new WindowExpression();
         $this->assertSame('', $w->sql(new ValueBinder()));
 
-        $w->partition('')->order([]);
+        $w->partition('')->orderBy([]);
         $this->assertSame('', $w->sql(new ValueBinder()));
     }
 
@@ -76,15 +76,15 @@ class WindowExpressionTest extends TestCase
     /**
      * Tests windows with order by
      */
-    public function testOrder(): void
+    public function testOrderBy(): void
     {
-        $w = (new WindowExpression())->order('test');
+        $w = (new WindowExpression())->orderBy('test');
         $this->assertEqualsSql(
             'ORDER BY test',
             $w->sql(new ValueBinder())
         );
 
-        $w->order(['test2' => 'DESC']);
+        $w->orderBy(['test2' => 'DESC']);
         $this->assertEqualsSql(
             'ORDER BY test, test2 DESC',
             $w->sql(new ValueBinder())
@@ -97,14 +97,23 @@ class WindowExpressionTest extends TestCase
         );
 
         $w = (new WindowExpression())
-            ->order(function () {
+            ->orderBy(function () {
                 return 'test';
             })
-            ->order(function (QueryExpression $expr) {
+            ->orderBy(function (QueryExpression $expr) {
                 return [$expr->add('test2'), new OrderClauseExpression(new IdentifierExpression('test3'), 'DESC')];
             });
         $this->assertEqualsSql(
             'ORDER BY test, test2, test3 DESC',
+            $w->sql(new ValueBinder())
+        );
+    }
+
+    public function testOrderDeprecated(): void
+    {
+        $w = (new WindowExpression())->order('test');
+        $this->assertEqualsSql(
+            'ORDER BY test',
             $w->sql(new ValueBinder())
         );
     }
@@ -344,19 +353,19 @@ class WindowExpressionTest extends TestCase
             $w->sql(new ValueBinder())
         );
 
-        $w = (new WindowExpression())->order('test')->range(null);
+        $w = (new WindowExpression())->orderBy('test')->range(null);
         $this->assertEqualsSql(
             'ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
-        $w = (new WindowExpression())->partition('test')->order('test')->range(null);
+        $w = (new WindowExpression())->partition('test')->orderBy('test')->range(null);
         $this->assertEqualsSql(
             'PARTITION BY test ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
             $w->sql(new ValueBinder())
         );
 
-        $w = (new WindowExpression())->partition('test')->order('test')->range(null)->excludeCurrent();
+        $w = (new WindowExpression())->partition('test')->orderBy('test')->range(null)->excludeCurrent();
         $this->assertEqualsSql(
             'PARTITION BY test ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW',
             $w->sql(new ValueBinder())
@@ -384,7 +393,7 @@ class WindowExpressionTest extends TestCase
             $w->sql(new ValueBinder())
         );
 
-        $w->order('test');
+        $w->orderBy('test');
         $this->assertFalse($w->isNamedOnly());
         $this->assertEqualsSql(
             'new_name ORDER BY test',
@@ -399,7 +408,7 @@ class WindowExpressionTest extends TestCase
     {
         $w = (new WindowExpression('test1'))
             ->partition('test2')
-            ->order('test3')
+            ->orderBy('test3')
             ->range(new QueryExpression("'1 day'"));
 
         $expressions = [];
@@ -436,8 +445,8 @@ class WindowExpressionTest extends TestCase
         $w2 = (clone $w1)->partition('new');
         $this->assertNotSame($w1->sql(new ValueBinder()), $w2->sql(new ValueBinder()));
 
-        $w1 = (new WindowExpression())->order('test');
-        $w2 = (clone $w1)->order('new');
+        $w1 = (new WindowExpression())->orderBy('test');
+        $w2 = (clone $w1)->orderBy('new');
         $this->assertNotSame($w1->sql(new ValueBinder()), $w2->sql(new ValueBinder()));
 
         $w1 = (new WindowExpression())->rows(0, null);

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -66,7 +66,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     {
         $this->_insert();
         $query = $this->connection->selectQuery('id', 'ordered_uuid_items')
-            ->order('id')
+            ->orderBy('id')
             ->setDefaultTypes(['id' => 'ordered_uuid']);
 
         $query->setSelectTypeMap($query->getTypeMap());
@@ -120,7 +120,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
                 ['id' => ['48298a29-81c0-4c26-a7fb-413140cf8569', '482b7756-8da0-419a-b21f-27da40cf8569']],
                 ['id' => 'ordered_uuid[]']
             )
-            ->order('id')
+            ->orderBy('id')
             ->execute()
             ->fetchAll('assoc');
 

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -148,14 +148,14 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         //Append more tables to next execution
-        $result = $query->select('name')->from(['authors'])->order(['name' => 'desc', 'articles.id' => 'asc'])->execute();
+        $result = $query->select('name')->from(['authors'])->orderBy(['name' => 'desc', 'articles.id' => 'asc'])->execute();
         $this->assertEquals(['body' => 'First Article Body', 'author_id' => 1, 'name' => 'nate'], $result->fetch('assoc'));
         $this->assertEquals(['body' => 'Second Article Body', 'author_id' => 3, 'name' => 'nate'], $result->fetch('assoc'));
         $this->assertEquals(['body' => 'Third Article Body', 'author_id' => 1, 'name' => 'nate'], $result->fetch('assoc'));
         $result->closeCursor();
 
         // Overwrite tables and only fetch from authors
-        $result = $query->select('name', true)->from('authors', true)->order(['name' => 'desc'], true)->execute();
+        $result = $query->select('name', true)->from('authors', true)->orderBy(['name' => 'desc'], true)->execute();
         $this->assertSame(['nate'], $result->fetch());
         $this->assertSame(['mariano'], $result->fetch());
         $result->closeCursor();
@@ -210,7 +210,7 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         $result = $query->select(['name' => 'b.name'])->from(['b' => 'authors'])
-            ->order(['text' => 'desc', 'name' => 'desc'])
+            ->orderBy(['text' => 'desc', 'name' => 'desc'])
             ->execute();
         $this->assertEquals(
             ['text' => 'Third Article Body', 'author_id' => 1, 'name' => 'nate'],
@@ -233,7 +233,7 @@ class SelectQueryTest extends TestCase
             ->select(['title', 'name'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->order(['title' => 'asc'])
+            ->orderBy(['title' => 'asc'])
             ->execute();
 
         $rows = $result->fetchAll('assoc');
@@ -266,7 +266,7 @@ class SelectQueryTest extends TestCase
             ->select(['title', 'name'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => [$query->newExpr()->equalFields('author_id ', 'a.id')]])
-            ->order(['title' => 'asc'])
+            ->orderBy(['title' => 'asc'])
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
         $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $result->fetch('assoc'));
@@ -278,7 +278,7 @@ class SelectQueryTest extends TestCase
             ->select(['title', 'name'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $conditions])
-            ->order(['title' => 'asc'])
+            ->orderBy(['title' => 'asc'])
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
         $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $result->fetch('assoc'));
@@ -306,7 +306,7 @@ class SelectQueryTest extends TestCase
             ->select(['title', 'name'])
             ->from('articles')
             ->join(['a' => 'authors'])
-            ->order(['name' => 'desc', 'articles.id' => 'asc'])
+            ->orderBy(['name' => 'desc', 'articles.id' => 'asc'])
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'name' => 'nate'], $result->fetch('assoc'));
         $this->assertEquals(['title' => 'Second Article', 'name' => 'nate'], $result->fetch('assoc'));
@@ -318,7 +318,7 @@ class SelectQueryTest extends TestCase
             ->select(['title', 'name'])
             ->from('articles')
             ->join(['a' => ['table' => 'authors', 'conditions' => $conditions]])
-            ->order(['title' => 'asc'])
+            ->orderBy(['title' => 'asc'])
             ->execute();
         $this->assertEquals(['title' => 'First Article', 'name' => 'mariano'], $result->fetch('assoc'));
         $this->assertEquals(['title' => 'Second Article', 'name' => 'larry'], $result->fetch('assoc'));
@@ -357,7 +357,7 @@ class SelectQueryTest extends TestCase
             ->select(['title', 'name' => 'c.comment'])
             ->from('articles')
             ->leftJoin(['c' => 'comments'], ['created >' => $time], $types)
-            ->order(['created' => 'asc'])
+            ->orderBy(['created' => 'asc'])
             ->execute();
         $this->assertEquals(
             ['title' => 'First Article', 'name' => 'Second Comment for First Article'],
@@ -1579,7 +1579,7 @@ class SelectQueryTest extends TestCase
         $query->select(['id'])
             ->from('articles')
             ->whereInList('id', [2, 3])
-            ->order(['id']);
+            ->orderBy(['id']);
 
         $sql = $query->sql();
         $this->assertQuotedQuery(
@@ -1642,7 +1642,7 @@ class SelectQueryTest extends TestCase
         $query->select(['id'])
             ->from('articles')
             ->whereNotInList('id', [], ['allowEmpty' => true])
-            ->order(['id']);
+            ->orderBy(['id']);
 
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \(<id>\) IS NOT NULL',
@@ -1683,7 +1683,7 @@ class SelectQueryTest extends TestCase
         $query->select(['id'])
             ->from('articles')
             ->whereNotInListOrNull('id', [], ['allowEmpty' => true])
-            ->order(['id']);
+            ->orderBy(['id']);
 
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \(<id>\) IS NOT NULL',
@@ -1696,7 +1696,7 @@ class SelectQueryTest extends TestCase
     }
 
     /**
-     * Tests order() method both with simple fields and expressions
+     * Tests orderBy() method both with simple fields and expressions
      */
     public function testSelectOrderBy(): void
     {
@@ -1704,32 +1704,32 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('comments')
-            ->order(['id' => 'desc'])
+            ->orderBy(['id' => 'desc'])
             ->execute();
         $this->assertEquals(['id' => 6], $result->fetch('assoc'));
         $this->assertEquals(['id' => 5], $result->fetch('assoc'));
         $this->assertEquals(['id' => 4], $result->fetch('assoc'));
         $result->closeCursor();
 
-        $result = $query->order(['id' => 'asc'])->execute();
+        $result = $query->orderBy(['id' => 'asc'])->execute();
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
         $this->assertEquals(['id' => 2], $result->fetch('assoc'));
         $this->assertEquals(['id' => 3], $result->fetch('assoc'));
         $result->closeCursor();
 
-        $result = $query->order(['comment' => 'asc'])->execute();
+        $result = $query->orderBy(['comment' => 'asc'])->execute();
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
         $this->assertEquals(['id' => 2], $result->fetch('assoc'));
         $this->assertEquals(['id' => 3], $result->fetch('assoc'));
         $result->closeCursor();
 
-        $result = $query->order(['comment' => 'asc'], true)->execute();
+        $result = $query->orderBy(['comment' => 'asc'], true)->execute();
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
         $this->assertEquals(['id' => 5], $result->fetch('assoc'));
         $this->assertEquals(['id' => 4], $result->fetch('assoc'));
         $result->closeCursor();
 
-        $result = $query->order(['user_id' => 'asc', 'created' => 'desc'], true)
+        $result = $query->orderBy(['user_id' => 'asc', 'created' => 'desc'], true)
             ->execute();
         $this->assertEquals(['id' => 5], $result->fetch('assoc'));
         $this->assertEquals(['id' => 4], $result->fetch('assoc'));
@@ -1738,7 +1738,7 @@ class SelectQueryTest extends TestCase
 
         $expression = $query->newExpr(['(id + :offset) % 2']);
         $result = $query
-            ->order([$expression, 'id' => 'desc'], true)
+            ->orderBy([$expression, 'id' => 'desc'], true)
             ->bind(':offset', 1, null)
             ->execute();
         $this->assertEquals(['id' => 5], $result->fetch('assoc'));
@@ -1747,8 +1747,8 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
 
         $result = $query
-            ->order($expression, true)
-            ->order(['id' => 'asc'])
+            ->orderBy($expression, true)
+            ->orderBy(['id' => 'asc'])
             ->bind(':offset', 1, null)
             ->execute();
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
@@ -1757,15 +1757,42 @@ class SelectQueryTest extends TestCase
         $result->closeCursor();
     }
 
+    public function testSelectOrderDeprecated(): void
+    {
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('comments')
+            ->order(['id' => 'desc'])
+            ->execute();
+        $this->assertEquals([6, 5, 4, 3, 2, 1], array_column($result->fetchAll('assoc'), 'id'));
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select(['id'])
+            ->from('comments')
+            ->orderDesc('id')
+            ->execute();
+        $this->assertEquals([6, 5, 4, 3, 2, 1], array_column($result->fetchAll('assoc'), 'id'));
+
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select(['user_id'])
+            ->from('comments')
+            ->orderAsc('user_id')
+            ->execute();
+        $this->assertEquals([1, 1, 1, 2, 2, 4], array_column($result->fetchAll('assoc'), 'user_id'));
+    }
+
     /**
-     * Test that order() being a string works.
+     * Test that orderBy() being a string works.
      */
     public function testSelectOrderByString(): void
     {
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->order('id asc');
+            ->orderBy('id asc');
         $result = $query->execute();
         $this->assertEquals(['id' => 1], $result->fetch('assoc'));
         $this->assertEquals(['id' => 2], $result->fetch('assoc'));
@@ -1774,7 +1801,7 @@ class SelectQueryTest extends TestCase
     }
 
     /**
-     * Test exception for order() with an associative array which contains extra values.
+     * Test exception for orderBy() with an associative array which contains extra values.
      */
     public function testSelectOrderByAssociativeArrayContainingExtraExpressions(): void
     {
@@ -1788,13 +1815,13 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->order([
+            ->orderBy([
                 'id' => 'desc -- Comment',
             ]);
     }
 
     /**
-     * Tests that order() works with closures.
+     * Tests that orderBy() works with closures.
      */
     public function testSelectOrderByClosure(): void
     {
@@ -1802,7 +1829,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->order(function ($exp, $q) use ($query) {
+            ->orderBy(function ($exp, $q) use ($query) {
                 $this->assertInstanceOf(QueryExpression::class, $exp);
                 $this->assertSame($query, $q);
 
@@ -1819,7 +1846,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->order(function ($exp) {
+            ->orderBy(function ($exp) {
                 return [$exp->add(['id % 2 = 0']), 'title' => 'ASC'];
             });
 
@@ -1833,7 +1860,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->order(function ($exp) {
+            ->orderBy(function ($exp) {
                 return $exp->add('a + b');
             });
 
@@ -1847,7 +1874,7 @@ class SelectQueryTest extends TestCase
         $query
             ->select('*')
             ->from('articles')
-            ->order(function ($exp, $q) {
+            ->orderBy(function ($exp, $q) {
                 return $q->func()->sum('a');
             });
 
@@ -1859,14 +1886,14 @@ class SelectQueryTest extends TestCase
     }
 
     /**
-     * Test orderAsc() and its input types.
+     * Test orderByAsc() and its input types.
      */
-    public function testSelectOrderAsc(): void
+    public function testSelectOrderByAsc(): void
     {
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderAsc('id');
+            ->orderByAsc('id');
 
         $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
@@ -1885,7 +1912,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderAsc($query->func()->concat(['id' => 'identifier', '3']));
+            ->orderByAsc($query->func()->concat(['id' => 'identifier', '3']));
 
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1898,14 +1925,14 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderAsc(function (QueryExpression $exp, Query $query) {
+            ->orderByAsc(function (QueryExpression $exp, Query $query) {
                 return $exp
                     ->case()
                     ->when(['author_id' => 1])
                     ->then(1)
                     ->else($query->identifier('id'));
             })
-            ->orderAsc('id');
+            ->orderByAsc('id');
         $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1922,14 +1949,14 @@ class SelectQueryTest extends TestCase
     }
 
     /**
-     * Test orderDesc() and its input types.
+     * Test orderByDesc() and its input types.
      */
-    public function testSelectOrderDesc(): void
+    public function testSelectOrderByDesc(): void
     {
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderDesc('id');
+            ->orderByDesc('id');
         $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1947,7 +1974,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderDesc($query->func()->concat(['id' => 'identifier', '3']));
+            ->orderByDesc($query->func()->concat(['id' => 'identifier', '3']));
 
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1960,14 +1987,14 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($this->connection);
         $query->select(['id'])
             ->from('articles')
-            ->orderDesc(function (QueryExpression $exp, Query $query) {
+            ->orderByDesc(function (QueryExpression $exp, Query $query) {
                 return $exp
                     ->case()
                     ->when(['author_id' => 1])
                     ->then(1)
                     ->else($query->identifier('id'));
             })
-            ->orderDesc('id');
+            ->orderByDesc('id');
         $sql = $query->sql();
         $result = $query->execute()->fetchAll('assoc');
         $expected = [
@@ -1987,7 +2014,33 @@ class SelectQueryTest extends TestCase
      * Tests that group by fields can be passed similar to select fields
      * and that it sends the correct query to the database
      */
-    public function testSelectGroup(): void
+    public function testSelectGroupBy(): void
+    {
+        $query = new SelectQuery($this->connection);
+        $result = $query
+            ->select(['total' => 'count(author_id)', 'author_id'])
+            ->from('articles')
+            ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
+            ->groupBy('author_id')
+            ->orderBy(['total' => 'desc'])
+            ->execute();
+        $expected = [['total' => 2, 'author_id' => 1], ['total' => '1', 'author_id' => 3]];
+        $this->assertEquals($expected, $result->fetchAll('assoc'));
+
+        $result = $query->select(['total' => 'count(title)', 'name'], true)
+            ->groupBy(['name'], true)
+            ->orderBy(['total' => 'asc'])
+            ->execute();
+        $expected = [['total' => 1, 'name' => 'larry'], ['total' => 2, 'name' => 'mariano']];
+        $this->assertEquals($expected, $result->fetchAll('assoc'));
+
+        $result = $query->select(['articles.id'])
+            ->groupBy(['articles.id'])
+            ->execute();
+        $this->assertCount(3, $result->fetchAll());
+    }
+
+    public function testSelectGroupDeprecated(): void
     {
         $query = new SelectQuery($this->connection);
         $result = $query
@@ -1995,22 +2048,10 @@ class SelectQueryTest extends TestCase
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => 'author_id = a.id'])
             ->group('author_id')
-            ->order(['total' => 'desc'])
+            ->orderBy(['total' => 'desc'])
             ->execute();
         $expected = [['total' => 2, 'author_id' => 1], ['total' => '1', 'author_id' => 3]];
         $this->assertEquals($expected, $result->fetchAll('assoc'));
-
-        $result = $query->select(['total' => 'count(title)', 'name'], true)
-            ->group(['name'], true)
-            ->order(['total' => 'asc'])
-            ->execute();
-        $expected = [['total' => 1, 'name' => 'larry'], ['total' => 2, 'name' => 'mariano']];
-        $this->assertEquals($expected, $result->fetchAll('assoc'));
-
-        $result = $query->select(['articles.id'])
-            ->group(['articles.id'])
-            ->execute();
-        $this->assertCount(3, $result->fetchAll());
     }
 
     /**
@@ -2042,7 +2083,7 @@ class SelectQueryTest extends TestCase
             ->select(['author_id'])
             ->distinct(['author_id'])
             ->from(['a' => 'articles'])
-            ->order(['author_id' => 'ASC'])
+            ->orderBy(['author_id' => 'ASC'])
             ->execute();
         $results = $result->fetchAll('assoc');
         $this->assertCount(2, $results);
@@ -2056,7 +2097,7 @@ class SelectQueryTest extends TestCase
             ->select(['author_id'])
             ->distinct('author_id')
             ->from(['a' => 'articles'])
-            ->order(['author_id' => 'ASC'])
+            ->orderBy(['author_id' => 'ASC'])
             ->execute();
         $results = $result->fetchAll('assoc');
         $this->assertCount(2, $results);
@@ -2140,7 +2181,7 @@ class SelectQueryTest extends TestCase
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
+            ->groupBy('author_id')
             ->having(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
             ->execute();
         $expected = [['total' => 1, 'author_id' => 3]];
@@ -2170,7 +2211,7 @@ class SelectQueryTest extends TestCase
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
+            ->groupBy('author_id')
             ->having(['count(author_id) >' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) <' => 2], ['count(author_id)' => 'integer'])
             ->execute();
@@ -2181,7 +2222,7 @@ class SelectQueryTest extends TestCase
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
+            ->groupBy('author_id')
             ->having(['count(author_id)' => 2], ['count(author_id)' => 'integer'])
             ->andHaving(['count(author_id) >' => 1], ['count(author_id)' => 'integer'])
             ->execute();
@@ -2193,7 +2234,7 @@ class SelectQueryTest extends TestCase
             ->select(['total' => 'count(author_id)', 'author_id'])
             ->from('articles')
             ->join(['table' => 'authors', 'alias' => 'a', 'conditions' => $query->newExpr()->equalFields('author_id', 'a.id')])
-            ->group('author_id')
+            ->groupBy('author_id')
             ->andHaving(function ($e) {
                 return $e->add('count(author_id) = 2 - 1');
             })
@@ -2249,7 +2290,7 @@ class SelectQueryTest extends TestCase
         $result = $query->select('id')->from('comments')
             ->limit(1)
             ->offset(0)
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->execute();
         $rows = $result->fetchAll('assoc');
         $this->assertCount(1, $rows);
@@ -2275,7 +2316,7 @@ class SelectQueryTest extends TestCase
 
         $query = new SelectQuery($this->connection);
         $result = $query->select('id')->from('articles')
-            ->order(['id' => 'DESC'])
+            ->orderBy(['id' => 'DESC'])
             ->limit(1)
             ->offset(0)
             ->execute();
@@ -2334,7 +2375,7 @@ class SelectQueryTest extends TestCase
         $result = $query->select('id')->from('comments')
             ->limit(1)
             ->page(2)
-            ->order(['id' => 'asc'])
+            ->orderBy(['id' => 'asc'])
             ->execute();
         $rows = $result->fetchAll('assoc');
         $this->assertCount(1, $rows);
@@ -2368,7 +2409,7 @@ class SelectQueryTest extends TestCase
                 'ids_added' => $query->newExpr()->add('(user_id + article_id)'),
             ])
             ->from('comments')
-            ->order(['ids_added' => 'asc'])
+            ->orderBy(['ids_added' => 'asc'])
             ->limit(2)
             ->page(3)
             ->execute();
@@ -2584,7 +2625,7 @@ class SelectQueryTest extends TestCase
             ->select(['id', 'name', 'other' => 'id', 'nameish' => 'name'])
             ->from(['b' => 'authors'])
             ->where(['id ' => 1])
-            ->order(['id' => 'desc']);
+            ->orderBy(['id' => 'desc']);
 
         $query->select(['foo' => 'id', 'bar' => 'comment'])->union($union);
         $result = $query->execute();
@@ -2605,7 +2646,7 @@ class SelectQueryTest extends TestCase
     }
 
     /**
-     * Tests that it is possible to run unions with order statements
+     * Tests that it is possible to run unions with order by statements
      */
     public function testUnionOrderBy(): void
     {
@@ -2617,12 +2658,12 @@ class SelectQueryTest extends TestCase
         $union = (new SelectQuery($this->connection))
             ->select(['id', 'title'])
             ->from(['a' => 'articles'])
-            ->order(['a.id' => 'asc']);
+            ->orderBy(['a.id' => 'asc']);
 
         $query = new SelectQuery($this->connection);
         $result = $query->select(['id', 'comment'])
             ->from(['c' => 'comments'])
-            ->order(['c.id' => 'asc'])
+            ->orderBy(['c.id' => 'asc'])
             ->union($union)
             ->execute();
         $this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result->fetchAll());
@@ -2648,7 +2689,7 @@ class SelectQueryTest extends TestCase
             ->select(['id', 'name', 'other' => 'id', 'nameish' => 'name'])
             ->from(['b' => 'authors'])
             ->where(['id ' => 1])
-            ->order(['id' => 'desc']);
+            ->orderBy(['id' => 'desc']);
 
         $query->select(['foo' => 'id', 'bar' => 'comment'])->unionAll($union);
         $result = $query->execute();
@@ -2667,7 +2708,7 @@ class SelectQueryTest extends TestCase
         $result = $query
             ->select(['id', 'title'])
             ->from('articles')
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->decorateResults(function ($row) {
                 $row['modified_id'] = $row['id'] + 1;
 
@@ -2812,7 +2853,7 @@ class SelectQueryTest extends TestCase
                 'c' => $query->func()->concat(['comment' => 'literal', ' is appended']),
             ])
             ->from('comments')
-            ->order(['c' => 'ASC'])
+            ->orderBy(['c' => 'ASC'])
             ->limit(1)
             ->execute();
         $expected = [
@@ -3154,15 +3195,15 @@ class SelectQueryTest extends TestCase
     {
         $this->connection->getDriver()->enableAutoQuoting(true);
         $query = new SelectQuery($this->connection);
-        $sql = $query->select('*')->group(['something'])->sql();
+        $sql = $query->select('*')->groupBy(['something'])->sql();
         $this->assertQuotedQuery('GROUP BY <something>', $sql);
 
         $query = new SelectQuery($this->connection);
-        $sql = $query->select('*')->group([$query->newExpr('bar')])->sql();
+        $sql = $query->select('*')->groupBy([$query->newExpr('bar')])->sql();
         $this->assertQuotedQuery('GROUP BY \(bar\)', $sql);
 
         $query = new SelectQuery($this->connection);
-        $sql = $query->select('*')->group([new IdentifierExpression('bar')])->sql();
+        $sql = $query->select('*')->groupBy([new IdentifierExpression('bar')])->sql();
         $this->assertQuotedQuery('GROUP BY \(<bar>\)', $sql);
     }
 
@@ -3509,7 +3550,7 @@ class SelectQueryTest extends TestCase
     public function testCloneGroupExpression(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->group($query->newExpr('group'));
+        $query->groupBy($query->newExpr('group'));
 
         $clause = $query->clause('group');
         $clauseClone = (clone $query)->clause('group');
@@ -3563,9 +3604,9 @@ class SelectQueryTest extends TestCase
     {
         $query = new SelectQuery($this->connection);
         $query
-            ->order($query->newExpr('order'))
-            ->orderAsc($query->newExpr('order_asc'))
-            ->orderDesc($query->newExpr('order_desc'));
+            ->orderBy($query->newExpr('order'))
+            ->orderByAsc($query->newExpr('order_asc'))
+            ->orderByDesc($query->newExpr('order_desc'));
 
         $clause = $query->clause('order');
         $clauseClone = (clone $query)->clause('order');
@@ -3650,7 +3691,7 @@ class SelectQueryTest extends TestCase
             ->where(['Articles.id' => 1])
             ->offset(10)
             ->limit(1)
-            ->order(['Articles.id' => 'DESC']);
+            ->orderBy(['Articles.id' => 'DESC']);
         $dupe = clone $query;
 
         $this->assertEquals($query->clause('where'), $dupe->clause('where'));
@@ -3665,7 +3706,7 @@ class SelectQueryTest extends TestCase
         $this->assertEquals($query->clause('order'), $dupe->clause('order'));
         $this->assertNotSame($query->clause('order'), $dupe->clause('order'));
 
-        $query->order(['Articles.title' => 'ASC']);
+        $query->orderBy(['Articles.title' => 'ASC']);
         $this->assertNotEquals($query->clause('order'), $dupe->clause('order'));
 
         $this->assertNotSame(
@@ -3993,8 +4034,8 @@ class SelectQueryTest extends TestCase
         $query
             ->select(['id'])
             ->from('articles')
-            ->orderDesc($subquery)
-            ->orderAsc('id')
+            ->orderByDesc($subquery)
+            ->orderByAsc('id')
             ->setSelectTypeMap(new TypeMap([
                 'id' => 'integer',
             ]));
@@ -4067,8 +4108,8 @@ class SelectQueryTest extends TestCase
                 'computedB' => $subqueryB,
             ])
             ->from('articles')
-            ->orderDesc($subqueryB)
-            ->orderAsc('id')
+            ->orderByDesc($subqueryB)
+            ->orderByAsc('id')
             ->setSelectTypeMap(new TypeMap([
                 'id' => 'integer',
                 'computedA' => 'integer',

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -228,9 +228,9 @@ class QueryTest extends TestCase
     public function testCloneOrderExpression(): void
     {
         $this->query
-            ->order($this->query->newExpr('order'))
-            ->orderAsc($this->query->newExpr('order_asc'))
-            ->orderDesc($this->query->newExpr('order_desc'));
+            ->orderBy($this->query->newExpr('order'))
+            ->orderByAsc($this->query->newExpr('order_asc'))
+            ->orderByDesc($this->query->newExpr('order_desc'));
 
         $clause = $this->query->clause('order');
         $clauseClone = (clone $this->query)->clause('order');

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -79,8 +79,8 @@ class CaseExpressionQueryTest extends TestCase
                 ];
             })
             ->from('products')
-            ->orderAsc('category')
-            ->orderAsc('name');
+            ->orderByAsc('category')
+            ->orderByAsc('name');
 
         $expected = [
             [
@@ -120,8 +120,8 @@ class CaseExpressionQueryTest extends TestCase
                 ];
             })
             ->from('products')
-            ->orderAsc('price')
-            ->orderAsc('name')
+            ->orderByAsc('price')
+            ->orderByAsc('name')
             ->setSelectTypeMap($typeMap);
 
         $expected = [
@@ -154,14 +154,14 @@ class CaseExpressionQueryTest extends TestCase
         $query = $this->query
             ->select(['article_id', 'user_id'])
             ->from('comments')
-            ->orderAsc('comments.article_id')
-            ->orderDesc(function (QueryExpression $exp, Query $query) {
+            ->orderByAsc('comments.article_id')
+            ->orderByDesc(function (QueryExpression $exp, Query $query) {
                 return $query->newExpr()
                     ->case($query->identifier('comments.article_id'))
                     ->when(1)
                     ->then($query->identifier('comments.user_id'));
             })
-            ->orderAsc(function (QueryExpression $exp, Query $query) {
+            ->orderByAsc(function (QueryExpression $exp, Query $query) {
                 return $query->newExpr()
                     ->case($query->identifier('comments.article_id'))
                     ->when(2)
@@ -204,7 +204,7 @@ class CaseExpressionQueryTest extends TestCase
             ->select(['articles.title'])
             ->from('articles')
             ->leftJoin('comments', ['comments.article_id = articles.id'])
-            ->group(['articles.id', 'articles.title'])
+            ->groupBy(['articles.id', 'articles.title'])
             ->having(function (QueryExpression $exp, Query $query) {
                 $expression = $query->newExpr()
                     ->case()

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -104,7 +104,7 @@ class TupleComparisonQueryTest extends TestCase
                     'NOT IN'
                 ),
             ])
-            ->orderAsc('articles.id')
+            ->orderByAsc('articles.id')
             ->execute();
     }
 
@@ -130,7 +130,7 @@ class TupleComparisonQueryTest extends TestCase
                     'IN'
                 ),
             ])
-            ->orderAsc('articles.id')
+            ->orderByAsc('articles.id')
             ->setSelectTypeMap($typeMap);
 
         $expected = [
@@ -197,7 +197,7 @@ class TupleComparisonQueryTest extends TestCase
                     'IN'
                 ),
             ])
-            ->orderAsc('articles.id')
+            ->orderByAsc('articles.id')
             ->setSelectTypeMap($typeMap);
 
         $expected = [
@@ -245,7 +245,7 @@ class TupleComparisonQueryTest extends TestCase
                     '='
                 ),
             ])
-            ->orderAsc('articles.id')
+            ->orderByAsc('articles.id')
             ->execute();
     }
 
@@ -300,7 +300,7 @@ class TupleComparisonQueryTest extends TestCase
                     '='
                 ),
             ])
-            ->orderAsc('articles.id')
+            ->orderByAsc('articles.id')
             ->setSelectTypeMap($typeMap);
 
         $expected = [

--- a/tests/TestCase/Database/QueryTests/WindowQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/WindowQueryTest.php
@@ -122,16 +122,16 @@ class WindowQueryTest extends TestCase
         $result = $query
             ->select(['num_rows' => $query->func()->count('*')->partition('article_id')])
             ->from('comments')
-            ->order(['article_id'])
+            ->orderBy(['article_id'])
             ->execute()
             ->fetchAll('assoc');
         $this->assertEquals(4, $result[0]['num_rows']);
 
         $query = new SelectQuery($this->connection);
         $result = $query
-            ->select(['num_rows' => $query->func()->count('*')->partition('article_id')->order('updated')])
+            ->select(['num_rows' => $query->func()->count('*')->partition('article_id')->orderBy('updated')])
             ->from('comments')
-            ->order(['updated'])
+            ->orderBy(['updated'])
             ->execute()
             ->fetchAll('assoc');
         $this->assertEquals(1, $result[0]['num_rows']);
@@ -155,7 +155,7 @@ class WindowQueryTest extends TestCase
             ->select(['num_rows' => $query->func()->count('*')->over('window1')])
             ->from('comments')
             ->window('window1', (new WindowExpression())->partition('article_id'))
-            ->order(['article_id'])
+            ->orderBy(['article_id'])
             ->execute()
             ->fetchAll('assoc');
         $this->assertEquals(4, $result[0]['num_rows']);
@@ -179,7 +179,7 @@ class WindowQueryTest extends TestCase
             ->from('comments')
             ->window('window1', (new WindowExpression())->partition('article_id'))
             ->window('window2', new WindowExpression('window1'))
-            ->order(['article_id'])
+            ->orderBy(['article_id'])
             ->execute()
             ->fetchAll('assoc');
         $this->assertEquals(4, $result[0]['num_rows']);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1719,7 +1719,7 @@ class BelongsToManyTest extends TestCase
 
         $results = $table->find()
             ->contain('SpecialTags', function ($query) {
-                return $query->order(['SpecialTags.tag_id']);
+                return $query->orderBy(['SpecialTags.tag_id']);
             })
             ->where(['id' => 2])
             ->toArray();

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -114,7 +114,7 @@ class BelongsToTest extends TestCase
             ->belongsTo('Authors')
             ->setForeignKey('author_id');
 
-        $article = $table->find()->contain(['Authors'])->orderAsc('Articles.id')->first();
+        $article = $table->find()->contain(['Authors'])->orderByAsc('Articles.id')->first();
         $this->assertSame('mariano', $article->author->name);
 
         $assoc
@@ -123,7 +123,7 @@ class BelongsToTest extends TestCase
                 'Authors.name' => 'larry',
             ]);
 
-        $article = $table->find()->contain(['Authors'])->orderAsc('Articles.id')->first();
+        $article = $table->find()->contain(['Authors'])->orderByAsc('Articles.id')->first();
         $this->assertSame('larry', $article->author->name);
     }
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -740,7 +740,7 @@ class HasManyTest extends TestCase
         $query = $Authors->find();
         $result = $query
             ->contain('Articles')
-            ->order(['name' => 'ASC'])
+            ->orderBy(['name' => 'ASC'])
             ->limit(2)
             ->toArray();
 
@@ -1350,7 +1350,7 @@ class HasManyTest extends TestCase
 
         $others = $articles->find('all')
             ->where(['Articles.author_id' => 1, 'published' => 'N'])
-            ->orderAsc('title')
+            ->orderByAsc('title')
             ->toArray();
         $this->assertCount(
             1,

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -86,7 +86,7 @@ class HasOneTest extends TestCase
             ->hasOne('Profiles')
             ->setForeignKey('user_id');
 
-        $user = $table->find()->contain(['Profiles'])->orderAsc('Users.id')->first();
+        $user = $table->find()->contain(['Profiles'])->orderByAsc('Users.id')->first();
         $this->assertSame('mariano', $user->profile->first_name);
 
         $assoc
@@ -95,7 +95,7 @@ class HasOneTest extends TestCase
                 'Profiles.first_name' => 'larry',
             ]);
 
-        $user = $table->find()->contain(['Profiles'])->orderAsc('Users.id')->first();
+        $user = $table->find()->contain(['Profiles'])->orderByAsc('Users.id')->first();
         $this->assertSame('larry', $user->profile->first_name);
     }
 
@@ -126,7 +126,7 @@ class HasOneTest extends TestCase
         $query = $this->user->find();
         $association->attachTo($query);
 
-        $results = $query->order('Users.id')->toArray();
+        $results = $query->orderBy('Users.id')->toArray();
         $this->assertCount(1, $results, 'Only one record because of conditions & join type');
         $this->assertSame('masters', $results[0]->Profiles['last_name']);
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -165,7 +165,7 @@ class TranslateBehaviorEavTest extends TestCase
         $results = $table->find('all', ['locale' => 'cze'])
             ->select(['id', 'title', 'body'])
             ->disableHydration()
-            ->orderAsc('Articles.id')
+            ->orderByAsc('Articles.id')
             ->toArray();
         $expected = [
             ['id' => 1, 'title' => 'Titulek #1', 'body' => 'Obsah #1', '_locale' => 'cze'],
@@ -268,7 +268,7 @@ class TranslateBehaviorEavTest extends TestCase
                 ],
             ])
             ->enableHydration(false)
-            ->orderAsc('Articles.id')
+            ->orderByAsc('Articles.id')
             ->toArray();
 
         $expected = [
@@ -736,7 +736,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $results = $table->find()
             ->select(['title', 'body'])
-            ->order(['title' => 'asc'])
+            ->orderBy(['title' => 'asc'])
             ->contain(['Authors' => function (SelectQuery $q) {
                 return $q->select(['id', 'name']);
             }]);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -379,7 +379,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->addBehavior('Translate');
         $table->setLocale('eng');
 
-        $query = $table->find()->select(['id'])->order(['title' => 'desc']);
+        $query = $table->find()->select(['id'])->orderBy(['title' => 'desc']);
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
@@ -523,21 +523,21 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     /**
      * testNoAmbiguousOrder
      */
-    public function testNoAmbiguousOrder(): void
+    public function testNoAmbiguousOrderBy(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate');
         $table->setLocale('eng');
 
         $article = $table->find('all')
-            ->order(['id' => 'desc'])
+            ->orderBy(['id' => 'desc'])
             ->enableHydration(false)
             ->toArray();
 
         $this->assertSame([3, 2, 1], Hash::extract($article, '{n}.id'));
 
         $article = $table->find('all')
-            ->order(['title' => 'asc'])
+            ->orderBy(['title' => 'asc'])
             ->enableHydration(false)
             ->toArray();
 

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -639,7 +639,7 @@ class TreeBehaviorTest extends TestCase
 
         $expectedLevels = $table
             ->find('list', ['valueField' => 'depth'])
-            ->order('lft')
+            ->orderBy('lft')
             ->toArray();
         $table->updateAll(['lft' => null, 'rght' => null, 'depth' => null], []);
         $table->behaviors()->Tree->setConfig('level', 'depth');
@@ -662,7 +662,7 @@ class TreeBehaviorTest extends TestCase
 
         $result = $table
             ->find('list', ['valueField' => 'depth'])
-            ->order('lft')
+            ->orderBy('lft')
             ->toArray();
         $this->assertSame($expectedLevels, $result);
     }
@@ -978,7 +978,7 @@ class TreeBehaviorTest extends TestCase
         $this->assertSame(17, $entity->lft);
         $this->assertSame(18, $entity->rght);
 
-        $result = $table->find()->order('lft')->enableHydration(false);
+        $result = $table->find()->orderBy('lft')->enableHydration(false);
 
         $expected = [
             ' 1:20 -  1:electronics',
@@ -1265,7 +1265,7 @@ class TreeBehaviorTest extends TestCase
         $this->assertSame(21, $entity->lft);
         $this->assertSame(22, $entity->rght);
         $this->assertNull($entity->parent_id);
-        $result = $table->find()->order('lft')->enableHydration(false);
+        $result = $table->find()->orderBy('lft')->enableHydration(false);
         $expected = [
             ' 1:18 -  1:electronics',
             '_ 2: 9 -  2:televisions',
@@ -1291,11 +1291,11 @@ class TreeBehaviorTest extends TestCase
         $table = $this->table;
         $entity = $table->get(6);
         $this->assertSame($entity, $table->removeFromTree($entity));
-        $result = $table->find('threaded')->order('lft')->enableHydration(false)->toArray();
+        $result = $table->find('threaded')->orderBy('lft')->enableHydration(false)->toArray();
         $this->assertSame(21, $entity->lft);
         $this->assertSame(22, $entity->rght);
         $this->assertNull($entity->parent_id);
-        $result = $table->find()->order('lft')->enableHydration(false);
+        $result = $table->find()->orderBy('lft')->enableHydration(false);
         $expected = [
             ' 1:18 -  1:electronics',
             '_ 2: 9 -  2:televisions',
@@ -1320,7 +1320,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->table;
         $entity = $table->get(1);
         $this->assertSame($entity, $table->removeFromTree($entity));
-        $result = $table->find('threaded')->order('lft')->enableHydration(false)->toArray();
+        $result = $table->find('threaded')->orderBy('lft')->enableHydration(false)->toArray();
         $this->assertSame(21, $entity->lft);
         $this->assertSame(22, $entity->rght);
         $this->assertNull($entity->parent_id);

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -47,7 +47,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
             'this text has been processed via a custom type',
             'this text also has been processed via a custom type',
         ];
-        $result = $table->find()->orderAsc('id')->all()->extract('val')->toArray();
+        $result = $table->find()->orderByAsc('id')->all()->extract('val')->toArray();
         $this->assertSame($expected, $result);
     }
 

--- a/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
+++ b/tests/TestCase/ORM/Query/CaseExpressionQueryTest.php
@@ -42,8 +42,8 @@ class CaseExpressionQueryTest extends TestCase
                         ->setReturnType('boolean'),
                 ];
             })
-            ->orderAsc('price')
-            ->orderAsc('name')
+            ->orderByAsc('price')
+            ->orderByAsc('name')
             ->disableHydration();
 
         $expected = [

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -524,7 +524,7 @@ class CompositeKeysTest extends TestCase
         $table->setDisplayField('name');
         $query = $table->find('list')
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             '1;1' => 'mark',
             '2;2' => 'juan',
@@ -536,7 +536,7 @@ class CompositeKeysTest extends TestCase
         $table->setDisplayField(['name', 'site_id']);
         $query = $table->find('list')
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             '1;1' => 'mark;1',
             '2;2' => 'juan;2',
@@ -547,7 +547,7 @@ class CompositeKeysTest extends TestCase
 
         $query = $table->find('list', ['groupField' => ['site_id', 'site_id']])
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             '1;1' => [
                 '1;1' => 'mark;1',

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -208,7 +208,7 @@ class QueryRegressionTest extends TestCase
 
         $results = $table->find()
             ->contain(['Authors.Stuff', 'Things.Stuff'])
-            ->order(['Articles.id' => 'ASC'])
+            ->orderBy(['Articles.id' => 'ASC'])
             ->toArray();
 
         $this->assertCount(5, $results);
@@ -535,7 +535,7 @@ class QueryRegressionTest extends TestCase
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->setLocale('eng');
         $query = $table->find('translations')
-            ->order(['Articles.id' => 'ASC'])
+            ->orderBy(['Articles.id' => 'ASC'])
             ->limit(10)
             ->offset(1);
         $result = $query->toArray();
@@ -666,7 +666,7 @@ class QueryRegressionTest extends TestCase
             ->find()
             ->select(['title', 'id'])
             ->where('title LIKE :val')
-            ->group(['id', 'title'])
+            ->groupBy(['id', 'title'])
             ->bind(':val', '%Second%');
         $count = $query->count();
         $this->assertSame(1, $count);
@@ -952,7 +952,7 @@ class QueryRegressionTest extends TestCase
             ->matching('Users', function ($q) {
                 return $q->where(['Users.id >=' => 1]);
             })
-            ->order(['Comments.id' => 'ASC'])
+            ->orderBy(['Comments.id' => 'ASC'])
             ->first();
         $this->assertInstanceOf('Cake\ORM\Entity', $result->article);
         $this->assertInstanceOf('Cake\ORM\Entity', $result->user);
@@ -1448,7 +1448,7 @@ class QueryRegressionTest extends TestCase
 
         $query->select(['inside.content'])
             ->from(['inside' => $inner->unionAll($inner2)])
-            ->orderAsc($order);
+            ->orderByAsc($order);
 
         $results = $query->toArray();
         $this->assertCount(5, $results);
@@ -1469,7 +1469,7 @@ class QueryRegressionTest extends TestCase
             ->enableAutoFields()
             ->contain(['Comments'])
             ->limit(5)
-            ->order(['score' => 'desc']);
+            ->orderBy(['score' => 'desc']);
         $result = $query->all();
         $this->assertCount(3, $result);
     }
@@ -1482,20 +1482,20 @@ class QueryRegressionTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
-        $query->orderDesc(
+        $query->orderByDesc(
             $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0)
         );
-        $query->order(['title' => 'desc']);
+        $query->orderBy(['title' => 'desc']);
         // Executing the normal query before getting the count
         $query->all();
         $this->assertSame(3, $query->count());
 
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
-        $query->orderDesc(
+        $query->orderByDesc(
             $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0)
         );
-        $query->orderDesc($query->newExpr()->add(['id' => 3]));
+        $query->orderByDesc($query->newExpr()->add(['id' => 3]));
         // Not executing the query first, just getting the count
         $this->assertSame(3, $query->count());
     }

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -175,7 +175,7 @@ class SelectQueryTest extends TestCase
         $results = $query->select()
             ->contain('authors')
             ->enableHydration(false)
-            ->order(['articles.id' => 'asc'])
+            ->orderBy(['articles.id' => 'asc'])
             ->toArray();
         $expected = [
             [
@@ -471,7 +471,7 @@ class SelectQueryTest extends TestCase
 
         $results = $query->select()
             ->contain(['authors' => ['posts']])
-            ->order(['articles.id' => 'ASC'])
+            ->orderBy(['articles.id' => 'ASC'])
             ->enableHydration(false)
             ->toArray();
         $expected = [
@@ -1092,7 +1092,7 @@ class SelectQueryTest extends TestCase
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
         $query = new SelectQuery($table);
-        $query->select(['a' => 'id'])->limit(2)->order(['id' => 'ASC']);
+        $query->select(['a' => 'id'])->limit(2)->orderBy(['id' => 'ASC']);
         $query->mapReduce(function ($v, $k, $mr): void {
             $mr->emit($v['a']);
         });
@@ -1374,7 +1374,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($table);
         $results = $query->select()
             ->contain('authors')
-            ->order(['articles.id' => 'asc'])
+            ->orderBy(['articles.id' => 'asc'])
             ->toArray();
 
         $this->assertCount(3, $results);
@@ -1493,7 +1493,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($table);
         $results = $query->select()
             ->contain('authors')
-            ->order(['articles.id' => 'asc'])
+            ->orderBy(['articles.id' => 'asc'])
             ->toArray();
 
         $first = $results[0];
@@ -1597,7 +1597,7 @@ class SelectQueryTest extends TestCase
             ->on('Model.beforeFind', function (EventInterface $event, $query): void {
                 $query
                     ->limit(1)
-                    ->order(['Articles.title' => 'DESC']);
+                    ->orderBy(['Articles.title' => 'DESC']);
             });
 
         $query = $table->find();
@@ -1633,7 +1633,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('articles');
         $query = $table->find('all');
         $query->select(['author_id', 's' => $query->func()->sum('id')])
-            ->group(['author_id']);
+            ->groupBy(['author_id']);
         $result = $query->count();
         $this->assertEquals(2, $result);
     }
@@ -1649,11 +1649,11 @@ class SelectQueryTest extends TestCase
         $query
             ->select(['author_id', 's' => $query->func()->sum('id')])
             ->where(['id >' => 2])
-            ->group(['author_id'])
+            ->groupBy(['author_id'])
             ->counter(function ($q) use ($query) {
                 $this->assertNotSame($q, $query);
 
-                return $q->select([], true)->group([], true)->count();
+                return $q->select([], true)->groupBy([], true)->count();
             });
 
         $result = $query->count();
@@ -2372,7 +2372,7 @@ class SelectQueryTest extends TestCase
         };
         $query = $table->find()
             ->contain(['Articles' => $builder, 'Articles.Authors' => $builder])
-            ->order(['ArticlesTags.article_id' => 'ASC']);
+            ->orderBy(['ArticlesTags.article_id' => 'ASC']);
 
         $query->formatResults(function ($results) {
             return $results->map(function ($row) {
@@ -2454,7 +2454,7 @@ class SelectQueryTest extends TestCase
 
         $query = $table->find()
             ->contain(['Authors'])
-            ->order(['Authors.id' => 'asc'])
+            ->orderBy(['Authors.id' => 'asc'])
             ->select(['Authors.id']);
         $results = $query->all()->extract('author.id')->toList();
         $expected = [1, 1, 3];
@@ -2472,7 +2472,7 @@ class SelectQueryTest extends TestCase
         $table->getAssociation('Articles')->getTarget()->belongsTo('Authors');
 
         $query = $table->find()
-            ->order(['Articles.id' => 'ASC'])
+            ->orderBy(['Articles.id' => 'ASC'])
             ->contain([
                 'Articles' => function ($q) {
                     return $q->contain('Authors');
@@ -2641,7 +2641,7 @@ class SelectQueryTest extends TestCase
                     'conditions' => [$query->newExpr()->equalFields('person.id', 'articles.author_id')],
                 ],
             ])
-            ->order(['articles.id' => 'ASC'])
+            ->orderBy(['articles.id' => 'ASC'])
             ->enableHydration(false)
             ->toArray();
         $expected = [
@@ -2798,7 +2798,7 @@ class SelectQueryTest extends TestCase
         $query = $table->find();
         $query->offset(10)
             ->limit(1)
-            ->order(['Articles.id' => 'DESC'])
+            ->orderBy(['Articles.id' => 'DESC'])
             ->contain(['Comments'])
             ->matching('Comments');
         $copy = $query->cleanCopy();
@@ -2830,7 +2830,7 @@ class SelectQueryTest extends TestCase
         $query->offset(10)
             ->limit(1)
             ->where(['Articles.id BETWEEN :start AND :end'])
-            ->order(['Articles.id' => 'DESC'])
+            ->orderBy(['Articles.id' => 'DESC'])
             ->bind(':start', 1)
             ->bind(':end', 2);
         $copy = $query->cleanCopy();
@@ -2849,13 +2849,13 @@ class SelectQueryTest extends TestCase
             ->on('Model.beforeFind', function (EventInterface $event, $query): void {
                 $query
                     ->limit(5)
-                    ->order(['Articles.title' => 'DESC']);
+                    ->orderBy(['Articles.title' => 'DESC']);
             });
 
         $query = $table->find();
         $query->offset(10)
             ->limit(1)
-            ->order(['Articles.id' => 'DESC'])
+            ->orderBy(['Articles.id' => 'DESC'])
             ->contain(['Comments']);
         $copy = $query->cleanCopy();
 
@@ -3216,7 +3216,7 @@ class SelectQueryTest extends TestCase
             ->select(['total_articles' => 'count(articles.id)'])
             ->enableAutoFields()
             ->leftJoinWith('articles')
-            ->group(['authors.id', 'authors.name']);
+            ->groupBy(['authors.id', 'authors.name']);
 
         $expected = [
             1 => 2,
@@ -3240,7 +3240,7 @@ class SelectQueryTest extends TestCase
             ->find()
             ->leftJoinWith('articles')
             ->where(['articles.id IS NOT' => null])
-            ->order(['authors.id']);
+            ->orderBy(['authors.id']);
 
         $this->assertEquals([1, 1, 3], $results->all()->extract('id')->toList());
         $this->assertEquals(['id', 'name'], array_keys($results->first()->toArray()));
@@ -3265,7 +3265,7 @@ class SelectQueryTest extends TestCase
             ->leftJoinWith('articles.tags', function ($q) {
                 return $q->where(['tags.name' => 'tag3']);
             })
-            ->group(['authors.id']);
+            ->groupBy(['authors.id']);
 
         $expected = [
             1 => 0,
@@ -3510,7 +3510,7 @@ class SelectQueryTest extends TestCase
         $results = $table->find()
             ->enableHydration(false)
             ->notMatching('articles')
-            ->order(['authors.id'])
+            ->orderBy(['authors.id'])
             ->toArray();
 
         $expected = [
@@ -3524,7 +3524,7 @@ class SelectQueryTest extends TestCase
             ->notMatching('articles', function ($q) {
                 return $q->where(['articles.author_id' => 1]);
             })
-            ->order(['authors.id'])
+            ->orderBy(['authors.id'])
             ->toArray();
         $expected = [
             ['id' => 2, 'name' => 'nate'],
@@ -3616,7 +3616,7 @@ class SelectQueryTest extends TestCase
                     return $q->where(['tags.name' => 'tag3']);
                 });
             })
-            ->order(['authors.id' => 'ASC', 'articles.id' => 'ASC']);
+            ->orderBy(['authors.id' => 'ASC', 'articles.id' => 'ASC']);
 
         $expected = [
             'id' => 1,
@@ -3741,7 +3741,7 @@ class SelectQueryTest extends TestCase
                 'posts.author_id',
                 'post_count' => $query->func()->count('posts.id'),
             ])
-            ->group(['posts.author_id'])
+            ->groupBy(['posts.author_id'])
             ->having([$query->newExpr()->gte('post_count', 2, 'integer')])
             ->enableHydration(false)
             ->toArray();
@@ -3787,7 +3787,7 @@ class SelectQueryTest extends TestCase
                             ->rowNumber()
                             ->over()
                             ->partition('author_id')
-                            ->order(['id' => 'ASC']),
+                            ->orderBy(['id' => 'ASC']),
                     ];
             });
 
@@ -3802,7 +3802,7 @@ class SelectQueryTest extends TestCase
             ->enableAutoFields()
             ->from([$table->getAlias() => 'cte'])
             ->where(['row_num' => 1], ['row_num' => 'integer'])
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->disableHydration();
 
         $expected = [

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -277,7 +277,7 @@ class ResultSetTest extends TestCase
         $query = $this->table->find();
         $query->select([
             'counter' => 'COUNT(*)',
-        ])->group('author_id');
+        ])->groupBy('author_id');
 
         $min = $query->all()->min('counter');
         $max = $query->all()->max('counter');

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -614,7 +614,7 @@ class LinkConstraintTest extends TestCase
                             new IdentifierExpression('RecentComments.article_id')
                         );
                     })
-                    ->order(['RecentComments.created' => 'DESC'])
+                    ->orderBy(['RecentComments.created' => 'DESC'])
                     ->limit(1);
 
                 return $exp->add(['Comments.id' => $subQuery]);
@@ -650,7 +650,7 @@ class LinkConstraintTest extends TestCase
                             new IdentifierExpression('RecentComments.article_id')
                         );
                     })
-                    ->order(['RecentComments.created' => 'DESC'])
+                    ->orderBy(['RecentComments.created' => 'DESC'])
                     ->limit(1);
 
                 return $exp->add(['Comments.id' => $subQuery]);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -254,7 +254,7 @@ class TableTest extends TestCase
 
         $query = $this->getTableLocator()->get('Articles')->find()
             ->where(['Articles.author_id IN' => $subquery])
-            ->order(['Articles.id' => 'ASC']);
+            ->orderBy(['Articles.id' => 'ASC']);
 
         $results = $query->all()->toList();
         $this->assertCount(2, $results);
@@ -273,8 +273,8 @@ class TableTest extends TestCase
         $query
             ->select(['Authors.id', 'total_articles' => $query->func()->count('articles.author_id')])
             ->leftJoin(['articles' => $subquery], ['articles.author_id' => new IdentifierExpression('Authors.id')])
-            ->group(['Authors.id'])
-            ->order(['Authors.id' => 'ASC']);
+            ->groupBy(['Authors.id'])
+            ->orderBy(['Authors.id' => 'ASC']);
 
         $results = $query->all()->toList();
         $this->assertEquals(1, $results[0]->id);
@@ -538,7 +538,7 @@ class TableTest extends TestCase
         $results = $table
             ->find('all')
             ->where(['id IN' => [1, 2]])
-            ->order('id')
+            ->orderBy('id')
             ->enableHydration(false)
             ->toArray();
         $expected = [
@@ -572,7 +572,7 @@ class TableTest extends TestCase
         $results = $table->find('all')
             ->select(['username', 'password'])
             ->enableHydration(false)
-            ->order('username')->toArray();
+            ->orderBy('username')->toArray();
         $expected = [
             ['username' => 'garrett', 'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO'],
             ['username' => 'larry', 'password' => '$2a$10$u05j8FjsvLBNdfhBhc21LOuVMpzpabVXQ9OpC2wO3pSO0q6t7HHMO'],
@@ -583,7 +583,7 @@ class TableTest extends TestCase
 
         $results = $table->find('all')
             ->select(['foo' => 'username', 'password'])
-            ->order('username')
+            ->orderBy('username')
             ->enableHydration(false)
             ->toArray();
         $expected = [
@@ -609,7 +609,7 @@ class TableTest extends TestCase
             ->select(['id', 'username'])
             ->where(['created >=' => new DateTime('2010-01-22 00:00')])
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             ['id' => 3, 'username' => 'larry'],
             ['id' => 4, 'username' => 'garrett'],
@@ -623,7 +623,7 @@ class TableTest extends TestCase
                 'created >=' => new DateTime('2010-01-22 00:00'),
                 'users.created' => new DateTime('2008-03-17 01:18:23'),
             ]])
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             ['id' => 2, 'username' => 'nate'],
             ['id' => 3, 'username' => 'larry'],
@@ -1056,7 +1056,7 @@ class TableTest extends TestCase
 
         $result = $table->find('all')
             ->select(['username'])
-            ->order(['id' => 'asc'])
+            ->orderBy(['id' => 'asc'])
             ->enableHydration(false)
             ->toArray();
         $expected = array_fill(0, 3, $fields);
@@ -1193,7 +1193,7 @@ class TableTest extends TestCase
         $table->setDisplayField('username');
         $query = $table->find('list')
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             1 => 'mariano',
             2 => 'nate',
@@ -1204,7 +1204,7 @@ class TableTest extends TestCase
 
         $query = $table->find('list', ['fields' => ['id', 'username']])
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             1 => 'mariano',
             2 => 'nate',
@@ -1216,7 +1216,7 @@ class TableTest extends TestCase
         $query = $table->find('list', ['groupField' => 'odd'])
             ->select(['id', 'username', 'odd' => new QueryExpression('id % 2')])
             ->enableHydration(false)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             1 => [
                 1 => 'mariano',
@@ -1367,7 +1367,7 @@ class TableTest extends TestCase
         $table->setDisplayField('username');
         $query = $table
             ->find('list', ['fields' => ['id', 'username']])
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             1 => 'mariano',
             2 => 'nate',
@@ -1379,7 +1379,7 @@ class TableTest extends TestCase
         $query = $table->find('list', ['groupField' => 'odd'])
             ->select(['id', 'username', 'odd' => new QueryExpression('id % 2')])
             ->enableHydration(true)
-            ->order('id');
+            ->orderBy('id');
         $expected = [
             1 => [
                 1 => 'mariano',
@@ -1430,7 +1430,7 @@ class TableTest extends TestCase
         $this->assertSame($expected, $query->clause('select'));
 
         $query = $articles->find('list', ['valueField' => ['author_id', 'title']])
-            ->order('id');
+            ->orderBy('id');
         $expected = ['id', 'author_id', 'title'];
         $this->assertSame($expected, $query->clause('select'));
 
@@ -1445,7 +1445,7 @@ class TableTest extends TestCase
                 'valueField' => ['id', 'title'],
                 'valueSeparator' => ' : ',
             ])
-            ->order('id');
+            ->orderBy('id');
 
         $expected = [
             1 => '1 : First Article',
@@ -1469,7 +1469,7 @@ class TableTest extends TestCase
 
         $query = $table
             ->find('list')
-            ->order('id');
+            ->orderBy('id');
         $this->assertEmpty($query->clause('select'));
 
         $expected = [
@@ -1497,7 +1497,7 @@ class TableTest extends TestCase
         $articles->belongsTo('Authors');
         $query = $articles->find('list', ['valueField' => 'author.name'])
             ->contain(['Authors'])
-            ->order('articles.id');
+            ->orderBy('articles.id');
         $this->assertEmpty($query->clause('select'));
 
         $expected = [
@@ -2774,7 +2774,7 @@ class TableTest extends TestCase
         $table->hasMany('articles', ['sort' => 'articles.id']);
 
         $entities = $table->find()
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->contain(['articles'])
             ->all();
         $entities->first()->name = 'admad';
@@ -2805,7 +2805,7 @@ class TableTest extends TestCase
         $this->assertFalse($result->first()->articles[0]->isDirty());
 
         $first = $table->find()
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->first();
         $this->assertSame('admad', $first->name);
     }
@@ -2888,7 +2888,7 @@ class TableTest extends TestCase
         $table = $this->getTableLocator()->get('authors');
 
         $entities = $table->find()
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->all();
         $entities->first()->name = 'admad';
 
@@ -2896,7 +2896,7 @@ class TableTest extends TestCase
         $this->assertSame($entities, $result);
 
         $first = $table->find()
-            ->order(['id' => 'ASC'])
+            ->orderBy(['id' => 'ASC'])
             ->first();
         $this->assertSame('admad', $first->name);
     }


### PR DESCRIPTION
Now that Query doesn't proxy Collection, we can add orderBy() and groupBy() that match the sql statements like other functions.