### PR TITLE
4.next: Allow Route Path params inside string representation

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>[a-z0-9_/]*)
+            (?<params>[a-z0-9_/:]*)
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {
@@ -1035,7 +1035,16 @@ class Router
 
         if ($matches['params'] !== '') {
             $paramsArray = array_values(array_filter(explode('/', $matches['params'])));
-            $defaults += $paramsArray;
+            $convertedArray = [];
+            foreach ($paramsArray as $param) {
+                if (strpos($param, ':') !== false) {
+                    $explodedParam = explode(':', $param);
+                    $convertedArray[$explodedParam[0]] = $explodedParam[1];
+                } else {
+                    $convertedArray[] = $param;
+                }
+            }
+            $defaults += $convertedArray;
         }
 
         static::$_routePaths[$url] = $defaults;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1001,7 +1001,7 @@ class Router
      * - Vendor/Cms.Management/Admin/Articles::view
      *
      * @param string $url Route path in [Plugin.][Prefix/]Controller::action format
-     * @return array<string, string>
+     * @return array<string|int, string>
      */
     public static function parseRoutePath(string $url): array
     {
@@ -1015,6 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
+            (?<params>[a-z0-9_/]*)
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {
@@ -1031,6 +1032,11 @@ class Router
         }
         $defaults['controller'] = $matches['controller'];
         $defaults['action'] = $matches['action'];
+
+        if ($matches['params'] !== '') {
+            $paramsArray = array_values(array_filter(explode('/', $matches['params'])));
+            $defaults += $paramsArray;
+        }
 
         static::$_routePaths[$url] = $defaults;
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>(?:/(?:[a-z][a-z0-9-_]*=)?[a-z0-9-_]+)+/?)?
+            (?<params>(?:/(?:[a-z][a-z0-9-_]*=)?(["\']?[a-z0-9-_=]+[\'"]?))+/?)?
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {
@@ -1038,8 +1038,11 @@ class Router
             $convertedArray = [];
             foreach ($paramsArray as $param) {
                 if (strpos($param, '=') !== false) {
-                    $explodedParam = explode('=', $param);
-                    $convertedArray[$explodedParam[0]] = $explodedParam[1];
+                    $paramsRegex = '/(?<key>.+?)(=)(?<value>.*)/';
+                    if (!preg_match($paramsRegex, $param, $paramMatches)) {
+                        throw new InvalidArgumentException("Could not parse a key=value from `{$param}`.");
+                    }
+                    $convertedArray[$paramMatches['key']] = trim(trim($paramMatches['value'], '"'), "'");
                 } else {
                     $convertedArray[] = $param;
                 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>(?:/(?:[a-z][a-z0-9-_]*=)?[a-z0-9-_]+)+/?)
+            (?<params>[a-z0-9-_/=]*)
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1034,7 +1034,7 @@ class Router
         $defaults['action'] = $matches['action'];
 
         if ($matches['params'] !== '') {
-            $paramsArray = array_values(array_filter(explode('/', $matches['params'])));
+            $paramsArray = explode('/', trim($matches['params'], '/'));
             $convertedArray = [];
             foreach ($paramsArray as $param) {
                 if (strpos($param, '=') !== false) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1033,7 +1033,7 @@ class Router
         $defaults['controller'] = $matches['controller'];
         $defaults['action'] = $matches['action'];
 
-        if ($matches['params'] !== '') {
+        if (isset($matches['params']) && $matches['params'] !== '') {
             $paramsArray = explode('/', trim($matches['params'], '/'));
             $convertedArray = [];
             foreach ($paramsArray as $param) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>[a-z0-9_/:]*)
+            (?<params>[a-z0-9_/:=]*)
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {
@@ -1037,8 +1037,8 @@ class Router
             $paramsArray = array_values(array_filter(explode('/', $matches['params'])));
             $convertedArray = [];
             foreach ($paramsArray as $param) {
-                if (strpos($param, ':') !== false) {
-                    $explodedParam = explode(':', $param);
+                if (strpos($param, '=') !== false) {
+                    $explodedParam = explode('=', $param);
                     $convertedArray[$explodedParam[0]] = $explodedParam[1];
                 } else {
                     $convertedArray[] = $param;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1042,7 +1042,12 @@ class Router
                     if (!preg_match($paramsRegex, $param, $paramMatches)) {
                         throw new InvalidArgumentException("Could not parse a key=value from `{$param}`.");
                     }
-                    $convertedArray[$paramMatches['key']] = trim(trim($paramMatches['value'], '"'), "'");
+                    $paramKey = $paramMatches['key'];
+                    if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $paramKey)) {
+                        throw new InvalidArgumentException("Param key `{$paramKey}` is not valid.");
+                    }
+                    $paramValue = trim(trim($paramMatches['value'], '"'), "'");
+                    $convertedArray[$paramKey] = $paramValue;
                 } else {
                     $convertedArray[] = $param;
                 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>[a-z0-9-_/=]*)
+            (?<params>(?:/(?:[a-z][a-z0-9-_]*=)?[a-z0-9-_]+)+/?)
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>[a-z0-9_/:=]*)
+            (?<params>[a-z0-9-_/=]*)
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1015,7 +1015,7 @@ class Router
             (?<controller>[a-z0-9]+)
             ::
             (?<action>[a-z0-9_]+)
-            (?<params>[a-z0-9-_/=]*)
+            (?<params>(?:/(?:[a-z][a-z0-9-_]*=)?[a-z0-9-_]+)+/?)?
             $#ix';
 
         if (!preg_match($regex, $url, $matches)) {

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2260,6 +2260,24 @@ class RouterTest extends TestCase
             'action' => 'view',
         ];
         $this->assertSame($expected, Router::parseRoutePath('Vendor/Cms.Management/Admin/Articles::view'));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            '1',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/1'));
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/1/'));
+
+        $expected = [
+            'plugin' => 'Cms',
+            'controller' => 'Articles',
+            'action' => 'edit',
+            '2023',
+            '03',
+            '5th',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath('Cms.Articles::edit/2023/03/5th'));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2278,6 +2278,22 @@ class RouterTest extends TestCase
             '5th',
         ];
         $this->assertSame($expected, Router::parseRoutePath('Cms.Articles::edit/2023/03/5th'));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'organisation' => 'cakephp',
+            'repository' => 'debug_kit',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organisation:cakephp/repository:debug_kit'));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'organisation' => 'cakephp',
+            'bake',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organisation:cakephp/bake'));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2282,18 +2282,18 @@ class RouterTest extends TestCase
         $expected = [
             'controller' => 'Bookmarks',
             'action' => 'view',
-            'organisation' => 'cakephp',
+            'organization' => 'cakephp',
             'repository' => 'debug_kit',
         ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organisation:cakephp/repository:debug_kit'));
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization:cakephp/repository:debug_kit'));
 
         $expected = [
             'controller' => 'Bookmarks',
             'action' => 'view',
-            'organisation' => 'cakephp',
+            'organization' => 'cakephp',
             'bake',
         ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organisation:cakephp/bake'));
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization:cakephp/bake'));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2330,6 +2330,14 @@ class RouterTest extends TestCase
             'organization' => 'cakephp',
         ];
         $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/organization='cakephp'"));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Param key `1invalid` is not valid.');
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/1invalid=cakephp'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Param key `-invalid` is not valid.');
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/-invalid=cakephp'));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2294,6 +2294,42 @@ class RouterTest extends TestCase
             'bake',
         ];
         $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization=cakephp/bake'));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'organization' => 'cakephp=test',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization="cakephp=test"'));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'test' => 'repo=debug_kit',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/test='repo=debug_kit'"));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'organization' => 'cakephp=test',
+            'test' => 'repo=debug_kit',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization="cakephp=test"/test=\'repo=debug_kit\''));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'organization' => 'cakephp=',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/organization='cakephp='"));
+
+        $expected = [
+            'controller' => 'Bookmarks',
+            'action' => 'view',
+            'organization' => 'cakephp',
+        ];
+        $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/organization='cakephp'"));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2285,7 +2285,7 @@ class RouterTest extends TestCase
             'organization' => 'cakephp',
             'repository' => 'debug_kit',
         ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization:cakephp/repository:debug_kit'));
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization=cakephp/repository=debug_kit'));
 
         $expected = [
             'controller' => 'Bookmarks',
@@ -2293,7 +2293,7 @@ class RouterTest extends TestCase
             'organization' => 'cakephp',
             'bake',
         ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization:cakephp/bake'));
+        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization=cakephp/bake'));
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2221,123 +2221,167 @@ class RouterTest extends TestCase
         Router::parseRequest($this->makeRequest('/blog/foobar', 'GET'));
     }
 
