### PR TITLE
Fix infinite loop.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -20,6 +20,7 @@ use ArrayObject;
 use BadMethodCallException;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\TypeFactory;
@@ -387,9 +388,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if ($this->_table === null) {
             $table = namespaceSplit(static::class);
-            $table = substr(end($table), 0, -5);
+            $table = substr(end($table), 0, -5) ?: $this->_alias;
             if (!$table) {
-                $table = $this->getAlias();
+                throw new CakeException(
+                    'You must specify either the `alias` or the `table` option for the constructor.'
+                );
             }
             $this->_table = Inflector::underscore($table);
         }
@@ -419,7 +422,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if ($this->_alias === null) {
             $alias = namespaceSplit(static::class);
-            $alias = substr(end($alias), 0, -5) ?: $this->getTable();
+            $alias = substr(end($alias), 0, -5) ?: $this->_table;
+            if (!$alias) {
+                throw new CakeException(
+                    'You must specify either the `alias` or the `table` option for the constructor.'
+                );
+            }
             $this->_alias = $alias;
         }
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM;
 use ArrayObject;
 use BadMethodCallException;
 use Cake\Collection\Collection;
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Expression\QueryExpression;
@@ -267,6 +268,24 @@ class TableTest extends TestCase
 
         $table->setAlias('AnotherOne');
         $this->assertSame('AnotherOne', $table->getAlias());
+    }
+
+    public function testGetAliasException(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('You must specify either the `alias` or the `table` option for the constructor.');
+
+        $table = new Table();
+        $table->getAlias();
+    }
+
+    public function testGetTableException(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('You must specify either the `alias` or the `table` option for the constructor.');
+
+        $table = new Table();
+        $table->getTable();
     }
 
     /**


### PR DESCRIPTION
Throw an exception if both `alias` and `table` are not specified for a `Table` and they can't be inferred from the classname.

Closes #16874.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
