### PR TITLE
Throw exception when creating a plugin with empty name.

### DIFF
--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Countable;
 use Generator;
@@ -232,6 +233,10 @@ class PluginCollection implements Iterator, Countable
      */
     public function create(string $name, array $config = []): PluginInterface
     {
+        if ($name === '') {
+            throw new CakeException('Cannot create a plugin with empty name');
+        }
+
         if (strpos($name, '\\') !== false) {
             /** @var \Cake\Core\PluginInterface */
             return new $name($config);

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\PluginCollection;
 use Cake\Core\PluginInterface;
@@ -127,6 +128,15 @@ class PluginCollectionTest extends TestCase
         $plugin = $plugins->create('TestTheme');
         $this->assertInstanceOf(BasePlugin::class, $plugin);
         $this->assertSame('TestTheme', $plugin->getName());
+    }
+
+    public function testCreateException(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Cannot create a plugin with empty name');
+
+        $plugins = new PluginCollection();
+        $plugins->create('');
     }
 
     public function testIterator(): void


### PR DESCRIPTION
Currently `PluginCollection::create('')` returns a `BasePlugin` instance with invalid path and has no valid use case:

```
object(Cake\Core\BasePlugin) id:0 {
  [protected] bootstrapEnabled => true
  [protected] consoleEnabled => true
  [protected] middlewareEnabled => true
  [protected] servicesEnabled => true
  [protected] routesEnabled => true
  [protected] path => '/cakephp/tests/test_app/Plugin//'
  [protected] classPath => null
  [protected] configPath => null
  [protected] templatePath => null
  [protected] name => 'Cake/Core'
}
```

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
