### PR TITLE
Fix up notice on PHP 8.2

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -157,8 +157,14 @@ trait StaticConfigTrait
         if (!isset(static::$_config[$config])) {
             return false;
         }
-        if (isset(static::$_registry)) {
-            static::$_registry->unload($config);
+
+        /**
+         * @phpstan-ignore-next-line
+         * @var \Cake\Core\ObjectRegistry|null $registry
+         */
+        $registry = static::$_registry;
+        if ($registry) {
+            $registry->unload($config);
         }
         unset(static::$_config[$config]);
 


### PR DESCRIPTION
This resolves both phpstan issue and missing IDE typehint (clickable):
```
  Line   Core/StaticConfigTrait.php (in context of class Cake\Mailer\Mailer)             
 ------ -------------------------------------------------------------------------------- 
  162    Access to an undefined static property static(Cake\Mailer\Mailer)::$_registry. 
```

Needs fix of https://github.com/cakephp/cakephp/pull/16985 to work