### PR TITLE
4.next: redirect status check

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -684,10 +684,14 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     {
         $this->autoRender = false;
 
-        if ($status) {
-            $this->response = $this->response->withStatus($status);
+        if ($status < 300 || $status > 399) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid status code `%s`. It should be within the range ' .
+                    '`300` - `399` for redirect responses.', $status)
+            );
         }
 
+        $this->response = $this->response->withStatus($status);
         $event = $this->dispatchEvent('Controller.beforeRedirect', [$url, $this->response]);
         if ($event->getResult() instanceof Response) {
             return $this->response = $event->getResult();

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -498,7 +498,6 @@ class ControllerTest extends TestCase
             [304, 'Not Modified'],
             [305, 'Use Proxy'],
             [307, 'Temporary Redirect'],
-            [403, 'Forbidden'],
         ];
     }
 
@@ -566,6 +565,14 @@ class ControllerTest extends TestCase
         $result = $Controller->redirect('http://cakephp.org');
         $this->assertSame($newResponse, $result);
         $this->assertSame($newResponse, $Controller->getResponse());
+    }
+
+    public function testRedirectWithInvalidStatusCode(): void
+    {
+        $Controller = new Controller();
+        $uri = new Uri('/foo/bar');
+        $this->expectException(\InvalidArgumentException::class);
+        $Controller->redirect($uri, 200);
     }
 
     /**


### PR DESCRIPTION
As we have seen in the support channel people aren't afraid of putting non 3xx HTTP codes into redirect responses created by `->redirect()` like so:

```
if ($this->request->is('post')) {
    try {
        $this->Contracts->add($this->request->getData());
    } catch (Exception $e) {
        $this->log($e->getMessage(), 'error');

        return $this->redirect(['action' => 'add'], $e->getCode());
    }

    return $this->redirect(['action' => 'index'], 200);
}
```

This PR prevents non 3xx HTTP Codes to be set via `->redirect()`