### PR TITLE
4.next: update psalm to v5

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phpstan" version="1.10.2" installed="1.10.2" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="4.30.0" installed="4.30.0" location="./tools/psalm" copy="false"/>
+  <phar name="psalm" version="5.9.0" installed="5.9.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: src/Controller/ControllerFactory.php
 
 		-
-			message: "#^PHPDoc tag @param for parameter \\$object with type TObject is not subtype of native type object\\.$#"
-			count: 1
-			path: src/Core/ObjectRegistry.php
-
-		-
 			message: "#^Property Cake\\\\Database\\\\Driver\\:\\:\\$_connection \\(PDO\\) does not accept null\\.$#"
 			count: 2
 			path: src/Database/Driver.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.x-dev@">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/Cache/Engine/RedisEngine.php">
     <InvalidReturnStatement occurrences="4">
       <code>$this-&gt;_Redis-&gt;set($key, $value)</code>
@@ -17,468 +17,154 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Collection/CollectionTrait.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$iterator</code>
-      <code>$iterator</code>
-    </ArgumentTypeCoercion>
-    <MissingParamType occurrences="28">
-      <code>$callback</code>
-      <code>$condition</code>
-      <code>$groupPath</code>
-      <code>$idPath</code>
-      <code>$initial</code>
-      <code>$item</code>
-      <code>$item</code>
-      <code>$items</code>
-      <code>$items</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$keyPath</code>
-      <code>$nestingKey</code>
-      <code>$order</code>
-      <code>$parentPath</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$path</code>
-      <code>$value</code>
-      <code>$valuePath</code>
-      <code>$values</code>
-    </MissingParamType>
+    <InvalidArrayOffset>
+      <code>$collectionArraysCounts[$changeIndex]</code>
+      <code>$value[$keys[$index]]</code>
+    </InvalidArrayOffset>
   </file>
   <file src="src/Collection/Iterator/ZipIterator.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$set</code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/Command/Command.php">
-    <DeprecatedMethod occurrences="1">
-      <code>loadModel</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="2">
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Command/CompletionCommand.php">
-    <DeprecatedClass occurrences="1">
-      <code>\Cake\Console\Shell</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Console/CommandCollection.php">
-    <DeprecatedClass occurrences="6">
-      <code>Shell::class</code>
-      <code>\Cake\Console\CommandInterface|\Cake\Console\Shell|class-string</code>
-      <code>\Cake\Console\CommandInterface|\Cake\Console\Shell|string</code>
-      <code>\Traversable&lt;string, \Cake\Console\Shell|\Cake\Console\CommandInterface|class-string&gt;</code>
-      <code>array&lt;string, \Cake\Console\Shell|\Cake\Console\CommandInterface|string&gt;</code>
-      <code>array&lt;string, \Cake\Console\Shell|\Cake\Console\CommandInterface|string&gt;</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Console/CommandFactoryInterface.php">
-    <DeprecatedClass occurrences="1">
-      <code>\Cake\Console\Shell|\Cake\Console\CommandInterface</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Console/CommandRunner.php">
-    <DeprecatedClass occurrences="3">
-      <code>\Cake\Console\CommandInterface|\Cake\Console\Shell</code>
-      <code>\Cake\Console\CommandInterface|\Cake\Console\Shell</code>
-      <code>\Cake\Console\Shell</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Console/Shell.php">
-    <DeprecatedMethod occurrences="1">
-      <code>loadModel</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="1">
-      <code>$this-&gt;modelClass</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Console/ShellDispatcher.php">
-    <DeprecatedClass occurrences="5">
-      <code>$instance</code>
-      <code>Shell</code>
-      <code>Shell</code>
-      <code>\Cake\Console\Shell</code>
-      <code>\Cake\Console\Shell</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Console/TaskRegistry.php">
-    <DeprecatedClass occurrences="5">
-      <code>Shell</code>
-      <code>TaskRegistry</code>
-      <code>\Cake\Console\Shell</code>
-      <code>\Cake\Console\Shell</code>
-      <code>\Cake\Console\Shell</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Console/TestSuite/LegacyShellDispatcher.php">
-    <DeprecatedClass occurrences="5">
-      <code>$instance</code>
-      <code>Shell</code>
-      <code>ShellDispatcher</code>
-      <code>\Cake\Console\Shell</code>
-      <code>parent::__construct($args, $bootstrap)</code>
-    </DeprecatedClass>
+    <MissingTemplateParam>
+      <code>ZipIterator</code>
+    </MissingTemplateParam>
   </file>
   <file src="src/Controller/Component/RequestHandlerComponent.php">
