### PR TITLE
5.x - Add aliases for date & time

### DIFF
--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -198,3 +198,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
         return static::diffFormatter()->dateAgoInWords($this, $options);
     }
 }
+
+// phpcs:disable
+class_alias(Date::class, 'Cake\I18n\FrozenDate');
+// phpcs:enable

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -368,3 +368,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         return array_combine($identifiers, $identifiers);
     }
 }
+
+// phpcs:disable
+class_alias(DateTime::class, 'Cake\I18n\FrozenTime');
+// phpcs:enable

--- a/src/I18n/FrozenDate.php
+++ b/src/I18n/FrozenDate.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+deprecationWarning('5.0.0', 'Cake\I18n\FrozenDate is deprecated. Use Cake\I18n\Date instead');
+
+class_exists('Cake\I18n\Date');

--- a/src/I18n/FrozenTime.php
+++ b/src/I18n/FrozenTime.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+deprecationWarning('5.0.0', 'Cake\I18n\FrozenTime is deprecated. Use Cake\I18n\DateTime instead');
+
+class_exists('Cake\I18n\DateTime');


### PR DESCRIPTION
Add aliases for FrozenDate and FrozenTime as we can't easily deprecate those classes in 4.x because `Date` is already in use, and I thought it would be good to be consistent with DateTime.

Refs #16976