### PR TITLE
Ensure loading of deprecated classes.

### DIFF
--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -68,3 +68,10 @@ class Command extends BaseCommand
     {
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Command\Command',
+    'Cake\Console\Command'
+);
+// phpcs:enable

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -4,8 +4,4 @@ declare(strict_types=1);
 /**
  * @deprecated 4.0.0 Use {@link \Cake\Command\Command} instead.
  */
-
-class_alias(
-    'Cake\Command\Command',
-    'Cake\Console\Command'
-);
+class_exists('Cake\Command\Command');

--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Error\ConsoleErrorHandler',
-    'Cake\Console\ConsoleErrorHandler'
-);
+class_exists('Cake\Error\ConsoleErrorHandler');
 deprecationWarning(
     'Use Cake\Error\ConsoleErrorHandler instead of Cake\Console\ConsoleErrorHandler.'
 );

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Datasource\Paging\NumericPaginator',
-    'Cake\Datasource\Paginator'
-);
+class_exists('Cake\Paging\NumericPaginator');
 deprecationWarning(
     'Use Cake\Datasource\Paging\NumericPaginator instead of Cake\Datasource\Paginator.'
 );

--- a/src/Datasource/PaginatorInterface.php
+++ b/src/Datasource/PaginatorInterface.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Datasource\Paging\PaginatorInterface',
-    'Cake\Datasource\PaginatorInterface'
-);
+class_exists('Cake\Datasource\Paging\PaginatorInterface');
 deprecationWarning(
     'Use Cake\Datasource\Paging\PaginatorInterface instead of Cake\Datasource\PaginatorInterface.'
 );

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -680,3 +680,10 @@ class NumericPaginator implements PaginatorInterface
         return $options;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Datasource\Paging\NumericPaginator',
+    'Cake\Datasource\Paginator'
+);
+// phpcs:enable

--- a/src/Datasource/Paging/PaginatorInterface.php
+++ b/src/Datasource/Paging/PaginatorInterface.php
@@ -43,7 +43,8 @@ interface PaginatorInterface
 }
 
 // phpcs:disable
-// The old interface Cake\Datasource\PaginatorInterface will not get loaded during
-// instanceof / type checks so ensure it's loaded here.
-class_exists('Cake\Datasource\PaginatorInterface');
+class_alias(
+    'Cake\Datasource\Paging\PaginatorInterface',
+    'Cake\Datasource\PaginatorInterface'
+);
 // phpcs:enable

--- a/src/Datasource/Paging/SimplePaginator.php
+++ b/src/Datasource/Paging/SimplePaginator.php
@@ -40,3 +40,10 @@ class SimplePaginator extends NumericPaginator
         return null;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Datasource\Paging\SimplePaginator',
+    'Cake\Datasource\SimplePaginator'
+);
+// phpcs:enable

--- a/src/Datasource/SimplePaginator.php
+++ b/src/Datasource/SimplePaginator.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Datasource\Paging\SimplePaginator',
-    'Cake\Datasource\SimplePaginator'
-);
+class_exists('Cake\Datasource\Paging\SimplePaginator');
 deprecationWarning(
     'Use Cake\Datasource\Paging\SimplePaginator instead of Cake\Datasource\SimplePaginator.'
 );

--- a/src/Error/ConsoleErrorHandler.php
+++ b/src/Error/ConsoleErrorHandler.php
@@ -130,3 +130,10 @@ class ConsoleErrorHandler extends BaseErrorHandler
         exit($code);
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Error\ConsoleErrorHandler',
+    'Cake\Console\ConsoleErrorHandler'
+);
+// phpcs:enable

--- a/src/Http/Exception/MissingControllerException.php
+++ b/src/Http/Exception/MissingControllerException.php
@@ -32,3 +32,10 @@ class MissingControllerException extends CakeException
      */
     protected $_messageTemplate = 'Controller class %s could not be found.';
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Http\Exception\MissingControllerException',
+    'Cake\Routing\Exception\MissingControllerException'
+);
+// phpcs:enable

--- a/src/Routing/Exception/MissingControllerException.php
+++ b/src/Routing/Exception/MissingControllerException.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Http\Exception\MissingControllerException',
-    'Cake\Routing\Exception\MissingControllerException'
-);
+class_exists('Cake\Http\Exception\MissingControllerException');
 deprecationWarning(
     'Use Cake\Http\Exception\MissingControllerException instead of Cake\Routing\Exception\MissingControllerException.',
     0


### PR DESCRIPTION
This fixes "Class not found" errors when they are used in type declarations or instanceof checks.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
