### PR TITLE
Fix up bug detected by Psalm

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -52,6 +52,6 @@ class QueryLogger extends BaseLog
             $context = $context['query']->getContext() + $context;
             $message = 'connection={connection} duration={took} rows={numRows} ' . $message;
         }
-        Log::write('debug', $message, $context);
+        Log::write('debug', (string)$message, $context);
     }
 }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -56,10 +56,29 @@ class QueryLoggerTest extends TestCase
             'className' => 'Array',
             'scopes' => ['foo'],
         ]);
-        $logger->log(LogLevel::DEBUG, (string)$query, compact('query'));
+        $logger->log(LogLevel::DEBUG, $query, compact('query'));
 
         $this->assertCount(1, Log::engine('queryLoggerTest')->read());
         $this->assertCount(0, Log::engine('queryLoggerTest2')->read());
+    }
+
+    /**
+     * Tests that passed Stringable also work.
+     */
+    public function testLogFunctionStringable(): void
+    {
+        $this->skipIf(version_compare(PHP_VERSION, '8.0', '<'), 'Stringable exists since 8.0');
+
+        $logger = new QueryLogger(['connection' => '']);
+        $stringable = new class implements \Stringable
+        {
+            public function __toString(): string
+            {
+                return 'FooBar';
+            }
+        };
+
+        $logger->log(LogLevel::DEBUG, $stringable, ['query' => null]);
     }
 
     /**


### PR DESCRIPTION
Sometimes it can be worth executing PHPStan/Psalm in latest PHP version
it does show some extra issues that might be upcoming in those.

For 8.x it seems about Stringable not being able to be used for string param type with strict_types on:
https://github.com/vimeo/psalm/issues/9204

As such, we should fix our method here by casting first.