### PR TITLE
5.0 - PSR 17 Http Factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "league/container": "^4.2",
         "psr/container": "^2.0",
         "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^3.0",
@@ -56,6 +57,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",
+        "http-interop/http-factory-tests": "^0.9.0",
         "mikey179/vfsstream": "^1.6.10",
         "paragonie/csp-builder": "^2.3",
         "phpunit/phpunit": "^9.5.19"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,9 @@
             <directory>tests/TestCase/Database/</directory>
             <directory>tests/TestCase/ORM/</directory>
         </testsuite>
+        <testsuite name="http-interop-http-factory">
+            <directory>./vendor/http-interop/http-factory-tests/test</directory>
+        </testsuite>
     </testsuites>
 
     <extensions>
@@ -55,5 +58,13 @@
         <!-- SQL Server
         <env name="DB_URL" value="sqlserver://localhost/cake_test?timezone=UTC"/>
         -->
+
+        <!-- Fully qualified class names to your classes -->
+        <const name="REQUEST_FACTORY" value="Cake\Http\RequestFactory"/>
+        <const name="RESPONSE_FACTORY" value="Cake\Http\ResponseFactory"/>
+        <const name="SERVER_REQUEST_FACTORY" value="Cake\Http\ServerRequestFactory"/>
+        <const name="STREAM_FACTORY" value="Cake\Http\StreamFactory"/>
+        <const name="UPLOADED_FILE_FACTORY" value="Cake\Http\UploadedFileFactory"/>
+        <const name="URI_FACTORY" value="Cake\Http\UriFactory"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -59,7 +59,7 @@
         <env name="DB_URL" value="sqlserver://localhost/cake_test?timezone=UTC"/>
         -->
 
-        <!-- Fully qualified class names to your classes -->
+        <!-- Constants used by Http Interop's Http Factory tests -->
         <const name="REQUEST_FACTORY" value="Cake\Http\RequestFactory"/>
         <const name="RESPONSE_FACTORY" value="Cake\Http\ResponseFactory"/>
         <const name="SERVER_REQUEST_FACTORY" value="Cake\Http\ServerRequestFactory"/>

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -18,6 +18,7 @@ namespace Cake\Http\Client;
 use Laminas\Diactoros\RequestTrait;
 use Laminas\Diactoros\Stream;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Implements methods for HTTP requests.
@@ -35,13 +36,13 @@ class Request extends Message implements RequestInterface
      * Provides backwards compatible defaults for some properties.
      *
      * @phpstan-param array<non-empty-string, non-empty-string> $headers
