### PR TITLE
4.next: add more fallbacks to table displayField logic

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -700,12 +700,28 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function getDisplayField()
     {
         if ($this->_displayField === null) {
+            $displayFieldFound = false;
             $schema = $this->getSchema();
             $this->_displayField = $this->getPrimaryKey();
-            foreach (['title', 'name', 'label'] as $field) {
+            $expectedFields = ['title', 'name', 'label'];
+            foreach ($expectedFields as $field) {
                 if ($schema->hasColumn($field)) {
                     $this->_displayField = $field;
+                    $displayFieldFound = true;
                     break;
+                }
+            }
+            if (!$displayFieldFound) {
+                foreach ($schema->columns() as $column) {
+                    $columnSchema = $schema->getColumn($column);
+                    if (
+                        $columnSchema &&
+                        $columnSchema['null'] !== true &&
+                        $columnSchema['type'] === 'string'
+                    ) {
+                        $this->_displayField = $column;
+                        break;
+                    }
                 }
             }
         }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -717,7 +717,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     if (
                         $columnSchema &&
                         $columnSchema['null'] !== true &&
-                        $columnSchema['type'] === 'string'
+                        $columnSchema['type'] === 'string' &&
+                        !preg_match('/pass|token|secret/', $column)
                     ) {
                         $this->_displayField = $column;
                         break;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -428,6 +428,19 @@ class TableTest extends TestCase
             ],
         ]);
         $this->assertSame('custom_name', $table->getDisplayField());
+
+        $table = new Table([
+            'table' => 'users',
+            'schema' => [
+                'id' => ['type' => 'integer'],
+                'nullable_title' => ['type' => 'string', 'null' => true],
+                'password' => ['type' => 'string'],
+                'user_secret' => ['type' => 'string'],
+                'api_token' => ['type' => 'string'],
+                '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+            ],
+        ]);
+        $this->assertSame('id', $table->getDisplayField());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -382,9 +382,58 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests that displayField will fallback to first *_name field
+     */
+    public function testDisplayNameFallback(): void
+    {
+        $table = new Table([
+            'table' => 'users',
+            'schema' => [
+                'id' => ['type' => 'integer'],
+                'custom_title' => ['type' => 'string'],
+                '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+            ],
+        ]);
+        $this->assertSame('custom_title', $table->getDisplayField());
+
+        $table = new Table([
+            'table' => 'users',
+            'schema' => [
+                'id' => ['type' => 'integer'],
+                'name' => ['type' => 'string'],
+                'custom_title' => ['type' => 'string'],
+                '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+            ],
+        ]);
+        $this->assertSame('name', $table->getDisplayField());
+
+        $table = new Table([
+            'table' => 'users',
+            'schema' => [
+                'id' => ['type' => 'integer'],
+                'title_id' => ['type' => 'integer'],
+                'custom_name' => ['type' => 'string'],
+                '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+            ],
+        ]);
+        $this->assertSame('custom_name', $table->getDisplayField());
+
+        $table = new Table([
+            'table' => 'users',
+            'schema' => [
+                'id' => ['type' => 'integer'],
+                'nullable_title' => ['type' => 'string', 'null' => true],
+                'custom_name' => ['type' => 'string'],
+                '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+            ],
+        ]);
+        $this->assertSame('custom_name', $table->getDisplayField());
+    }
+
+    /**
      * Tests that no displayField will fallback to primary key
      */
-    public function testDisplayFallback(): void
+    public function testDisplayIdFallback(): void
     {
         $table = new Table([
             'table' => 'users',


### PR DESCRIPTION
Refs: https://github.com/cakephp/bake/issues/907

It would be nice if CakePHP is a bit more lenient regarding what is detected as a display field.

Currently we are only allowing `'title', 'name', 'label'` but this PR extends this to allow any `'*_title', '*_name', '*_label'` if no initial `'title', 'name', 'label'` was found.