### PR TITLE
Add runtime deprecations for class aliases

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-/**
- * @deprecated 4.0.0 Use {@link \Cake\Command\Command} instead.
- */
+deprecationWarning(
+    'Since 4.0.0: Cake\Console\Command is deprecated use Cake\Command\Command instead'
+);
 class_exists('Cake\Command\Command');

--- a/src/Console/ConsoleErrorHandler.php
+++ b/src/Console/ConsoleErrorHandler.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_exists('Cake\Error\ConsoleErrorHandler');
 deprecationWarning(
-    'Use Cake\Error\ConsoleErrorHandler instead of Cake\Console\ConsoleErrorHandler.'
+    'Since 4.3.0: Cake\Console\ConsoleErrorHandler is deprecated. ' .
+    'Use Cake\Error\ConsoleErrorHandler instead.'
 );
+class_exists('Cake\Error\ConsoleErrorHandler');

--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -343,3 +343,10 @@ trait ConsoleIntegrationTestTrait
         return $argv;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\ConsoleIntegrationTestTrait',
+    'Cake\TestSuite\ConsoleIntegrationTestTrait'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ContentsBase.php
+++ b/src/Console/TestSuite/Constraint/ContentsBase.php
@@ -46,3 +46,10 @@ abstract class ContentsBase extends Constraint
         $this->output = $output;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ContentsBase',
+    'Cake\TestSuite\Constraint\Console\ContentsBase'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ContentsContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsContain.php
@@ -43,3 +43,10 @@ class ContentsContain extends ContentsBase
         return sprintf('is in %s,' . PHP_EOL . 'actual result:' . PHP_EOL, $this->output) . $this->contents;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ContentsContain',
+    'Cake\TestSuite\Constraint\Console\ContentsContain'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ContentsContainRow.php
+++ b/src/Console/TestSuite/Constraint/ContentsContainRow.php
@@ -59,3 +59,10 @@ class ContentsContainRow extends ContentsRegExp
         return '`' . $this->exporter()->shortenedExport($other) . '` ' . $this->toString();
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ContentsContainRow',
+    'Cake\TestSuite\Constraint\Console\ContentsContainRow'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ContentsEmpty.php
+++ b/src/Console/TestSuite/Constraint/ContentsEmpty.php
@@ -54,3 +54,10 @@ class ContentsEmpty extends ContentsBase
         return $this->toString();
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ContentsEmpty',
+    'Cake\TestSuite\Constraint\Console\ContentsEmpty'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ContentsNotContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsNotContain.php
@@ -43,3 +43,10 @@ class ContentsNotContain extends ContentsBase
         return sprintf('is not in %s', $this->output);
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ContentsNotContain',
+    'Cake\TestSuite\Constraint\Console\ContentsNotContain'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ContentsRegExp.php
+++ b/src/Console/TestSuite/Constraint/ContentsRegExp.php
@@ -52,3 +52,10 @@ class ContentsRegExp extends ContentsBase
         return '`' . $other . '` ' . $this->toString();
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ContentsRegExp',
+    'Cake\TestSuite\Constraint\Console\ContentsRegExp'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/Constraint/ExitCode.php
+++ b/src/Console/TestSuite/Constraint/ExitCode.php
@@ -60,3 +60,10 @@ class ExitCode extends Constraint
         return sprintf('matches exit code %s', $this->exitCode ?? 'null');
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\Constraint\ExitCode',
+    'Cake\TestSuite\Constraint\Console\ExitCode'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/LegacyCommandRunner.php
+++ b/src/Console/TestSuite/LegacyCommandRunner.php
@@ -37,3 +37,10 @@ class LegacyCommandRunner
         return $dispatcher->dispatch();
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\LegacyCommandRunner',
+    'Cake\TestSuite\LegacyCommandRunner'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/LegacyShellDispatcher.php
+++ b/src/Console/TestSuite/LegacyShellDispatcher.php
@@ -62,3 +62,10 @@ class LegacyShellDispatcher extends ShellDispatcher
         return $instance;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\LegacyShellDispatcher',
+    'Cake\TestSuite\LegacyShellDispatcher'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/MissingConsoleInputException.php
+++ b/src/Console/TestSuite/MissingConsoleInputException.php
@@ -35,5 +35,8 @@ class MissingConsoleInputException extends RuntimeException
 }
 
 // phpcs:disable
