### PR TITLE
Add new find() options keys.

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -698,13 +698,17 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     public function applyOptions(array $options)
     {
         $valid = [
+            'select' => 'select',
             'fields' => 'select',
             'conditions' => 'where',
+            'where' => 'where',
             'join' => 'join',
             'order' => 'orderBy',
+            'orderBy' => 'orderBy',
             'limit' => 'limit',
             'offset' => 'offset',
             'group' => 'groupBy',
+            'groupBy' => 'groupBy',
             'having' => 'having',
             'contain' => 'contain',
             'page' => 'page',

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -999,6 +999,36 @@ class SelectQueryTest extends TestCase
         $this->assertEquals($expected, $query->getContain());
     }
 
+    public function testApplyOptionsSelectWhere(): void
+    {
+        $options = [
+            'select' => ['field_a', 'field_b'],
+            'where' => ['field_a' => 1, 'field_b' => 'something'],
+            'orderBy' => ['field_a'],
+            'groupBy' => ['field_b'],
+        ];
+        $query = new SelectQuery($this->table);
+        $query->applyOptions($options);
+
+        $this->assertEquals(['field_a', 'field_b'], $query->clause('select'));
+
+        $typeMap = new TypeMap([
+            'foo.id' => 'integer',
+            'id' => 'integer',
+            'foo__id' => 'integer',
+        ]);
+
+        $expected = new QueryExpression($options['where'], $typeMap);
+        $result = $query->clause('where');
+        $this->assertEquals($expected, $result);
+
+        $expected = new OrderByExpression($options['orderBy']);
+        $result = $query->clause('order');
+        $this->assertEquals($expected, $result);
+
+        $this->assertSame($options['groupBy'], $query->clause('group'));
+    }
+
     /**
      * Test that page is applied after limit.
      */


### PR DESCRIPTION
"select" and "where" are added to match the SQL clauses.

Not sure why the keys didn't match the method names earlier.

Similarly for associations the keys are `fields`, `conditions` and `sort` for which ones matching the SQL clauses should be added.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
