### PR TITLE
Add Controller::addViewClasses().

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -171,6 +171,13 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     protected $middlewares = [];
 
     /**
+     * View classes for content negotiation.
+     *
+     * @var array<string>
+     */
+    protected $viewClasses = [];
+
+    /**
      * Constructor.
      *
      * Sets a number of properties based on conventions if they are empty. To override the
@@ -791,7 +798,25 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function viewClasses(): array
     {
-        return [];
+        return $this->viewClasses;
+    }
+
+    /**
+     * Add View classes this controller can perform content negotiation with.
+     *
+     * Each view class must implement the `getContentType()` hook method
+     * to participate in negotiation.
+     *
+     * @param array $viewClasses View classes list.
+     * @return $this
+     * @see Cake\Http\ContentTypeNegotiation
+     * @since 4.5.0
+     */
+    public function addViewClasses(array $viewClasses)
+    {
+        $this->viewClasses = array_merge($this->viewClasses, $viewClasses);
+
+        return $this;
     }
 
     /**

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -27,6 +27,7 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
+use Cake\View\XmlView;
 use Laminas\Diactoros\Uri;
 use ReflectionFunction;
 use RuntimeException;
@@ -39,6 +40,7 @@ use TestApp\Controller\TestController;
 use TestApp\Controller\WithDefaultTableController;
 use TestApp\Model\Table\ArticlesTable;
 use TestApp\Model\Table\PostsTable;
+use TestApp\View\PlainTextView;
 use TestPlugin\Controller\Admin\CommentsController;
 use TestPlugin\Controller\TestPluginController;
 use UnexpectedValueException;
@@ -270,6 +272,18 @@ class ControllerTest extends TestCase
 
         $result = $Controller->render('/element/test_element');
         $this->assertMatchesRegularExpression('/this is the test element/', (string)$result);
+    }
+
+    public function testAddViewClasses()
+    {
+        $controller = new ContentTypesController();
+        $this->assertSame([], $controller->viewClasses());
+
+        $controller->addViewClasses([PlainTextView::class]);
+        $this->assertSame([PlainTextView::class], $controller->viewClasses());
+
+        $controller->addViewClasses([XmlView::class]);
+        $this->assertSame([PlainTextView::class, XmlView::class], $controller->viewClasses());
     }
 
     /**

--- a/tests/test_app/TestApp/Controller/ContentTypesController.php
+++ b/tests/test_app/TestApp/Controller/ContentTypesController.php
@@ -26,16 +26,6 @@ use TestApp\View\PlainTextView;
  */
 class ContentTypesController extends AppController
 {
-    /**
-     * @var array<string>
-     */
-    protected $viewClasses = [];
-
-    public function viewClasses(): array
-    {
-        return $this->viewClasses;
-    }
-
     public function all()
     {
         $this->viewClasses = [JsonView::class, XmlView::class];


### PR DESCRIPTION
This allows setting view classes for content negotiation from outside the controller, for e.g. from components and event listeners.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