-class_alias(MissingConsoleInputException::class, 'Cake\TestSuite\Stub\MissingConsoleInputException');
+class_alias(
+    'Cake\Console\TestSuite\MissingConsoleInputException',
+    'Cake\TestSuite\Stub\MissingConsoleInputException'
+);
 // phpcs:enable

--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -86,3 +86,10 @@ class StubConsoleInput extends ConsoleInput
         return true;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\StubConsoleInput',
+    'Cake\TestSuite\Stub\ConsoleInput'
+);
+// phpcs:enable

--- a/src/Console/TestSuite/StubConsoleOutput.php
+++ b/src/Console/TestSuite/StubConsoleOutput.php
@@ -82,3 +82,10 @@ class StubConsoleOutput extends ConsoleOutput
         return implode("\n", $this->_out);
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Console\TestSuite\StubConsoleOutput',
+    'Cake\TestSuite\Stub\ConsoleOutput'
+);
+// phpcs:enable

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -353,3 +353,10 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         ]);
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Controller\ControllerFactory',
+    'Cake\Http\ControllerFactory'
+);
+// phpcs:enable

--- a/src/Core/Exception/CakeException.php
+++ b/src/Core/Exception/CakeException.php
@@ -115,5 +115,8 @@ class CakeException extends RuntimeException
 }
 
 // phpcs:disable
-class_exists('Cake\Core\Exception\Exception');
+class_alias(
+    'Cake\Core\Exception\CakeException',
+    'Cake\Core\Exception\Exception'
+);
 // phpcs:enable

--- a/src/Core/Exception/Exception.php
+++ b/src/Core/Exception/Exception.php
@@ -12,5 +12,8 @@ declare(strict_types=1);
  * @since         4.2.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
-class_alias('Cake\Core\Exception\CakeException', 'Cake\Core\Exception\Exception');
+deprecationWarning(
+    'Since 4.2.0: Cake\Core\Exception\Exception is deprecated.' .
+    'Use Cake\Core\Exception\CakeException instead.'
+);
+class_exists('Cake\Core\Exception\CakeException');

--- a/src/Core/TestSuite/ContainerStubTrait.php
+++ b/src/Core/TestSuite/ContainerStubTrait.php
@@ -172,3 +172,10 @@ trait ContainerStubTrait
         $this->containerServices = [];
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Core\TestSuite\ContainerStubTrait',
+    'Cake\TestSuite\ContainerStubTrait'
+);
+// phpcs:enable

--- a/src/Database/Driver/SqlDialectTrait.php
+++ b/src/Database/Driver/SqlDialectTrait.php
@@ -306,3 +306,10 @@ trait SqlDialectTrait
         return 'ROLLBACK TO SAVEPOINT LEVEL' . $name;
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Database\Driver\SqlDialectTrait',
+    'Cake\Database\SqlDialectTrait'
+);
+// phpcs:enable

--- a/src/Database/Exception.php
+++ b/src/Database/Exception.php
@@ -1,16 +1,8 @@
 <?php
 declare(strict_types=1);
 
-/**
- * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- *
- * Licensed under The MIT License
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @since         4.2.0
- * @license       https://opensource.org/licenses/mit-license.php MIT License
- */
-
-class_alias('Cake\Database\Exception\DatabaseException', 'Cake\Database\Exception');
+deprecationWarning(
+    'Since 4.2.0: Cake\Database\Exception is deprecated. ' .
+    'Use Cake\Database\Exception\DatabaseException instead.'
+);
+class_exists('Cake\Database\Exception\DatabaseException');

--- a/src/Database/Exception/DatabaseException.php
+++ b/src/Database/Exception/DatabaseException.php
@@ -26,5 +26,8 @@ class DatabaseException extends CakeException
 }
 
 // phpcs:disable
-class_exists('Cake\Database\Exception');
+class_alias(
+    'Cake\Database\Exception\DatabaseException',
+    'Cake\Database\Exception'
+);
 // phpcs:enable

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
 
+deprecationWarning('Since 4.1.0: `Comparison` deprecated. Use `ComparisonExpression` instead.');
 class_exists('Cake\Database\Expression\ComparisonExpression');
-
-deprecationWarning('`Comparison` deprecated in 4.1.0, use `ComparisonExpression` instead.');

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -317,7 +317,8 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
 }
 
 // phpcs:disable
-// Comparison will not load during instanceof checks so ensure it's loaded here
-// @deprecated 4.1.0 Add backwards compatible alias.
-class_alias('Cake\Database\Expression\ComparisonExpression', 'Cake\Database\Expression\Comparison');
+class_alias(
+    'Cake\Database\Expression\ComparisonExpression',
+    'Cake\Database\Expression\Comparison'
+);
 // phpcs:enable

