### PR TITLE
4.next: remove / from input tag

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -207,7 +207,7 @@ class ConsoleIo
     }
 
     /**
-     * Convenience method for out() that wraps message between <info /> tag
+     * Convenience method for out() that wraps message between <info> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
@@ -225,7 +225,7 @@ class ConsoleIo
     }
 
     /**
-     * Convenience method for out() that wraps message between <comment /> tag
+     * Convenience method for out() that wraps message between <comment> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
@@ -243,7 +243,7 @@ class ConsoleIo
     }
 
     /**
-     * Convenience method for err() that wraps message between <warning /> tag
+     * Convenience method for err() that wraps message between <warning> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
@@ -259,7 +259,7 @@ class ConsoleIo
     }
 
     /**
-     * Convenience method for err() that wraps message between <error /> tag
+     * Convenience method for err() that wraps message between <error> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
@@ -275,7 +275,7 @@ class ConsoleIo
     }
 
     /**
-     * Convenience method for out() that wraps message between <success /> tag
+     * Convenience method for out() that wraps message between <success> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -719,7 +719,7 @@ class Shell
     }
 
     /**
-     * Convenience method for out() that wraps message between <info /> tag
+     * Convenience method for out() that wraps message between <info> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
@@ -733,7 +733,7 @@ class Shell
     }
 
     /**
-     * Convenience method for err() that wraps message between <warning /> tag
+     * Convenience method for err() that wraps message between <warning> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
@@ -746,7 +746,7 @@ class Shell
     }
 
     /**
-     * Convenience method for out() that wraps message between <success /> tag
+     * Convenience method for out() that wraps message between <success> tag
      *
      * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -1157,7 +1157,7 @@ class Debugger
      *
      * - HTML escape the message.
      * - Convert `bool` into `<code>bool</code>`
-     * - Convert newlines into `<br />`
+     * - Convert newlines into `<br>`
      *
      * @param string $message The string message to format.
      * @return string Formatted message.

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1151,7 +1151,7 @@ class Message implements JsonSerializable, Serializable
      * ```
      *
      * The `contentId` key allows you to specify an inline attachment. In your email text, you
-     * can use `<img src="cid:abc123"/>` to display the image inline.
+     * can use `<img src="cid:abc123">` to display the image inline.
      *
      * The `contentDisposition` key allows you to disable the `Content-Disposition` header, this can improve
      * attachment compatibility with outlook email clients.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -113,9 +113,9 @@ class FormHelper extends Helper
             // Wrapper content used to hide other content.
             'hiddenBlock' => '<div style="display:none;">{{content}}</div>',
             // Generic input element.
-            'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}/>',
+            'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
             // Submit input element.
-            'inputSubmit' => '<input type="{{type}}"{{attrs}}/>',
+            'inputSubmit' => '<input type="{{type}}"{{attrs}}>',
             // Container element used by control().
             'inputContainer' => '<div class="input {{type}}{{required}}">{{content}}</div>',
             // Container element used by control() when a field has an error.
@@ -1581,8 +1581,8 @@ class FormHelper extends Helper
 
     /**
      * Missing method handler - implements various simple input types. Is used to create inputs
-     * of various types. e.g. `$this->Form->text();` will create `<input type="text"/>` while
-     * `$this->Form->range();` will create `<input type="range"/>`
+     * of various types. e.g. `$this->Form->text();` will create `<input type="text">` while
+     * `$this->Form->range();` will create `<input type="range">`
      *
      * ### Usage
      *
@@ -1592,7 +1592,7 @@ class FormHelper extends Helper
      *
      * Will make an input like:
      *
-     * `<input type="search" id="UserQuery" name="User[query]" value="test"/>`
+     * `<input type="search" id="UserQuery" name="User[query]" value="test">`
      *
      * The first argument to an input type should always be the fieldname, in `Model.field` format.
      * The second argument should always be an array of attributes for the input.
@@ -1796,7 +1796,7 @@ class FormHelper extends Helper
      * @param array|string|null $url Cake-relative URL or array of URL parameters, or
      *   external URL (starts with http://)
      * @param array<string, mixed> $options Array of HTML attributes.
-     * @return string An `<a />` element.
+     * @return string An `<a>` element.
      * @link https://book.cakephp.org/4/en/views/helpers/form.html#creating-standalone-buttons-and-post-links
      */
     public function postLink(string $title, $url = null, array $options = []): string
