### PR TITLE
4.5 - Add UpdateQuery shim

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -28,6 +28,7 @@ use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\UpdateQuery;
 use Cake\Database\Retry\ReconnectStrategy;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\Schema\Collection as SchemaCollection;
@@ -486,11 +487,33 @@ class Connection implements ConnectionInterface
     public function update(string $table, array $values, array $conditions = [], array $types = []): StatementInterface
     {
         return $this->getDisconnectRetry()->run(function () use ($table, $values, $conditions, $types) {
-            return $this->newQuery()->update($table)
-                ->set($values, $types)
-                ->where($conditions, $types)
-                ->execute();
+            return $this->updateQuery($table, $values, $conditions, $types)->execute();
         });
+    }
+
+    /**
+     * Create a new UpdateQuery instance for this connection.
+     *
+     * @param \Cake\Database\ExpressionInterface|string|null $table The table to update rows of.
+     * @param array $values Values to be updated.
+     * @param array $conditions Conditions to be set for the update statement.
+     * @param array<string, string> $types Associative array containing the types to be used for casting.
+     * @return \Cake\Database\Query\UpdateQuery
+     */
+    public function updateQuery($table = null, array $values = [], array $conditions = [], array $types = []): UpdateQuery
+    {
+        $query = new UpdateQuery($this);
+        if ($table) {
+            $query->update($table);
+        }
+        if ($values) {
+            $query->set($values, $types);
+        }
+        if ($conditions) {
+            $query->where($conditions, $types);
+        }
+
+        return $query;
     }
 
     /**

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -500,8 +500,12 @@ class Connection implements ConnectionInterface
      * @param array<string, string> $types Associative array containing the types to be used for casting.
      * @return \Cake\Database\Query\UpdateQuery
      */
-    public function updateQuery($table = null, array $values = [], array $conditions = [], array $types = []): UpdateQuery
-    {
+    public function updateQuery(
+        $table = null,
+        array $values = [],
+        array $conditions = [],
+        array $types = []
+    ): UpdateQuery {
         $query = new UpdateQuery($this);
         if ($table) {
             $query->update($table);

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Database\Query;
+
+use Cake\Database\Query;
+
+/**
+ * Update Query forward compatibility shim.
+ */
+class UpdateQuery extends Query
+{
+    /**
+     * Type of this query (select, insert, update, delete).
+     *
+     * @var string
+     */
+    protected $_type = 'update';
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(?string $table = null)
+    {
+        $this->_deprecatedMethod('delete()', 'Create your query with deleteQuery() instead.');
+
+        return parent::delete($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function select($fields = [], bool $overwrite = false)
+    {
+        $this->_deprecatedMethod('select()', 'Create your query with selectQuery() instead.');
+
+        return parent::select($fields, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function distinct($on = [], $overwrite = false)
+    {
+        $this->_deprecatedMethod('distinct()');
+
+        return parent::distinct($on, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function modifier($modifiers, $overwrite = false)
+    {
+        $this->_deprecatedMethod('modifier()');
+
+        return parent::modifier($modifiers, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function group($fields, $overwrite = false)
+    {
+        $this->_deprecatedMethod('group()');
+
+        return parent::group($fields, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function having($conditions = null, $types = [], $overwrite = false)
+    {
+        $this->_deprecatedMethod('having()');
+
+        return parent::having($conditions, $types, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function andHaving($conditions, $types = [])
+    {
+        $this->_deprecatedMethod('andHaving()');
+
+        return parent::andHaving($conditions, $types);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function page(int $num, ?int $limit = null)
+    {
+        $this->_deprecatedMethod('page()');
+
+        return parent::page($num, $limit);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offset($offset)
+    {
+        $this->_deprecatedMethod('offset()');
+
+        return parent::offset($offset);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function union($query, $overwrite = false)
+    {
+        $this->_deprecatedMethod('union()');
+
+        return parent::union($query, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unionAll($query, $overwrite = false)
+    {
+        $this->_deprecatedMethod('union()');
+
+        return parent::unionAll($query, $overwrite);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insert(array $columns, array $types = [])
+    {
+        $this->_deprecatedMethod('insert()', 'Create your query with insertQuery() instead.');
+
+        return parent::insert($columns, $types);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function into(string $table)
+    {
+        $this->_deprecatedMethod('into()', 'Use update() instead.');
+
+        return parent::into($table);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function values($data)
+    {
+        $this->_deprecatedMethod('values()');
+
+        return parent::values($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function from($tables = [], $overwrite = false)
+    {
+        $this->_deprecatedMethod('from()', 'Use update() instead.');
+
+        return parent::from($tables, $overwrite);
+    }
+}

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -519,6 +519,24 @@ class ConnectionTest extends TestCase
     }
 
     /**
+     * Tests you can bind types to update values
+     */
+    public function testUpdateQueryWithConditionsAndTypes(): void
+    {
+        $title = 'changed the title!';
+        $body = new DateTime('2012-01-01');
+        $values = compact('title', 'body');
+        $query = $this->connection->updateQuery('things', $values, ['id' => '1'], ['body' => 'date', 'id' => 'integer']);
+        $query->execute()->closeCursor();
+
+        $result = $this->connection->execute('SELECT * FROM things WHERE title = :title AND body = :body', $values, ['body' => 'date']);
+        $this->assertCount(1, $result);
+        $row = $result->fetch('assoc');
+        $this->assertSame('2012-01-01', $row['body']);
+        $result->closeCursor();
+    }
+
+    /**
      * Tests delete from table with no conditions
      */
     public function testDeleteNoConditions(): void

--- a/tests/TestCase/Database/QueryTests/ForwardsCompatibilityTest.php
+++ b/tests/TestCase/Database/QueryTests/ForwardsCompatibilityTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\QueryTests;
 use Cake\Database\Connection;
 use Cake\Database\Query\DeleteQuery;
 use Cake\Database\Query\InsertQuery;
+use Cake\Database\Query\UpdateQuery;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
@@ -34,6 +35,7 @@ class ForwardsCompatibilityTest extends TestCase
         return [
             [fn (Connection $connection) => new DeleteQuery($connection), 'delete'],
             [fn (Connection $connection) => new InsertQuery($connection), 'insert'],
+            [fn (Connection $connection) => new UpdateQuery($connection), 'update'],
         ];
     }
 
@@ -74,11 +76,9 @@ class ForwardsCompatibilityTest extends TestCase
             $statement->closeCursor();
         };
 
-        /*
         if ($query instanceof UpdateQuery) {
             return $scenario();
         }
-         */
         $this->deprecated($scenario);
     }
 


### PR DESCRIPTION
Only selectQuery() and the deprecation for Connection::query() remain.