### PR TITLE
Fix up TypeError cases for PHPStan level 8

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -141,12 +141,11 @@ class Cache
 
         if (empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
-                sprintf('The "%s" cache configuration does not exist.', $name)
+                sprintf('The `%s` cache configuration does not exist.', $name)
             );
         }
 
         $config = static::$_config[$name];
-        assert(is_array($config));
 
         try {
             $registry->load($name, $config);
@@ -185,6 +184,7 @@ class Cache
         }
 
         if (!empty($config['groups'])) {
+            /** @var string $group */
             foreach ($config['groups'] as $group) {
                 static::$_groups[$group][] = $name;
                 static::$_groups[$group] = array_unique(static::$_groups[$group]);
@@ -356,7 +356,7 @@ class Cache
     public static function increment(string $key, int $offset = 1, string $config = 'default'): int|false
     {
         if ($offset < 0) {
-            throw new InvalidArgumentException('Offset cannot be less than 0.');
+            throw new InvalidArgumentException('Offset cannot be less than `0`.');
         }
 
         return static::pool($config)->increment($key, $offset);
@@ -375,7 +375,7 @@ class Cache
     public static function decrement(string $key, int $offset = 1, string $config = 'default'): int|false
     {
         if ($offset < 0) {
-            throw new InvalidArgumentException('Offset cannot be less than 0.');
+            throw new InvalidArgumentException('Offset cannot be less than `0`.');
         }
 
         return static::pool($config)->decrement($key, $offset);

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -127,7 +127,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
     /**
      * Obtains multiple cache items by their unique keys.
      *
-     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param iterable<string> $keys A list of keys that can obtained in a single operation.
      * @param mixed $default Default value to return for keys that do not exist.
      * @return iterable<string, mixed> A list of key value pairs. Cache keys that do not exist or are stale will have $default as value.
      * @throws \Cake\Cache\InvalidArgumentException If $keys is neither an array nor a Traversable,
@@ -377,7 +377,10 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
             return $ttl;
         }
 
-        return (int)DateTime::createFromFormat('U', '0')
+        /** @var \DateTime $datetime */
+        $datetime = DateTime::createFromFormat('U', '0');
+
+        return (int)$datetime
             ->add($ttl)
             ->format('U');
     }

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -79,7 +79,7 @@ class CacheRegistry extends ObjectRegistry
         }
         unset($config['className']);
 
-        assert($instance instanceof CacheEngine, 'Cache engines must extend Cake\Cache\CacheEngine.');
+        assert($instance instanceof CacheEngine, 'Cache engines must extend `' . CacheEngine::class . '`.');
 
         if (!$instance->init($config)) {
             throw new CakeException(

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -352,7 +352,7 @@ class MemcachedEngine extends CacheEngine
     /**
      * Read many keys from the cache at once
      *
-     * @param iterable $keys An array of identifiers for the data
+     * @param iterable<string> $keys An array of identifiers for the data
      * @param mixed $default Default value to return for keys that do not exist.
      * @return iterable<string, mixed> An array containing, for each of the given $keys, the cached data or
      *   false if cached data could not be retrieved.

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -1023,7 +1023,6 @@ trait CollectionTrait
         $iterator = $this->unwrap();
 
         if ($iterator::class === ArrayIterator::class) {
-            /** @phpstan-ignore-next-line */
             $iterator = $iterator->getArrayCopy();
         }
 

--- a/src/Command/Helper/TableHelper.php
+++ b/src/Command/Helper/TableHelper.php
@@ -75,7 +75,7 @@ class TableHelper extends Helper
 
         $styles = $this->_io->styles();
         $tags = implode('|', array_keys($styles));
-        $text = preg_replace('#</?(?:' . $tags . ')>#', '', $text);
+        $text = (string)preg_replace('#</?(?:' . $tags . ')>#', '', $text);
 
         return mb_strwidth($text);
     }

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -838,7 +838,7 @@ class I18nExtractCommand extends Command
             $files = array_keys(iterator_to_array($files));
             sort($files);
             if ($pattern) {
-                $files = preg_grep($pattern, $files, PREG_GREP_INVERT);
+                $files = preg_grep($pattern, $files, PREG_GREP_INVERT) ?: [];
                 $files = array_values($files);
             }
             $this->_files = array_merge($this->_files, $files);

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -265,7 +265,7 @@ abstract class BaseCommand implements CommandInterface
         if (is_string($command)) {
             assert(
                 is_subclass_of($command, CommandInterface::class),
-                "Command '{$command}' is not a subclass of Cake\Console\CommandInterface."
+                sprintf('Command `%s` is not a subclass of `%s`.', $command, CommandInterface::class)
             );
 
             $command = new $command();

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -67,10 +67,11 @@ class CommandCollection implements IteratorAggregate, Countable
             assert(
                 is_subclass_of($command, CommandInterface::class),
                 sprintf(
-                    "Cannot use '%s' for command '%s'. " .
-                    "It is not a subclass of Cake\Console\CommandInterface.",
+                    'Cannot use `%s` for command `%s`. ' .
+                    'It is not a subclass of `%s`.',
                     $command,
-                    $name
+                    $name,
+                    CommandInterface::class
                 )
             );
         }
@@ -186,7 +187,7 @@ class CommandCollection implements IteratorAggregate, Countable
     /**
      * Resolve names based on existing commands
      *
-     * @param array $input The results of a CommandScanner operation.
+     * @param array<array<string, string>> $input The results of a CommandScanner operation.
      * @return array<string, class-string<\Cake\Console\CommandInterface>> A flat map of command names => class names.
      */
     protected function resolveNames(array $input): array
@@ -203,9 +204,11 @@ class CommandCollection implements IteratorAggregate, Countable
                 $name = $info['fullName'];
             }
 
-            $out[$name] = $info['class'];
+            /** @var class-string<\Cake\Console\CommandInterface> $class */
+            $class = $info['class'];
+            $out[$name] = $class;
             if ($addLong) {
-                $out[$info['fullName']] = $info['class'];
+                $out[$info['fullName']] = $class;
             }
         }
 

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Console;
 
 use Cake\Console\Exception\ConsoleException;