-     * @param string $url The request URL
+     * @param \Psr\Http\Message\UriInterface|string $url The request URL
      * @param string $method The HTTP method to use.
      * @param array $headers The HTTP headers to set.
      * @param array|string|null $data The request body to use.
      */
     public function __construct(
-        string $url = '',
+        UriInterface|string $url = '',
         string $method = self::METHOD_GET,
         array $headers = [],
         array|string|null $data = null

--- a/src/Http/RequestFactory.php
+++ b/src/Http/RequestFactory.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Cake\Http\Client\Request;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Factory for creating request instances.
+ */
+class RequestFactory implements RequestFactoryInterface
+{
+    /**
+     * Create a new request.
+     *
+     * @param string $method The HTTP method associated with the request.
+     * @param \Psr\Http\Message\UriInterface|string $uri The URI associated with the request.
+     * @return \Psr\Http\Message\RequestInterface
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     */
+    public function createRequest(string $method, $uri): RequestInterface
+    {
+        return new Request($uri, $method);
+    }
+}

--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Factory class for creating response instances.
+ */
+class ResponseFactory implements ResponseFactoryInterface
+{
+    /**
+     * Create a new response.
+     *
+     * @param int $code The HTTP status code. Defaults to 200.
+     * @param string $reasonPhrase The reason phrase to associate with the status code
+     *   in the generated response. If none is provided, implementations MAY use
+     *   the defaults as suggested in the HTTP specification.
+     */
+    public function createResponse(int $code = 200, string $reasonPhrase = ''): ResponseInterface
+    {
+        return (new Response())->withStatus($code, $reasonPhrase);
+    }
+}

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -176,11 +176,10 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         $serverParams['REQUEST_METHOD'] = $method;
         $options = ['environment' => $serverParams];
 
-        if ($uri instanceof UriInterface) {
-            $options['uri'] = $uri;
-        } else {
-            $options['url'] = $uri;
+        if (is_string($uri)) {
+            $uri = (new UriFactory())->createUri($uri);
         }
+        $options['uri'] = $uri;
 
         return new ServerRequest($options);
     }
@@ -288,7 +287,12 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         }
 
         if (!$baseUrl) {
-            $base = dirname(Hash::get($server, 'PHP_SELF'));
+            $phpSelf = Hash::get($server, 'PHP_SELF');
+            if ($phpSelf === null) {
+                return ['', '/'];
+            }
+
+            $base = dirname(Hash::get($server, 'PHP_SELF', DIRECTORY_SEPARATOR));
             // Clean up additional / which cause following code to fail..
             $base = (string)preg_replace('#/+#', '/', $base);
 

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -33,7 +33,7 @@ use function Laminas\Diactoros\normalizeUploadedFiles;
  * attributes. Furthermore the Uri's path is corrected to only contain the
  * 'virtual' path for the request.
  */
-abstract class ServerRequestFactory implements ServerRequestFactoryInterface
+class ServerRequestFactory implements ServerRequestFactoryInterface
 {
     /**
      * Create a request from the supplied superglobal values.

--- a/src/Http/StreamFactory.php
+++ b/src/Http/StreamFactory.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Laminas\Diactoros\Stream;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Factory class for creating stream instances.
+ */
+class StreamFactory implements StreamFactoryInterface
+{
+    /**
+     * Create a new stream from a string.
+     *
+     * The stream SHOULD be created with a temporary resource.
+     *
+     * @param string $content String content with which to populate the stream.
+     */
+    public function createStream(string $content = ''): StreamInterface
+    {
+        $resource = fopen('php://temp', 'r+');
+        fwrite($resource, $content);
+        rewind($resource);
+
+        return $this->createStreamFromResource($resource);
+    }
+
+    /**
+     * Create a stream from an existing file.
+     *
+     * The file MUST be opened using the given mode, which may be any mode
+     * supported by the `fopen` function.
+     *
+     * The `$filename` MAY be any string supported by `fopen()`.
+     *
+     * @param string $filename The filename or stream URI to use as basis of stream.
+     * @param string $mode The mode with which to open the underlying filename/stream.
+     * @throws \RuntimeException If the file cannot be opened.
+     * @throws \InvalidArgumentException If the mode is invalid.
+     */
+    public function createStreamFromFile(string $filename, string $mode = 'r'): StreamInterface
+    {
+        return new Stream($filename, $mode);
+    }
+
+    /**
+     * Create a new stream from an existing resource.
+     *
+     * The stream MUST be readable and may be writable.
+     *
+     * @param resource $resource The PHP resource to use as the basis for the stream.
+     */
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        return new Stream($resource);
+    }
+}

--- a/src/Http/StreamFactory.php
+++ b/src/Http/StreamFactory.php
@@ -35,6 +35,7 @@ class StreamFactory implements StreamFactoryInterface
     public function createStream(string $content = ''): StreamInterface
     {
         $resource = fopen('php://temp', 'r+');
+        assert($resource !== false, 'Unable to create resource');
         fwrite($resource, $content);
         rewind($resource);
 

--- a/src/Http/UploadedFileFactory.php
+++ b/src/Http/UploadedFileFactory.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Laminas\Diactoros\UploadedFile;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Factory class for creating uploaded file instances.
+ */
+class UploadedFileFactory implements UploadedFileFactoryInterface
+{
+    /**
+     * Create a new uploaded file.
+     *
+     * If a size is not provided it will be determined by checking the size of
+     * the stream.
+     *
+     * @link http://php.net/manual/features.file-upload.post-method.php
+     * @link http://php.net/manual/features.file-upload.errors.php
+     * @param \Psr\Http\Message\StreamInterface $stream The underlying stream representing the
+     *     uploaded file content.
+     * @param int|null $size The size of the file in bytes.
+     * @param int $error The PHP file upload error.
+     * @param string|null $clientFilename The filename as provided by the client, if any.
+     * @param string|null $clientMediaType The media type as provided by the client, if any.
+     * @throws \InvalidArgumentException If the file resource is not readable.
+     */
+    public function createUploadedFile(
+        StreamInterface $stream,
+        ?int $size = null,
+        int $error = UPLOAD_ERR_OK,
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null
+    ): UploadedFileInterface {
+        if ($size === null) {
+            $size = $stream->getSize();
+        }
+
+        return new UploadedFile($stream, $size, $error, $clientFilename, $clientMediaType);
+    }
+}

--- a/src/Http/UploadedFileFactory.php
+++ b/src/Http/UploadedFileFactory.php
@@ -50,7 +50,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
         ?string $clientMediaType = null
     ): UploadedFileInterface {
         if ($size === null) {
-            $size = $stream->getSize();
+            $size = $stream->getSize() ?? 0;
         }
 
         return new UploadedFile($stream, $size, $error, $clientFilename, $clientMediaType);

--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Http;
+
+use Laminas\Diactoros\Uri;
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Factory class for creating uri instances.
+ */
+class UriFactory implements UriFactoryInterface
+{
+    /**
+     * Create a new URI.
+     *
+     * @param string $uri The URI to parse.
+     * @throws \InvalidArgumentException If the given URI cannot be parsed.
+     */
+    public function createUri(string $uri = ''): UriInterface
+    {
+        return new Uri($uri);
+    }
+}

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -29,13 +29,15 @@
         "cakephp/utility": "^5.0",
         "composer/ca-bundle": "^1.2",
         "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "laminas/laminas-diactoros": "^2.1",
         "laminas/laminas-httphandlerrunner": "^1.0"
     },
     "provide": {
-        "psr/http-client-implementation": "^1.0"
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0"
     },
     "suggest": {
         "cakephp/cache": "To use cache session storage",

--- a/tests/TestCase/Http/RequestFactoryTest.php
+++ b/tests/TestCase/Http/RequestFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\RequestFactory;
+use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Uri;
+
+/**
+ * Test case for the request factory.
+ */
+class RequestFactoryTest extends TestCase
+{
+    public function testCreateRequest(): void
+    {
+        $factory = new RequestFactory();
+
+        $request = $factory->createRequest('POST', 'http://example.com');
+
+        $this->assertSame('http://example.com', (string)$request->getUri());
+        $this->assertStringContainsString($request->getMethod(), 'POST');
+
+        $uri = new Uri('http://example.com');
+        $request = $factory->createRequest('GET', $uri);
+
+        $this->assertSame($uri, $request->getUri());
+        $this->assertStringContainsString($request->getMethod(), 'GET');
+    }
+}

--- a/tests/TestCase/Http/ResponseFactoryTest.php
+++ b/tests/TestCase/Http/ResponseFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\ResponseFactory;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for the response factory.
+ */
+class ResponseFactoryTest extends TestCase
+{
+    public function testCreateResponse(): void
+    {
+        $factory = new ResponseFactory();
+        $response = $factory->createResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', $response->getReasonPhrase());
+    }
+}

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -1385,4 +1385,15 @@ class ServerRequestFactoryTest extends TestCase
             ],
         ]);
     }
