### PR TITLE
927 (DebugKit) - Refactor fallback feature to reuse it on DebugEngine

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -888,4 +888,20 @@ class CacheTest extends TestCase
         $pool = Cache::pool('tests');
         $this->assertInstanceOf(SimpleCacheInterface::class, $pool);
     }
+
+    /**
+     * @return void
+     */
+    public function getFallbackEngine(): void
+    {
+        $this->markTestSkipped('TODO');
+    }
+
+    /**
+     * @return void
+     */
+    public function registerFallbackEngine(): void
+    {
+        $this->markTestSkipped('TODO');
+    }
 }


### PR DESCRIPTION
While fixing [Issue 927 from DebugKit](https://github.com/cakephp/debug_kit/issues/927) I found `fallback` feature was not being used in DebugEngine. So this PR refactors `fallback` feature inside `Cache` class to allow using it from same class and also DebugEngine.

After this is merged and released I will create the PR on DebugKit repo. 

You can see the DebugKit changes here: 
https://github.com/CakeDC/debug_kit/commit/91800d2e4738954e0ae0f88e878843d8cdcd6f51


Please let me know if you agree with the approach so I will implement missing tests