+    public static function routePathProvider(): array
+    {
+        // Input path, output route data.
+        return [
+            // Controller + action
+            [
+                'Bookmarks::view',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                ],
+            ],
+            // Prefix controller
+            [
+                'Admin/Bookmarks::view',
+                [
+                    'prefix' => 'Admin',
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                ],
+            ],
+            // Nested prefixes
+            [
+                'LongPrefix/BackEnd/Bookmarks::view',
+                [
+                    'prefix' => 'LongPrefix/BackEnd',
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                ],
+            ],
+            // Plugins
+            [
+                'Cms.Articles::edit',
+                [
+                    'plugin' => 'Cms',
+                    'controller' => 'Articles',
+                    'action' => 'edit',
+                ],
+            ],
+            // Vendor plugins & nested prefix
+            [
+                'Vendor/Cms.Management/Admin/Articles::view',
+                [
+                    'plugin' => 'Vendor/Cms',
+                    'prefix' => 'Management/Admin',
+                    'controller' => 'Articles',
+                    'action' => 'view',
+                ],
+            ],
+
+            // Passed parameters
+            [
+                'Bookmarks::view/1/',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    '1',
+                ],
+            ],
+            [
+                'Bookmarks::view/1',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    '1',
+                ],
+            ],
+            [
+                'Cms.Articles::edit/2023/03/5th',
+                [
+                    'plugin' => 'Cms',
+                    'controller' => 'Articles',
+                    'action' => 'edit',
+                    '2023',
+                    '03',
+                    '5th',
+                ],
+            ],
+            [
+                'Bookmarks::view/organization=cakephp/repository=debug_kit',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'cakephp',
+                    'repository' => 'debug_kit',],
+                ],
+            [
+            'Bookmarks::view/organization=cakephp/bake',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'cakephp',
+                    'bake',
+                ],
+            ],
+            [
+                'Bookmarks::view/organization="cakephp=test"',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'cakephp=test',
+                ],
+            ],
+            [
+                "Bookmarks::view/test='repo=debug_kit'",
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'test' => 'repo=debug_kit',
+                ],
+            ],
+            [
+                'Bookmarks::view/organization="cakephp=test"/test=\'repo=debug_kit\'',
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'cakephp=test',
+                    'test' => 'repo=debug_kit',
+                ],
+            ],
+            [
+                "Bookmarks::view/organization='cakephp='",
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'cakephp=',
+                ],
+            ],
+            [
+                "Bookmarks::view/organization='cakephp'",
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'cakephp',
+                ],
+            ],
+        ];
+    }
+
     /**
      * Test parseRoutePath() with valid strings
+     *
+     * @dataProvider routePathProvider
      */
