### PR TITLE
Fix up console output to be empty.

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -214,17 +214,19 @@ class ConsoleOutput
         if ($this->_outputAs === static::RAW) {
             return $text;
         }
-        if ($this->_outputAs === static::PLAIN) {
-            $tags = implode('|', array_keys(static::$_styles));
-
-            $output = preg_replace('#</?(?:' . $tags . ')>#', '', $text);
-        } else {
+        if ($this->_outputAs !== static::PLAIN) {
             $output = preg_replace_callback(
                 '/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims',
                 [$this, '_replaceTags'],
                 $text
             );
+            if ($output !== null) {
+                return $output;
+            }
         }
+
+        $tags = implode('|', array_keys(static::$_styles));
+        $output = preg_replace('#</?(?:' . $tags . ')>#', '', $text);
 
         if ($output === null) {
             return $text;

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -217,14 +217,20 @@ class ConsoleOutput
         if ($this->_outputAs === static::PLAIN) {
             $tags = implode('|', array_keys(static::$_styles));
 
-            return preg_replace('#</?(?:' . $tags . ')>#', '', $text);
+            $output = preg_replace('#</?(?:' . $tags . ')>#', '', $text);
+        } else {
+            $output = preg_replace_callback(
+                '/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims',
+                [$this, '_replaceTags'],
+                $text
+            );
         }
 
-        return preg_replace_callback(
-            '/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims',
-            [$this, '_replaceTags'],
-            $text
-        );
+        if ($output === null) {
+            return $text;
+        }
+
+        return $output;
     }
 
     /**


### PR DESCRIPTION
With longer, more complex output you get

> [TypeError] Cake\Console\ConsoleOutput::styleText(): Return value must be of type string, null returned in 
vendor/cakephp/cakephp/src/Console/ConsoleOutput.php on line 224

As the regex fails to apply.

We should in this case rather fallback to plain text instead of this type error or a cast, which would still silence the actual output we want to print.

Since we are running phpstan level: 6, those kind of things are still unnoticed. Preventing TypeErrors would need level 8 here for nullable safety. (Currently still "Found 473 errors " on that level though).