### PR TITLE
Move DateFormatTrait methods into Date and DateTime and update parameters

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,108 +1,148 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/Cache/Engine/FileEngine.php">
-    <TooManyTemplateParams occurrences="1">
+    <TooManyTemplateParams>
       <code>$iterator</code>
     </TooManyTemplateParams>
   </file>
   <file src="src/Cache/Engine/RedisEngine.php">
-    <InvalidReturnStatement occurrences="4">
-      <code>$this-&gt;_Redis-&gt;set($key, $value)</code>
-      <code>$this-&gt;_Redis-&gt;setEx($key, $duration, $value)</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->_Redis->set($key, $value)]]></code>
+      <code><![CDATA[$this->_Redis->setEx($key, $duration, $value)]]></code>
       <code>$value</code>
       <code>$value</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="3">
+    <InvalidReturnType>
       <code>bool</code>
       <code>int|false</code>
       <code>int|false</code>
     </InvalidReturnType>
   </file>
   <file src="src/Datasource/Paging/PaginatedResultSet.php">
-    <MethodSignatureMustProvideReturnType occurrences="1">
+    <MethodSignatureMustProvideReturnType>
       <code>://cakephp.org)</code>
     </MethodSignatureMustProvideReturnType>
   </file>
   <file src="src/Event/EventDispatcherTrait.php">
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$subject</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Event/EventManager.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>_callListener</code>
       <code>addEventToList</code>
       <code>addEventToList</code>
     </InvalidArgument>
-    <InvalidReturnStatement occurrences="2">
+    <InvalidReturnStatement>
       <code>$event</code>
       <code>$event</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>EventInterface</code>
     </InvalidReturnType>
   </file>
   <file src="src/I18n/Date.php">
-    <ImpureMethodCall occurrences="2">
+    <ImpureFunctionCall>
+      <code>call_user_func(static::$_jsonEncodeFormat, $this)</code>
+      <code>static::$_jsonEncodeFormat</code>
+    </ImpureFunctionCall>
+    <ImpureMethodCall>
+      <code>_formatObject</code>
       <code>dateAgoInWords</code>
       <code>diffFormatter</code>
+      <code>getDefaultLocale</code>
     </ImpureMethodCall>
-  </file>
-  <file src="src/I18n/DateFormatTrait.php">
-    <InaccessibleProperty occurrences="2">
-      <code>$this-&gt;native</code>
-      <code>$time-&gt;native</code>
-    </InaccessibleProperty>
-    <RedundantCondition occurrences="1">
-      <code>$time instanceof DateTime</code>
-    </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
-      <code>$time instanceof DateTime</code>
-    </TypeDoesNotContainType>
+    <ImpureStaticProperty>
+      <code>static::$_jsonEncodeFormat</code>
+      <code>static::$_jsonEncodeFormat</code>
+      <code>static::$_jsonEncodeFormat</code>
+      <code>static::$_toStringFormat</code>
+      <code>static::$niceFormat</code>
+    </ImpureStaticProperty>
   </file>
   <file src="src/I18n/DateTime.php">
-    <ImpureMethodCall occurrences="2">
+    <ImpureFunctionCall>
+      <code>call_user_func(static::$_jsonEncodeFormat, $this)</code>
+      <code>static::$_jsonEncodeFormat</code>
+    </ImpureFunctionCall>
+    <ImpureMethodCall>
+      <code>_formatObject</code>
       <code>diffFormatter</code>
+      <code>getDefaultLocale</code>
       <code>timeAgoInWords</code>
     </ImpureMethodCall>
+    <ImpureStaticProperty>
+      <code>static::$_jsonEncodeFormat</code>
+      <code>static::$_jsonEncodeFormat</code>
+      <code>static::$_jsonEncodeFormat</code>
+      <code>static::$_toStringFormat</code>
+      <code>static::$niceFormat</code>
+    </ImpureStaticProperty>
   </file>
   <file src="src/ORM/Table.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;_behaviors-&gt;callFinder($type, [$query, $options])</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->_behaviors->callFinder($type, [$query, $options])]]></code>
     </InvalidReturnStatement>
   </file>
   <file src="src/TestSuite/Constraint/EventFired.php">
