### PR TITLE
Fix up TypeError cases found by PHPStan level 8

### DIFF
--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -53,7 +53,7 @@ class MissingTemplateException extends CakeException
     public function __construct(array|string $file, array $paths = [], ?int $code = null, ?Throwable $previous = null)
     {
         if (is_array($file)) {
-            $this->filename = array_pop($file);
+            $this->filename = (string)array_pop($file);
             $this->templateName = array_pop($file);
         } else {
             $this->filename = $file;

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -205,11 +205,11 @@ class ArrayContext implements ContextInterface
         $required = Hash::get($this->_context['required'], $field)
             ?? Hash::get($this->_context['required'], $this->stripNesting($field));
 
-        if (!empty($required) || $required === '0') {
+        if ($required || $required === '0') {
             return true;
         }
 
-        return $required;
+        return $required !== null ? (bool)$required : null;
     }
 
     /**
@@ -343,6 +343,6 @@ class ArrayContext implements ContextInterface
      */
     protected function stripNesting(string $field): string
     {
-        return preg_replace('/\.\d*\./', '.', $field);
+        return (string)preg_replace('/\.\d*\./', '.', $field);
     }
 }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -289,7 +289,7 @@ class EntityContext implements ContextInterface
         }
         $field = end($parts);
         $defaults = $table->getSchema()->defaultValues();
-        if (!array_key_exists($field, $defaults)) {
+        if ($field === false || !array_key_exists($field, $defaults)) {
             return null;
         }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1021,8 +1021,6 @@ class FormHelper extends Helper
      * @param array<string, mixed> $options Each type of input takes different options.
      * @return string Completed form widget.
      * @link https://book.cakephp.org/4/en/views/helpers/form.html#creating-form-controls
-     * @psalm-suppress InvalidReturnType
-     * @psalm-suppress InvalidReturnStatement
      */
     public function control(string $fieldName, array $options = []): string
     {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1108,6 +1108,7 @@ class FormHelper extends Helper
             $options['hiddenField'] = '_split';
         }
 
+        /** @var string $input */
         $input = $this->_getInput($fieldName, $options + ['labelOptions' => $labelOptions]);
         if ($options['type'] === 'hidden' || $options['type'] === 'submit') {
             if ($newTemplates) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -583,7 +583,7 @@ class HtmlHelper extends Helper
      */
     public function scriptEnd(): ?string
     {
-        $buffer = ob_get_clean();
+        $buffer = (string)ob_get_clean();
         $options = $this->_scriptBlockOptions;
         $this->_scriptBlockOptions = [];
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -395,7 +395,7 @@ class PaginatorHelper extends Helper
                 $title = str_replace('.', ' ', $title);
             }
 
-            $title = __(Inflector::humanize(preg_replace('/_id$/', '', $title)));
+            $title = __(Inflector::humanize((string)preg_replace('/_id$/', '', $title)));
         }
 
         $defaultDir = isset($options['direction']) ? strtolower($options['direction']) : 'asc';

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -99,7 +99,7 @@ class TextHelper extends Helper
             )/ixu';
         // phpcs:enable Generic.Files.LineLength
 
-        $text = preg_replace_callback(
+        $text = (string)preg_replace_callback(
             $pattern,
             [&$this, '_insertPlaceHolder'],
             $text
@@ -249,14 +249,14 @@ class TextHelper extends Helper
     {
         $text = $text ?? '';
         if (trim($text) !== '') {
-            $text = preg_replace('|<br[^>]*>\s*<br[^>]*>|i', "\n\n", $text . "\n");
-            $text = preg_replace("/\n\n+/", "\n\n", str_replace(["\r\n", "\r"], "\n", $text));
-            $texts = preg_split('/\n\s*\n/', $text, -1, PREG_SPLIT_NO_EMPTY);
+            $text = (string)preg_replace('|<br[^>]*>\s*<br[^>]*>|i', "\n\n", $text . "\n");
+            $text = (string)preg_replace("/\n\n+/", "\n\n", str_replace(["\r\n", "\r"], "\n", $text));
+            $texts = preg_split('/\n\s*\n/', $text, -1, PREG_SPLIT_NO_EMPTY) ?: [];
             $text = '';
             foreach ($texts as $txt) {
                 $text .= '<p>' . nl2br(trim($txt, "\n")) . "</p>\n";
             }
-            $text = preg_replace('|<p>\s*</p>|', '', $text);
+            $text = (string)preg_replace('|<p>\s*</p>|', '', $text);
         }
 
         return $text;

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -147,7 +147,7 @@ class JsonView extends SerializedView
             $jsonOptions |= JSON_PRETTY_PRINT;
         }
 
-        return json_encode($data, $jsonOptions);
+        return (string)json_encode($data, $jsonOptions);
     }
 
     /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -724,7 +724,7 @@ class View implements EventDispatcherInterface
             throw $exception;
         }
 
-        $result = ob_get_clean();
+        $result = (string)ob_get_clean();
 
         Cache::write($options['key'], $result, $options['config']);
 
@@ -1195,7 +1195,7 @@ class View implements EventDispatcherInterface
             throw $exception;
         }
 
-        return ob_get_clean();
+        return (string)ob_get_clean();
     }
 
     /**
@@ -1406,7 +1406,7 @@ class View implements EventDispatcherInterface
             return $file;
         }
         $absolute = realpath($file);
-        if (!str_starts_with($absolute, $path)) {
+        if ($absolute === false || !str_starts_with($absolute, $path)) {
             throw new InvalidArgumentException(sprintf(
                 'Cannot use `%s` as a template, it is not within any view template path.',
                 $file

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -115,9 +115,9 @@ class ViewBlock
 
         $mode = end($this->_active);
         $active = key($this->_active);
-        $content = ob_get_clean();
+        $content = (string)ob_get_clean();
         if ($mode === ViewBlock::OVERRIDE) {
-            $this->_blocks[$active] = (string)$content;
+            $this->_blocks[$active] = $content;
         } else {
             $this->concat($active, $content, $mode);
         }
@@ -213,6 +213,7 @@ class ViewBlock
     {
         end($this->_active);
 
+        /** @var string|null */
         return key($this->_active);
     }
 

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -146,6 +146,7 @@ class XmlView extends SerializedView
             $options['pretty'] = true;
         }
 
+        /** @var string|false $result */
         $result = Xml::fromArray($data, $options)->saveXML();
         if ($result === false) {
             throw new SerializationFailureException(


### PR DESCRIPTION
In order to avoid some easy type error cases now with more strict API and strict types enabled, we need to look more into level 7 and 8 of phpstan instead of keeping level 6
Overall 3xx errors to be fixed

I now fixed the ones in View/namespace.