### PR TITLE
4.next: add psalm template annotation

### DIFF
--- a/src/Datasource/ResultSetInterface.php
+++ b/src/Datasource/ResultSetInterface.php
@@ -22,6 +22,8 @@ use Serializable;
 
 /**
  * Describes how a collection of datasource results should look like
+ *
+ * @template T
  */
 interface ResultSetInterface extends CollectionInterface, Countable, Serializable
 {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -55,6 +55,7 @@ class ResultSet implements ResultSetInterface
      * Last record fetched from the statement
      *
      * @var \Cake\Datasource\EntityInterface|array
+     * @psalm-var T
      */
     protected $_current;
 
@@ -186,6 +187,7 @@ class ResultSet implements ResultSetInterface
      * Part of Iterator interface.
      *
      * @return \Cake\Datasource\EntityInterface|array
+     * @psalm-return T
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -280,6 +282,7 @@ class ResultSet implements ResultSetInterface
      * This method will also close the underlying statement cursor.
      *
      * @return \Cake\Datasource\EntityInterface|array|null
+     * @psalm-return T|null
      */
     public function first()
     {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -29,6 +29,9 @@ use SplFixedArray;
  * This object is responsible for correctly nesting result keys reported from
  * the query, casting each field to the correct type and executing the extra
  * queries required for eager loading external associations.
+ *
+ * @template T
+ * @implements \Cake\Datasource\ResultSetInterface<T>
  */
 class ResultSet implements ResultSetInterface
 {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -30,7 +30,7 @@ use SplFixedArray;
  * the query, casting each field to the correct type and executing the extra
  * queries required for eager loading external associations.
  *
- * @template T
+ * @template T of \Cake\Datasource\EntityInterface|array
  * @implements \Cake\Datasource\ResultSetInterface<T>
  */
 class ResultSet implements ResultSetInterface
@@ -54,7 +54,7 @@ class ResultSet implements ResultSetInterface
     /**
      * Last record fetched from the statement
      *
-     * @var object|array
+     * @var \Cake\Datasource\EntityInterface|array
      */
     protected $_current;
 
@@ -185,7 +185,7 @@ class ResultSet implements ResultSetInterface
      *
      * Part of Iterator interface.
      *
-     * @return object|array
+     * @return \Cake\Datasource\EntityInterface|array
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -279,7 +279,7 @@ class ResultSet implements ResultSetInterface
      *
      * This method will also close the underlying statement cursor.
      *
-     * @return object|array|null
+     * @return \Cake\Datasource\EntityInterface|array|null
      */
     public function first()
     {


### PR DESCRIPTION
Relates to https://github.com/dereuromark/cakephp-ide-helper/issues/291

So what does this do?

Currently if someone annotates everything with the IDE Helper plugin from @dereuromark controllers will get a method annotation to tell the editor which kind of return value will be present for the `$this->paginate()` method.

This looks like this:
```
 * @method \Cake\Datasource\ResultSetInterface<\AlfredProjects\Model\Entity\ProjectStatisticEntry> paginate($object = null, array $settings = [])
```

If you then try to check that with psalm it will result in 
```
ERROR: TooManyTemplateParams - plugins/AlfredProjects/src/Controller/ProjectStatisticEntriesController.php:24:36 - Cake\Datasource\ResultSetInterface<AlfredProjects\Model\Entity\ProjectStatisticEntry> has too many template params, expecting 0 (see https://psalm.dev/184)
        $projectStatisticEntries = $this->paginate($this->ProjectStatisticEntries);
```

Why? Because of how psalm treats [Template Annotations](https://psalm.dev/docs/annotating_code/templated_annotations/)

Since we are not specifying in our `ResultSetInterface` that it can have a specific type returned inside our ResultSetInterface its not happy, that the annotation in the controller actually has one.

This happens in other places as well (table class annotations for e.g. `saveMany()`) but lets just focus on the controller paginate one because all others have the same problem related to the ResultSetInterface

This PR fixes that error