### PR TITLE
Decoupled connection roles from ConnectionManager

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -524,6 +524,16 @@ abstract class Driver implements DriverInterface
     }
 
     /**
+     * Returns the connection role this driver performs.
+     *
+     * @return string
+     */
+    public function getRole(): string
+    {
+        return $this->_config['_role'] ?? Connection::ROLE_WRITE;
+    }
+
+    /**
      * Destructor
      */
     public function __destruct()
@@ -542,6 +552,7 @@ abstract class Driver implements DriverInterface
     {
         return [
             'connected' => $this->_connection !== null,
+            'role' => $this->getRole(),
         ];
     }
 }

--- a/src/Database/DriverInterface.php
+++ b/src/Database/DriverInterface.php
@@ -28,6 +28,7 @@ use Closure;
  * @method bool supports(string $feature) Checks whether a feature is supported by the driver.
  * @method bool inTransaction() Returns whether a transaction is active.
  * @method array config() Get the configuration data used to create the driver.
+ * @method string getRole() Returns the connection role this driver prforms.
  */
 interface DriverInterface
 {

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -130,6 +130,7 @@ class LoggedQuery implements JsonSerializable
         return [
             'numRows' => $this->numRows,
             'took' => $this->took,
+            'role' => $this->driver ? $this->driver->getRole() : '',
         ];
     }
 

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -50,7 +50,7 @@ class QueryLogger extends BaseLog
 
         if ($context['query'] instanceof LoggedQuery) {
             $context = $context['query']->getContext() + $context;
-            $message = 'connection={connection} duration={took} rows={numRows} ' . $message;
+            $message = 'connection={connection} role={role} duration={took} rows={numRows} ' . $message;
         }
         Log::write('debug', $message, $context);
     }

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Query;
 
+use Cake\Database\Connection;
 use Cake\Database\Query;
 
 /**
@@ -88,5 +89,39 @@ class SelectQuery extends Query
         $this->_deprecatedMethod('set()');
 
         return parent::set($key, $value, $types);
+    }
+
+    /**
+     * Sets the connection role.
+     *
+     * @param string $role Connection role ('read' or 'write')
+     * @return $this
+     */
+    public function setConnectionRole(string $role)
+    {
+        assert($role === Connection::ROLE_READ || $role === Connection::ROLE_WRITE);
+        $this->connectionRole = $role;
+
+        return $this;
+    }
+
+    /**
+     * Sets the connection role to read.
+     *
+     * @return $this
+     */
+    public function useReadRole()
+    {
+        return $this->setConnectionRole(Connection::ROLE_READ);
+    }
+
+    /**
+     * Sets the connection role to write.
+     *
+     * @return $this
+     */
+    public function useWriteRole()
+    {
+        return $this->setConnectionRole(Connection::ROLE_WRITE);
     }
 }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -201,7 +201,7 @@ class QueryCompiler
         $distinct = $query->clause('distinct');
         $modifiers = $this->_buildModifierPart($query->clause('modifier'), $query, $binder);
 
