### PR TITLE
Update acceptable types for Log::setConfig()

### DIFF
--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -273,7 +273,7 @@ class Log
      * ```
      *
      * @param array<string, mixed>|string $key The name of the logger config, or an array of multiple configs.
-     * @param array<string, mixed>|callable|null $config An array of name => config data for adapter.
+     * @param array<string, mixed>|\Closure|null $config An array of name => config data for adapter.
      * @return void
      * @throws \BadMethodCallException When trying to modify an existing config.
      */

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -273,7 +273,7 @@ class Log
      * ```
      *
      * @param array<string, mixed>|string $key The name of the logger config, or an array of multiple configs.
-     * @param array<string, mixed>|null $config An array of name => config data for adapter.
+     * @param array<string, mixed>|callable|null $config An array of name => config data for adapter.
      * @return void
      * @throws \BadMethodCallException When trying to modify an existing config.
      */


### PR DESCRIPTION
Per the docs, `Log::setConfig()` can accept a callable (factory function) as its second parameter, however this is not reflected in the docblock for the method, causing warnings when linting.