### PR TITLE
4.5 Deprecate RouteCollection::parse()

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -21,7 +21,6 @@ use Cake\Routing\Exception\MissingRouteException;
 use Cake\Routing\Route\Route;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
-
 use function Cake\Core\deprecationWarning;
 
 /**

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -22,6 +22,8 @@ use Cake\Routing\Route\Route;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
+use function Cake\Core\deprecationWarning;
+
 /**
  * Contains a collection of routes.
  *
@@ -134,6 +136,7 @@ class RouteCollection
      */
     public function parse(string $url, string $method = ''): array
     {
+        deprecationWarning('4.5.0 - Use parseRequest() instead.');
         $decoded = urldecode($url);
         if ($decoded !== '/') {
             $decoded = rtrim($decoded, '/');

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -132,7 +132,7 @@ class RouteCollection
      * @param string $method The HTTP method to use.
      * @return array An array of request parameters parsed from the URL.
      * @throws \Cake\Routing\Exception\MissingRouteException When a URL has no matching route.
-     * @deprecated 4.5.0 - Use parseRequest() instead.
+     * @deprecated 4.5.0 Use parseRequest() instead.
      */
     public function parse(string $url, string $method = ''): array
     {

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -739,7 +739,7 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/');
         $routes->resources('Articles');
 
-        $this->deprecated(function() {
+        $this->deprecated(function () {
             $result = $this->collection->parse('/articles', 'GET');
             $this->assertSame('Articles', $result['controller']);
             $this->assertSame('index', $result['action']);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Routing;
 use BadMethodCallException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\Plugin;
+use Cake\Http\ServerRequest;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\Route\RedirectRoute;
 use Cake\Routing\Route\Route;
@@ -165,20 +166,22 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/articles', ['controller' => 'Articles']);
         $routes->connect('/', ['action' => 'index']);
 
-        $expected = [
-            'plugin' => null,
-            'controller' => 'Articles',
-            'action' => 'index',
-            'pass' => [],
-            '_matchedRoute' => '/articles',
-        ];
-        $result = $this->collection->parse('/articles');
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $expected = [
+                'plugin' => null,
+                'controller' => 'Articles',
+                'action' => 'index',
+                'pass' => [],
+                '_matchedRoute' => '/articles',
+            ];
+            $result = $this->collection->parse('/articles');
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/articles/');
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/articles/');
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -198,20 +201,22 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/my-articles/view', 'Articles::view');
-        $expected = [
-            'pass' => [],
-            'controller' => 'Articles',
-            'action' => 'view',
-            'plugin' => null,
-            '_matchedRoute' => '/my-articles/view',
-        ];
-        $result = $this->collection->parse('/my-articles/view');
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $expected = [
+                'pass' => [],
+                'controller' => 'Articles',
+                'action' => 'view',
+                'plugin' => null,
+                '_matchedRoute' => '/my-articles/view',
+            ];
+            $result = $this->collection->parse('/my-articles/view');
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
 
-        $url = $expected['_matchedRoute'];
-        unset($expected['_matchedRoute']);
-        $this->assertSame($url, '/' . $this->collection->match($expected, []));
+            $url = $expected['_matchedRoute'];
+            unset($expected['_matchedRoute']);
+            $this->assertSame($url, '/' . $this->collection->match($expected, []));
+        });
     }
 
     /**
@@ -221,21 +226,23 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/admin/bookmarks', 'Admin/Bookmarks::index');
-        $expected = [
-            'pass' => [],
-            'plugin' => null,
-            'prefix' => 'Admin',
-            'controller' => 'Bookmarks',
-            'action' => 'index',
-            '_matchedRoute' => '/admin/bookmarks',
-        ];
-        $result = $this->collection->parse('/admin/bookmarks');
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $expected = [
+                'pass' => [],
+                'plugin' => null,
+                'prefix' => 'Admin',
+                'controller' => 'Bookmarks',
+                'action' => 'index',
+                '_matchedRoute' => '/admin/bookmarks',
+            ];
+            $result = $this->collection->parse('/admin/bookmarks');
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
 
-        $url = $expected['_matchedRoute'];
-        unset($expected['_matchedRoute']);
-        $this->assertSame($url, '/' . $this->collection->match($expected, []));
+            $url = $expected['_matchedRoute'];
+            unset($expected['_matchedRoute']);
+            $this->assertSame($url, '/' . $this->collection->match($expected, []));
+        });
     }
 
     /**
@@ -245,20 +252,22 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/blog/articles/view', 'Blog.Articles::view');
-        $expected = [
-            'pass' => [],
-            'plugin' => 'Blog',
-            'controller' => 'Articles',
-            'action' => 'view',
-            '_matchedRoute' => '/blog/articles/view',
-        ];
-        $result = $this->collection->parse('/blog/articles/view');
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $expected = [
+                'pass' => [],
+                'plugin' => 'Blog',
+                'controller' => 'Articles',
+                'action' => 'view',
+                '_matchedRoute' => '/blog/articles/view',
+            ];
+            $result = $this->collection->parse('/blog/articles/view');
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
 
-        $url = $expected['_matchedRoute'];
-        unset($expected['_matchedRoute']);
-        $this->assertSame($url, '/' . $this->collection->match($expected, []));
+            $url = $expected['_matchedRoute'];
+            unset($expected['_matchedRoute']);
+            $this->assertSame($url, '/' . $this->collection->match($expected, []));
+        });
     }
 
     /**
@@ -268,21 +277,23 @@ class RouteBuilderTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/admin/blog/articles/view', 'Vendor/Blog.Management/Admin/Articles::view');
-        $expected = [
-            'pass' => [],
-            'plugin' => 'Vendor/Blog',
-            'prefix' => 'Management/Admin',
-            'controller' => 'Articles',
-            'action' => 'view',
-            '_matchedRoute' => '/admin/blog/articles/view',
-        ];
-        $result = $this->collection->parse('/admin/blog/articles/view');
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $expected = [
+                'pass' => [],
+                'plugin' => 'Vendor/Blog',
+                'prefix' => 'Management/Admin',
+                'controller' => 'Articles',
+                'action' => 'view',
+                '_matchedRoute' => '/admin/blog/articles/view',
+            ];
+            $result = $this->collection->parse('/admin/blog/articles/view');
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
 
-        $url = $expected['_matchedRoute'];
-        unset($expected['_matchedRoute']);
-        $this->assertSame($url, '/' . $this->collection->match($expected, []));
+            $url = $expected['_matchedRoute'];
+            unset($expected['_matchedRoute']);
+            $this->assertSame($url, '/' . $this->collection->match($expected, []));
+        });
     }
 
     /**
@@ -684,8 +695,10 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('Articles', $all[0]->defaults['controller']);
         $this->assertSame('conditions', $all[0]->defaults['action']);
 
-        $result = $this->collection->parse('/api/articles/conditions', 'DELETE');
-        $this->assertNotNull($result);
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/api/articles/conditions', 'DELETE');
+            $this->assertNotNull($result);
+        });
     }
 
     /**
@@ -726,30 +739,32 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/');
         $routes->resources('Articles');
 
-        $result = $this->collection->parse('/articles', 'GET');
-        $this->assertSame('Articles', $result['controller']);
-        $this->assertSame('index', $result['action']);
-        $this->assertEquals([], $result['pass']);
+        $this->deprecated(function() {
+            $result = $this->collection->parse('/articles', 'GET');
+            $this->assertSame('Articles', $result['controller']);
+            $this->assertSame('index', $result['action']);
+            $this->assertEquals([], $result['pass']);
 
-        $result = $this->collection->parse('/articles/1', 'GET');
-        $this->assertSame('Articles', $result['controller']);
-        $this->assertSame('view', $result['action']);
-        $this->assertEquals([1], $result['pass']);
+            $result = $this->collection->parse('/articles/1', 'GET');
+            $this->assertSame('Articles', $result['controller']);
+            $this->assertSame('view', $result['action']);
+            $this->assertEquals([1], $result['pass']);
 
-        $result = $this->collection->parse('/articles', 'POST');
-        $this->assertSame('Articles', $result['controller']);
-        $this->assertSame('add', $result['action']);
-        $this->assertEquals([], $result['pass']);
+            $result = $this->collection->parse('/articles', 'POST');
+            $this->assertSame('Articles', $result['controller']);
+            $this->assertSame('add', $result['action']);
+            $this->assertEquals([], $result['pass']);
 
-        $result = $this->collection->parse('/articles/1', 'PUT');
-        $this->assertSame('Articles', $result['controller']);
-        $this->assertSame('edit', $result['action']);
-        $this->assertEquals([1], $result['pass']);
+            $result = $this->collection->parse('/articles/1', 'PUT');
+            $this->assertSame('Articles', $result['controller']);
+            $this->assertSame('edit', $result['action']);
+            $this->assertEquals([1], $result['pass']);
 
-        $result = $this->collection->parse('/articles/1', 'DELETE');
-        $this->assertSame('Articles', $result['controller']);
-        $this->assertSame('delete', $result['action']);
-        $this->assertEquals([1], $result['pass']);
+            $result = $this->collection->parse('/articles/1', 'DELETE');
+            $this->assertSame('Articles', $result['controller']);
+            $this->assertSame('delete', $result['action']);
+            $this->assertEquals([1], $result['pass']);
+        });
     }
 
     /**
@@ -1141,9 +1156,11 @@ class RouteBuilderTest extends TestCase
         });
         $this->assertCount(2, $this->collection->routes());
         $this->assertEquals(['faq', 'article:update'], array_keys($this->collection->named()));
-        $this->assertNotEmpty($this->collection->parse('/faq/things_you_know', 'GET'));
-        $result = $this->collection->parse('/articles/123', 'POST');
-        $this->assertEquals(['123'], $result['pass']);
+        $this->deprecated(function () {
+            $this->assertNotEmpty($this->collection->parse('/faq/things_you_know', 'GET'));
+            $result = $this->collection->parse('/articles/123', 'POST');
+            $this->assertEquals(['123'], $result['pass']);
+        });
     }
 
     /**
@@ -1165,7 +1182,7 @@ class RouteBuilderTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/');
         $routes->loadPlugin('TestPlugin');
         $this->assertCount(1, $this->collection->routes());
-        $this->assertNotEmpty($this->collection->parse('/test_plugin', 'GET'));
+        $this->assertNotEmpty($this->collection->parseRequest(new ServerRequest(['url' => '/test_plugin'])));
 
         $plugin = Plugin::getCollection()->get('TestPlugin');
         $this->assertFalse($plugin->isEnabled('routes'), 'Hook should be disabled preventing duplicate routes');

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -52,8 +52,10 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/', ['controller' => 'Articles']);
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
 
-        $result = $this->collection->parse('/');
-        $this->assertEquals([], $result, 'Should not match, missing /b');
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/');
+            $this->assertEquals([], $result, 'Should not match, missing /b');
+        });
     }
 
     /**
@@ -66,10 +68,12 @@ class RouteCollectionTest extends TestCase
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->connect('/', ['controller' => 'Articles', '_method' => ['GET']]);
 
-        $result = $this->collection->parse('/b', 'GET');
-        $this->assertNotEmpty($result, 'Route should be found');
-        $result = $this->collection->parse('/b', 'POST');
-        $this->assertEquals([], $result, 'Should not match with missing method');
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/b', 'GET');
+            $this->assertNotEmpty($result, 'Route should be found');
+            $result = $this->collection->parse('/b', 'POST');
+            $this->assertEquals([], $result, 'Should not match with missing method');
+        });
     }
 
     /**
@@ -82,55 +86,57 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
 
-        $result = $this->collection->parse('/b/');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'index',
-            'pass' => [],
-            'plugin' => null,
-            'key' => 'value',
-            '_matchedRoute' => '/b',
-        ];
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/b/');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'index',
+                'pass' => [],
+                'plugin' => null,
+                'key' => 'value',
+                '_matchedRoute' => '/b',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/b/the-thing?one=two');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'view',
-            'id' => 'the-thing',
-            'pass' => [],
-            'plugin' => null,
-            'key' => 'value',
-            '?' => ['one' => 'two'],
-            '_matchedRoute' => '/b/{id}',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/b/the-thing?one=two');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'id' => 'the-thing',
+                'pass' => [],
+                'plugin' => null,
+                'key' => 'value',
+                '?' => ['one' => 'two'],
+                '_matchedRoute' => '/b/{id}',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/b/media/search');
-        unset($result['_route']);
-        $expected = [
-            'key' => 'value',
-            'pass' => [],
-            'plugin' => null,
-            'controller' => 'Media',
-            'action' => 'search',
-            '_matchedRoute' => '/b/media/search/*',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/b/media/search');
+            unset($result['_route']);
+            $expected = [
+                'key' => 'value',
+                'pass' => [],
+                'plugin' => null,
+                'controller' => 'Media',
+                'action' => 'search',
+                '_matchedRoute' => '/b/media/search/*',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/b/media/search/thing');
-        unset($result['_route']);
-        $expected = [
-            'key' => 'value',
-            'pass' => ['thing'],
-            'plugin' => null,
-            'controller' => 'Media',
-            'action' => 'search',
-            '_matchedRoute' => '/b/media/search/*',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/b/media/search/thing');
+            unset($result['_route']);
+            $expected = [
+                'key' => 'value',
+                'pass' => ['thing'],
+                'plugin' => null,
+                'controller' => 'Media',
+                'action' => 'search',
+                '_matchedRoute' => '/b/media/search/*',
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -142,30 +148,32 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search']);
 
-        $result = $this->collection->parse('/media/search/php?one=two');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Media',
-            'action' => 'search',
-            'pass' => ['php'],
-            'plugin' => null,
-            '_matchedRoute' => '/media/search/*',
-            '?' => ['one' => 'two'],
-        ];
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/media/search/php?one=two');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Media',
+                'action' => 'search',
+                'pass' => ['php'],
+                'plugin' => null,
+                '_matchedRoute' => '/media/search/*',
+                '?' => ['one' => 'two'],
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/thing?one=two');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'view',
-            'pass' => [],
-            'id' => 'thing',
-            'plugin' => null,
-            '_matchedRoute' => '/{id}',
-            '?' => ['one' => 'two'],
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/thing?one=two');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => [],
+                'id' => 'thing',
+                'plugin' => null,
+                '_matchedRoute' => '/{id}',
+                '?' => ['one' => 'two'],
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -178,57 +186,59 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/{id}', ['controller' => 'Articles', 'action' => 'view']);
         $routes->connect('/media/search/*', ['controller' => 'Media', 'action' => 'search'], ['_name' => 'media_search']);
 
-        $result = $this->collection->parse('/b/');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'index',
-            'pass' => [],
-            'plugin' => null,
-            'key' => 'value',
-            '_matchedRoute' => '/b',
-        ];
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/b/');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'index',
+                'pass' => [],
+                'plugin' => null,
+                'key' => 'value',
+                '_matchedRoute' => '/b',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/b/the-thing?one=two');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'view',
-            'id' => 'the-thing',
-            'pass' => [],
-            'plugin' => null,
-            'key' => 'value',
-            '?' => ['one' => 'two'],
-            '_matchedRoute' => '/b/{id}',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/b/the-thing?one=two');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'id' => 'the-thing',
+                'pass' => [],
+                'plugin' => null,
+                'key' => 'value',
+                '?' => ['one' => 'two'],
+                '_matchedRoute' => '/b/{id}',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/b/media/search');
-        unset($result['_route']);
-        $expected = [
-            'key' => 'value',
-            'pass' => [],
-            'plugin' => null,
-            'controller' => 'Media',
-            'action' => 'search',
-            '_matchedRoute' => '/b/media/search/*',
-            '_name' => 'media_search',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/b/media/search');
+            unset($result['_route']);
+            $expected = [
+                'key' => 'value',
+                'pass' => [],
+                'plugin' => null,
+                'controller' => 'Media',
+                'action' => 'search',
+                '_matchedRoute' => '/b/media/search/*',
+                '_name' => 'media_search',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->collection->parse('/b/media/search/thing');
-        unset($result['_route']);
-        $expected = [
-            'key' => 'value',
-            'pass' => ['thing'],
-            'plugin' => null,
-            'controller' => 'Media',
-            'action' => 'search',
-            '_matchedRoute' => '/b/media/search/*',
-            '_name' => 'media_search',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $this->collection->parse('/b/media/search/thing');
+            unset($result['_route']);
+            $expected = [
+                'key' => 'value',
+                'pass' => ['thing'],
+                'plugin' => null,
+                'controller' => 'Media',
+                'action' => 'search',
+                '_matchedRoute' => '/b/media/search/*',
+                '_name' => 'media_search',
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -239,25 +249,28 @@ class RouteCollectionTest extends TestCase
     {
         $routes = new RouteBuilder($this->collection, '/');
         $routes->connect('/ден/{day}-{month}', ['controller' => 'Events', 'action' => 'index']);
-        $url = '/%D0%B4%D0%B5%D0%BD/15-%D0%BE%D0%BA%D1%82%D0%BE%D0%BC%D0%B2%D1%80%D0%B8?test=foo';
-        $result = $this->collection->parse($url);
-        unset($result['_route']);
-        $expected = [
-            'pass' => [],
-            'plugin' => null,
-            'controller' => 'Events',
-            'action' => 'index',
-            'day' => '15',
-            'month' => 'октомври',
-            '?' => ['test' => 'foo'],
-            '_matchedRoute' => '/ден/{day}-{month}',
-        ];
-        $this->assertEquals($expected, $result);
 
-        $request = new ServerRequest(['url' => $url]);
-        $result = $this->collection->parseRequest($request);
-        unset($result['_route']);
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $url = '/%D0%B4%D0%B5%D0%BD/15-%D0%BE%D0%BA%D1%82%D0%BE%D0%BC%D0%B2%D1%80%D0%B8?test=foo';
+            $result = $this->collection->parse($url);
+            unset($result['_route']);
+            $expected = [
+                'pass' => [],
+                'plugin' => null,
+                'controller' => 'Events',
+                'action' => 'index',
+                'day' => '15',
+                'month' => 'октомври',
+                '?' => ['test' => 'foo'],
+                '_matchedRoute' => '/ден/{day}-{month}',
+            ];
+            $this->assertEquals($expected, $result);
+
+            $request = new ServerRequest(['url' => $url]);
+            $result = $this->collection->parseRequest($request);
+            unset($result['_route']);
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -271,17 +284,19 @@ class RouteCollectionTest extends TestCase
         $routes->connect('/{controller}', ['action' => 'index'], ['routeClass' => 'InflectedRoute']);
         $routes->connect('/{controller}/{action}', [], ['routeClass' => 'InflectedRoute']);
 
-        $result = $this->collection->parse('/articles/add');
-        unset($result['_route']);
-        $expected = [
-            'controller' => 'Articles',
-            'action' => 'add',
-            'plugin' => null,
-            'pass' => [],
-            '_matchedRoute' => '/{controller}/{action}',
+        $this->deprecated(function () {
+            $result = $this->collection->parse('/articles/add');
+            unset($result['_route']);
+            $expected = [
+                'controller' => 'Articles',
+                'action' => 'add',
+                'plugin' => null,
+                'pass' => [],
+                '_matchedRoute' => '/{controller}/{action}',
 
-        ];
-        $this->assertEquals($expected, $result);
+            ];
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**


### PR DESCRIPTION
This impacts a bunch of tests but shouldn't impact userland code. My plan for these tests is to delete them in 5.x unless they impact coverage.

Refs #17087