### PR TITLE
allow setting sortDefault & directionDefault when order contains mult…

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -363,7 +363,7 @@ class NumericPaginator implements PaginatorInterface
         $order = (array)$data['options']['order'];
         $sortDefault = $directionDefault = false;
 
-        if (!empty($defaults['order']) && count($defaults['order']) === 1) {
+        if (!empty($defaults['order']) && count($defaults['order']) >= 1) {
             $sortDefault = key($defaults['order']);
             $directionDefault = current($defaults['order']);
         }
@@ -582,7 +582,7 @@ class NumericPaginator implements PaginatorInterface
 
         if (
             $options['sort'] === null
-            && count($options['order']) === 1
+            && count($options['order']) >= 1
             && !is_numeric(key($options['order']))
         ) {
             $options['sort'] = key($options['order']);

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -221,15 +221,14 @@ trait PaginatorTestTrait
                 'whitelist' => ['limit', 'sort', 'page', 'direction'],
                 'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
                 'scope' => null,
-                'sort' => null,
+                'sort' => 'PaginatorPosts.id',
             ]);
 
         $this->Paginator->paginate($table, [], $settings);
 
         $pagingParams = $this->Paginator->getPagingParams();
-        $this->assertNull($pagingParams['PaginatorPosts']['direction']);
-        $this->assertFalse($pagingParams['PaginatorPosts']['sortDefault']);
-        $this->assertFalse($pagingParams['PaginatorPosts']['directionDefault']);
+        $this->assertEquals('PaginatorPosts.id', $pagingParams['PaginatorPosts']['sortDefault']);
+        $this->assertEquals('DESC', $pagingParams['PaginatorPosts']['directionDefault']);
     }
 
     /**


### PR DESCRIPTION
…iple key => value pairs

this brings functionality in line to what happens when starting to sort via pagination links

(indication of current sort order via sort links, possibility to have a link without sorting params when using default order)

Fixes #16882 

