### PR TITLE
Fix URL parsing.

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -134,15 +134,15 @@ class RouteCollection
      */
     public function parse(string $url, string $method = ''): array
     {
-        $decoded = urldecode($url);
-        if ($decoded !== '/') {
-            $decoded = rtrim($decoded, '/');
-        }
-
         $queryParameters = [];
         if (strpos($url, '?') !== false) {
             [$url, $qs] = explode('?', $url, 2);
             parse_str($qs, $queryParameters);
+        }
+
+        $decoded = urldecode($url);
+        if ($decoded !== '/') {
+            $decoded = rtrim($decoded, '/');
         }
 
         if (isset($this->staticPaths[$decoded])) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -150,7 +150,7 @@ class RouteCollection
                 // Extension parsing was enabled after the route was added to
                 // the collection and it can no longer be treated as a static route.
                 if ($route->getExtensions()) {
-                    continue;
+                    // continue;
                 }
 
                 $r = $route->parse($url, $method);
@@ -214,12 +214,6 @@ class RouteCollection
 
         if (isset($this->staticPaths[$urlPath])) {
             foreach ($this->staticPaths[$urlPath] as $route) {
-                // Extension parsing was enabled after the route was added to
-                // the collection and it can no longer be treated as a static route.
-                if ($route->getExtensions()) {
-                    continue;
-                }
-
                 $r = $route->parseRequest($request);
                 if ($r === null) {
                     continue;

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -117,7 +117,7 @@ class RouteCollection
             $this->setExtensions($extensions);
         }
 
-        if ($path === $route->template && !$extensions) {
+        if ($path === $route->template) {
             $this->staticPaths[$path][] = $route;
         }
 
@@ -147,12 +147,6 @@ class RouteCollection
 
         if (isset($this->staticPaths[$decoded])) {
             foreach ($this->staticPaths[$decoded] as $route) {
-                // Extension parsing was enabled after the route was added to
-                // the collection and it can no longer be treated as a static route.
-                if ($route->getExtensions()) {
-                    // continue;
-                }
-
                 $r = $route->parse($url, $method);
                 if ($r === null) {
                     continue;

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -191,7 +191,7 @@ class RoutingMiddlewareTest extends TestCase
             ];
             $this->assertEquals($expected, $req->getAttribute('params'));
             $this->assertNotEmpty(Router::routes());
-            $this->assertSame('/app/articles', Router::routes()[0]->template);
+            $this->assertSame('/app/articles', Router::routes()[5]->template);
 
             return new Response();
         });

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -386,14 +386,14 @@ class RouteBuilderTest extends TestCase
         $this->assertInstanceOf(RedirectRoute::class, $route);
 
         $routes->redirect('/old', '/forums', ['status' => 301]);
-        $route = $this->collection->routes()[0];
+        $route = $this->collection->routes()[1];
 
         $this->assertInstanceOf(RedirectRoute::class, $route);
         $this->assertSame('/forums', $route->redirect[0]);
 
         $route = $routes->redirect('/old', '/forums');
         $this->assertInstanceOf(RedirectRoute::class, $route);
-        $this->assertSame($route, $this->collection->routes()[1]);
+        $this->assertSame($route, $this->collection->routes()[2]);
     }
 
     /**
@@ -551,12 +551,12 @@ class RouteBuilderTest extends TestCase
             $routes->resources('Comments');
         });
         $all = $this->collection->routes();
-        $this->assertSame('Articles', $all[0]->defaults['controller']);
-        $this->assertSame('/api/posts', $all[0]->template);
-        $this->assertSame('/api/posts/{id}', $all[2]->template);
+        $this->assertSame('Articles', $all[8]->defaults['controller']);
+        $this->assertSame('/api/posts', $all[8]->template);
+        $this->assertSame('/api/posts/{id}', $all[1]->template);
         $this->assertSame(
             '/api/posts/{article_id}/comments',
-            $all[5]->template,
+            $all[4]->template,
             'parameter name should reflect resource name'
         );
     }
@@ -583,7 +583,7 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(5, $all);
 
-        $this->assertSame('/api/articles', $all[0]->template);
+        $this->assertSame('/api/articles', $all[4]->template);
         foreach ($all as $route) {
             $this->assertSame('Api/Rest', $route->defaults['prefix']);
             $this->assertSame('Articles', $route->defaults['controller']);
@@ -626,9 +626,9 @@ class RouteBuilderTest extends TestCase
         $all = $this->collection->routes();
         $this->assertCount(10, $all);
 
-        $this->assertSame('/api/network-objects', $all[0]->template);
+        $this->assertSame('/api/network-objects', $all[8]->template);
         $this->assertSame('/api/network-objects/{id}', $all[2]->template);
-        $this->assertSame('/api/network-objects/{network_object_id}/attributes', $all[5]->template);
+        $this->assertSame('/api/network-objects/{network_object_id}/attributes', $all[4]->template);
     }
 
     /**
@@ -775,13 +775,13 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertSame('/articles', $result[0]->template);
-        $this->assertSame('index', $result[0]->defaults['action']);
-        $this->assertSame('GET', $result[0]->defaults['_method']);
+        $this->assertSame('/articles', $result[1]->template);
+        $this->assertSame('index', $result[1]->defaults['action']);
+        $this->assertSame('GET', $result[1]->defaults['_method']);
 
-        $this->assertSame('/articles/{id}', $result[1]->template);
-        $this->assertSame('delete', $result[1]->defaults['action']);
-        $this->assertSame('DELETE', $result[1]->defaults['_method']);
+        $this->assertSame('/articles/{id}', $result[0]->template);
+        $this->assertSame('delete', $result[0]->defaults['action']);
+        $this->assertSame('DELETE', $result[0]->defaults['_method']);
     }
 
     /**
@@ -797,11 +797,11 @@ class RouteBuilderTest extends TestCase
 
         $result = $this->collection->routes();
         $this->assertCount(2, $result);
-        $this->assertSame('/articles', $result[0]->template);
-        $this->assertSame('showList', $result[0]->defaults['action']);
+        $this->assertSame('/articles', $result[1]->template);
+        $this->assertSame('showList', $result[1]->defaults['action']);
 
-        $this->assertSame('/articles/{id}', $result[1]->template);
-        $this->assertSame('delete', $result[1]->defaults['action']);
+        $this->assertSame('/articles/{id}', $result[0]->template);
+        $this->assertSame('delete', $result[0]->defaults['action']);
     }
 
     /**
@@ -815,7 +815,7 @@ class RouteBuilderTest extends TestCase
             $this->assertEquals(['prefix' => 'Api'], $routes->params());
 
             $routes->resources('Comments');
-            $route = $this->collection->routes()[5];
+            $route = $this->collection->routes()[3];
             $this->assertSame('/api/articles/{article_id}/comments', $route->template);
         });
     }

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -494,6 +494,25 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testParseRequestExtension(): void
+    {
+        $builder = new RouteBuilder($this->collection, '/');
+        $builder->connect('/foo', ['controller' => 'Articles'])->setExtensions(['json']);
+
+        $request = new ServerRequest(['url' => '/foo.json']);
+        $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'pass' => [],
+            'plugin' => null,
+            '_ext' => 'json',
+            '_matchedRoute' => '/foo',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+
     /**
      * Test parsing routes that match non-ascii urls
      */
@@ -697,8 +716,8 @@ class RouteCollectionTest extends TestCase
 
         $routes = $this->collection->routes();
         $this->assertCount(2, $routes);
-        $this->assertSame($one, $routes[1]);
-        $this->assertSame($two, $routes[0]);
+        $this->assertSame($one, $routes[0]);
+        $this->assertSame($two, $routes[1]);
     }
 
     /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -499,6 +499,18 @@ class RouteCollectionTest extends TestCase
         $builder = new RouteBuilder($this->collection, '/');
         $builder->connect('/foo', ['controller' => 'Articles'])->setExtensions(['json']);
 
+        $request = new ServerRequest(['url' => '/foo']);
+        $result = $this->collection->parseRequest($request);
+        unset($result['_route']);
+        $expected = [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'pass' => [],
+            'plugin' => null,
+            '_matchedRoute' => '/foo',
+        ];
+        $this->assertEquals($expected, $result);
+
         $request = new ServerRequest(['url' => '/foo.json']);
         $result = $this->collection->parseRequest($request);
         unset($result['_route']);


### PR DESCRIPTION
Recheck whether a route is static when parsing a URL. Extension parsing can be enabled after a route was added to the collection and it can no longer be treated as a static route.

Refs #17081

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
