### PR TITLE
4.5 Register the container as a service

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -268,6 +268,8 @@ abstract class BaseApplication implements
     protected function buildContainer(): ContainerInterface
     {
         $container = new Container();
+        $container->add(ContainerInterface::class, $container);
+
         $this->services($container);
         foreach ($this->plugins->with('services') as $plugin) {
             $plugin->services($container);

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -235,6 +235,7 @@ class BaseApplicationTest extends TestCase
 
         $this->assertInstanceOf(ContainerInterface::class, $container);
         $this->assertSame($container, $app->getContainer(), 'Should return a reference');
+        $this->assertTrue($container->has(ContainerInterface::class), 'Should have the container registered');
     }
 
     public function testBuildContainerEvent(): void


### PR DESCRIPTION
Having the Container available within the container allows plugins and application services to act as factories that use the container to generate implementations. This is useful in plugins like cakephp/queue.
