### PR TITLE
4.5 Exception Event

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -132,7 +132,7 @@ class ErrorTrap
             if ($event->isStopped()) {
                 return true;
             }
-            $renderer->write($renderer->render($error, $debug));
+            $renderer->write($event->getResult() ?: $renderer->render($error, $debug));
         } catch (Exception $e) {
             // Fatal errors always log.
             $this->logger()->logMessage('error', 'Could not render error. Got: ' . $e->getMessage());

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -236,8 +236,12 @@ class ExceptionTrap
         $this->logException($exception, $request);
 
         try {
-            $renderer = $this->renderer($exception);
-            $renderer->write($renderer->render());
+            $event = $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception, 'request' => $request]);
+            $exception = $event->getData('exception');
+            assert($exception instanceof Throwable);
+
+            $renderer = $this->renderer($exception, $request);
+            $renderer->write($event->getResult() ?? $renderer->render());
         } catch (Throwable $exception) {
             $this->logInternalError($exception);
         }
@@ -363,7 +367,6 @@ class ExceptionTrap
                 $this->logger()->log($exception, $request);
             }
         }
-        $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception]);
     }
 
     /**

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -303,4 +303,19 @@ class ErrorTrapTest extends TestCase
         restore_error_handler();
         $this->assertSame('', $out);
     }
+
+    public function testEventReturnResponse(): void
+    {
+        $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);
+        $trap->register();
+        $trap->getEventManager()->on('Error.beforeRender', function ($event, PhpError $error) {
+            return "This ain't so bad";
+        });
+
+        ob_start();
+        trigger_error('Oh no it was bad', E_USER_NOTICE);
+        $out = ob_get_clean();
+        restore_error_handler();
+        $this->assertSame("This ain't so bad", $out);
+    }
 }

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -23,6 +23,8 @@ use Cake\Error\ExceptionRendererInterface;
 use Cake\Error\ExceptionTrap;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Error\Renderer\WebExceptionRenderer;
+use Cake\Event\EventInterface;
+use Cake\Event\EventManager;
 use Cake\Http\Exception\MissingControllerException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Exception\RedirectException;
@@ -35,7 +37,9 @@ use Error;
 use InvalidArgumentException;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\TestRequestHandler;
+use Throwable;
 
 /**
  * Test for ErrorHandlerMiddleware
@@ -345,6 +349,28 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->assertStringContainsString('Exception Attributes:', $logs[0]);
         $this->assertStringContainsString("'class' => 'Articles'", $logs[0]);
         $this->assertStringContainsString('Request URL:', $logs[0]);
+    }
+
+    public function testExceptionBeforeRenderEvent(): void
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        $middleware = new ErrorHandlerMiddleware(new ExceptionTrap([
+            'exceptionRenderer' => WebExceptionRenderer::class,
+        ]));
+        $handler = new TestRequestHandler(function (): void {
+            throw new NotFoundException('whoops');
+        });
+
+        EventManager::instance()->on(
+            'Exception.beforeRender',
+            function (EventInterface $event, Throwable $e, ServerRequestInterface $req) {
+                return 'Response string from event';
+            }
+        );
+
+        $result = $middleware->process($request, $handler);
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame('Response string from event', (string)$result->getBody());
     }
 
     /**


### PR DESCRIPTION
Allow returning a response from `Error.beforeRender` and `Exception.beforeRender` events. For `Exception.beforeRender` you can also switch the exception.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