--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -1,5 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Load new class location and alias for old location
+deprecationWarning(
+    'Since 4.1.0: Cake\Database\Schema\BaseSchema is deprecated. ' .
+    'Use Cake\Database\Schema\SchemaDialect instead.'
+);
 class_exists('Cake\Database\Schema\SchemaDialect');

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -1,5 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Load new class location and alias for old location
+deprecationWarning(
+    'Since 4.1.0: Cake\Database\Schema\MysqlSchema is deprecated. ' .
+    'Use Cake\Database\Schema\MysqlSchemaDialect instead.'
+);
 class_exists('Cake\Database\Schema\MysqlSchemaDialect');

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -662,6 +662,8 @@ class MysqlSchemaDialect extends SchemaDialect
 }
 
 // phpcs:disable
-// Add backwards compatible alias.
-class_alias('Cake\Database\Schema\MysqlSchemaDialect', 'Cake\Database\Schema\MysqlSchema');
+class_alias(
+    'Cake\Database\Schema\MysqlSchemaDialect',
+    'Cake\Database\Schema\MysqlSchema'
+);
 // phpcs:enable

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -1,5 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Load new class location and alias for old location
+deprecationWarning(
+    'Since 4.1.0: Cake\Database\Schema\PostgresSchema is deprecated. ' .
+    'Use Cake\Database\Schema\PostgresSchemaDialect instead.'
+);
 class_exists('Cake\Database\Schema\PostgresSchemaDialect');

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -693,6 +693,8 @@ class PostgresSchemaDialect extends SchemaDialect
 }
 
 // phpcs:disable
-// Add backwards compatible alias.
-class_alias('Cake\Database\Schema\PostgresSchemaDialect', 'Cake\Database\Schema\PostgresSchema');
+class_alias(
+    'Cake\Database\Schema\PostgresSchemaDialect',
+    'Cake\Database\Schema\PostgresSchema'
+);
 // phpcs:enable

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -339,6 +339,8 @@ abstract class SchemaDialect
 }
 
 // phpcs:disable
-// Add backwards compatible alias.
-class_alias('Cake\Database\Schema\SchemaDialect', 'Cake\Database\Schema\BaseSchema');
+class_alias(
+    'Cake\Database\Schema\SchemaDialect',
+    'Cake\Database\Schema\BaseSchema'
+);
 // phpcs:enable

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -1,5 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Load new class location and alias for old location
+deprecationWarning(
+    'Since 4.1.0: Cake\Database\Schema\SqliteSchema is deprecated. ' .
+    'Use Cake\Database\Schema\SqliteSchemaDialect instead.'
+);
 class_exists('Cake\Database\Schema\SqliteSchemaDialect');

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -642,6 +642,8 @@ class SqliteSchemaDialect extends SchemaDialect
 }
 
 // phpcs:disable
-// Add backwards compatible alias.
-class_alias('Cake\Database\Schema\SqliteSchemaDialect', 'Cake\Database\Schema\SqliteSchema');
+class_alias(
+    'Cake\Database\Schema\SqliteSchemaDialect',
+    'Cake\Database\Schema\SqliteSchema'
+);
 // phpcs:enable

--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -1,5 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Load new class location and alias for old location
+deprecationWarning(
+    'Since 4.1.0: Cake\Database\Schema\SqlserverSchema is deprecated. ' .
+    'Use Cake\Database\Schema\SqlServerSchemaDialect instead.'
+);
 class_exists('Cake\Database\Schema\SqlServerSchemaDialect');

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -700,6 +700,8 @@ class SqlserverSchemaDialect extends SchemaDialect
 }
 
 // phpcs:disable
-// Add backwards compatible alias.
-class_alias('Cake\Database\Schema\SqlserverSchemaDialect', 'Cake\Database\Schema\SqlserverSchema');
+class_alias(
+    'Cake\Database\Schema\SqlserverSchemaDialect', 
+    'Cake\Database\Schema\SqlserverSchema'
+);
 // phpcs:enable

--- a/src/Database/SqlDialectTrait.php
+++ b/src/Database/SqlDialectTrait.php
@@ -1,5 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated 4.1.0 Add backwards compatible alias.
-class_alias('Cake\Database\Driver\SqlDialectTrait', 'Cake\Database\SqlDialectTrait');
+deprecationWarning(
+    'Since 4.1.0: Cake\Database\SqlDialectTrait is deprecated. ' .
+    'Use Cake\Database\Driver\SqlDialectTrait instead.'
+);
+class_exists('Cake\Database\Driver\SqlDialectTrait');

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -1,5 +1,7 @@
 <?php
 declare(strict_types=1);
 