-    <DeprecatedMethod occurrences="1">
-      <code>prefers</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Controller/Controller.php">
-    <DeprecatedMethod occurrences="1">
-      <code>loadModel</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="7">
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-    </DeprecatedProperty>
-    <PropertyTypeCoercion occurrences="1">
-      <code>$result</code>
-    </PropertyTypeCoercion>
-  </file>
-  <file src="src/Controller/ControllerFactory.php">
-    <ArgumentTypeCoercion occurrences="3">
-      <code>$request</code>
-      <code>$request</code>
-      <code>$request</code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/Core/TestSuite/ContainerStubTrait.php">
-    <DeprecatedClass occurrences="2">
-      <code>$this</code>
-      <code>$this</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Database/Connection.php">
-    <DeprecatedMethod occurrences="1">
-      <code>supportsDynamicConstraints</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Database/Driver.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>$value</code>
-      <code>$value</code>
-    </InvalidScalarArgument>
+    <RedundantCondition>
+      <code>is_string($type)</code>
+    </RedundantCondition>
   </file>
   <file src="src/Database/Expression/QueryExpression.php">
-    <DeprecatedClass occurrences="1">
-      <code>new CaseExpression($conditions, $values, $types)</code>
-    </DeprecatedClass>
+    <RedundantCondition>
+      <code>$typeMultiple</code>
+    </RedundantCondition>
   </file>
-  <file src="src/Database/Schema/MysqlSchemaDialect.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$_driver</code>
-    </NonInvariantDocblockPropertyType>
+  <file src="src/Database/Query.php">
+    <MissingTemplateParam>
+      <code>IteratorAggregate</code>
+    </MissingTemplateParam>
   </file>
   <file src="src/Database/Statement/PDOStatement.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$_statement</code>
-    </NonInvariantDocblockPropertyType>
+    <RedundantCondition>
+      <code><![CDATA[$property === 'queryString' && isset($this->_statement->queryString)]]></code>
+    </RedundantCondition>
   </file>
-  <file src="src/Database/Type/DateTimeType.php">
-    <DeprecatedClass occurrences="1">
-      <code>Time::class</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Database/Type/DateType.php">
-    <DeprecatedClass occurrences="1">
-      <code>Date::class</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Datasource/ModelAwareTrait.php">
-    <DeprecatedClass occurrences="1">
-      <code>$this</code>
-    </DeprecatedClass>
-    <DeprecatedProperty occurrences="4">
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-      <code>$this-&gt;modelClass</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Error/BaseErrorHandler.php">
-    <DeprecatedMethod occurrences="2">
-      <code>log</code>
-      <code>logMessage</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Error/ErrorHandler.php">
-    <DeprecatedClass occurrences="1">
-      <code>ExceptionRenderer::class</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="1">
-      <code>outputError</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Error/ErrorTrap.php">
-    <DeprecatedMethod occurrences="2">
-      <code>logMessage</code>
-      <code>logMessage</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Error/ExceptionTrap.php">
-    <DeprecatedClass occurrences="2">
-      <code>ExceptionRenderer::class</code>
-      <code>ExceptionRenderer::class</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="1">
-      <code>log</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Http/BaseApplication.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$request</code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/Http/MiddlewareQueue.php">
-    <DeprecatedClass occurrences="2">
-      <code>new DoublePassDecoratorMiddleware($middleware)</code>
-      <code>new DoublePassDecoratorMiddleware($middleware)</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Http/Response.php">
-    <DeprecatedMethod occurrences="1">
-      <code>notModified</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Http/ServerRequest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;data</code>
-    </ArgumentTypeCoercion>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;scheme()</code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="src/Http/ServerRequestFactory.php">
-    <PossiblyNullArgument occurrences="1">
-      <code>$request-&gt;scheme()</code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="src/I18n/Date.php">
-    <DeprecatedClass occurrences="2">
-      <code>MutableDate</code>
-      <code>parent::__construct($time, $tz)</code>
-    </DeprecatedClass>
+  <file src="src/Error/Renderer/ConsoleExceptionRenderer.php">
+    <InvalidArrayOffset>
+      <code>$exceptions[$i - 1]</code>
+    </InvalidArrayOffset>
   </file>
   <file src="src/I18n/DateFormatTrait.php">
-    <DeprecatedClass occurrences="5">
-      <code>$time-&gt;setTimezone($timezone)</code>
-      <code>Time::UNIX_TIMESTAMP_FORMAT</code>
-      <code>static|null</code>
-      <code>static|null</code>
-      <code>static|null</code>
-    </DeprecatedClass>
-    <MissingParamType occurrences="1">
-      <code>$format</code>
-    </MissingParamType>
+    <RedundantCondition>
+      <code>$time !== false</code>
+    </RedundantCondition>
   </file>
