### PR TITLE
Cast field name to string to prevent type hint issues with integer field names

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -231,7 +231,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Validates and returns an array of failed fields and their error messages.
      *
-     * @param array $data The data to be checked for errors
+     * @param array<string|int, mixed> $data The data to be checked for errors
      * @param bool $newRecord whether the data to be validated is new or to be updated.
      * @return array<array> Array of failed fields
      */
@@ -423,7 +423,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Returns the rule set for a field
      *
-     * @param string $field name of the field to check
+     * @param string|int $field name of the field to check
      * @return \Cake\Validation\ValidationSet
      */
     public function offsetGet($field): ValidationSet
@@ -677,7 +677,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * You can also set mode and message for all passed fields, the individual
      * setting takes precedence over group settings.
      *
-     * @param array|string $field the name of the field or list of fields.
+     * @param array<string|int, mixed>|string $field the name of the field or list of fields.
      * @param callable|string|bool $mode Valid values are true, false, 'create', 'update'.
      *   If a callable is passed then the field will be required only when the callback
      *   returns true.
@@ -1145,7 +1145,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @param string|int $fieldName name of field
      * @param array<string, mixed> $defaults default settings
-     * @param array<string, mixed>|string $settings settings from data
+     * @param array<string|int, mixed>|string $settings settings from data
      * @return array<array>
      * @throws \InvalidArgumentException
      */
@@ -1228,7 +1228,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      *
      * @deprecated 3.7.0 Use {@link notEmptyString()}, {@link notEmptyArray()}, {@link notEmptyFile()},
      *   {@link notEmptyDate()}, {@link notEmptyTime()} or {@link notEmptyDateTime()} instead.
-     * @param array|string $field the name of the field or list of fields
+     * @param array<string|int, mixed>|string $field the name of the field or list of fields
      * @param string|null $message The message to show if the field is not
      * @param callable|string|bool $when Indicates when the field is not allowed
      *   to be empty. Valid values are true (always), 'create', 'update'. If a

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -240,6 +240,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $errors = [];
 
         foreach ($this->_fields as $name => $field) {
+            $name = (string)$name;
             $keyPresent = array_key_exists($name, $data);
 
             $providers = $this->_providers;
@@ -427,7 +428,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function offsetGet($field): ValidationSet
     {
-        return $this->field($field);
+        return $this->field((string)$field);
     }
 
     /**
@@ -698,7 +699,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             $settings = $this->_convertValidatorToArray($fieldName, $defaults, $setting);
             $fieldName = current(array_keys($settings));
 
-            $this->field($fieldName)->requirePresence($settings[$fieldName]['mode']);
+            $this->field((string)$fieldName)->requirePresence($settings[$fieldName]['mode']);
             if ($settings[$fieldName]['message']) {
                 $this->_presenceMessages[$fieldName] = $settings[$fieldName]['message'];
             }
@@ -1255,7 +1256,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
             $whenSetting = $this->invertWhenClause($settings[$fieldName]['when']);
 
-            $this->field($fieldName)->allowEmpty($whenSetting);
+            $this->field((string)$fieldName)->allowEmpty($whenSetting);
             $this->_allowEmptyFlags[$fieldName] = static::EMPTY_ALL;
             if ($settings[$fieldName]['message']) {
                 $this->_allowEmptyMessages[$fieldName] = $settings[$fieldName]['message'];

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1151,6 +1151,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     protected function _convertValidatorToArray($fieldName, array $defaults = [], $settings = []): array
     {
+        if (is_int($settings)) {
+            $settings = (string)$settings;
+        }
         if (is_string($settings)) {
             $fieldName = $settings;
             $settings = [];

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1890,7 +1890,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator
-            ->add(('0', 'alpha', ['rule' => 'alphanumeric']);
+            ->add('0', 'alpha', ['rule' => 'alphanumeric']);
         $this->assertSame($validator->offsetGet(0), $validator->field('0'));
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -332,8 +332,8 @@ class ValidatorTest extends TestCase
             ],
             'another_field',
         ]);
-        $this->assertTrue($validator->field((string)0)->isPresenceRequired());
-        $this->assertFalse($validator->field((string)1)->isPresenceRequired());
+        $this->assertTrue($validator->field('0')->isPresenceRequired());
+        $this->assertFalse($validator->field('1')->isPresenceRequired());
     }
 
     /**
@@ -1465,8 +1465,8 @@ class ValidatorTest extends TestCase
             ], 'Not empty', true);
         });
 
-        $this->assertTrue($validator->field((string)0)->isEmptyAllowed());
-        $this->assertFalse($validator->field((string)1)->isEmptyAllowed());
+        $this->assertTrue($validator->field('0')->isEmptyAllowed());
+        $this->assertFalse($validator->field('1')->isEmptyAllowed());
 
         $errors = $validator->validate([
             0 => '',
@@ -1890,7 +1890,7 @@ class ValidatorTest extends TestCase
     {
         $validator = new Validator();
         $validator
-            ->add((string)0, 'alpha', ['rule' => 'alphanumeric']);
+            ->add(('0', 'alpha', ['rule' => 'alphanumeric']);
         $this->assertSame($validator->offsetGet(0), $validator->field('0'));
     }
 


### PR DESCRIPTION
Potentially, there could be many more such cases but it seems casting the field name within ``validate()`` covers most of the cases, as this method is called from many classes throughout the framework.