-    public function testParseRoutePath(): void
+    public function testParseRoutePath($path, $expected): void
     {
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view'));
+        $this->assertSame($expected, Router::parseRoutePath($path));
+    }
 
-        $expected = [
-            'prefix' => 'Admin',
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Admin/Bookmarks::view'));
-
-        $expected = [
-            'prefix' => 'LongPrefix/BackEnd',
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('LongPrefix/BackEnd/Bookmarks::view'));
-
-        $expected = [
-            'plugin' => 'Cms',
-            'controller' => 'Articles',
-            'action' => 'edit',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Cms.Articles::edit'));
-
-        $expected = [
-            'plugin' => 'Vendor/Cms',
-            'prefix' => 'Management/Admin',
-            'controller' => 'Articles',
-            'action' => 'view',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Vendor/Cms.Management/Admin/Articles::view'));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            '1',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/1'));
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/1/'));
-
-        $expected = [
-            'plugin' => 'Cms',
-            'controller' => 'Articles',
-            'action' => 'edit',
-            '2023',
-            '03',
-            '5th',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Cms.Articles::edit/2023/03/5th'));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'organization' => 'cakephp',
-            'repository' => 'debug_kit',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization=cakephp/repository=debug_kit'));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'organization' => 'cakephp',
-            'bake',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization=cakephp/bake'));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'organization' => 'cakephp=test',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization="cakephp=test"'));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'test' => 'repo=debug_kit',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/test='repo=debug_kit'"));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'organization' => 'cakephp=test',
-            'test' => 'repo=debug_kit',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/organization="cakephp=test"/test=\'repo=debug_kit\''));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'organization' => 'cakephp=',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/organization='cakephp='"));
-
-        $expected = [
-            'controller' => 'Bookmarks',
-            'action' => 'view',
-            'organization' => 'cakephp',
-        ];
-        $this->assertSame($expected, Router::parseRoutePath("Bookmarks::view/organization='cakephp'"));
-
+    public function testParseRoutePathInvalidNumeric(): void
+    {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Param key `1invalid` is not valid.');
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/1invalid=cakephp'));
+        Router::parseRoutePath('Bookmarks::view/1invalid=cakephp');
+    }
 
