### PR TITLE
4.next: Add DI container to itself

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -306,6 +306,7 @@ abstract class BaseApplication implements
     ): ResponseInterface {
         $container = $this->getContainer();
         $container->add(ServerRequest::class, $request);
+        $container->add(ContainerInterface::class, $container);
 
         if ($this->controllerFactory === null) {
             $this->controllerFactory = new ControllerFactory($container);

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -75,7 +75,9 @@ class BaseApplicationTest extends TestCase
         $result = $app->handle($request);
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertSame('Hello Jane', '' . $result->getBody());
-        $this->assertSame($request, $app->getContainer()->get(ServerRequest::class));
+        $container = $app->getContainer();
+        $this->assertSame($request, $container->get(ServerRequest::class));
+        $this->assertSame($container, $container->get(ContainerInterface::class));
     }
 
     /**


### PR DESCRIPTION
As mentioned in https://github.com/cakephp/queue/pull/109#pullrequestreview-1194927460 this PR adds the DI Container to itself so plugin devs have an easier time leveraging the DI container for e.g. commands.