### PR TITLE
5.x: DI delegate

### DIFF
--- a/src/Core/ContainerInterface.php
+++ b/src/Core/ContainerInterface.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use League\Container\DefinitionContainerInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 
 /**
  * Interface for the Dependency Injection Container in CakePHP applications
@@ -29,4 +30,9 @@ use League\Container\DefinitionContainerInterface;
  */
 interface ContainerInterface extends DefinitionContainerInterface
 {
+    /**
+     * @param \Psr\Container\ContainerInterface $container The container instance to use as delegation
+     * @return \Psr\Container\ContainerInterface
+     */
+    public function delegate(PsrContainerInterface $container): PsrContainerInterface;
 }


### PR DESCRIPTION
Currently if someone uses the Auto-Wiring feature documented in our [Cookbook](https://book.cakephp.org/4/en/development/dependency-injection.html#auto-wiring) AND has static analysis like PHPStan or Psalm active in their projects they get the following error:

```
 ------ ----------------------------------------------------------------------- 
  Line   src/Application.php                                                    
 ------ ----------------------------------------------------------------------- 
  205    Call to an undefined method Cake\Core\ContainerInterface::delegate().  
 ------ ----------------------------------------------------------------------- 
```

## Why?

The param type of `services()` inside our [Application.php](https://github.com/cakephp/app/blob/4.x/src/Application.php#L114) is `\Cake\Core\ContainerInterface` which doesn't have any special methods but the default inherited ones from [DefinitionContainerInterface](https://github.com/thephpleague/container/blob/4.x/src/DefinitionContainerInterface.php) (which doesn't contain `delegate()`)

Thats why this PR adds at least the `delegate()` method to our interface so that our documented features can be found by the static analysis gods.