### PR TITLE
Fix up null issue on PHP8.2+

### DIFF
--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -179,6 +179,8 @@ class StringTemplate
             $template = $this->get($name);
             if ($template === null) {
                 $this->_compiled[$name] = [null, null];
+
+                continue;
             }
 
             $template = str_replace('%', '%%', $template);


### PR DESCRIPTION
Does not solve it, but it is related to https://github.com/cakephp/cakephp/issues/17011
Another issue in there.

If null, there is no point in the further string operations, and passing null is actually dangerous.