### PR TITLE
4.5 Fix compatibility issues with Chronos 2.next

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4.0",
+        "php": ">=7.4.0,<9",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "^2.2",
+        "cakephp/chronos": "dev-2.next as 2.5.0",
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "dev-2.next as 2.5.0",
+        "cakephp/chronos": "^2.4.0-RC1",
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1 || ^2.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -475,8 +475,3 @@ parameters:
 			count: 1
 			path: src/View/Form/NullContext.php
 
-		-
-			message: "#^Call to an undefined method DateTimeInterface\\:\\:setTimezone\\(\\)\\.$#"
-			count: 1
-			path: src/View/Helper/TimeHelper.php
-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -277,9 +277,15 @@
       <code>$request-&gt;scheme()</code>
     </PossiblyNullArgument>
   </file>
+  <file src="src/I18n/Date.php">
+    <DeprecatedClass occurrences="2">
+      <code>MutableDate</code>
+      <code>parent::__construct($time, $tz)</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/I18n/DateFormatTrait.php">
     <DeprecatedClass occurrences="5">
-      <code>$time-&gt;timezone($timezone)</code>
+      <code>$time-&gt;setTimezone($timezone)</code>
       <code>Time::UNIX_TIMESTAMP_FORMAT</code>
       <code>static|null</code>
       <code>static|null</code>
@@ -288,6 +294,12 @@
     <MissingParamType occurrences="1">
       <code>$format</code>
     </MissingParamType>
+  </file>
+  <file src="src/I18n/Time.php">
+    <DeprecatedClass occurrences="2">
+      <code>MutableDateTime</code>
+      <code>parent::__construct($time, $tz)</code>
+    </DeprecatedClass>
   </file>
   <file src="src/I18n/functions.php">
     <InternalMethod occurrences="8">

--- a/src/Database/Expression/CaseExpressionTrait.php
+++ b/src/Database/Expression/CaseExpressionTrait.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Expression;
 
-use Cake\Chronos\Date;
+use Cake\Chronos\ChronosDate;
 use Cake\Chronos\MutableDate;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
@@ -52,7 +52,7 @@ trait CaseExpressionTrait
         } elseif (is_bool($value)) {
             $type = 'boolean';
         } elseif (
-            $value instanceof Date ||
+            $value instanceof ChronosDate ||
             $value instanceof MutableDate
         ) {
             $type = 'date';

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -52,6 +52,6 @@ class QueryLogger extends BaseLog
             $context = $context['query']->getContext() + $context;
             $message = 'connection={connection} role={role} duration={took} rows={numRows} ' . $message;
         }
