### PR TITLE
4.5 - Add Database/DeleteQuery forwards compatibility

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -26,6 +26,7 @@ use Cake\Database\Exception\NestedTransactionRollbackException;
 use Cake\Database\Log\LoggedQuery;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
+use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Retry\ReconnectStrategy;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection as SchemaCollection;
@@ -487,6 +488,27 @@ class Connection implements ConnectionInterface
                 ->where($conditions, $types)
                 ->execute();
         });
+    }
+
+    /**
+     * Create a new DeleteQuery instance for this connection.
+     *
+     * @param string|null $table The table to delete rows from.
+     * @param array $conditions Conditions to be set for the delete statement.
+     * @param array<string, string> $types Associative array containing the types to be used for casting.
+     * @return \Cake\Database\Query\DeleteQuery
+     */
+    public function deleteQuery(?string $table = null, array $conditions = [], array $types = []): DeleteQuery
+    {
+        $query = new DeleteQuery($this);
+        if ($table) {
+            $query->from($table);
+        }
+        if ($conditions) {
+            $query->where($conditions, $types);
+        }
+
+        return $query;
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2499,4 +2499,19 @@ class Query implements ExpressionInterface, IteratorAggregate
             'executed' => $this->_iterator ? true : false,
         ];
     }
+
+    /**
+     * Helper for Query deprecation methods.
+     *
+     * @param string $method The method that is invalid.
+     * @param string $message An additional message.
+     * @return void
+     * @internal
+     */
+    protected function _deprecatedMethod($method, $message = '')
+    {
+        $class = static::class;
+        $text = "As of 4.5.0 calling {$method}() on {$class} is deprecated. " . $message;
+        deprecationWarning($text);
+    }
 }

