### PR TITLE
4.5 Make deprecation ignores able to cover other libraries

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -122,6 +122,17 @@ class ErrorTrap
         $trace = Debugger::trace(['start' => 1, 'format' => 'points']);
         $error = new PhpError($code, $description, $file, $line, $trace);
 
+        $ignoredPaths = (array)Configure::read('Error.ignoredDeprecationPaths');
+        if ($code === E_USER_DEPRECATED && $ignoredPaths) {
+            $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', substr($file, strlen(ROOT) + 1));
+            foreach ($ignoredPaths as $pattern) {
+                $pattern = str_replace(DIRECTORY_SEPARATOR, '/', $pattern);
+                if (fnmatch($pattern, $relativePath)) {
+                    return true;
+                }
+            }
+        }
+
         $debug = Configure::read('debug');
         $renderer = $this->renderer();
 

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -124,7 +124,7 @@ class ErrorTrap
 
         $ignoredPaths = (array)Configure::read('Error.ignoredDeprecationPaths');
         if ($code === E_USER_DEPRECATED && $ignoredPaths) {
-            $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', substr($file, strlen(ROOT) + 1));
+            $relativePath = str_replace(DIRECTORY_SEPARATOR, '/', substr((string)$file, strlen(ROOT) + 1));
             foreach ($ignoredPaths as $pattern) {
                 $pattern = str_replace(DIRECTORY_SEPARATOR, '/', $pattern);
                 if (fnmatch($pattern, $relativePath)) {

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -271,6 +271,30 @@ class ErrorTrapTest extends TestCase
         $this->assertSame('', $output);
     }
 
+    public function testRegisterIgnoredDeprecations()
+    {
+        $trap = new ErrorTrap([
+            'errorRenderer' => TextErrorRenderer::class,
+            'trace' => false,
+        ]);
+        $trap->register();
+
+        ob_start();
+        Configure::write('Error.ignoredDeprecationPaths', [
+            'tests/TestCase/Error/ErrorTrap*',
+        ]);
+        trigger_error('Should be ignored', E_USER_DEPRECATED);
+
+        Configure::write('Error.ignoredDeprecationPaths', []);
+        trigger_error('Not ignored', E_USER_DEPRECATED);
+
+        $output = ob_get_clean();
+        restore_error_handler();
+
+        $this->assertStringNotContainsString('Should be ignored', $output);
+        $this->assertStringContainsString('Not ignored', $output);
+    }
+
     public function testEventTriggered()
     {
         $trap = new ErrorTrap(['errorRenderer' => TextErrorRenderer::class]);


### PR DESCRIPTION
We're adding a bunch of deprecations to chronos. Unfortunately those deprecations can't use `deprecationWarning()` because that function is cake only.

I think it would be beneficial for CakePHP to provide a more comprehensive way to ignore deprecations and incrementally update an application. By having ignored path support in `ErrorTrap` user land code can ignore deprecations from any library as long as the cakephp error trap is the active error handler.

I've left the existing ignored path logic in `deprecationWarning()` as I didn't want to risk any potential regressions.