### PR TITLE
5.x Make global functions opt-in

### DIFF
--- a/src/Collection/functions_global.php
+++ b/src/Collection/functions_global.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+// phpcs:disable PSR1.Files.SideEffects
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         2.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Collection\CollectionInterface;
+use function Cake\Collection\collection as cakeCollection;
+
+if (!function_exists('collection')) {
+    /**
+     * Returns a new {@link \Cake\Collection\Collection} object wrapping the passed argument.
+     *
+     * @param iterable $items The items from which the collection will be built.
+     * @return \Cake\Collection\Collection
+     */
+    function collection(iterable $items): CollectionInterface
+    {
+        return cakeCollection($items);
+    }
+}

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -1,0 +1,171 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+// phpcs:disable PSR1.Files.SideEffects
+
+use function Cake\Core\deprecationWarning as cakeDeprecationWarning;
+use function Cake\Core\env as cakeEnv;
+use function Cake\Core\h as cakeH;
+use function Cake\Core\namespaceSplit as cakeNamespaceSplit;
+use function Cake\Core\pj as cakePj;
+use function Cake\Core\pluginSplit as cakePluginSplit;
+use function Cake\Core\pr as cakePr;
+use function Cake\Core\triggerWarning as cakeTriggerWarning;
+
+if (!function_exists('h')) {
+    /**
+     * Convenience method for htmlspecialchars.
+     *
+     * @param mixed $text Text to wrap through htmlspecialchars. Also works with arrays, and objects.
+     *    Arrays will be mapped and have all their elements escaped. Objects will be string cast if they
+     *    implement a `__toString` method. Otherwise, the class name will be used.
+     *    Other scalar types will be returned unchanged.
+     * @param bool $double Encode existing html entities.
+     * @param string|null $charset Character set to use when escaping.
+     *   Defaults to config value in `mb_internal_encoding()` or 'UTF-8'.
+     * @return mixed Wrapped text.
+     * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#h
+     */
+    function h(mixed $text, bool $double = true, ?string $charset = null): mixed
+    {
+        return cakeH($text, $double, $charset);
+    }
+}
+
+if (!function_exists('pluginSplit')) {
+    /**
+     * Splits a dot syntax plugin name into its plugin and class name.
+     * If $name does not have a dot, then index 0 will be null.
+     *
+     * Commonly used like
+     * ```
+     * list($plugin, $name) = pluginSplit($name);
+     * ```
+     *
+     * @param string $name The name you want to plugin split.
+     * @param bool $dotAppend Set to true if you want the plugin to have a '.' appended to it.
+     * @param string|null $plugin Optional default plugin to use if no plugin is found. Defaults to null.
+     * @return array Array with 2 indexes. 0 => plugin name, 1 => class name.
+     * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#pluginSplit
+     * @psalm-return array{string|null, string}
+     */
+    function pluginSplit(string $name, bool $dotAppend = false, ?string $plugin = null): array
+    {
+        return cakePluginSplit($name, $dotAppend, $plugin);
+    }
+}
+
+if (!function_exists('namespaceSplit')) {
+    /**
+     * Split the namespace from the classname.
+     *
+     * Commonly used like `list($namespace, $className) = namespaceSplit($class);`.
+     *
+     * @param string $class The full class name, ie `Cake\Core\App`.
+     * @return array<string> Array with 2 indexes. 0 => namespace, 1 => classname.
+     */
+    function namespaceSplit(string $class): array
+    {
+        return cakeNamespaceSplit($class);
+    }
+}
+
+if (!function_exists('pr')) {
+    /**
+     * print_r() convenience function.
+     *
+     * In terminals this will act similar to using print_r() directly, when not run on CLI
+     * print_r() will also wrap `<pre>` tags around the output of given variable. Similar to debug().
+     *
+     * This function returns the same variable that was passed.
+     *
+     * @param mixed $var Variable to print out.
+     * @return mixed the same $var that was passed to this function
+     * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#pr
+     * @see debug()
+     */
+    function pr(mixed $var): mixed
+    {
+        return cakePr($var);
+    }
+}
+
+if (!function_exists('pj')) {
+    /**
+     * JSON pretty print convenience function.
+     *
+     * In terminals this will act similar to using json_encode() with JSON_PRETTY_PRINT directly, when not run on CLI
+     * will also wrap `<pre>` tags around the output of given variable. Similar to pr().
+     *
+     * This function returns the same variable that was passed.
+     *
+     * @param mixed $var Variable to print out.
+     * @return mixed the same $var that was passed to this function
+     * @see pr()
+     * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#pj
+     */
+    function pj(mixed $var): mixed
+    {
+        return cakePj($var);
+    }
+}
+
+if (!function_exists('env')) {
+    /**
+     * Gets an environment variable from available sources, and provides emulation
+     * for unsupported or inconsistent environment variables (i.e. DOCUMENT_ROOT on
+     * IIS, or SCRIPT_NAME in CGI mode). Also exposes some additional custom
+     * environment information.
+     *
+     * @param string $key Environment variable name.
+     * @param string|bool|null $default Specify a default value in case the environment variable is not defined.
+     * @return string|float|int|bool|null Environment variable setting.
+     * @link https://book.cakephp.org/4/en/core-libraries/global-constants-and-functions.html#env
+     */
+    function env(string $key, string|float|int|bool|null $default = null): string|float|int|bool|null
+    {
+        return cakeEnv($key, $default);
+    }
+}
+
+if (!function_exists('triggerWarning')) {
+    /**
+     * Triggers an E_USER_WARNING.
+     *
+     * @param string $message The warning message.
+     * @return void
+     */
+    function triggerWarning(string $message): void
+    {
+        return cakeTriggerWarning($message);
+    }
+}
+
+if (!function_exists('deprecationWarning')) {
+    /**
+     * Helper method for outputting deprecation warnings
+     *
+     * @param string $version The version that added this deprecation warning.
+     * @param string $message The message to output as a deprecation warning.
+     * @param int $stackFrame The stack frame to include in the error. Defaults to 1
+     *   as that should point to application/plugin code.
+     * @return void
+     */
+    function deprecationWarning(string $version, string $message, int $stackFrame = 1): void
+    {
+        return cakeDeprecationWarning($version, $message, $stackFrame);
+    }
+}

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -150,7 +150,7 @@ if (!function_exists('triggerWarning')) {
      */
     function triggerWarning(string $message): void
     {
-        return cakeTriggerWarning($message);
+        cakeTriggerWarning($message);
     }
 }
 