-// @deprecated Backwards compatibility alias. Will be removed in 5.0
-class_alias('Cake\Database\TypeFactory', 'Cake\Database\Type');
+deprecationWarning(
+    'Since 4.0.0: Cake\Database\Type is deprecated. Use Cake\Database\TypeFactory instead.'
+);
+class_exists('Cake\Database\TypeFactory');

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -162,3 +162,10 @@ class TypeFactory
         static::$_builtTypes = [];
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Database\TypeFactory',
+    'Cake\Database\Type'
+);
+// phpcs:enable

--- a/src/Datasource/Exception/PageOutOfBoundsException.php
+++ b/src/Datasource/Exception/PageOutOfBoundsException.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Datasource\Paging\Exception\PageOutOfBoundsException',
-    'Cake\Datasource\Exception\PageOutOfBoundsException'
+deprecationWarning(
+    'Since 4.2.0: Cake\Datasource\Exception\PageOutOfBoundsException is deprecated. ' .
+    'Use Cake\Datasource\Paging\Exception\PageOutOfBoundsException instead.'
 );
+class_exists('Cake\Datasource\Paging\Exception\PageOutOfBoundsException');

--- a/src/Datasource/Paginator.php
+++ b/src/Datasource/Paginator.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_exists('Cake\Datasource\Paging\NumericPaginator');
 deprecationWarning(
-    'Use Cake\Datasource\Paging\NumericPaginator instead of Cake\Datasource\Paginator.'
+    'Since 4.2.0: Cake\Datasource\Paginator is deprecated.' .
+    'Use Cake\Datasource\Paging\NumericPaginator instead.'
 );
+class_exists('Cake\Datasource\Paging\NumericPaginator');

--- a/src/Datasource/PaginatorInterface.php
+++ b/src/Datasource/PaginatorInterface.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_exists('Cake\Datasource\Paging\PaginatorInterface');
 deprecationWarning(
-    'Use Cake\Datasource\Paging\PaginatorInterface instead of Cake\Datasource\PaginatorInterface.'
+    'Since 4.2.0:  Cake\Datasource\PaginatorInterface is deprecated. ' .
+    'Use Cake\Datasource\Paging\PaginatorInterface instead.'
 );
+class_exists('Cake\Datasource\Paging\PaginatorInterface');

--- a/src/Datasource/Paging/Exception/PageOutOfBoundsException.php
+++ b/src/Datasource/Paging/Exception/PageOutOfBoundsException.php
@@ -28,5 +28,8 @@ class PageOutOfBoundsException extends CakeException
 }
 
 // phpcs:disable
-class_exists('Cake\Datasource\Exception\PageOutOfBoundsException');
+class_alias(
+    'Cake\Datasource\Paging\Exception\PageOutOfBoundsException',
+    'Cake\Datasource\Exception\PageOutOfBoundsException'
+);
 // phpcs:enable

--- a/src/Datasource/SimplePaginator.php
+++ b/src/Datasource/SimplePaginator.php
@@ -1,7 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_exists('Cake\Datasource\Paging\SimplePaginator');
 deprecationWarning(
-    'Use Cake\Datasource\Paging\SimplePaginator instead of Cake\Datasource\SimplePaginator.'
+    'Since 4.2.0: Cake\Datasource\SimplePaginator is deprecated. ' .
+    'Use Cake\Datasource\Paging\SimplePaginator instead.'
 );
+class_exists('Cake\Datasource\Paging\SimplePaginator');

--- a/src/Http/ControllerFactory.php
+++ b/src/Http/ControllerFactory.php
@@ -1,10 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_alias(
-    'Cake\Controller\ControllerFactory',
-    'Cake\Http\ControllerFactory'
-);
 deprecationWarning(
-    'Use Cake\Controller\ControllerFactory instead of Cake\Http\ControllerFactory.'
+    'Since 4.2.0: Cake\Http\ControllerFactory is deprecated. ' .
+    'Use Cake\Controller\ControllerFactory instead.'
 );
+class_exists('Cake\Controller\ControllerFactory');

--- a/src/Http/TestSuite/HttpClientTrait.php
+++ b/src/Http/TestSuite/HttpClientTrait.php
@@ -115,3 +115,10 @@ trait HttpClientTrait
         Client::addMockResponse('DELETE', $url, $response, $options);
     }
 }
