### PR TITLE
Add support for using plugin error controller within prefixes

### DIFF
--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -167,10 +167,17 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             $params['controller'] = 'Error';
 
             $factory = new ControllerFactory(new Container());
+            // Check including plugin + prefix
             $class = $factory->getControllerClass($request->withAttribute('params', $params));
 
+            if (!$class && !empty($params['prefix']) && !empty($params['plugin'])) {
+                unset($params['prefix']);
+                // Fallback to only plugin
+                $class = $factory->getControllerClass($request->withAttribute('params', $params));
+            }
+
             if (!$class) {
-                /** @var string $class */
+                // Fallback to app/core provided controller.
                 $class = App::className('Error', 'Controller', 'Controller');
             }
 

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -178,6 +178,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
 
             if (!$class) {
                 // Fallback to app/core provided controller.
+                /** @var string $class */
                 $class = App::className('Error', 'Controller', 'Controller');
             }
 

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -44,12 +44,13 @@ use Cake\View\Exception\MissingTemplateException;
 use Exception;
 use OutOfBoundsException;
 use RuntimeException;
-use TestApp\Controller\Admin\ErrorController;
+use TestApp\Controller\Admin\ErrorController as PrefixErrorController;
 use TestApp\Error\Exception\MissingWidgetThing;
 use TestApp\Error\Exception\MissingWidgetThingException;
 use TestApp\Error\Exception\MyPDOException;
 use TestApp\Error\MyCustomExceptionRenderer;
 use TestApp\Error\TestAppsExceptionRenderer;
+use TestPlugin\Controller\ErrorController as PluginErrorController;
 
 class ExceptionRendererTest extends TestCase
 {
@@ -91,8 +92,7 @@ class ExceptionRendererTest extends TestCase
 
     public function testControllerInstanceForPrefixedRequest(): void
     {
-        $namespace = Configure::read('App.namespace');
-        Configure::write('App.namespace', 'TestApp');
+        $this->setAppNamespace('TestApp');
 
         $exception = new NotFoundException('Page not found');
         $request = new ServerRequest();
@@ -103,11 +103,35 @@ class ExceptionRendererTest extends TestCase
         $ExceptionRenderer = new MyCustomExceptionRenderer($exception, $request);
 
         $this->assertInstanceOf(
-            ErrorController::class,
+            PrefixErrorController::class,
             $ExceptionRenderer->__debugInfo()['controller']
         );
+    }
 
-        Configure::write('App.namespace', $namespace);
+    /**
+     * Test that prefixed controllers in plugins use the plugin
+     * error controller if it exists.
+     *
+     * @return void
+     */
+    public function testControllerInstanceForPluginPrefixedRequest(): void
+    {
+        $this->loadPlugins(['TestPlugin']);
+        $this->setAppNamespace('TestApp');
+
+        $exception = new NotFoundException('Page not found');
+        $request = new ServerRequest();
+        $request = $request
+            ->withParam('controller', 'Comments')
+            ->withParam('plugin', 'TestPlugin')
+            ->withParam('prefix', 'Admin');
+
+        $ExceptionRenderer = new MyCustomExceptionRenderer($exception, $request);
+
+        $this->assertInstanceOf(
+            PluginErrorController::class,
+            $ExceptionRenderer->__debugInfo()['controller']
+        );
     }
 
     /**

--- a/tests/test_app/Plugin/TestPlugin/src/Controller/ErrorController.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Controller/ErrorController.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Controller;
+
+use Cake\Controller\ErrorController as CoreErrorController;
+
+/**
+ * Error Handling Controller
+ *
+ * Controller used by ErrorHandler to render error views.
+ */
+class ErrorController extends CoreErrorController
+{
+}


### PR DESCRIPTION
When within a plugin + prefix routing scope if there isn't an ErrorController for the plugin + prefix, fallback to just the plugin before falling back to the application/core error controller.

This allows plugins to provide error handling for all of their routes if they need it.

Fixes #17025