### PR TITLE
Speed up parsing/dispatching of static routes.

### DIFF
--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -191,7 +191,7 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
             $this->assertNotEmpty(Router::routes());
-            $this->assertSame('/app/articles', Router::routes()[5]->template);
+            $this->assertSame('/app/articles', Router::routes()[0]->template);
 
             return new Response();
         });

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -386,14 +386,14 @@ class RouteBuilderTest extends TestCase
         $this->assertInstanceOf(RedirectRoute::class, $route);
 
         $routes->redirect('/old', '/forums', ['status' => 301]);
-        $route = $this->collection->routes()[1];
+        $route = $this->collection->routes()[0];
 
         $this->assertInstanceOf(RedirectRoute::class, $route);
         $this->assertSame('/forums', $route->redirect[0]);
 
         $route = $routes->redirect('/old', '/forums');
         $this->assertInstanceOf(RedirectRoute::class, $route);
-        $this->assertSame($route, $this->collection->routes()[2]);
+        $this->assertSame($route, $this->collection->routes()[1]);
     }
 
     /**
@@ -551,12 +551,12 @@ class RouteBuilderTest extends TestCase
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();
-        $this->assertSame('Articles', $all[8]->defaults['controller']);
-        $this->assertSame('/api/posts', $all[8]->template);
-        $this->assertSame('/api/posts/{id}', $all[1]->template);
+        $this->assertSame('Articles', $all[0]->defaults['controller']);
+        $this->assertSame('/api/posts', $all[0]->template);
+        $this->assertSame('/api/posts/{id}', $all[2]->template);
         $this->assertSame(
             '/api/posts/{article_id}/comments',
-            $all[4]->template,
+            $all[5]->template,
             'parameter name should reflect resource name'
         );
     }
@@ -583,7 +583,7 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertSame('/api/articles', $all[4]->template);
+        $this->assertSame('/api/articles', $all[0]->template);
         foreach ($all as $route) {
             $this->assertSame('Api/Rest', $route->defaults['prefix']);
             $this->assertSame('Articles', $route->defaults['controller']);
@@ -626,9 +626,9 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(10, $all);
 
-        $this->assertSame('/api/network-objects', $all[8]->template);
+        $this->assertSame('/api/network-objects', $all[0]->template);
         $this->assertSame('/api/network-objects/{id}', $all[2]->template);
-        $this->assertSame('/api/network-objects/{network_object_id}/attributes', $all[4]->template);
+        $this->assertSame('/api/network-objects/{network_object_id}/attributes', $all[5]->template);
     }
 
     /**
@@ -775,13 +775,13 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertSame('/articles', $result[1]->template);
-        $this->assertSame('index', $result[1]->defaults['action']);
-        $this->assertSame('GET', $result[1]->defaults['_method']);
+        $this->assertSame('/articles', $result[0]->template);
+        $this->assertSame('index', $result[0]->defaults['action']);
+        $this->assertSame('GET', $result[0]->defaults['_method']);
 
-        $this->assertSame('/articles/{id}', $result[0]->template);
-        $this->assertSame('delete', $result[0]->defaults['action']);
-        $this->assertSame('DELETE', $result[0]->defaults['_method']);
+        $this->assertSame('/articles/{id}', $result[1]->template);
+        $this->assertSame('delete', $result[1]->defaults['action']);
+        $this->assertSame('DELETE', $result[1]->defaults['_method']);
     }
 
     /**
@@ -797,11 +797,11 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertSame('/articles', $result[1]->template);
-        $this->assertSame('showList', $result[1]->defaults['action']);
+        $this->assertSame('/articles', $result[0]->template);
+        $this->assertSame('showList', $result[0]->defaults['action']);
 
-        $this->assertSame('/articles/{id}', $result[0]->template);
-        $this->assertSame('delete', $result[0]->defaults['action']);
+        $this->assertSame('/articles/{id}', $result[1]->template);
+        $this->assertSame('delete', $result[1]->defaults['action']);
     }
 
     /**
@@ -815,7 +815,7 @@ class RouteBuilderTest extends TestCase
             $this->assertEquals(['prefix' => 'Api'], $routes->params());
 
             $routes->resources('Comments');
-            $route = $this->collection->routes()[3];
+            $route = $this->collection->routes()[5];
             $this->assertSame('/api/articles/{article_id}/comments', $route->template);
         });
     }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -625,8 +625,8 @@ class RouteCollectionTest extends TestCase
 
         $routes = $this->collection->routes();
         $this->assertCount(2, $routes);
-        $this->assertSame($one, $routes[0]);
-        $this->assertSame($two, $routes[1]);
+        $this->assertSame($one, $routes[1]);
+        $this->assertSame($two, $routes[0]);
     }
 
     /**


### PR DESCRIPTION
Storing routes with static templates separately allows checking of matching URLs directly as a hash key instead of looping through all connected routes and doing substring matches.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
