### PR TITLE
Update PHPStan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
       run: composer update
 
     - name: Install PHP tools with phive.
-      run: phive install --trust-gpg-keys 'CF1A108D0E7AE720,12CE0F1D262429A5'
+      run: phive install --trust-gpg-keys 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5'
 
     - name: Run phpcs
       if: always()

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="1.10.2" installed="1.10.2" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="1.10.11" installed="1.10.11" location="./tools/phpstan" copy="false"/>
   <phar name="psalm" version="4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
 </phive>


### PR DESCRIPTION
Is there any way to not have to deal with the key topic?

```
Error:    Needs tty to be able to confirm

	Fingerprint: CA7C 2C7A 30C8 E8E1 274A 8476 51C6 7305 FFC2 E5C0

	PHPStan Bot <ondrej+phpstanbot@mirtes.cz>

	Created: 2023-03-12

Import this key? [y|N] 
Error: Process completed with exit code 4.
```