### PR TITLE
Fix up Stan issues.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         ],
         "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
         "stan-baseline": "phpstan.phar --generate-baseline",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.9.0 psalm/phar:~5.1.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:~1.9.0 psalm/phar:~5.4.0 && mv composer.backup composer.json",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -295,6 +295,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             return $this->components()->get($name);
         }
 
+        /** @var array<int, array<string, mixed>> $trace */
         $trace = debug_backtrace();
         $parts = explode('\\', static::class);
         trigger_error(

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -107,14 +107,15 @@ class Debugger
     /**
      * Returns a reference to the Debugger singleton object instance.
      *
-     * @param string|null $class Class name.
+     * @param class-string<\Cake\Error\Debugger>|null $class Class name.
      * @return static
      */
     public static function getInstance(?string $class = null): static
     {
+        /** @var array<int, static> $instance */
         static $instance = [];
         if ($class) {
-            if (!$instance || strtolower($class) !== strtolower((string)get_class($instance[0]))) {
+            if (!$instance || strtolower($class) !== strtolower(get_class($instance[0]))) {
                 $instance[0] = new $class();
             }
         }
@@ -122,6 +123,7 @@ class Debugger
             $instance[0] = new Debugger();
         }
 
+        /** @var static */
         return $instance[0];
     }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -331,9 +331,11 @@ class Cookie implements CookieInterface
     {
         $value = $this->value;
         if ($this->isExpanded) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            assert(is_array($value), '$value is not an array');
+
             $value = $this->_flatten($value);
         }
+
         $headerValue = [];
         /** @var string $value */
         $headerValue[] = sprintf('%s=%s', $this->name, rawurlencode($value));
@@ -423,11 +425,13 @@ class Cookie implements CookieInterface
     public function getScalarValue(): string
     {
         if ($this->isExpanded) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            assert(is_array($this->value), '$value is not an array');
+
             return $this->_flatten($this->value);
         }
 
-        /** @var string */
+        assert(is_string($this->value), '$value is not a string');
+
         return $this->value;
     }
 
@@ -654,11 +658,12 @@ class Cookie implements CookieInterface
     public function check(string $path): bool
     {
         if ($this->isExpanded === false) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            assert(is_string($this->value), '$value is not a string');
             $this->value = $this->_expand($this->value);
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
+        assert(is_array($this->value), '$value is not an array');
+
         return Hash::check($this->value, $path);
     }
 
