### PR TITLE
Fix DateTimeType::manyToPHP() with int value

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -229,10 +229,9 @@ class DateTimeType extends BaseType implements BatchCastingInterface
         $class = $this->_className;
         if (is_int($value)) {
             $instance = new $class('@' . $value);
+        } elseif (strpos($value, '0000-00-00') === 0) {
+            return null;
         } else {
-            if (strpos($value, '0000-00-00') === 0) {
-                return null;
-            }
             $instance = new $class($value, $this->dbTimezone);
         }
 
@@ -282,14 +281,13 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             }
 
             $value = $values[$field];
-            if (strpos($value, '0000-00-00') === 0) {
-                $values[$field] = null;
-                continue;
-            }
 
             $class = $this->_className;
             if (is_int($value)) {
                 $instance = new $class('@' . $value);
+            } elseif (strpos($value, '0000-00-00') === 0) {
+                $values[$field] = null;
+                continue;
             } else {
                 $instance = new $class($value, $this->dbTimezone);
             }

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -113,11 +113,13 @@ class DateTimeTypeTest extends TestCase
     {
         $values = [
             'a' => null,
-            'b' => '2001-01-04 12:13:14',
+            'b' => 978610394,
+            'c' => '2001-01-04 12:13:14',
         ];
         $expected = [
             'a' => null,
             'b' => new Time('2001-01-04 12:13:14'),
+            'c' => new Time('2001-01-04 12:13:14'),
         ];
         $this->assertEquals(
             $expected,

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -86,13 +86,15 @@ class DateTypeTest extends TestCase
     {
         $values = [
             'a' => null,
-            'b' => '2001-01-04',
-            'c' => '2001-01-04 12:13:14.12345',
+            'b' => 978606794,
+            'c' => '2001-01-04',
+            'd' => '2001-01-04 12:13:14.12345',
         ];
         $expected = [
             'a' => null,
             'b' => new Date('2001-01-04'),
             'c' => new Date('2001-01-04'),
+            'd' => new Date('2001-01-04'),
         ];
         $this->assertEquals(
             $expected,


### PR DESCRIPTION
Synchronize the logic between toPHP() and manyToPHP() to avoid type error when int is in value array.