-        Log::write('debug', $message, $context);
+        Log::write('debug', (string)$message, $context);
     }
 }

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -104,7 +104,7 @@ class DateType extends DateTimeType
     public function marshal($value): ?DateTimeInterface
     {
         if ($value instanceof DateTimeInterface) {
-            return new FrozenDate($value);
+            return new FrozenDate('@' . $value->getTimestamp());
         }
 
         /** @var class-string<\Cake\Chronos\ChronosDate> $class */

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -22,6 +22,7 @@ use Cake\I18n\I18nDateTimeInterface;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Exception;
 
 /**
  * Class DateType
@@ -102,14 +103,61 @@ class DateType extends DateTimeType
      */
     public function marshal($value): ?DateTimeInterface
     {
-        $date = parent::marshal($value);
-        /** @psalm-var \DateTime|\DateTimeImmutable|null $date */
-        if ($date && !$date instanceof I18nDateTimeInterface) {
-            // Clear time manually when I18n types aren't available and raw DateTime used
-            $date = $date->setTime(0, 0, 0);
+        if ($value instanceof DateTimeInterface) {
+            return new FrozenDate($value);
         }
 
-        return $date;
+        /** @var class-string<\Cake\Chronos\ChronosDate> $class */
+        $class = $this->_className;
+        try {
+            if ($value === '' || $value === null || is_bool($value)) {
+                return null;
+            }
+
+            if (is_int($value) || (is_string($value) && ctype_digit($value))) {
+                /** @var \Cake\I18n\FrozenDate|\DateTimeImmutable $dateTime */
+                $dateTime = new $class('@' . $value);
+
+                return $dateTime;
+            }
+
+            if (is_string($value)) {
+                if ($this->_useLocaleMarshal) {
+                    $dateTime = $this->_parseLocaleValue($value);
+                } else {
+                    $dateTime = $this->_parseValue($value);
+                }
+
+                return $dateTime;
+            }
+        } catch (Exception $e) {
+            return null;
+        }
+
+        if (is_array($value) && implode('', $value) === '') {
+            return null;
+        }
+        $format = '';
+        if (
+            isset($value['year'], $value['month'], $value['day']) &&
+            (
+                is_numeric($value['year']) &&
+                is_numeric($value['month']) &&
+                is_numeric($value['day'])
+            )
+        ) {
+            $format .= sprintf('%d-%02d-%02d', $value['year'], $value['month'], $value['day']);
+        }
+
+        if (empty($format)) {
+            // Invalid array format.
+            return null;
+        }
+
+        /** @var \Cake\I18n\FrozenDate|\DateTimeImmutable $dateTime */
+        $dateTime = new $class($format);
+
+        return $dateTime;
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -190,7 +190,7 @@ trait DateFormatTrait
         if ($timezone) {
             // Handle the immutable and mutable object cases.
             $time = clone $this;
-            $time = $time->timezone($timezone);
+            $time = $time->setTimezone($timezone);
         }
 
         $format = $format ?? static::$_toStringFormat;

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\I18n;
 
-use Cake\Chronos\Date as ChronosDate;
+use Cake\Chronos\ChronosDate;
 use IntlDateFormatter;
 
 /**

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -101,7 +101,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
     {
         $options = $this->_options($options, FrozenTime::class);
         if ($options['timezone']) {
-            $time = $time->timezone($options['timezone']);
+            $time = $time->setTimezone($options['timezone']);
         }
 
         $now = $options['from']->format('U');

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -267,7 +267,7 @@ class TimeHelper extends Helper
             'timezone' => null,
         ];
         $options['timezone'] = $this->_getTimezone($options['timezone']);
-        if ($options['timezone'] && method_exists($dateTime, 'setTimezone')) {
+        if ($options['timezone'] && is_object($dateTime) && method_exists($dateTime, 'setTimezone')) {
             $dateTime = $dateTime->setTimezone($options['timezone']);
             unset($options['timezone']);
         }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -71,7 +71,7 @@ class TimeHelper extends Helper
     {
         $time = new FrozenTime($dateString);
         if ($timezone !== null) {
-            $time = $time->timezone($timezone);
+            $time = $time->setTimezone($timezone);
         }
 
         return $time;
@@ -226,7 +226,7 @@ class TimeHelper extends Helper
     {
         $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
 
-        return (new FrozenTime($dateString))->timezone($timezone)->toAtomString();
+        return (new FrozenTime($dateString))->setTimezone($timezone)->toAtomString();
     }
 
     /**
@@ -240,7 +240,7 @@ class TimeHelper extends Helper
     {
         $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
 
-        return (new FrozenTime($dateString))->timezone($timezone)->toRssString();
+        return (new FrozenTime($dateString))->setTimezone($timezone)->toRssString();
     }
 
     /**
@@ -268,8 +268,7 @@ class TimeHelper extends Helper
             'timezone' => null,
         ];
         $options['timezone'] = $this->_getTimezone($options['timezone']);
-        /** @psalm-suppress UndefinedInterfaceMethod */
-        if ($options['timezone'] && $dateTime instanceof DateTimeInterface) {
+        if ($options['timezone'] && method_exists($dateTime, 'setTimezone')) {
             $dateTime = $dateTime->setTimezone($options['timezone']);
             unset($options['timezone']);
         }

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -19,7 +19,6 @@ namespace Cake\View\Helper;
 use Cake\I18n\FrozenTime;
 use Cake\View\Helper;
 use Cake\View\StringTemplateTrait;
-use DateTimeInterface;
 use Exception;
 
 /**

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database\Expression;
 
 use Cake\Chronos\Chronos;
-use Cake\Chronos\Date as ChronosDate;
+use Cake\Chronos\ChronosDate;
 use Cake\Chronos\MutableDate as ChronosMutableDate;
 use Cake\Database\Expression\CaseStatementExpression;
 use Cake\Database\Expression\ComparisonExpression;

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Type;
 
-use Cake\Chronos\Date;
+use Cake\Chronos\ChronosDate;
 use Cake\Core\Configure;
 use Cake\Database\Type\DateType;
 use Cake\I18n\Time;
@@ -91,8 +91,8 @@ class DateTypeTest extends TestCase
         ];
         $expected = [
             'a' => null,
-            'b' => new Date('2001-01-04'),
-            'c' => new Date('2001-01-04'),
+            'b' => new ChronosDate('2001-01-04'),
+            'c' => new ChronosDate('2001-01-04'),
         ];
         $this->assertEquals(
             $expected,
@@ -109,7 +109,7 @@ class DateTypeTest extends TestCase
         $result = $this->type->toDatabase($value, $this->driver);
         $this->assertSame($value, $result);
 
-        $date = new Date('2013-08-12');
+        $date = new ChronosDate('2013-08-12');
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertSame('2013-08-12', $result);
 
@@ -129,7 +129,7 @@ class DateTypeTest extends TestCase
             'src/I18n/Date.php',
         ]);
 
-        $date = new Date('@1392387900');
+        $date = new ChronosDate('@1392387900');
 
         $data = [
             // invalid types.
@@ -144,7 +144,7 @@ class DateTypeTest extends TestCase
             // valid string types
             ['1392387900', $date],
             [1392387900, $date],
-            ['2014-02-14', new Date('2014-02-14')],
+            ['2014-02-14', new ChronosDate('2014-02-14')],
 
             // valid array types
             [
@@ -153,7 +153,7 @@ class DateTypeTest extends TestCase
             ],
             [
                 ['year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 13, 'minute' => 14, 'second' => 15],
-                new Date('2014-02-14'),
+                new ChronosDate('2014-02-14'),
             ],
             [
                 [
@@ -161,7 +161,7 @@ class DateTypeTest extends TestCase
                     'hour' => 1, 'minute' => 14, 'second' => 15,
                     'meridian' => 'am',
                 ],
-                new Date('2014-02-14'),
+                new ChronosDate('2014-02-14'),
             ],
             [
                 [
@@ -169,13 +169,13 @@ class DateTypeTest extends TestCase
                     'hour' => 1, 'minute' => 14, 'second' => 15,
                     'meridian' => 'pm',
                 ],
-                new Date('2014-02-14'),
+                new ChronosDate('2014-02-14'),
             ],
             [
                 [
                     'year' => 2014, 'month' => 2, 'day' => 14,
                 ],
-                new Date('2014-02-14'),
+                new ChronosDate('2014-02-14'),
             ],
 
             // Invalid array types
@@ -192,7 +192,7 @@ class DateTypeTest extends TestCase
                     'year' => '2014', 'month' => '02', 'day' => '14',
                     'hour' => 'farts', 'minute' => 'farts',
                 ],
-                new Date('2014-02-14'),
+                new ChronosDate('2014-02-14'),
             ],
         ];
 
@@ -226,7 +226,7 @@ class DateTypeTest extends TestCase
         $this->type->useLocaleParser();
         $this->assertNull($this->type->marshal('11/derp/2013'));
 
-        $expected = new Date('13-10-2013');
+        $expected = new ChronosDate('13-10-2013');
         $result = $this->type->marshal('10/13/2013');
         $this->assertSame($expected->format('Y-m-d'), $result->format('Y-m-d'));
 
@@ -243,7 +243,7 @@ class DateTypeTest extends TestCase
         $this->type->useLocaleParser()->setLocaleFormat('dd MMM, y');
         $this->assertNull($this->type->marshal('11/derp/2013'));
 
-        $expected = new Date('13-10-2013');
+        $expected = new ChronosDate('13-10-2013');
         $result = $this->type->marshal('13 Oct, 2013');
         $this->assertSame($expected->format('Y-m-d'), $result->format('Y-m-d'));
 

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -181,11 +181,11 @@ class DateTypeTest extends TestCase
             // Invalid array types
             [
                 ['year' => 'farts', 'month' => 'derp'],
-                new Date(date('Y-m-d')),
+                null,
             ],
             [
                 ['year' => 'farts', 'month' => 'derp', 'day' => 'farts'],
-                new Date(date('Y-m-d')),
+                null,
             ],
             [
                 [

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -128,7 +128,7 @@ class TimeHelperTest extends TestCase
             'element' => 'span',
         ]);
         $vancouver = clone $timestamp;
-        $vancouver = $vancouver->timezone('America/Vancouver');
+        $vancouver = $vancouver->setTimezone('America/Vancouver');
 
         $expected = [
             'span' => [
@@ -197,7 +197,7 @@ class TimeHelperTest extends TestCase
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $dateTime = new FrozenTime();
         $vancouver = clone $dateTime;
-        $vancouver = $vancouver->timezone('America/Vancouver');
+        $vancouver = $vancouver->setTimezone('America/Vancouver');
         $this->assertSame($vancouver->format(Time::ATOM), $this->Time->toAtom($vancouver));
     }
 
@@ -227,7 +227,7 @@ class TimeHelperTest extends TestCase
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $dateTime = new FrozenTime();
         $vancouver = clone $dateTime;
-        $vancouver = $vancouver->timezone('America/Vancouver');
+        $vancouver = $vancouver->setTimezone('America/Vancouver');
 
         $this->assertSame($vancouver->format('r'), $this->Time->toRss($vancouver));
     }


### PR DESCRIPTION
* Add a more specific and limited marshal() method for DateType. I don't love the fallback to DateTimeImmutable as it doesn't honor the Date contract. If we wanted to keep that we could have cakephp/database depend on chronos as well.
* Upgrade chronos to a dev dependency on 2.next. We'll need to change this once we have an beta/RC made for chronos.
* Update internal usage of deprecated methods.
