### PR TITLE
Fix id attribute usage in FormHelper

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1572,7 +1572,7 @@ class FormHelper extends Helper
             ]);
         }
         if ($generatedHiddenId) {
-         unset($attributes['id']);
+            unset($attributes['id']);
         }
         $radio = $this->widget('radio', $attributes);
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1552,10 +1552,11 @@ class FormHelper extends Helper
         $attributes['options'] = $options;
         $attributes['idPrefix'] = $this->_idPrefix;
 
+        $generatedHiddenId = false;
         if (!isset($attributes['id'])) {
             $attributes['id'] = true;
+            $generatedHiddenId = true;
         }
-
         $attributes = $this->_initInputField($fieldName, $attributes);
 
         $hiddenField = $attributes['hiddenField'] ?? true;
@@ -1570,11 +1571,9 @@ class FormHelper extends Helper
                 'id' => $attributes['id'],
             ]);
         }
-
-        if (!isset($attributes['type']) && isset($attributes['name'])) {
-            unset($attributes['id']);
+        if ($generatedHiddenId) {
+         unset($attributes['id']);
         }
-
         $radio = $this->widget('radio', $attributes);
 
         return $hidden . $radio;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2118,8 +2118,10 @@ class FormHelper extends Helper
             'secure' => true,
         ];
 
+        $generatedHiddenId = false;
         if (!isset($attributes['id'])) {
             $attributes['id'] = true;
+            $generatedHiddenId = true;
         }
 
         $attributes = $this->_initInputField($fieldName, $attributes);
@@ -2139,7 +2141,7 @@ class FormHelper extends Helper
         }
         unset($attributes['hiddenField']);
 
-        if (!isset($attributes['type']) && isset($attributes['name'])) {
+        if ($generatedHiddenId) {
             unset($attributes['id']);
         }
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4439,19 +4439,6 @@ class FormHelperTest extends TestCase
      */
     public function testRadio(): void
     {
-        $result = $this->Form->radio('Model.field', ['option A']);
-        $expected = [
-            'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
-            'label' => ['for' => 'model-field-0'],
-            ['input' => ['type' => 'radio', 'name' => 'Model[field]', 'value' => '0', 'id' => 'model-field-0']],
-            'option A',
-            '/label',
-        ];
-        $this->assertHtml($expected, $result);
-
-        $result = $this->Form->radio('Model.field', new Collection(['option A']));
-        $this->assertHtml($expected, $result);
-
         $result = $this->Form->radio('Model.field', ['option A', 'option B']);
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[field]', 'value' => '', 'id' => 'model-field'],
@@ -4466,20 +4453,23 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
+        $result = $this->Form->radio('Model.field', new Collection(['option A', 'option B']));
+        $this->assertHtml($expected, $result);
+
         $result = $this->Form->radio(
-            'Employee.gender',
-            ['male' => 'Male', 'female' => 'Female'],
-            ['form' => 'my-form']
+            'Employee.vegetarian',
+            ['yes' => 'Yes', 'no' => 'No'],
+            ['form' => 'my-form', 'id' => 'id-veg']
         );
         $expected = [
-            'input' => ['type' => 'hidden', 'name' => 'Employee[gender]', 'value' => '', 'form' => 'my-form', 'id' => 'employee-gender'],
-            ['label' => ['for' => 'employee-gender-male']],
-            ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'male', 'id' => 'employee-gender-male', 'form' => 'my-form']],
-            'Male',
+            'input' => ['type' => 'hidden', 'name' => 'Employee[vegetarian]', 'value' => '', 'form' => 'my-form', 'id' => 'id-veg'],
+            ['label' => ['for' => 'id-veg-yes']],
+            ['input' => ['type' => 'radio', 'name' => 'Employee[vegetarian]', 'value' => 'yes', 'id' => 'id-veg-yes', 'form' => 'my-form']],
+            'Yes',
             '/label',
-            ['label' => ['for' => 'employee-gender-female']],
-            ['input' => ['type' => 'radio', 'name' => 'Employee[gender]', 'value' => 'female', 'id' => 'employee-gender-female', 'form' => 'my-form']],
-            'Female',
+            ['label' => ['for' => 'id-veg-no']],
+            ['input' => ['type' => 'radio', 'name' => 'Employee[vegetarian]', 'value' => 'no', 'id' => 'id-veg-no', 'form' => 'my-form']],
+            'No',
             '/label',
         ];
         $this->assertHtml($expected, $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5657,6 +5657,42 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testSelectCheckboxMultipleOverrideName method
+     *
+     * Test that select() with multiple = checkbox works with overriding name attribute.
+     */
+    public function testSelectCheckboxMultipleCustomId(): void
+    {
+        $result = $this->Form->select('category', ['1', '2'], [
+            'multiple' => 'checkbox',
+            'id' => 'cat',
+        ]);
+        $expected = [
+            'input' => ['type' => 'hidden', 'name' => 'category', 'value' => '', 'id' => 'cat'],
+            ['div' => ['class' => 'checkbox']],
+                ['label' => ['for' => 'cat-0']],
+                    ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '0', 'id' => 'cat-0']],
+                    '1',
+                '/label',
+            '/div',
+            ['div' => ['class' => 'checkbox']],
+                ['label' => ['for' => 'cat-1']],
+                    ['input' => ['type' => 'checkbox', 'name' => 'category[]', 'value' => '1', 'id' => 'cat-1']],
+                    '2',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Form->multiCheckbox(
+            'category',
+            ['1', '2'],
+            ['id' => 'cat']
+        );
+        $this->assertHtml($expected, $result);
+    }
+
+    /**
      * testControlMultiCheckbox method
      *
      * Test that control() works with multicheckbox.


### PR DESCRIPTION
When #16475 was merged a regression was introduced that caused the id values generated for radio options to be wrong when an `id` attribute was set.

Fixes #16835