+    public function testParseRoutePathInvalidParameterKey()
+    {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Param key `-invalid` is not valid.');
-        $this->assertSame($expected, Router::parseRoutePath('Bookmarks::view/-invalid=cakephp'));
+        Router::parseRoutePath('Bookmarks::view/-invalid=cakephp');
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2237,37 +2237,37 @@ class RouterTest extends TestCase
             [
                 'Admin/Bookmarks::view',
                 [
-                    'prefix' => 'Admin',
                     'controller' => 'Bookmarks',
                     'action' => 'view',
+                    'prefix' => 'Admin',
                 ],
             ],
             // Nested prefixes
             [
                 'LongPrefix/BackEnd/Bookmarks::view',
                 [
-                    'prefix' => 'LongPrefix/BackEnd',
                     'controller' => 'Bookmarks',
                     'action' => 'view',
+                    'prefix' => 'LongPrefix/BackEnd',
                 ],
             ],
             // Plugins
             [
                 'Cms.Articles::edit',
                 [
-                    'plugin' => 'Cms',
                     'controller' => 'Articles',
                     'action' => 'edit',
+                    'plugin' => 'Cms',
                 ],
             ],
             // Vendor plugins & nested prefix
             [
                 'Vendor/Cms.Management/Admin/Articles::view',
                 [
-                    'plugin' => 'Vendor/Cms',
-                    'prefix' => 'Management/Admin',
                     'controller' => 'Articles',
                     'action' => 'view',
+                    'plugin' => 'Vendor/Cms',
+                    'prefix' => 'Management/Admin',
                 ],
             ],
 
@@ -2291,9 +2291,9 @@ class RouterTest extends TestCase
             [
                 'Cms.Articles::edit/2023/03/5th',
                 [
-                    'plugin' => 'Cms',
                     'controller' => 'Articles',
                     'action' => 'edit',
+                    'plugin' => 'Cms',
                     '2023',
                     '03',
                     '5th',
@@ -2357,6 +2357,14 @@ class RouterTest extends TestCase
                     'organization' => 'cakephp',
                 ],
             ],
+            [
+                "Bookmarks::view/organization='foo@bar.com~1!#$%^&*()'",
+                [
+                    'controller' => 'Bookmarks',
+                    'action' => 'view',
+                    'organization' => 'foo@bar.com~1!#$%^&*()',
+                ],
+            ],
         ];
     }
 
@@ -2373,14 +2381,14 @@ class RouterTest extends TestCase
     public function testParseRoutePathInvalidNumeric(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Param key `1invalid` is not valid.');
+        $this->expectExceptionMessage('Param key `1invalid` is not valid');
         Router::parseRoutePath('Bookmarks::view/1invalid=cakephp');
     }
 
     public function testParseRoutePathInvalidParameterKey()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Param key `-invalid` is not valid.');
+        $this->expectExceptionMessage('Param key `-invalid` is not valid');
         Router::parseRoutePath('Bookmarks::view/-invalid=cakephp');
     }
 
@@ -2430,18 +2438,18 @@ class RouterTest extends TestCase
         $this->assertSame($expected, urlArray('Bookmarks::view'));
 
         $expected = [
-            'prefix' => 'Admin',
             'controller' => 'Bookmarks',
             'action' => 'view',
+            'prefix' => 'Admin',
             'plugin' => false,
         ];
         $this->assertSame($expected, urlArray('Admin/Bookmarks::view'));
 
         $expected = [
-            'plugin' => 'Vendor/Cms',
-            'prefix' => 'Management/Admin',
             'controller' => 'Articles',
             'action' => 'view',
+            'plugin' => 'Vendor/Cms',
+            'prefix' => 'Management/Admin',
             3,
             '?' => ['query' => 'string'],
         ];


### PR DESCRIPTION
Currently our `parseRoutePath()` method inside the Router only allows Routes to be represented like
```
[Plugin.][Prefix/]Controller::action
```

But it may easily be the case, that Routes need to be represented with action params as well like
```
[Plugin.][Prefix/]Controller::action/param1/param2/param3
```

This PR adds exactly this functionality.

I also fixed the Regex to properly escape `/` characters which is recommended even if they are inside a capture group.

Are there any additional edge-cases I am not thinking of? Happy to get some feedback 😁 