### PR TITLE
4.5 Add deprecations for most of ModelAwareTrait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "cakephp/chronos": "^2.4.0-RC1",
+        "cakephp/chronos": "^2.4.0-RC2",
         "composer/ca-bundle": "^1.2",
         "laminas/laminas-diactoros": "^2.2.2",
         "laminas/laminas-httphandlerrunner": "^1.1 || ^2.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -65,9 +65,6 @@
       <code>$this-&gt;modelClass</code>
       <code>$this-&gt;modelClass</code>
     </DeprecatedProperty>
-    <DeprecatedTrait occurrences="1">
-      <code>ModelAwareTrait</code>
-    </DeprecatedTrait>
   </file>
   <file src="src/Command/CompletionCommand.php">
     <DeprecatedClass occurrences="1">
@@ -103,9 +100,6 @@
     <DeprecatedProperty occurrences="1">
       <code>$this-&gt;modelClass</code>
     </DeprecatedProperty>
-    <DeprecatedTrait occurrences="1">
-      <code>ModelAwareTrait</code>
-    </DeprecatedTrait>
   </file>
   <file src="src/Console/ShellDispatcher.php">
     <DeprecatedClass occurrences="5">
@@ -140,8 +134,7 @@
     </DeprecatedMethod>
   </file>
   <file src="src/Controller/Controller.php">
-    <DeprecatedMethod occurrences="2">
-      <code>loadModel</code>
+    <DeprecatedMethod occurrences="1">
       <code>loadModel</code>
     </DeprecatedMethod>
     <DeprecatedProperty occurrences="7">
@@ -153,9 +146,6 @@
       <code>$this-&gt;modelClass</code>
       <code>$this-&gt;modelClass</code>
     </DeprecatedProperty>
-    <DeprecatedTrait occurrences="1">
-      <code>ModelAwareTrait</code>
-    </DeprecatedTrait>
     <PropertyTypeCoercion occurrences="1">
       <code>$result</code>
     </PropertyTypeCoercion>
@@ -213,7 +203,8 @@
     <DeprecatedClass occurrences="1">
       <code>$this</code>
     </DeprecatedClass>
-    <DeprecatedProperty occurrences="3">
+    <DeprecatedProperty occurrences="4">
+      <code>$this-&gt;modelClass</code>
       <code>$this-&gt;modelClass</code>
       <code>$this-&gt;modelClass</code>
       <code>$this-&gt;modelClass</code>
@@ -337,9 +328,6 @@
     <DeprecatedProperty occurrences="1">
       <code>$this-&gt;modelClass</code>
     </DeprecatedProperty>
-    <DeprecatedTrait occurrences="1">
-      <code>ModelAwareTrait</code>
-    </DeprecatedTrait>
   </file>
   <file src="src/Mailer/Transport/SmtpTransport.php">
     <LessSpecificReturnStatement occurrences="1">
@@ -481,11 +469,6 @@
       <code>addTestFile</code>
       <code>addTestFile</code>
     </InternalMethod>
-  </file>
-  <file src="src/View/Cell.php">
-    <DeprecatedTrait occurrences="1">
-      <code>ModelAwareTrait</code>
-    </DeprecatedTrait>
   </file>
   <file src="src/View/Helper/NumberHelper.php">
     <DeprecatedMethod occurrences="1">

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -320,7 +320,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             }
 
             if ($class === $name) {
-                return $this->loadModel();
+                return $this->fetchModel();
             }
         }
 

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -162,6 +162,11 @@ trait ModelAwareTrait
      */
     public function getModelType(): string
     {
+        deprecationWarning(
+            '4.5.0 getModelType() is deprecated. ' .
+            'Use ORM\LocatorAwareTrait or datasource specific registries instead.'
+        );
+
         return $this->_modelType;
     }
 
