### PR TITLE
Consolidate code fencing in exception messages.

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -249,7 +249,7 @@ class Cache
         if ($success === false && $value !== '') {
             trigger_error(
                 sprintf(
-                    "%s cache was unable to write '%s' to %s cache",
+                    '%s cache was unable to write `%s` to `%s` cache',
                     $config,
                     $key,
                     $backend::class

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -84,7 +84,7 @@ class CacheRegistry extends ObjectRegistry
         if (!$instance->init($config)) {
             throw new CakeException(
                 sprintf(
-                    'Cache engine %s is not properly configured. Check error log for additional information.',
+                    'Cache engine `%s` is not properly configured. Check error log for additional information.',
                     $instance::class
                 )
             );

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -204,7 +204,7 @@ class ApcuEngine extends CacheEngine
                     $value = 1;
                     if (apcu_store($group, $value) === false) {
                         $this->warning(
-                            sprintf('Failed to store key "%s" with value "%s" into APCu cache.', $group, $value)
+                            sprintf('Failed to store key `%s` with value `%s` into APCu cache.', $group, $value)
                         );
                     }
                     $groups[$group] = $value;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -390,7 +390,7 @@ class FileEngine extends CacheEngine
 
             if (!$exists && !chmod($this->_File->getPathname(), (int)$this->_config['mask'])) {
                 trigger_error(sprintf(
-                    'Could not apply permission mask "%s" on cache file "%s"',
+                    'Could not apply permission mask `%s` on cache file `%s`',
                     $this->_File->getPathname(),
                     $this->_config['mask']
                 ), E_USER_WARNING);

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -267,7 +267,7 @@ class I18nExtractCommand extends Command
 
         $this->_output = rtrim($this->_output, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         if (!$this->_isPathUsable($this->_output)) {
-            $io->err(sprintf('The output directory %s was not found or writable.', $this->_output));
+            $io->err(sprintf('The output directory `%s` was not found or writable.', $this->_output));
 
             return static::CODE_ERROR;
         }

--- a/src/Command/SchemacacheBuildCommand.php
+++ b/src/Command/SchemacacheBuildCommand.php
@@ -61,7 +61,7 @@ class SchemacacheBuildCommand extends Command
         $tables = $cache->build($args->getArgument('name'));
 
         foreach ($tables as $table) {
-            $io->verbose(sprintf('Cached "%s"', $table));
+            $io->verbose(sprintf('Cached `%s`', $table));
         }
 
         $io->out('<success>Cache build complete</success>');

--- a/src/Command/SchemacacheClearCommand.php
+++ b/src/Command/SchemacacheClearCommand.php
@@ -61,7 +61,7 @@ class SchemacacheClearCommand extends Command
         $tables = $cache->clear($args->getArgument('name'));
 
         foreach ($tables as $table) {
-            $io->verbose(sprintf('Cleared "%s"', $table));
+            $io->verbose(sprintf('Cleared `%s`', $table));
         }
 
         $io->out('<success>Cache clear complete</success>');

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -167,7 +167,7 @@ class ConsoleInputArgument
         if (!in_array($value, $this->_choices, true)) {
             throw new ConsoleException(
                 sprintf(
-                    '"%s" is not a valid value for %s. Please use one of "%s"',
+                    '`%s` is not a valid value for `%s`. Please use one of `%s`',
                     $value,
                     $this->_name,
                     implode(', ', $this->_choices)

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -132,7 +132,7 @@ class ConsoleInputOption
 
         if (strlen($this->_short) > 1) {
             throw new ConsoleException(
-                sprintf('Short option "%s" is invalid, short options must be one letter.', $this->_short)
+                sprintf('Short option `%s` is invalid, short options must be one letter.', $this->_short)
             );
         }
         if (isset($this->_default) && $this->prompt) {
@@ -271,7 +271,7 @@ class ConsoleInputOption
         if (!in_array($value, $this->_choices, true)) {
             throw new ConsoleException(
                 sprintf(
-                    '"%s" is not a valid value for --%s. Please use one of "%s"',
+                    '`%s` is not a valid value for `--%s`. Please use one of `%s`',
                     (string)$value,
                     $this->_name,
                     implode(', ', $this->_choices)

--- a/src/Console/Exception/MissingHelperException.php
+++ b/src/Console/Exception/MissingHelperException.php
@@ -22,5 +22,5 @@ class MissingHelperException extends ConsoleException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'Helper class %s could not be found.';
+    protected string $_messageTemplate = 'Helper class `%s` could not be found.';
 }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -299,7 +299,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         $parts = explode('\\', static::class);
         trigger_error(
             sprintf(
-                'Undefined property: %s::$%s in %s on line %s',
+                'Undefined property `%s::$%s` in `%s` on line %s',
                 array_pop($parts),
                 $name,
                 $trace[0]['file'],

--- a/src/Controller/Exception/InvalidParameterException.php
+++ b/src/Controller/Exception/InvalidParameterException.php
@@ -26,11 +26,11 @@ class InvalidParameterException extends CakeException
      * @var array<string, string>
      */
     protected array $templates = [
-        'failed_coercion' => 'Unable to coerce "%s" to `%s` for `%s` in action %s::%s().',
+        'failed_coercion' => 'Unable to coerce `%s` to `%s` for `%s` in action `%s::%s()`.',
         'missing_dependency' => 'Failed to inject dependency from service container for parameter `%s` ' .
-            'with type `%s` in action %s::%s().',
-        'missing_parameter' => 'Missing passed parameter for `%s` in action %s::%s().',
-        'unsupported_type' => 'Type declaration for `%s` in action %s::%s() is unsupported.',
+            'with type `%s` in action `%s::%s()`.',
+        'missing_parameter' => 'Missing passed parameter for `%s` in action `%s::%s()`.',
+        'unsupported_type' => 'Type declaration for `%s` in action `%s::%s()` is unsupported.',
     ];
 
     /**

--- a/src/Controller/Exception/MissingActionException.php
+++ b/src/Controller/Exception/MissingActionException.php
@@ -25,5 +25,5 @@ class MissingActionException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Action %s::%s() could not be found, or is not accessible.';
+    protected string $_messageTemplate = 'Action `%s::%s()` could not be found, or is not accessible.';
 }

--- a/src/Controller/Exception/MissingComponentException.php
+++ b/src/Controller/Exception/MissingComponentException.php
@@ -24,5 +24,5 @@ class MissingComponentException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Component class %s could not be found.';
+    protected string $_messageTemplate = 'Component class `%s` could not be found.';
 }

--- a/src/Core/Exception/MissingPluginException.php
+++ b/src/Core/Exception/MissingPluginException.php
@@ -22,5 +22,5 @@ class MissingPluginException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Plugin %s could not be found.';
+    protected string $_messageTemplate = 'Plugin `%s` could not be found.';
 }

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -129,7 +129,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     protected function _checkDuplicate(string $name, array $config): void
     {
         $existing = $this->_loaded[$name];
-        $msg = sprintf('The "%s" alias has already been loaded.', $name);
+        $msg = sprintf('The `%s` alias has already been loaded.', $name);
         $hasConfig = method_exists($existing, 'getConfig');
         if (!$hasConfig) {
             throw new CakeException($msg);

--- a/src/Database/Exception/MissingExtensionException.php
+++ b/src/Database/Exception/MissingExtensionException.php
@@ -27,5 +27,5 @@ class MissingExtensionException extends CakeException
      * @inheritDoc
      */
     // phpcs:ignore Generic.Files.LineLength
-    protected string $_messageTemplate = 'Database driver %s cannot be used due to a missing PHP extension or unmet dependency. Requested by connection "%s"';
+    protected string $_messageTemplate = 'Database driver `%s` cannot be used due to a missing PHP extension or unmet dependency. Requested by connection `%s`';
 }

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -101,7 +101,7 @@ class MysqlSchemaDialect extends SchemaDialect
     {
         preg_match('/([a-z]+)(?:\(([0-9,]+)\))?\s*([a-z]+)?/i', $column, $matches);
         if (empty($matches)) {
-            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
         $col = strtolower($matches[1]);

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -102,7 +102,7 @@ class PostgresSchemaDialect extends SchemaDialect
     {
         preg_match('/([a-z\s]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
-            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
         $col = strtolower($matches[1]);

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -58,7 +58,7 @@ class SqliteSchemaDialect extends SchemaDialect
 
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
-            throw new DatabaseException(sprintf('Unable to parse column type from "%s"', $column));
+            throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
         $unsigned = false;

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -471,7 +471,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
 
         if (!in_array($attrs['type'], static::$_validIndexTypes, true)) {
             throw new DatabaseException(sprintf(
-                'Invalid index type "%s" in index "%s" in table "%s".',
+                'Invalid index type `%s` in index `%s` in table `%s`.',
                 $attrs['type'],
                 $name,
                 $this->_table
@@ -479,7 +479,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         }
         if (empty($attrs['columns'])) {
             throw new DatabaseException(sprintf(
-                'Index "%s" in table "%s" must have at least one column.',
+                'Index `%s` in table `%s` must have at least one column.',
                 $name,
                 $this->_table
             ));
@@ -488,8 +488,8 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         foreach ($attrs['columns'] as $field) {
             if (empty($this->_columns[$field])) {
                 $msg = sprintf(
-                    'Columns used in index "%s" in table "%s" must be added to the Table schema first. ' .
-                    'The column "%s" was not found.',
+                    'Columns used in index `%s` in table `%s` must be added to the Table schema first. ' .
+                    'The column `%s` was not found.',
                     $name,
                     $this->_table,
                     $field
@@ -548,14 +548,14 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         $attrs += static::$_indexKeys;
         if (!in_array($attrs['type'], static::$_validConstraintTypes, true)) {
             throw new DatabaseException(sprintf(
-                'Invalid constraint type "%s" in table "%s".',
+                'Invalid constraint type `%s` in table `%s`.',
                 $attrs['type'],
                 $this->_table
             ));
         }
         if (empty($attrs['columns'])) {
             throw new DatabaseException(sprintf(
-                'Constraints in table "%s" must have at least one column.',
+                'Constraints in table `%s` must have at least one column.',
                 $this->_table
             ));
         }
@@ -564,7 +564,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             if (empty($this->_columns[$field])) {
                 $msg = sprintf(
                     'Columns used in constraints must be added to the Table schema first. ' .
-                    'The column "%s" was not found in table "%s".',
+                    'The column `%s` was not found in table `%s`.',
                     $field,
                     $this->_table
                 );

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -75,7 +75,7 @@ class TypeFactory
             return static::$_builtTypes[$name];
         }
         if (!isset(static::$_types[$name])) {
-            throw new InvalidArgumentException(sprintf('Unknown type "%s"', $name));
+            throw new InvalidArgumentException(sprintf('Unknown type `%s`', $name));
         }
 
         return static::$_builtTypes[$name] = new static::$_types[$name]($name);

--- a/src/Datasource/Exception/MissingDatasourceConfigException.php
+++ b/src/Datasource/Exception/MissingDatasourceConfigException.php
@@ -24,5 +24,5 @@ class MissingDatasourceConfigException extends CakeException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'The datasource configuration "%s" was not found.';
+    protected string $_messageTemplate = 'The datasource configuration `%s` was not found.';
 }

--- a/src/Datasource/Exception/MissingDatasourceException.php
+++ b/src/Datasource/Exception/MissingDatasourceException.php
@@ -24,5 +24,5 @@ class MissingDatasourceException extends CakeException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'Datasource class %s could not be found. %s';
+    protected string $_messageTemplate = 'Datasource class `%s` could not be found. %s';
 }

--- a/src/Datasource/Exception/MissingModelException.php
+++ b/src/Datasource/Exception/MissingModelException.php
@@ -26,5 +26,5 @@ class MissingModelException extends CakeException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'Model class "%s" of type "%s" could not be found.';
+    protected string $_messageTemplate = 'Model class `%s` of type `%s` could not be found.';
 }

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -68,7 +68,7 @@ class FactoryLocator
         }
 
         throw new InvalidArgumentException(sprintf(
-            'Unknown repository type "%s". Make sure you register a type before trying to use it.',
+            'Unknown repository type `%s`. Make sure you register a type before trying to use it.',
             $type
         ));
     }

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -55,7 +55,7 @@ abstract class AbstractLocator implements LocatorInterface
         if (isset($this->instances[$alias])) {
             if (!empty($storeOptions) && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
                 throw new CakeException(sprintf(
-                    'You cannot configure "%s", it already exists in the registry.',
+                    'You cannot configure `%s`, it already exists in the registry.',
                     $alias
                 ));
             }

--- a/src/Datasource/Paging/Exception/PageOutOfBoundsException.php
+++ b/src/Datasource/Paging/Exception/PageOutOfBoundsException.php
@@ -24,5 +24,5 @@ class PageOutOfBoundsException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Page number %s could not be found.';
+    protected string $_messageTemplate = 'Page number `%s` could not be found.';
 }

--- a/src/Http/Exception/MissingControllerException.php
+++ b/src/Http/Exception/MissingControllerException.php
@@ -30,5 +30,5 @@ class MissingControllerException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Controller class %s could not be found.';
+    protected string $_messageTemplate = 'Controller class `%s` could not be found.';
 }

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -268,7 +268,7 @@ class Session
         $className = App::className($class, 'Http/Session');
         if ($className === null) {
             throw new InvalidArgumentException(
-                sprintf('The class "%s" does not exist and cannot be used as a session engine', $class)
+                sprintf('The class `%s` does not exist and cannot be used as a session engine', $class)
             );
         }
 

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -145,7 +145,7 @@ class FileLog extends BaseLog
         if (!$selfError && !$exists && !chmod($pathname, (int)$mask)) {
             $selfError = true;
             trigger_error(vsprintf(
-                'Could not apply permission mask "%s" on log file "%s"',
+                'Could not apply permission mask `%s` on log file `%s`',
                 [$mask, $pathname]
             ), E_USER_WARNING);
             $selfError = false;

--- a/src/Mailer/Exception/MissingMailerException.php
+++ b/src/Mailer/Exception/MissingMailerException.php
@@ -26,5 +26,5 @@ class MissingMailerException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Mailer class "%s" could not be found.';
+    protected string $_messageTemplate = 'Mailer class `%s` could not be found.';
 }

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -737,9 +737,9 @@ class Message implements JsonSerializable
 
         $context = ltrim($context, '_');
         if ($email === '') {
-            throw new InvalidArgumentException(sprintf('The email set for "%s" is empty.', $context));
+            throw new InvalidArgumentException(sprintf('The email set for `%s` is empty.', $context));
         }
-        throw new InvalidArgumentException(sprintf('Invalid email set for "%s". You passed "%s".', $context, $email));
+        throw new InvalidArgumentException(sprintf('Invalid email set for `%s`. You passed `%s`.', $context, $email));
     }
 
     /**
@@ -1193,7 +1193,7 @@ class Message implements JsonSerializable
                 $fileName = $fileInfo['file'];
                 $fileInfo['file'] = realpath($fileInfo['file']);
                 if ($fileInfo['file'] === false || !file_exists($fileInfo['file'])) {
-                    throw new InvalidArgumentException(sprintf('File not found: "%s"', $fileName));
+                    throw new InvalidArgumentException(sprintf('File not found: `%s`', $fileName));
                 }
                 if (is_int($name)) {
                     $name = basename($fileInfo['file']);
@@ -1514,7 +1514,7 @@ class Message implements JsonSerializable
         foreach ($content as $type => $text) {
             if (!in_array($type, $this->emailFormatAvailable, true)) {
                 throw new InvalidArgumentException(sprintf(
-                    'Invalid message type: "%s". Valid types are: "text", "html".',
+                    'Invalid message type: `%s`. Valid types are: `text`, `html`.',
                     $type
                 ));
             }

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -79,13 +79,13 @@ class TransportFactory
     {
         if (!isset(static::$_config[$name])) {
             throw new InvalidArgumentException(
-                sprintf('The "%s" transport configuration does not exist', $name)
+                sprintf('The `%s` transport configuration does not exist', $name)
             );
         }
 
         if (is_array(static::$_config[$name]) && empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
-                sprintf('Transport config "%s" is invalid, the required `className` option is missing', $name)
+                sprintf('Transport config `%s` is invalid, the required `className` option is missing', $name)
             );
         }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -571,8 +571,8 @@ abstract class Association
         if (!isset($this->_propertyName)) {
             $this->_propertyName = $this->_propertyName();
             if (in_array($this->_propertyName, $this->_sourceTable->getSchema()->columns(), true)) {
-                $msg = 'Association property name "%s" clashes with field of same name of table "%s".' .
-                    ' You should explicitly specify the "propertyName" option.';
+                $msg = 'Association property name `%s` clashes with field of same name of table `%s`.' .
+                    ' You should explicitly specify the `propertyName` option.';
                 trigger_error(
                     sprintf($msg, $this->_propertyName, $this->_sourceTable->getTable()),
                     E_USER_WARNING

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -635,7 +635,7 @@ class BelongsToMany extends Association
     public function setSaveStrategy(string $strategy)
     {
         if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
-            $msg = sprintf('Invalid save strategy "%s"', $strategy);
+            $msg = sprintf('Invalid save strategy `%s`', $strategy);
             throw new InvalidArgumentException($msg);
         }
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -112,7 +112,7 @@ class HasMany extends Association
     public function setSaveStrategy(string $strategy)
     {
         if (!in_array($strategy, [self::SAVE_APPEND, self::SAVE_REPLACE], true)) {
-            $msg = sprintf('Invalid save strategy "%s"', $strategy);
+            $msg = sprintf('Invalid save strategy `%s`', $strategy);
             throw new InvalidArgumentException($msg);
         }
 

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -220,7 +220,7 @@ class TimestampBehavior extends Behavior
         $type = TypeFactory::build($columnType);
         assert(
             $type instanceof DateTimeType,
-            'TimestampBehavior only supports columns of type DateTimeType.'
+            sprintf('TimestampBehavior only supports columns of type `%s`.', DateTimeType::class)
         );
 
         $class = $type->getDateTimeClassName();

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -261,7 +261,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call `%s` it does not belong to any attached behavior.', $method)
+            sprintf('Cannot call `%s`, it does not belong to any attached behavior.', $method)
         );
     }
 
@@ -286,7 +286,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call finder "%s" it does not belong to any attached behavior.', $type)
+            sprintf('Cannot call finder `%s`, it does not belong to any attached behavior.', $type)
         );
     }
 }

--- a/src/ORM/Exception/MissingBehaviorException.php
+++ b/src/ORM/Exception/MissingBehaviorException.php
@@ -24,5 +24,5 @@ class MissingBehaviorException extends CakeException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'Behavior class %s could not be found.';
+    protected string $_messageTemplate = 'Behavior class `%s` could not be found.';
 }

--- a/src/ORM/Exception/MissingEntityException.php
+++ b/src/ORM/Exception/MissingEntityException.php
@@ -28,5 +28,5 @@ class MissingEntityException extends CakeException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'Entity class %s could not be found.';
+    protected string $_messageTemplate = 'Entity class `%s` could not be found.';
 }

--- a/src/ORM/Exception/RolledbackTransactionException.php
+++ b/src/ORM/Exception/RolledbackTransactionException.php
@@ -24,6 +24,6 @@ class RolledbackTransactionException extends CakeException
     /**
      * @var string
      */
-    protected string $_messageTemplate = 'The afterSave event in "%s" is aborting the transaction'
+    protected string $_messageTemplate = 'The afterSave event in `%s` is aborting the transaction'
         . ' before the save process is done.';
 }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2088,7 +2088,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $primary = (array)$this->getPrimaryKey();
         if (empty($primary)) {
             $msg = sprintf(
-                'Cannot insert row in "%s" table, it has no primary key.',
+                'Cannot insert row in `%s` table, it has no primary key.',
                 $this->getTable()
             );
             throw new DatabaseException($msg);
@@ -2689,7 +2689,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         throw new BadMethodCallException(
-            sprintf('Unknown method "%s" called on %s', $method, static::class)
+            sprintf('Unknown method `%s` called on `%s`', $method, static::class)
         );
     }
 

--- a/src/Routing/Exception/DuplicateNamedRouteException.php
+++ b/src/Routing/Exception/DuplicateNamedRouteException.php
@@ -25,7 +25,7 @@ class DuplicateNamedRouteException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'A route named "%s" has already been connected to "%s".';
+    protected string $_messageTemplate = 'A route named `%s` has already been connected to `%s`.';
 
     /**
      * Constructor.

--- a/src/Routing/Exception/MissingDispatcherFilterException.php
+++ b/src/Routing/Exception/MissingDispatcherFilterException.php
@@ -24,5 +24,5 @@ class MissingDispatcherFilterException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Dispatcher filter %s could not be found.';
+    protected string $_messageTemplate = 'Dispatcher filter `%s` could not be found.';
 }

--- a/src/Routing/Exception/MissingRouteException.php
+++ b/src/Routing/Exception/MissingRouteException.php
@@ -26,14 +26,14 @@ class MissingRouteException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'A route matching "%s" could not be found.';
+    protected string $_messageTemplate = 'A route matching `%s` could not be found.';
 
     /**
      * Message template to use when the requested method is included.
      *
      * @var string
      */
-    protected string $_messageTemplateWithMethod = 'A "%s" route matching "%s" could not be found.';
+    protected string $_messageTemplateWithMethod = 'A `%s` route matching `%s` could not be found.';
 
     /**
      * Constructor.

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -89,7 +89,7 @@ class EventFiredWith extends Constraint
 
         if (count($events) > 1) {
             throw new AssertionFailedError(sprintf(
-                'Event "%s" was fired %d times, cannot make data assertion',
+                'Event `%s` was fired %d times, cannot make data assertion',
                 $other,
                 count($events)
             ));

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -74,7 +74,7 @@ class TestFixture implements FixtureInterface
             $connection = $this->connection;
             if (!str_starts_with($connection, 'test')) {
                 $message = sprintf(
-                    'Invalid datasource name "%s" for "%s" fixture. Fixture datasource names must begin with "test".',
+                    'Invalid datasource name `%s` for `%s` fixture. Fixture datasource names must begin with `test`.',
                     $connection,
                     static::class
                 );

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1387,10 +1387,10 @@ trait IntegrationTestTrait
         $message = PHP_EOL;
         foreach ($exceptions as $i => $error) {
             if ($i == 0) {
-                $message .= sprintf('Possibly related to %s: "%s"', $error::class, $error->getMessage());
+                $message .= sprintf('Possibly related to `%s`: "%s"', $error::class, $error->getMessage());
                 $message .= PHP_EOL;
             } else {
-                $message .= sprintf('Caused by %s: "%s"', $error::class, $error->getMessage());
+                $message .= sprintf('Caused by `%s`: "%s"', $error::class, $error->getMessage());
                 $message .= PHP_EOL;
             }
             $message .= $error->getTraceAsString();

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -682,7 +682,7 @@ abstract class TestCase extends BaseTestCase
                     $type = 'Text equals';
                 }
                 $regex[] = [
-                    sprintf('%s "%s"', $type, $tags),
+                    sprintf('%s `%s`', $type, $tags),
                     $tags,
                     $i,
                 ];
@@ -703,7 +703,7 @@ abstract class TestCase extends BaseTestCase
                 foreach ($attributes as $attr => $val) {
                     if (is_numeric($attr) && preg_match('/^preg\:\/(.+)\/$/i', (string)$val, $matches)) {
                         $attrs[] = $matches[1];
-                        $explanations[] = sprintf('Regex "%s" matches', $matches[1]);
+                        $explanations[] = sprintf('Regex `%s` matches', $matches[1]);
                         continue;
                     }
                     $val = (string)$val;
@@ -712,7 +712,7 @@ abstract class TestCase extends BaseTestCase
                     if (is_numeric($attr)) {
                         $attr = $val;
                         $val = '.+?';
-                        $explanations[] = sprintf('Attribute "%s" present', $attr);
+                        $explanations[] = sprintf('Attribute `%s` present', $attr);
                     } elseif (!empty($val) && preg_match('/^preg\:\/(.+)\/$/i', $val, $matches)) {
                         $val = str_replace(
                             ['.*', '.+'],
@@ -721,9 +721,9 @@ abstract class TestCase extends BaseTestCase
                         );
                         $quotes = $val !== $matches[1] ? '["\']' : '["\']?';
 
-                        $explanations[] = sprintf('Attribute "%s" matches "%s"', $attr, $val);
+                        $explanations[] = sprintf('Attribute `%s` matches `%s`', $attr, $val);
                     } else {
-                        $explanations[] = sprintf('Attribute "%s" == "%s"', $attr, $val);
+                        $explanations[] = sprintf('Attribute `%s` == `%s`', $attr, $val);
                         $val = preg_quote($val, '/');
                     }
                     $attrs[] = '[\s]+' . preg_quote($attr, '/') . '=' . $quotes . $val . $quotes;

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -178,7 +178,7 @@ class Filesystem
         // phpcs:ignore
         if (@mkdir($dir, $mode, true) === false) {
             umask($old);
-            throw new CakeException(sprintf('Failed to create directory "%s"', $dir));
+            throw new CakeException(sprintf('Failed to create directory `%s`', $dir));
         }
 
         umask($old);
@@ -198,7 +198,7 @@ class Filesystem
         }
 
         if (!is_dir($path)) {
-            throw new CakeException(sprintf('"%s" is not a directory', $path));
+            throw new CakeException(sprintf('`%s` is not a directory', $path));
         }
 
         /** @var \RecursiveDirectoryIterator<\SplFileInfo> $iterator Replace type for psalm */

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1458,7 +1458,7 @@ class Validation
         ];
         if ($options['type'] !== 'latLong') {
             throw new InvalidArgumentException(sprintf(
-                'Unsupported coordinate type "%s". Use "latLong" instead.',
+                'Unsupported coordinate type `%s`. Use `latLong` instead.',
                 $options['type']
             ));
         }

--- a/src/View/Exception/MissingHelperException.php
+++ b/src/View/Exception/MissingHelperException.php
@@ -24,5 +24,5 @@ class MissingHelperException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'Helper class %s could not be found.';
+    protected string $_messageTemplate = 'Helper class `%s` could not be found.';
 }

--- a/src/View/Exception/MissingViewException.php
+++ b/src/View/Exception/MissingViewException.php
@@ -26,5 +26,5 @@ class MissingViewException extends CakeException
     /**
      * @inheritDoc
      */
-    protected string $_messageTemplate = 'View class "%s" is missing.';
+    protected string $_messageTemplate = 'View class `%s` is missing.';
 }

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -101,7 +101,7 @@ class PluginLoadCommandTest extends TestCase
     {
         $this->exec('plugin load NopeNotThere');
         $this->assertExitCode(CommandInterface::CODE_ERROR);
-        $this->assertErrorContains('Plugin NopeNotThere could not be found');
+        $this->assertErrorContains('Plugin `NopeNotThere` could not be found');
 
         $config = include $this->configFile;
         $this->assertFalse(isset($config['NopeNotThere']));

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -210,7 +210,7 @@ class ComponentRegistryTest extends TestCase
     public function testUnloadUnknown(): void
     {
         $this->expectException(MissingComponentException::class);
-        $this->expectExceptionMessage('Component class FooComponent could not be found.');
+        $this->expectExceptionMessage('Component class `FooComponent` could not be found.');
         $this->Components->unload('Foo');
     }
 

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -109,7 +109,7 @@ class ComponentTest extends TestCase
     public function testDuplicateComponentInitialize(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The "Banana" alias has already been loaded. The `property` key');
+        $this->expectExceptionMessage('The `Banana` alias has already been loaded. The `property` key');
         $Collection = new ComponentRegistry(new Controller(new ServerRequest()));
         $Collection->load('Banana', ['property' => ['closure' => function (): void {
         }]]);
@@ -198,7 +198,7 @@ class ComponentTest extends TestCase
     public function testLazyLoadingDoesNotExists(): void
     {
         $this->expectException(MissingComponentException::class);
-        $this->expectExceptionMessage('Component class YouHaveNoBananasComponent could not be found.');
+        $this->expectExceptionMessage('Component class `YouHaveNoBananasComponent` could not be found.');
         $Component = new ConfiguredComponent(new ComponentRegistry(new Controller(new ServerRequest())), [], ['YouHaveNoBananas']);
         $bananas = $Component->YouHaveNoBananas;
     }

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -178,7 +178,7 @@ class ControllerFactoryTest extends TestCase
     public function testAbstractClassFailure(): void
     {
         $this->expectException(MissingControllerException::class);
-        $this->expectExceptionMessage('Controller class Abstract could not be found.');
+        $this->expectExceptionMessage('Controller class `Abstract` could not be found.');
         $request = new ServerRequest([
             'url' => 'abstract/index',
             'params' => [
@@ -192,7 +192,7 @@ class ControllerFactoryTest extends TestCase
     public function testInterfaceFailure(): void
     {
         $this->expectException(MissingControllerException::class);
-        $this->expectExceptionMessage('Controller class Interface could not be found.');
+        $this->expectExceptionMessage('Controller class `Interface` could not be found.');
         $request = new ServerRequest([
             'url' => 'interface/index',
             'params' => [
@@ -206,7 +206,7 @@ class ControllerFactoryTest extends TestCase
     public function testMissingClassFailure(): void
     {
         $this->expectException(MissingControllerException::class);
-        $this->expectExceptionMessage('Controller class Invisible could not be found.');
+        $this->expectExceptionMessage('Controller class `Invisible` could not be found.');
         $request = new ServerRequest([
             'url' => 'interface/index',
             'params' => [
@@ -220,7 +220,7 @@ class ControllerFactoryTest extends TestCase
     public function testSlashedControllerFailure(): void
     {
         $this->expectException(MissingControllerException::class);
-        $this->expectExceptionMessage('Controller class Admin/Posts could not be found.');
+        $this->expectExceptionMessage('Controller class `Admin/Posts` could not be found.');
         $request = new ServerRequest([
             'url' => 'admin/posts/index',
             'params' => [
@@ -234,7 +234,7 @@ class ControllerFactoryTest extends TestCase
     public function testAbsoluteReferenceFailure(): void
     {
         $this->expectException(MissingControllerException::class);
-        $this->expectExceptionMessage('Controller class TestApp\Controller\CakesController could not be found.');
+        $this->expectExceptionMessage('Controller class `TestApp\Controller\CakesController` could not be found.');
         $request = new ServerRequest([
             'url' => 'interface/index',
             'params' => [
@@ -549,7 +549,7 @@ class ControllerFactoryTest extends TestCase
 
         $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage(
-            'Failed to inject dependency from service container for parameter `dep` with type `stdClass` in action Dependencies::requiredDep()'
+            'Failed to inject dependency from service container for parameter `dep` with type `stdClass` in action `Dependencies::requiredDep()`'
         );
         $this->factory->invoke($controller);
     }
@@ -567,7 +567,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Missing passed parameter for `one` in action Dependencies::requiredParam()');
+        $this->expectExceptionMessage('Missing passed parameter for `one` in action `Dependencies::requiredParam()`');
         $this->factory->invoke($controller);
     }
 
@@ -716,7 +716,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Missing passed parameter for `str` in action Dependencies::requiredString()');
+        $this->expectExceptionMessage('Missing passed parameter for `str` in action `Dependencies::requiredString()`');
         $this->factory->invoke($controller);
     }
 
@@ -810,7 +810,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "true" to `float` for `one` in action Dependencies::requiredTyped()');
+        $this->expectExceptionMessage('Unable to coerce `true` to `float` for `one` in action `Dependencies::requiredTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -831,7 +831,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "2.0" to `int` for `two` in action Dependencies::requiredTyped()');
+        $this->expectExceptionMessage('Unable to coerce `2.0` to `int` for `two` in action `Dependencies::requiredTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -852,7 +852,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "true" to `bool` for `three` in action Dependencies::requiredTyped()');
+        $this->expectExceptionMessage('Unable to coerce `true` to `bool` for `three` in action `Dependencies::requiredTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -873,7 +873,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Unable to coerce "test" to `iterable` for `one` in action Dependencies::unsupportedTyped()');
+        $this->expectExceptionMessage('Unable to coerce `test` to `iterable` for `one` in action `Dependencies::unsupportedTyped()`');
         $this->factory->invoke($controller);
     }
 
@@ -894,7 +894,7 @@ class ControllerFactoryTest extends TestCase
         $controller = $this->factory->create($request);
 
         $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Type declaration for `one` in action Dependencies::unsupportedTypedUnion() is unsupported.');
+        $this->expectExceptionMessage('Type declaration for `one` in action `Dependencies::unsupportedTypedUnion()` is unsupported.');
         $this->factory->invoke($controller);
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -964,7 +964,7 @@ class ControllerTest extends TestCase
             $controller->loadComponent('FormProtection', ['bad' => 'settings']);
             $this->fail('No exception');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "FormProtection" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The `FormProtection` alias has already been loaded', $e->getMessage());
         }
     }
 

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -103,7 +103,7 @@ class ControllerTest extends TestCase
 
         $this->expectNotice();
         $this->expectNoticeMessage(sprintf(
-            'Undefined property: Controller::$Foo in %s on line %s',
+            'Undefined property `Controller::$Foo` in `%s` on line %s',
             __FILE__,
             __LINE__ + 2
         ));
@@ -722,7 +722,7 @@ class ControllerTest extends TestCase
     public function testGetActionMissingAction(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::missing() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::missing()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/missing',
             'params' => ['controller' => 'Test', 'action' => 'missing'],
@@ -738,7 +738,7 @@ class ControllerTest extends TestCase
     public function testGetActionPrivate(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::private_m() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::private_m()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/private_m/',
             'params' => ['controller' => 'Test', 'action' => 'private_m'],
@@ -754,7 +754,7 @@ class ControllerTest extends TestCase
     public function testGetActionProtected(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::protected_m() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::protected_m()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/protected_m/',
             'params' => ['controller' => 'Test', 'action' => 'protected_m'],
@@ -770,7 +770,7 @@ class ControllerTest extends TestCase
     public function testGetActionBaseMethods(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::redirect() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::redirect()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/redirect/',
             'params' => ['controller' => 'Test', 'action' => 'redirect'],
@@ -786,7 +786,7 @@ class ControllerTest extends TestCase
     public function testGetActionMethodCasing(): void
     {
         $this->expectException(MissingActionException::class);
-        $this->expectExceptionMessage('Action TestController::RETURNER() could not be found, or is not accessible.');
+        $this->expectExceptionMessage('Action `TestController::RETURNER()` could not be found, or is not accessible.');
         $url = new ServerRequest([
             'url' => 'test/RETURNER/',
             'params' => ['controller' => 'Test', 'action' => 'RETURNER'],

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -151,8 +151,8 @@ class ConnectionTest extends TestCase
     {
         $this->expectException(MissingExtensionException::class);
         $this->expectExceptionMessage(
-            'Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency. ' .
-            'Requested by connection "custom_connection_name"'
+            'Database driver `DriverMock` cannot be used due to a missing PHP extension or unmet dependency. ' .
+            'Requested by connection `custom_connection_name`'
         );
         $mock = $this->getMockBuilder(Mysql::class)
             ->onlyMethods(['enabled'])

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -104,7 +104,7 @@ class ConnectionManagerTest extends TestCase
     public function testGetFailOnMissingConfig(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The datasource configuration "test_variant" was not found.');
+        $this->expectExceptionMessage('The datasource configuration `test_variant` was not found.');
         ConnectionManager::get('test_variant');
     }
 
@@ -128,7 +128,7 @@ class ConnectionManagerTest extends TestCase
     public function testGetNoAlias(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The datasource configuration "other_name" was not found.');
+        $this->expectExceptionMessage('The datasource configuration `other_name` was not found.');
         $config = ConnectionManager::getConfig('test');
         $this->skipIf(empty($config), 'No test config, skipping');
 

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -40,7 +40,7 @@ class FactoryLocatorTest extends TestCase
     public function testGetNonExistent(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
+        $this->expectExceptionMessage('Unknown repository type `Test`. Make sure you register a type before trying to use it.');
         FactoryLocator::get('Test');
     }
 
@@ -60,7 +60,7 @@ class FactoryLocatorTest extends TestCase
     public function testDrop(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown repository type "Test". Make sure you register a type before trying to use it.');
+        $this->expectExceptionMessage('Unknown repository type `Test`. Make sure you register a type before trying to use it.');
         FactoryLocator::drop('Test');
 
         FactoryLocator::get('Test');

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -744,7 +744,7 @@ trait PaginatorTestTrait
             $this->fail('No exception raised');
         } catch (PageOutOfBoundsException $exception) {
             $this->assertEquals(
-                'Page number 3000 could not be found.',
+                'Page number `3000` could not be found.',
                 $exception->getMessage()
             );
 

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -180,7 +180,7 @@ class ExceptionTrapTest extends TestCase
         $trap->handleException($error);
         $out = $output->messages();
 
-        $this->assertStringContainsString('Controller class Articles', $out[0]);
+        $this->assertStringContainsString('Controller class `Articles`', $out[0]);
         $this->assertStringContainsString('Exception Attributes', $out[0]);
         $this->assertStringContainsString('Articles', $out[0]);
     }

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -323,7 +323,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
 
         $logs = $this->logger->read();
         $this->assertStringContainsString(
-            '[Cake\Http\Exception\MissingControllerException] Controller class Articles could not be found.',
+            '[Cake\Http\Exception\MissingControllerException] Controller class `Articles` could not be found.',
             $logs[0]
         );
         $this->assertStringContainsString('Exception Attributes:', $logs[0]);

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -687,7 +687,7 @@ class WebExceptionRendererTest extends TestCase
         $helpers = $controller->viewBuilder()->getHelpers();
         sort($helpers);
         $this->assertEquals([], $helpers);
-        $this->assertStringContainsString('Helper class Fail', (string)$response->getBody());
+        $this->assertStringContainsString('Helper class `Fail`', (string)$response->getBody());
     }
 
     /**

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -503,7 +503,7 @@ class SessionTest extends TestCase
     public function testBadEngine(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The class "Derp" does not exist and cannot be used as a session engine');
+        $this->expectExceptionMessage('The class `Derp` does not exist and cannot be used as a session engine');
         $session = new Session();
         $session->engine('Derp');
     }

--- a/tests/TestCase/Mailer/MailerAwareTraitTest.php
+++ b/tests/TestCase/Mailer/MailerAwareTraitTest.php
@@ -50,7 +50,7 @@ class MailerAwareTraitTest extends TestCase
     public function testGetMailerThrowsException(): void
     {
         $this->expectException(MissingMailerException::class);
-        $this->expectExceptionMessage('Mailer class "Test" could not be found.');
+        $this->expectExceptionMessage('Mailer class `Test` could not be found.');
         $stub = new Stub();
         $stub->getMailer('Test');
     }

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -99,7 +99,7 @@ class MailerTest extends TestCase
     public function testTransportInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "Invalid" transport configuration does not exist');
+        $this->expectExceptionMessage('The `Invalid` transport configuration does not exist');
         $this->mailer->setTransport('Invalid');
     }
 

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -571,7 +571,7 @@ HTML;
     public function testUnsetEmailPattern(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid email set for "to". You passed "fail.@example.com".');
+        $this->expectExceptionMessage('Invalid email set for `to`. You passed `fail.@example.com`.');
         $email = new Message();
         $this->assertSame(Message::EMAIL_PATTERN, $email->getEmailPattern());
 
@@ -588,7 +588,7 @@ HTML;
     public function testEmptyTo(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The email set for "to" is empty.');
+        $this->expectExceptionMessage('The email set for `to` is empty.');
         $email = new Message();
         $email->setTo('');
     }

--- a/tests/TestCase/Mailer/TransportFactoryTest.php
+++ b/tests/TestCase/Mailer/TransportFactoryTest.php
@@ -63,7 +63,7 @@ class TransportFactoryTest extends TestCase
     public function testGetMissingClassName(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Transport config "debug" is invalid, the required `className` option is missing');
+        $this->expectExceptionMessage('Transport config `debug` is invalid, the required `className` option is missing');
 
         TransportFactory::drop('debug');
         TransportFactory::setConfig('debug', []);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -383,7 +383,7 @@ class BelongsToManyTest extends TestCase
     public function testSaveStrategyInvalid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid save strategy "depsert"');
+        $this->expectExceptionMessage('Invalid save strategy `depsert`');
         new BelongsToMany('Test', ['saveStrategy' => 'depsert']);
     }
 

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -386,7 +386,7 @@ class AssociationTest extends TestCase
     public function testPropertyNameClash(): void
     {
         $this->expectWarning();
-        $this->expectWarningMessageMatches('/^Association property name "foo" clashes with field of same name of table "test"/');
+        $this->expectWarningMessageMatches('/^Association property name `foo` clashes with field of same name of table `test`/');
         $this->source->setSchema(['foo' => ['type' => 'string']]);
         $this->assertSame('foo', $this->association->getProperty());
     }

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -228,7 +228,7 @@ class TimestampBehaviorTest extends TestCase
     public function testNonDateTimeTypeException(): void
     {
         $this->expectException(AssertionError::class);
-        $this->expectExceptionMessage('TimestampBehavior only supports columns of type `DateTimeType`.');
+        $this->expectExceptionMessage('TimestampBehavior only supports columns of type `Cake\Database\Type\DateTimeType`.');
 
         $table = $this->getTableInstance();
         $this->Behavior = new TimestampBehavior($table, [

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -228,7 +228,7 @@ class TimestampBehaviorTest extends TestCase
     public function testNonDateTimeTypeException(): void
     {
         $this->expectException(AssertionError::class);
-        $this->expectExceptionMessage('TimestampBehavior only supports columns of type DateTimeType.');
+        $this->expectExceptionMessage('TimestampBehavior only supports columns of type `DateTimeType`.');
 
         $table = $this->getTableInstance();
         $this->Behavior = new TimestampBehavior($table, [

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -278,7 +278,7 @@ class BehaviorRegistryTest extends TestCase
     public function testCallError(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call `nope` it does not belong to any attached behavior.');
+        $this->expectExceptionMessage('Cannot call `nope`, it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->call('nope');
     }
@@ -314,7 +314,7 @@ class BehaviorRegistryTest extends TestCase
     public function testCallFinderError(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call finder "nope"');
+        $this->expectExceptionMessage('Cannot call finder `nope`');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->callFinder('nope');
     }
@@ -325,7 +325,7 @@ class BehaviorRegistryTest extends TestCase
     public function testUnloadBehaviorThenCall(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call `slugify` it does not belong to any attached behavior.');
+        $this->expectExceptionMessage('Cannot call `slugify`, it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
 
@@ -338,7 +338,7 @@ class BehaviorRegistryTest extends TestCase
     public function testUnloadBehaviorThenCallFinder(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cannot call finder "noslug" it does not belong to any attached behavior.');
+        $this->expectExceptionMessage('Cannot call finder `noslug`, it does not belong to any attached behavior.');
         $this->Behaviors->load('Sluggable');
         $this->Behaviors->unload('Sluggable');
 
@@ -378,7 +378,7 @@ class BehaviorRegistryTest extends TestCase
     public function testUnloadUnknown(): void
     {
         $this->expectException(MissingBehaviorException::class);
-        $this->expectExceptionMessage('Behavior class FooBehavior could not be found.');
+        $this->expectExceptionMessage('Behavior class `FooBehavior` could not be found.');
         $this->Behaviors->unload('Foo');
     }
 

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -285,7 +285,7 @@ class TableLocatorTest extends TestCase
         $this->assertNotEmpty($users);
 
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('You cannot configure "Users", it already exists in the registry.');
+        $this->expectExceptionMessage('You cannot configure `Users`, it already exists in the registry.');
 
         $this->_locator->get('Users', ['table' => 'my_users']);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1598,7 +1598,7 @@ class TableTest extends TestCase
     public function testTableClassNonExistent(): void
     {
         $this->expectException(MissingEntityException::class);
-        $this->expectExceptionMessage('Entity class FooUser could not be found.');
+        $this->expectExceptionMessage('Entity class `FooUser` could not be found.');
         $table = new Table();
         $table->setEntityClass('FooUser');
     }
@@ -1758,7 +1758,7 @@ class TableTest extends TestCase
             $table->addBehavior('Sluggable', ['thing' => 'thing']);
             $this->fail('No exception raised');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "Sluggable" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The `Sluggable` alias has already been loaded', $e->getMessage());
         }
     }
 
@@ -2391,7 +2391,7 @@ class TableTest extends TestCase
     public function testSaveNewErrorOnNoPrimaryKey(): void
     {
         $this->expectException(DatabaseException::class);
-        $this->expectExceptionMessage('Cannot insert row in "users" table, it has no primary key');
+        $this->expectExceptionMessage('Cannot insert row in `users` table, it has no primary key');
         $entity = new Entity(['username' => 'superuser']);
         $table = $this->getTableLocator()->get('users', [
             'schema' => [

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -47,7 +47,7 @@ class RouteCollectionTest extends TestCase
     public function testParseMissingRoute(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/" could not be found');
+        $this->expectExceptionMessage('A route matching `/` could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
@@ -62,7 +62,7 @@ class RouteCollectionTest extends TestCase
     public function testParseMissingRouteMethod(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A "POST" route matching "/b" could not be found');
+        $this->expectExceptionMessage('A `POST` route matching `/b` could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles', '_method' => ['GET']]);
 
@@ -255,7 +255,7 @@ class RouteCollectionTest extends TestCase
     public function testParseRequestMissingRoute(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/" could not be found');
+        $this->expectExceptionMessage('A route matching `/` could not be found');
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
@@ -340,7 +340,7 @@ class RouteCollectionTest extends TestCase
     public function testParseRequestCheckHostConditionFail(string $host): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "/fallback" could not be found');
+        $this->expectExceptionMessage('A route matching `/fallback` could not be found');
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect(
             '/fallback',
@@ -454,7 +454,7 @@ class RouteCollectionTest extends TestCase
     public function testMatchError(): void
     {
         $this->expectException(MissingRouteException::class);
-        $this->expectExceptionMessage('A route matching "array (');
+        $this->expectExceptionMessage('A route matching `array (');
         $context = [
             '_base' => '/',
             '_scheme' => 'http',

--- a/tests/TestCase/TestSuite/AssertHtmlTest.php
+++ b/tests/TestCase/TestSuite/AssertHtmlTest.php
@@ -238,7 +238,7 @@ HTML;
             $this->fail('Assertion should fail');
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
-                'Attribute did not match. Was expecting Attribute "clAss" == "active"',
+                'Attribute did not match. Was expecting Attribute `clAss` == `active`',
                 $e->getMessage()
             );
         }

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1503,49 +1503,49 @@ class IntegrationTestTraitTest extends TestCase
 
         return [
             'assertContentType' => ['assertContentType', 'Failed asserting that \'test\' is set as the Content-Type (`text/html`).', '/posts/index', 'test'],
-            'assertContentTypeVerbose' => ['assertContentType', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test'],
+            'assertContentTypeVerbose' => ['assertContentType', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertCookie' => ['assertCookie', 'Failed asserting that \'test\' is in cookie \'remember_me\'.', '/posts/index', 'test', 'remember_me'],
-            'assertCookieVerbose' => ['assertCookie', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test', 'remember_me'],
+            'assertCookieVerbose' => ['assertCookie', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'remember_me'],
             'assertCookieEncrypted' => ['assertCookieEncrypted', 'Failed asserting that \'test\' is encrypted in cookie \'secrets\'.', '/posts/secretCookie', 'test', 'secrets'],
-            'assertCookieEncryptedVerbose' => ['assertCookieEncrypted', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test', 'NameOfCookie'],
+            'assertCookieEncryptedVerbose' => ['assertCookieEncrypted', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'NameOfCookie'],
             'assertCookieNotSet' => ['assertCookieNotSet', 'Failed asserting that \'remember_me\' cookie is not set.', '/posts/index', 'remember_me'],
             'assertFileResponse' => ['assertFileResponse', 'Failed asserting that \'test\' file was sent.', '/posts/file', 'test'],
-            'assertFileResponseVerbose' => ['assertFileResponse', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test'],
+            'assertFileResponseVerbose' => ['assertFileResponse', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertHeader' => ['assertHeader', 'Failed asserting that \'test\' equals content in header \'X-Cake\' (`custom header`).', '/posts/header', 'X-Cake', 'test'],
             'assertHeaderContains' => ['assertHeaderContains', 'Failed asserting that \'test\' is in header \'X-Cake\' (`custom header`)', '/posts/header', 'X-Cake', 'test'],
             'assertHeaderNotContains' => ['assertHeaderNotContains', 'Failed asserting that \'custom header\' is not in header \'X-Cake\' (`custom header`)', '/posts/header', 'X-Cake', 'custom header'],
-            'assertHeaderContainsVerbose' => ['assertHeaderContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'X-Cake', 'test'],
-            'assertHeaderNotContainsVerbose' => ['assertHeaderNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'X-Cake', 'test'],
+            'assertHeaderContainsVerbose' => ['assertHeaderContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
+            'assertHeaderNotContainsVerbose' => ['assertHeaderNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
             'assertLayout' => ['assertLayout', 'Failed asserting that \'custom_layout\' equals layout file `' . $templateDir . 'layout' . DS . 'default.php`.', '/posts/index', 'custom_layout'],
-            'assertLayoutVerbose' => ['assertLayout', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'custom_layout'],
+            'assertLayoutVerbose' => ['assertLayout', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'custom_layout'],
             'assertRedirect' => ['assertRedirect', 'Failed asserting that \'http://localhost/\' equals content in header \'Location\' (`http://localhost/posts`).', '/posts/flashNoRender', '/'],
-            'assertRedirectVerbose' => ['assertRedirect', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/'],
+            'assertRedirectVerbose' => ['assertRedirect', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/'],
             'assertRedirectContains' => ['assertRedirectContains', 'Failed asserting that \'/posts/somewhere-else\' is in header \'Location\' (`http://localhost/posts`).', '/posts/flashNoRender', '/posts/somewhere-else'],
-            'assertRedirectContainsVerbose' => ['assertRedirectContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/posts/somewhere-else'],
-            'assertRedirectNotContainsVerbose' => ['assertRedirectNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/posts/somewhere-else'],
+            'assertRedirectContainsVerbose' => ['assertRedirectContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
+            'assertRedirectNotContainsVerbose' => ['assertRedirectNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
             'assertResponseCode' => ['assertResponseCode', 'Failed asserting that `302` matches response status code `200`.', '/posts/index', 302],
             'assertResponseContains' => ['assertResponseContains', 'Failed asserting that \'test\' is in response body.', '/posts/index', 'test'],
             'assertResponseEmpty' => ['assertResponseEmpty', 'Failed asserting that response body is empty.', '/posts/index'],
             'assertResponseEquals' => ['assertResponseEquals', 'Failed asserting that \'test\' matches response body.', '/posts/index', 'test'],
-            'assertResponseEqualsVerbose' => ['assertResponseEquals', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'test'],
+            'assertResponseEqualsVerbose' => ['assertResponseEquals', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertResponseError' => ['assertResponseError', 'Failed asserting that 200 is between 400 and 429.', '/posts/index'],
             'assertResponseFailure' => ['assertResponseFailure', 'Failed asserting that 200 is between 500 and 505.', '/posts/index'],
             'assertResponseNotContains' => ['assertResponseNotContains', 'Failed asserting that \'index\' is not in response body.', '/posts/index', 'index'],
             'assertResponseNotEmpty' => ['assertResponseNotEmpty', 'Failed asserting that response body is not empty.', '/posts/empty_response'],
             'assertResponseNotEquals' => ['assertResponseNotEquals', 'Failed asserting that \'posts index\' does not match response body.', '/posts/index/error', 'posts index'],
             'assertResponseNotRegExp' => ['assertResponseNotRegExp', 'Failed asserting that `/index/` PCRE pattern not found in response body.', '/posts/index/error', '/index/'],
-            'assertResponseNotRegExpVerbose' => ['assertResponseNotRegExp', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', '/index/'],
+            'assertResponseNotRegExpVerbose' => ['assertResponseNotRegExp', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/index/'],
             'assertResponseOk' => ['assertResponseOk', 'Failed asserting that 404 is between 200 and 204.', '/posts/missing', '/index/'],
             'assertResponseRegExp' => ['assertResponseRegExp', 'Failed asserting that `/test/` PCRE pattern found in response body.', '/posts/index/error', '/test/'],
             'assertResponseSuccess' => ['assertResponseSuccess', 'Failed asserting that 404 is between 200 and 308.', '/posts/missing'],
-            'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to Cake\Controller\Exception\MissingActionException: "Action PostsController::missing() could not be found, or is not accessible."', '/posts/missing'],
+            'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to Cake\Controller\Exception\MissingActionException: "Action `PostsController::missing()` could not be found, or is not accessible."', '/posts/missing'],
 
             'assertSession' => ['assertSession', 'Failed asserting that \'test\' is in session path \'Missing.path\'.', '/posts/index', 'test', 'Missing.path'],
             'assertSessionHasKey' => ['assertSessionHasKey', 'Failed asserting that \'Missing.path\' is a path present in the session.', '/posts/index', 'Missing.path'],
             'assertSessionNotHasKey' => ['assertSessionNotHasKey', 'Failed asserting that \'Flash.flash\' is not a path present in the session.', '/posts/index', 'Flash.flash'],
 
             'assertTemplate' => ['assertTemplate', 'Failed asserting that \'custom_template\' equals template file `' . $templateDir . 'Posts' . DS . 'index.php`.', '/posts/index', 'custom_template'],
-            'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."', '/notfound', 'custom_template'],
+            'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'custom_template'],
             'assertFlashMessage' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'flash\' message.', '/posts/index', 'missing'],
             'assertFlashMessageWithKey' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'auth\' message.', '/posts/index', 'missing', 'auth'],
             'assertFlashMessageAt' => ['assertFlashMessageAt', 'Failed asserting that \'missing\' is in \'flash\' message #0.', '/posts/index', 0, 'missing'],
@@ -1579,7 +1579,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertCookieNotSetVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withCookie(new Cookie('cookie', 'value'));
         $this->assertCookieNotSet('cookie');
@@ -1591,7 +1591,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertNoRedirectVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withHeader('Location', '/redirect');
         $this->assertNoRedirect();
@@ -1603,7 +1603,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertHeaderVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: `"A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->assertHeader('Etag', 'abc123');
     }
@@ -1614,7 +1614,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertResponseNotEqualsVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withStringBody('body');
         $this->assertResponseNotEquals('body');
@@ -1626,7 +1626,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertResponseRegExpVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching "/notfound" could not be found."');
+        $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withStringBody('body');
         $this->assertResponseRegExp('/patternNotFound/');
@@ -1641,7 +1641,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertSessionRelatedVerboseMessages(string $assertMethod, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to OutOfBoundsException: "oh no!"');
+        $this->expectExceptionMessage('Possibly related to OutOfBoundsException: `oh no!`');
         $this->get('/posts/throw_exception');
         $this->_requestSession = new Session();
         call_user_func_array($this->$assertMethod(...), $rest);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -1486,7 +1486,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertMessagePrevious()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Caused by RuntimeException');
+        $this->expectExceptionMessage('Caused by `RuntimeException`');
 
         $this->get('/posts/throw_chained');
         $this->assertContentType('test');
@@ -1503,49 +1503,49 @@ class IntegrationTestTraitTest extends TestCase
 
         return [
             'assertContentType' => ['assertContentType', 'Failed asserting that \'test\' is set as the Content-Type (`text/html`).', '/posts/index', 'test'],
-            'assertContentTypeVerbose' => ['assertContentType', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
+            'assertContentTypeVerbose' => ['assertContentType', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertCookie' => ['assertCookie', 'Failed asserting that \'test\' is in cookie \'remember_me\'.', '/posts/index', 'test', 'remember_me'],
-            'assertCookieVerbose' => ['assertCookie', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'remember_me'],
+            'assertCookieVerbose' => ['assertCookie', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'remember_me'],
             'assertCookieEncrypted' => ['assertCookieEncrypted', 'Failed asserting that \'test\' is encrypted in cookie \'secrets\'.', '/posts/secretCookie', 'test', 'secrets'],
-            'assertCookieEncryptedVerbose' => ['assertCookieEncrypted', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'NameOfCookie'],
+            'assertCookieEncryptedVerbose' => ['assertCookieEncrypted', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'test', 'NameOfCookie'],
             'assertCookieNotSet' => ['assertCookieNotSet', 'Failed asserting that \'remember_me\' cookie is not set.', '/posts/index', 'remember_me'],
             'assertFileResponse' => ['assertFileResponse', 'Failed asserting that \'test\' file was sent.', '/posts/file', 'test'],
-            'assertFileResponseVerbose' => ['assertFileResponse', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
+            'assertFileResponseVerbose' => ['assertFileResponse', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertHeader' => ['assertHeader', 'Failed asserting that \'test\' equals content in header \'X-Cake\' (`custom header`).', '/posts/header', 'X-Cake', 'test'],
             'assertHeaderContains' => ['assertHeaderContains', 'Failed asserting that \'test\' is in header \'X-Cake\' (`custom header`)', '/posts/header', 'X-Cake', 'test'],
             'assertHeaderNotContains' => ['assertHeaderNotContains', 'Failed asserting that \'custom header\' is not in header \'X-Cake\' (`custom header`)', '/posts/header', 'X-Cake', 'custom header'],
-            'assertHeaderContainsVerbose' => ['assertHeaderContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
-            'assertHeaderNotContainsVerbose' => ['assertHeaderNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
+            'assertHeaderContainsVerbose' => ['assertHeaderContains', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
+            'assertHeaderNotContainsVerbose' => ['assertHeaderNotContains', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'X-Cake', 'test'],
             'assertLayout' => ['assertLayout', 'Failed asserting that \'custom_layout\' equals layout file `' . $templateDir . 'layout' . DS . 'default.php`.', '/posts/index', 'custom_layout'],
-            'assertLayoutVerbose' => ['assertLayout', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'custom_layout'],
+            'assertLayoutVerbose' => ['assertLayout', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'custom_layout'],
             'assertRedirect' => ['assertRedirect', 'Failed asserting that \'http://localhost/\' equals content in header \'Location\' (`http://localhost/posts`).', '/posts/flashNoRender', '/'],
-            'assertRedirectVerbose' => ['assertRedirect', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/'],
+            'assertRedirectVerbose' => ['assertRedirect', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', '/'],
             'assertRedirectContains' => ['assertRedirectContains', 'Failed asserting that \'/posts/somewhere-else\' is in header \'Location\' (`http://localhost/posts`).', '/posts/flashNoRender', '/posts/somewhere-else'],
-            'assertRedirectContainsVerbose' => ['assertRedirectContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
-            'assertRedirectNotContainsVerbose' => ['assertRedirectNotContains', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
+            'assertRedirectContainsVerbose' => ['assertRedirectContains', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
+            'assertRedirectNotContainsVerbose' => ['assertRedirectNotContains', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', '/posts/somewhere-else'],
             'assertResponseCode' => ['assertResponseCode', 'Failed asserting that `302` matches response status code `200`.', '/posts/index', 302],
             'assertResponseContains' => ['assertResponseContains', 'Failed asserting that \'test\' is in response body.', '/posts/index', 'test'],
             'assertResponseEmpty' => ['assertResponseEmpty', 'Failed asserting that response body is empty.', '/posts/index'],
             'assertResponseEquals' => ['assertResponseEquals', 'Failed asserting that \'test\' matches response body.', '/posts/index', 'test'],
-            'assertResponseEqualsVerbose' => ['assertResponseEquals', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
+            'assertResponseEqualsVerbose' => ['assertResponseEquals', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'test'],
             'assertResponseError' => ['assertResponseError', 'Failed asserting that 200 is between 400 and 429.', '/posts/index'],
             'assertResponseFailure' => ['assertResponseFailure', 'Failed asserting that 200 is between 500 and 505.', '/posts/index'],
             'assertResponseNotContains' => ['assertResponseNotContains', 'Failed asserting that \'index\' is not in response body.', '/posts/index', 'index'],
             'assertResponseNotEmpty' => ['assertResponseNotEmpty', 'Failed asserting that response body is not empty.', '/posts/empty_response'],
             'assertResponseNotEquals' => ['assertResponseNotEquals', 'Failed asserting that \'posts index\' does not match response body.', '/posts/index/error', 'posts index'],
             'assertResponseNotRegExp' => ['assertResponseNotRegExp', 'Failed asserting that `/index/` PCRE pattern not found in response body.', '/posts/index/error', '/index/'],
-            'assertResponseNotRegExpVerbose' => ['assertResponseNotRegExp', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', '/index/'],
+            'assertResponseNotRegExpVerbose' => ['assertResponseNotRegExp', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', '/index/'],
             'assertResponseOk' => ['assertResponseOk', 'Failed asserting that 404 is between 200 and 204.', '/posts/missing', '/index/'],
             'assertResponseRegExp' => ['assertResponseRegExp', 'Failed asserting that `/test/` PCRE pattern found in response body.', '/posts/index/error', '/test/'],
             'assertResponseSuccess' => ['assertResponseSuccess', 'Failed asserting that 404 is between 200 and 308.', '/posts/missing'],
-            'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to Cake\Controller\Exception\MissingActionException: "Action `PostsController::missing()` could not be found, or is not accessible."', '/posts/missing'],
+            'assertResponseSuccessVerbose' => ['assertResponseSuccess', 'Possibly related to `Cake\Controller\Exception\MissingActionException`: "Action `PostsController::missing()` could not be found, or is not accessible."', '/posts/missing'],
 
             'assertSession' => ['assertSession', 'Failed asserting that \'test\' is in session path \'Missing.path\'.', '/posts/index', 'test', 'Missing.path'],
             'assertSessionHasKey' => ['assertSessionHasKey', 'Failed asserting that \'Missing.path\' is a path present in the session.', '/posts/index', 'Missing.path'],
             'assertSessionNotHasKey' => ['assertSessionNotHasKey', 'Failed asserting that \'Flash.flash\' is not a path present in the session.', '/posts/index', 'Flash.flash'],
 
             'assertTemplate' => ['assertTemplate', 'Failed asserting that \'custom_template\' equals template file `' . $templateDir . 'Posts' . DS . 'index.php`.', '/posts/index', 'custom_template'],
-            'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."', '/notfound', 'custom_template'],
+            'assertTemplateVerbose' => ['assertTemplate', 'Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."', '/notfound', 'custom_template'],
             'assertFlashMessage' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'flash\' message.', '/posts/index', 'missing'],
             'assertFlashMessageWithKey' => ['assertFlashMessage', 'Failed asserting that \'missing\' is in \'auth\' message.', '/posts/index', 'missing', 'auth'],
             'assertFlashMessageAt' => ['assertFlashMessageAt', 'Failed asserting that \'missing\' is in \'flash\' message #0.', '/posts/index', 0, 'missing'],
@@ -1579,7 +1579,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertCookieNotSetVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
+        $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withCookie(new Cookie('cookie', 'value'));
         $this->assertCookieNotSet('cookie');
@@ -1591,7 +1591,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertNoRedirectVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
+        $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withHeader('Location', '/redirect');
         $this->assertNoRedirect();
@@ -1603,7 +1603,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertHeaderVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: `"A route matching `/notfound` could not be found."');
+        $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->assertHeader('Etag', 'abc123');
     }
@@ -1614,7 +1614,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertResponseNotEqualsVerbose(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to Cake\Routing\Exception\MissingRouteException: "A route matching `/notfound` could not be found."');
+        $this->expectExceptionMessage('Possibly related to `Cake\Routing\Exception\MissingRouteException`: "A route matching `/notfound` could not be found."');
         $this->get('/notfound');
         $this->_response = $this->_response->withStringBody('body');
         $this->assertResponseNotEquals('body');
@@ -1641,7 +1641,7 @@ class IntegrationTestTraitTest extends TestCase
     public function testAssertSessionRelatedVerboseMessages(string $assertMethod, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Possibly related to OutOfBoundsException: `oh no!`');
+        $this->expectExceptionMessage('Possibly related to `OutOfBoundsException`: "oh no!"');
         $this->get('/posts/throw_exception');
         $this->_requestSession = new Session();
         call_user_func_array($this->$assertMethod(...), $rest);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -249,7 +249,7 @@ class HelperRegistryTest extends TestCase
     public function testUnloadUnknown(): void
     {
         $this->expectException(MissingHelperException::class);
-        $this->expectExceptionMessage('Helper class FooHelper could not be found.');
+        $this->expectExceptionMessage('Helper class `FooHelper` could not be found.');
         $this->Helpers->unload('Foo');
     }
 
@@ -295,7 +295,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadMultipleTimesDifferentConfigured(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The "Html" alias has already been loaded');
+        $this->expectExceptionMessage('The `Html` alias has already been loaded');
         $this->Helpers->load('Html');
         $this->Helpers->load('Html', ['same' => 'stuff']);
     }
@@ -306,7 +306,7 @@ class HelperRegistryTest extends TestCase
     public function testLoadMultipleTimesDifferentConfigValues(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('The "Html" alias has already been loaded');
+        $this->expectExceptionMessage('The `Html` alias has already been loaded');
         $this->Helpers->load('Html', ['key' => 'value']);
         $this->Helpers->load('Html', ['key' => 'new value']);
     }

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingViewException;
+use Cake\View\View;
 use Cake\View\ViewBuilder;
 
 /**
@@ -253,7 +254,7 @@ class ViewBuilderTest extends TestCase
         static::setAppNamespace('Nope');
         $builder = new ViewBuilder();
         $view = $builder->build();
-        $this->assertInstanceOf('Cake\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
     }
 
     /**
@@ -273,7 +274,7 @@ class ViewBuilderTest extends TestCase
     public function testBuildMissingViewClass(): void
     {
         $this->expectException(MissingViewException::class);
-        $this->expectExceptionMessage('View class "Foo" is missing.');
+        $this->expectExceptionMessage('View class `Foo` is missing.');
         $builder = new ViewBuilder();
         $builder->setClassName('Foo');
         $builder->build();

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -871,7 +871,7 @@ class ViewTest extends TestCase
             $View->loadHelper('Html', ['test' => 'value']);
             $this->fail('No exception');
         } catch (RuntimeException $e) {
-            $this->assertStringContainsString('The "Html" alias has already been loaded', $e->getMessage());
+            $this->assertStringContainsString('The `Html` alias has already been loaded', $e->getMessage());
         }
     }
 

--- a/tests/TestCase/View/ViewVarsTraitTest.php
+++ b/tests/TestCase/View/ViewVarsTraitTest.php
@@ -19,6 +19,7 @@ use Cake\Controller\Controller;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingViewException;
+use Cake\View\XmlView;
 
 /**
  * ViewVarsTrait test case
@@ -108,7 +109,7 @@ class ViewVarsTraitTest extends TestCase
     {
         $this->subject->viewBuilder()->setClassName('View');
         $view = $this->subject->createView('Xml');
-        $this->assertInstanceOf('Cake\View\XmlView', $view);
+        $this->assertInstanceOf(XmlView::class, $view);
     }
 
     /**
@@ -117,7 +118,7 @@ class ViewVarsTraitTest extends TestCase
     public function testCreateViewException(): void
     {
         $this->expectException(MissingViewException::class);
-        $this->expectExceptionMessage('View class "Foo" is missing.');
+        $this->expectExceptionMessage('View class `Foo` is missing.');
         $this->subject->createView('Foo');
     }
 }


### PR DESCRIPTION
This will help to make it easier to copy and paste them
Most online tools like SO/github will auto render, so will e.g. Slack/Discourse when sharing such errors.
Makes it much easier to read the highlighted code piece in question.

The majority of code was already adjusted, these seem to be the left overs.

~~I skipped TestSuite and ORM right now as there is some funky things going on in there it seems.~~
Lets see if we can figure those out too
It is difficult to skip them, as the tests are sometimes cross over