-    <InternalClass occurrences="1"/>
-    <InternalMethod occurrences="1"/>
+    <InternalClass>
+      <code><![CDATA[new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code><![CDATA[new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )]]></code>
+    </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/EventFiredWith.php">
-    <InternalClass occurrences="2"/>
-    <InternalMethod occurrences="2"/>
+    <InternalClass>
+      <code><![CDATA[new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )]]></code>
+      <code><![CDATA[new AssertionFailedError(sprintf(
+                'Event `%s` was fired %d times, cannot make data assertion',
+                $other,
+                count($events)
+            ))]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code><![CDATA[new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )]]></code>
+      <code><![CDATA[new AssertionFailedError(sprintf(
+                'Event `%s` was fired %d times, cannot make data assertion',
+                $other,
+                count($events)
+            ))]]></code>
+    </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/Response/ResponseBase.php">
-    <InternalClass occurrences="1">
-      <code>new AssertionFailedError('No response set, cannot assert content.')</code>
+    <InternalClass>
+      <code><![CDATA[new AssertionFailedError('No response set, cannot assert content.')]]></code>
     </InternalClass>
-    <InternalMethod occurrences="1">
-      <code>new AssertionFailedError('No response set, cannot assert content.')</code>
+    <InternalMethod>
+      <code><![CDATA[new AssertionFailedError('No response set, cannot assert content.')]]></code>
     </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/Session/FlashParamEquals.php">
-    <InternalClass occurrences="1">
+    <InternalClass>
       <code>new AssertionFailedError($message)</code>
     </InternalClass>
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>new AssertionFailedError($message)</code>
     </InternalMethod>
   </file>
   <file src="src/Utility/Filesystem.php">
-    <TooManyTemplateParams occurrences="2">
+    <TooManyTemplateParams>
       <code>$iterator</code>
       <code>$iterator</code>
     </TooManyTemplateParams>
   </file>
   <file src="src/Utility/Hash.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>is_array($_list)</code>
     </RedundantCondition>
   </file>

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -53,11 +53,11 @@ class DateType extends BaseType implements BatchCastingInterface
     /**
      * The locale-aware format `marshal()` uses when `_useLocaleParser` is true.
      *
-     * See `Cake\I18n\Time::parseDateTime()` for accepted formats.
+     * See `Cake\I18n\Date::parseDate()` for accepted formats.
      *
-     * @var array|string|int|null
+     * @var string|int|null
      */
-    protected array|string|int|null $_localeMarshalFormat = null;
+    protected string|int|null $_localeMarshalFormat = null;
 
     /**
      * The classname to use when creating objects.
@@ -235,13 +235,13 @@ class DateType extends BaseType implements BatchCastingInterface
     /**
      * Sets the locale-aware format used by `marshal()` when parsing strings.
      *
-     * See `Cake\I18n\Time::parseDateTime()` for accepted formats.
+     * See `Cake\I18n\Date::parseDate()` for accepted formats.
      *
-     * @param array|string $format The locale-aware format
-     * @see \Cake\I18n\Time::parseDateTime()
+     * @param string|int $format The locale-aware format
+     * @see \Cake\I18n\Date::parseDate()
      * @return $this
      */
