### PR TITLE
4.x: handle numeric keys in cookies being parsed from the server request

### DIFF
--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -88,7 +88,7 @@ class CookieCollection implements IteratorAggregate, Countable
         $data = $request->getCookieParams();
         $cookies = [];
         foreach ($data as $name => $value) {
-            $cookies[] = new Cookie($name, $value);
+            $cookies[] = new Cookie((string)$name, $value);
         }
 
         return new static($cookies);

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -474,15 +474,25 @@ class CookieCollectionTest extends TestCase
      */
     public function testCreateFromServerRequest(): void
     {
-        $request = new ServerRequest(['cookies' => ['name' => 'val', 'cakephp' => 'rocks']]);
+        $request = new ServerRequest([
+            'cookies' => [
+                'name' => 'val',
+                'cakephp' => 'rocks',
+                '123' => 'a integer key cookie',
+            ],
+        ]);
         $cookies = CookieCollection::createFromServerRequest($request);
-        $this->assertCount(2, $cookies);
+        $this->assertCount(3, $cookies);
         $this->assertTrue($cookies->has('name'));
         $this->assertTrue($cookies->has('cakephp'));
+        $this->assertTrue($cookies->has('123'));
 
         $cookie = $cookies->get('name');
         $this->assertSame('val', $cookie->getValue());
         $this->assertSame('/', $cookie->getPath());
         $this->assertSame('', $cookie->getDomain(), 'No domain on request cookies');
+
+        $cookie = $cookies->get('123');
+        $this->assertSame('a integer key cookie', $cookie->getValue());
     }
 }

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -1605,9 +1605,11 @@ XML;
                 'user' => [
                     'remember' => '1',
                 ],
+                '123' => 'a integer key cookie',
             ],
         ]);
         $this->assertSame('A value in the cookie', $request->getCookie('testing'));
+        $this->assertSame('a integer key cookie', $request->getCookie('123'));
         $this->assertNull($request->getCookie('not there'));
         $this->assertSame('default', $request->getCookie('not there', 'default'));
 


### PR DESCRIPTION
Fixes #17094 

integer strings in array keys will always be converted to actual integer keys