### PR TITLE
4.5 Improve rendering of error pages

### DIFF
--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -38,13 +38,18 @@ foreach ($exceptions as $level => $exc):
     <div class="stack-frame">
         <?php
         $line = $exc->getLine();
-        $excerpt = Debugger::excerpt($exc->getFile(), $line, 4);
+        $file = $exc->getFile();
+        $excerpt = Debugger::excerpt($file, $line, 4);
 
         $lineno = $line ? $line - 4 : 0;
         ?>
         <span class="stack-frame-file">
-            <?= h(Debugger::trimPath($exc->getFile())); ?> at line <?= h($line) ?>
+            <?= h(Debugger::trimPath($file)); ?> at line <?= h($line) ?>
         </span>
+        <?php if ($line !== null): ?>
+            <?= $this->Html->link('(edit)', Debugger::editorUrl($file, $line), ['class' => 'stack-frame-edit']); ?>
+        <?php endif; ?>
+
         <table class="code-excerpt" cellspacing="0" cellpadding="0">
         <?php foreach ($excerpt as $l => $line): ?>
             <tr>
@@ -95,6 +100,13 @@ foreach ($exceptions as $level => $exc):
                     <span class="stack-frame-file">
                         <?= h(Debugger::trimPath($file)); ?>
                     </span>
+
+                    <?php if ($line !== null): ?>
+                        <span class="stack-frame-line">
+                            <span class="stack-frame-label">at line</span><?= h($line) ?>
+                        </span>
+                    <?php endif ?>
+
                     <span class="stack-function">
                         <?php if (isset($stack['class']) || isset($stack['function'])): ?>
                             <span class="stack-frame-label">in</span>
@@ -105,12 +117,6 @@ foreach ($exceptions as $level => $exc):
                             <?= h($stack['function']) ?>
                         <?php endif; ?>
                     </span>
-
-                    <?php if ($line !== null): ?>
-                        <span class="stack-frame-line">
-                            <span class="stack-frame-label">at line</span><?= h($line) ?>
-                        </span>
-                    <?php endif ?>
 
                     <?php if ($line !== null): ?>
                         <?= $this->Html->link('(edit)', Debugger::editorUrl($file, $line), ['class' => 'stack-frame-edit']); ?>

--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -18,6 +18,7 @@
 use Cake\Error\Debugger;
 use function Cake\Core\h;
 
+
 foreach ($exceptions as $level => $exc):
     $parent = $exceptions[$level - 1] ?? null;
     $stackTrace = Debugger::getUniqueFrames($exc, $parent);
@@ -33,6 +34,27 @@ foreach ($exceptions as $level => $exc):
             <span class="stack-exception-type"><?= h(get_class($exc)); ?></span>
         </div>
     <?php endif; ?>
+
+    <div class="stack-frame">
+        <?php
+        $line = $exc->getLine();
+        $excerpt = Debugger::excerpt($exc->getFile(), $line, 4);
+
+        $lineno = $line ? $line - 4 : 0;
+        ?>
+        <span class="stack-frame-file">
+            <?= h(Debugger::trimPath($exc->getFile())); ?> at line <?= h($line) ?>
+        </span>
+        <table class="code-excerpt" cellspacing="0" cellpadding="0">
+        <?php foreach ($excerpt as $l => $line): ?>
+            <tr>
+                <td class="excerpt-number" data-number="<?= $lineno + $l ?>"></td>
+                <td class="excerpt-line"><?= $line ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </table>
+    </div>
+
     <ul class="stack-frames">
     <?php
     foreach ($stackTrace as $i => $stack):
@@ -61,15 +83,11 @@ foreach ($exceptions as $level => $exc):
         endif;
 
         $frameId = "{$level}-{$i}";
-        $activeFrame = $i == 0;
         $vendorFrame = isset($stack['file']) && strpos($stack['file'], APP) === false ? 'vendor-frame' : '';
     ?>
         <li id="stack-frame-<?= $frameId ?>" class="stack-frame <?= $vendorFrame ?>">
             <div class="stack-frame-header">
-                <button
-                    data-frame-id="<?= h($frameId) ?>"
-                    class="stack-frame-toggle <?= $activeFrame ? 'active' : '' ?>"
-                >
+                <button data-frame-id="<?= h($frameId) ?>" class="stack-frame-toggle">
                     &#x25BC;
                 </button>
 
@@ -102,7 +120,7 @@ foreach ($exceptions as $level => $exc):
             <div
                 class="stack-frame-contents"
                 id="stack-frame-details-<?= $frameId ?>"
-                style="display: <?= $activeFrame ? 'block' : 'none' ?>"
+                style="display: none"
             >
                 <table class="code-excerpt" cellspacing="0" cellpadding="0">
                 <?php $lineno = isset($stack['line']) && is_numeric($stack['line']) ? $stack['line'] - 4 : 0 ?>

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -335,24 +335,26 @@ use function Cake\Core\h;
         <span class="header-type"><?= get_class($error) ?></span>
     </header>
     <div class="error-content">
-            <?php if ($this->fetch('subheading')): ?>
-            <p class="error-subheading">
-                <?= $this->fetch('subheading') ?>
-            </p>
-            <?php endif; ?>
+        <?php if ($this->fetch('subheading')): ?>
+        <p class="error-subheading">
+            <?= $this->fetch('subheading') ?>
+        </p>
+        <?php endif; ?>
 
-<div class="error-suggestion">
-<?= $this->fetch('file') ?>
-</div>
+        <?php if ($this->fetch('file')): ?>
+        <div class="error-suggestion">
+            <?= $this->fetch('file') ?>
+        </div>
+        <?php endif; ?>
 
-            <?= $this->element('dev_error_stacktrace'); ?>
+        <?= $this->element('dev_error_stacktrace'); ?>
 
-            <?php if ($this->fetch('templateName')): ?>
-            <p class="customize">
-                If you want to customize this error message, create
-                <em><?= 'templates' . DIRECTORY_SEPARATOR . 'Error' . DIRECTORY_SEPARATOR . $this->fetch('templateName') ?></em>
-            </p>
-            <?php endif; ?>
+        <?php if ($this->fetch('templateName')): ?>
+        <p class="customize">
+            If you want to customize this error message, create
+            <em><?= 'templates' . DIRECTORY_SEPARATOR . 'Error' . DIRECTORY_SEPARATOR . $this->fetch('templateName') ?></em>
+        </p>
+        <?php endif; ?>
     </div>
 
     <script type="text/javascript">

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -287,9 +287,13 @@ use function Cake\Core\h;
     .code-highlight {
         display: block;
         background: #fff59d;
+        padding-left: 4px;
     }
     .excerpt-line {
         padding: 0;
+    }
+    .excerpt-line > code {
+        padding-left: 4px;
     }
     .excerpt-number {
         background: #f6f6f6;
@@ -297,7 +301,7 @@ use function Cake\Core\h;
         text-align: right;
         color: #666;
         border-right: 1px solid #ddd;
-        padding: 2px;
+        padding: 2px 4px;
     }
     .excerpt-number:after {
         content: attr(data-number);


### PR DESCRIPTION
PHP exceptions don't include the source line/file in the stacktrace so our error pages started on the frame *after* the line where the error actually was. This makes debugging harder as the problematic line isn't as obvious.

These changes add an unclosable frame before each stack that shows the line the exception came from. I've also removed the `activeFrame` logic as we don't want to show two adjacent frames open by default.

![Screenshot from 2023-04-09 00-15-51](https://user-images.githubusercontent.com/24086/230754393-557c78f2-6fec-402c-8535-555e63f1d39b.png)
