### PR TITLE
5.x: fix intl ICU 72.1 time format change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: mbstring, intl, apcu, memcached, redis, pdo_${{ matrix.db-type }}
+        extensions: mbstring, intl-72.1, apcu, memcached, redis, pdo_${{ matrix.db-type }}
         ini-values: apc.enable_cli = 1, zend.assertions = 1
         coverage: pcov
 

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -80,9 +80,8 @@ class DateTest extends TestCase
         $this->assertSame($expected, $result);
 
         $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
-        $result = $time->i18nFormat($format);
-        $expected = '12:00 AM';
-        $this->assertSame($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $time->i18nFormat($format));
+        $this->assertSame('12:00 AM', $result);
 
         $result = $time->i18nFormat('HH:mm:ss', 'Australia/Sydney');
         $expected = '00:00:00';
@@ -99,8 +98,8 @@ class DateTest extends TestCase
 
         $time = new Date('2014-01-01T00:00:00Z');
         $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'en-US');
-        $expected = 'Wednesday, January 1, 2014 at 12:00:00 AM';
-        $this->assertStringStartsWith($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertStringStartsWith('Wednesday, January 1, 2014 at 12:00:00 AM', $result);
     }
 
     public function testDiffForHumans(): void

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -81,7 +81,7 @@ class DateTest extends TestCase
 
         $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
         $result = $time->i18nFormat($format);
-        $expected = '12:00 AM';
+        $expected = '12:00 AM';
         $this->assertSame($expected, $result);
 
         $result = $time->i18nFormat('HH:mm:ss', 'Australia/Sydney');
@@ -99,7 +99,7 @@ class DateTest extends TestCase
 
         $time = new Date('2014-01-01T00:00:00Z');
         $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'en-US');
-        $expected = 'Wednesday, January 1, 2014 at 12:00:00 AM';
+        $expected = 'Wednesday, January 1, 2014 at 12:00:00 AM';
         $this->assertStringStartsWith($expected, $result);
     }
 

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -360,10 +360,12 @@ class DateTimeTest extends TestCase
     public function testNice(): void
     {
         $time = new DateTime('2014-04-20 20:00', 'UTC');
-        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $time->nice());
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $time->nice());
+        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $result);
 
         $result = $time->nice('America/New_York');
-        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
         $this->assertSame('UTC', $time->getTimezone()->getName());
 
         $this->assertTimeFormat('20 avr. 2014 20:00', $time->nice(null, 'fr-FR'));
@@ -382,9 +384,8 @@ class DateTimeTest extends TestCase
         $time = new DateTime('Thu Jan 14 13:59:28 2010');
 
         // Test the default format which should be SHORT
-        $result = $time->i18nFormat();
-        $expected = '1/14/10, 1:59 PM';
-        $this->assertTimeFormat($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $time->i18nFormat());
+        $this->assertTimeFormat('1/14/10, 1:59 PM', $result);
 
         // Test with a custom timezone
         $result = $time->i18nFormat('HH:mm:ss', 'Australia/Sydney');
@@ -393,9 +394,8 @@ class DateTimeTest extends TestCase
 
         // Test using a time-specific format
         $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
-        $result = $time->i18nFormat($format);
-        $expected = '1:59 PM';
-        $this->assertTimeFormat($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $time->i18nFormat($format));
+        $this->assertTimeFormat('1:59 PM', $result);
 
         // Test using a specific format, timezone and locale
         $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'es-ES');
@@ -436,22 +436,26 @@ class DateTimeTest extends TestCase
     {
         $time = new DateTime('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00:00+09');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00:00-01:30');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00Z');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
     }
 

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -360,10 +360,10 @@ class DateTimeTest extends TestCase
     public function testNice(): void
     {
         $time = new DateTime('2014-04-20 20:00', 'UTC');
-        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $time->nice());
+        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $time->nice());
 
         $result = $time->nice('America/New_York');
