### PR TITLE
Allow specifying default value when converting to associative form.

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -1155,10 +1155,11 @@ class Hash
      *
      * @param array $data List to normalize
      * @param bool $assoc If true, $data will be converted to an associative array.
+     * @param mixed $default The default value to use when a top level numeric key is converted to associative form.
      * @return array
      * @link https://book.cakephp.org/4/en/core-libraries/hash.html#Cake\Utility\Hash::normalize
      */
-    public static function normalize(array $data, bool $assoc = true): array
+    public static function normalize(array $data, bool $assoc = true, $default = null): array
     {
         $keys = array_keys($data);
         $count = count($keys);
@@ -1176,7 +1177,7 @@ class Hash
             $newList = [];
             for ($i = 0; $i < $count; $i++) {
                 if (is_int($keys[$i])) {
-                    $newList[$data[$keys[$i]]] = null;
+                    $newList[$data[$keys[$i]]] = $default;
                 } else {
                     $newList[$keys[$i]] = $data[$keys[$i]];
                 }

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -772,8 +772,16 @@ class HashTest extends TestCase
         $expected = ['one', 'two', 'three'];
         $this->assertSame($expected, $result);
 
+        $result = Hash::normalize(['one', 'two', 'three'], false, []);
+        $expected = ['one', 'two', 'three'];
+        $this->assertSame($expected, $result);
+
         $result = Hash::normalize(['one' => 1, 'two' => 2, 'three' => 3, 'four'], false);
         $expected = ['one' => 1, 'two' => 2, 'three' => 3, 'four' => null];
+        $this->assertSame($expected, $result);
+
+        $result = Hash::normalize(['one' => 1, 'two' => 2, 'three' => 3, 'four'], false, []);
+        $expected = ['one' => 1, 'two' => 2, 'three' => 3, 'four' => []];
         $this->assertSame($expected, $result);
 
         $result = Hash::normalize(['one' => 1, 'two' => 2, 'three' => 3, 'four']);
@@ -782,6 +790,10 @@ class HashTest extends TestCase
 
         $result = Hash::normalize(['one' => ['a', 'b', 'c' => 'cee'], 'two' => 2, 'three']);
         $expected = ['one' => ['a', 'b', 'c' => 'cee'], 'two' => 2, 'three' => null];
+        $this->assertSame($expected, $result);
+
+        $result = Hash::normalize(['one' => ['a', 'b', 'c' => 'cee'], 'two' => 2, 'three'], true, 'x');
+        $expected = ['one' => ['a', 'b', 'c' => 'cee'], 'two' => 2, 'three' => 'x'];
         $this->assertSame($expected, $result);
     }
 


### PR DESCRIPTION
Often times when normalizing config for custom behavior for e.g. I have wanted the default value to be an empty array instead of null.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
