### PR TITLE
4.next: Remove `/` from HTML void elements

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -46,11 +46,11 @@ class HtmlHelper extends Helper
      */
     protected $_defaultConfig = [
         'templates' => [
-            'meta' => '<meta{{attrs}}/>',
-            'metalink' => '<link href="{{url}}"{{attrs}}/>',
+            'meta' => '<meta{{attrs}}>',
+            'metalink' => '<link href="{{url}}"{{attrs}}>',
             'link' => '<a href="{{url}}"{{attrs}}>{{content}}</a>',
             'mailto' => '<a href="mailto:{{url}}"{{attrs}}>{{content}}</a>',
-            'image' => '<img src="{{url}}"{{attrs}}/>',
+            'image' => '<img src="{{url}}"{{attrs}}>',
             'tableheader' => '<th{{attrs}}>{{content}}</th>',
             'tableheaderrow' => '<tr{{attrs}}>{{content}}</tr>',
             'tablecell' => '<td{{attrs}}>{{content}}</td>',
@@ -64,9 +64,9 @@ class HtmlHelper extends Helper
             'tagselfclosing' => '<{{tag}}{{attrs}}/>',
             'para' => '<p{{attrs}}>{{content}}</p>',
             'parastart' => '<p{{attrs}}>',
-            'css' => '<link rel="{{rel}}" href="{{url}}"{{attrs}}/>',
+            'css' => '<link rel="{{rel}}" href="{{url}}"{{attrs}}>',
             'style' => '<style{{attrs}}>{{content}}</style>',
-            'charset' => '<meta charset="{{charset}}"/>',
+            'charset' => '<meta charset="{{charset}}">',
             'ul' => '<ul{{attrs}}>{{content}}</ul>',
             'ol' => '<ol{{attrs}}>{{content}}</ol>',
             'li' => '<li{{attrs}}>{{content}}</li>',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -3096,38 +3096,38 @@ class PaginatorHelperTest extends TestCase
             // Verifies that no next and prev links are created for single page results.
             [1, false, false, 1, [], ''],
             // Verifies that first and last pages are created for single page results.
-            [1, false, false, 1, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar" rel="first"/>' .
-                '<link href="http://localhost/?foo=bar" rel="last"/>'],
+            [1, false, false, 1, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar" rel="first">' .
+                '<link href="http://localhost/?foo=bar" rel="last">'],
             // Verifies that first page is created for single page results.
-            [1, false, false, 1, ['first' => true], '<link href="http://localhost/?foo=bar" rel="first"/>'],
+            [1, false, false, 1, ['first' => true], '<link href="http://localhost/?foo=bar" rel="first">'],
             // Verifies that last page is created for single page results.
-            [1, false, false, 1, ['last' => true], '<link href="http://localhost/?foo=bar" rel="last"/>'],
+            [1, false, false, 1, ['last' => true], '<link href="http://localhost/?foo=bar" rel="last">'],
             // Verifies that page 1 only has a next link.
-            [1, false, true, 2, [], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next"/>'],
+            [1, false, true, 2, [], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next">'],
             // Verifies that page 1 only has next, first and last link.
-            [1, false, true, 2, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next"/>' .
-                '<link href="http://localhost/?foo=bar" rel="first"/>' .
-                '<link href="http://localhost/?foo=bar&amp;page=2" rel="last"/>'],
+            [1, false, true, 2, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next">' .
+                '<link href="http://localhost/?foo=bar" rel="first">' .
+                '<link href="http://localhost/?foo=bar&amp;page=2" rel="last">'],
             // Verifies that page 1 only has next and first link.
-            [1, false, true, 2, ['first' => true], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next"/>' .
-                '<link href="http://localhost/?foo=bar" rel="first"/>'],
+            [1, false, true, 2, ['first' => true], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next">' .
+                '<link href="http://localhost/?foo=bar" rel="first">'],
             // Verifies that page 1 only has next and last link.
-            [1, false, true, 2, ['last' => true], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next"/>' .
-                '<link href="http://localhost/?foo=bar&amp;page=2" rel="last"/>'],
+            [1, false, true, 2, ['last' => true], '<link href="http://localhost/?foo=bar&amp;page=2" rel="next">' .
+                '<link href="http://localhost/?foo=bar&amp;page=2" rel="last">'],
             // Verifies that the last page only has a prev link.
-            [2, true, false, 2, [], '<link href="http://localhost/?foo=bar" rel="prev"/>'],
+            [2, true, false, 2, [], '<link href="http://localhost/?foo=bar" rel="prev">'],
             // Verifies that the last page only has a prev, first and last link.
-            [2, true, false, 2, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar" rel="prev"/>' .
-                '<link href="http://localhost/?foo=bar" rel="first"/>' .
-                '<link href="http://localhost/?foo=bar&amp;page=2" rel="last"/>'],
+            [2, true, false, 2, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar" rel="prev">' .
+                '<link href="http://localhost/?foo=bar" rel="first">' .
+                '<link href="http://localhost/?foo=bar&amp;page=2" rel="last">'],
             // Verifies that a page in the middle has both links.
-            [5, true, true, 10, [], '<link href="http://localhost/?foo=bar&amp;page=4" rel="prev"/>' .
-                '<link href="http://localhost/?foo=bar&amp;page=6" rel="next"/>'],
+            [5, true, true, 10, [], '<link href="http://localhost/?foo=bar&amp;page=4" rel="prev">' .
+                '<link href="http://localhost/?foo=bar&amp;page=6" rel="next">'],
             // Verifies that a page in the middle has both links.
-            [5, true, true, 10, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar&amp;page=4" rel="prev"/>' .
-                '<link href="http://localhost/?foo=bar&amp;page=6" rel="next"/>' .
-                '<link href="http://localhost/?foo=bar" rel="first"/>' .
-                '<link href="http://localhost/?foo=bar&amp;page=10" rel="last"/>'],
+            [5, true, true, 10, ['first' => true, 'last' => true], '<link href="http://localhost/?foo=bar&amp;page=4" rel="prev">' .
+                '<link href="http://localhost/?foo=bar&amp;page=6" rel="next">' .
+                '<link href="http://localhost/?foo=bar" rel="first">' .
+                '<link href="http://localhost/?foo=bar&amp;page=10" rel="last">'],
         ];
     }
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1034,7 +1034,7 @@ class ViewTest extends TestCase
         $View->setTemplatePath($this->PostsController->getName());
         $result = $View->render('index');
 
-        $this->assertMatchesRegularExpression("/<meta charset=\"utf-8\"\/>\s*<title>/", $result);
+        $this->assertMatchesRegularExpression("/<meta charset=\"utf-8\">\s*<title>/", $result);
         $this->assertMatchesRegularExpression("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
         $this->assertMatchesRegularExpression("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
 
@@ -1048,7 +1048,7 @@ class ViewTest extends TestCase
         $View->setTemplatePath($this->PostsController->getName());
         $result = $View->render('index');
 
-        $this->assertMatchesRegularExpression("/<meta charset=\"utf-8\"\/>\s*<title>/", $result);
+        $this->assertMatchesRegularExpression("/<meta charset=\"utf-8\">\s*<title>/", $result);
         $this->assertMatchesRegularExpression("/<div id=\"content\">\s*posts index\s*<\/div>/", $result);
     }
 


### PR DESCRIPTION
I recently noticed, that the official https://validator.w3.org/ added a new notice for `void elements` containing a trailing `/` at the end.

For our https://cakephp.org it currently looks like this:

<img width="987" alt="image" src="https://user-images.githubusercontent.com/9105243/200124420-ec348189-089a-4e57-9f67-21f7ff6a9085.png">

See https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements
and https://html.spec.whatwg.org/multipage/syntax.html#void-elements

This PR changes at least those specific `void elements` to not contain that unnecessary `/` at the end (if generated by the HtmlHelper).

But what could be up for debate is the `tagselfclosing` template which could be used for basically any other (custom) HTML tags.