--- a/src/Database/Query/DeleteQuery.php
+++ b/src/Database/Query/DeleteQuery.php
@@ -1,0 +1,222 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Query;
+
+use Cake\Database\Query;
+
+/**
+ * Delete Query forward compatibility shim.
+ */
+class DeleteQuery extends Query
+{
+    /**
+     * Type of this query (select, insert, update, delete).
+     *
+     * @var string
+     */
+    protected $_type = 'delete';
+
+    /**
+     * @inheritDoc
+     */
+    public function select($fields = [], bool $overwrite = false)
+    {
+        $this->_deprecatedMethod('select()', 'Create your query with selectQuery() instead.');
+
+        return parent::select($fields, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function distinct($on = [], $overwrite = false)
+    {
+        $this->_deprecatedMethod('distint()');
+
+        return parent::distinct($on, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function modifier($modifiers, $overwrite = false)
+    {
+        $this->_deprecatedMethod('modifier()');
+
+        return parent::modifier($modifiers, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function order($fields, $overwrite = false)
+    {
+        $this->_deprecatedMethod('order()');
+
+        return parent::order($fields, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function orderAsc($field, $overwrite = false)
+    {
+        $this->_deprecatedMethod('orderAsc()');
+
+        return parent::orderAsc($field, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function orderDesc($field, $overwrite = false)
+    {
+        $this->_deprecatedMethod('orderDesc()');
+
+        return parent::orderDesc($field, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function group($fields, $overwrite = false)
+    {
+        $this->_deprecatedMethod('group()');
+
+        return parent::group($fields, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function having($conditions = null, $types = [], $overwrite = false)
+    {
+        $this->_deprecatedMethod('having()');
+
+        return parent::having($conditions, $types, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function andHaving($conditions, $types = [])
+    {
+        $this->_deprecatedMethod('andHaving()');
+
+        return parent::andHaving($conditions, $types);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function page(int $num, ?int $limit = null)
+    {
+        $this->_deprecatedMethod('page()');
+
+        return parent::page($num, $limit);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function limit($limit)
+    {
+        $this->_deprecatedMethod('limit()');
+
+        return parent::limit($limit);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offset($offset)
+    {
+        $this->_deprecatedMethod('offset()');
+
+        return parent::offset($offset);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function union($query, $overwrite = false)
+    {
+        $this->_deprecatedMethod('union()');
+
+        return parent::union($query, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unionAll($query, $overwrite = false)
+    {
+        $this->_deprecatedMethod('unionAll()');
+
+        return parent::unionAll($query, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insert(array $columns, array $types = [])
+    {
+        $this->_deprecatedMethod('insert()', 'Create your query with insertQuery() instead.');
+
+        return parent::insert($columns, $types);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function into(string $table)
+    {
+        $this->_deprecatedMethod('into()');
+
+        return parent::into($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function values($data)
+    {
+        $this->_deprecatedMethod('values()');
+
+        return parent::values($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update($table)
+    {
+        $this->_deprecatedMethod('update()', 'Create your query with updateQuery() instead.');
+
+        return parent::update($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value = null, $types = [])
+    {
+        $this->_deprecatedMethod('set()');
+
+        return parent::set($key, $value, $types);
+    }
+}

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -516,12 +516,25 @@ class ConnectionTest extends TestCase
         $this->assertCount(1, $result);
         $result->closeCursor();
 
-        $this->connection->delete('things', ['id' => '1'], ['id' => 'integer']);
+        $this->connection->delete('things', ['id' => '2'], ['id' => 'integer']);
+        $result = $this->connection->execute('SELECT * FROM things');
+        $this->assertCount(0, $result);
+        $result->closeCursor();
+    }
+
+    /**
+     * Tests delete from table with conditions
+     */
+    public function testDeleteQuery(): void
+    {
+        $query = $this->connection->deleteQuery('things', ['id' => '1'], ['id' => 'integer']);
+        $query->execute()->closeCursor();
         $result = $this->connection->execute('SELECT * FROM things');
         $this->assertCount(1, $result);
         $result->closeCursor();
 
-        $this->connection->delete('things', ['id' => '2'], ['id' => 'integer']);
+        $query = $this->connection->deleteQuery('things')->where(['id' => 2], ['id' => 'integer']);
+        $query->execute()->closeCursor();
         $result = $this->connection->execute('SELECT * FROM things');
         $this->assertCount(0, $result);
         $result->closeCursor();

--- a/tests/TestCase/Database/QueryTests/ForwardsCompatibilityTest.php
+++ b/tests/TestCase/Database/QueryTests/ForwardsCompatibilityTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\QueryTests;
+
+use Cake\Database\Connection;
+use Cake\Datasource\ConnectionManager;
+use Cake\Database\Query\DeleteQuery;
+use Cake\TestSuite\TestCase;
+
+class ForwardsCompatibilityTest extends TestCase
+{
+    protected $fixtures = [
+        'core.Articles',
+        'core.Authors',
+    ];
+
+    public static function queryProvider()
+    {
+        return [
+            [fn (Connection $connection) => new DeleteQuery($connection), 'delete'],
+        ];
+    }
+
+    /**
+     * @dataProvider queryProvider
+     */
+    public function testAsInsert($queryFactory)
+    {
+        $query = $queryFactory(ConnectionManager::get('test'));
+        $scenario = function () use ($query) {
+            $statement = $query
+                ->insert(['author_id', 'title', 'body', 'published'])
+                ->into('articles')
+                ->values([1, 'custom article', 'so long'])
+                ->execute();
+            $this->assertEquals(1, $statement->rowCount());
+            $statement->closeCursor();
+        };
+        /*
+        if ($query instanceof InsertQuery) {
+            return $scenario();
+        }
+         */
+        $this->deprecated($scenario);
+    }
+
+    /**
+     * @dataProvider queryProvider
+     */
+    public function testAsUpdate($queryFactory)
+    {
+        $query = $queryFactory(ConnectionManager::get('test'));
+        $scenario = function () use ($query) {
+            $statement = $query
+                ->update('articles')
+                ->set(['title' => 'Updated'])
+                ->where(['title' => 'First Article'])
+                ->execute();
+            $this->assertEquals(1, $statement->rowCount());
+            $statement->closeCursor();
+        };
+
+        /*
+        if ($query instanceof UpdateQuery) {
+            return $scenario();
+        }
+         */
+        $this->deprecated($scenario);
+    }
+
+    /**
+     * @dataProvider queryProvider
+     */
+    public function testAsDelete($queryFactory)
+    {
+        $query = $queryFactory(ConnectionManager::get('test'));
+        $scenario = function () use ($query) {
+            $statement = $query
+                ->delete('articles')
+                ->where(['title' => 'First Article'])
+                ->epilog('')
+                ->execute();
+            $this->assertEquals(1, $statement->rowCount());
+            $statement->closeCursor();
+        };
+        if ($query instanceof DeleteQuery) {
+            return $scenario();
+        }
+        $this->deprecated($scenario);
+    }
+
+    /**
+     * @dataProvider queryProvider
+     */
+    public function testAsSelect($queryFactory)
+    {
+        $query = $queryFactory(ConnectionManager::get('test'));
+        $scenario = function () use ($query) {
+            $statement = $query
+                ->select(['title', 'body'])
+                ->from(['Articles' => 'articles'])
+                ->where(['title' => 'First Article'])
+                ->execute();
+            $this->assertEquals(1, $statement->rowCount());
+            $statement->closeCursor();
+        };
+        /*
+        if ($query instanceof SelectQuery) {
+            return $scenario();
+        }
+        */
+        $this->deprecated($scenario);
+    }
+}

--- a/tests/TestCase/Database/QueryTests/ForwardsCompatibilityTest.php
+++ b/tests/TestCase/Database/QueryTests/ForwardsCompatibilityTest.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\QueryTests;
 
 use Cake\Database\Connection;
-use Cake\Datasource\ConnectionManager;
 use Cake\Database\Query\DeleteQuery;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
 class ForwardsCompatibilityTest extends TestCase


### PR DESCRIPTION
While writing the docs I noticed that we would also need to backport the new `Connection` methods and Database\Query subclasses as well.

Having these shims will let us deprecate `Connection::query()` and give a good upgrade path for users on the standalone database package.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
