### PR TITLE
5.x: update stan-setup to always use latest minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         ],
         "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
         "stan-baseline": "phpstan.phar --generate-baseline",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.9.0 psalm/phar:~5.1.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.9 psalm/phar:^5.4 && mv composer.backup composer.json",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",


### PR DESCRIPTION
I had some confusion in https://github.com/cakephp/cakephp/pull/16934 because our composer.json has
```
phpstan/phpstan:~1.9.0 psalm/phar:~5.1.0
```
as a version string in `composer stan-setup`

This resulted in different versions being installed locally than what is used in Github Actions 

as can be seen [here](https://github.com/cakephp/cakephp/actions/runs/3851076621/jobs/6561901300#step:3:23) Github Actions always installs the latest version despite what is defined in `composer stan-setup`

so we should do it for our local setups as well