### PR TITLE
Add deprecation for Controller.shutdown removal.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -625,7 +625,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             'Controller.initialize' => 'beforeFilter',
             'Controller.beforeRender' => 'beforeRender',
             'Controller.beforeRedirect' => 'beforeRedirect',
-            'Controller.shutdown' => 'afterFilter',
+            'Controller.afterFilter' => 'afterFilter',
         ];
     }
 
@@ -664,9 +664,20 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function shutdownProcess(): ?ResponseInterface
     {
-        $event = $this->dispatchEvent('Controller.shutdown');
+        $event = $this->dispatchEvent('Controller.afterFilter');
         if ($event->getResult() instanceof ResponseInterface) {
             return $event->getResult();
+        }
+
+        if ($this->getEventManager()->listeners('Controller.shutdown')) {
+            deprecationWarning(
+                '4.5.0 : Listenting to `Controller.shutdown` is deprecated. ' .
+                'Use the `Controller.afterFilter` event instead.'
+            );
+            $event = $this->dispatchEvent('Controller.shutdown');
+            if ($event->getResult() instanceof ResponseInterface) {
+                return $event->getResult();
+            }
         }
 
         return null;


### PR DESCRIPTION
We're removing the `shutdown` event in 5.x. Now we have an easier time upgrading without hard breaks.

Found this when going through the breaking change list for 5.0. I'll probably have a few more like this. I would like to try and make this the simplest major we've ever done. Its a personal goal of mine to see if I can improve the upgrade experience. I continue to believe that early notifications let users opt into - and out of - fixing these issues at their own speed.