@@ -173,6 +178,10 @@ trait ModelAwareTrait
      */
     public function setModelType(string $modelType)
     {
+        deprecationWarning(
+            '4.5.0 setModelType() is deprecated. ' .
+            'Use ORM\LocatorAwareTrait or datasource specific registries instead.'
+        );
         $this->_modelType = $modelType;
 
         return $this;

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -183,9 +183,12 @@ trait ModelAwareTrait
 
         $factory = $this->_modelFactories[$modelType] ?? FactoryLocator::get($modelType);
         if ($factory instanceof LocatorInterface) {
-            return $factory->get($modelClass, $options);
+            $instance = $factory->get($modelClass, $options);
         } else {
-            return $factory($modelClass, $options);
+            $instance = $factory($modelClass, $options);
+        }
+        if ($instance) {
+            return $instance;
         }
 
         throw new MissingModelException([$modelClass, $modelType]);

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -27,8 +27,6 @@ use UnexpectedValueException;
  *
  * Example users of this trait are Cake\Controller\Controller and
  * Cake\Console\Shell.
- *
- * @deprecated 4.3.0 Use `Cake\ORM\Locator\LocatorAwareTrait` instead.
  */
 trait ModelAwareTrait
 {
@@ -78,10 +76,11 @@ trait ModelAwareTrait
     }
 
     /**
-     * Loads and constructs repository objects required by this object
+     * Fetch or construct a model and set it to a property on this object.
      *
-     * Typically used to load ORM Table objects as required. Can
-     * also be used to load other types of repository objects your application uses.
+     * Uses a modelFactory based on `$modelType` to fetch and construct a `RepositoryInterface`
+     * and set it as a property on the current object. The default `modelType`
+     * can be defined with `setModelType()`.
      *
      * If a repository provider does not return an object a MissingModelException will
      * be thrown.
@@ -93,7 +92,7 @@ trait ModelAwareTrait
      * @throws \Cake\Datasource\Exception\MissingModelException If the model class cannot be found.
      * @throws \UnexpectedValueException If $modelClass argument is not provided
      *   and ModelAwareTrait::$modelClass property value is empty.
-     * @deprecated 4.3.0 Use `LocatorAwareTrait::fetchTable()` instead.
+     * @deprecated 4.3.0 Prefer `LocatorAwareTrait::fetchTable()` or `ModelAwareTrait::fetchModel()` instead.
      */
     public function loadModel(?string $modelClass = null, ?string $modelType = null): RepositoryInterface
     {
@@ -116,6 +115,12 @@ trait ModelAwareTrait
             );
             $modelClass = $alias;
         }
+        if (!property_exists($this, $alias)) {
+            deprecationWarning(
+                '4.5.0 - Dynamic properties will be removed in PHP 8.2. ' .
+                "Add `public \${$alias} = null;` to your class definition."
+            );
+        }
 
         if (isset($this->{$alias})) {
             return $this->{$alias};
@@ -133,6 +138,57 @@ trait ModelAwareTrait
         }
 
         return $this->{$alias};
