### PR TITLE
5.0 - Add deprecation for logging config change

### DIFF
--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -58,11 +58,11 @@ abstract class BaseLog extends AbstractLogger
     {
         $this->setConfig($config);
 
-        assert(
-            $this->_config['scopes'] !== false,
-            new InvalidArgumentException('Use `null` instead of `false` to disable scopes.')
-        );
-
+        // Backwards compatibility shim as we can't deprecate using false because of how 4.x merges configuration.
+        if ($this->_config['scopes'] === false) {
+            deprecationWarning('5.0.0', 'Using `false` to disable logging scopes is deprecated. Use `null` instead.');
+            $this->_config['scopes'] = null;
+        }
         if ($this->_config['scopes'] !== null) {
             $this->_config['scopes'] = (array)$this->_config['scopes'];
         }

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -20,7 +20,6 @@ use ArrayObject;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Log\Formatter\AbstractFormatter;
 use Cake\Log\Formatter\DefaultFormatter;
-use InvalidArgumentException;
 use JsonSerializable;
 use Psr\Log\AbstractLogger;
 use Serializable;

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -397,6 +397,27 @@ class LogTest extends TestCase
     }
 
     /**
+     * Test scoped logging backwards compat
+     */
+    public function testScopedLoggingBackwardsCompat(): void
+    {
+        $this->_deleteLogs();
+
+        Log::setConfig('debug', [
+            'engine' => 'File',
+            'path' => LOGS,
+            'levels' => ['notice', 'info', 'debug'],
+            'file' => 'debug',
+            'scopes' => false,
+        ]);
+
+        $this->deprecated(function () {
+            Log::write('debug', 'debug message', 'orders');
+        });
+        $this->assertFileDoesNotExist(LOGS . 'debug.log');
+    }
+
+    /**
      * Test scoped logging without the default loggers catching everything
      */
     public function testScopedLoggingStrict(): void


### PR DESCRIPTION
I was going through the 5.0 upgrade guide and saw that we didn't have a deprecation for this change. I attempted to put this deprecation in 4.next. However it didn't work as well because of how configuration is merged. I thought that supporting false|null|array as a config value and converting false -> null with a deprecation was pretty reasonable. This configuration value will be used rarely.
