### PR TITLE
Cleanup Router.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -212,16 +212,13 @@ class Router
     public static function setRequest(ServerRequest $request): void
     {
         static::$_request = $request;
+        $uri = $request->getUri();
 
         static::$_requestContext['_base'] = $request->getAttribute('base', '');
         static::$_requestContext['params'] = $request->getAttribute('params', []);
-
-        $uri = $request->getUri();
-        static::$_requestContext += [
-            '_scheme' => $uri->getScheme(),
-            '_host' => $uri->getHost(),
-            '_port' => $uri->getPort(),
-        ];
+        static::$_requestContext['_scheme'] ??= $uri->getScheme();
+        static::$_requestContext['_host'] ??= $uri->getHost();
+        static::$_requestContext['_port'] ??= $uri->getPort();
     }
 
     /**
@@ -383,12 +380,10 @@ class Router
     public static function url(UriInterface|array|string|null $url = null, bool $full = false): string
     {
         $context = static::$_requestContext;
-        $request = static::getRequest();
-
         $context['_base'] ??= '';
 
         if (empty($url)) {
-            $here = $request ? $request->getRequestTarget() : '/';
+            $here = static::getRequest()?->getRequestTarget() ?? '/';
             $output = $context['_base'] . $here;
             if ($full) {
                 $output = static::fullBaseUrl() . $output;
@@ -464,7 +459,7 @@ class Router
         } else {
             $url = (string)$url;
 
-            $plainString = (
+            if (
                 str_starts_with($url, 'javascript:') ||
                 str_starts_with($url, 'mailto:') ||
                 str_starts_with($url, 'tel:') ||
@@ -473,11 +468,10 @@ class Router
                 str_starts_with($url, '?') ||
                 str_starts_with($url, '//') ||
                 str_contains($url, '://')
-            );
-
-            if ($plainString) {
+            ) {
                 return $url;
             }
+
             $output = $context['_base'] . $url;
         }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -213,7 +213,7 @@ class Router
     {
         static::$_request = $request;
 
-        static::$_requestContext['_base'] = $request->getAttribute('base');
+        static::$_requestContext['_base'] = $request->getAttribute('base', '');
         static::$_requestContext['params'] = $request->getAttribute('params', []);
 
         $uri = $request->getUri();
@@ -385,7 +385,7 @@ class Router
         $context = static::$_requestContext;
         $request = static::getRequest();
 
-        $context['_base'] = $context['_base'] ?? Configure::read('App.base') ?: '';
+        $context['_base'] ??= '';
 
         if (empty($url)) {
             $here = $request ? $request->getRequestTarget() : '/';

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -90,6 +90,8 @@ class RouterTest extends TestCase
     {
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
+        Router::setRequest(ServerRequestFactory::fromGlobals());
+
         $this->assertSame('http://example.com/cakephp/tasks', Router::url('/tasks', true));
     }
 
@@ -101,6 +103,8 @@ class RouterTest extends TestCase
     {
         Configure::write('App.base', '/cakephp');
         Router::fullBaseUrl('http://example.com');
+        Router::setRequest(ServerRequestFactory::fromGlobals());
+
         Router::createRouteBuilder('/')
             ->scope('/', function (RouteBuilder $routes): void {
                 $routes->get('/{controller}', ['action' => 'index']);


### PR DESCRIPTION
Value of `App.base` is already accounted for when generating request instance through `ServerRequestFactory::fromGlobals()`, so no need to check for it again in `Router::url()`.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
