### PR TITLE
Fix type checks in DateTimeType

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -308,7 +308,6 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             if ($value instanceof NativeDateTime) {
                 $value = clone $value;
             }
-            assert($value instanceof DateTime || $value instanceof DateTimeImmutable);
 
             return $value->setTimezone($this->defaultTimezone);
         }
@@ -323,7 +322,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             if (is_int($value) || (is_string($value) && ctype_digit($value))) {
                 /** @var \DateTime|\DateTimeImmutable $dateTime */
                 $dateTime = new $class('@' . $value);
-                assert($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable);
+                assert($dateTime instanceof NativeDateTime || $dateTime instanceof DateTimeImmutable);
 
                 return $dateTime->setTimezone($this->defaultTimezone);
             }
@@ -335,7 +334,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
                     $dateTime = $this->_parseValue($value);
                 }
 
-                if ($dateTime instanceof DateTime || $dateTime instanceof DateTimeImmutable) {
+                if ($dateTime instanceof NativeDateTime || $dateTime instanceof DateTimeImmutable) {
                     $dateTime = $dateTime->setTimezone($this->defaultTimezone);
                 }
 

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -19,6 +19,8 @@ namespace Cake\Test\TestCase\Database\Type;
 use Cake\Database\Type\DateTimeType;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 
 /**
@@ -204,6 +206,11 @@ class DateTimeTypeTest extends TestCase
             ['2014-02-14T13:14', new DateTime('2014-02-14T13:14:00')],
             ['2014-02-14T13:14:15', new DateTime('2014-02-14T13:14:15')],
             ['2017-04-05T17:18:00+00:00', new DateTime('2017-04-05T17:18:00+00:00')],
+            ['2017-04-05T17:18:00+00:00', new DateTime('2017-04-05T17:18:00+00:00')],
+
+            [new DateTime('2017-04-05T17:18:00+00:00'), new DateTime('2017-04-05T17:18:00+00:00')],
+            [new NativeDateTime('2017-04-05T17:18:00+00:00'), new DateTime('2017-04-05T17:18:00+00:00')],
+            [new DateTimeImmutable('2017-04-05T17:18:00+00:00'), new DateTime('2017-04-05T17:18:00+00:00')],
 
             // valid array types
             [
@@ -266,10 +273,6 @@ class DateTimeTypeTest extends TestCase
                     'hour' => 'farts', 'minute' => 'farts',
                 ],
                 new DateTime('2014-02-14 00:00:00'),
-            ],
-            [
-                DateTime::now(),
-                DateTime::now(),
             ],
         ];
     }

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -16,10 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
-use Cake\Chronos\ChronosDate;
 use Cake\Database\Type\DateType;
+use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
 use DateTimeImmutable;
 
 /**
@@ -74,8 +75,8 @@ class DateTypeTest extends TestCase
         ];
         $expected = [
             'a' => null,
-            'b' => new ChronosDate('2001-01-04'),
-            'c' => new ChronosDate('2001-01-04'),
+            'b' => new Date('2001-01-04'),
+            'c' => new Date('2001-01-04'),
         ];
         $this->assertEquals(
             $expected,
@@ -108,7 +109,7 @@ class DateTypeTest extends TestCase
      */
     public function marshalProvider(): array
     {
-        $date = new ChronosDate('@1392387900');
+        $date = new Date('@1392387900');
 
         return [
             // invalid types.
@@ -123,7 +124,11 @@ class DateTypeTest extends TestCase
             // valid string types
             ['1392387900', $date],
             [1392387900, $date],
-            ['2014-02-14', new ChronosDate('2014-02-14')],
+            ['2014-02-14', new Date('2014-02-14')],
+
+            [new Date('2014-02-14'), new Date('2014-02-14')],
+            [new NativeDateTime('2014-02-14'), new Date('2014-02-14')],
+            [new DateTimeImmutable('2014-02-14'), new Date('2014-02-14')],
 
             // valid array types
             [
@@ -132,7 +137,7 @@ class DateTypeTest extends TestCase
             ],
             [
                 ['year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 13, 'minute' => 14, 'second' => 15],
-                new ChronosDate('2014-02-14'),
+                new Date('2014-02-14'),
             ],
             [
                 [
@@ -140,7 +145,7 @@ class DateTypeTest extends TestCase
                     'hour' => 1, 'minute' => 14, 'second' => 15,
                     'meridian' => 'am',
                 ],
-                new ChronosDate('2014-02-14'),
+                new Date('2014-02-14'),
             ],
             [
                 [
@@ -148,30 +153,30 @@ class DateTypeTest extends TestCase
                     'hour' => 1, 'minute' => 14, 'second' => 15,
                     'meridian' => 'pm',
                 ],
-                new ChronosDate('2014-02-14'),
+                new Date('2014-02-14'),
             ],
             [
                 [
                     'year' => 2014, 'month' => 2, 'day' => 14,
                 ],
-                new ChronosDate('2014-02-14'),
+                new Date('2014-02-14'),
             ],
 
             // Invalid array types
             [
                 ['year' => 'farts', 'month' => 'derp'],
-                new ChronosDate(date('Y-m-d')),
+                new Date(date('Y-m-d')),
             ],
             [
                 ['year' => 'farts', 'month' => 'derp', 'day' => 'farts'],
-                new ChronosDate(date('Y-m-d')),
+                new Date(date('Y-m-d')),
             ],
             [
                 [
                     'year' => '2014', 'month' => '02', 'day' => '14',
                     'hour' => 'farts', 'minute' => 'farts',
                 ],
-                new ChronosDate('2014-02-14'),
+                new Date('2014-02-14'),
             ],
         ];
     }
@@ -197,7 +202,7 @@ class DateTypeTest extends TestCase
         $this->type->useLocaleParser();
         $this->assertNull($this->type->marshal('11/derp/2013'));
 
-        $expected = new ChronosDate('13-10-2013');
+        $expected = new Date('13-10-2013');
         $result = $this->type->marshal('10/13/2013');
         $this->assertSame($expected->format('Y-m-d'), $result->format('Y-m-d'));
     }
@@ -210,7 +215,7 @@ class DateTypeTest extends TestCase
         $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y');
         $this->assertNull($this->type->marshal('11/derp/2013'));
 
-        $expected = new ChronosDate('13-10-2013');
+        $expected = new Date('13-10-2013');
         $result = $this->type->marshal('13 Oct, 2013');
         $this->assertSame($expected->format('Y-m-d'), $result->format('Y-m-d'));
     }

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Type\TimeType;
 use Cake\I18n\DateTime;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
+use DateTime as NativeDateTime;
 use DateTimeImmutable;
 
 /**
@@ -138,6 +139,10 @@ class TimeTypeTest extends TestCase
             ['13:10:10', new DateTime('13:10:10')],
             ['14:15', new DateTime('14:15:00')],
 
+            [new DateTime('13:10:10'), new DateTime('13:10:10')],
+            [new NativeDateTime('13:10:10'), new DateTime('13:10:10')],
+            [new DateTimeImmutable('13:10:10'), new DateTime('13:10:10')],
+
             // valid array types
             [
                 ['hour' => '', 'minute' => '', 'second' => ''],
@@ -201,7 +206,6 @@ class TimeTypeTest extends TestCase
         $result = $this->type->marshal($value);
         if (is_object($expected)) {
             $this->assertEquals($expected, $result);
-            $this->assertInstanceOf(DateTimeImmutable::class, $result);
         } else {
             $this->assertSame($expected, $result);
         }


### PR DESCRIPTION
These were mixed up during the FrozenTime to DateTime rename. 

Need to fix these before the Chronos update so the change makes sense.