### PR TITLE
4.5 - Deprecate newQuery()

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -425,6 +425,13 @@ class Connection implements ConnectionInterface
      */
     public function newQuery(): Query
     {
+        deprecationWarning(
+            'As of 4.5.0, using newQuery() is deprecated. Instead, use `insertQuery()`, ' .
+            '`deleteQuery()`, `selectQuery()` or `updateQuery()`. The query objects ' .
+            'returned by these methods will emit deprecations that will become fatal errors in 5.0.' .
+            'See https://book.cakephp.org/4/en/appendices/4-5-migration-guide.html for more information.'
+        );
+
         return new Query($this);
     }
 

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -90,8 +90,7 @@ trait TupleComparisonTranslatorTrait
         }
 
         $surrogate = $query->getConnection()
-            ->newQuery()
-            ->select($true);
+            ->selectQuery($true);
 
         if (!is_array(current($value))) {
             $value = [$value];

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -473,7 +473,7 @@ class Query implements ExpressionInterface, IteratorAggregate
         }
 
         if ($cte instanceof Closure) {
-            $query = $this->getConnection()->newQuery();
+            $query = $this->getConnection()->selectQuery();
             $cte = $cte(new CommonTableExpression(), $query);
             if (!($cte instanceof CommonTableExpression)) {
                 throw new RuntimeException(

--- a/src/Datasource/ConnectionInterface.php
+++ b/src/Datasource/ConnectionInterface.php
@@ -30,8 +30,6 @@ use Psr\SimpleCache\CacheInterface;
  *   already created tables. {@see \Cake\Database\Connnection::supportsDynamicConstraints()}
  * @method \Cake\Database\Schema\Collection getSchemaCollection() Gets a Schema\Collection object for this connection.
  *    {@see \Cake\Database\Connnection::getSchemaCollection()}
- * @method \Cake\Database\Query newQuery() Create a new Query instance for this connection.
- *    {@see \Cake\Database\Connnection::newQuery()}
  * @method \Cake\Database\StatementInterface prepare($sql) Prepares a SQL statement to be executed.
  *    {@see \Cake\Database\Connnection::prepare()}
  * @method \Cake\Database\StatementInterface execute($query, $params = [], array $types = []) Executes a query using

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -995,8 +995,8 @@ class Query extends DatabaseQuery implements JsonSerializable, QueryInterface
                 ->disableAutoFields()
                 ->execute();
         } else {
-            $statement = $this->getConnection()->newQuery()
-                ->select($count)
+            $statement = $this->getConnection()
+                ->selectQuery($count)
                 ->from(['count_source' => $query])
                 ->execute();
         }

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -335,7 +335,8 @@ class TestFixture implements ConstraintsInterface, FixtureInterface, TableSchema
     {
         if (!empty($this->records)) {
             [$fields, $values, $types] = $this->_getRecords();
-            $query = $connection->newQuery()
+            /** @var \Cake\Database\Connection $connection */
+            $query = $connection->insertQuery()
                 ->insert($fields, $types)
                 ->into($this->sourceName());
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -30,6 +30,7 @@ use Cake\Database\Exception\MissingExtensionException;
 use Cake\Database\Exception\NestedTransactionRollbackException;
 use Cake\Database\Log\LoggingStatement;
 use Cake\Database\Log\QueryLogger;
+use Cake\Database\Query;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
@@ -246,7 +247,7 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
         $this->assertEquals($sql, $result->queryString);
 
-        $query = $this->connection->newQuery()->select('1 + 1');
+        $query = $this->connection->selectQuery('1 + 1');
         $result = $this->connection->prepare($query);
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
         $sql = '#SELECT [`"\[]?1 \+ 1[`"\]]?#';
@@ -1494,5 +1495,13 @@ class ConnectionTest extends TestCase
         $conn->query('SELECT 1');
 
         $this->assertSame('[RECONNECT]', $logger->getMessage());
+    }
+
+    public function testNewQuery()
+    {
+        $this->deprecated(function () {
+            $query = $this->connection->newQuery();
+            $this->assertInstanceOf(Query::class, $query);
+        });
     }
 }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -499,7 +499,7 @@ class SqlserverTest extends TestCase
         $connection = ConnectionManager::get('test');
         $this->skipIf(!$connection->getDriver() instanceof Sqlserver);
 
-        $query = $connection->newQuery()
+        $query = $connection->selectQuery()
             ->from('articles')
             ->whereInList('id', range(0, 2100));
 

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -1378,7 +1378,7 @@ class CaseStatementExpressionTest extends TestCase
                 [Chronos::now(), null, 'datetime'],
                 [new IdentifierExpression('Table.column'), 'Table.column', null],
                 [new QueryExpression('Table.column'), 'Table.column', null],
-                [ConnectionManager::get('test')->newQuery()->select('a'), '(SELECT a)', null],
+                [ConnectionManager::get('test')->selectQuery('a'), '(SELECT a)', null],
                 [new TestObjectWithToString(), null, 'string'],
                 [new stdClass(), null, null],
             ];
@@ -1504,7 +1504,7 @@ class CaseStatementExpressionTest extends TestCase
                     ],
                 ],
                 [
-                    ConnectionManager::get('test')->newQuery()->select('a'),
+                    ConnectionManager::get('test')->selectQuery('a'),
                     'CASE :c0 WHEN (SELECT a) THEN :c1 ELSE NULL END',
                     [
                         ':c0' => [
@@ -1644,7 +1644,7 @@ class CaseStatementExpressionTest extends TestCase
                     ],
                 ],
                 [
-                    ConnectionManager::get('test')->newQuery()->select('a'),
+                    ConnectionManager::get('test')->selectQuery('a'),
                     'CASE WHEN (SELECT a) THEN :c0 ELSE NULL END',
                     [
                         ':c0' => [
@@ -1747,7 +1747,7 @@ class CaseStatementExpressionTest extends TestCase
                 [Chronos::now(), null, 'datetime'],
                 [new IdentifierExpression('Table.column'), 'Table.column', null],
                 [new QueryExpression('Table.column'), 'Table.column', null],
-                [ConnectionManager::get('test')->newQuery()->select('a'), '(SELECT a)', null],
+                [ConnectionManager::get('test')->selectQuery('a'), '(SELECT a)', null],
                 [new TestObjectWithToString(), null, 'string'],
                 [new stdClass(), null, null],
             ];
@@ -1831,7 +1831,7 @@ class CaseStatementExpressionTest extends TestCase
                 [Chronos::now(), null, 'datetime'],
                 [new IdentifierExpression('Table.column'), 'Table.column', null],
                 [new QueryExpression('Table.column'), 'Table.column', null],
-                [ConnectionManager::get('test')->newQuery()->select('a'), '(SELECT a)', null],
+                [ConnectionManager::get('test')->selectQuery('a'), '(SELECT a)', null],
                 [new TestObjectWithToString(), null, 'string'],
                 [new stdClass(), null, null],
             ];

--- a/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CommonTableExpressionTest.php
@@ -46,12 +46,12 @@ class CommonTableExpressionTest extends TestCase
      */
     public function testCteConstructor(): void
     {
-        $cte = new CommonTableExpression('test', $this->connection->newQuery());
+        $cte = new CommonTableExpression('test', $this->connection->selectQuery());
         $this->assertEqualsSql('test AS ()', $cte->sql(new ValueBinder()));
 
         $cte = (new CommonTableExpression())
             ->name('test')
-            ->query($this->connection->newQuery());
+            ->query($this->connection->selectQuery());
         $this->assertEqualsSql('test AS ()', $cte->sql(new ValueBinder()));
     }
 
@@ -60,7 +60,7 @@ class CommonTableExpressionTest extends TestCase
      */
     public function testFields(): void
     {
-        $cte = (new CommonTableExpression('test', $this->connection->newQuery()))
+        $cte = (new CommonTableExpression('test', $this->connection->selectQuery()))
             ->field('col1')
             ->field([new IdentifierExpression('col2')]);
         $this->assertEqualsSql('test(col1, col2) AS ()', $cte->sql(new ValueBinder()));
@@ -71,7 +71,7 @@ class CommonTableExpressionTest extends TestCase
      */
     public function testMaterialized(): void
     {
-        $cte = (new CommonTableExpression('test', $this->connection->newQuery()))
+        $cte = (new CommonTableExpression('test', $this->connection->selectQuery()))
             ->materialized();
         $this->assertEqualsSql('test AS MATERIALIZED ()', $cte->sql(new ValueBinder()));
 
@@ -84,7 +84,7 @@ class CommonTableExpressionTest extends TestCase
      */
     public function testRecursive(): void
     {
-        $cte = (new CommonTableExpression('test', $this->connection->newQuery()))
+        $cte = (new CommonTableExpression('test', $this->connection->selectQuery()))
             ->recursive();
         $this->assertTrue($cte->isRecursive());
     }
@@ -95,12 +95,12 @@ class CommonTableExpressionTest extends TestCase
     public function testQueryClosures(): void
     {
         $cte = new CommonTableExpression('test', function () {
-            return $this->connection->newQuery();
+            return $this->connection->selectQuery();
         });
         $this->assertEqualsSql('test AS ()', $cte->sql(new ValueBinder()));
 
         $cte->query(function () {
-            return $this->connection->newQuery()->select('1');
+            return $this->connection->selectQuery('1');
         });
         $this->assertEqualsSql('test AS (SELECT 1)', $cte->sql(new ValueBinder()));
     }
@@ -110,7 +110,7 @@ class CommonTableExpressionTest extends TestCase
      */
     public function testTraverse(): void
     {
-        $query = $this->connection->newQuery()->select('1');
+        $query = $this->connection->selectQuery('1');
         $cte = (new CommonTableExpression('test', $query))->field('field');
 
         $expressions = [];
@@ -129,7 +129,7 @@ class CommonTableExpressionTest extends TestCase
     public function testClone(): void
     {
         $cte = new CommonTableExpression('test', function () {
-            return $this->connection->newQuery()->select('1');
+            return $this->connection->selectQuery('1');
         });
         $cte2 = (clone $cte)->name('test2');
         $this->assertNotSame($cte->sql(new ValueBinder()), $cte2->sql(new ValueBinder()));

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -98,9 +98,7 @@ class FunctionExpressionTest extends TestCase
      */
     public function testFunctionWithDatabaseQuery(): void
     {
-        $query = ConnectionManager::get('test')
-            ->newQuery()
-            ->select(['column']);
+        $query = ConnectionManager::get('test')->selectQuery(['column']);
 
         $binder = new ValueBinder();
         $function = new $this->expressionClass('MyFunction', [$query]);

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -47,7 +47,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
 
     protected function _insert(): void
     {
-        $query = $this->connection->newQuery();
+        $query = $this->connection->insertQuery();
         $query
             ->insert(['id', 'published', 'name'], ['id' => 'ordered_uuid'])
             ->into('ordered_uuid_items')
@@ -65,8 +65,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     public function testInsert(): void
     {
         $this->_insert();
-        $query = $this->connection->newQuery()
-            ->select('id')
+        $query = $this->connection
+            ->selectQuery('id')
             ->from('ordered_uuid_items')
             ->order('id')
             ->setDefaultTypes(['id' => 'ordered_uuid']);
@@ -85,8 +85,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     public function testSelectWithConditions(): void
     {
         $this->_insert();
-        $result = $this->connection->newQuery()
-            ->select('id')
+        $result = $this->connection
+            ->selectQuery('id')
             ->from('ordered_uuid_items')
             ->where(['id' => '48298a29-81c0-4c26-a7fb-413140cf8569'], ['id' => 'ordered_uuid'])
             ->execute()
@@ -102,8 +102,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     public function testSelectWithConditionsValueObject(): void
     {
         $this->_insert();
-        $result = $this->connection->newQuery()
-            ->select('id')
+        $result = $this->connection
+            ->selectQuery('id')
             ->from('ordered_uuid_items')
             ->where(['id' => new UuidValue('48298a29-81c0-4c26-a7fb-413140cf8569')], ['id' => 'ordered_uuid'])
             ->execute()
@@ -121,8 +121,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     public function testSelectWithInCondition(): void
     {
         $this->_insert();
-        $result = $this->connection->newQuery()
-            ->select('id')
+        $result = $this->connection
+            ->selectQuery('id')
             ->from('ordered_uuid_items')
             ->where(
                 ['id' => ['48298a29-81c0-4c26-a7fb-413140cf8569', '482b7756-8da0-419a-b21f-27da40cf8569']],
@@ -143,8 +143,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     public function testSelectWithBetween(): void
     {
         $this->_insert();
-        $result = $this->connection->newQuery()
-            ->select('id')
+        $result = $this->connection
+            ->selectQuery('id')
             ->from('ordered_uuid_items')
             ->where(function (QueryExpression $exp) {
                 return $exp->between(
@@ -166,8 +166,8 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
     public function testSelectWithFunction(): void
     {
         $this->_insert();
-        $result = $this->connection->newQuery()
-            ->select('id')
+        $result = $this->connection
+            ->selectQuery('id')
             ->from('ordered_uuid_items')
             ->where(function (QueryExpression $exp, Query $q) {
                 return $exp->eq(

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -776,7 +776,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('menu_link_trees')
-            ->whereNull($this->connection->newQuery()->select('parent_id'))
+            ->whereNull($this->connection->selectQuery('parent_id'))
             ->execute();
         $this->assertCount(5, $result);
         $result->closeCursor();
@@ -809,7 +809,7 @@ class QueryTest extends TestCase
         $result = $query
             ->select(['id'])
             ->from('menu_link_trees')
-            ->whereNotNull($this->connection->newQuery()->select('parent_id'))
+            ->whereNotNull($this->connection->selectQuery('parent_id'))
             ->execute();
         $this->assertCount(13, $result);
         $result->closeCursor();

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1585,8 +1585,7 @@ class QueryRegressionTest extends TestCase
                         ->ABS([
                             $table
                                 ->getConnection()
-                                ->newQuery()
-                                ->select(-1),
+                                ->selectQuery(-1),
                         ])
                         ->setReturnType('integer'),
                 ];
@@ -1641,8 +1640,7 @@ class QueryRegressionTest extends TestCase
                             [
                                 $table
                                     ->getConnection()
-                                    ->newQuery()
-                                    ->select(1.23456),
+                                    ->selectQuery(1.23456),
                                 2,
                             ],
                             [null, 'integer']

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -626,8 +626,7 @@ class LinkConstraintTest extends TestCase
             'conditions' => function (QueryExpression $exp, Query $query) {
                 $connection = $query->getConnection();
                 $subQuery = $connection
-                    ->newQuery()
-                    ->select(['RecentComments.id'])
+                    ->selectQuery(['RecentComments.id'])
                     ->from(['RecentComments' => 'comments'])
                     ->where(function (QueryExpression $exp) {
                         return $exp->eq(
@@ -663,8 +662,7 @@ class LinkConstraintTest extends TestCase
             'conditions' => function (QueryExpression $exp, Query $query) {
                 $connection = $query->getConnection();
                 $subQuery = $connection
-                    ->newQuery()
-                    ->select(['RecentComments.id'])
+                    ->selectQuery(['RecentComments.id'])
                     ->from(['RecentComments' => 'comments'])
                     ->where(function (QueryExpression $exp) {
                         return $exp->eq(

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -120,14 +120,14 @@ class FixtureHelperTest extends TestCase
          * @var \Cake\Database\Connection $connection
          */
         $connection = ConnectionManager::get('test');
-        $connection->newQuery()->delete('articles')->execute()->closeCursor();
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $connection->deleteQuery('articles')->execute()->closeCursor();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
         $helper = new FixtureHelper();
         $helper->insert($helper->loadFixtures(['core.Articles']));
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());
         $rows->closeCursor();
     }
@@ -166,13 +166,13 @@ class FixtureHelperTest extends TestCase
          * @var \Cake\Database\Connection $connection
          */
         $connection = ConnectionManager::get('test');
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());
         $rows->closeCursor();
 
         $helper = new FixtureHelper();
         $helper->truncate($helper->loadFixtures(['core.Articles']));
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
     }

--- a/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TransactionStrategyTest.php
@@ -33,19 +33,19 @@ class TransactionStrategyTest extends TestCase
          * @var \Cake\Database\Connection $connection
          */
         $connection = ConnectionManager::get('test');
-        $connection->newQuery()->delete('articles')->execute()->closeCursor();
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $connection->deleteQuery('articles')->execute()->closeCursor();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
         $strategy = new TransactionStrategy();
         $strategy->setupTest(['core.Articles']);
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());
         $rows->closeCursor();
 
         $strategy->teardownTest();
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
     }

--- a/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
+++ b/tests/TestCase/TestSuite/Fixture/TruncateStrategyTest.php
@@ -33,19 +33,19 @@ class TruncateStrategyTest extends TestCase
          * @var \Cake\Database\Connection $connection
          */
         $connection = ConnectionManager::get('test');
-        $connection->newQuery()->delete('articles')->execute()->closeCursor();
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $connection->deleteQuery('articles')->execute()->closeCursor();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
 
         $strategy = new TruncateStrategy();
         $strategy->setupTest(['core.Articles']);
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertNotEmpty($rows->fetchAll());
         $rows->closeCursor();
 
         $strategy->teardownTest();
-        $rows = $connection->newQuery()->select('*')->from('articles')->execute();
+        $rows = $connection->selectQuery('*')->from('articles')->execute();
         $this->assertEmpty($rows->fetchAll());
         $rows->closeCursor();
     }

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -273,11 +273,11 @@ class TestFixtureTest extends TestCase
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()
             ->getMock();
-        $query = $this->getMockBuilder('Cake\Database\Query')
+        $query = $this->getMockBuilder('Cake\Database\Query\InsertQuery')
             ->setConstructorArgs([$db])
             ->getMock();
         $db->expects($this->once())
-            ->method('newQuery')
+            ->method('insertQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -324,11 +324,11 @@ class TestFixtureTest extends TestCase
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()
             ->getMock();
-        $query = $this->getMockBuilder('Cake\Database\Query')
+        $query = $this->getMockBuilder('Cake\Database\Query\InsertQuery')
             ->setConstructorArgs([$db])
             ->getMock();
         $db->expects($this->once())
-            ->method('newQuery')
+            ->method('insertQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())
@@ -369,11 +369,11 @@ class TestFixtureTest extends TestCase
         $db = $this->getMockBuilder('Cake\Database\Connection')
             ->disableOriginalConstructor()
             ->getMock();
-        $query = $this->getMockBuilder('Cake\Database\Query')
+        $query = $this->getMockBuilder('Cake\Database\Query\InsertQuery')
             ->setConstructorArgs([$db])
             ->getMock();
         $db->expects($this->once())
-            ->method('newQuery')
+            ->method('insertQuery')
             ->will($this->returnValue($query));
 
         $query->expects($this->once())


### PR DESCRIPTION
This completes the backport of the separate query classes to 4.5