-  <file src="src/I18n/Time.php">
-    <DeprecatedClass occurrences="2">
-      <code>MutableDateTime</code>
-      <code>parent::__construct($time, $tz)</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/I18n/functions.php">
-    <InternalMethod occurrences="8">
-      <code>translate</code>
-      <code>translate</code>
-      <code>translate</code>
-      <code>translate</code>
-      <code>translate</code>
-      <code>translate</code>
-      <code>translate</code>
-      <code>translate</code>
-    </InternalMethod>
-  </file>
-  <file src="src/Log/Engine/ArrayLog.php">
-    <DeprecatedMethod occurrences="1">
-      <code>_format</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Log/Engine/ConsoleLog.php">
-    <DeprecatedMethod occurrences="1">
-      <code>_format</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Log/Engine/FileLog.php">
-    <DeprecatedMethod occurrences="1">
-      <code>_format</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Log/Engine/SyslogLog.php">
-    <DeprecatedMethod occurrences="1">
-      <code>_format</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Mailer/Mailer.php">
-    <DeprecatedProperty occurrences="1">
-      <code>$this-&gt;modelClass</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Mailer/Transport/SmtpTransport.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;_content</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>array{headers: string, message: string}</code>
-    </MoreSpecificReturnType>
-  </file>
-  <file src="src/ORM/Locator/LocatorAwareTrait.php">
-    <DeprecatedClass occurrences="1">
-      <code>$this</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/ORM/Locator/TableLocator.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$instances</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/ORM/Query.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$this-&gt;_repository</code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/ORM/Table.php">
-    <DeprecatedClass occurrences="6">
+  <file src="src/ORM/SaveOptionsBuilder.php">
+    <MissingTemplateParam>
       <code>SaveOptionsBuilder</code>
-      <code>\Cake\ORM\SaveOptionsBuilder</code>
-      <code>\Cake\ORM\SaveOptionsBuilder|\ArrayAccess|array</code>
-      <code>\Cake\ORM\SaveOptionsBuilder|\ArrayAccess|array</code>
-      <code>\Cake\ORM\SaveOptionsBuilder|\ArrayAccess|array</code>
-      <code>new SaveOptionsBuilder($this, $options)</code>
-    </DeprecatedClass>
+    </MissingTemplateParam>
   </file>
-  <file src="src/Routing/Middleware/RoutingMiddleware.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$request</code>
-      <code>$request</code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/Routing/Router.php">
-    <DeprecatedMethod occurrences="3">
-      <code>static::scope($path, $params, $callback)</code>
-      <code>static::scope($path, $params, $callback)</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Shell/Task/CommandTask.php">
-    <DeprecatedClass occurrences="1">
-      <code>Shell</code>
-    </DeprecatedClass>
+  <file src="src/Shell/Helper/TableHelper.php">
+    <InvalidCast>
+      <code>$v</code>
+    </InvalidCast>
   </file>
   <file src="src/TestSuite/Constraint/EventFired.php">
-    <InternalClass occurrences="1"/>
-    <InternalMethod occurrences="1"/>
+    <InternalClass>
+      <code>new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )</code>
+    </InternalClass>
+    <InternalMethod>
+      <code>new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )</code>
+    </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/EventFiredWith.php">
-    <InternalClass occurrences="2"/>
-    <InternalMethod occurrences="2"/>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/ContentType.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$response</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/CookieEncryptedEquals.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$response</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/CookieEquals.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$response</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/CookieSet.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$response</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/FileSent.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$response</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
-  <file src="src/TestSuite/Constraint/Response/FileSentAs.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$response</code>
-    </NonInvariantDocblockPropertyType>
+    <InternalClass>
+      <code>new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )</code>
+      <code><![CDATA[new AssertionFailedError(sprintf(
+                'Event "%s" was fired %d times, cannot make data assertion',
+                $other,
+                count($events)
+            ))]]></code>
+    </InternalClass>
+    <InternalMethod>
+      <code>new AssertionFailedError(
+                'The event manager you are asserting against is not configured to track events.'
+            )</code>
+      <code><![CDATA[new AssertionFailedError(sprintf(
+                'Event "%s" was fired %d times, cannot make data assertion',
+                $other,
+                count($events)
+            ))]]></code>
+    </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/Response/ResponseBase.php">
-    <InternalClass occurrences="1">
+    <InternalClass>
       <code>new AssertionFailedError('No response set, cannot assert content.')</code>
     </InternalClass>
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>new AssertionFailedError('No response set, cannot assert content.')</code>
     </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/Session/FlashParamEquals.php">
-    <InternalClass occurrences="1">
+    <InternalClass>
       <code>new AssertionFailedError($message)</code>
     </InternalClass>
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>new AssertionFailedError($message)</code>
     </InternalMethod>
   </file>