+    }
+
+    /**
+     * Fetch or construct a model instance from a locator.
+     *
+     * Uses a modelFactory based on `$modelType` to fetch and construct a `RepositoryInterface`
+     * and return it. The default `modelType` can be defined with `setModelType()`.
+     *
+     * Unlike `loadModel()` this method will *not* set an object property.
+     *
+     * If a repository provider does not return an object a MissingModelException will
+     * be thrown.
+     *
+     * @param string|null $modelClass Name of model class to load. Defaults to $this->modelClass.
+     *  The name can be an alias like `'Post'` or FQCN like `App\Model\Table\PostsTable::class`.
+     * @param string|null $modelType The type of repository to load. Defaults to the getModelType() value.
+     * @return \Cake\Datasource\RepositoryInterface The model instance created.
+     * @throws \Cake\Datasource\Exception\MissingModelException If the model class cannot be found.
+     * @throws \UnexpectedValueException If $modelClass argument is not provided
+     *   and ModelAwareTrait::$modelClass property value is empty.
+     */
+    public function fetchModel(?string $modelClass = null, ?string $modelType = null): RepositoryInterface
+    {
+        $modelClass = $modelClass ?? $this->modelClass;
+        if (empty($modelClass)) {
+            throw new UnexpectedValueException('Default modelClass is empty');
+        }
+        $modelType = $modelType ?? $this->getModelType();
+
+        $options = [];
+        if (strpos($modelClass, '\\') === false) {
+            [, $alias] = pluginSplit($modelClass, true);
+        } else {
+            $options['className'] = $modelClass;
+            /** @psalm-suppress PossiblyFalseOperand */
+            $alias = substr(
+                $modelClass,
+                strrpos($modelClass, '\\') + 1,
+                -strlen($modelType)
+            );
+            $modelClass = $alias;
+        }
+
+        $factory = $this->_modelFactories[$modelType] ?? FactoryLocator::get($modelType);
+        if ($factory instanceof LocatorInterface) {
+            return $factory->get($modelClass, $options);
+        } else {
+            return $factory($modelClass, $options);
+        }
+
+        throw new MissingModelException([$modelClass, $modelType]);
     }
 
     /**
@@ -162,11 +218,6 @@ trait ModelAwareTrait
      */
     public function getModelType(): string
     {
-        deprecationWarning(
-            '4.5.0 getModelType() is deprecated. ' .
-            'Use ORM\LocatorAwareTrait or datasource specific registries instead.'
-        );
-
         return $this->_modelType;
     }
 
