### PR TITLE
Use 0770 as default perms.

### DIFF
--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -50,6 +50,7 @@ class FileEngine extends CacheEngine
      *    handy for deleting a complete group from cache.
      * - `lock` Used by FileCache. Should files be locked before writing to them?
      * - `mask` The mask used for created files
+     * - `dirMask` The mask used for created folders
      * - `path` Path to where cachefiles should be saved. Defaults to system's temp dir.
      * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
@@ -63,6 +64,7 @@ class FileEngine extends CacheEngine
         'groups' => [],
         'lock' => true,
         'mask' => 0664,
+        'dirMask' => 0770,
         'path' => null,
         'prefix' => 'cake_',
         'serialize' => true,
@@ -371,7 +373,7 @@ class FileEngine extends CacheEngine
         $dir = $this->_config['path'] . $groups;
 
         if (!is_dir($dir)) {
-            mkdir($dir, 0770, true);
+            mkdir($dir, $this->_config['dirMask'], true);
         }
 
         $path = new SplFileInfo($dir . $key);
@@ -418,7 +420,7 @@ class FileEngine extends CacheEngine
         $success = true;
         if (!is_dir($path)) {
             // phpcs:disable
-            $success = @mkdir($path, 0770, true);
+            $success = @mkdir($path, $this->_config['dirMask'], true);
             // phpcs:enable
         }
 

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -371,7 +371,7 @@ class FileEngine extends CacheEngine
         $dir = $this->_config['path'] . $groups;
 
         if (!is_dir($dir)) {
-            mkdir($dir, 0775, true);
+            mkdir($dir, 0770, true);
         }
 
         $path = new SplFileInfo($dir . $key);
@@ -418,7 +418,7 @@ class FileEngine extends CacheEngine
         $success = true;
         if (!is_dir($path)) {
             // phpcs:disable
-            $success = @mkdir($path, 0775, true);
+            $success = @mkdir($path, 0770, true);
             // phpcs:enable
         }
 

--- a/src/Command/I18nInitCommand.php
+++ b/src/Command/I18nInitCommand.php
@@ -66,7 +66,7 @@ class I18nInitCommand extends Command
         $sourceFolder = rtrim($response, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $targetFolder = $sourceFolder . $language . DIRECTORY_SEPARATOR;
         if (!is_dir($targetFolder)) {
-            mkdir($targetFolder, 0775, true);
+            mkdir($targetFolder, 0770, true);
         }
 
         $count = 0;

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -91,7 +91,7 @@ class FileLog extends BaseLog
 
         $this->_path = $this->getConfig('path', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
         if (!is_dir($this->_path)) {
-            mkdir($this->_path, 0775, true);
+            mkdir($this->_path, 0770, true);
         }
 
         if (!empty($this->_config['file'])) {

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -41,6 +41,7 @@ class FileLog extends BaseLog
      *   If value is 0, old versions are removed rather then rotated.
      * - `mask` A mask is applied when log files are created. Left empty no chmod
      *   is made.
+     * - `dirMask` The mask used for created folders.
      * - `dateFormat` PHP date() format.
      *
      * @var array<string, mixed>
@@ -54,6 +55,7 @@ class FileLog extends BaseLog
         'rotate' => 10,
         'size' => 10485760, // 10MB
         'mask' => null,
+        'dirMask' => 0770,
         'formatter' => [
             'className' => DefaultFormatter::class,
         ],
@@ -91,7 +93,7 @@ class FileLog extends BaseLog
 
         $this->_path = $this->getConfig('path', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
         if (!is_dir($this->_path)) {
-            mkdir($this->_path, 0770, true);
+            mkdir($this->_path, $this->_config['dirMask'], true);
         }
 
         if (!empty($this->_config['file'])) {


### PR DESCRIPTION
If we do create dirs on prod on the fly, we probably don't want to expose them by default to outside more than necessary

Refs and follows https://github.com/cakephp/cakephp/pull/17090

For me 0770 always sufficed here - no need to have "others"?