@@ -166,6 +166,6 @@ if (!function_exists('deprecationWarning')) {
      */
     function deprecationWarning(string $version, string $message, int $stackFrame = 1): void
     {
-        return cakeDeprecationWarning($version, $message, $stackFrame);
+        cakeDeprecationWarning($version, $message, $stackFrame);
     }
 }

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -26,6 +26,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use function Cake\I18n\__d;
 
 /**
  * Provides CSRF protection via session based tokens.

--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -226,10 +226,3 @@ function __dxn(
         ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args
     );
 }
-
-/**
- * Include global functions.
- */
-if (!getenv('CAKE_DISABLE_GLOBAL_FUNCS')) {
-    include 'functions_global.php';
-}

--- a/src/Routing/functions.php
+++ b/src/Routing/functions.php
@@ -57,10 +57,3 @@ function url(UriInterface|array|string|null $url = null, bool $full = false): st
 {
     return Router::url($url, $full);
 }
-
-/**
- * Include global functions.
- */
-if (!getenv('CAKE_DISABLE_GLOBAL_FUNCS')) {
-    include 'functions_global.php';
-}

--- a/src/Routing/functions_global.php
+++ b/src/Routing/functions_global.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  * @since         4.1.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+// phpcs:disable PSR1.Files.SideEffects
 
 use Psr\Http\Message\UriInterface;
 use function Cake\Routing\url as cakeUrl;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Create global aliases for all functions in the split modules.
+ *
+ * This uses a bit of codegen hackery and we recommend you don't plan on using
+ * it long term. If there are scenarios where you find global aliases are greatly
+ * beneficial please look for an open issue for function aliases or create a new
+ * one if your usecase hasn't been covered yet.
+ */
+$setup = function (): void {
+    $packages = ['Collection', 'Core', 'I18n', 'Routing'];
+    foreach ($packages as $packageName) {
+        $path = __DIR__ . "/{$packageName}/functions_global.php";
+        if (file_exists($path)) {
+            require_once $path;
+        }
+    }
+};
+
+$setup();
+unset($setup);

--- a/src/functions.php
+++ b/src/functions.php
@@ -17,21 +17,8 @@ declare(strict_types=1);
 
 /**
  * Create global aliases for all functions in the split modules.
- *
- * This uses a bit of codegen hackery and we recommend you don't plan on using
- * it long term. If there are scenarios where you find global aliases are greatly
- * beneficial please look for an open issue for function aliases or create a new
- * one if your usecase hasn't been covered yet.
  */
-$setup = function (): void {
-    $packages = ['Collection', 'Core', 'I18n', 'Routing'];
-    foreach ($packages as $packageName) {
-        $path = __DIR__ . "/{$packageName}/functions_global.php";
-        if (file_exists($path)) {
-            require_once $path;
-        }
-    }
-};
-
-$setup();
-unset($setup);
+require __DIR__ . '/Collection/functions_global.php';
+require __DIR__ . '/Core/functions_global.php';
+require __DIR__ . '/I18n/functions_global.php';
+require __DIR__ . '/Routing/functions_global.php';


### PR DESCRIPTION
Remove the automatic loading of functions_global.php and add an opt-in function loader. This is a breaking change from 4.x but we'll give notice and tools to upgrade and its a one-line fix if you don't.

If you want to keep using global functions just add

```
require CAKE . 'functions.php';
```
to your bootstrap.php.
