### PR TITLE
Fix up TypeError cases found by PHPStan level 7/8

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -205,7 +205,7 @@ class Sqlserver extends Driver
             }
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
+        /** @var string $sql */
         $statement = $this->getPdo()->prepare(
             $sql,
             [

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -121,12 +121,15 @@ class CommonTableExpression implements ExpressionInterface
     public function field(IdentifierExpression|array|string $fields)
     {
         $fields = (array)$fields;
+        /** @var array<string|\Cake\Database\Expression\IdentifierExpression> $fields */
         foreach ($fields as &$field) {
             if (!($field instanceof IdentifierExpression)) {
                 $field = new IdentifierExpression($field);
             }
         }
-        $this->fields = array_merge($this->fields, $fields);
+        /** @var array<\Cake\Database\Expression\IdentifierExpression> $mergedFields */
+        $mergedFields = array_merge($this->fields, $fields);
+        $this->fields = $mergedFields;
 
         return $this;
     }

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -229,7 +229,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             // better just throw an exception here
             if ($value === '') {
                 $field = $this->_field instanceof ExpressionInterface ? $this->_field->sql($binder) : $this->_field;
-                /** @psalm-suppress PossiblyInvalidCast */
+                /** @var string $field */
                 throw new DatabaseException(
                     "Impossible to generate condition with empty list of values for field ($field)"
                 );

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -112,6 +112,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
     {
         $put = $prepend ? 'array_unshift' : 'array_push';
         $typeMap = $this->getTypeMap()->setTypes($types);
+        /** @var array $conditions */
         foreach ($conditions as $k => $p) {
             if ($p === 'literal') {
                 $put($this->_conditions, $k);

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -120,7 +120,7 @@ class LoggedQuery implements JsonSerializable, Stringable
             $keys[] = is_string($key) ? "/:$key\b/" : '/[?]/';
         }
 
-        return preg_replace($keys, $params, $this->query, $limit);
+        return (string)preg_replace($keys, $params, $this->query, $limit);
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -742,9 +742,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $table = current($table);
         }
 
-        /**
-         * @psalm-suppress InvalidArrayOffset
-         */
+        /** @var string $alias */
         return [
             $alias => [
                 'table' => $table,

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -484,9 +484,7 @@ class SelectQuery extends Query implements IteratorAggregate
             $table = current($table);
         }
 
-        /**
-         * @psalm-suppress InvalidArrayOffset
-         */
+        /** @var string $alias */
         return [
             $alias => [
                 'table' => $table,
@@ -766,6 +764,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function getIterator(): Traversable
     {
+        /** @var \Traversable|array $results */
         $results = $this->all();
         if (is_array($results)) {
             return new ArrayIterator($results);
@@ -781,7 +780,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * row with any possible modifications.
      *
      * Callbacks will be executed lazily, if only 3 rows are fetched for database it will
-     * called 3 times, event though there might be more rows to be fetched in the cursor.
+     * be called 3 times, event though there might be more rows to be fetched in the cursor.
      *
      * Callbacks are stacked in the order they are registered, if you wish to reset the stack
      * the call this function with the second parameter set to true.

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -1001,6 +1001,7 @@ trait EntityTrait
         $entity = $this;
         $len = count($path);
         while ($len) {
+            /** @var string $part */
             $part = array_shift($path);
             $len = count($path);
             $val = null;

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -173,8 +173,8 @@ class NumericPaginator implements PaginatorInterface
 
         assert(
             $target instanceof RepositoryInterface,
-            'Pagination target must be an instance of Cake\Datasource\QueryInterface'
-                . ' or Cake\Datasource\RepositoryInterface.'
+            'Pagination target must be an instance of `' . QueryInterface::class
+                . '` or `' . RepositoryInterface::class . '`.'
         );
 
         $data = $this->extractData($target, $params, $settings);

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -128,6 +128,7 @@ class CounterCacheBehavior extends Behavior
 
         foreach ($this->_config as $assoc => $settings) {
             $assoc = $this->_table->getAssociation($assoc);
+            /** @var string|int $field */
             foreach ($settings as $field => $config) {
                 if (is_int($field)) {
                     continue;

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -267,7 +267,7 @@ class EavStrategy implements TranslateStrategyInterface
         }
 
         $primaryKey = (array)$this->table->getPrimaryKey();
-        $key = $entity->get(current($primaryKey));
+        $key = $entity->get((string)current($primaryKey));
 
         // When we have no key and bundled translations, we
         // need to mark the entity dirty so the root
@@ -385,7 +385,7 @@ class EavStrategy implements TranslateStrategyInterface
 
             $row['_locale'] = $locale;
             if ($hydrated) {
-                /** @psalm-suppress PossiblyInvalidMethodCall */
+                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->clean();
             }
 
@@ -451,7 +451,7 @@ class EavStrategy implements TranslateStrategyInterface
 
         $fields = $this->_config['fields'];
         $primaryKey = (array)$this->table->getPrimaryKey();
-        $key = $entity->get(current($primaryKey));
+        $key = $entity->get((string)current($primaryKey));
         $find = [];
         $contents = [];
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -379,7 +379,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         }
 
         $primaryKey = (array)$this->table->getPrimaryKey();
-        $id = $entity->get(current($primaryKey));
+        $id = $entity->get((string)current($primaryKey));
 
         // When we have no key and bundled translations, we
         // need to mark the entity dirty so the root
@@ -487,21 +487,23 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 unset($row['translation']);
 
                 if ($hydrated) {
-                    /** @psalm-suppress PossiblyInvalidMethodCall */
+                    /** @var \Cake\Datasource\EntityInterface $row */
                     $row->clean();
                 }
 
                 return $row;
             }
 
-            /** @var \Cake\ORM\Entity|array $translation */
+            /** @var \Cake\Datasource\EntityInterface|array $translation */
             $translation = $row['translation'];
 
-            /**
-             * @psalm-suppress PossiblyInvalidMethodCall
-             * @psalm-suppress PossiblyInvalidArgument
-             */
-            $keys = $hydrated ? $translation->getVisible() : array_keys($translation);
+            if ($hydrated) {
+                /** @var \Cake\Datasource\EntityInterface $translation */
+                $keys = $translation->getVisible();
+            } else {
+                /** @var array $translation */
+                $keys = array_keys($translation);
+            }
 
             foreach ($keys as $field) {
                 if ($field === 'locale') {
@@ -516,10 +518,11 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 }
             }
 
+            /** @var array $row */
             unset($row['translation']);
 
             if ($hydrated) {
-                /** @psalm-suppress PossiblyInvalidMethodCall */
+                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->clean();
             }
 
@@ -579,7 +582,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         }
 
         $primaryKey = (array)$this->table->getPrimaryKey();
-        $key = $entity->get(current($primaryKey));
+        $key = $entity->get((string)current($primaryKey));
 
         foreach ($translations as $lang => $translation) {
             if (!$translation->id) {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -353,7 +353,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     protected function referenceName(Table $table): string
     {
         $name = namespaceSplit($table::class);
-        $name = substr(end($name), 0, -5);
+        $name = substr((string)end($name), 0, -5);
         if (empty($name)) {
             $name = $table->getTable() ?: $table->getAlias();
             $name = Inflector::camelize($name);

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -229,7 +229,7 @@ class TreeBehavior extends Behavior
         $this->_ensureFields($entity);
         $left = $entity->get($config['left']);
         $right = $entity->get($config['right']);
-        $diff = $right - $left + 1;
+        $diff = (int)($right - $left + 1);
 
         if ($diff > 2) {
             if ($this->getConfig('cascadeCallbacks')) {

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -279,6 +279,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
 
         if ($this->hasFinder($type) && $this->has($this->_finderMap[$type][0])) {
             [$behavior, $callMethod] = $this->_finderMap[$type];
+            /** @var callable $callable */
             $callable = [$this->_loaded[$behavior], $callMethod];
 
             return $callable(...$args);

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -785,8 +785,8 @@ class EagerLoader
 
             $alias = $source->getAlias();
             $pkFields = [];
+            /** @var string $key */
             foreach ($keys as $key) {
-                /** @psalm-suppress PossiblyFalseArgument getForeignKey() returns false */
                 $pkFields[] = key($query->aliasField($key, $alias));
             }
             $collectKeys[$meta->aliasPath()] = [$alias, $pkFields, count($pkFields) === 1];

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -59,6 +59,7 @@ class LazyEagerLoader
 
         $entities = $this->_injectResults($entities, $query, $associations, $source);
 
+        /** @var \Cake\Datasource\EntityInterface|array<\Cake\Datasource\EntityInterface> */
         return $returnSingle ? array_shift($entities) : $entities;
     }
 
@@ -120,8 +121,9 @@ class LazyEagerLoader
         $map = [];
         $container = $source->associations();
         foreach ($associations as $assoc) {
-            /** @psalm-suppress PossiblyNullReference */
-            $map[$assoc] = $container->get($assoc)->getProperty();
+            /** @var \Cake\ORM\Association $association */
+            $association = $container->get($assoc);
+            $map[$assoc] = $association->getProperty();
         }
 
         return $map;

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -90,8 +90,8 @@ class Marshaller
             }
             // If the key is not a special field like _ids or _joinData
             // it is a missing association that we should error on.
-            if (!$this->_table->hasAssociation($key)) {
-                if (!str_starts_with($key, '_')) {
+            if (!$this->_table->hasAssociation((string)$key)) {
+                if (!str_starts_with((string)$key, '_')) {
                     throw new InvalidArgumentException(sprintf(
                         'Cannot marshal data for `%s` association. It is not associated with `%s`.',
                         (string)$key,
@@ -100,7 +100,7 @@ class Marshaller
                 }
                 continue;
             }
-            $assoc = $this->_table->getAssociation($key);
+            $assoc = $this->_table->getAssociation((string)$key);
 
             if (isset($options['forceNew'])) {
                 $nested['forceNew'] = $options['forceNew'];
@@ -165,7 +165,7 @@ class Marshaller
      * ]);
      * ```
      *
-     * @param array $data The data to hydrate.
+     * @param array<string, mixed> $data The data to hydrate.
      * @param array<string, mixed> $options List of options
      * @return \Cake\Datasource\EntityInterface
      * @see \Cake\ORM\Table::newEntity()
@@ -190,6 +190,9 @@ class Marshaller
         $options['isMerge'] = false;
         $propertyMap = $this->_buildPropertyMap($data, $options);
         $properties = [];
+        /**
+         * @var string $key
+         */
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {
                 if ($entity instanceof InvalidPropertyInterface) {
@@ -258,7 +261,7 @@ class Marshaller
     /**
      * Returns data and options prepared to validate and marshall.
      *
-     * @param array $data The data to prepare.
+     * @param array<string, mixed> $data The data to prepare.
      * @param array<string, mixed> $options The options passed to this marshaller.
      * @return array An array containing prepared data and options.
      */
@@ -544,6 +547,9 @@ class Marshaller
         $options['isMerge'] = true;
         $propertyMap = $this->_buildPropertyMap($data, $options);
         $properties = [];
+        /**
+         * @var string $key
+         */
         foreach ($data as $key => $value) {
             if (!empty($errors[$key])) {
                 if ($entity instanceof InvalidPropertyInterface) {
@@ -739,10 +745,14 @@ class Marshaller
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
         $type = $assoc->type();
         if (in_array($type, $types, true)) {
+            /** @var \Cake\Datasource\EntityInterface $original */
             return $marshaller->merge($original, $value, $options);
         }
         if ($type === Association::MANY_TO_MANY) {
-            /** @phpstan-ignore-next-line */
+            /**
+             * @var array<\Cake\Datasource\EntityInterface> $original
+             * @var \Cake\ORM\Association\BelongsToMany $assoc
+             */
             return $marshaller->_mergeBelongsToMany($original, $assoc, $value, $options);
         }
 
@@ -757,7 +767,9 @@ class Marshaller
             }
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
+        /**
+         * @var array<\Cake\Datasource\EntityInterface> $original
+         */
         return $marshaller->mergeMany($original, $value, $options);
     }
 

--- a/src/ORM/Query/CommonQueryTrait.php
+++ b/src/ORM/Query/CommonQueryTrait.php
@@ -66,7 +66,7 @@ trait CommonQueryTrait
     {
         assert(
             $repository instanceof Table,
-            '`$repository` must be an instance of Cake\ORM\Table.'
+            '`$repository` must be an instance of `' . Table::class . '`.'
         );
 
         $this->_repository = $repository;

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -155,20 +155,21 @@ class ResultSetFactory
 
         foreach ($data['containAssoc'] as $assoc) {
             $alias = $assoc['nestKey'];
-
-            if ($assoc['canBeJoined'] && empty($data['fields'][$alias])) {
+            /** @var bool $canBeJoined */
+            $canBeJoined = $assoc['canBeJoined'];
+            if ($canBeJoined && empty($data['fields'][$alias])) {
                 continue;
             }
 
             $instance = $assoc['instance'];
             assert($instance instanceof Association);
 
-            if (!$assoc['canBeJoined'] && !isset($row[$alias])) {
-                $results = $instance->defaultRowValue($results, $assoc['canBeJoined']);
+            if (!$canBeJoined && !isset($row[$alias])) {
+                $results = $instance->defaultRowValue($results, $canBeJoined);
                 continue;
             }
 
-            if (!$assoc['canBeJoined']) {
+            if (!$canBeJoined) {
                 $results[$alias] = $row[$alias];
             }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -407,7 +407,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if ($this->_table === null) {
             $table = namespaceSplit(static::class);
-            $table = substr(end($table), 0, -5) ?: $this->_alias;
+            $table = substr((string)end($table), 0, -5) ?: $this->_alias;
             if (!$table) {
                 throw new CakeException(
                     'You must specify either the `alias` or the `table` option for the constructor.'
@@ -441,7 +441,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         if ($this->_alias === null) {
             $alias = namespaceSplit(static::class);
-            $alias = substr(end($alias), 0, -5) ?: $this->_table;
+            $alias = substr((string)end($alias), 0, -5) ?: $this->_table;
             if (!$alias) {
                 throw new CakeException(
                     'You must specify either the `alias` or the `table` option for the constructor.'
@@ -538,6 +538,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
 
+        /** @var \Cake\Database\Schema\TableSchemaInterface */
         return $this->_schema;
     }
 


### PR DESCRIPTION
Fixing issues on model layer based on PHPStan level 8

We can (string) cast the theoretical only topics, or where it is OK to just continue.
In other places we should throw a meaningful exception.

In general it is always better to replace psalm specific annotation with of a more agnostic one that serves also other stan tools and the IDE.