### PR TITLE
Adding provide psr/simple-cache-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,9 @@
         "lib-ICU": "The intl PHP library, to use Text::transliterate() or Text::slug()",
         "paragonie/csp-builder": "CSP builder, to use the CSP Middleware"
     },
+    "provide": {
+        "psr/simple-cache-implementation": "^1.0.0"
+    },
     "config": {
         "process-timeout": 900,
         "sort-packages": true,


### PR DESCRIPTION
The cakephp/cache library has ```"provide": {
        "psr/simple-cache-implementation": "^1.0.0"
    },``` but the cakephp/cakephp doesn't "provide" psr/simple-cache-implementation. So trying to use CakePHP PSR-16 cache engine will fail because cakephp/cakephp doesn't implement PSR-16 according to the composer.json.


To reproduce, create new project and then try to run `composer require unleash/client guzzlehttp/guzzle` and it will fail due to no psr/simple-cache-implementation.


