### PR TITLE
5.x: fix HTML Helper not working anymore with simple array options

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -297,7 +297,7 @@ class StringTemplate
 
         foreach ($options as $key => $value) {
             if (!isset($exclude[$key]) && $value !== false && $value !== null) {
-                $attributes[] = $this->_formatAttribute($key, $value, $escape);
+                $attributes[] = $this->_formatAttribute((string)$key, $value, $escape);
             }
         }
         $out = trim(implode(' ', $attributes));

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1015,6 +1015,12 @@ class HtmlHelperTest extends TestCase
             'script' => ['src' => 'js/jquery-1.3.2.js', 'defer' => 'defer', 'encoding' => 'utf-8'],
         ];
         $this->assertHtml($expected, $result);
+
+        $result = $this->Html->script('defered', ['defer']);
+        $expected = [
+            'script' => ['src' => 'js/defered.js', 'defer' => 'defer'],
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/16933
Was introduced in https://github.com/cakephp/cakephp/commit/c94a5033a92982c81d7f7d2d5e83c135f2e0ee90#diff-9b8ccf6470217d08217e9f8973aadc95252315804e16c3ec3c053c49c26bc16e

~~Had to adjust some other classes as well to please the static analysis gods~~
For some reason I don't get the same stan result locally as here in GA 🤔 