### PR TITLE
Backport phive to 4.x

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,9 @@ end_of_line = crlf
 [*.yml]
 indent_size = 2
 
+[*.xml]
+indent_size = 2
+
 [Makefile]
 indent_style = tab
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Check the [cakephp-codesniffer](https://github.com/cakephp/cakephp-codesniffer)
 repository to set up the CakePHP standard. The [README](https://github.com/cakephp/cakephp-codesniffer/blob/master/README.md) contains installation info
 for the sniff and phpcs.
 
-To run static analysis tools [PHPStan](https://github.com/phpstan/phpstan) and [Psalm](https://github.com/vimeo/psalm) you first have to install the additional packages via:
+To run static analysis tools [PHPStan](https://github.com/phpstan/phpstan) and [Psalm](https://github.com/vimeo/psalm) you first have to install the additional packages via [phive](https://phar.io).
 
     composer stan-setup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
         binPath: "${{ github.workspace }}/tools/phive"
 
     - name: Install PHP tools with phive.
-      uses: szepeviktor/phive@v1
+      uses: szepeviktor/phive-install@v1
       with:
         home: "${{ runner.temp }}/.phive"
         binPath: "${{ github.workspace }}/tools/phive"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,9 +228,23 @@ jobs:
         php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
-        tools: phive
+        tools: phive, cs2pr
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Get date part for cache key
+      id: key-date
+      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
+
+    - name: Cache composer dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
  
     - name: Phive install
       uses: szepeviktor/phive@v1
@@ -246,6 +260,7 @@ jobs:
         trustGpgKeys: "CF1A108D0E7AE720, 12CE0F1D262429A5"
 
     - name: Run phpcs
+      if: always()
       run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
 
     - name: Run psalm
@@ -257,5 +272,5 @@ jobs:
       run: composer phpstan analyse --error-format=github
 
     - name: Run phpstan for tests
-      if: ${{ inputs.check_tests }}
+      if: always()
       run: composer phpstan analyse -c tests/phpstan.neon --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,8 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.1'
-        extensions: mbstring, intl
+        php-version: '7.4'
+        extensions: mbstring, intl, apcu, memcached, redis
         coverage: none
         tools: phive, cs2pr
       env:
@@ -248,33 +248,22 @@ jobs:
 
     - name: Composer install
       run: composer update
- 
-    - name: Phive install
-      uses: szepeviktor/phive@v1
-      with:
-        home: "${{ runner.temp }}/.phive"
-        binPath: "${{ github.workspace }}/tools/phive"
 
     - name: Install PHP tools with phive.
-      id: phive-install
-      uses: szepeviktor/phive-install@v1
-      with:
-        home: "${{ runner.temp }}/.phive"
-        binPath: "${{ github.workspace }}/tools/phive"
-        trustGpgKeys: "CF1A108D0E7AE720,12CE0F1D262429A5"
+      run: phive install --trust-gpg-keys 'CF1A108D0E7AE720,12CE0F1D262429A5'
 
     - name: Run phpcs
       if: always()
       run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
 
     - name: Run psalm
-      if: steps.phive-install.outcome == 'success'
+      if: always()
       run: tools/psalm --output-format=github
 
     - name: Run phpstan
-      if: steps.phive-install.outcome == 'success'
+      if: always()
       run: tools/phpstan analyse --error-format=github
 
     - name: Run phpstan for tests
-      if: steps.phive-install.outcome == 'success'
+      if: always()
       run: tools/phpstan analyse -c tests/phpstan.neon --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
       with:
         home: "${{ runner.temp }}/.phive"
         binPath: "${{ github.workspace }}/tools/phive"
-        trustGpgKeys: "CF1A108D0E7AE720, 12CE0F1D262429A5"
+        trustGpgKeys: "CF1A108D0E7AE720,12CE0F1D262429A5"
 
     - name: Run phpcs
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,7 @@ jobs:
       run: composer update
  
     - name: Phive install
+      id: phive-install
       uses: szepeviktor/phive@v1
       with:
         home: "${{ runner.temp }}/.phive"
@@ -267,13 +268,13 @@ jobs:
       run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
 
     - name: Run psalm
-      if: always()
-      run: composer psalm --output-format=github
+      if: steps.phive-install.outputs.outcome == 'success'
+      run: tools/psalm --output-format=github
 
     - name: Run phpstan
-      if: always()
-      run: composer phpstan analyse --error-format=github
+      if: steps.phive-install.outputs.outcome == 'success'
+      run: tools/phpstan analyse --error-format=github
 
     - name: Run phpstan for tests
-      if: always()
-      run: composer phpstan analyse -c tests/phpstan.neon --error-format=github
+      if: steps.phive-install.outputs.outcome == 'success'
+      run: tools/phpstan analyse -c tests/phpstan.neon --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,9 @@ jobs:
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+
+    - name: Composer install
+      run: composer update
  
     - name: Phive install
       uses: szepeviktor/phive@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,44 +220,42 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
-        extensions: mbstring, intl, apcu, memcached, redis
-        tools: cs2pr
+        php-version: '8.1'
+        extensions: mbstring, intl
         coverage: none
-
-    - name: Get composer cache directory
-      id: composer-cache
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-    - name: Get date part for cache key
-      id: key-date
-      run: echo "date=$(date +'%Y-%m')" >> $GITHUB_OUTPUT
-
-    - name: Cache composer dependencies
-      uses: actions/cache@v3
+        tools: phive
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ 
+    - name: Phive install
+      uses: szepeviktor/phive@v1
       with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ steps.key-date.outputs.date }}-${{ hashFiles('composer.json') }}-${{ matrix.prefer-lowest }}
+        home: "${{ runner.temp }}/.phive"
+        binPath: "${{ github.workspace }}/tools/phive"
 
-    - name: Composer install
-      run: composer stan-setup
+    - name: Install PHP tools with phive.
+      uses: szepeviktor/phive@v1
+      with:
+        home: "${{ runner.temp }}/.phive"
+        binPath: "${{ github.workspace }}/tools/phive"
+        trustGpgKeys: "CF1A108D0E7AE720, 12CE0F1D262429A5"
 
-    - name: Run PHP CodeSniffer
+    - name: Run phpcs
       run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
 
     - name: Run psalm
       if: always()
-      run: vendor/bin/psalm.phar --output-format=github
+      run: composer psalm --output-format=github
 
     - name: Run phpstan
       if: always()
-      run: vendor/bin/phpstan.phar analyse --error-format=github
+      run: composer phpstan analyse --error-format=github
 
     - name: Run phpstan for tests
-      if: always()
-      run: vendor/bin/phpstan.phar analyse -c tests/phpstan.neon --error-format=github
+      if: ${{ inputs.check_tests }}
+      run: composer phpstan analyse -c tests/phpstan.neon --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,13 +250,13 @@ jobs:
       run: composer update
  
     - name: Phive install
-      id: phive-install
       uses: szepeviktor/phive@v1
       with:
         home: "${{ runner.temp }}/.phive"
         binPath: "${{ github.workspace }}/tools/phive"
 
     - name: Install PHP tools with phive.
+      id: phive-install
       uses: szepeviktor/phive-install@v1
       with:
         home: "${{ runner.temp }}/.phive"
@@ -268,13 +268,13 @@ jobs:
       run: vendor/bin/phpcs --report=checkstyle src/ tests/ | cs2pr
 
     - name: Run psalm
-      if: steps.phive-install.outputs.outcome == 'success'
+      if: steps.phive-install.outcome == 'success'
       run: tools/psalm --output-format=github
 
     - name: Run phpstan
-      if: steps.phive-install.outputs.outcome == 'success'
+      if: steps.phive-install.outcome == 'success'
       run: tools/phpstan analyse --error-format=github
 
     - name: Run phpstan for tests
-      if: steps.phive-install.outputs.outcome == 'success'
+      if: steps.phive-install.outcome == 'success'
       run: tools/phpstan analyse -c tests/phpstan.neon --error-format=github

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /composer.lock
 /phpunit.xml
 /phpstan.neon
+/tools
 /vendor
 /vendors
 /composer.phar

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpstan" version="1.9.12" installed="1.9.12" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
+</phive>

--- a/composer.json
+++ b/composer.json
@@ -107,15 +107,15 @@
         ],
         "cs-check": "phpcs --colors --parallel=16 -p src/ tests/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
-        "phpstan": "phpstan.phar analyse",
-        "psalm": "psalm.phar --show-info=false",
+        "phpstan": "tools/phpstan analyse",
+        "psalm": "tools/psalm --show-info=false",
         "stan": [
             "@phpstan",
             "@psalm"
         ],
         "stan-tests": "phpstan.phar analyze -c tests/phpstan.neon",
         "stan-baseline": "phpstan.phar --generate-baseline",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev symfony/polyfill-php81 phpstan/phpstan:~1.9.0 psalm/phar:~4.30.0 && mv composer.backup composer.json",
+        "stan-setup": "phive install",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",


### PR DESCRIPTION
I like this workflow quite a bit. We should use it in 4.x too. It is faster and more efficient than before.

I'm also trying to use it in CI configuration. If it goes well I can spread this around to the 5.x config repository.
