### PR TITLE
Fix cookie expire set to 1 when app timezone is not UTC

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -621,7 +621,7 @@ class Cookie implements CookieInterface
     public function withExpired()
     {
         $new = clone $this;
-        $new->expiresAt = new DateTimeImmutable('1970-01-01 00:00:01', new DateTimeZone('UTC'));
+        $new->expiresAt = new DateTimeImmutable('@1');
 
         return $new;
     }

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -621,7 +621,7 @@ class Cookie implements CookieInterface
     public function withExpired()
     {
         $new = clone $this;
-        $new->expiresAt = new DateTimeImmutable('1970-01-01 00:00:01');
+        $new->expiresAt = new DateTimeImmutable('1970-01-01 00:00:01', new DateTimeZone('UTC'));
 
         return $new;
     }

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -237,6 +237,21 @@ class CookieTest extends TestCase
     }
 
     /**
+     * Test the expired method
+     */
+    public function testWithExpiredNotUtc(): void
+    {
+        date_default_timezone_set('Europe/Paris');
+
+        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        $new = $cookie->withExpired();
+
+        $this->assertStringContainsString('01-Jan-1970 00:00:01 UTC', $new->toHeaderValue());
+
+        date_default_timezone_set('UTC');
+    }
+
+    /**
      * Test the withExpiry method
      */
     public function testWithExpiry(): void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -246,7 +246,7 @@ class CookieTest extends TestCase
         $cookie = new Cookie('cakephp', 'cakephp-rocks');
         $new = $cookie->withExpired();
 
-        $this->assertStringContainsString('01-Jan-1970 00:00:01 UTC', $new->toHeaderValue());
+        $this->assertStringContainsString('01-Jan-1970 00:00:01 GMT+0000', $new->toHeaderValue());
 
         date_default_timezone_set('UTC');
     }

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -910,6 +910,19 @@ class ResponseTest extends TestCase
         $this->assertSame(1, $new->getCookie('yay')['expires']);
     }
 
+    public function testWithExpiredCookieNotUtc()
+    {
+        date_default_timezone_set('Europe/Paris');
+
+        $response = new Response();
+        $cookie = new Cookie('yay', 'a value');
+        $response = $response->withExpiredCookie($cookie);
+
+        $this->assertSame(1, $response->getCookie('yay')['expires']);
+
+        date_default_timezone_set('UTC');
+    }
+
     /**
      * Test getCookies() and array data.
      */

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -917,10 +917,9 @@ class ResponseTest extends TestCase
         $response = new Response();
         $cookie = new Cookie('yay', 'a value');
         $response = $response->withExpiredCookie($cookie);
-
-        $this->assertSame(1, $response->getCookie('yay')['expires']);
-
         date_default_timezone_set('UTC');
+        
+        $this->assertSame(1, $response->getCookie('yay')['expires']);
     }
 
     /**


### PR DESCRIPTION
Try to fix #17048 