### PR TITLE
Fix up TypeError cases found by PHPStan level 8

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -184,6 +184,7 @@ abstract class BaseCommand implements CommandInterface
             $io->setInteractive(false);
         }
 
+        /** @var int|null */
         return $this->execute($args, $io);
     }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -225,9 +225,12 @@ class ConsoleOutput
             return (string)preg_replace('#</?(?:' . $tags . ')>#', '', $text);
         }
 
+        /** @var callable $callback */
+        $callback = $this->_replaceTags(...);
+
         return (string)preg_replace_callback(
             '/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims',
-            $this->_replaceTags(...),
+            $callback,
             $text
         );
     }

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -102,11 +102,11 @@ class Postgres extends Driver
         }
 
         if (!empty($config['timezone'])) {
-            $config['init'][] = sprintf('SET timezone = %s', $this->pdo->quote($config['timezone']));
+            $config['init'][] = sprintf('SET timezone = %s', $this->getPdo()->quote($config['timezone']));
         }
 
         foreach ($config['init'] as $command) {
-            $this->pdo->exec($command);
+            $this->getPdo()->exec($command);
         }
     }
 

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -57,9 +57,9 @@ class DateType extends BaseType implements BatchCastingInterface
      *
      * See `Cake\I18n\Time::parseDateTime()` for accepted formats.
      *
-     * @var string|int|null
+     * @var array|string|int|null
      */
-    protected string|int|null $_localeMarshalFormat = null;
+    protected array|string|int|null $_localeMarshalFormat = null;
 
     /**
      * The classname to use when creating objects.

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -116,7 +116,6 @@ class TimeType extends DateTimeType
         /** @psalm-var class-string<\Cake\I18n\DateTime> $class */
         $class = $this->_className;
 
