### PR TITLE
Change behavior of EntityInterface::has().

### DIFF
--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -19,8 +19,6 @@ use Throwable;
 
 /**
  * Base class that all CakePHP Exceptions extend.
- *
- * @method int getCode() Gets the Exception code.
  */
 class CakeException extends RuntimeException
 {

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -223,8 +223,9 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getOriginalValues(): array;
 
     /**
-     * Returns whether this entity contains a field named $field
-     * and is not set to null.
+     * Returns whether this entity contains a field named $field.
+     *
+     * The mehod will return `true` even when the field is set to `null`.
      *
      * @param array<string>|string $field The field to check.
      * @return bool

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -234,7 +234,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     /**
      * Returns whether this entity contains a field named $field.
      *
-     * The mehod will return `true` even when the field is set to `null`.
+     * The method will return `true` even when the field is set to `null`.
      *
      * @param array<string>|string $field The field to check.
      * @return bool

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -208,6 +208,15 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function &get(string $field): mixed;
 
     /**
+     * Enable/disable field presence check when accessing a property.
+     *
+     * If enabled an exception will be thrown when trying to access a non-existent property.
+     *
+     * @param bool $value `true` to enable, `false` to disable.
+     */
+    public function requireFieldPresence(bool $value = true): void;
+
+    /**
      * Returns the original value of a field.
      *
      * @param string $field The name of the field.

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -119,6 +119,13 @@ trait EntityTrait
      */
     protected string $_registryAlias = '';
 
+    /**
+     * Whether the presence of a field is checked when accessing a property.
+     *
+     * If enabled an exception will be thrown when trying to access a non-existent property.
+     *
+     * @var bool
+     */
     protected bool $requireFieldPresence = false;
 
     /**
@@ -374,8 +381,8 @@ trait EntityTrait
      * $entity->has(['name', 'last_name']);
      * ```
      *
-     * When checking multiple fields all fields must have a value present for
-     * the method to return `true`.
+     * When checking multiple fields all fields must have a value (even `null`)
+     * present for the method to return `true`.
      *
      * @param array<string>|string $field The field or fields to check.
      * @return bool

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -151,7 +151,7 @@ trait EntityTrait
      */
     public function __isset(string $field): bool
     {
-        return $this->has($field);
+        return $this->get($field) !== null;
     }
 
     /**
@@ -281,7 +281,7 @@ trait EntityTrait
 
         $value = null;
 
-        if (isset($this->_fields[$field])) {
+        if (array_key_exists($field, $this->_fields)) {
             $value = &$this->_fields[$field];
         }
 
@@ -333,15 +333,16 @@ trait EntityTrait
     }
 
     /**
-     * Returns whether this entity contains a field named $field
-     * that contains a non-null value.
+     * Returns whether this entity contains a field named $field.
+     *
+     * It will return `true` even for fields set to `null`.
      *
      * ### Example:
      *
      * ```
      * $entity = new Entity(['id' => 1, 'name' => null]);
      * $entity->has('id'); // true
-     * $entity->has('name'); // false
+     * $entity->has('name'); // true
      * $entity->has('last_name'); // false
      * ```
      *
@@ -351,10 +352,8 @@ trait EntityTrait
      * $entity->has(['name', 'last_name']);
      * ```
      *
-     * All fields must not be null to get a truthy result.
-     *
-     * When checking multiple fields. All fields must not be null
-     * in order for true to be returned.
+     * When checking multiple fields all fields must have a value present for
+     * the method to return `true`.
      *
      * @param array<string>|string $field The field or fields to check.
      * @return bool
@@ -362,7 +361,7 @@ trait EntityTrait
     public function has(array|string $field): bool
     {
         foreach ((array)$field as $prop) {
-            if ($this->get($prop) === null) {
+            if (!array_key_exists($prop, $this->_fields) && !static::_accessor($prop, 'get')) {
                 return false;
             }
         }
@@ -579,7 +578,7 @@ trait EntityTrait
      */
     public function offsetExists(mixed $offset): bool
     {
-        return $this->has($offset);
+        return $this->__isset($offset);
     }
 
     /**

--- a/src/Datasource/Exception/MissingPropertyException.php
+++ b/src/Datasource/Exception/MissingPropertyException.php
@@ -19,7 +19,7 @@ namespace Cake\Datasource\Exception;
 use Cake\Core\Exception\CakeException;
 
 /**
- * Used when a property does not exist for an entity.
+ * A required property does not exist for an entity.
  */
 class MissingPropertyException extends CakeException
 {

--- a/src/Datasource/Exception/MissingPropertyException.php
+++ b/src/Datasource/Exception/MissingPropertyException.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Datasource\Exception;
+
+use Cake\Core\Exception\CakeException;
+
+/**
+ * Used when a property does not exist for an entity.
+ */
+class MissingPropertyException extends CakeException
+{
+    /**
+     * @var string
+     */
+    protected string $_messageTemplate = 'Property `%s` does not exist for the entity `%s`.';
+}

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -460,18 +460,18 @@ class EntityTest extends TestCase
         $entity = new Entity(['id' => 1, 'name' => 'Juan', 'foo' => null]);
         $this->assertTrue($entity->has('id'));
         $this->assertTrue($entity->has('name'));
-        $this->assertFalse($entity->has('foo'));
+        $this->assertTrue($entity->has('foo'));
         $this->assertFalse($entity->has('last_name'));
 
         $this->assertTrue($entity->has(['id']));
         $this->assertTrue($entity->has(['id', 'name']));
-        $this->assertFalse($entity->has(['id', 'foo']));
+        $this->assertTrue($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
 
         $entity = $this->getMockBuilder(Entity::class)
             ->addMethods(['_getThings'])
             ->getMock();
-        $entity->expects($this->once())->method('_getThings')
+        $entity->expects($this->never())->method('_getThings')
             ->will($this->returnValue(0));
         $this->assertTrue($entity->has('things'));
     }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -16,12 +16,14 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use stdClass;
 use TestApp\Model\Entity\Extending;
 use TestApp\Model\Entity\NonExtending;
+use TestApp\Model\Entity\VirtualUser;
 
 /**
  * Entity test case.
@@ -271,6 +273,27 @@ class EntityTest extends TestCase
         $entity = new Entity(['id' => 1, 'foo' => 'bar']);
         $this->assertSame(1, $entity->get('id'));
         $this->assertSame('bar', $entity->get('foo'));
+    }
+
+    public function testRequirePresenceException(): void
+    {
+        $this->expectException(MissingPropertyException::class);
+        $this->expectExceptionMessage('Property `foo` does not exist for the entity `Cake\ORM\Entity`');
+
+        $entity = new Entity();
+        $entity->requireFieldPresence();
+        $entity->get('foo');
+    }
+
+    public function testRequirePresenceNoException(): void
+    {
+        $entity = new Entity(['foo' => null]);
+        $entity->requireFieldPresence();
+        $this->assertNull($entity->get('foo'));
+
+        $entity = new VirtualUser();
+        $entity->requireFieldPresence();
+        $this->assertSame('bonus', $entity->get('bonus'));
     }
 
     /**

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -278,18 +278,18 @@ class EntityTest extends TestCase
     public function testRequirePresenceException(): void
     {
         $this->expectException(MissingPropertyException::class);
-        $this->expectExceptionMessage('Property `foo` does not exist for the entity `Cake\ORM\Entity`');
+        $this->expectExceptionMessage('Property `not_present` does not exist for the entity `Cake\ORM\Entity`');
 
         $entity = new Entity();
         $entity->requireFieldPresence();
-        $entity->get('foo');
+        $entity->get('not_present');
     }
 
     public function testRequirePresenceNoException(): void
     {
-        $entity = new Entity(['foo' => null]);
+        $entity = new Entity(['is_present' => null]);
         $entity->requireFieldPresence();
-        $this->assertNull($entity->get('foo'));
+        $this->assertNull($entity->get('is_present'));
 
         $entity = new VirtualUser();
         $entity->requireFieldPresence();


### PR DESCRIPTION
It now returns `true` when a field is set to `null`. __set() and offsetExists() still retain the default PHP behavior and will return `false` even for `null` values.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