+
+    public function testCreateServerRequest(): void
+    {
+        $factory = new ServerRequestFactory();
+        $request = $factory->createServerRequest('GET', '/posts', ['foo' => 'bar']);
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/posts', $request->getRequestTarget());
+        $expected = ['foo' => 'bar', 'REQUEST_URI' => '/posts', 'REQUEST_METHOD' => 'GET'];
+        $this->assertEquals($expected, $request->getServerParams());
+    }
 }

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Http;
 
 use Cake\Core\Configure;
+use Cake\Http\ServerRequest;
 use Cake\Http\ServerRequestFactory;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
@@ -1389,11 +1390,12 @@ class ServerRequestFactoryTest extends TestCase
     public function testCreateServerRequest(): void
     {
         $factory = new ServerRequestFactory();
-        $request = $factory->createServerRequest('GET', '/posts', ['foo' => 'bar']);
+        $request = $factory->createServerRequest('GET', 'https://cakephp.org/team', ['foo' => 'bar']);
 
+        $this->assertInstanceOf(ServerRequest::class, $request);
         $this->assertSame('GET', $request->getMethod());
-        $this->assertSame('/posts', $request->getRequestTarget());
-        $expected = ['foo' => 'bar', 'REQUEST_URI' => '/posts', 'REQUEST_METHOD' => 'GET'];
+        $this->assertSame('/team', $request->getRequestTarget());
+        $expected = ['foo' => 'bar', 'REQUEST_METHOD' => 'GET'];
         $this->assertEquals($expected, $request->getServerParams());
     }
 }