+
+// phpcs:disable
+class_alias(
+    'Cake\Http\TestSuite\HttpClientTrait', 
+    'Cake\TestSuite\HttpClientTrait'
+);
+// phpcs:enable

--- a/src/Routing/Exception/MissingControllerException.php
+++ b/src/Routing/Exception/MissingControllerException.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
 
-class_exists('Cake\Http\Exception\MissingControllerException');
 deprecationWarning(
-    'Use Cake\Http\Exception\MissingControllerException instead of Cake\Routing\Exception\MissingControllerException.',
-    0
+    'Since 4.2.0:  Cake\Routing\Exception\MissingControllerException is deprecated.' .
+    'Use Cake\Http\Exception\MissingControllerException instead.'
 );
+class_exists('Cake\Http\Exception\MissingControllerException');

--- a/src/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/TestSuite/ConsoleIntegrationTestTrait.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
-
-class_alias(ConsoleIntegrationTestTrait::class, 'Cake\TestSuite\ConsoleIntegrationTestTrait');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\ConsoleIntegrationTestTrait is deprecated. ' .
+    'Use Cake\Console\TestSuite\ConsoleIntegrationTestTrait instead.'
+);
+class_exists('Cake\Console\TestSuite\ConsoleIntegrationTestTrait');

--- a/src/TestSuite/Constraint/Console/ContentsBase.php
+++ b/src/TestSuite/Constraint/Console/ContentsBase.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ContentsBase;
-
-class_alias(ContentsBase::class, 'Cake\TestSuite\Constraint\Console\ContentsBase');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Console\ContentsBase is deprecated. ' .
+    'Use Cake\Console\TestSuite\Constraint\ContentsBase instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ContentsBase');

--- a/src/TestSuite/Constraint/Console/ContentsContain.php
+++ b/src/TestSuite/Constraint/Console/ContentsContain.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ContentsContain;
-
-class_alias(ContentsContain::class, 'Cake\TestSuite\Constraint\Console\ContentsContain');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Console\ContentsContain is deprecated. ' .
+    'Use Cake\Console\TestSuite\Constraint\Console\ContentsContain instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ContentsContain');

--- a/src/TestSuite/Constraint/Console/ContentsContainRow.php
+++ b/src/TestSuite/Constraint/Console/ContentsContainRow.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ContentsContainRow;
-
-class_alias(ContentsContainRow::class, 'Cake\TestSuite\Constraint\Console\ContentsContainRow');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Constraint\Console\ContentsContainRow is deprecated.' .
+    'Use Cake\Console\TestSuite\Constraint\ContentsContainRow instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ContentsContainRow');

--- a/src/TestSuite/Constraint/Console/ContentsEmpty.php
+++ b/src/TestSuite/Constraint/Console/ContentsEmpty.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ContentsEmpty;
-
-class_alias(ContentsEmpty::class, 'Cake\TestSuite\Constraint\Console\ContentsEmpty');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Console\ContentsEmpty is deprecated. ' .
+    'Use Cake\Console\TestSuite\Constraint\ContentsEmpty instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ContentsEmpty');

--- a/src/TestSuite/Constraint/Console/ContentsNotContain.php
+++ b/src/TestSuite/Constraint/Console/ContentsNotContain.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ContentsNotContain;
-
-class_alias(ContentsNotContain::class, 'Cake\TestSuite\Constraint\Console\ContentsNotContain');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Console\ContentsNotContain is deprecated. ' .
+    'Use Cake\Console\TestSuite\Constraint\ContentsNotContain instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ContentsNotContain');

--- a/src/TestSuite/Constraint/Console/ContentsRegExp.php
+++ b/src/TestSuite/Constraint/Console/ContentsRegExp.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ContentsRegExp;
-
-class_alias(ContentsRegExp::class, 'Cake\TestSuite\Constraint\Console\ContentsRegExp');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Console\ContentsRegExp is deprecated. ' .
+    'Use Cake\Console\TestSuite\Constraint\ContentsRegExp instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ContentsRegExp');

--- a/src/TestSuite/Constraint/Console/ExitCode.php
+++ b/src/TestSuite/Constraint/Console/ExitCode.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\Constraint\ExitCode;
-
-class_alias(ExitCode::class, 'Cake\TestSuite\Constraint\Console\ExitCode');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Constraint\Console\ExitCode is deprecated. ' .
+    'Use Cake\Console\TestSuite\Constraint\ExitCode instead.'
+);
+class_exists('Cake\Console\TestSuite\Constraint\ExitCode');

