### PR TITLE
Numeric assoc keys can happen to be int.

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -80,7 +80,7 @@ trait StaticConfigTrait
                 throw new LogicException('If config is null, key must be an array.');
             }
             foreach ($key as $name => $settings) {
-                static::setConfig($name, $settings);
+                static::setConfig((string)$name, $settings);
             }
 
             return;


### PR DESCRIPTION
PHP and numeric assoc keys can be painful moving forward with strict typing and types in place..
As for arrays the numeric key is Schrödingers type: Can be int or string it seems.
```php
Configure::write('Log.404.className', 'File');
```
leads to

> TypeError thrown in vendor/cakephp/cakephp/src/Log/Log.php on line 271 while loading bootstrap file tests/bootstrap.php: Cake\Log\Log::setConfig(): Argument # 1 ($key) must be of type array|string, int given, called in vendor/cakephp/cakephp/src/Core/StaticConfigTrait.php on line 83

Debugging the `Log::setConfig(Configure::consume('Log'));` input makes it clear why:
```php
[
  'debug' => [
    'className' => 'File',
    ...
  ],
  ...
  (int) 404 => [
    'className' => 'File'
  ]
]
```