### PR TITLE
4.x: i18n extract - check if folder exists before recursively checking php files

### DIFF
--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -830,7 +830,11 @@ class I18nExtractCommand extends Command
         }
 
         foreach ($this->_paths as $path) {
-            $path = realpath($path) . DIRECTORY_SEPARATOR;
+            $path = realpath($path);
+            if ($path === false) {
+                continue;
+            }
+            $path .= DIRECTORY_SEPARATOR;
             $fs = new Filesystem();
             $files = $fs->findRecursive($path, '/\.php$/');
             $files = array_keys(iterator_to_array($files));

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -373,4 +373,23 @@ class I18nExtractCommandTest extends TestCase
         $expected = '#: ./tests/test_app/templates/Pages/extract.php:';
         $this->assertStringContainsString($expected, $result);
     }
+
+    /**
+     * test invalid path options
+     */
+    public function testExtractWithInvalidPaths(): void
+    {
+        $this->exec(
+            'i18n extract ' .
+            '--extract-core=no ' .
+            '--paths=' . TEST_APP . 'templates,' . TEST_APP . 'unknown ' .
+            '--output=' . $this->path . DS
+        );
+        $this->assertExitSuccess();
+        $this->assertFileExists($this->path . DS . 'default.pot');
+        $result = file_get_contents($this->path . DS . 'default.pot');
+
+        $expected = '#: ./tests/test_app/templates/Pages/extract.php:';
+        $this->assertStringContainsString($expected, $result);
+    }
 }


### PR DESCRIPTION
## What is the problem?

If you try to extract a `pot` file via 
```
../../bin/cake i18n extract --paths $PWD/src/,$PWD/templates --overwrite --output $PWD/resources/locales/de_DE --extract-core no
```
from within a freshly baked plugin it will throw an error like this one:
```
2023-01-10 21:28:40 error: [UnexpectedValueException] RecursiveDirectoryIterator::__construct(//usr/sbin/authserver): Failed to open directory: Permission denied in /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/vendor/cakephp/cakephp/src/Command/I18nExtractCommand.php on line 836
Stack Trace:
- [internal]:??
- [internal]:??
- [internal]:??
- [internal]:??
- /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/vendor/cakephp/cakephp/src/Command/I18nExtractCommand.php:836
- /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/vendor/cakephp/cakephp/src/Command/I18nExtractCommand.php:263
- /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/vendor/cakephp/cakephp/src/Console/BaseCommand.php:189
- /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/vendor/cakephp/cakephp/src/Console/CommandRunner.php:334
- /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/vendor/cakephp/cakephp/src/Console/CommandRunner.php:172
- /Users/kevinpfeifer/Documents/CakePHP/organisation-repos/app/bin/cake.php:12
```

As you can see, it tried to read `/usr/sbin/authserver` which it should never have tried to.

## Why is this happening?
~~Inside the `I18nExtractCommand.php` the property `_paths` always contains at least the `src` and `templates` directory of the app/plugin to search through.~~ see comment bellow

BUT we do not check, if that folder actually exists.
In the case of a fresh baked plugin we don't create a `templates` folder as you can see here:
 https://github.com/cakephp/bake/tree/2.x/templates/bake/Plugin

Therefore `realpath($path)` returns false which will then be concatinated with `DIRECTORY_SEPARATOR` to `/` => therefore recursively checking the whole filesystem which is not good.

This PR adds a simple check if that folder exists - if not, continue the loop of `_paths`.