### PR TITLE
Add conveninence function for generating URLs.

### DIFF
--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -14,27 +14,51 @@ declare(strict_types=1);
  * @since         4.1.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+// phpcs:disable SlevomatCodingStandard.Namespaces.NamespaceDeclaration.DisallowedBracketedSyntax
+namespace {
 
-use Cake\Routing\Router;
+    use Cake\Routing\Router;
 
-if (!function_exists('urlArray')) {
+    if (!function_exists('urlArray')) {
+        /**
+         * Returns an array URL from a route path string.
+         *
+         * @param string $path Route path.
+         * @param array $params An array specifying any additional parameters.
+         *   Can be also any special parameters supported by `Router::url()`.
+         * @return array URL
+         * @see \Cake\Routing\Router::pathUrl()
+         */
+        function urlArray(string $path, array $params = []): array
+        {
+            $url = Router::parseRoutePath($path);
+            $url += [
+                'plugin' => false,
+                'prefix' => false,
+            ];
+
+            return $url + $params;
+        }
+    }
+}
+
+namespace Cake\Routing {
     /**
-     * Returns an array URL from a route path string.
+     * Convenience wrapper for Router::url().
      *
-     * @param string $path Route path.
-     * @param array $params An array specifying any additional parameters.
-     *   Can be also any special parameters supported by `Router::url()`.
-     * @return array URL
-     * @see \Cake\Routing\Router::pathUrl()
+     * @param \Psr\Http\Message\UriInterface|array|string|null $url An array specifying any of the following:
+     *   'controller', 'action', 'plugin' additionally, you can provide routed
+     *   elements or query string parameters. If string it can be name any valid url
+     *   string or it can be an UriInterface instance.
+     * @param bool $full If true, the full base URL will be prepended to the result.
+     *   Default is false.
+     * @return string Full translated URL with base path.
+     * @throws \Cake\Core\Exception\CakeException When the route name is not found
+     * @see \Cake\Routing\Router::url()
+     * @since 4.5.0
      */
-    function urlArray(string $path, array $params = []): array
+    function url($url = null, bool $full = false): string
     {
-        $url = Router::parseRoutePath($path);
-        $url += [
-            'plugin' => false,
-            'prefix' => false,
-        ];
-
-        return $url + $params;
+        return Router::url($url, $full);
     }
 }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -29,6 +29,7 @@ use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
 use RuntimeException;
+use function Cake\Routing\url;
 
 /**
  * RouterTest class
@@ -3324,6 +3325,16 @@ class RouterTest extends TestCase
         $this->expectExceptionMessage('cannot be used when defining route targets with a string route path.');
 
         Router::url(['_path' => 'Articles::index'] + $params);
+    }
+
+    /**
+     * Test the url() function which wraps Router::url()
+     *
+     * @return void
+     */
+    public function testUrlFunction(): void
+    {
+        $this->assertSame(Router::url('/'), url('/'));
     }
 
     /**


### PR DESCRIPTION
Ideally ~~this new `url()` function and~~ various other global functions we have should be namespaced. While the `function_exists()` checks avoid errors, if the same function is already implemented by another package our function becomes unavailable altogether.

 This is actually the case with `dd()`. If one uses the repl plugin psysh pulls in a symfony dependency which implements `dd()` first making our implementation of `dd()` unavailable.
