### PR TITLE
Fix dynamic property on PHP 8.2

### DIFF
--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -75,8 +75,14 @@ class LoggingStatement extends StatementDecorator
             $result = parent::execute($params);
             $this->loggedQuery->took = (int)round((microtime(true) - $this->startTime) * 1000, 0);
         } catch (Exception $e) {
-            /** @psalm-suppress UndefinedPropertyAssignment */
-            $e->queryString = $this->queryString;
+            if (version_compare(PHP_VERSION, '8.2.0', '<')) {
+                deprecationWarning(
+                    '4.4.12 - Having queryString set on exceptions is deprecated.' .
+                    'If you are not using this attribute there is no action to take.'
+                );
+                /** @psalm-suppress UndefinedPropertyAssignment */
+                $e->queryString = $this->queryString;
+            }
             $this->loggedQuery->error = $e;
             $this->_log();
             throw $e;

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -140,6 +140,10 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteWithError(): void
     {
+        $this->skipIf(
+            version_compare(PHP_VERSION, '8.2.0', '>='),
+            'Setting queryString on exceptions does not work on 8.2+'
+        );
         $exception = new MyPDOException('This is bad');
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -155,12 +155,14 @@ class LoggingStatementTest extends TestCase
             ->method('__get')
             ->willReturn('SELECT bar FROM foo');
         $st->setLogger(new QueryLogger(['connection' => 'test']));
-        try {
-            $st->execute();
-        } catch (MyPDOException $e) {
-            $this->assertSame('This is bad', $e->getMessage());
-            $this->assertSame($st->queryString, $e->queryString);
-        }
+        $this->deprecated(function () use ($st) {
+            try {
+                $st->execute();
+            } catch (MyPDOException $e) {
+                $this->assertSame('This is bad', $e->getMessage());
+                $this->assertSame($st->queryString, $e->queryString);
+            }
+        });
 
         $messages = Log::engine('queries')->read();
         $this->assertCount(1, $messages);


### PR DESCRIPTION
Emit a deprecation for users on PHP versions that are lower that this behavior will be going away. I'm also ok with just silently not adding that property in PHP 8.2

Fixes #16963
