### PR TITLE
Use array_key_exists instead of isset

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -281,7 +281,7 @@ trait EntityTrait
         $value = null;
         $method = static::_accessor($field, 'get');
 
-        if (isset($this->_fields[$field])) {
+        if (array_key_exists($field, $this->_fields)) {
             $value = &$this->_fields[$field];
         }
 


### PR DESCRIPTION
To check whether an entity proptery exists.

Should be backwards compatible, as we only retrieve the value form the ``_fields`` array entry, anyway.