### PR TITLE
addHelper() for initialize()

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1244,6 +1244,8 @@ class View implements EventDispatcherInterface
     }
 
     /**
+     * Adds a helper from within `initialize()` method.
+     *
      * @param string $helper Helper.
      * @param array<string, mixed> $config Config.
      * @return void
@@ -1260,7 +1262,9 @@ class View implements EventDispatcherInterface
     }
 
     /**
-     * Loads a helper. Delegates to the `HelperRegistry::load()` to load the helper
+     * Loads a helper. Delegates to the `HelperRegistry::load()` to load the helper.
+     *
+     * Deprecated: The use within `initialize()` method is deprecated, use `addHelper()` instead.
      *
      * @param string $name Name of the helper to load.
      * @param array<string, mixed> $config Settings for the helper

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1263,7 +1263,7 @@ class View implements EventDispatcherInterface
     /**
      * Loads a helper. Delegates to the `HelperRegistry::load()` to load the helper.
      *
-     * Deprecated: The use within `initialize()` method is deprecated, use `addHelper()` instead.
+     * You should use `addHelper()` instead of this method from the `initialize()` hook of `AppView` or other custom View classes.
      *
      * @param string $name Name of the helper to load.
      * @param array<string, mixed> $config Settings for the helper

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1254,8 +1254,7 @@ class View implements EventDispatcherInterface
     {
         [$plugin, $name] = pluginSplit($helper);
         if ($plugin) {
-            $config['class'] = $helper;
-            $config['config'] = $config;
+            $config['className'] = $helper;
         }
 
         $this->helpers[$name] = $config;

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1244,6 +1244,22 @@ class View implements EventDispatcherInterface
     }
 
     /**
+     * @param string $helper Helper.
+     * @param array<string, mixed> $config Config.
+     * @return void
+     */
+    protected function addHelper(string $helper, array $config = []): void
+    {
+        [$plugin, $name] = pluginSplit($helper);
+        if ($plugin) {
+            $config['class'] = $helper;
+            $config['config'] = $config;
+        }
+
+        $this->helpers[$name] = $config;
+    }
+
+    /**
      * Loads a helper. Delegates to the `HelperRegistry::load()` to load the helper
      *
      * @param string $name Name of the helper to load.

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -833,6 +833,18 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test adding helpers in initialize().
+     */
+    public function testAddHelper(): void
+    {
+        $View = new TestView();
+        $this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
+
+        $config = $View->Html->getConfig();
+        $this->assertSame('myval', $config['mykey']);
+    }
+
+    /**
      * Test loading helper using loadHelper().
      */
     public function testLoadHelper(): void
@@ -997,7 +1009,7 @@ class ViewTest extends TestCase
 
         $attached = $View->helpers()->loaded();
         // HtmlHelper is loaded in TestView::initialize()
-        $this->assertEquals(['Html', 'Form', 'Number'], $attached);
+        $this->assertEquals(['Form', 'Number', 'Html'], $attached);
 
         $this->PostsController->viewBuilder()->addHelpers(
             ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
@@ -1009,7 +1021,7 @@ class ViewTest extends TestCase
         $this->assertSame('posts index', $result);
 
         $attached = $View->helpers()->loaded();
-        $expected = ['Html', 'Form', 'Number', 'PluggedHelper'];
+        $expected = ['Form', 'Number', 'Html', 'PluggedHelper'];
         $this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
     }
 

--- a/tests/test_app/TestApp/View/TestView.php
+++ b/tests/test_app/TestApp/View/TestView.php
@@ -7,7 +7,7 @@ class TestView extends AppView
 {
     public function initialize(): void
     {
-        $this->loadHelper('Html', ['mykey' => 'myval']);
+        $this->addHelper('Html', ['mykey' => 'myval']);
     }
 
     /**


### PR DESCRIPTION
I have already been using that for some time in 
https://github.com/dereuromark/cakephp-sandbox/blob/371458342dc563454c4f3e2097d312140bf69e01/src/View/AppView.php#L59-L88

It completes the API around add vs load on the helpers, similar to what was done in https://github.com/cakephp/cakephp/pull/16118 and before

The main issue remains a non-normalized config setup that throws exceptions if defined differently on different levels

`$this->viewBuilder()->addHelpers($helpers);` of a plugin
vs 
project level

In general, initialize() can also be multiple levels deep (e.g. plugin View extended on project level)
If it ever needs to modify the helpers to e.g. exchange one, it is much more cumbersome to remove and readd then overwriting the correct key.

As for correct key: Defining 

    'Time', ['className' => 'Tools.Time', 'config' => ['engine' => 'Tools\Utility\FrozenTime']

and

    'Tools.Time', ['config' => ['engine' => 'Tools\Utility\FrozenTime']
    
should also get normalized now this way for a better and more consistent experience on working with those keys.
As it always can only exist once as "Time" then.

So I propose that we use the same adding only for now and let the actual loadHelpers() do its job.
In 5.x we could then make loadHelper protected and make sure we use only one way forward of adding them within AppView as well.