+use Cake\Core\Exception\CakeException;
 
 /**
  * Object wrapper for interacting with stdin
@@ -49,7 +50,12 @@ class ConsoleInput
     public function __construct(string $handle = 'php://stdin')
     {
         $this->_canReadline = (extension_loaded('readline') && $handle === 'php://stdin');
-        $this->_input = fopen($handle, 'rb');
+        $input = fopen($handle, 'rb');
+        if ($input === false) {
+            throw new CakeException(sprintf('Cannot open handle `%s`', $handle));
+        }
+
+        $this->_input = $input;
     }
 
     /**

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -70,7 +70,7 @@ class ConsoleInputArgument
                 $this->{'_' . $key} = $value;
             }
         } else {
-            /** @psalm-suppress PossiblyInvalidPropertyAssignmentValue */
+            /** @var string $name */
             $this->_name = $name;
             $this->_help = $help;
             $this->_required = $required;

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -516,7 +516,7 @@ class ConsoleOptionParser
      * Add multiple arguments at once. Take an array of argument definitions.
      * The keys are used as the argument names, and the values as params for the argument.
      *
-     * @param array $args Array of arguments to add.
+     * @param array<string, array<string, mixed>|\Cake\Console\ConsoleInputArgument> $args Array of arguments to add.
      * @see \Cake\Console\ConsoleOptionParser::addArgument()
      * @return $this
      */

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -217,10 +217,10 @@ class ConsoleOutput
         if ($this->_outputAs === static::PLAIN) {
             $tags = implode('|', array_keys(static::$_styles));
 
-            return preg_replace('#</?(?:' . $tags . ')>#', '', $text);
+            return (string)preg_replace('#</?(?:' . $tags . ')>#', '', $text);
         }
 