-        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
+        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
         $this->assertSame('UTC', $time->getTimezone()->getName());
 
         $this->assertTimeFormat('20 avr. 2014 20:00', $time->nice(null, 'fr-FR'));
@@ -383,7 +383,7 @@ class DateTimeTest extends TestCase
 
         // Test the default format which should be SHORT
         $result = $time->i18nFormat();
-        $expected = '1/14/10, 1:59 PM';
+        $expected = '1/14/10, 1:59 PM';
         $this->assertTimeFormat($expected, $result);
 
         // Test with a custom timezone
@@ -394,7 +394,7 @@ class DateTimeTest extends TestCase
         // Test using a time-specific format
         $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
         $result = $time->i18nFormat($format);
-        $expected = '1:59 PM';
+        $expected = '1:59 PM';
         $this->assertTimeFormat($expected, $result);
 
         // Test using a specific format, timezone and locale
@@ -436,22 +436,22 @@ class DateTimeTest extends TestCase
     {
         $time = new DateTime('2014-01-01T00:00:00+00');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00:00+09');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT+09:00';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00:00-01:30');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT-01:30';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('2014-01-01T00:00Z');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
-        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
+        $expected = 'Wednesday January 1 2014 12:00:00 AM GMT';
         $this->assertTimeFormat($expected, $result);
     }
 

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -155,10 +155,10 @@ class TimeHelperTest extends TestCase
     public function testNice(): void
     {
         $time = '2014-04-20 20:00';
-        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $this->Time->nice($time));
+        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $this->Time->nice($time));
 
         $result = $this->Time->nice($time, 'America/New_York');