-        $driver = $query->getConnection()->getDriver();
+        $driver = $query->getConnection()->getDriver($query->getConnectionRole());
         $quoteIdentifiers = $driver->isAutoQuotingEnabled() || $this->_quotedSelectAliases;
         $normalized = [];
         $parts = $this->_stringifyExpressions($parts, $binder);

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -86,6 +86,16 @@ class BufferedStatement implements Iterator, StatementInterface
     }
 
     /**
+     * Returns the connection driver.
+     *
+     * @return \Cake\Database\DriverInterface
+     */
+    protected function getDriver(): DriverInterface
+    {
+        return $this->_driver;
+    }
+
+    /**
      * Magic getter to return $queryString as read-only.
      *
      * @param string $property internal property to get

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -73,6 +73,16 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
     }
 
     /**
+     * Returns the connection driver.
+     *
+     * @return \Cake\Database\DriverInterface
+     */
+    protected function getDriver(): DriverInterface
+    {
+        return $this->_driver;
+    }
+
+    /**
      * Magic getter to return $queryString as read-only.
      *
      * @param string $property internal property to get

--- a/src/Database/TypeConverterTrait.php
+++ b/src/Database/TypeConverterTrait.php
@@ -36,8 +36,8 @@ trait TypeConverterTrait
             $type = TypeFactory::build($type);
         }
         if ($type instanceof TypeInterface) {
-            $value = $type->toDatabase($value, $this->_driver);
-            $type = $type->toStatement($value, $this->_driver);
+            $value = $type->toDatabase($value, $this->getDriver());
+            $type = $type->toStatement($value, $this->getDriver());
         }
 
         return [$value, $type];

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -85,19 +85,6 @@ class ConnectionManager
         }
 
         static::_setConfig($key, $config);
-
-        foreach (static::$_config as $name => $config) {
-            if (preg_match('/(.*):read$/', $name, $matches) === 1) {
-                $writeName = $matches[1];
-                if (empty(static::$_config[$writeName])) {
-                    throw new MissingDatasourceConfigException(sprintf(
-                        'Missing write datasource %s for read-only datasource %s',
-                        $writeName,
-                        $name
-                    ));
-                }
-            }
-        }
     }
 
     /**
@@ -206,17 +193,12 @@ class ConnectionManager
      *
      * @param string $name The connection name.
      * @param bool $useAliases Whether connection aliases are used
-     * @param string|null $role Which connection role to get. Defaults to whatever role `$name` resolves to.
      * @return \Cake\Datasource\ConnectionInterface
      * @throws \Cake\Datasource\Exception\MissingDatasourceConfigException When config
      * data is missing.
      */
-    public static function get(string $name, bool $useAliases = true, ?string $role = null)
+    public static function get(string $name, bool $useAliases = true)
     {
-        if ($role) {
-            $roleName = static::getName($role, $name, $useAliases);
-        }
-
         if ($useAliases && isset(static::$_aliasMap[$name])) {
             $name = static::$_aliasMap[$name];
         }
@@ -230,64 +212,5 @@ class ConnectionManager
         }
 
         return static::$_registry->{$name} ?? static::$_registry->load($name, static::$_config[$name]);
-    }
-
-    /**
-     * Gets the connection name (or alias if `$useAliases` is true) for a role.
-     *
-     * @param string $role Connection role - read or write
-     * @param string $name Connection name
-     * @param bool $useAliases Whether connection aliases are used
-     * @return string
-     */
-    public static function getName(string $role, string $name, $useAliases = true): string
-    {
-        assert(in_array($role, [ConnectionInterface::ROLE_READ, ConnectionInterface::ROLE_WRITE], true));
-        if ($role === ConnectionInterface::ROLE_READ) {
-            return static::getReadName($name, $useAliases);
-        }
-
-        return static::getWriteName($name, $useAliases);
-    }
-
-    /**
-     * Gets the read connection name (or alias if `$useAliases` is true).
-     *
-     * @param string $name Connection name
-     * @param bool $useAliases Whether connection aliases are used
-     * @return string
-     */
-    protected static function getReadName(string $name, bool $useAliases): string
-    {
-        $readName = $name;
-        $writeName = $name;
-        if (preg_match('/(.*):read$/', $name, $matches) === 1) {
-            $writeName = $matches[1];
-        } else {
-            $readName = $name . ':read';
-        }
-
-        if (($useAliases && isset(static::$_aliasMap[$readName])) || isset(static::$_config[$readName])) {
-            return $readName;
-        }
-
-        return $writeName;
-    }
-
-    /**
-     * Gets the write connection name (or alias if `$useAliases` is true).
-     *
-     * @param string $name Connection name
-     * @param bool $useAliases Whether connection aliases are used
-     * @return string
-     */
-    protected static function getWriteName(string $name, bool $useAliases): string
-    {
-        $writeName = $name;
-        if (preg_match('/(.*):read$/', $name, $matches) === 1) {
-            $writeName = $matches[1];
-        }
-
-        return $writeName;
     }
 }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -630,7 +630,7 @@ class EagerLoader
             return $statement;
         }
 
