### PR TITLE
Add optional support for wrapping PDOException with DatabaseException

### DIFF
--- a/src/Database/Exception/DatabaseException.php
+++ b/src/Database/Exception/DatabaseException.php
@@ -23,6 +23,10 @@ use Cake\Core\Exception\CakeException;
  */
 class DatabaseException extends CakeException
 {
+    /**
+     * @inheritDoc
+     */
+    protected $_messageTemplate = '%s';
 }
 
 // phpcs:disable

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -20,7 +20,6 @@ use Cake\Core\Configure;
 use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Statement\StatementDecorator;
 use Exception;
-use PDOException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -82,10 +81,15 @@ class LoggingStatement extends StatementDecorator
             $this->_log();
 
             if (Configure::read('Error.wrapStatementException', false) === true) {
+                $code = $e->getCode();
+                if (!is_int($code)) {
+                    $code = null;
+                }
+
                 throw new DatabaseException([
                     'message' => $e->getMessage(),
                     'queryString' => $this->queryString,
-                ], $e->getCode(), $e);
+                ], $code, $e);
             }
 
             if (version_compare(PHP_VERSION, '8.2.0', '<')) {

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -80,7 +80,7 @@ class LoggingStatement extends StatementDecorator
             $this->loggedQuery->error = $e;
             $this->_log();
 
-            if (Configure::read('Error.wrapStatementException', false) === true) {
+            if (Configure::read('Error.convertStatementToDatabaseException', false) === true) {
                 $code = $e->getCode();
                 if (!is_int($code)) {
                     $code = null;

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -95,7 +95,8 @@ class LoggingStatement extends StatementDecorator
             if (version_compare(PHP_VERSION, '8.2.0', '<')) {
                 deprecationWarning(
                     '4.4.12 - Having queryString set on exceptions is deprecated.' .
-                    'If you are not using this attribute there is no action to take.'
+                    'If you are not using this attribute there is no action to take.' .
+                    'Otherwise, enable Error.convertStatementToDatabaseException.'
                 );
                 /** @psalm-suppress UndefinedPropertyAssignment */
                 $e->queryString = $this->queryString;

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -178,12 +178,51 @@ class LoggingStatementTest extends TestCase
     }
 
     /**
-     * Tests that queries are logged despite database errors
+     * Tests that we do exception wrapping correctly.
+     * The exception returns a string code like most PDOExceptions
      */
-    public function testExecuteWithErrorWrapStatement(): void
+    public function testExecuteWithErrorWrapStatementStringCode(): void
     {
         Configure::write('Error.wrapStatementException', true);
         $exception = new MyPDOStringException('This is bad', 1234);
+        $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
+        $inner->expects($this->once())
+            ->method('execute')
+            ->will($this->throwException($exception));
+
+        $driver = $this->getMockBuilder(DriverInterface::class)->getMock();
+        $st = $this->getMockBuilder(LoggingStatement::class)
+            ->onlyMethods(['__get'])
+            ->setConstructorArgs([$inner, $driver])
+            ->getMock();
+        $st->expects($this->any())
+            ->method('__get')
+            ->willReturn('SELECT bar FROM foo');
+        $st->setLogger(new QueryLogger(['connection' => 'test']));
+        try {
+            $st->execute();
+            $this->fail('Exception not thrown');
+        } catch (DatabaseException $e) {
+            $attrs = $e->getAttributes();
+
+            $this->assertSame('This is bad', $e->getMessage());
+            $this->assertArrayHasKey('queryString', $attrs);
+            $this->assertSame($st->queryString, $attrs['queryString']);
+        }
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(1, $messages);
+        $this->assertMatchesRegularExpression("/^debug: connection=test duration=\d+ rows=0 SELECT bar FROM foo$/", $messages[0]);
+    }
+
+    /**
+     * Tests that we do exception wrapping correctly.
+     * The exception returns an int code.
+     */
+    public function testExecuteWithErrorWrapStatementIntCode(): void
+    {
+        Configure::write('Error.wrapStatementException', true);
+        $exception = new MyPDOException('This is bad', 1234);
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())
             ->method('execute')

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -182,7 +182,7 @@ class LoggingStatementTest extends TestCase
     public function testExecuteWithErrorWrapStatement(): void
     {
         Configure::write('Error.wrapStatementException', true);
-        $exception = new MyPDOException('This is bad');
+        $exception = new MyPDOException('This is bad', 'DBCODE11111');
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())
             ->method('execute')

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -26,6 +26,7 @@ use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use DateTime;
 use TestApp\Error\Exception\MyPDOException;
+use TestApp\Error\Exception\MyPDOStringException;
 
 /**
  * Tests LoggingStatement class
@@ -182,7 +183,7 @@ class LoggingStatementTest extends TestCase
     public function testExecuteWithErrorWrapStatement(): void
     {
         Configure::write('Error.wrapStatementException', true);
-        $exception = new MyPDOException('This is bad', 'DBCODE11111');
+        $exception = new MyPDOStringException('This is bad', 1234);
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())
             ->method('execute')

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -46,7 +46,7 @@ class LoggingStatementTest extends TestCase
     {
         parent::tearDown();
         Log::drop('queries');
-        Configure::delete('Error.wrapStatementException');
+        Configure::delete('Error.convertStatementToDatabaseException');
     }
 
     /**
@@ -183,7 +183,7 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteWithErrorWrapStatementStringCode(): void
     {
-        Configure::write('Error.wrapStatementException', true);
+        Configure::write('Error.convertStatementToDatabaseException', true);
         $exception = new MyPDOStringException('This is bad', 1234);
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())
@@ -221,7 +221,7 @@ class LoggingStatementTest extends TestCase
      */
     public function testExecuteWithErrorWrapStatementIntCode(): void
     {
-        Configure::write('Error.wrapStatementException', true);
+        Configure::write('Error.convertStatementToDatabaseException', true);
         $exception = new MyPDOException('This is bad', 1234);
         $inner = $this->getMockBuilder(StatementInterface::class)->getMock();
         $inner->expects($this->once())

--- a/tests/test_app/TestApp/Error/Exception/MyPDOStringException.php
+++ b/tests/test_app/TestApp/Error/Exception/MyPDOStringException.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Error\Exception;
+
+use PDOException;
+
+/**
+ * Exception class for testing error page for PDOException.
+ * This also emulates typical PDOException instances that return
+ * strings for getCode().
+ */
+class MyPDOStringException extends PDOException
+{
+    public $queryString;
+
+    public $params;
+
+    /**
+     * @inheritDoc
+    */
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
+    {
+       parent::__construct($message, $code, $previous);
+       $this->code = 'DB' . strval($code);
+    }
+}

--- a/tests/test_app/TestApp/Error/Exception/MyPDOStringException.php
+++ b/tests/test_app/TestApp/Error/Exception/MyPDOStringException.php
@@ -18,10 +18,10 @@ class MyPDOStringException extends PDOException
 
     /**
      * @inheritDoc
-    */
-    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null)
+     */
+    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
     {
-       parent::__construct($message, $code, $previous);
-       $this->code = 'DB' . strval($code);
+        parent::__construct($message, $code, $previous);
+        $this->code = 'DB' . strval($code);
     }
 }


### PR DESCRIPTION
Conditionally wrap PDOExceptions with DatabaseException to have a way to access the queryString without using dynamic properties. This allows applications to preserve the existing behavior and opt in to get the queryString if they prefer.

