### PR TITLE
Fix ShadowStrategy failing on missing data

### DIFF
--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -537,7 +537,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
     public function groupTranslations($results): CollectionInterface
     {
         return $results->map(function ($row) {
-            $translations = (array)$row['_i18n'];
+            if (!($row instanceof EntityInterface)) {
+                return $row;
+            }
+            $translations = (array)$row->get('_i18n');
             if (empty($translations) && $row->get('_translations')) {
                 return $row;
             }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -655,6 +655,33 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorTest
     }
 
     /**
+     * A find containing a translated association doesn't error on incomplete data
+     */
+    public function testFindTranslationsAssociatedContain(): void
+    {
+        $comments = $this->fetchTable('Comments');
+        $comments->belongsTo('Articles');
+
+        $articles = $this->fetchTable('Articles');
+
+        // Remove all articles so we have a missing record.
+        $articles->deleteAll('1=1');
+
+        $articles->addBehavior('Translate');
+        $articles->setLocale('eng');
+
+        $query = $comments
+            ->find()
+            ->where(['Comments.id' => 1])
+            ->contain([
+                'Articles' => function ($q) {
+                    return $q->find('translations');
+                }]);
+        $record = $query->firstOrFail();
+        $this->assertNull($record->article);
+    }
+
+    /**
      * testFindTranslations
      *
      * The parent test expects description translations in only some of the records


### PR DESCRIPTION
When loading optional associations with contain() and also loading translations for those associations we should not raise an error when association data is missing. Instead return the null value like EavStrategy does.

Fixes #16914