-        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
+        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
     }
 
     /**
@@ -168,7 +168,7 @@ class TimeHelperTest extends TestCase
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
         $time = '2014-04-20 20:00';
-        $this->assertTimeFormat('Apr 20, 2014, 1:00 PM', $this->Time->nice($time));
+        $this->assertTimeFormat('Apr 20, 2014, 1:00 PM', $this->Time->nice($time));
     }
 
     /**
@@ -462,11 +462,11 @@ class TimeHelperTest extends TestCase
         $time = strtotime('Thu Jan 14 13:59:28 2010');
 
         $result = $this->Time->format($time);
-        $expected = '1/14/10, 1:59 PM';
+        $expected = '1/14/10, 1:59 PM';
         $this->assertTimeFormat($expected, $result);
 
         $result = $this->Time->format($time, IntlDateFormatter::FULL);
-        $expected = 'Thursday, January 14, 2010 at 1:59:28 PM';
+        $expected = 'Thursday, January 14, 2010 at 1:59:28 PM';
         $this->assertStringStartsWith($expected, $result);
 
         $result = $this->Time->format('invalid date', null, 'Date invalid');
@@ -490,12 +490,12 @@ class TimeHelperTest extends TestCase
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
         $result = $this->Time->format($time);
-        $expected = '1/14/10, 12:59 AM';
+        $expected = '1/14/10, 12:59 AM';
         $this->assertTimeFormat($expected, $result);
 
         $time = new DateTime('Thu Jan 14 8:59:28 2010', 'UTC');
         $result = $this->Time->format($time);
-        $expected = '1/14/10, 12:59 AM';
+        $expected = '1/14/10, 12:59 AM';
         $this->assertTimeFormat($expected, $result);
     }
 
@@ -508,7 +508,7 @@ class TimeHelperTest extends TestCase
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
         $result = $this->Time->i18nFormat($time, [IntlDateFormatter::SHORT, IntlDateFormatter::FULL]);
-        $expected = '1/14/10, 12:59:28 AM';
+        $expected = '1/14/10, 12:59:28 AM';
         $this->assertStringStartsWith($expected, $result);
     }
 
@@ -519,7 +519,7 @@ class TimeHelperTest extends TestCase
     {
         $time = '2010-01-14 13:59:28';
         $result = $this->Time->format($time);
-        $this->assertTimeFormat('1/14/10 1:59 PM', $result);
+        $this->assertTimeFormat('1/14/10 1:59 PM', $result);
 
         $result = $this->Time->format($time, 'HH:mm', false, 'America/New_York');
         $this->assertTimeFormat('08:59', $result);

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -155,10 +155,13 @@ class TimeHelperTest extends TestCase
     public function testNice(): void
     {
         $time = '2014-04-20 20:00';
-        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $this->Time->nice($time));
+        $result = $this->Time->nice($time);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('Apr 20, 2014, 8:00 PM', $result);
 
         $result = $this->Time->nice($time, 'America/New_York');
-        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('Apr 20, 2014, 4:00 PM', $result);
     }
 
     /**
@@ -167,8 +170,9 @@ class TimeHelperTest extends TestCase
     public function testNiceOutputTimezone(): void
     {
         $this->Time->setConfig('outputTimezone', 'America/Vancouver');
-        $time = '2014-04-20 20:00';
-        $this->assertTimeFormat('Apr 20, 2014, 1:00 PM', $this->Time->nice($time));
+        $result = $this->Time->nice('2014-04-20 20:00');
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('Apr 20, 2014, 1:00 PM', $result);
     }
 
     /**
@@ -462,12 +466,12 @@ class TimeHelperTest extends TestCase
         $time = strtotime('Thu Jan 14 13:59:28 2010');
 
         $result = $this->Time->format($time);
-        $expected = '1/14/10, 1:59 PM';
-        $this->assertTimeFormat($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('1/14/10, 1:59 PM', $result);
 
         $result = $this->Time->format($time, IntlDateFormatter::FULL);
-        $expected = 'Thursday, January 14, 2010 at 1:59:28 PM';
-        $this->assertStringStartsWith($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertStringStartsWith('Thursday, January 14, 2010 at 1:59:28 PM', $result);
 
         $result = $this->Time->format('invalid date', null, 'Date invalid');
         $expected = 'Date invalid';
@@ -490,13 +494,13 @@ class TimeHelperTest extends TestCase
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
         $result = $this->Time->format($time);
-        $expected = '1/14/10, 12:59 AM';
-        $this->assertTimeFormat($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('1/14/10, 12:59 AM', $result);
 
         $time = new DateTime('Thu Jan 14 8:59:28 2010', 'UTC');
         $result = $this->Time->format($time);
-        $expected = '1/14/10, 12:59 AM';
-        $this->assertTimeFormat($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('1/14/10, 12:59 AM', $result);
     }
 
     /**
@@ -508,8 +512,8 @@ class TimeHelperTest extends TestCase
 
         $time = strtotime('Thu Jan 14 8:59:28 2010 UTC');
         $result = $this->Time->i18nFormat($time, [IntlDateFormatter::SHORT, IntlDateFormatter::FULL]);
-        $expected = '1/14/10, 12:59:28 AM';
-        $this->assertStringStartsWith($expected, $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertStringStartsWith('1/14/10, 12:59:28 AM', $result);
     }
 
     /**
@@ -519,7 +523,8 @@ class TimeHelperTest extends TestCase
     {
         $time = '2010-01-14 13:59:28';
         $result = $this->Time->format($time);
-        $this->assertTimeFormat('1/14/10 1:59 PM', $result);
+        $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
+        $this->assertTimeFormat('1/14/10 1:59 PM', $result);
 
         $result = $this->Time->format($time, 'HH:mm', false, 'America/New_York');
         $this->assertTimeFormat('08:59', $result);


### PR DESCRIPTION
As described in https://icu.unicode.org/download/72#h.u2dtz3f7ik9a the intl ICU 72.1 extension introduced a change regarding `In many formatting patterns, ASCII spaces are replaced with Unicode spaces (e.g., a "thin space").`

This results in them using a [Narrow No-Break Space](https://www.compart.com/en/unicode/U+202F) `NNBSP` instead of a normal whitespace before the `AM` and `PM` part of english time formatting.

Currently our used [shivammathur/setup-php@v2](https://github.com/shivammathur/setup-php) CI action doesn't default to that version but it may very well in the near future.

