### PR TITLE
Add note about PHPStan execution

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -84,6 +84,10 @@ And after that perform the checks via:
 
     composer stan
 
+Note that updating the baselines need to be done with the same PHP version it is run online.
+That is usually the minimum version.
+Make sure to "composer install" and set up the stan tools with it and then also execute them.
+
 ## Reporting a Security Issue
 
 If you've found a security related issue in CakePHP, please don't open an issue in github. Instead, contact us at security@cakephp.org. For more information on how we handle security issues, [see the CakePHP Security Issue Process](https://book.cakephp.org/4/en/contributing/tickets.html#reporting-security-issues).


### PR DESCRIPTION
My local system is 8.2.2
Just executing the tools locally does not provide the same output, generating baselines would then fail on CI

For it to work I needed to run
```
/usr/bin/php7.4 /usr/local/bin/composer update --ignore-platform-reqs
/usr/bin/php7.4 tools/phpstan --generate-baseline
```

I guess adding this note could be helpful also to others