-        return preg_replace_callback(
+        return (string)preg_replace_callback(
             '/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims',
             $this->_replaceTags(...),
             $text

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -107,13 +107,13 @@ class App
      *
      * ```
      * App::shortName(
-     *     'Cake\Controller\Component\RequestHanderComponent',
+     *     'Cake\Controller\Component\FlashComponent',
      *     'Controller/Component',
      *     'Component'
      * )
      * ```
      *
-     * Returns: RequestHander
+     * Returns: Flash
      *
      * @param string $class Class name
      * @param string $type Type of class

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -83,14 +83,14 @@ class JsonConfig implements ConfigEngineInterface
         $values = json_decode($jsonContent, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new CakeException(sprintf(
-                'Error parsing JSON string fetched from config file "%s.json": %s',
+                'Error parsing JSON string fetched from config file `%s.json`: %s',
                 $key,
                 json_last_error_msg()
             ));
         }
         if (!is_array($values)) {
             throw new CakeException(sprintf(
-                'Decoding JSON config file "%s.json" did not return an array',
+                'Decoding JSON config file `%s.json` did not return an array',
                 $key
             ));
         }

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -32,7 +32,7 @@ trait StaticConfigTrait
     /**
      * Configuration sets.
      *
-     * @var array<string|int, mixed>
+     * @var array<string|int, array<string, mixed>>
      */
     protected static array $_config = [];
 
@@ -276,6 +276,9 @@ REGEXP;
 
         parse_str($query, $queryArgs);
 
+        /**
+         * @var string $key
+         */
         foreach ($queryArgs as $key => $value) {
             if ($value === 'true') {
                 $queryArgs[$key] = true;
@@ -291,10 +294,11 @@ REGEXP;
         if (empty($parsed['className'])) {
             $classMap = static::getDsnClassMap();
 
-            $parsed['className'] = $parsed['scheme'];
-            if (isset($classMap[$parsed['scheme']])) {
-                /** @psalm-suppress PossiblyNullArrayOffset */
-                $parsed['className'] = $classMap[$parsed['scheme']];
+            /** @var string $scheme */
+            $scheme = $parsed['scheme'];
+            $parsed['className'] = $scheme;
+            if (isset($classMap[$scheme])) {
+                $parsed['className'] = $classMap[$scheme];
             }
         }
 

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -94,7 +94,7 @@ class HtmlFormatter implements FormatterInterface
         ob_start();
         include __DIR__ . DIRECTORY_SEPARATOR . 'dumpHeader.html';
 
-        return ob_get_clean();
+        return (string)ob_get_clean();
     }
 
     /**

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -113,8 +113,8 @@ class Debugger
     public static function getInstance(?string $class = null): static
     {
         static $instance = [];
-        if (!empty($class)) {
-            if (!$instance || strtolower($class) !== strtolower(get_class($instance[0]))) {
+        if ($class) {
+            if (!$instance || strtolower($class) !== strtolower((string)get_class($instance[0]))) {
                 $instance[0] = new $class();
             }
         }
@@ -840,7 +840,7 @@ class Debugger
     public static function formatHtmlMessage(string $message): string
     {
         $message = h($message);
-        $message = preg_replace('/`([^`]+)`/', '<code>$0</code>', $message);
+        $message = (string)preg_replace('/`([^`]+)`/', '<code>$0</code>', $message);
 
         return nl2br($message);
     }

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -386,7 +386,7 @@ class EventManager implements EventManagerInterface
         return array_intersect_key(
             $this->_listeners,
             array_flip(
-                preg_grep($matchPattern, array_keys($this->_listeners), 0)
+                preg_grep($matchPattern, array_keys($this->_listeners), 0) ?: []
             )
         );
     }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -306,7 +306,7 @@ class Form implements EventListenerInterface, EventDispatcherInterface, Validato
             $write = [$name => $value];
         }
 
-        /** @psalm-suppress PossiblyInvalidIterator */
+        /** @var array<string, mixed> $write */
         foreach ($write as $key => $val) {
             $this->_data = Hash::insert($this->_data, $key, $val);
         }

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -132,7 +132,7 @@ class FormProtector
         }
 
         $field = implode('.', $field);
-        $field = preg_replace('/(\.\d+)+$/', '', $field);
+        $field = (string)preg_replace('/(\.\d+)+$/', '', $field);
 
         if ($lock) {
             if (!in_array($field, $this->fields, true)) {
@@ -328,6 +328,7 @@ class FormProtector
             )
         );
 
+        /** @var string $key */
         foreach ($fieldList as $i => $key) {
             $isLocked = in_array($key, $locked, true);
 
@@ -410,7 +411,7 @@ class FormProtector
         return [
             'fields' => urlencode($fields . ':' . $locked),
             'unlocked' => urlencode(implode('|', $unlockedFields)),
-            'debug' => urlencode(json_encode([
+            'debug' => urlencode((string)json_encode([
                 $url,
                 $this->fields,
                 $this->unlockedFields,

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -217,6 +217,7 @@ class Oauth
             rewind($resource);
             $credentials['privateKeyPassphrase'] = $passphrase;
         }
+        /** @var \OpenSSLAsymmetricKey|\OpenSSLCertificate|array|string $privateKey */
         $privateKey = openssl_pkey_get_private($credentials['privateKey'], $credentials['privateKeyPassphrase']);
         $this->checkSslError();
 

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -202,7 +202,9 @@ class BodyParserMiddleware implements MiddlewareInterface
         try {
             $xml = Xml::build($body, ['return' => 'domdocument', 'readFile' => false]);
             // We might not get child nodes if there are nested inline entities.
-            if ((int)$xml->childNodes->length > 0) {
+            /** @var \DOMNodeList $domNodeList */
+            $domNodeList = $xml->childNodes;
+            if ((int)$domNodeList->length > 0) {
                 return Xml::toArray($xml);
             }
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1486,8 +1486,7 @@ class Response implements ResponseInterface, Stringable
             return;
         }
 
-        /** @psalm-suppress PossiblyInvalidOperand */
-        $this->_setHeader('Content-Length', (string)($end - $start + 1));
+        $this->_setHeader('Content-Length', (string)((int)$end - (int)$start + 1));
         $this->_setHeader('Content-Range', 'bytes ' . $start . '-' . $end . '/' . $fileSize);
         $this->_setStatus(206);
         /**

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -131,6 +131,7 @@ class ResponseEmitter
         $body = new RelativeStream($body, $first);
         $body->rewind();
         $pos = 0;
+        /** @var int $length */
         $length = $last - $first + 1;
         while (!$body->eof() && $pos < $length) {
             if ($pos + $this->maxBufferLength > $length) {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -764,8 +764,9 @@ class ServerRequest implements ServerRequestInterface
         }
 
         if (isset(static::$_detectors[$name], $detector['options'])) {
-            /** @psalm-suppress PossiblyInvalidArgument */
-            $detector = Hash::merge(static::$_detectors[$name], $detector);
+            /** @var array $data */
+            $data = static::$_detectors[$name];
+            $detector = Hash::merge($data, $detector);
         }
         static::$_detectors[$name] = $detector;
     }

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -180,7 +180,7 @@ trait DateFormatTrait
             $calendar,
             $pattern
         );
-        if (empty($formatter)) {
+        if (!$formatter) {
             $key = "{$locale}.{$dateFormat}.{$timeFormat}.{$timezone}.{$calendar}.{$pattern}";
             throw new CakeException(
                 'Your version of icu does not support creating a date formatter for ' .
@@ -188,7 +188,7 @@ trait DateFormatTrait
             );
         }
 
-        return $formatter->format($date->format('U'));
+        return (string)$formatter->format($date->format('U'));
     }
 
     /**

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -86,7 +86,7 @@ class Number
     {
         $formatter = static::formatter(['precision' => $precision, 'places' => $precision] + $options);
 
-        return $formatter->format((float)$value);
+        return (string)$formatter->format((float)$value);
     }
 
     /**
@@ -239,6 +239,7 @@ class Number
         $abs = abs($value);
         if (!empty($options['fractionSymbol']) && $abs > 0 && $abs < 1) {
             $value *= 100;
+            /** @var string $pos */
             $pos = $options['fractionPosition'] ?? 'after';
 
             return static::format($value, ['precision' => 0, $pos => $options['fractionSymbol']]);
@@ -325,6 +326,7 @@ class Number
      */
     public static function formatter(array $options = []): NumberFormatter
     {
+        /** @var string $locale */
         $locale = $options['locale'] ?? ini_get('intl.default_locale');
 
         if (!$locale) {
@@ -333,7 +335,7 @@ class Number
 
         $type = NumberFormatter::DECIMAL;
         if (!empty($options['type'])) {
-            $type = $options['type'];
+            $type = (int)$options['type'];
             if ($options['type'] === static::FORMAT_CURRENCY) {
                 $type = NumberFormatter::CURRENCY;
             } elseif ($options['type'] === static::FORMAT_CURRENCY_ACCOUNTING) {
@@ -417,6 +419,6 @@ class Number
      */
     public static function ordinal(float|int $value, array $options = []): string
     {
-        return static::formatter(['type' => NumberFormatter::ORDINAL] + $options)->format($value);
+        return (string)static::formatter(['type' => NumberFormatter::ORDINAL] + $options)->format($value);
     }
 }

--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -66,7 +66,7 @@ class MoFileParser
         if ($stat['size'] < self::MO_HEADER_SIZE) {
             throw new CakeException('Invalid format for MO translations file');
         }
-        $magic = unpack('V1', fread($stream, 4));
+        $magic = unpack('V1', (string)fread($stream, 4));
         $magic = hexdec(substr(dechex(current($magic)), -8));
 
         if ($magic === self::MO_LITTLE_ENDIAN_MAGIC) {
@@ -103,7 +103,7 @@ class MoFileParser
             }
 
             fseek($stream, $offset);
-            $singularId = fread($stream, $length);
+            $singularId = (string)fread($stream, $length);
 
             if (str_contains($singularId, "\x04")) {
                 [$context, $singularId] = explode("\x04", $singularId);
@@ -117,7 +117,7 @@ class MoFileParser
             $length = $this->_readLong($stream, $isBigEndian);
             $offset = $this->_readLong($stream, $isBigEndian);
             fseek($stream, $offset);
-            $translated = fread($stream, $length);
+            $translated = (string)fread($stream, $length);
 
             if ($pluralId !== null || str_contains($translated, "\000")) {
                 $translated = explode("\000", $translated);
@@ -154,7 +154,7 @@ class MoFileParser
      */
     protected function _readLong($stream, bool $isBigEndian): int
     {
-        $result = unpack($isBigEndian ? 'N1' : 'V1', fread($stream, 4));
+        $result = unpack($isBigEndian ? 'N1' : 'V1', (string)fread($stream, 4));
         $result = current($result);
 
         return (int)substr((string)$result, -8);

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -241,7 +241,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
                 $days = (int)$future['d'] - (int)$past['d'];
             } else {
                 $daysInPastMonth = (int)date('t', $pastTime);
-                $daysInFutureMonth = (int)date('t', mktime(0, 0, 0, (int)$future['m'] - 1, 1, (int)$future['Y']));
+                $daysInFutureMonth = (int)date('t', (int)mktime(0, 0, 0, (int)$future['m'] - 1, 1, (int)$future['Y']));
 
                 if (!$backwards) {
                     $days = $daysInPastMonth - (int)$past['d'] + (int)$future['d'];

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -73,16 +73,17 @@ abstract class BaseLog extends AbstractLogger
             $this->_config['levels'] = (array)$this->_config['types'];
         }
 
+        /** @var \Cake\Log\Formatter\AbstractFormatter|class-string<\Cake\Log\Formatter\AbstractFormatter> $formatter */
         $formatter = $this->_config['formatter'] ?? DefaultFormatter::class;
         if (!is_object($formatter)) {
             if (is_array($formatter)) {
+                /** @var class-string<\Cake\Log\Formatter\AbstractFormatter> $class */
                 $class = $formatter['className'];
                 $options = $formatter;
             } else {
                 $class = $formatter;
                 $options = [];
             }
-            /** @var class-string<\Cake\Log\Formatter\AbstractFormatter> $class */
             $formatter = new $class($options);
         }
 

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -206,7 +206,7 @@ class FileLog extends BaseLog
         if ($files) {
             $filesToDelete = count($files) - $rotate;
             while ($filesToDelete > 0) {
-                unlink(array_shift($files));
+                unlink((string)array_shift($files));
                 $filesToDelete--;
             }
         }

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -70,6 +70,7 @@ class LogEngineRegistry extends ObjectRegistry
     protected function _create(callable|object|string $class, string $alias, array $config): LoggerInterface
     {
         if (is_string($class)) {
+            /** @var class-string<\Psr\Log\LoggerInterface> $class */
             return new $class($config);
         }
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -322,7 +322,7 @@ class Message implements JsonSerializable
         if ($this->appCharset !== null) {
             $this->charset = $this->appCharset;
         }
-        $this->domain = preg_replace('/\:\d+$/', '', (string)env('HTTP_HOST'));
+        $this->domain = (string)preg_replace('/\:\d+$/', '', (string)env('HTTP_HOST'));
         if (empty($this->domain)) {
             $this->domain = php_uname('n');
         }
@@ -1890,7 +1890,7 @@ class Message implements JsonSerializable
         $array = $this->jsonSerialize();
         array_walk_recursive($array, function (&$item, $key): void {
             if ($item instanceof SimpleXMLElement) {
-                $item = json_decode(json_encode((array)$item), true);
+                $item = json_decode((string)json_encode((array)$item), true);
             }
         });
 

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -199,6 +199,7 @@ class SmtpTransport extends AbstractTransport
             $this->_disconnect();
         }
 
+        /** @var array{headers: string, message: string} */
         return $this->_content;
     }
 
@@ -476,7 +477,7 @@ class SmtpTransport extends AbstractTransport
     protected function _sendRcpt(Message $message): void
     {
         $from = $this->_prepareFromAddress($message);
-        $this->_smtpSend($this->_prepareFromCmd(key($from)));
+        $this->_smtpSend($this->_prepareFromCmd((string)key($from)));
 
         $messages = $this->_prepareRecipientAddresses($message);
         foreach ($messages as $mail) {

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -89,7 +89,6 @@ class TransportFactory
             );
         }
 
-        /** @phpstan-ignore-next-line */
         static::getRegistry()->load($name, static::$_config[$name]);
     }
 

--- a/src/Routing/Asset.php
+++ b/src/Routing/Asset.php
@@ -214,7 +214,7 @@ class Asset
     protected static function encodeUrl(string $url): string
     {
         $path = parse_url($url, PHP_URL_PATH);
-        if ($path === false) {
+        if ($path === false || $path === null) {
             $path = $url;
         }
 
@@ -243,7 +243,7 @@ class Asset
         $timestamp ??= Configure::read('Asset.timestamp');
         $timestampEnabled = $timestamp === 'force' || ($timestamp === true && Configure::read('debug'));
         if ($timestampEnabled) {
-            $filepath = preg_replace(
+            $filepath = (string)preg_replace(
                 '/^' . preg_quote(static::requestWebroot(), '/') . '/',
                 '',
                 urldecode($path)

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -345,11 +345,11 @@ class Route
             $names[] = $name;
         }
         if (preg_match('#\/\*\*$#', $route)) {
-            $parsed = preg_replace('#/\\\\\*\\\\\*$#', '(?:/(?P<_trailing_>.*))?', $parsed);
+            $parsed = (string)preg_replace('#/\\\\\*\\\\\*$#', '(?:/(?P<_trailing_>.*))?', $parsed);
             $this->_greedy = true;
         }
         if (preg_match('#\/\*$#', $route)) {
-            $parsed = preg_replace('#/\\\\\*$#', '(?:/(?P<_args_>.*))?', $parsed);
+            $parsed = (string)preg_replace('#/\\\\\*$#', '(?:/(?P<_args_>.*))?', $parsed);
             $this->_greedy = true;
         }
         $mode = empty($this->options['multibytePattern']) ? '' : 'u';

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -682,7 +682,7 @@ class Router
         if ($request) {
             $base = $request->getAttribute('base', '');
             if ($base !== '' && stristr($url, $base)) {
-                $url = preg_replace('/^' . preg_quote($base, '/') . '/', '', $url, 1);
+                $url = (string)preg_replace('/^' . preg_quote($base, '/') . '/', '', $url, 1);
             }
         }
         $url = '/' . $url;

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\TestSuite\Fixture;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Database\Connection;
 use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
@@ -80,6 +81,9 @@ class SchemaLoader
                 throw new InvalidArgumentException(sprintf('Unable to load SQL file `%s`.', $file));
             }
             $sql = file_get_contents($file);
+            if ($sql === false) {
+                throw new CakeException(sprintf('Cannot read file content of `%s`', $file));
+            }
 
             // Use the underlying PDO connection so we can avoid prepared statements
             // which don't support multiple queries in postgres.

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -760,7 +760,7 @@ abstract class TestCase extends BaseTestCase
             $expression = '';
             foreach ((array)$expressions as $expression) {
                 $expression = sprintf('/^%s/s', $expression);
-                if (preg_match($expression, $string, $match)) {
+                if ($string && preg_match($expression, $string, $match)) {
                     $matches = true;
                     $string = substr($string, strlen($match[0]));
                     break;
@@ -773,7 +773,7 @@ abstract class TestCase extends BaseTestCase
                 }
                 $this->assertMatchesRegularExpression(
                     $expression,
-                    $string,
+                    (string)$string,
                     sprintf('Item #%d / regex #%d failed: %s', $itemNum, $i, $description)
                 );
 

--- a/src/Utility/Crypto/OpenSsl.php
+++ b/src/Utility/Crypto/OpenSsl.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Utility\Crypto;
 
+use Cake\Core\Exception\CakeException;
+
 /**
  * OpenSSL implementation of crypto features for Cake\Utility\Security
  *
@@ -47,6 +49,9 @@ class OpenSsl
     {
         $method = static::METHOD_AES_256_CBC;
         $ivSize = openssl_cipher_iv_length($method);
+        if ($ivSize === false) {
+            throw new CakeException(sprintf('Cannot get the cipher iv length for `%s`', $method));
+        }
 
         $iv = openssl_random_pseudo_bytes($ivSize);
 
@@ -65,6 +70,9 @@ class OpenSsl
     {
         $method = static::METHOD_AES_256_CBC;
         $ivSize = openssl_cipher_iv_length($method);
+        if ($ivSize === false) {
+            throw new CakeException(sprintf('Cannot get the cipher iv length for `%s`', $method));
+        }
 
         $iv = mb_substr($cipher, 0, $ivSize, '8bit');
         $cipher = mb_substr($cipher, $ivSize, null, '8bit');

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -184,8 +184,8 @@ class Hash
     /**
      * Split token conditions
      *
-     * @param string $token the token being splitted.
-     * @return array [token, conditions] with token splitted
+     * @param string $token the token being split.
+     * @return array [token, conditions] with token split
      */
     protected static function _splitConditions(string $token): array
     {
@@ -313,6 +313,7 @@ class Hash
             return static::_simpleOp('insert', $data, $tokens, $values);
         }
 
+        /** @var string $token */
         $token = array_shift($tokens);
         $nextPath = implode('.', $tokens);
 
@@ -404,6 +405,7 @@ class Hash
             return static::_simpleOp('remove', $data, $tokens);
         }
 
+        /** @var string $token */
         $token = array_shift($tokens);
         $nextPath = implode('.', $tokens);
 
@@ -459,6 +461,7 @@ class Hash
         }
 
         if (is_array($keyPath)) {
+            /** @var string $format */
             $format = array_shift($keyPath);
             $keys = static::format($data, $keyPath, $format);
             assert(is_array($keys));

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -301,7 +301,7 @@ class Inflector
 
         foreach (static::$_plural as $rule => $replacement) {
             if (preg_match($rule, $word)) {
-                static::$_cache['pluralize'][$word] = preg_replace($rule, $replacement, $word);
+                static::$_cache['pluralize'][$word] = (string)preg_replace($rule, $replacement, $word);
 
                 return static::$_cache['pluralize'][$word];
             }
@@ -356,7 +356,7 @@ class Inflector
 
         foreach (static::$_singular as $rule => $replacement) {
             if (preg_match($rule, $word)) {
-                static::$_cache['singularize'][$word] = preg_replace($rule, $replacement, $word);
+                static::$_cache['singularize'][$word] = (string)preg_replace($rule, $replacement, $word);
 
                 return static::$_cache['singularize'][$word];
             }
@@ -456,7 +456,7 @@ class Inflector
         $result = static::_cache($cacheKey, $string);
 
         if ($result === false) {
-            $result = mb_strtolower(preg_replace('/(?<=\\w)([A-Z])/', $delimiter . '\\1', $string));
+            $result = mb_strtolower((string)preg_replace('/(?<=\\w)([A-Z])/', $delimiter . '\\1', $string));
             static::_cache($cacheKey, $string, $result);
         }
 

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -110,7 +110,10 @@ class Security
      */
     public static function randomBytes(int $length): string
     {
-        /** @psalm-suppress ArgumentTypeCoercion */
+        if ($length < 1) {
+            throw new InvalidArgumentException('Length must be `int<1, max>`');
+        }
+
         return random_bytes($length);
     }
 

--- a/src/Validation/RulesProvider.php
+++ b/src/Validation/RulesProvider.php
@@ -69,7 +69,9 @@ class RulesProvider
     {
         $method = $this->_reflection->getMethod($method);
         $argumentList = $method->getParameters();
-        if (array_pop($argumentList)->getName() !== 'context') {
+        /** @var \ReflectionParameter $argument */
+        $argument = array_pop($argumentList);
+        if ($argument->getName() !== 'context') {
             $arguments = array_slice($arguments, 0, -1);
         }
         $object = is_string($this->_class) ? null : $this->_class;

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -129,10 +129,11 @@ class ValidationRule
         }
 
         if (!$isCallable) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            /** @var string $method */
+            $method = $this->_rule;
             $message = sprintf(
-                'Unable to call method "%s" in "%s" provider for field "%s"',
-                $this->_rule,
+                'Unable to call method `%s` in `%s` provider for field `%s`',
+                $method,
                 $this->_provider,
                 $context['field']
             );

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -534,9 +534,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!is_array($value)) {
                 return false;
             }
-            foreach ($this->providers() as $provider) {
-                /** @psalm-suppress PossiblyNullArgument */
-                $validator->setProvider($provider, $this->getProvider($provider));
+            foreach ($this->providers() as $name) {
+                /** @var object|class-string $provider */
+                $provider = $this->getProvider($name);
+                $validator->setProvider($name, $provider);
             }
             $errors = $validator->validate($value, $context['newRecord']);
 
@@ -581,9 +582,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!is_array($value)) {
                 return false;
             }
-            foreach ($this->providers() as $provider) {
-                /** @psalm-suppress PossiblyNullArgument */
-                $validator->setProvider($provider, $this->getProvider($provider));
+            foreach ($this->providers() as $name) {
+                /** @var object|class-string $provider */
+                $provider = $this->getProvider($name);
+                $validator->setProvider($name, $provider);
             }
             $errors = [];
             foreach ($value as $i => $row) {

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -55,7 +55,7 @@ class FormContext implements ContextInterface
     {
         assert(
             isset($context['entity']) && $context['entity'] instanceof Form,
-            "`\$context['entity']` must be an instance of Cake\Form\Form"
+            "`\$context['entity']` must be an instance of " . Form::class
         );
 
         $this->_form = $context['entity'];

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -197,7 +197,7 @@ class SelectBoxWidget extends BasicWidget
      * Render the contents of an optgroup element.
      *
      * @param string $label The optgroup label text
-     * @param \ArrayAccess<string, mixed>|array $optgroup The opt group data.
+     * @param \ArrayAccess<string, mixed>|array<string, mixed> $optgroup The optgroup data.
      * @param array|null $disabled The options to disable.
      * @param array|string|int|false|null $selected The options to select.
      * @param array $templateVars Additional template variables.
@@ -266,6 +266,7 @@ class SelectBoxWidget extends BasicWidget
                     )
                 )
             ) {
+                /** @var \ArrayAccess<string, mixed>|array<string, mixed> $val */
                 $out[] = $this->_renderOptgroup((string)$key, $val, $disabled, $selected, $templateVars, $escape);
                 continue;
             }

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -111,6 +111,7 @@ class XmlView extends SerializedView
      */
     protected function _serialize(array|string $serialize): string
     {
+        /** @var string $rootNode */
         $rootNode = $this->getConfig('rootNode', 'response');
 
         if (is_array($serialize)) {
@@ -132,6 +133,7 @@ class XmlView extends SerializedView
                 }
             }
         } else {
+            /** @var array<mixed>|string $data */
             $data = $this->viewVars[$serialize] ?? [];
             if (
                 $data &&
@@ -146,7 +148,10 @@ class XmlView extends SerializedView
             $options['pretty'] = true;
         }
 
-        /** @var string|false $result */
+        /**
+         * @var array<mixed> $data
+         * @var string|false $result
+         */
         $result = Xml::fromArray($data, $options)->saveXML();
         if ($result === false) {
             throw new SerializationFailureException(

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Cache;
 
 use BadMethodCallException;
 use Cake\Cache\Cache;
+use Cake\Cache\CacheEngine;
 use Cake\Cache\CacheRegistry;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Cache\Engine\NullEngine;
@@ -246,7 +247,7 @@ class CacheTest extends TestCase
         ]);
 
         $this->expectError();
-        $this->expectErrorMessage('Cache engines must extend Cake\Cache\CacheEngine');
+        $this->expectErrorMessage('Cache engines must extend `' . CacheEngine::class . '`');
 
         Cache::pool('tests');
     }

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -100,7 +100,7 @@ class CacheCommandsTest extends TestCase
     {
         $this->exec('cache clear foo');
         $this->assertExitCode(CommandInterface::CODE_ERROR);
-        $this->assertErrorContains('The "foo" cache configuration does not exist');
+        $this->assertErrorContains('The `foo` cache configuration does not exist');
     }
 
     /**

--- a/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
+++ b/tests/TestCase/Core/Configure/Engine/JsonConfigTest.php
@@ -96,7 +96,7 @@ class JsonConfigTest extends TestCase
     public function testReadEmptyFile(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('config file "empty.json"');
+        $this->expectExceptionMessage('config file `empty.json`');
         $engine = new JsonConfig($this->path);
         $config = $engine->read('empty');
     }
@@ -107,7 +107,7 @@ class JsonConfigTest extends TestCase
     public function testReadWithInvalidJson(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Error parsing JSON string fetched from config file "invalid.json"');
+        $this->expectExceptionMessage('Error parsing JSON string fetched from config file `invalid.json`');
         $engine = new JsonConfig($this->path);
         $engine->read('invalid');
     }

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -92,7 +92,7 @@ class ValidationRuleTest extends TestCase
     public function testCustomMethodMissingError(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to call method "totallyMissing" in "default" provider for field "test"');
+        $this->expectExceptionMessage('Unable to call method `totallyMissing` in `default` provider for field `test`');
         $def = ['rule' => ['totallyMissing']];
         $data = 'some data';
         $providers = ['default' => $this];


### PR DESCRIPTION
Fixing issues based on PHPStan level 8 - prepared those yesterday evening but waited for the merge of previous PR

Follows https://github.com/cakephp/cakephp/pull/16945 for the rest of the namespaces.

We can (string) cast the theoretical only topics, or where it is OK to just continue.
In other places we should throw a meaningful exception.

In general, it is always better to replace psalm-specific annotation with of a more agnostic one that serves also other stan tools and the IDE if those are indeed relevant more more than just one tool.

---

With this, we went down from 300+ errors to ~100.
In the near future, we can baseline the remaining ones that are not fixable or false positives and make sure we dont introduce regressions in following changes or additions.