### PR TITLE
Ensure log files in logs subdirectories are created in non-debug mode

### DIFF
--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -90,7 +90,7 @@ class FileLog extends BaseLog
         parent::__construct($config);
 
         $this->_path = $this->getConfig('path', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
-        if (Configure::read('debug') && !is_dir($this->_path)) {
+        if (!is_dir($this->_path)) {
             mkdir($this->_path, 0775, true);
         }
 

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Log\Engine;
 
-use Cake\Core\Configure;
 use Cake\Log\Formatter\DefaultFormatter;
 use Cake\Utility\Text;
 


### PR DESCRIPTION
Background: A log file can only be created if the respective log directory exists. You can define custom directories to save log files to:

```
Log::setConfig($this->getMyShortcode(), [
    'className' => 'File',
    'path' => LOGS . 'payments' . DS . $this->getMyShortcode() . DS,
    'levels' => [],
    'scopes' => [$this->getMyShortcode()],
    'file' => date('Y_m_d') . '.log',
]);
```

This currently leads to (missing) log directories like `logs/payments/foo`. In case these subdirectories do not exist, the log file can not be created. This leads to errors [1] displayed when debug is true and [2] logged when debug is false.

https://book.cakephp.org/4/en/core-libraries/logging.html#error-and-exception-logging

> In debug mode missing directories will be automatically created to avoid unnecessary errors thrown when using the FileEngine.

https://book.cakephp.org/4/en/core-libraries/logging.html#logging-to-files

This proposed change ensures that (like the `logs` directory itself) custom log directories are created on-the-fly so that log files can be saved to those custom log directories.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