@@ -673,11 +678,11 @@ class Cookie implements CookieInterface
     {
         $new = clone $this;
         if ($new->isExpanded === false) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            assert(is_string($new->value), '$value is not a string');
             $new->value = $new->_expand($new->value);
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
+        assert(is_array($new->value), '$value is not an array');
         $new->value = Hash::insert($new->value, $path, $value);
 
         return $new;
@@ -693,11 +698,12 @@ class Cookie implements CookieInterface
     {
         $new = clone $this;
         if ($new->isExpanded === false) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            assert(is_string($new->value), '$value is not a string');
             $new->value = $new->_expand($new->value);
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
+        assert(is_array($new->value), '$value is not an array');
+
         $new->value = Hash::remove($new->value, $path);
 
         return $new;
@@ -715,7 +721,8 @@ class Cookie implements CookieInterface
     public function read(?string $path = null): mixed
     {
         if ($this->isExpanded === false) {
-            /** @psalm-suppress PossiblyInvalidArgument */
+            assert(is_string($this->value), '$value is not a string');
+
             $this->value = $this->_expand($this->value);
         }
 
@@ -723,7 +730,8 @@ class Cookie implements CookieInterface
             return $this->value;
         }
 
-        /** @psalm-suppress PossiblyInvalidArgument */
+        assert(is_array($this->value), '$value is not an array');
+
         return Hash::get($this->value, $path);
     }
 

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -85,6 +85,7 @@ class PoFileParser
 
         $messages = [];
         $item = $defaults;
+        /** @var array<int, string> $stage */
         $stage = [];
 
         while ($line = fgets($stream)) {
@@ -109,20 +110,16 @@ class PoFileParser
             } elseif ($line[0] === '"') {
                 switch (count($stage)) {
                     case 2:
+                        assert(isset($stage[0]));
+                        assert(isset($stage[1]));
                         /**
-                         * @psalm-suppress PossiblyUndefinedArrayOffset
                          * @psalm-suppress InvalidArrayOffset
-                         * @psalm-suppress PossiblyNullArrayAccess
                          */
                         $item[$stage[0]][$stage[1]] .= substr($line, 1, -1);
                         break;
 
                     case 1:
-                        /**
-                         * @psalm-suppress PossiblyUndefinedArrayOffset
-                         * @psalm-suppress PossiblyInvalidOperand
-                         * @psalm-suppress PossiblyNullOperand
-                         */
+                        assert(isset($stage[0]));
                         $item[$stage[0]] .= substr($line, 1, -1);
                         break;
                 }


### PR DESCRIPTION
Down to 17 issues left

```
 ------ -------------------------------------------------------------------------------- 
  Line   Core/StaticConfigTrait.php (in context of class Cake\Mailer\Mailer)             
 ------ -------------------------------------------------------------------------------- 
  160    Access to an undefined static property static(Cake\Mailer\Mailer)::$_registry.  
 ------ -------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------ 
  Line   Database/Schema/SqliteSchemaDialect.php                     
 ------ ------------------------------------------------------------ 
  511    Offset 'type' does not exist on array<string, mixed>|null.  
 ------ ------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Event/EventManager.php                                                                                                                                                                      
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  300    Method Cake\Event\EventManager::dispatch() should return Cake\Event\EventInterface<TSubject of object> but returns Cake\Event\Event<object>|Cake\Event\EventInterface<TSubject of object>.  
  316    Method Cake\Event\EventManager::dispatch() should return Cake\Event\EventInterface<TSubject of object> but returns Cake\Event\Event<object>|Cake\Event\EventInterface<TSubject of object>.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------ 
  Line   Http/Cookie/Cookie.php                                                              
 ------ ------------------------------------------------------------------------------------ 
  171    Call to an undefined method Cake\Chronos\Chronos|DateTimeInterface::setTimezone().  
  543    Call to an undefined method Cake\Chronos\Chronos|DateTimeInterface::setTimezone().  
 ------ ------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------------- 
  Line   I18n/Parser/PoFileParser.php                                                                             
 ------ --------------------------------------------------------------------------------------------------------- 
  117    Offset 1 does not exist on array{'context'}|array{'ids', 'plural'|'singular'}|array{'translated', int}.  
 ------ --------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   I18n/RelativeTimeFormatter.php                                                 
 ------ ------------------------------------------------------------------------------- 
  109    Call to an undefined method Cake\I18n\Date|Cake\I18n\DateTime::setTimezone().  
 ------ ------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Behavior/TreeBehavior.php                                                                                                                                    
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  948    Method Cake\ORM\Behavior\TreeBehavior::_scope() should return T of Cake\ORM\Query\DeleteQuery|Cake\ORM\Query\SelectQuery|Cake\ORM\Query\UpdateQuery but returns  
         Cake\ORM\Query\DeleteQuery|Cake\ORM\Query\SelectQuery|Cake\ORM\Query\UpdateQuery.                                                                                
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------ 
  Line   View/Helper/TimeHelper.php                                                          
 ------ ------------------------------------------------------------------------------------ 
  306    Call to an undefined method Cake\Chronos\Chronos|DateTimeInterface::setTimezone().  
 ------ ------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------- 
  Line   View/ViewVarsTrait.php (in context of class Cake\Mailer\Renderer)  
 ------ ------------------------------------------------------------------- 
  60     Access to an undefined property Cake\Mailer\Renderer::$name.       
  60     Access to an undefined property Cake\Mailer\Renderer::$plugin.     
  67     Access to an undefined property Cake\Mailer\Renderer::$request.    
  68     Access to an undefined property Cake\Mailer\Renderer::$response.   
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------- 
  Line   View/ViewVarsTrait.php (in context of class Cake\View\Cell)  
 ------ ------------------------------------------------------------- 
  60     Access to an undefined property Cake\View\Cell::$name.       
  60     Access to an undefined property Cake\View\Cell::$plugin.     
 ------ ------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------- 
  Line   View/Widget/DateTimeWidget.php                                                                                        
 ------ ---------------------------------------------------------------------------------------------------------------------- 
  214    Call to an undefined method Cake\Chronos\Chronos|Cake\Chronos\ChronosDate|DateTime|DateTimeImmutable::setTimezone().  
 ------ ---------------------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 17 errors         
```

The remaining setTimezone() issue is the only one left of relevance, the rest could be baselined and we can enable level 8 now.