### PR TITLE
Set request context for the router before running middleware queue.

### DIFF
--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Http;
 
+use Cake\Routing\Router;
+use Cake\Routing\RoutingApplicationInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -54,6 +56,13 @@ class Runner implements RequestHandlerInterface
         $this->queue = $queue;
         $this->queue->rewind();
         $this->fallbackHandler = $fallbackHandler;
+
+        if (
+            $fallbackHandler instanceof RoutingApplicationInterface &&
+            $request instanceof ServerRequest
+        ) {
+            Router::setRequest($request);
+        }
 
         return $this->handle($request);
     }

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -19,9 +19,13 @@ namespace Cake\Test\TestCase\Http;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\Response;
 use Cake\Http\Runner;
+use Cake\Http\ServerRequest;
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
+use TestApp\Application;
+use Throwable;
 
 /**
  * Test case for runner.
@@ -125,5 +129,19 @@ class RunnerTest extends TestCase
 
         $runner = new Runner();
         $runner->run($this->queue, $req);
+    }
+
+    public function testRunSetRouterContext(): void
+    {
+        $runner = new Runner();
+        $request = new ServerRequest();
+        $app = new Application(CONFIG);
+
+        try {
+            $runner->run($this->queue, $request, $app);
+        } catch (Throwable $e) {
+        }
+
+        $this->assertSame($request, Router::getRequest());
     }
 }


### PR DESCRIPTION
This allows the Router to properly generate at least URLs for static assets incase an exception occurs before the RoutingMiddleware is run.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