-        $driver = $query->getConnection()->getDriver();
+        $driver = $query->getConnection()->getDriver($query->getConnectionRole());
         [$collected, $statement] = $this->_collectKeys($external, $query, $statement);
 
         // No records found, skip trying to attach associations.

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -161,7 +161,7 @@ class ResultSet implements ResultSetInterface
     {
         $repository = $query->getRepository();
         $this->_statement = $statement;
-        $this->_driver = $query->getConnection()->getDriver();
+        $this->_driver = $query->getConnection()->getDriver($query->getConnectionRole());
         $this->_defaultTable = $repository;
         $this->_calculateAssociationMap($query);
         $this->_hydrate = $query->isHydrationEnabled();

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -158,6 +158,7 @@ class LoggedQueryTest extends TestCase
         $expected = [
             'numRows' => 10,
             'took' => 15,
+            'role' => '',
         ];
         $this->assertSame($expected, $query->getContext());
     }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -77,6 +77,6 @@ class QueryLoggerTest extends TestCase
         ]);
         $logger->log(LogLevel::DEBUG, '', compact('query'));
 
-        $this->assertStringContainsString('connection=test duration=', current(Log::engine('queryLoggerTest')->read()));
+        $this->assertStringContainsString('connection=test role= duration=', current(Log::engine('queryLoggerTest')->read()));
     }
 }

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -15,9 +15,7 @@ namespace Cake\Test\TestCase\Datasource;
 
 use BadMethodCallException;
 use Cake\Core\Exception\CakeException;
-use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
-use Cake\Datasource\Exception\MissingDatasourceConfigException;
 use Cake\Datasource\Exception\MissingDatasourceException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
@@ -36,9 +34,7 @@ class ConnectionManagerTest extends TestCase
         parent::tearDown();
         $this->clearPlugins();
         ConnectionManager::drop('test_variant');
-        ConnectionManager::drop('missing_write:read');
         ConnectionManager::dropAlias('other_name');
-        ConnectionManager::dropAlias('test:read');
         ConnectionManager::dropAlias('test2');
     }
 
@@ -209,69 +205,6 @@ class ConnectionManagerTest extends TestCase
         ConnectionManager::alias('test_variant', 'other_name');
         $result = ConnectionManager::get('test_variant');
         $this->assertSame($result, ConnectionManager::get('other_name'));