-        /** @psalm-suppress PossiblyInvalidArgument */
         return $class::parseTime($value, $this->_localeMarshalFormat);
     }
 

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -116,6 +116,7 @@ class EventManager implements EventManagerInterface
         }
 
         if (!$callable) {
+            /** @var callable $options */
             $this->_listeners[$eventKey][static::$defaultPriority][] = [
                 'callable' => $options(...),
             ];

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -321,10 +321,10 @@ trait DateFormatTrait
      * ```
      *
      * @param string $time The time string to parse.
-     * @param string|int|null $format Any format accepted by IntlDateFormatter.
+     * @param array|string|int|null $format Any format accepted by IntlDateFormatter.
      * @return static|null
      */
-    public static function parseTime(string $time, string|int|null $format = null): ?static
+    public static function parseTime(string $time, array|string|int|null $format = null): ?static
     {
         if (is_int($format)) {
             $format = [IntlDateFormatter::NONE, $format];

--- a/src/I18n/Parser/MoFileParser.php
+++ b/src/I18n/Parser/MoFileParser.php
@@ -66,7 +66,7 @@ class MoFileParser
 
         $stat = fstat($stream);
 
-        if ($stat['size'] < self::MO_HEADER_SIZE) {
+        if ($stat === false || $stat['size'] < self::MO_HEADER_SIZE) {
             throw new CakeException('Invalid format for MO translations file');
         }
         /** @var array $magic */


### PR DESCRIPTION
Final result:

```
 ------ ------------------------------------------------------------------------------------------ 
  Line   Console/BaseCommand.php                                                                   
 ------ ------------------------------------------------------------------------------------------ 
  48     Parameter #1 $assertion of function assert expects bool|string, int<0, max>|false given.  
 ------ ------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   Controller/Controller.php                                                                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  305    Offset 'file' does not exist on array{function: string, line?: int, file?: string, class?: class-string, type?: '->'|'::', args?: array, object?: object}.  
  306    Offset 'line' does not exist on array{function: string, line?: int, file?: string, class?: class-string, type?: '->'|'::', args?: array, object?: object}.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------- 
  Line   Core/StaticConfigTrait.php (in context of class Cake\Mailer\Mailer)             
 ------ -------------------------------------------------------------------------------- 
  160    Access to an undefined static property static(Cake\Mailer\Mailer)::$_registry.  
 ------ -------------------------------------------------------------------------------- 

 ------ ----------------------------------------- 
  Line   Database/Driver/Postgres.php             
 ------ ----------------------------------------- 
  105    Cannot call method quote() on PDO|null.  
  109    Cannot call method exec() on PDO|null.   
 ------ ----------------------------------------- 

 ------ ------------------------------------------------------------ 
  Line   Database/Schema/SqliteSchemaDialect.php                     
 ------ ------------------------------------------------------------ 
  511    Offset 'type' does not exist on array<string, mixed>|null.  
 ------ ------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------- 
  Line   Database/Type/DateType.php                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------- 
  250    Property Cake\Database\Type\DateType::$_localeMarshalFormat (int|string|null) does not accept array|string.  
 ------ ------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Type/TimeType.php                                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------- 
  120    Parameter #2 $format of static method Cake\I18n\DateTime::parseTime() expects int|string|null, array|int|string|null given.  
 ------ ----------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------ 
  Line   Error/Debugger.php                                          
 ------ ------------------------------------------------------------ 
  122    Cannot access offset 0 on 0|0.0|''|'0'|array{}|false|null.  
 ------ ------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Event/EventManager.php                                                                                                                                                                      
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  300    Method Cake\Event\EventManager::dispatch() should return Cake\Event\EventInterface<TSubject of object> but returns Cake\Event\Event<object>|Cake\Event\EventInterface<TSubject of object>.  
  316    Method Cake\Event\EventManager::dispatch() should return Cake\Event\EventInterface<TSubject of object> but returns Cake\Event\Event<object>|Cake\Event\EventInterface<TSubject of object>.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------- 
  Line   Http/Cookie/Cookie.php                                                                                       
 ------ ------------------------------------------------------------------------------------------------------------- 
  171    Call to an undefined method Cake\Chronos\Chronos|DateTimeInterface::setTimezone().                           
  335    Parameter #1 $array of method Cake\Http\Cookie\Cookie::_flatten() expects array, array|string given.         
  427    Parameter #1 $array of method Cake\Http\Cookie\Cookie::_flatten() expects array, array|string given.         
  539    Call to an undefined method Cake\Chronos\Chronos|DateTimeInterface::setTimezone().                           
  658    Parameter #1 $string of method Cake\Http\Cookie\Cookie::_expand() expects string, array|string given.        
  662    Parameter #1 $data of static method Cake\Utility\Hash::check() expects array, array|string given.            
  677    Parameter #1 $string of method Cake\Http\Cookie\Cookie::_expand() expects string, array|string given.        
  681    Parameter #1 $data of static method Cake\Utility\Hash::insert() expects array, array|string given.           
  697    Parameter #1 $string of method Cake\Http\Cookie\Cookie::_expand() expects string, array|string given.        
  701    Parameter #1 $data of static method Cake\Utility\Hash::remove() expects array, array|string given.           
  719    Parameter #1 $string of method Cake\Http\Cookie\Cookie::_expand() expects string, array|string given.        
  727    Parameter #1 $data of static method Cake\Utility\Hash::get() expects array|ArrayAccess, array|string given.  
 ------ ------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------- 
  Line   I18n/Parser/PoFileParser.php                                                                             
 ------ --------------------------------------------------------------------------------------------------------- 
  117    Offset 1 does not exist on array{'context'}|array{'ids', 'plural'|'singular'}|array{'translated', int}.  
 ------ --------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   I18n/RelativeTimeFormatter.php                                                                                            
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  50     Parameter #1 $timezone of method Cake\Chronos\Chronos::now() expects DateTimeZone|string|null, DateTimeZone|false given.  
  109    Call to an undefined method Cake\I18n\Date|Cake\I18n\DateTime::setTimezone().                                             
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Behavior/TreeBehavior.php                                                                                                                                    
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  948    Method Cake\ORM\Behavior\TreeBehavior::_scope() should return T of Cake\ORM\Query\DeleteQuery|Cake\ORM\Query\SelectQuery|Cake\ORM\Query\UpdateQuery but returns  
         Cake\ORM\Query\DeleteQuery|Cake\ORM\Query\SelectQuery|Cake\ORM\Query\UpdateQuery.                                                                                
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   TestSuite/TestCase.php                                                                                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  750    Parameter #1 $assertions of method Cake\TestSuite\TestCase::_assertAttributes() expects array<string, mixed>, array<int|string, array<int, string>|int<1, max>|string> given.  
  750    Parameter #2 $string of method Cake\TestSuite\TestCase::_assertAttributes() expects string, string|false given.                                                                
  759    Offset 0 does not exist on array{attrs?: non-empty-array<int, string>, explains?: array<int, non-falsy-string>, 0?: non-falsy-string, 1?: string, 2?: int<1, max>}.            
  759    Offset 1 does not exist on array{attrs?: non-empty-array<int, string>, explains?: array<int, non-falsy-string>, 0?: non-falsy-string, 1?: string, 2?: int<1, max>}.            
  759    Offset 2 does not exist on array{attrs?: non-empty-array<int, string>, explains?: array<int, non-falsy-string>, 0?: non-falsy-string, 1?: string, 2?: int<1, max>}.            
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------ 
  Line   View/Helper/TimeHelper.php                                                          
 ------ ------------------------------------------------------------------------------------ 
  306    Call to an undefined method Cake\Chronos\Chronos|DateTimeInterface::setTimezone().  
 ------ ------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------- 
  Line   View/ViewVarsTrait.php (in context of class Cake\Mailer\Renderer)  
 ------ ------------------------------------------------------------------- 
  60     Access to an undefined property Cake\Mailer\Renderer::$name.       
  60     Access to an undefined property Cake\Mailer\Renderer::$plugin.     
  67     Access to an undefined property Cake\Mailer\Renderer::$request.    
  68     Access to an undefined property Cake\Mailer\Renderer::$response.   
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------- 
  Line   View/ViewVarsTrait.php (in context of class Cake\View\Cell)  
 ------ ------------------------------------------------------------- 
  60     Access to an undefined property Cake\View\Cell::$name.       
  60     Access to an undefined property Cake\View\Cell::$plugin.     
 ------ ------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------- 
  Line   View/Widget/DateTimeWidget.php                                                                                        
 ------ ---------------------------------------------------------------------------------------------------------------------- 
  214    Call to an undefined method Cake\Chronos\Chronos|Cake\Chronos\ChronosDate|DateTime|DateTimeImmutable::setTimezone().  
 ------ ---------------------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 41 errors                                                                                                
```