### PR TITLE
remove default association config from tests

### DIFF
--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1543,7 +1543,7 @@ class BelongsToManyTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'through' => 'ArticlesTags',
         ]);
         $table->Tags->junction()->deleteAll('1=1');
@@ -1561,7 +1561,7 @@ class BelongsToManyTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
@@ -1579,7 +1579,7 @@ class BelongsToManyTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'conditions' => [
                 'OR' => [
                     'SpecialTags.highlighted' => true,
@@ -1601,7 +1601,7 @@ class BelongsToManyTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
@@ -1621,7 +1621,7 @@ class BelongsToManyTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'conditions' => [new QueryExpression("name LIKE 'tag%'")],
             'through' => 'SpecialTags',
         ]);
@@ -1641,7 +1641,7 @@ class BelongsToManyTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -519,7 +519,6 @@ class BelongsToManyTest extends TestCase
         $config = [
             'sourceTable' => $articles,
             'targetTable' => $tags,
-            'joinTable' => 'articles_tags',
             'saveStrategy' => BelongsToMany::SAVE_APPEND,
         ];
         $assoc = $articles->belongsToMany('Tags', $config);
@@ -554,7 +553,6 @@ class BelongsToManyTest extends TestCase
         $config = [
             'sourceTable' => $articles,
             'targetTable' => $tags,
-            'joinTable' => 'articles_tags',
             'saveStrategy' => BelongsToMany::SAVE_APPEND,
         ];
         $assoc = $articles->belongsToMany('Tags', $config);
@@ -824,7 +822,6 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $articles,
             'targetTable' => $tags,
             'through' => $joint,
-            'joinTable' => 'articles_tags',
         ]);
         $entity = $articles->get(1, ['contain' => 'Tags']);
 
@@ -929,7 +926,6 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $articles,
             'targetTable' => $tags,
             'through' => $joint,
-            'joinTable' => 'articles_tags',
         ]);
         $joint->setEntityClass(ArticlesTag::class);
 
@@ -960,7 +956,6 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $tags,
             'targetTable' => $articles,
             'through' => $joint,
-            'joinTable' => 'articles_tags',
             'finder' => ['published' => ['title' => 'First Article']],
         ]);
         $entity = $tags->get(1, ['contain' => 'Articles']);
@@ -992,7 +987,6 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $tags,
             'targetTable' => $articles,
             'through' => $joint,
-            'joinTable' => 'articles_tags',
             'finder' => 'withAuthors',
         ]);
         $tag = $tags->get(1);
@@ -1021,7 +1015,6 @@ class BelongsToManyTest extends TestCase
             'sourceTable' => $articles,
             'targetTable' => $tags,
             'through' => $this->getTableLocator()->get('ArticlesTags'),
-            'joinTable' => 'articles_tags',
         ]);
         $entity = $articles->get(1, ['contain' => 'Tags']);
         $originalCount = count($entity->tags);
@@ -1541,11 +1534,7 @@ class BelongsToManyTest extends TestCase
     public function testAssociationProxyFindNoJoinRecords(): void
     {
         $table = $this->getTableLocator()->get('Articles');
-        $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
-            'through' => 'ArticlesTags',
-        ]);
+        $table->belongsToMany('Tags');
         $table->Tags->junction()->deleteAll('1=1');
 
         $query = $table->Tags->find();
@@ -1560,8 +1549,6 @@ class BelongsToManyTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
@@ -1578,8 +1565,6 @@ class BelongsToManyTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
             'conditions' => [
                 'OR' => [
                     'SpecialTags.highlighted' => true,
@@ -1600,8 +1585,6 @@ class BelongsToManyTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
@@ -1620,8 +1603,6 @@ class BelongsToManyTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
             'conditions' => [new QueryExpression("name LIKE 'tag%'")],
             'through' => 'SpecialTags',
         ]);
@@ -1640,8 +1621,6 @@ class BelongsToManyTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
             'conditions' => ['SpecialTags.highlighted' => true],
             'through' => 'SpecialTags',
         ]);