-    }
-
-    public function testWriteRoleName(): void
-    {
-        $writeRole = ConnectionInterface::ROLE_WRITE;
-        $this->assertSame('test', ConnectionManager::getName($writeRole, 'test'));
-        $this->assertSame('test', ConnectionManager::getName($writeRole, 'test:read'));
-        $this->assertSame('default', ConnectionManager::getName($writeRole, 'default'));
-        $this->assertSame('default', ConnectionManager::getName($writeRole, 'default:read'));
-
-        $this->assertSame('test', ConnectionManager::getName($writeRole, 'test', false));
-        $this->assertSame('test', ConnectionManager::getName($writeRole, 'test:read', false));
-        $this->assertSame('default', ConnectionManager::getName($writeRole, 'default', false));
-        $this->assertSame('default', ConnectionManager::getName($writeRole, 'default:read', false));
-
-        ConnectionManager::alias('test', 'test:read');
-        $this->assertSame('test', ConnectionManager::getName($writeRole, 'test:read'));
-        $this->assertSame('default', ConnectionManager::getName($writeRole, 'default:read'));
-
-        $this->assertSame('test', ConnectionManager::getName($writeRole, 'test:read', false));
-        $this->assertSame('default', ConnectionManager::getName($writeRole, 'default:read', false));
-    }
-
-    public function testReadRoleName(): void
-    {
-        $readRole = ConnectionInterface::ROLE_READ;
-        $this->assertSame('test', ConnectionManager::getName($readRole, 'test'));
-        $this->assertSame('test', ConnectionManager::getName($readRole, 'test:read'));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default'));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default:read'));
-
-        $this->assertSame('test', ConnectionManager::getName($readRole, 'test', false));
-        $this->assertSame('test', ConnectionManager::getName($readRole, 'test:read', false));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default', false));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default:read', false));
-
-        ConnectionManager::alias('test', 'test:read');
-        $this->assertSame('test:read', ConnectionManager::getName($readRole, 'test'));
-        $this->assertSame('test:read', ConnectionManager::getName($readRole, 'test:read'));
-        // The default alias does not know about test:read
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default'));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default:read'));
-
-        $this->assertSame('test', ConnectionManager::getName($readRole, 'test', false));
-        // With no alias, defaults to the physical test connection
-        $this->assertSame('test', ConnectionManager::getName($readRole, 'test:read', false));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default', false));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default:read', false));
-
-        ConnectionManager::alias('test', 'default:read');
-        $this->assertSame('default:read', ConnectionManager::getName($readRole, 'default'));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default', false));
-        $this->assertSame('default:read', ConnectionManager::getName($readRole, 'default:read'));
-        $this->assertSame('default', ConnectionManager::getName($readRole, 'default:read', false));
-    }
-
-    public function testMissingWriteConnection(): void
-    {
-        $this->expectException(MissingDatasourceConfigException::class);
-        ConnectionManager::setConfig('missing_write:read', [
-            'className' => FakeConnection::class,
-            'database' => ':memory:',
-        ]);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Connection;
+use Cake\Database\Driver;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
@@ -206,9 +207,13 @@ class BelongsToManyTest extends TestCase
      */
     public function testJunctionConnection(): void
     {
+        $driver = $this->getMockBuilder(Driver::class)->getMock();
+        $driver->expects($this->once())
+            ->method('enabled')
+            ->will($this->returnValue(true));
+
         $mock = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['createDriver'])
-            ->setConstructorArgs([['name' => 'other_source']])
+            ->setConstructorArgs([['name' => 'other_source', 'driver' => $driver]])
             ->getMock();
         ConnectionManager::setConfig('other_source', $mock);
         $this->article->setConnection(ConnectionManager::get('other_source'));

--- a/tests/test_app/TestApp/Database/Driver/DisabledDriver.php
+++ b/tests/test_app/TestApp/Database/Driver/DisabledDriver.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Database\Driver;
+
+use Cake\Database\Driver\Sqlite;
+
+class DisabledDriver extends Sqlite
+{
+    /**
+     * @inheritDoc
+     */
+    public function enabled(): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
replaces https://github.com/cakephp/cakephp/pull/16785

After implementing the connection name solution for read/write roles, we discovered a couple limitations that would break manually created connections. This implements an original proposal but cleaned up and simplified.

## Config

Users can now specify a `read` and `write` key in their connection config. 

* If set, these values override the shared config in the top-level config and a separate Driver instance is created.
* If the configs are identical, the one driver is created and shared the same as if `read` and `write` didn't exist.
* The `driver` key is not customizable per role so users cannot accidentally create drivers from two different architectures for one connection.
* The `driver` key can still be set to a driver instance and will be used as both read and write role regardless of other config.

## Use

Users can only change the connection role for `SelectQuery` instances. All other queries default to the `write` role and cannot be changed.

You can set it using:

```php
$selectQuery->setConnectionRole(Connection::ROLE_READ)
```

## Implementation

All operations that affect write-only features default to using the write role. This includes getting table schemas, transactions, save points and foreign key flags.

Users must pass the connection role from the query to `Connection::getDriver()` if they're expecting a non-default role.

```php
$query->getConnection()->getDriver($query->getConnectionRole())
```
