### PR TITLE
5.x: add requestAsJson method to IntegrationTestTrait

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -268,6 +268,21 @@ trait IntegrationTestTrait
     }
 
     /**
+     * Sets HTTP headers for the *next* request to be identified as JSON request.
+     *
+     * @return void
+     */
+    public function setJsonHeader(): void
+    {
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+    }
+
+    /**
      * Configures the data for the *next* request.
      *
      * This data is cleared in the tearDown() method.
@@ -281,7 +296,7 @@ trait IntegrationTestTrait
      */
     public function configRequest(array $data): void
     {
-        $this->_request = $data + $this->_request;
+        $this->_request = array_merge_recursive($data, $this->_request);
     }
 
     /**

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -268,21 +268,6 @@ trait IntegrationTestTrait
     }
 
     /**
-     * Sets HTTP headers for the *next* request to be identified as JSON request.
-     *
-     * @return void
-     */
-    public function setJsonHeader(): void
-    {
-        $this->configRequest([
-            'headers' => [
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ],
-        ]);
-    }
-
-    /**
      * Configures the data for the *next* request.
      *
      * This data is cleared in the tearDown() method.
@@ -297,6 +282,21 @@ trait IntegrationTestTrait
     public function configRequest(array $data): void
     {
         $this->_request = array_merge_recursive($data, $this->_request);
+    }
+
+    /**
+     * Sets HTTP headers for the *next* request to be identified as JSON request.
+     *
+     * @return void
+     */
+    public function requestAsJson(): void
+    {
+        $this->configRequest([
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+        ]);
     }
 
     /**

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -158,11 +158,10 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testRequestBuilding(): void
     {
+        $this->setJsonHeader();
         $this->configRequest([
             'headers' => [
                 'X-CSRF-Token' => 'abc123',
-                'Content-Type' => 'application/json',
-                'Accept' => 'application/json',
             ],
             'base' => '',
             'webroot' => '/',

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -158,7 +158,7 @@ class IntegrationTestTraitTest extends TestCase
      */
     public function testRequestBuilding(): void
     {
-        $this->setJsonHeader();
+        $this->requestAsJson();
         $this->configRequest([
             'headers' => [
                 'X-CSRF-Token' => 'abc123',


### PR DESCRIPTION
This PR contains 2 changes:

1) The `setJsonHeader()` helper method has been added to the IntegrationTestTrait so users have an easier time testing JSON requests.

2) `configRequest()` has been changed to use `array_merge_recursive()` to actually allow merging e.g. `header` config values to support the above helper method as well as calling multiple `configRequest()` inside one test like so:

```
$this->configRequest([
    'headers' => [
        'Accept' => 'application/json',
        'Content-Type' => 'application/json',
    ],
]);
$this->configRequest([
    'headers' => [
        'X-CSRF-Token' => 'abc123',
    ],
]);
```