### PR TITLE
Document flexibility of ' IS' notation in Query::where()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1011,7 +1011,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * ]);
      * ```
      *
-     * If $category is `null` - it will actually convert that into `category_id IS NULL` - if it's `4` it will convert it into `category_id = 4`     
+     * If $category is `null` - it will actually convert that into `category_id IS NULL` - if it's `4` it will convert it into `category_id = 4`
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The conditions to filter on.
      * @param array<string, string> $types Associative array of type names used to bind values to query

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1000,6 +1000,19 @@ class Query implements ExpressionInterface, IteratorAggregate
      * If you use string conditions make sure that your values are correctly quoted.
      * The safest thing you can do is to never use string conditions.
      *
+     * ### Using null-able values
+     *
+     * When using values that can be null you can use the 'IS' keyword to let the ORM generate the correct SQL based on the value's type
+     *
+     * ```
+     * $query->where([
+     *     'posted >=' => new DateTime('3 days ago'),
+     *     'category_id IS' => $category,
+     * ]);
+     * ```
+     *
+     * If $category is `null` - it will actually convert that into `category_id IS NULL` - if it's `4` it will convert it into `category_id = 4`     
+     *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The conditions to filter on.
      * @param array<string, string> $types Associative array of type names used to bind values to query
      * @param bool $overwrite whether to reset conditions with passed list or not


### PR DESCRIPTION
I just got some help from dereuromark on the Cake slack and though these things should be documented so the next person in line would not rely on getting help from someone :-)

If anyone is interested in the Slack discussion, it's here: https://cakesf.slack.com/archives/C053DPNGT/p1674120135286559

Feel free to change/decline if anyone disagrees with the wording or anything.
