### PR TITLE
Change return type for TypeInterface::toStatement().

### DIFF
--- a/src/Database/Type/BaseType.php
+++ b/src/Database/Type/BaseType.php
@@ -61,7 +61,7 @@ abstract class BaseType implements TypeInterface
     /**
      * @inheritDoc
      */
-    public function toStatement(mixed $value, Driver $driver): mixed
+    public function toStatement(mixed $value, Driver $driver): int
     {
         if ($value === null) {
             return PDO::PARAM_NULL;

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -65,11 +65,7 @@ class BinaryType extends BaseType
     }
 
     /**
-     * Get the correct PDO binding type for Binary data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -86,11 +86,7 @@ class BinaryUuidType extends BaseType
     }
 
     /**
-     * Get the correct PDO binding type for Binary data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -93,11 +93,7 @@ class BoolType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Get the correct PDO binding type for bool data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -449,13 +449,9 @@ class DateTimeType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Casts given value to Statement equivalent
-     *
-     * @param mixed $value value to be converted to PDO statement
-     * @param \Cake\Database\Driver $driver object from which database preferences and configuration will be extracted
-     * @return mixed
+     * @inheritDoc
      */
-    public function toStatement(mixed $value, Driver $driver): mixed
+    public function toStatement(mixed $value, Driver $driver): int
     {
         return PDO::PARAM_STR;
     }

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -110,11 +110,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Get the correct PDO binding type for decimal data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -122,11 +122,7 @@ class EnumType extends BaseType
     }
 
     /**
-     * Get the correct PDO binding type for string or integer data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -93,11 +93,7 @@ class FloatType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Get the correct PDO binding type for float data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -97,11 +97,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Get the correct PDO binding type for integer data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -87,11 +87,7 @@ class JsonType extends BaseType implements BatchCastingInterface
     }
 
     /**
-     * Get the correct PDO binding type for string data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -72,11 +72,7 @@ class StringType extends BaseType implements OptionalConvertInterface
     }
 
     /**
-     * Get the correct PDO binding type for string data.
-     *
-     * @param mixed $value The value being bound.
-     * @param \Cake\Database\Driver $driver The driver.
-     * @return int
+     * @inheritDoc
      */
     public function toStatement(mixed $value, Driver $driver): int
     {

--- a/src/Database/TypeInterface.php
+++ b/src/Database/TypeInterface.php
@@ -41,13 +41,13 @@ interface TypeInterface
     public function toPHP(mixed $value, Driver $driver): mixed;
 
     /**
-     * Casts given value to its Statement equivalent.
+     * Get the binding type to use in a PDO statement.
      *
-     * @param mixed $value Value to be converted to PDO statement.
+     * @param mixed $value The value being bound.
      * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted.
-     * @return mixed Given value casted to its Statement equivalent.
+     * @return int One of PDO::PARAM_* constants.
      */
-    public function toStatement(mixed $value, Driver $driver): mixed;
+    public function toStatement(mixed $value, Driver $driver): int;
 
     /**
      * Marshals flat data into PHP objects.


### PR DESCRIPTION
Earlier the return was mixed to potentially allow non PDO driver implementations but since DriverInterface is dropped in 5.x we will only have PDO based drivers.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
