### PR TITLE
4.5 - Add deprecation for enableBufferedResults()

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2216,6 +2216,11 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function enableBufferedResults(bool $enable = true)
     {
+        if (!$enable) {
+            deprecationWarning(
+                '4.5.0 enableBufferedResults() is deprecated. Results will always be buffered in 5.0.'
+            );
+        }
         $this->_dirty();
         $this->_useBufferedResults = $enable;
 

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -206,10 +206,10 @@ class QueryExpressionTest extends TestCase
      */
     public function testDeprecatedAddCaseStatement(): void
     {
-        $this->expectDeprecation();
-        $this->expectDeprecationMessage('QueryExpression::addCase() is deprecated, use case() instead.');
-
-        (new QueryExpression())->addCase([]);
+        $this->deprecated(function () {
+            (new QueryExpression())->addCase([]);
+            $this->assertTrue(true);
+        });
     }
 
     public function testCaseWithoutValue(): void

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1220,14 +1220,16 @@ class QueryTest extends TestCase
      */
     public function testFirstUnbuffered(): void
     {
-        $table = $this->getTableLocator()->get('Articles');
-        $query = new Query($this->connection, $table);
-        $query->select(['id']);
+        $this->deprecated(function () {
+            $table = $this->getTableLocator()->get('Articles');
+            $query = new Query($this->connection, $table);
+            $query->select(['id']);
 
-        $first = $query->enableHydration(false)
-            ->enableBufferedResults(false)->first();
+            $first = $query->enableHydration(false)
+                ->enableBufferedResults(false)->first();
 
-        $this->assertEquals(['id' => 1], $first);
+            $this->assertEquals(['id' => 1], $first);
+        });
     }
 
     /**
@@ -2686,7 +2688,6 @@ class QueryTest extends TestCase
         $table->hasMany('articles');
         $query = $table->find()
             ->where(['id > ' => 1])
-            ->enableBufferedResults(false)
             ->enableHydration(false)
             ->matching('articles')
             ->applyOptions(['foo' => 'bar'])
@@ -2726,7 +2727,7 @@ class QueryTest extends TestCase
             'decorators' => 0,
             'executed' => false,
             'hydrate' => false,
-            'buffered' => false,
+            'buffered' => true,
             'formatters' => 1,
             'mapReducers' => 1,
             'contain' => [],

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -91,16 +91,18 @@ class ResultSetTest extends TestCase
      */
     public function testRewindStreaming(): void
     {
-        $query = $this->table->find('all')->enableBufferedResults(false);
-        $results = $query->all();
-        $first = $second = [];
-        foreach ($results as $result) {
-            $first[] = $result;
-        }
-        $this->expectException(DatabaseException::class);
-        foreach ($results as $result) {
-            $second[] = $result;
-        }
+        $this->deprecated(function () {
+            $query = $this->table->find('all')->enableBufferedResults(false);
+            $results = $query->all();
+            $first = $second = [];
+            foreach ($results as $result) {
+                $first[] = $result;
+            }
+            $this->expectException(DatabaseException::class);
+            foreach ($results as $result) {
+                $second[] = $result;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Add another deprecation outlined in #16267 I'm not sure what the part about `count()` is though. Both versions have a count() method that does roughly the same thing.