--- a/src/TestSuite/ContainerStubTrait.php
+++ b/src/TestSuite/ContainerStubTrait.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Core\TestSuite\ContainerStubTrait;
-
-class_alias(ContainerStubTrait::class, 'Cake\TestSuite\ContainerStubTrait');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\ContainerStubTrait is deprecated. ' .
+    'Use Cake\Core\TestSuite\ContainerStubTrait instead.'
+);
+class_exists('Cake\Core\TestSuite\ContainerStubTrait');

--- a/src/TestSuite/HttpClientTrait.php
+++ b/src/TestSuite/HttpClientTrait.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Http\TestSuite\HttpClientTrait;
-
-class_alias(HttpClientTrait::class, 'Cake\TestSuite\HttpClientTrait');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\HttpClientTrait is deprecated. ' .
+    'Use Cake\Http\TestSuite\HttpClientTrait instead.'
+);
+class_exists('Cake\Http\TestSuite\HttpClientTrait');

--- a/src/TestSuite/LegacyCommandRunner.php
+++ b/src/TestSuite/LegacyCommandRunner.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\LegacyCommandRunner;
-
-class_alias(LegacyCommandRunner::class, 'Cake\TestSuite\LegacyCommandRunner');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\LegacyCommandRunner is deprecated. ' .
+    'Use Cake\Console\TestSuite\LegacyCommandRunner instead.'
+);
+class_exists('Cake\Console\TestSuite\LegacyCommandRunner');

--- a/src/TestSuite/LegacyShellDispatcher.php
+++ b/src/TestSuite/LegacyShellDispatcher.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\LegacyShellDispatcher;
-
-class_alias(LegacyShellDispatcher::class, 'Cake\TestSuite\LegacyShellDispatcher');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\LegacyShellDispatcher is deprecated. ' .
+    'Use Cake\Console\TestSuite\LegacyShellDispatcher.'
+);
+class_exists('Cake\Console\TestSuite\LegacyShellDispatcher');

--- a/src/TestSuite/Stub/ConsoleInput.php
+++ b/src/TestSuite/Stub/ConsoleInput.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\StubConsoleInput;
-
-class_alias(StubConsoleInput::class, 'Cake\TestSuite\Stub\ConsoleInput');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Stub\ConsoleInput is deprecated. ' .
+    'Use Cake\Console\TestSuite\StubConsoleInput.'
+);
+class_exists('Cake\Console\TestSuite\StubConsoleInput');

--- a/src/TestSuite/Stub/ConsoleOutput.php
+++ b/src/TestSuite/Stub/ConsoleOutput.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\StubConsoleOutput;
-
-class_alias(StubConsoleOutput::class, 'Cake\TestSuite\Stub\ConsoleOutput');
+deprecationWarning(
+    'Since 4.3.0: Cake\TestSuite\Stub\ConsoleOutput is deprecated. ' .
+    'Use Cake\Console\TestSuite\StubConsoleOutput instead.'
+);
+class_exists('Cake\Console\TestSuite\StubConsoleOutput');

--- a/src/TestSuite/Stub/MissingConsoleInputException.php
+++ b/src/TestSuite/Stub/MissingConsoleInputException.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Console\TestSuite\MissingConsoleInputException;
-
-class_exists(MissingConsoleInputException::class);
+deprecationWarning(
+    'Since 4.2.0: Cake\TestSuite\Stub\MissingConsoleInputException is deprecated. ' .
+    'Use Cake\Console\TestSuite\MissingConsoleInputException instead.'
+);
+class_exists('Cake\Console\TestSuite\MissingConsoleInputException');

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -142,7 +142,7 @@ class ExceptionsTest extends TestCase
             ['Cake\Controller\Exception\SecurityException', 400],
             ['Cake\Core\Exception\CakeException', 0],
             ['Cake\Core\Exception\MissingPluginException', 0],
-            ['Cake\Database\Exception', 0],
+            ['Cake\Database\Exception\DatabaseException', 0],
             ['Cake\Database\Exception\MissingConnectionException', 0],
             ['Cake\Database\Exception\MissingDriverException', 0],
             ['Cake\Database\Exception\MissingExtensionException', 0],


### PR DESCRIPTION
We added many class rename deprecations during 4.x but didn't include runtime deprecations for them. Adding runtime deprecations in 4.5 will encourage developers to update their code before the breaking change in 5.0

Refs cakephp/docs#7561