-    public function setLocaleFormat(array|string $format)
+    public function setLocaleFormat(string|int $format)
     {
         $this->_localeMarshalFormat = $format;
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -16,10 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\I18n;
 
-use Cake\Chronos\ChronosDate;
 use Cake\Chronos\DifferenceFormatterInterface;
 use Cake\Core\Exception\CakeException;
-use Closure;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
@@ -34,119 +32,23 @@ use InvalidArgumentException;
 trait DateFormatTrait
 {
     /**
-     * Returns a nicely formatted date string for this object.
-     *
-     * The format to be used is stored in the static property `Time::niceFormat`.
-     *
-     * @param \DateTimeZone|string|null $timezone Timezone string or DateTimeZone object
-     * in which the date will be displayed. The timezone stored for this object will not
-     * be changed.
-     * @param string|null $locale The locale name in which the date should be displayed (e.g. pt-BR)
-     * @return string Formatted date string
-     */
-    public function nice(DateTimeZone|string|null $timezone = null, ?string $locale = null): string
-    {
-        return (string)$this->i18nFormat(static::$niceFormat, $timezone, $locale);
-    }
-
-    /**
-     * Returns a formatted string for this time object using the preferred format and
-     * language for the specified locale.
-     *
-     * It is possible to specify the desired format for the string to be displayed.
-     * You can either pass `IntlDateFormatter` constants as the first argument of this
-     * function, or pass a full ICU date formatting string as specified in the following
-     * resource: https://unicode-org.github.io/icu/userguide/format_parse/datetime/#datetime-format-syntax.
-     *
-     * Additional to `IntlDateFormatter` constants and date formatting string you can use
-     * Time::UNIX_TIMESTAMP_FORMAT to get a unix timestamp
-     *
-     * ### Examples
-     *
-     * ```
-     * $time = new Time('2014-04-20 22:10');
-     * $time->i18nFormat(); // outputs '4/20/14, 10:10 PM' for the en-US locale
-     * $time->i18nFormat(\IntlDateFormatter::FULL); // Use the full date and time format
-     * $time->i18nFormat([\IntlDateFormatter::FULL, \IntlDateFormatter::SHORT]); // Use full date but short time format
-     * $time->i18nFormat('yyyy-MM-dd HH:mm:ss'); // outputs '2014-04-20 22:10'
-     * $time->i18nFormat(Time::UNIX_TIMESTAMP_FORMAT); // outputs '1398031800'
-     * ```
-     *
-     * You can control the default format used through `Time::setToStringFormat()`.
-     *
-     * You can read about the available IntlDateFormatter constants at
-     * https://secure.php.net/manual/en/class.intldateformatter.php
-     *
-     * If you need to display the date in a different timezone than the one being used for
-     * this Time object without altering its internal state, you can pass a timezone
-     * string or object as the second parameter.
-     *
-     * Finally, should you need to use a different locale for displaying this time object,
-     * pass a locale string as the third parameter to this function.
-     *
-     * ### Examples
-     *
-     * ```
-     * $time = new Time('2014-04-20 22:10');
-     * $time->i18nFormat(null, null, 'de-DE');
-     * $time->i18nFormat(\IntlDateFormatter::FULL, 'Europe/Berlin', 'de-DE');
-     * ```
-     *
-     * You can control the default locale used through `Time::setDefaultLocale()`.
-     * If empty, the default will be taken from the `intl.default_locale` ini config.
-     *
-     * @param array<int>|string|int|null $format Format string.
-     * @param \DateTimeZone|string|null $timezone Timezone string or DateTimeZone object
-     * in which the date will be displayed. The timezone stored for this object will not
-     * be changed.
-     * @param string|null $locale The locale name in which the date should be displayed (e.g. pt-BR)
-     * @return string|int Formatted and translated date string
-     */
-    public function i18nFormat(
-        array|string|int|null $format = null,
-        DateTimeZone|string|null $timezone = null,
-        ?string $locale = null
-    ): string|int {
-        if ($format === DateTime::UNIX_TIMESTAMP_FORMAT) {
-            if ($this instanceof ChronosDate) {
-                return $this->native->getTimestamp();
-            } else {
-                return $this->getTimestamp();
-            }
-        }
-
-        $time = $this;
-
-        if ($time instanceof DateTime && $timezone) {
-            $time = $time->setTimezone($timezone);
-        }
-
-        $format ??= static::$_toStringFormat;
-        $locale = $locale ?: DateTime::getDefaultLocale();
-
-        return $this->_formatObject($time instanceof DateTimeInterface ? $time : $time->native, $format, $locale);
-    }
-
-    /**
      * Returns a translated and localized date string.
      * Implements what IntlDateFormatter::formatObject() is in PHP 5.5+
      *
      * @param \DateTimeInterface $date Date.
-     * @param array<int>|string|int $format Format.
+     * @param array<int>|string $format Format.
      * @param string|null $locale The locale name in which the date should be displayed.
      * @return string
      */
     protected function _formatObject(
         DateTimeInterface $date,
-        array|string|int $format,
+        array|string $format,
         ?string $locale
     ): string {
         $pattern = '';
 
         if (is_array($format)) {
             [$dateFormat, $timeFormat] = $format;
-        } elseif (is_int($format)) {
-            $dateFormat = $timeFormat = $format;
         } else {
             $dateFormat = $timeFormat = IntlDateFormatter::FULL;
             $pattern = $format;
@@ -192,20 +94,10 @@ trait DateFormatTrait
     }
 
     /**
-     * @inheritDoc
-     */
-    public function __toString(): string
-    {
-        return (string)$this->i18nFormat();
-    }
-
-    /**
      * Returns a new Time object after parsing the provided time string based on
      * the passed or configured date time format. This method is locale dependent,
      * Any string that is passed to this function will be interpreted as a locale
      * dependent string.
-     *
-     * When no $format is provided, the `toString` format will be used.
      *
      * Unlike DateTime, the time zone of the returned instance is always converted
      * to `$tz` (default time zone if null) even if the `$time` string specified a
@@ -222,22 +114,19 @@ trait DateFormatTrait
      * ```
      *
      * @param string $time The time string to parse.
-     * @param array<int>|string|int|null $format Any format accepted by IntlDateFormatter.
+     * @param array<int>|string $format Any format accepted by IntlDateFormatter.
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      * @return static|null
      */
-    public static function parseDateTime(
+    protected static function _parseDateTime(
         string $time,
-        array|string|int|null $format = null,
+        array|string $format,
         DateTimeZone|string|null $tz = null
     ): ?static {
-        $format ??= static::$_toStringFormat;
         $pattern = '';
 
         if (is_array($format)) {
             [$dateFormat, $timeFormat] = $format;
-        } elseif (is_int($format)) {
-            $dateFormat = $timeFormat = $format;
         } else {
             $dateFormat = $timeFormat = IntlDateFormatter::FULL;
             $pattern = $format;
@@ -270,82 +159,6 @@ trait DateFormatTrait
         $dateTime = $dateTime->setTimezone($tz);
 
         return new static($dateTime);
-    }
-
-    /**
-     * Returns a new Time object after parsing the provided $date string based on
-     * the passed or configured date time format. This method is locale dependent,
-     * Any string that is passed to this function will be interpreted as a locale
-     * dependent string.
-     *
-     * When no $format is provided, the `wordFormat` format will be used.
-     *
-     * If it was impossible to parse the provided time, null will be returned.
-     *
-     * Example:
-     *
-     * ```
-     *  $time = Time::parseDate('10/13/2013');
-     *  $time = Time::parseDate('13 Oct, 2013', 'dd MMM, y');
-     *  $time = Time::parseDate('13 Oct, 2013', IntlDateFormatter::SHORT);
-     * ```
-     *
-     * @param string $date The date string to parse.
-     * @param array|string|int|null $format Any format accepted by IntlDateFormatter.
-     * @return static|null
-     */
-    public static function parseDate(string $date, array|string|int|null $format = null): ?static
-    {
-        if (is_int($format)) {
-            $format = [$format, IntlDateFormatter::NONE];
-        }
-        $format = $format ?: static::$wordFormat;
-
-        return static::parseDateTime($date, $format);
-    }
-
-    /**
-     * Returns a new Time object after parsing the provided $time string based on
-     * the passed or configured date time format. This method is locale dependent,
-     * Any string that is passed to this function will be interpreted as a locale
-     * dependent string.
-     *
-     * When no $format is provided, the IntlDateFormatter::SHORT format will be used.
-     *
-     * If it was impossible to parse the provided time, null will be returned.
-     *
-     * Example:
-     *
-     * ```
-     *  $time = Time::parseTime('11:23pm');
-     * ```
-     *
-     * @param string $time The time string to parse.
-     * @param array|string|int|null $format Any format accepted by IntlDateFormatter.
-     * @return static|null
-     */
-    public static function parseTime(string $time, array|string|int|null $format = null): ?static
-    {
-        if (is_int($format)) {
-            $format = [IntlDateFormatter::NONE, $format];
-        }
-        $format = $format ?: [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
-
-        return static::parseDateTime($time, $format);
-    }
-
-    /**
-     * Returns a string that should be serialized when converting this object to JSON
-     *
-     * @return string|int
-     */
-    public function jsonSerialize(): mixed
-    {
-        if (static::$_jsonEncodeFormat instanceof Closure) {
-            return call_user_func(static::$_jsonEncodeFormat, $this);
-        }
-
-        return $this->i18nFormat(static::$_jsonEncodeFormat);
     }
 
     /**

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -22,7 +22,6 @@ use Cake\I18n\DateTime;
 use Cake\I18n\I18n;
 use Cake\I18n\Package;
 use Cake\TestSuite\TestCase;
-use DateTimeZone;
 use IntlDateFormatter;
 
 /**
@@ -79,27 +78,23 @@ class DateTest extends TestCase
         $expected = '1/14/10';
         $this->assertSame($expected, $result);
 
-        $format = [IntlDateFormatter::NONE, IntlDateFormatter::SHORT];
-        $result = preg_replace('/[\pZ\pC]/u', ' ', $time->i18nFormat($format));
-        $this->assertSame('12:00 AM', $result);
-
-        $result = $time->i18nFormat('HH:mm:ss', 'Australia/Sydney');
+        $result = $time->i18nFormat('HH:mm:ss');
         $expected = '00:00:00';
         $this->assertSame($expected, $result);
 
         DateTime::setDefaultLocale('fr-FR');
         $result = $time->i18nFormat(IntlDateFormatter::FULL);
         $result = str_replace(' à', '', $result);
-        $expected = 'jeudi 14 janvier 2010 00:00:00';
+        $expected = 'jeudi 14 janvier 2010';
         $this->assertStringStartsWith($expected, $result);
 
-        $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'es-ES');
+        $result = $time->i18nFormat(IntlDateFormatter::FULL, 'es-ES');
         $this->assertStringContainsString('14 de enero de 2010', $result, 'Default locale should not be used');
 
         $time = new Date('2014-01-01T00:00:00Z');
-        $result = $time->i18nFormat(IntlDateFormatter::FULL, null, 'en-US');
+        $result = $time->i18nFormat(IntlDateFormatter::FULL, 'en-US');
         $result = preg_replace('/[\pZ\pC]/u', ' ', $result);
-        $this->assertStringStartsWith('Wednesday, January 1, 2014 at 12:00:00 AM', $result);
+        $this->assertStringStartsWith('Wednesday, January 1, 2014', $result);
     }
 
     public function testDiffForHumans(): void
@@ -127,8 +122,7 @@ class DateTest extends TestCase
         $date = new Date('2015-11-06 11:32:45');
 
         $this->assertSame('Nov 6, 2015', $date->nice());
-        $this->assertSame('Nov 6, 2015', $date->nice(new DateTimeZone('America/New_York')));
-        $this->assertSame('6 nov. 2015', $date->nice(null, 'fr-FR'));
+        $this->assertSame('6 nov. 2015', $date->nice('fr-FR'));
     }
 
     /**
@@ -170,19 +164,6 @@ class DateTest extends TestCase
 
         DateTime::setDefaultLocale('fr-FR');
         $date = Date::parseDate('13 10, 2015');
-        $this->assertSame('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
-    }
-
-    /**
-     * test parseDateTime()
-     */
-    public function testParseDateTime(): void
-    {
-        $date = Date::parseDate('11/6/15 12:33:12');
-        $this->assertSame('2015-11-06 00:00:00', $date->format('Y-m-d H:i:s'));
-
-        DateTime::setDefaultLocale('fr-FR');
-        $date = Date::parseDate('13 10, 2015 12:54:12');
         $this->assertSame('2015-10-13 00:00:00', $date->format('Y-m-d H:i:s'));
     }
 
@@ -465,17 +446,6 @@ class DateTest extends TestCase
     {
         date_default_timezone_set('Europe/Paris');
         $result = Date::parseDate('25-02-2016', 'd-M-y');
-        $this->assertSame('25-02-2016', $result->format('d-m-Y'));
-    }
-
-    /**
-     * Tests that parsing a full date + time in a timezone other
-     * than UTC respects the timezone when grabbing the date.
-     */
-    public function testParseDateTimeDifferentTimezone(): void
-    {
-        date_default_timezone_set('America/Toronto');
-        $result = Date::parseDateTime('25-02-2016 23:00:00', 'd-M-y H:m:s');
         $this->assertSame('25-02-2016', $result->format('d-m-Y'));
     }
 


### PR DESCRIPTION
This fixes the parameter types and hides most of the time-specific formatting for Date objects. It's still possible with a string format, but that's on the user.

Date no longer defaults to Date + Time format when passing an int formatter. Date no longer allows array formatters.

This helps align the API for when I18n\Time is added to wrap ChronosTime.
