### PR TITLE
4.x: Simplify template path building

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1601,8 +1601,8 @@ class View implements EventDispatcherInterface
         $templatePaths = App::path(static::NAME_TEMPLATE);
         $pluginPaths = $themePaths = [];
         if (!empty($plugin)) {
-            for ($i = 0, $count = count($templatePaths); $i < $count; $i++) {
-                $pluginPaths[] = $templatePaths[$i]
+            foreach ($templatePaths as $templatePath) {
+                $pluginPaths[] = $templatePath
                     . static::PLUGIN_TEMPLATE_FOLDER
                     . DIRECTORY_SEPARATOR
                     . $plugin
@@ -1615,16 +1615,14 @@ class View implements EventDispatcherInterface
             $themePaths[] = Plugin::templatePath(Inflector::camelize($this->theme));
 
             if ($plugin) {
-                for ($i = 0, $count = count($themePaths); $i < $count; $i++) {
-                    array_unshift(
-                        $themePaths,
-                        $themePaths[$i]
-                            . static::PLUGIN_TEMPLATE_FOLDER
-                            . DIRECTORY_SEPARATOR
-                            . $plugin
-                            . DIRECTORY_SEPARATOR
-                    );
-                }
+                array_unshift(
+                    $themePaths,
+                    $themePaths[0]
+                        . static::PLUGIN_TEMPLATE_FOLDER
+                        . DIRECTORY_SEPARATOR
+                        . $plugin
+                        . DIRECTORY_SEPARATOR
+                );
             }
         }
 


### PR DESCRIPTION
- Use a foreach to iterate over the items of $templatePaths in case it's an associative array.
- Remove the for-loop for $themePaths. It always only contains one item.