-  <file src="src/TestSuite/Fixture/FixtureInjector.php">
-    <DeprecatedInterface occurrences="1">
-      <code>FixtureInjector</code>
-    </DeprecatedInterface>
-  </file>
-  <file src="src/TestSuite/Fixture/FixtureManager.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$test-&gt;autoFixtures</code>
-      <code>$test-&gt;dropTables</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/TestSuite/IntegrationTestTrait.php">
-    <ArgumentTypeCoercion occurrences="2">
-      <code>$this-&gt;_response</code>
-      <code>$this-&gt;_response</code>
-    </ArgumentTypeCoercion>
-  </file>
-  <file src="src/TestSuite/TestCase.php">
-    <DeprecatedProperty occurrences="7">
-      <code>$this-&gt;autoFixtures</code>
-      <code>$this-&gt;autoFixtures</code>
-      <code>$this-&gt;autoFixtures</code>
-      <code>$this-&gt;autoFixtures</code>
-      <code>$this-&gt;autoFixtures</code>
-      <code>$this-&gt;dropTables</code>
-      <code>$this-&gt;dropTables</code>
-    </DeprecatedProperty>
+  <file src="src/TestSuite/Fixture/TestFixture.php">
+    <InvalidArrayOffset>
+      <code>$types[$field]</code>
+    </InvalidArrayOffset>
   </file>
   <file src="src/TestSuite/TestSuite.php">
-    <InternalClass occurrences="1">
+    <InternalClass>
       <code>BaseTestSuite</code>
     </InternalClass>
-    <InternalMethod occurrences="2">
+    <InternalMethod>
       <code>addTestFile</code>
       <code>addTestFile</code>
     </InternalMethod>
   </file>
-  <file src="src/View/Helper/NumberHelper.php">
-    <DeprecatedMethod occurrences="1">
-      <code>defaultCurrency</code>
-    </DeprecatedMethod>
+  <file src="src/Utility/Hash.php">
+    <RedundantCondition>
+      <code>is_array($_list)</code>
+    </RedundantCondition>
   </file>
-  <file src="src/View/SerializedView.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$this-&gt;_responseType</code>
-      <code>$this-&gt;_responseType</code>
-    </DeprecatedProperty>
+  <file src="src/Utility/Text.php">
+    <RedundantCast>
+      <code>(string)mb_internal_encoding()</code>
+    </RedundantCast>
+  </file>
+  <file src="src/Utility/Xml.php">
+    <TypeDoesNotContainType>
+      <code>!is_array($data)</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/View/Exception/MissingCellTemplateException.php">
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[array{name: string, file: string, paths: array<string>}]]></code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="src/View/View.php">
+    <InvalidReturnStatement>
+      <code>$config</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>array{key:string, config:string}</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/View/XmlView.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[Xml::fromArray($data, $options)->saveXML()]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>string</code>
+    </InvalidReturnType>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0"?>
 <psalm
+    errorLevel="5"
     allowStringToStandInForClass="true"