@@ -1892,7 +1892,7 @@ class FormHelper extends Helper
     }
 
     /**
-     * Creates a submit button element. This method will generate `<input />` elements that
+     * Creates a submit button element. This method will generate `<input>` elements that
      * can be used to submit, and reset forms by using $options. image submits can be created by supplying an
      * image path for $caption.
      *

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -129,7 +129,7 @@ class HtmlHelper extends Helper
      * @param array|string|null $content The address of the external resource or string for content attribute
      * @param array<string, mixed> $options Other attributes for the generated tag. If the type attribute is html,
      *    rss, atom, or icon, the mime-type is returned.
-     * @return string|null A completed `<link />` element, or null if the element was sent to a block.
+     * @return string|null A completed `<link>` element, or null if the element was sent to a block.
      * @link https://book.cakephp.org/4/en/views/helpers/html.html#creating-meta-tags
      */
     public function meta($type, $content = null, array $options = []): ?string
@@ -247,7 +247,7 @@ class HtmlHelper extends Helper
      * @param array|string|null $url Cake-relative URL or array of URL parameters, or
      *   external URL (starts with http://)
      * @param array<string, mixed> $options Array of options and HTML attributes.
-     * @return string An `<a />` element.
+     * @return string An `<a>` element.
      * @link https://book.cakephp.org/4/en/views/helpers/html.html#creating-links
      */
     public function link($title, $url = null, array $options = []): string
@@ -314,7 +314,7 @@ class HtmlHelper extends Helper
      * @param array $params An array specifying any additional parameters.
      *   Can be also any special parameters supported by `Router::url()`.
      * @param array<string, mixed> $options Array of options and HTML attributes.
-     * @return string An `<a />` element.
+     * @return string An `<a>` element.
      * @see \Cake\Routing\Router::pathUrl()
      * @link https://book.cakephp.org/4/en/views/helpers/html.html#creating-links
      */
@@ -371,7 +371,7 @@ class HtmlHelper extends Helper
      *   CSS stylesheets. If `$path` is prefixed with '/', the path will be relative to the webroot
      *   of your application. Otherwise, the path will be relative to your CSS path, usually webroot/css.
      * @param array<string, mixed> $options Array of options and HTML arguments.
-     * @return string|null CSS `<link />` or `<style />` tag, depending on the type of link.
+     * @return string|null CSS `<link>` or `<style>` tag, depending on the type of link.
      * @link https://book.cakephp.org/4/en/views/helpers/html.html#linking-to-css-files
      */
     public function css($path, array $options = []): ?string
@@ -470,7 +470,7 @@ class HtmlHelper extends Helper
      *
      * @param array<string>|string $url String or array of javascript files to include
      * @param array<string, mixed> $options Array of options, and html attributes see above.
-     * @return string|null String of `<script />` tags or null if block is specified in options
+     * @return string|null String of `<script>` tags or null if block is specified in options
      *   or if $once is true and the file has been included before.
      * @link https://book.cakephp.org/4/en/views/helpers/html.html#linking-to-javascript-files
      */
@@ -969,8 +969,8 @@ class HtmlHelper extends Helper
      *
      * ```
      * <video autoplay="autoplay">
-     *      <source src="/files/video.mp4" type="video/mp4"/>
-     *      <source src="/files/video.ogv" type="video/ogv; codecs='theora, vorbis'"/>
+     *      <source src="/files/video.mp4" type="video/mp4">
+     *      <source src="/files/video.ogv" type="video/ogv; codecs='theora, vorbis'">
      * </video>
      * ```
      *

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -294,11 +294,11 @@ class TextHelper extends Helper
 
     /**
      * Formats paragraphs around given text for all line breaks
-     *  <br /> added for single line return
+     *  <br> added for single line return
      *  <p> added for double line return
      *
      * @param string|null $text Text
-     * @return string The text with proper <p> and <br /> tags
+     * @return string The text with proper <p> and <br> tags
      * @link https://book.cakephp.org/4/en/views/helpers/text.html#converting-text-into-paragraphs
      */
     public function autoParagraph(?string $text): string

--- a/templates/element/auto_table_warning.php
+++ b/templates/element/auto_table_warning.php
@@ -33,11 +33,11 @@ instead of any other specific subclass.
     <li>The Table was used using associations but the association has a typo: <strong><em>$this->belongsTo('Articles')</em></strong></li>
     <li>The table class resides in a Plugin but <strong><em>no plugin notation</em></strong> was used in the association definition.</li>
 </ul>
-<br/>
+<br>
 <p>Please try correcting the issue for the following table aliases:</p>
 <ul>
 <?php foreach ($autoTables as $alias => $table) : ?>
     <li><strong><?= $alias ?></strong></li>
 <?php endforeach; ?>
 </ul>
-<br/>
+<br>


### PR DESCRIPTION
This is a follow up PR for https://github.com/cakephp/cakephp/pull/16849 because I missed the `input` tag from the FormHelper.

This PR also also adjusts all phpdoc text to not contain self-closing tags