@@ -1730,7 +1709,6 @@ class BelongsToManyTest extends TestCase
         $table->belongsToMany('Articles', [
             'through' => 'ArticlesTagsBindingKeys',
             'foreignKey' => 'tagname',
-            'targetForeignKey' => 'article_id',
             'bindingKey' => 'name',
         ]);
         $query = $table->find()

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -347,7 +347,6 @@ class BelongsToTest extends TestCase
     public function testAttachToBeforeFind(): void
     {
         $config = [
-            'foreignKey' => 'company_id',
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
         ];
@@ -370,7 +369,6 @@ class BelongsToTest extends TestCase
     public function testAttachToBeforeFindExtraOptions(): void
     {
         $config = [
-            'foreignKey' => 'company_id',
             'sourceTable' => $this->client,
             'targetTable' => $this->company,
         ];

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -92,7 +92,6 @@ class HasOneTest extends TestCase
     public function testAttachTo(): void
     {
         $config = [
-            'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
             'property' => 'profile',
@@ -256,7 +255,6 @@ class HasOneTest extends TestCase
     public function testAttachToBeforeFind(): void
     {
         $config = [
-            'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
         ];
@@ -282,7 +280,6 @@ class HasOneTest extends TestCase
     public function testAttachToBeforeFindExtraOptions(): void
     {
         $config = [
-            'foreignKey' => 'user_id',
             'sourceTable' => $this->user,
             'targetTable' => $this->profile,
         ];

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1189,9 +1189,7 @@ class QueryRegressionTest extends TestCase
     public function testComplexTypesInJoinedWhere(): void
     {
         $table = $this->getTableLocator()->get('Users');
-        $table->hasOne('Comments', [
-            'foreignKey' => 'user_id',
-        ]);
+        $table->hasOne('Comments');
         $query = $table->find()
             ->contain('Comments')
             ->where([
@@ -1209,9 +1207,7 @@ class QueryRegressionTest extends TestCase
     public function testComplexNestedTypesInJoinedWhere(): void
     {
         $table = $this->getTableLocator()->get('Users');
-        $table->hasOne('Comments', [
-            'foreignKey' => 'user_id',
-        ]);
+        $table->hasOne('Comments');
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
@@ -1234,9 +1230,7 @@ class QueryRegressionTest extends TestCase
     public function testComplexTypesInJoinedWhereWithMatching(): void
     {
         $table = $this->getTableLocator()->get('Users');
-        $table->hasOne('Comments', [
-            'foreignKey' => 'user_id',
-        ]);
+        $table->hasOne('Comments');
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
@@ -1291,9 +1285,7 @@ class QueryRegressionTest extends TestCase
     public function testComplexTypesInJoinedWhereWithInnerJoinWith(): void
     {
         $table = $this->getTableLocator()->get('Users');
-        $table->hasOne('Comments', [
-            'foreignKey' => 'user_id',
-        ]);
+        $table->hasOne('Comments');
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
@@ -1326,9 +1318,7 @@ class QueryRegressionTest extends TestCase
     public function testComplexTypesInJoinedWhereWithLeftJoinWith(): void
     {
         $table = $this->getTableLocator()->get('Users');
-        $table->hasOne('Comments', [
-            'foreignKey' => 'user_id',
-        ]);
+        $table->hasOne('Comments');
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1215,7 +1215,6 @@ class QueryRegressionTest extends TestCase
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
-            'foreignKey' => 'author_id',
         ]);
 
         $query = $table->find()
@@ -1241,7 +1240,6 @@ class QueryRegressionTest extends TestCase
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
-            'foreignKey' => 'author_id',
         ]);
 
         $query = $table->find()

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -82,9 +82,7 @@ class QueryRegressionTest extends TestCase
     public function testEagerLoadingAliasedAssociationFields(): void
     {
         $table = $this->getTableLocator()->get('Articles');
-        $table->belongsTo('Authors', [
-            'foreignKey' => 'author_id',
-        ]);
+        $table->belongsTo('Authors');
         $result = $table->find()
             ->contain(['Authors' => [
                 'fields' => [
@@ -157,17 +155,9 @@ class QueryRegressionTest extends TestCase
     public function testEagerLoadingNestedMatchingCalls(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
-            'joinTable' => 'articles_tags',
-        ]);
+        $articles->belongsToMany('Tags');
         $tags = $this->getTableLocator()->get('Tags');
-        $tags->belongsToMany('Authors', [
-            'foreignKey' => 'tag_id',
-            'targetForeignKey' => 'author_id',
-            'joinTable' => 'authors_tags',
-        ]);
+        $tags->belongsToMany('Authors');
 
         $query = $articles->find()
             ->matching('Tags', function ($q) {
@@ -242,7 +232,6 @@ class QueryRegressionTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Highlights', [
             'className' => 'TestApp\Model\Table\TagsTable',
-            'foreignKey' => 'article_id',
             'targetForeignKey' => 'tag_id',
             'through' => 'SpecialTags',
         ]);
@@ -330,7 +319,6 @@ class QueryRegressionTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Highlights', [
             'className' => 'TestApp\Model\Table\TagsTable',
-            'foreignKey' => 'article_id',
             'targetForeignKey' => 'tag_id',
             'through' => 'SpecialTags',
             'saveStrategy' => $strategy,
@@ -422,7 +410,6 @@ class QueryRegressionTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $articles->belongsToMany('Highlights', [
             'className' => 'TestApp\Model\Table\TagsTable',
-            'foreignKey' => 'article_id',
             'targetForeignKey' => 'tag_id',
             'through' => 'SpecialTags',
         ]);
@@ -1182,8 +1169,6 @@ class QueryRegressionTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
-            'foreignKey' => 'article_id',
-            'targetForeignKey' => 'tag_id',
             'through' => 'SpecialTags',
         ]);
         $query = $table->find()
@@ -1314,7 +1299,6 @@ class QueryRegressionTest extends TestCase
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
-            'foreignKey' => 'author_id',
         ]);
 
         $query = $table->find()
@@ -1350,7 +1334,6 @@ class QueryRegressionTest extends TestCase
         $table->Comments->belongsTo('Articles');
         $table->Comments->Articles->belongsTo('Authors', [
             'className' => 'Users',
-            'foreignKey' => 'author_id',
         ]);
 
         $query = $table->find()

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -1183,7 +1183,7 @@ class QueryRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsToMany('Tags', [
             'foreignKey' => 'article_id',
-            'associationForeignKey' => 'tag_id',
+            'targetForeignKey' => 'tag_id',
             'through' => 'SpecialTags',
         ]);
         $query = $table->find()

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1238,7 +1238,6 @@ class QueryTest extends TestCase
         $table = $this->getTableLocator()->get('authors');
         $this->getTableLocator()->get('articles');
         $table->hasMany('articles', [
-            'propertyName' => 'articles',
             'sort' => ['articles.id' => 'asc'],
         ]);
         $query = new Query($this->connection, $table);
@@ -1415,7 +1414,6 @@ class QueryTest extends TestCase
         $table = $this->getTableLocator()->get('authors');
         $article = $this->getTableLocator()->get('articles');
         $table->hasMany('articles', [
-            'propertyName' => 'articles',
             'sort' => ['articles.id' => 'asc'],
         ]);
         $article->belongsTo('authors', ['strategy' => $strategy]);
@@ -1474,7 +1472,6 @@ class QueryTest extends TestCase
             'entityClass' => '\\' . $articleEntity,
         ]);
         $table->hasMany('articles', [
-            'propertyName' => 'articles',
             'sort' => ['articles.id' => 'asc'],
         ]);
         $query = new Query($this->connection, $table);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -708,9 +708,8 @@ class TableTest extends TestCase
      */
     public function testHasOne(): void
     {
-        $options = ['foreignKey' => 'user_id', 'conditions' => ['b' => 'c']];
         $table = new Table(['table' => 'users']);
-        $hasOne = $table->hasOne('profile', $options);
+        $hasOne = $table->hasOne('profile', ['conditions' => ['b' => 'c']]);
         $this->assertInstanceOf(HasOne::class, $hasOne);
         $this->assertSame($hasOne, $table->getAssociation('profile'));
         $this->assertSame('profile', $hasOne->getName());
@@ -724,10 +723,9 @@ class TableTest extends TestCase
      */
     public function testHasOnePlugin(): void
     {
-        $options = ['className' => 'TestPlugin.Comments'];
         $table = new Table(['table' => 'users']);
 
-        $hasOne = $table->hasOne('Comments', $options);
+        $hasOne = $table->hasOne('Comments', ['className' => 'TestPlugin.Comments']);
         $this->assertInstanceOf(HasOne::class, $hasOne);
         $this->assertSame('Comments', $hasOne->getName());
 
@@ -735,10 +733,9 @@ class TableTest extends TestCase
         $this->assertSame('Comments', $hasOne->getAlias());
         $this->assertSame('TestPlugin.Comments', $hasOne->getRegistryAlias());
 
-        $options = ['className' => 'TestPlugin.Comments'];
         $table = new Table(['table' => 'users']);
 
-        $hasOne = $table->hasOne('TestPlugin.Comments', $options);
+        $hasOne = $table->hasOne('TestPlugin.Comments', ['className' => 'TestPlugin.Comments']);
         $this->assertInstanceOf(HasOne::class, $hasOne);
         $this->assertSame('Comments', $hasOne->getName());
 
@@ -2912,7 +2909,6 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasOne('articles', [
-            'foreignKey' => 'author_id',
             'dependent' => true,
         ]);
 
@@ -3173,7 +3169,6 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasOne('articles', [
-            'foreignKey' => 'author_id',
             'dependent' => true,
         ]);
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -753,12 +753,10 @@ class TableTest extends TestCase
     public function testNoneUniqueAssociationsSameClass(): void
     {
         $Users = new Table(['table' => 'users']);
-        $options = ['className' => 'Comments'];
-        $Users->hasMany('Comments', $options);
+        $Users->hasMany('Comments');
 
         $Articles = new Table(['table' => 'articles']);
-        $options = ['className' => 'Comments'];
-        $Articles->hasMany('Comments', $options);
+        $Articles->hasMany('Comments');
 
         $Categories = new Table(['table' => 'categories']);
         $options = ['className' => 'TestPlugin.Comments'];
@@ -828,7 +826,6 @@ class TableTest extends TestCase
     public function testHasMany(): void
     {
         $options = [
-            'foreignKey' => 'author_id',
             'conditions' => ['b' => 'c'],
             'sort' => ['foo' => 'asc'],
         ];
@@ -850,7 +847,6 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->hasMany('Comments', [
-            'className' => 'Comments',
             'conditions' => ['published' => 'Y'],
         ]);
 
@@ -2939,7 +2935,6 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('articles', [
-            'foreignKey' => 'author_id',
             'dependent' => true,
             'cascadeCallbacks' => true,
         ]);
@@ -2990,7 +2985,6 @@ class TableTest extends TestCase
     {
         $table = $this->getTableLocator()->get('authors');
         $table->hasMany('article', [
-            'foreignKey' => 'author_id',
             'dependent' => false,
         ]);
 
@@ -4276,9 +4270,7 @@ class TableTest extends TestCase
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
 
-        $authors->hasMany('Articles', [
-            'foreignKey' => 'author_id',
-        ]);
+        $authors->hasMany('Articles');
 
         $author = $authors->newEntity(['name' => 'mylux']);
         $author = $authors->save($author);
@@ -4314,7 +4306,6 @@ class TableTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
 
         $authors->hasMany('Articles', [
-            'foreignKey' => 'author_id',
             'saveStrategy' => 'replace',
         ]);
 
@@ -4364,7 +4355,6 @@ class TableTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
 
         $authors->hasMany('Articles', [
-            'foreignKey' => 'author_id',
             'saveStrategy' => 'replace',
         ]);
 
@@ -4417,7 +4407,6 @@ class TableTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
 
         $authors->hasMany('Articles', [
-            'foreignKey' => 'author_id',
             'saveStrategy' => 'replace',
         ]);
 
@@ -4463,7 +4452,6 @@ class TableTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
 
         $authors->hasMany('Articles', [
-            'foreignKey' => 'author_id',
             'saveStrategy' => 'replace',
         ]);
 
@@ -4691,9 +4679,7 @@ class TableTest extends TestCase
         $authors = $this->getTableLocator()->get('Authors');
         $articles = $this->getTableLocator()->get('Articles');
 
-        $authors->hasMany('Articles', [
-            'foreignKey' => 'author_id',
-        ]);
+        $authors->hasMany('Articles');
 
         $author = $authors->newEntity(['name' => 'mylux']);
         $author = $authors->save($author);


### PR DESCRIPTION
`associationForeignKey` has been renamed to `targetForeignKey` in 3.x as far as I know.
Therefore our current tests shouldn't use that as well