### PR TITLE
5.x: add a comment to a query instance

### DIFF
--- a/src/Database/PostgresCompiler.php
+++ b/src/Database/PostgresCompiler.php
@@ -48,6 +48,7 @@ class PostgresCompiler extends QueryCompiler
         'limit' => ' LIMIT %s',
         'offset' => ' OFFSET %s',
         'epilog' => ' %s',
+        'comment' => '/* %s */ ',
     ];
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
-use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
@@ -337,11 +336,7 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function traverseParts(Closure $visitor, array $parts)
     {
-        $debugMode = Configure::read('debug');
         foreach ($parts as $name) {
-            if ($name === 'comment' && !$debugMode) {
-                continue;
-            }
             $visitor($this->_parts[$name], $name);
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -98,6 +98,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * @var array<string, mixed>
      */
     protected array $_parts = [
+        'comment' => null,
         'delete' => true,
         'update' => [],
         'set' => [],
@@ -118,7 +119,6 @@ abstract class Query implements ExpressionInterface, Stringable
         'offset' => null,
         'union' => [],
         'epilog' => null,
-        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -118,6 +118,7 @@ abstract class Query implements ExpressionInterface, Stringable
         'offset' => null,
         'union' => [],
         'epilog' => null,
+        'comment' => null,
     ];
 
     /**
@@ -1448,6 +1449,27 @@ abstract class Query implements ExpressionInterface, Stringable
     {
         $this->_dirty();
         $this->_parts['epilog'] = $expression;
+
+        return $this;
+    }
+
+    /**
+     * A string or expression that will be appended to the generated query as a comment
+     *
+     * ### Examples:
+     * ```
+     * $query->select('id')->where(['author_id' => 1])->comment('Filter for admin user');
+     * ```
+     *
+     * Comment content is raw SQL and not suitable for use with user supplied data.
+     *
+     * @param \Cake\Database\ExpressionInterface|string|null $expression The comment to be added
+     * @return $this
+     */
+    public function comment(ExpressionInterface|string|null $expression = null)
+    {
+        $this->_dirty();
+        $this->_parts['comment'] = $expression;
 
         return $this;
     }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Expression\CommonTableExpression;
 use Cake\Database\Expression\IdentifierExpression;
@@ -336,7 +337,11 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function traverseParts(Closure $visitor, array $parts)
     {
+        $debugMode = Configure::read('debug');
         foreach ($parts as $name) {
+            if ($name === 'comment' && !$debugMode) {
+                continue;
+            }
             $visitor($this->_parts[$name], $name);
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1463,10 +1463,10 @@ abstract class Query implements ExpressionInterface, Stringable
      *
      * Comment content is raw SQL and not suitable for use with user supplied data.
      *
-     * @param \Cake\Database\ExpressionInterface|string|null $expression The comment to be added
+     * @param string|null $expression The comment to be added
      * @return $this
      */
-    public function comment(ExpressionInterface|string|null $expression = null)
+    public function comment(?string $expression = null)
     {
         $this->_dirty();
         $this->_parts['comment'] = $expression;

--- a/src/Database/Query/DeleteQuery.php
+++ b/src/Database/Query/DeleteQuery.php
@@ -45,6 +45,7 @@ class DeleteQuery extends Query
         'order' => null,
         'limit' => null,
         'epilog' => null,
+        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/DeleteQuery.php
+++ b/src/Database/Query/DeleteQuery.php
@@ -36,6 +36,7 @@ class DeleteQuery extends Query
      * @var array<string, mixed>
      */
     protected array $_parts = [
+        'comment' => null,
         'with' => [],
         'delete' => true,
         'modifier' => [],
@@ -45,7 +46,6 @@ class DeleteQuery extends Query
         'order' => null,
         'limit' => null,
         'epilog' => null,
-        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -44,6 +44,7 @@ class InsertQuery extends Query
         'modifier' => [],
         'values' => [],
         'epilog' => null,
+        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -39,12 +39,12 @@ class InsertQuery extends Query
      * @var array<string, mixed>
      */
     protected array $_parts = [
+        'comment' => null,
         'with' => [],
         'insert' => [],
         'modifier' => [],
         'values' => [],
         'epilog' => null,
-        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -66,6 +66,7 @@ class SelectQuery extends Query implements IteratorAggregate
         'offset' => null,
         'union' => [],
         'epilog' => null,
+        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -51,6 +51,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * @var array<string, mixed>
      */
     protected array $_parts = [
+        'comment' => null,
         'modifier' => [],
         'with' => [],
         'select' => [],
@@ -66,7 +67,6 @@ class SelectQuery extends Query implements IteratorAggregate
         'offset' => null,
         'union' => [],
         'epilog' => null,
-        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -39,6 +39,7 @@ class UpdateQuery extends Query
      * @var array<string, mixed>
      */
     protected array $_parts = [
+        'comment' => null,
         'with' => [],
         'update' => [],
         'modifier' => [],
@@ -48,7 +49,6 @@ class UpdateQuery extends Query
         'order' => null,
         'limit' => null,
         'epilog' => null,
-        'comment' => null,
     ];
 
     /**

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -48,6 +48,7 @@ class UpdateQuery extends Query
         'order' => null,
         'limit' => null,
         'epilog' => null,
+        'comment' => null,
     ];
 
     /**

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -43,6 +43,7 @@ class QueryCompiler
         'limit' => ' LIMIT %s',
         'offset' => ' OFFSET %s',
         'epilog' => ' %s',
+        'comment' => '/* %s */ ',
     ];
 
     /**
@@ -51,7 +52,7 @@ class QueryCompiler
      * @var array<string>
      */
     protected array $_selectParts = [
-        'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
+        'comment', 'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
         'limit', 'offset', 'union', 'epilog',
     ];
 
@@ -60,21 +61,21 @@ class QueryCompiler
      *
      * @var array<string>
      */
-    protected array $_updateParts = ['with', 'update', 'set', 'where', 'epilog'];
+    protected array $_updateParts = ['comment', 'with', 'update', 'set', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating a DELETE statement
      *
      * @var array<string>
      */
-    protected array $_deleteParts = ['with', 'delete', 'modifier', 'from', 'where', 'epilog'];
+    protected array $_deleteParts = ['comment', 'with', 'delete', 'modifier', 'from', 'where', 'epilog'];
 
     /**
      * The list of query clauses to traverse for generating an INSERT statement
      *
      * @var array<string>
      */
-    protected array $_insertParts = ['with', 'insert', 'values', 'epilog'];
+    protected array $_insertParts = ['comment', 'with', 'insert', 'values', 'epilog'];
 
     /**
      * Indicate whether this query dialect supports ordered unions.

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -54,7 +54,7 @@ class SqlserverCompiler extends QueryCompiler
      * @var array<string>
      */
     protected array $_selectParts = [
-        'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
+        'comment', 'with', 'select', 'from', 'join', 'where', 'group', 'having', 'window', 'order',
         'offset', 'limit', 'union', 'epilog',
     ];
 

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -46,6 +46,7 @@ class SqlserverCompiler extends QueryCompiler
         'order' => ' %s',
         'offset' => ' OFFSET %s ROWS',
         'epilog' => ' %s',
+        'comment' => '/* %s */ ',
     ];
 
     /**

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -108,20 +108,6 @@ class QueryCompilerTest extends TestCase
         $this->assertCount(3, $result);
     }
 
-    public function testSelectWithCommentExpression(): void
-    {
-        /** @var \Cake\Database\Query\SelectQuery $query */
-        $query = $this->newQuery(Query::TYPE_SELECT);
-        $query = $query->select('*')
-            ->from('articles')
-            ->comment($query->expr('This is a test'));
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('/* This is a test */ SELECT * FROM articles', $result);
-
-        $result = $query->all();
-        $this->assertCount(3, $result);
-    }
-
     public function testInsert(): void
     {
         /** @var \Cake\Database\Query\InsertQuery $query */
@@ -150,27 +136,6 @@ class QueryCompilerTest extends TestCase
             ->into('articles')
             ->values(['title' => 'A new article'])
             ->comment('This is a test');
-        $result = $this->compiler->compile($query, $this->binder);
-
-        if ($this->connection->getDriver() instanceof Sqlserver) {
-            $this->assertSame('/* This is a test */ INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)', $result);
-        } else {
-            $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
-        }
-
-        $result = $query->execute();
-        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $result->closeCursor();
-    }
-
-    public function testInsertWithCommentExpression(): void
-    {
-        /** @var \Cake\Database\Query\InsertQuery $query */
-        $query = $this->newQuery(Query::TYPE_INSERT);
-        $query = $query->insert(['title'])
-            ->into('articles')
-            ->values(['title' => 'A new article'])
-            ->comment($query->expr('This is a test'));
         $result = $this->compiler->compile($query, $this->binder);
 
         if ($this->connection->getDriver() instanceof Sqlserver) {
@@ -215,22 +180,6 @@ class QueryCompilerTest extends TestCase
         $result->closeCursor();
     }
 
-    public function testUpdateWithCommentExpression(): void
-    {
-        /** @var \Cake\Database\Query\UpdateQuery $query */
-        $query = $this->newQuery(Query::TYPE_UPDATE);
-        $query = $query->update('articles')
-            ->set('title', 'mark')
-            ->where(['id' => 1])
-            ->comment($query->expr('This is a test'));
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('/* This is a test */ UPDATE articles SET title = :c0 WHERE id = :c1', $result);
-
-        $result = $query->execute();
-        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $result->closeCursor();
-    }
-
     public function testDelete(): void
     {
         /** @var \Cake\Database\Query\DeleteQuery $query */
@@ -254,22 +203,6 @@ class QueryCompilerTest extends TestCase
             ->from('articles')
             ->where(['id !=' => 1])
             ->comment('This is a test');
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('/* This is a test */ DELETE FROM articles WHERE id != :c0', $result);
-
-        $result = $query->execute();
-        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $result->closeCursor();
-    }
-
-    public function testDeleteWithCommentExpression(): void
-    {
-        /** @var \Cake\Database\Query\DeleteQuery $query */
-        $query = $this->newQuery(Query::TYPE_DELETE);
-        $query = $query->delete()
-            ->from('articles')
-            ->where(['id !=' => 1])
-            ->comment($query->expr('This is a test'));
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ DELETE FROM articles WHERE id != :c0', $result);
 

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -107,6 +107,20 @@ class QueryCompilerTest extends TestCase
         $this->assertCount(3, $result);
     }
 
+    public function testSelectWithCommentExpression(): void
+    {
+        /** @var \Cake\Database\Query\SelectQuery $query */
+        $query = $this->newQuery(Query::TYPE_SELECT);
+        $query = $query->select('*')
+            ->from('articles')
+            ->comment($query->expr('This is a test'));
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('/* This is a test */ SELECT * FROM articles', $result);
+
+        $result = $query->all();
+        $this->assertCount(3, $result);
+    }
+
     public function testInsert(): void
     {
         /** @var \Cake\Database\Query\InsertQuery $query */
@@ -130,6 +144,22 @@ class QueryCompilerTest extends TestCase
             ->into('articles')
             ->values(['title' => 'A new article'])
             ->comment('This is a test');
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
+
+        $result = $query->execute();
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $result->closeCursor();
+    }
+
+    public function testInsertWithCommentExpression(): void
+    {
+        /** @var \Cake\Database\Query\InsertQuery $query */
+        $query = $this->newQuery(Query::TYPE_INSERT);
+        $query = $query->insert(['title'])
+            ->into('articles')
+            ->values(['title' => 'A new article'])
+            ->comment($query->expr('This is a test'));
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
 
@@ -169,6 +199,22 @@ class QueryCompilerTest extends TestCase
         $result->closeCursor();
     }
 
+    public function testUpdateWithCommentExpression(): void
+    {
+        /** @var \Cake\Database\Query\UpdateQuery $query */
+        $query = $this->newQuery(Query::TYPE_UPDATE);
+        $query = $query->update('articles')
+            ->set('title', 'mark')
+            ->where(['id' => 1])
+            ->comment($query->expr('This is a test'));
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('/* This is a test */ UPDATE articles SET title = :c0 WHERE id = :c1', $result);
+
+        $result = $query->execute();
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $result->closeCursor();
+    }
+
     public function testDelete(): void
     {
         /** @var \Cake\Database\Query\DeleteQuery $query */
@@ -192,6 +238,22 @@ class QueryCompilerTest extends TestCase
             ->from('articles')
             ->where(['id !=' => 1])
             ->comment('This is a test');
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('/* This is a test */ DELETE FROM articles WHERE id != :c0', $result);
+
+        $result = $query->execute();
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $result->closeCursor();
+    }
+
+    public function testDeleteWithCommentExpression(): void
+    {
+        /** @var \Cake\Database\Query\DeleteQuery $query */
+        $query = $this->newQuery(Query::TYPE_DELETE);
+        $query = $query->delete()
+            ->from('articles')
+            ->where(['id !=' => 1])
+            ->comment($query->expr('This is a test'));
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ DELETE FROM articles WHERE id != :c0', $result);
 

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Database;
 
 use Cake\Database\Connection;
+use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
 use Cake\Database\ValueBinder;
@@ -129,7 +130,12 @@ class QueryCompilerTest extends TestCase
             ->into('articles')
             ->values(['title' => 'A new article']);
         $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('INSERT INTO articles (title) VALUES (:c0)', $result);
+
+        if ($this->connection->getDriver() instanceof Sqlserver) {
+            $this->assertSame('INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)', $result);
+        } else {
+            $this->assertSame('INSERT INTO articles (title) VALUES (:c0)', $result);
+        }
 
         $result = $query->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
@@ -145,7 +151,12 @@ class QueryCompilerTest extends TestCase
             ->values(['title' => 'A new article'])
             ->comment('This is a test');
         $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
+
+        if ($this->connection->getDriver() instanceof Sqlserver) {
+            $this->assertSame('/* This is a test */ INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)', $result);
+        } else {
+            $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
+        }
 
         $result = $query->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
@@ -161,7 +172,12 @@ class QueryCompilerTest extends TestCase
             ->values(['title' => 'A new article'])
             ->comment($query->expr('This is a test'));
         $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
+
+        if ($this->connection->getDriver() instanceof Sqlserver) {
+            $this->assertSame('/* This is a test */ INSERT INTO articles (title) OUTPUT INSERTED.* VALUES (:c0)', $result);
+        } else {
+            $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
+        }
 
         $result = $query->execute();
         $this->assertInstanceOf('Cake\Database\StatementInterface', $result);

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -2,17 +2,15 @@
 declare(strict_types=1);
 
 /**
- * cakephp(tm) : rapid development framework (https://cakephp.org)
- * copyright (c) cake software foundation, inc. (https://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
- * licensed under the mit license
- * for full copyright and license information, please see the license.txt
- * redistributions of files must retain the above copyright notice.
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
  *
- * @copyright     copyright (c) cake software foundation, inc. (https://cakefoundation.org)
- * @link          https://cakephp.org cakephp(tm) project
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @since         5.0.0
- * @license       https://opensource.org/licenses/mit-license.php mit license
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Database;
 

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database;
 
-use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
@@ -42,15 +41,12 @@ class QueryCompilerTest extends TestCase
 
     protected ValueBinder $binder;
 
-    protected bool $debug;
-
     public function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
         $this->compiler = new QueryCompiler();
         $this->binder = new ValueBinder();
-        $this->debug = Configure::read('debug');
     }
 
     public function tearDown(): void
@@ -58,7 +54,6 @@ class QueryCompilerTest extends TestCase
         parent::tearDown();
         unset($this->compiler);
         unset($this->binder);
-        Configure::write('debug', $this->debug);
     }
 
     protected function newQuery(string $type): Query
@@ -103,18 +98,6 @@ class QueryCompilerTest extends TestCase
         $this->assertSame('/* This is a test */ SELECT * FROM articles', $result);
     }
 
-    public function testSelectWithCommentInProd(): void
-    {
-        Configure::write('debug', false);
-        /** @var \Cake\Database\Query\SelectQuery $query */
-        $query = $this->newQuery(Query::TYPE_SELECT);
-        $query = $query->select('*')
-            ->from('articles')
-            ->comment('This is a test');
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('SELECT * FROM articles', $result);
-    }
-
     public function testInsert(): void
     {
         /** @var \Cake\Database\Query\InsertQuery $query */
@@ -136,19 +119,6 @@ class QueryCompilerTest extends TestCase
             ->comment('This is a test');
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
-    }
-
-    public function testInsertWithCommentInProd(): void
-    {
-        Configure::write('debug', false);
-        /** @var \Cake\Database\Query\InsertQuery $query */
-        $query = $this->newQuery(Query::TYPE_INSERT);
-        $query = $query->insert(['title'])
-            ->into('articles')
-            ->values(['title' => 'A new article'])
-            ->comment('This is a test');
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('INSERT INTO articles (title) VALUES (:c0)', $result);
     }
 
     public function testUpdate(): void
@@ -174,19 +144,6 @@ class QueryCompilerTest extends TestCase
         $this->assertSame('/* This is a test */ UPDATE articles SET name = :c0 WHERE id = :c1', $result);
     }
 
-    public function testUpdateWithCommentInProd(): void
-    {
-        Configure::write('debug', false);
-        /** @var \Cake\Database\Query\UpdateQuery $query */
-        $query = $this->newQuery(Query::TYPE_UPDATE);
-        $query = $query->update('articles')
-            ->set('name', 'mark')
-            ->where(['id' => 1])
-            ->comment('This is a test');
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('UPDATE articles SET name = :c0 WHERE id = :c1', $result);
-    }
-
     public function testDelete(): void
     {
         /** @var \Cake\Database\Query\DeleteQuery $query */
@@ -208,18 +165,5 @@ class QueryCompilerTest extends TestCase
             ->comment('This is a test');
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ DELETE FROM articles WHERE id != :c0', $result);
-    }
-
-    public function testDeleteWithCommentInProd(): void
-    {
-        Configure::write('debug', false);
-        /** @var \Cake\Database\Query\DeleteQuery $query */
-        $query = $this->newQuery(Query::TYPE_DELETE);
-        $query = $query->delete()
-            ->from('articles')
-            ->where(['id !=' => 1])
-            ->comment('This is a test');
-        $result = $this->compiler->compile($query, $this->binder);
-        $this->assertSame('DELETE FROM articles WHERE id != :c0', $result);
     }
 }

--- a/tests/TestCase/Database/QueryCompilerTest.php
+++ b/tests/TestCase/Database/QueryCompilerTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database;
 
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Query;
 use Cake\Database\QueryCompiler;
@@ -41,12 +42,15 @@ class QueryCompilerTest extends TestCase
 
     protected ValueBinder $binder;
 
+    protected bool $debug;
+
     public function setUp(): void
     {
         parent::setUp();
         $this->connection = ConnectionManager::get('test');
         $this->compiler = new QueryCompiler();
         $this->binder = new ValueBinder();
+        $this->debug = Configure::read('debug');
     }
 
     public function tearDown(): void
@@ -54,6 +58,7 @@ class QueryCompilerTest extends TestCase
         parent::tearDown();
         unset($this->compiler);
         unset($this->binder);
+        Configure::write('debug', $this->debug);
     }
 
     protected function newQuery(string $type): Query
@@ -98,6 +103,18 @@ class QueryCompilerTest extends TestCase
         $this->assertSame('/* This is a test */ SELECT * FROM articles', $result);
     }
 
+    public function testSelectWithCommentInProd(): void
+    {
+        Configure::write('debug', false);
+        /** @var \Cake\Database\Query\SelectQuery $query */
+        $query = $this->newQuery(Query::TYPE_SELECT);
+        $query = $query->select('*')
+            ->from('articles')
+            ->comment('This is a test');
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('SELECT * FROM articles', $result);
+    }
+
     public function testInsert(): void
     {
         /** @var \Cake\Database\Query\InsertQuery $query */
@@ -119,6 +136,19 @@ class QueryCompilerTest extends TestCase
             ->comment('This is a test');
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ INSERT INTO articles (title) VALUES (:c0)', $result);
+    }
+
+    public function testInsertWithCommentInProd(): void
+    {
+        Configure::write('debug', false);
+        /** @var \Cake\Database\Query\InsertQuery $query */
+        $query = $this->newQuery(Query::TYPE_INSERT);
+        $query = $query->insert(['title'])
+            ->into('articles')
+            ->values(['title' => 'A new article'])
+            ->comment('This is a test');
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('INSERT INTO articles (title) VALUES (:c0)', $result);
     }
 
     public function testUpdate(): void
@@ -144,6 +174,19 @@ class QueryCompilerTest extends TestCase
         $this->assertSame('/* This is a test */ UPDATE articles SET name = :c0 WHERE id = :c1', $result);
     }
 
+    public function testUpdateWithCommentInProd(): void
+    {
+        Configure::write('debug', false);
+        /** @var \Cake\Database\Query\UpdateQuery $query */
+        $query = $this->newQuery(Query::TYPE_UPDATE);
+        $query = $query->update('articles')
+            ->set('name', 'mark')
+            ->where(['id' => 1])
+            ->comment('This is a test');
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('UPDATE articles SET name = :c0 WHERE id = :c1', $result);
+    }
+
     public function testDelete(): void
     {
         /** @var \Cake\Database\Query\DeleteQuery $query */
@@ -165,5 +208,18 @@ class QueryCompilerTest extends TestCase
             ->comment('This is a test');
         $result = $this->compiler->compile($query, $this->binder);
         $this->assertSame('/* This is a test */ DELETE FROM articles WHERE id != :c0', $result);
+    }
+
+    public function testDeleteWithCommentInProd(): void
+    {
+        Configure::write('debug', false);
+        /** @var \Cake\Database\Query\DeleteQuery $query */
+        $query = $this->newQuery(Query::TYPE_DELETE);
+        $query = $query->delete()
+            ->from('articles')
+            ->where(['id !=' => 1])
+            ->comment('This is a test');
+        $result = $this->compiler->compile($query, $this->binder);
+        $this->assertSame('DELETE FROM articles WHERE id != :c0', $result);
     }
 }

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2,17 +2,15 @@
 declare(strict_types=1);
 
 /**
- * cakephp(tm) : rapid development framework (https://cakephp.org)
- * copyright (c) cake software foundation, inc. (https://cakefoundation.org)
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  *
- * licensed under the mit license
- * for full copyright and license information, please see the license.txt
- * redistributions of files must retain the above copyright notice.
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
  *
- * @copyright     copyright (c) cake software foundation, inc. (https://cakefoundation.org)
- * @link          https://cakephp.org cakephp(tm) project
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
  * @since         3.0.0
- * @license       https://opensource.org/licenses/mit-license.php mit license
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Database;
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -313,7 +313,7 @@ class QueryTest extends TestCase
     public function testClauseUndefined(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The `nope` clause is not defined. Valid clauses are: `delete`, `update`');
+        $this->expectExceptionMessage('The `nope` clause is not defined. Valid clauses are: `comment`, `delete`, `update`');
 
         $this->assertEmpty($this->query->clause('where'));
         $this->query->clause('nope');


### PR DESCRIPTION
Refs: https://github.com/cakephp/debug_kit/pull/906

We currently have no way to add comment information to a specific query instance.
This would be helpful for debugging tools like debug_kit so users have an easier time identifying which query instance is causing which SQL query.

Since there was no `QueryCompilerTest` present till now I created one with some basic tests for all the major query types.
This should of course be extended to also contain some more "elaborate" query instances but I was just mainly focused on the comment feature for now.

Adjusting/Extending the code which generates SQL is of course always a very delicate place to be aware of SQL injection.
But SQL comments should also be handled just like e.g. the `orderByAsc` methods and are therefore not suitable for user input.