### PR TITLE
Add validation script not to miss deprecation aliases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,3 +261,7 @@ jobs:
     - name: Run phpstan for tests
       if: always()
       run: vendor/bin/phpstan.phar analyse -c tests/phpstan.neon --error-format=github
+
+    - name: Run validaton script
+      if: always()
+      run: php contrib/validate-deprecation-aliases.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,6 @@ jobs:
       if: always()
       run: vendor/bin/phpstan.phar analyse -c tests/phpstan.neon --error-format=github
 
-    - name: Run validaton script
+    - name: Run class deprecation aliasing validaton script
       if: always()
       run: php contrib/validate-deprecation-aliases.php

--- a/contrib/validate-deprecation-aliases.php
+++ b/contrib/validate-deprecation-aliases.php
@@ -1,0 +1,71 @@
+#!/usr/bin/php -q
+<?php
+
+$options = [
+	__DIR__ . '/../vendor/autoload.php',
+	__DIR__ . '/vendor/autoload.php',
+];
+if (!empty($_SERVER['PWD'])) {
+	array_unshift($options, $_SERVER['PWD'] . '/vendor/autoload.php');
+}
+
+foreach ($options as $file) {
+	if (file_exists($file)) {
+		define('COMPOSER_INSTALL', $file);
+
+		break;
+	}
+}
+require COMPOSER_INSTALL;
+
+$path = dirname(__DIR__) . DS . 'src' . DS;
+$di = new RecursiveDirectoryIterator($path, (RecursiveDirectoryIterator::SKIP_DOTS));
+/** @var \SplFileInfo[] $iterator */
+$iterator = new RecursiveIteratorIterator($di);
+
+$issues = [];
+$code = 0;
+foreach ($iterator as $file) {
+    if (pathinfo($file, PATHINFO_EXTENSION) !== 'php') {
+        continue;
+    }
+    if (pathinfo($file, PATHINFO_FILENAME) === 'functions') {
+        continue;
+    }
+    if (strpos($file->getRealPath(), '/TestSuite/')) {
+        continue;
+    }
+
+    $content = file_get_contents($file);
+    if (!strpos($content, 'class_alias(')) {
+        continue;
+    }
+
+    preg_match('#class_alias\(\s*\'([^\']+)\',#', $content, $matches);
+    if (!$matches) {
+        var_dump($content);
+        var_dump($file->getPath());
+        exit(1);
+    }
+
+    echo $matches[1] . PHP_EOL;
+    $filePath = str_replace('\\', '/', $matches[1]);
+    $filePath = str_replace('Cake/', $path, $filePath);
+    $filePath .= '.php';
+    if (!file_exists($filePath)) {
+        throw new RuntimeException('Cannot find path for ' . $matches[1]);
+    }
+
+    $newFileContent = file_get_contents($filePath);
+
+    if (strpos($newFileContent, 'class_exists(') === false && strpos($newFileContent, 'class_alias(') === false ) {
+        $oldPath = str_replace($path, '', $file->getRealPath());
+        $newPath = str_replace($path, '', $filePath);
+        echo "\033[31m" . ' * Missing class_exists() or class_alias() on new file for ' . $oldPath . ' => ' . $newPath . "\033[0m" . PHP_EOL;
+        $code = 1;
+    } else {
+        echo ' * OK' . PHP_EOL;
+    }
+}
+
+exit($code);


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/16965

Keeps our code base consistent and avoids accidental regressions ( https://github.com/cakephp/cakephp/issues/16867 ).


Currently all green here in 4.next, example output in 4.x for example:
![Screenshot from 2023-01-18 10-41-28](https://user-images.githubusercontent.com/39854/213137160-e91f900a-d028-4f00-9b5d-ca62c74ef54b.png)