@@ -178,10 +229,6 @@ trait ModelAwareTrait
      */
     public function setModelType(string $modelType)
     {
-        deprecationWarning(
-            '4.5.0 setModelType() is deprecated. ' .
-            'Use ORM\LocatorAwareTrait or datasource specific registries instead.'
-        );
         $this->_modelType = $modelType;
 
         return $this;

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -48,7 +48,7 @@ class CommandTest extends TestCase
     /**
      * test loadModel is configured properly
      */
-    public function testConstructorLoadModel(): void
+    public function testConstructorLoadModelDynamicProperty(): void
     {
         $this->deprecated(function () {
             $command = new Command();
@@ -62,10 +62,9 @@ class CommandTest extends TestCase
      */
     public function testConstructorAutoLoadModel(): void
     {
-        $this->deprecated(function () {
-            $command = new AutoLoadModelCommand();
-            $this->assertInstanceOf(Table::class, $command->Posts);
-        });
+        // No deprecation as AutoLoadModelCommand class defines Posts property
+        $command = new AutoLoadModelCommand();
+        $this->assertInstanceOf(Table::class, $command->Posts);
     }
 
     /**

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -50,9 +50,11 @@ class CommandTest extends TestCase
      */
     public function testConstructorLoadModel(): void
     {
-        $command = new Command();
-        $command->loadModel('Comments');
-        $this->assertInstanceOf(Table::class, $command->Comments);
+        $this->deprecated(function () {
+            $command = new Command();
+            $command->loadModel('Comments');
+            $this->assertInstanceOf(Table::class, $command->Comments);
+        });
     }
 
     /**
@@ -60,8 +62,10 @@ class CommandTest extends TestCase
      */
     public function testConstructorAutoLoadModel(): void
     {
-        $command = new AutoLoadModelCommand();
-        $this->assertInstanceOf(Table::class, $command->Posts);
+        $this->deprecated(function () {
+            $command = new AutoLoadModelCommand();
+            $this->assertInstanceOf(Table::class, $command->Posts);
+        });
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -87,20 +87,22 @@ class ControllerTest extends TestCase
         $Controller = new Controller($request, new Response());
         $Controller->modelClass = 'SiteArticles';
 
-        $this->assertFalse(isset($Controller->Articles));
-        $this->assertInstanceOf(
-            'Cake\ORM\Table',
-            $Controller->SiteArticles
-        );
-        unset($Controller->SiteArticles);
+        $this->deprecated(function () use ($Controller) {
+            $this->assertFalse(isset($Controller->Articles));
+            $this->assertInstanceOf(
+                'Cake\ORM\Table',
+                $Controller->SiteArticles
+            );
+            unset($Controller->SiteArticles);
 
-        $Controller->modelClass = 'Articles';
+            $Controller->modelClass = 'Articles';
 
-        $this->assertFalse(isset($Controller->SiteArticles));
-        $this->assertInstanceOf(
-            'TestApp\Model\Table\ArticlesTable',
-            $Controller->Articles
-        );
+            $this->assertFalse(isset($Controller->SiteArticles));
+            $this->assertInstanceOf(
+                'TestApp\Model\Table\ArticlesTable',
+                $Controller->Articles
+            );
+        });
     }
 
     /**
@@ -132,15 +134,17 @@ class ControllerTest extends TestCase
 
         $this->assertFalse(isset($Controller->Articles));
 
-        $result = $Controller->loadModel('Articles');
-        $this->assertInstanceOf(
-            'TestApp\Model\Table\ArticlesTable',
-            $result
-        );
-        $this->assertInstanceOf(
-            'TestApp\Model\Table\ArticlesTable',
-            $Controller->Articles
-        );
+        $this->deprecated(function () use ($Controller) {
+            $result = $Controller->loadModel('Articles');
+            $this->assertInstanceOf(
+                'TestApp\Model\Table\ArticlesTable',
+                $result
+            );
+            $this->assertInstanceOf(
+                'TestApp\Model\Table\ArticlesTable',
+                $Controller->Articles
+            );
+        });
     }
 
     public function testAutoLoadModelUsingDefaultTable()
@@ -148,7 +152,9 @@ class ControllerTest extends TestCase
         Configure::write('App.namespace', 'TestApp');
         $Controller = new WithDefaultTableController(new ServerRequest(), new Response());
 
-        $this->assertInstanceOf(PostsTable::class, $Controller->Posts);
+        $this->deprecated(function () use ($Controller) {
+            $this->assertInstanceOf(PostsTable::class, $Controller->Posts);
+        });
 
         Configure::write('App.namespace', 'App');
     }
@@ -161,7 +167,9 @@ class ControllerTest extends TestCase
         Configure::write('App.namespace', 'TestApp');
         $Controller = new ArticlesController(new ServerRequest(), new Response());
 
-        $this->assertInstanceOf(ArticlesTable::class, $Controller->Articles);
+        $this->deprecated(function () use ($Controller) {
+            $this->assertInstanceOf(ArticlesTable::class, $Controller->Articles);
+        });
 
         Configure::write('App.namespace', 'App');
     }
@@ -178,15 +186,17 @@ class ControllerTest extends TestCase
 
         $this->assertFalse(isset($Controller->TestPluginComments));
 
-        $result = $Controller->loadModel('TestPlugin.TestPluginComments');
-        $this->assertInstanceOf(
-            'TestPlugin\Model\Table\TestPluginCommentsTable',
-            $result
-        );
-        $this->assertInstanceOf(
-            'TestPlugin\Model\Table\TestPluginCommentsTable',
-            $Controller->TestPluginComments
-        );
+        $this->deprecated(function () use ($Controller) {
+            $result = $Controller->loadModel('TestPlugin.TestPluginComments');
+            $this->assertInstanceOf(
+                'TestPlugin\Model\Table\TestPluginCommentsTable',
+                $result
+            );
+            $this->assertInstanceOf(
+                'TestPlugin\Model\Table\TestPluginCommentsTable',
+                $Controller->TestPluginComments
+            );
+        });
     }
 
     /**
@@ -198,18 +208,20 @@ class ControllerTest extends TestCase
 
         $request = new ServerRequest();
         $response = new Response();
-        $controller = new PostsController($request, $response);
-        $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
-        $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
+        $this->deprecated(function () use ($request, $response) {
+            $controller = new PostsController($request, $response);
+            $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
+            $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
-        $controller = new AdminPostsController($request, $response);
-        $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
-        $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
+            $controller = new AdminPostsController($request, $response);
+            $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
+            $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
-        $request = $request->withParam('plugin', 'TestPlugin');
-        $controller = new CommentsController($request, $response);
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->loadModel());
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->Comments);
+            $request = $request->withParam('plugin', 'TestPlugin');
+            $controller = new CommentsController($request, $response);
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->loadModel());
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->Comments);
+        });
     }
 
     public function testConstructSetDefaultTable()
@@ -711,9 +723,11 @@ class ControllerTest extends TestCase
         $this->assertNotContains('Paginator', $Controller->viewBuilder()->getHelpers());
         $this->assertArrayNotHasKey('Paginator', $Controller->viewBuilder()->getHelpers());
 
-        $results = $Controller->paginate('Posts');
-        $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
-        $this->assertCount(3, $results);
+        $this->deprecated(function () use ($Controller) {
+            $results = $Controller->paginate('Posts');
+            $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+            $this->assertCount(3, $results);
+        });
 
         $results = $Controller->paginate($this->getTableLocator()->get('Posts'));
         $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
@@ -760,9 +774,11 @@ class ControllerTest extends TestCase
 
         $Controller = new Controller($request, $response);
         $Controller->modelClass = 'Posts';
-        $results = $Controller->paginate();
+        $this->deprecated(function () use ($Controller) {
+            $results = $Controller->paginate();
 
-        $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+            $this->assertInstanceOf('Cake\Datasource\ResultSetInterface', $results);
+        });
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -87,22 +87,20 @@ class ControllerTest extends TestCase
         $Controller = new Controller($request, new Response());
         $Controller->modelClass = 'SiteArticles';
 
-        $this->deprecated(function () use ($Controller) {
-            $this->assertFalse(isset($Controller->Articles));
-            $this->assertInstanceOf(
-                'Cake\ORM\Table',
-                $Controller->SiteArticles
-            );
-            unset($Controller->SiteArticles);
+        $this->assertFalse(isset($Controller->Articles));
+        $this->assertInstanceOf(
+            'Cake\ORM\Table',
+            $Controller->SiteArticles
+        );
+        unset($Controller->SiteArticles);
 
-            $Controller->modelClass = 'Articles';
+        $Controller->modelClass = 'Articles';
 
-            $this->assertFalse(isset($Controller->SiteArticles));
-            $this->assertInstanceOf(
-                'TestApp\Model\Table\ArticlesTable',
-                $Controller->Articles
-            );
-        });
+        $this->assertFalse(isset($Controller->SiteArticles));
+        $this->assertInstanceOf(
+            'TestApp\Model\Table\ArticlesTable',
+            $Controller->Articles
+        );
     }
 
     /**
@@ -152,9 +150,7 @@ class ControllerTest extends TestCase
         Configure::write('App.namespace', 'TestApp');
         $Controller = new WithDefaultTableController(new ServerRequest(), new Response());
 
-        $this->deprecated(function () use ($Controller) {
-            $this->assertInstanceOf(PostsTable::class, $Controller->Posts);
-        });
+        $this->assertInstanceOf(PostsTable::class, $Controller->Posts);
 
         Configure::write('App.namespace', 'App');
     }
@@ -167,9 +163,7 @@ class ControllerTest extends TestCase
         Configure::write('App.namespace', 'TestApp');
         $Controller = new ArticlesController(new ServerRequest(), new Response());
 
-        $this->deprecated(function () use ($Controller) {
-            $this->assertInstanceOf(ArticlesTable::class, $Controller->Articles);
-        });
+        $this->assertInstanceOf(ArticlesTable::class, $Controller->Articles);
 
         Configure::write('App.namespace', 'App');
     }
@@ -210,15 +204,18 @@ class ControllerTest extends TestCase
         $response = new Response();
         $this->deprecated(function () use ($request, $response) {
             $controller = new PostsController($request, $response);
+            $this->assertInstanceOf('Cake\ORM\Table', $controller->fetchModel());
             $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
             $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
             $controller = new AdminPostsController($request, $response);
+            $this->assertInstanceOf('Cake\ORM\Table', $controller->fetchModel());
             $this->assertInstanceOf('Cake\ORM\Table', $controller->loadModel());
             $this->assertInstanceOf('Cake\ORM\Table', $controller->Posts);
 
             $request = $request->withParam('plugin', 'TestPlugin');
             $controller = new CommentsController($request, $response);
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->fetchModel());
             $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->loadModel());
             $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $controller->Comments);
         });

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -43,29 +43,77 @@ class ModelAwareTraitTest extends TestCase
         $this->assertSame('StubArticles', $stub->getModelClass());
     }
 
+    public function testFetchModel(): void
+    {
+        $stub = new Stub();
+        $stub->setProps('Articles');
+        $stub->setModelType('Table');
+
+        $result = $stub->fetchModel();
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertNull($stub->Articles);
+
+        $result = $stub->fetchModel('Comments');
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertNull($stub->Comments);
+
+        $result = $stub->fetchModel(PaginatorPostsTable::class);
+        $this->assertInstanceOf(PaginatorPostsTable::class, $result);
+        $this->assertSame('PaginatorPosts', $result->getAlias());
+        $this->assertNull($stub->PaginatorPosts);
+    }
+
+    /**
+     * Test that calling fetchModel() without $modelClass argument when default
+     * $modelClass property is empty generates exception.
+     */
+    public function testFetchModelException(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Default modelClass is empty');
+
+        $stub = new Stub();
+        $stub->setProps('');
+        $stub->setModelType('Table');
+
+        $stub->fetchModel();
+    }
+
+    /**
+     * test fetchModel() with plugin prefixed models
+     */
+    public function testFetchModelPlugin(): void
+    {
+        $stub = new Stub();
+        $stub->setProps('Articles');
+        $stub->setModelType('Table');
+
+        $result = $stub->fetchModel('TestPlugin.Comments');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+        $this->assertNull($stub->Comments);
+    }
+
     /**
      * test loadModel()
      */
     public function testLoadModel(): void
     {
-        $this->deprecated(function () {
-            $stub = new Stub();
-            $stub->setProps('Articles');
-            $stub->setModelType('Table');
+        $stub = new Stub();
+        $stub->setProps('Articles');
+        $stub->setModelType('Table');
 
-            $result = $stub->loadModel();
-            $this->assertInstanceOf('Cake\ORM\Table', $result);
-            $this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
+        $result = $stub->loadModel();
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
 
-            $result = $stub->loadModel('Comments');
-            $this->assertInstanceOf('Cake\ORM\Table', $result);
-            $this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
+        $result = $stub->loadModel('Comments');
+        $this->assertInstanceOf('Cake\ORM\Table', $result);
+        $this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
 
-            $result = $stub->loadModel(PaginatorPostsTable::class);
-            $this->assertInstanceOf(PaginatorPostsTable::class, $result);
-            $this->assertInstanceOf(PaginatorPostsTable::class, $stub->PaginatorPosts);
-            $this->assertSame('PaginatorPosts', $result->getAlias());
-        });
+        $result = $stub->loadModel(PaginatorPostsTable::class);
+        $this->assertInstanceOf(PaginatorPostsTable::class, $result);
+        $this->assertInstanceOf(PaginatorPostsTable::class, $stub->PaginatorPosts);
+        $this->assertSame('PaginatorPosts', $result->getAlias());
     }
 
     /**
@@ -94,19 +142,17 @@ class ModelAwareTraitTest extends TestCase
      */
     public function testLoadModelPlugin(): void
     {
-        $this->deprecated(function () {
-            $stub = new Stub();
-            $stub->setProps('Articles');
-            $stub->setModelType('Table');
+        $stub = new Stub();
+        $stub->setProps('Articles');
+        $stub->setModelType('Table');
 
-            $result = $stub->loadModel('TestPlugin.Comments');
-            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
-            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
+        $result = $stub->loadModel('TestPlugin.Comments');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
 
-            $result = $stub->loadModel('Comments');
-            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
-            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
-        });
+        $result = $stub->loadModel('Comments');
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
     }
 
     /**
@@ -164,25 +210,25 @@ class ModelAwareTraitTest extends TestCase
     public function testGetSetModelType(): void
     {
         $this->deprecated(function () {
-            $stub = new Stub();
-            $stub->setProps('Articles');
-
             FactoryLocator::add('Test', function ($name) {
                 $mock = new stdClass();
                 $mock->name = $name;
 
                 return $mock;
             });
-
-            $stub->setModelType('Test');
-            $this->assertSame('Test', $stub->getModelType());
         });
+
+        $stub = new Stub();
+        $stub->setProps('Articles');
+
+        $stub->setModelType('Test');
+        $this->assertSame('Test', $stub->getModelType());
     }
 
     /**
      * test MissingModelException being thrown
      */
-    public function testMissingModelException(): void
+    public function testLoadModelMissingModelException(): void
     {
         $this->expectException(MissingModelException::class);
         $this->expectExceptionMessage('Model class "Magic" of type "Test" could not be found.');

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -48,22 +48,24 @@ class ModelAwareTraitTest extends TestCase
      */
     public function testLoadModel(): void
     {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-        $stub->setModelType('Table');
+        $this->deprecated(function () {
+            $stub = new Stub();
+            $stub->setProps('Articles');
+            $stub->setModelType('Table');
 
-        $result = $stub->loadModel();
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
+            $result = $stub->loadModel();
+            $this->assertInstanceOf('Cake\ORM\Table', $result);
+            $this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
 
-        $result = $stub->loadModel('Comments');
-        $this->assertInstanceOf('Cake\ORM\Table', $result);
-        $this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
+            $result = $stub->loadModel('Comments');
+            $this->assertInstanceOf('Cake\ORM\Table', $result);
+            $this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
 
-        $result = $stub->loadModel(PaginatorPostsTable::class);
-        $this->assertInstanceOf(PaginatorPostsTable::class, $result);
-        $this->assertInstanceOf(PaginatorPostsTable::class, $stub->PaginatorPosts);
-        $this->assertSame('PaginatorPosts', $result->getAlias());
+            $result = $stub->loadModel(PaginatorPostsTable::class);
+            $this->assertInstanceOf(PaginatorPostsTable::class, $result);
+            $this->assertInstanceOf(PaginatorPostsTable::class, $stub->PaginatorPosts);
+            $this->assertSame('PaginatorPosts', $result->getAlias());
+        });
     }
 
     /**
@@ -75,11 +77,13 @@ class ModelAwareTraitTest extends TestCase
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('Default modelClass is empty');
 
-        $stub = new Stub();
-        $stub->setProps('');
-        $stub->setModelType('Table');
+        $this->deprecated(function () {
+            $stub = new Stub();
+            $stub->setProps('');
+            $stub->setModelType('Table');
 
-        $stub->loadModel();
+            $stub->loadModel();
+        });
     }
 
     /**
@@ -90,17 +94,19 @@ class ModelAwareTraitTest extends TestCase
      */
     public function testLoadModelPlugin(): void
     {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-        $stub->setModelType('Table');
+        $this->deprecated(function () {
+            $stub = new Stub();
+            $stub->setProps('Articles');
+            $stub->setModelType('Table');
 
-        $result = $stub->loadModel('TestPlugin.Comments');
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
+            $result = $stub->loadModel('TestPlugin.Comments');
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
 
-        $result = $stub->loadModel('Comments');
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
-        $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
+            $result = $stub->loadModel('Comments');
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $result);
+            $this->assertInstanceOf('TestPlugin\Model\Table\CommentsTable', $stub->Comments);
+        });
     }
 
     /**
@@ -157,19 +163,20 @@ class ModelAwareTraitTest extends TestCase
      */
     public function testGetSetModelType(): void
     {
-        $stub = new Stub();
-        $stub->setProps('Articles');
-
         $this->deprecated(function () {
+            $stub = new Stub();
+            $stub->setProps('Articles');
+
             FactoryLocator::add('Test', function ($name) {
                 $mock = new stdClass();
                 $mock->name = $name;
 
                 return $mock;
             });
+
+            $stub->setModelType('Test');
+            $this->assertSame('Test', $stub->getModelType());
         });
-        $stub->setModelType('Test');
-        $this->assertSame('Test', $stub->getModelType());
     }
 
     /**

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -17,11 +17,9 @@ namespace Cake\Test\TestCase\Datasource;
 
 use Cake\Datasource\Exception\MissingModelException;
 use Cake\Datasource\FactoryLocator;
-use Cake\Datasource\Locator\LocatorInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use stdClass;
 use TestApp\Datasource\StubFactory;
 use TestApp\Model\Table\PaginatorPostsTable;
 use TestApp\Stub\Stub;

--- a/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
+++ b/tests/test_app/TestApp/Command/AutoLoadModelCommand.php
@@ -8,4 +8,6 @@ use Cake\Command\Command;
 class AutoLoadModelCommand extends Command
 {
     protected $modelClass = 'Posts';
+
+    public $Posts = null;
 }

--- a/tests/test_app/TestApp/Datasource/StubFactory.php
+++ b/tests/test_app/TestApp/Datasource/StubFactory.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Datasource;
+
+use Cake\Datasource\Locator\LocatorInterface;
+use Cake\Datasource\RepositoryInterface;
+
+class StubFactory implements LocatorInterface
+{
+    private $instances = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $alias, array $options = [])
+    {
+        if (!isset($this->instances[$alias])) {
+            return false;
+        }
+
+        return $this->instances[$alias];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(string $alias, RepositoryInterface $repository)
+    {
+        $this->instances[$alias] = $repository;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exists(string $alias): bool
+    {
+        return isset($this->instances[$alias]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function remove(string $alias): void
+    {
+        unset($this->instances[$alias]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): void
+    {
+        $this->instances = [];
+    }
+}

--- a/tests/test_app/TestApp/Shell/MergeShell.php
+++ b/tests/test_app/TestApp/Shell/MergeShell.php
@@ -35,4 +35,9 @@ class MergeShell extends Shell
      * @var string
      */
     protected $modelClass = 'Articles';
+
+    /**
+     * @var \TestApp\Model\Table\ArticlesTable
+     */
+    public $Articles;
 }

--- a/tests/test_app/TestApp/Shell/ShellTestShell.php
+++ b/tests/test_app/TestApp/Shell/ShellTestShell.php
@@ -55,6 +55,11 @@ class ShellTestShell extends Shell
     public $testMessage = 'all your base are belong to us';
 
     /**
+     * @var \TestPlugin\Model\Table\TestPluginCommentsTable
+     */
+    public $TestPluginComments;
+
+    /**
      * @inheritDoc
      */
     protected function _stop(int $status = Shell::CODE_SUCCESS): void

--- a/tests/test_app/TestApp/Stub/Stub.php
+++ b/tests/test_app/TestApp/Stub/Stub.php
@@ -8,10 +8,15 @@ use Cake\Datasource\ModelAwareTrait;
 /**
  * Testing stub.
  */
-#[\AllowDynamicProperties]
 class Stub
 {
     use ModelAwareTrait;
+
+    public $Articles = null;
+    public $Comments = null;
+    public $Foo = null;
+    public $Magic = null;
+    public $PaginatorPosts = null;
 
     public function setProps(string $name): void
     {


### PR DESCRIPTION
Adding deprecations to loadModel() is tricky. While it is important for this method to emit a deprecation so that developer can fix their usage, we also use it internally quite extensively to load ORM models.

We might need a more elaborate solution to emit deprecations for this method. One option that comes to mind is only emitting deprecations for non-ORM usage. We *could* have a `loadModel()` method in 5.0 that emits deprecations.

Refs #16974