--- a/tests/TestCase/Http/StreamFactoryTest.php
+++ b/tests/TestCase/Http/StreamFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\StreamFactory;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for the stream factory.
+ */
+class StreamFactoryTest extends TestCase
+{
+    protected StreamFactory $factory;
+
+    protected string $filename = TMP . 'stream-factory-file-test.txt';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new StreamFactory();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // phpcs:disable
+        @unlink($this->filename);
+        // phpcs:enable
+    }
+
+    public function testCreateStream(): void
+    {
+        $stream = $this->factory->createStream('test');
+        $this->assertSame('test', $stream->getContents());
+    }
+
+    public function testCreateStreamFile(): void
+    {
+        file_put_contents($this->filename, 'it works');
+
+        $stream = $this->factory->createStreamFromFile($this->filename);
+        $this->assertSame('it works', $stream->getContents());
+    }
+
+    public function testCreateStreamResource(): void
+    {
+        file_put_contents($this->filename, 'it works');
+        $resource = fopen($this->filename, 'r');
+
+        $stream = $this->factory->createStreamFromResource($resource);
+        $this->assertSame('it works', $stream->getContents());
+
+        fclose($resource);
+    }
+}

--- a/tests/TestCase/Http/UploadedFileFactoryTest.php
+++ b/tests/TestCase/Http/UploadedFileFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\UploadedFileFactory;
+use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Stream;
+
+/**
+ * Test case for the uploaded file factory.
+ */
+class UploadedFileFactoryTest extends TestCase
+{
+    protected UploadedFileFactory $factory;
+
+    protected string $filename = TMP . 'uploadedfile-factory-file-test.txt';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = new UploadedFileFactory();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // phpcs:disable
+        @unlink($this->filename);
+        // phpcs:enable
+    }
+
+    public function testCreateStreamResource(): void
+    {
+        file_put_contents($this->filename, 'it works');
+        $stream = new Stream($this->filename);
+
+        $uploadedFile = $this->factory->createUploadedFile($stream, null, UPLOAD_ERR_OK, 'my-name');
+        $this->assertSame('my-name', $uploadedFile->getClientFilename());
+        $this->assertSame($stream, $uploadedFile->getStream());
+    }
+}

--- a/tests/TestCase/Http/UriFactoryTest.php
+++ b/tests/TestCase/Http/UriFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Http;
+
+use Cake\Http\UriFactory;
+use Cake\TestSuite\TestCase;
+use Laminas\Diactoros\Uri;
+
+/**
+ * Test case for the uri factory.
+ */
+class UriFactoryTest extends TestCase
+{
+    public function testCreateUri(): void
+    {
+        $factory = new UriFactory();
+        $uri = $factory->createUri('https://cakephp.org');
+
+        $this->assertInstanceOf(Uri::class, $uri);
+    }
+}


### PR DESCRIPTION
This will allow using our `cakephp/http` package with 3rd party libs which require a PSR-17 implementation.