+    findUnusedPsalmSuppress="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+    resolveFromConfigFile="true"
     usePhpDocMethodsWithoutMagicCall="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    errorBaseline="psalm-baseline.xml"
     autoloader="tests/bootstrap.php"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -24,6 +24,8 @@ use Serializable;
 /**
  * A collection is an immutable list of elements with a handful of functions to
  * iterate, group, transform and extract information from it.
+ *
+ * @template-extends \IteratorIterator<mixed, mixed, \Traversable<mixed>>
  */
 class Collection extends IteratorIterator implements CollectionInterface, Serializable
 {

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -24,6 +24,8 @@ use Traversable;
  * Describes the methods a Collection should implement. A collection is an immutable
  * list of elements exposing a number of traversing and extracting method for
  * generating other collections.
+ *
+ * @template-extends \Iterator<mixed>
  */
 interface CollectionInterface extends Iterator, JsonSerializable
 {

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -25,6 +25,8 @@ use Traversable;
  * like an iterator for the original passed data after each result has been
  * processed, thus offering a transparent wrapper for results coming from any
  * source.
+ *
+ * @template-implements \IteratorAggregate<mixed>
  */
 class MapReduce implements IteratorAggregate
 {

--- a/src/Collection/Iterator/NestIterator.php
+++ b/src/Collection/Iterator/NestIterator.php
@@ -23,6 +23,8 @@ use Traversable;
 /**
  * A type of collection that is aware of nested items and exposes methods to
  * check or retrieve them
+ *
+ * @template-implements \RecursiveIterator<mixed, mixed>
  */
 class NestIterator extends Collection implements RecursiveIterator
 {

--- a/src/Collection/Iterator/NoChildrenIterator.php
+++ b/src/Collection/Iterator/NoChildrenIterator.php
@@ -23,6 +23,8 @@ use RecursiveIterator;
  * An iterator that can be used as an argument for other iterators that require
  * a RecursiveIterator but do not want children. This iterator will
  * always behave as having no nested items.
+ *
+ * @template-implements \RecursiveIterator<mixed, mixed>
  */
 class NoChildrenIterator extends Collection implements RecursiveIterator
 {

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -24,6 +24,8 @@ use RecursiveIteratorIterator;
 /**
  * A Recursive iterator used to flatten nested structures and also exposes
  * all Collection methods
+ *
+ * @template-extends \RecursiveIteratorIterator<\RecursiveIterator>
  */
 class TreeIterator extends RecursiveIteratorIterator implements CollectionInterface
 {

--- a/src/Collection/Iterator/TreePrinter.php
+++ b/src/Collection/Iterator/TreePrinter.php
@@ -24,6 +24,8 @@ use RecursiveIteratorIterator;
 /**
  * Iterator for flattening elements in a tree structure while adding some
  * visual markers for their relative position in the tree
+ *
+ * @template-extends \RecursiveIteratorIterator<\RecursiveIterator>
  */
 class TreePrinter extends RecursiveIteratorIterator implements CollectionInterface
 {

--- a/src/Collection/Iterator/UnfoldIterator.php
+++ b/src/Collection/Iterator/UnfoldIterator.php
@@ -26,6 +26,8 @@ use Traversable;
  *
  * @internal
  * @see \Cake\Collection\Collection::unfold()
+ * @template-implements \RecursiveIterator<mixed, mixed>
+ * @template-extends \IteratorIterator<mixed, mixed, \Traversable<mixed, mixed>>
  */
 class UnfoldIterator extends IteratorIterator implements RecursiveIterator
 {

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -28,6 +28,8 @@ use Traversable;
  * Used by Applications to specify their console commands.
  * CakePHP will use the mapped commands to construct and dispatch
  * shell commands.
+ *
+ * @template-implements \IteratorAggregate<string, \Cake\Console\CommandInterface|\Cake\Console\Shell|class-string<\Cake\Console\CommandInterface>>
  */
 class CommandCollection implements IteratorAggregate, Countable
 {
@@ -127,7 +129,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * Get the target for a command.
      *
      * @param string $name The named shell.
-     * @return \Cake\Console\CommandInterface|\Cake\Console\Shell|string Either the command class or an instance.
+     * @return \Cake\Console\CommandInterface|\Cake\Console\Shell|class-string<\Cake\Console\CommandInterface> Either the command class or an instance.
      * @throws \InvalidArgumentException when unknown commands are fetched.
      * @psalm-return \Cake\Console\CommandInterface|\Cake\Console\Shell|class-string
      */
@@ -144,7 +146,7 @@ class CommandCollection implements IteratorAggregate, Countable
      * Implementation of IteratorAggregate.
      *
      * @return \Traversable
-     * @psalm-return \Traversable<string, \Cake\Console\Shell|\Cake\Console\CommandInterface|class-string>
+     * @psalm-return \Traversable<string, (\Cake\Console\CommandInterface|\Cake\Console\Shell|class-string<\Cake\Console\CommandInterface>)>
      */
     public function getIterator(): Traversable
     {

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -39,7 +39,8 @@ use Traversable;
  * @see \Cake\Controller\ComponentRegistry
  * @see \Cake\View\HelperRegistry
  * @see \Cake\Console\TaskRegistry
- * @template TObject
+ * @template TObject of object
+ * @template-implements \IteratorAggregate<string, TObject>
  */
 abstract class ObjectRegistry implements Countable, IteratorAggregate
 {
@@ -336,7 +337,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      * @param object $object instance to store in the registry
      * @return $this
      * @psalm-param TObject $object
-     * @psalm-suppress MoreSpecificReturnType
      */
     public function set(string $name, object $object)
     {
@@ -351,7 +351,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         }
         $this->_loaded[$objName] = $object;
 
-        /** @psalm-suppress LessSpecificReturnStatement */
         return $this;
     }
 
@@ -362,7 +361,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
      *
      * @param string $name The name of the object to remove from the registry.
      * @return $this
-     * @psalm-suppress MoreSpecificReturnType
      */
     public function unload(string $name)
     {
@@ -377,7 +375,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         }
         unset($this->_loaded[$name]);
 
-        /** @psalm-suppress LessSpecificReturnStatement */
         return $this;
     }
 

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -35,6 +35,8 @@ use Iterator;
  *
  * While its implementation supported nested iteration it does not
  * support using `continue` or `break` inside loops.
+ *
+ * @template-implements \Iterator<string, \Cake\Core\PluginInterface>
  */
 class PluginCollection implements Iterator, Countable
 {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -881,7 +881,6 @@ class Query implements ExpressionInterface, IteratorAggregate
      * to use for joining.
      * @param string $type the join type to use
      * @return array
-     * @psalm-suppress InvalidReturnType
      */
     protected function _makeJoin($table, $conditions, $type): array
     {
@@ -894,7 +893,6 @@ class Query implements ExpressionInterface, IteratorAggregate
 
         /**
          * @psalm-suppress InvalidArrayOffset
-         * @psalm-suppress InvalidReturnStatement
          */
         return [
             $alias => [
@@ -2440,7 +2438,6 @@ class Query implements ExpressionInterface, IteratorAggregate
                             }
                         }
                     } elseif ($piece instanceof ExpressionInterface) {
-                        /** @psalm-suppress PossiblyUndefinedMethod */
                         $this->_parts[$name][$i] = clone $piece;
                     }
                 }

--- a/src/Database/SchemaCache.php
+++ b/src/Database/SchemaCache.php
@@ -62,7 +62,6 @@ class SchemaCache
         }
 
         foreach ($tables as $table) {
-            /** @psalm-suppress PossiblyNullArgument */
             $this->_schema->describe($table, ['forceRefresh' => true]);
         }
 
@@ -86,7 +85,6 @@ class SchemaCache
         $cacher = $this->_schema->getCacher();
 
         foreach ($tables as $table) {
-            /** @psalm-suppress PossiblyNullArgument */
             $key = $this->_schema->cacheKey($table);
             $cacher->delete($key);
         }

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -26,6 +26,8 @@ use Iterator;
  *
  * This statement decorator will save fetched results in memory, allowing
  * the iterator to be rewound and reused.
+ *
+ * @template-implements \Iterator<mixed>
  */
 class BufferedStatement implements Iterator, StatementInterface
 {

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -56,7 +56,6 @@ class PDOStatement extends StatementDecorator
     public function __get(string $property)
     {
         if ($property === 'queryString' && isset($this->_statement->queryString)) {
-            /** @psalm-suppress NoInterfaceProperties */
             return $this->_statement->queryString;
         }
 

--- a/src/Database/Statement/SqlserverStatement.php
+++ b/src/Database/Statement/SqlserverStatement.php
@@ -45,7 +45,6 @@ class SqlserverStatement extends PDOStatement
             [$value, $type] = $this->cast($value, $type);
         }
         if ($type === PDO::PARAM_LOB) {
-            /** @psalm-suppress UndefinedConstant */
             $this->_statement->bindParam($column, $value, $type, 0, PDO::SQLSRV_ENCODING_BINARY);
         } else {
             $this->_statement->bindValue($column, $value, $type);

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -32,6 +32,7 @@ use IteratorAggregate;
  * PDOStatement.
  *
  * @property-read string $queryString
+ * @template-implements \IteratorAggregate<string, \Cake\Database\StatementInterface>
  */
 class StatementDecorator implements StatementInterface, Countable, IteratorAggregate
 {
@@ -336,7 +337,6 @@ class StatementDecorator implements StatementInterface, Countable, IteratorAggre
                 /** @psalm-suppress InvalidOperand */
                 $index += $offset;
             }
-            /** @psalm-suppress InvalidScalarArgument */
             $this->bindValue($index, $value, $type);
         }
     }

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -25,6 +25,7 @@ use JsonSerializable;
  *
  * @property mixed $id Alias for commonly used primary key.
  * @method bool[] getAccessible() Accessible configuration for this entity.
+ * @template-extends \ArrayAccess<string, mixed>
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable
 {

--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -22,6 +22,9 @@ use Countable;
 /**
  * Generic ResultSet decorator. This will make any traversable object appear to
  * be a database result
+ *
+ * @template T of \Cake\Datasource\EntityInterface|array
+ * @implements \Cake\Datasource\ResultSetInterface<T>
  */
 class ResultSetDecorator extends Collection implements ResultSetInterface
 {

--- a/src/Event/EventList.php
+++ b/src/Event/EventList.php
@@ -21,6 +21,8 @@ use Countable;
 
 /**
  * The Event List
+ *
+ * @template-implements \ArrayAccess<int, \Cake\Event\EventInterface>
  */
 class EventList implements ArrayAccess, Countable
 {
@@ -69,7 +71,7 @@ class EventList implements ArrayAccess, Countable
      *
      * @link https://secure.php.net/manual/en/arrayaccess.offsetget.php
      * @param mixed $offset The offset to retrieve.
-     * @return mixed Can return all value types.
+     * @return \Cake\Event\EventInterface|null Can return all value types.
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)

--- a/src/Event/EventList.php
+++ b/src/Event/EventList.php
@@ -71,7 +71,7 @@ class EventList implements ArrayAccess, Countable
      *
      * @link https://secure.php.net/manual/en/arrayaccess.offsetget.php
      * @param mixed $offset The offset to retrieve.
-     * @return \Cake\Event\EventInterface|null Can return all value types.
+     * @return \Cake\Event\EventInterface|null
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)

--- a/src/Http/CallbackStream.php
+++ b/src/Http/CallbackStream.php
@@ -40,7 +40,6 @@ class CallbackStream extends BaseCallbackStream
     {
         $callback = $this->detach();
         $result = '';
-        /** @psalm-suppress TypeDoesNotContainType */
         if ($callback !== null) {
             $result = $callback();
         }

--- a/src/Http/Client/Adapter/Stream.php
+++ b/src/Http/Client/Adapter/Stream.php
@@ -314,7 +314,6 @@ class Stream implements AdapterInterface
             return true;
         });
         try {
-            /** @psalm-suppress PossiblyNullArgument */
             $this->_stream = fopen($url, 'rb', false, $this->_context);
         } finally {
             restore_error_handler();

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -35,6 +35,8 @@ use function Cake\Core\triggerWarning;
  *
  * Provides an immutable collection of cookies objects. Adding or removing
  * to a collection returns a *new* collection that you must retain.
+ *
+ * @template-implements \IteratorAggregate<string, \Cake\Http\Cookie\CookieInterface>
  */
 class CookieCollection implements IteratorAggregate, Countable
 {

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -232,7 +232,6 @@ class ResponseEmitter implements EmitterInterface
         }
 
         if (PHP_VERSION_ID >= 70300) {
-            /** @psalm-suppress InvalidArgument */
             return setcookie($cookie->getName(), $cookie->getScalarValue(), $cookie->getOptions());
         }
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -1799,7 +1799,6 @@ class ServerRequest implements ServerRequestInterface
      *   request-target forms allowed in request messages)
      * @param string $requestTarget The request target.
      * @return static
-     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function withRequestTarget($requestTarget)
     {

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -71,7 +71,6 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             $uri->getUri();
         }
 
-        /** @psalm-suppress NoInterfaceProperties */
         $sessionConfig = (array)Configure::read('Session') + [
             'defaults' => 'php',
             'cookiePath' => $webroot,

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -527,7 +527,6 @@ class Session
             $data = Hash::insert($data, $key, $val);
         }
 
-        /** @psalm-suppress PossiblyNullArgument */
         $this->_overwrite($_SESSION, $data);
     }
 

--- a/src/I18n/Parser/PoFileParser.php
+++ b/src/I18n/Parser/PoFileParser.php
@@ -94,7 +94,6 @@ class PoFileParser
             } elseif (substr($line, 0, 7) === 'msgid "') {
                 // We start a new msg so save previous
                 $this->_addMessage($messages, $item);
-                /** @psalm-suppress InvalidArrayOffset */
                 $item['ids']['singular'] = substr($line, 7, -1);
                 $stage = ['ids', 'singular'];
             } elseif (substr($line, 0, 8) === 'msgstr "') {
@@ -124,7 +123,6 @@ class PoFileParser
                         break;
                 }
             } elseif (substr($line, 0, 14) === 'msgid_plural "') {
-                /** @psalm-suppress InvalidArrayOffset */
                 $item['ids']['plural'] = substr($line, 14, -1);
                 $stage = ['ids', 'plural'];
             } elseif (substr($line, 0, 7) === 'msgstr[') {

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -80,7 +80,6 @@ class LogEngineRegistry extends ObjectRegistry
         }
 
         if (!isset($instance)) {
-            /** @psalm-suppress UndefinedClass */
             $instance = new $class($config);
         }
 

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -31,6 +31,8 @@ use function Cake\Core\pluginSplit;
  *
  * Contains methods for managing associations, and
  * ordering operations around saving and deleting.
+ *
+ * @template-implements \IteratorAggregate<string, \Cake\ORM\Association>
  */
 class AssociationCollection implements IteratorAggregate
 {

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -267,7 +267,6 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                     return $c;
                 }
 
-                /** @psalm-suppress ParadoxicalCondition */
                 if (in_array($field, $fields, true)) {
                     $joinRequired = true;
                     $field = "$alias.$field";
@@ -324,7 +323,6 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                     return;
                 }
 
-                /** @psalm-suppress ParadoxicalCondition */
                 if (in_array($field, $mainTableFields, true)) {
                     $expression->setField("$mainTableAlias.$field");
                 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -661,7 +661,6 @@ class Marshaller
      * @param array<string, mixed> $options List of options.
      * @return array<\Cake\Datasource\EntityInterface>
      * @see \Cake\ORM\Entity::$_accessible
-     * @psalm-suppress NullArrayOffset
      */
     public function mergeMany(iterable $entities, array $data, array $options = []): array
     {
@@ -757,7 +756,6 @@ class Marshaller
         $types = [Association::ONE_TO_ONE, Association::MANY_TO_ONE];
         $type = $assoc->type();
         if (in_array($type, $types, true)) {
-            /** @psalm-suppress PossiblyInvalidArgument, ArgumentTypeCoercion */
             return $marshaller->merge($original, $value, $options);
         }
         if ($type === Association::MANY_TO_MANY) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -223,7 +223,6 @@ class FixtureManager
             } else {
                 /** @psalm-var class-string<\Cake\Datasource\FixtureInterface> */
                 $className = $fixture;
-                /** @psalm-suppress PossiblyFalseArgument */
                 $name = preg_replace('/Fixture\z/', '', substr(strrchr($fixture, '\\'), 1));
             }
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -210,9 +210,6 @@ abstract class TestCase extends BaseTestCase
         /** @var bool $deprecation */
         $deprecation = false;
 
-        /**
-         * @psalm-suppress InvalidArgument
-         */
         $previousHandler = set_error_handler(
             function ($code, $message, $file, $line, $context = null) use (&$previousHandler, &$deprecation): bool {
                 if ($code == E_USER_DEPRECATED) {
@@ -765,7 +762,6 @@ abstract class TestCase extends BaseTestCase
                 continue;
             }
             foreach ($tags as $tag => $attributes) {
-                /** @psalm-suppress PossiblyFalseArgument */
                 $regex[] = [
                     sprintf('Open %s tag', $tag),
                     sprintf('[\s]*<%s', preg_quote($tag, '/')),
@@ -812,7 +808,6 @@ abstract class TestCase extends BaseTestCase
                         'attrs' => $attrs,
                     ];
                 }
-                /** @psalm-suppress PossiblyFalseArgument */
                 $regex[] = [
                     sprintf('End %s tag', $tag),
                     '[\s]*\/?[\s]*>[\n\r]*',
@@ -835,7 +830,6 @@ abstract class TestCase extends BaseTestCase
             }
 
             // If 'attrs' is not present then the array is just a regular int-offset one
-            /** @psalm-suppress PossiblyUndefinedArrayOffset */
             [$description, $expressions, $itemNum] = $assertion;
             $expression = '';
             foreach ((array)$expressions as $expression) {

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -475,7 +475,6 @@ class Xml
             }
 
             foreach ($xml->children($namespace, true) as $child) {
-                /** @psalm-suppress PossiblyNullArgument */
                 static::_toArray($child, $data, $namespace, $namespaces);
             }
         }

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -25,6 +25,9 @@ use Traversable;
 /**
  * ValidationSet object. Holds all validation rules for a field and exposes
  * methods to dynamically add or remove validation rules
+ *
+ * @template-implements \ArrayAccess<string, \Cake\Validation\ValidationRule>
+ * @template-implements \IteratorAggregate<string, \Cake\Validation\ValidationRule>
  */
 class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
 {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -34,6 +34,8 @@ use function Cake\I18n\__d;
  * Implements ArrayAccess to easily modify rules in the set
  *
  * @link https://book.cakephp.org/4/en/core-libraries/validation.html
+ * @template-implements \ArrayAccess<string, \Cake\Validation\ValidationSet>
+ * @template-implements \IteratorAggregate<string, \Cake\Validation\ValidationSet>
  */
 class Validator implements ArrayAccess, IteratorAggregate, Countable
 {

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -245,7 +245,6 @@ abstract class Cell implements EventDispatcherInterface
             return $default;
         }
 
-        /** @psalm-suppress PossiblyFalseOperand */
         return $this->_cache + $default;
     }
 

--- a/src/View/Exception/MissingCellTemplateException.php
+++ b/src/View/Exception/MissingCellTemplateException.php
@@ -56,7 +56,7 @@ class MissingCellTemplateException extends MissingTemplateException
      * Get the passed in attributes
      *
      * @return array
-     * @psalm-return array{name: string, file: string, paths: array}
+     * @psalm-return array{name: string, file: string, paths: array<string>}
      */
     public function getAttributes(): array
     {

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -87,7 +87,7 @@ class MissingTemplateException extends CakeException
      * Get the passed in attributes
      *
      * @return array
-     * @psalm-return array{file: string, paths: array}
+     * @psalm-return array{file: string, paths: array<string>}
      */
     public function getAttributes(): array
     {

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -95,6 +95,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         if (isset($this->_loaded[$name])) {
             return $this->_loaded[$name];
         }
+        /** @psalm-suppress NoValue */
         if (isset($this->{$name})) {
             return $this->_loaded[$name];
         }

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -126,7 +126,7 @@ class RadioWidget extends BasicWidget
      * Disabled attribute detection.
      *
      * @param array<string, mixed> $radio Radio info.
-     * @param array|true|null $disabled The disabled values.
+     * @param array|true|string|null $disabled The disabled values.
      * @return bool
      */
     protected function _isDisabled(array $radio, $disabled): bool

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -136,7 +136,6 @@ class XmlView extends SerializedView
                 $data &&
                 (!is_array($data) || Hash::numeric(array_keys($data)))
             ) {
-                /** @psalm-suppress InvalidArrayOffset */
                 $data = [$rootNode => [$serialize => $data]];
             }
         }


### PR DESCRIPTION
Tried to go on the same level 4 as Cake 5 but psalm level 5 already showed some false positives (imho)

Most of these changes are 
- removed `@psalm-suppress` and
- added `@template-implements` or `@template-extends` (which I mainly copied from the `5.x` branch)


