### PR TITLE
5.x - Fix SQL Server schema not recognizing unique indexes as unique.

### DIFF
--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -303,7 +303,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         if ($row['is_primary_key']) {
             $name = $type = TableSchema::CONSTRAINT_PRIMARY;
         }
-        if ($row['is_unique_constraint'] && $type === TableSchema::INDEX_INDEX) {
+        if (($row['is_unique'] || $row['is_unique_constraint']) && $type === TableSchema::INDEX_INDEX) {
             $type = TableSchema::CONSTRAINT_UNIQUE;
         }
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -283,13 +283,15 @@ SQL;
                 title VARCHAR(20) COMMENT 'A title',
                 body TEXT,
                 author_id INT NOT NULL,
+                unique_id INT NOT NULL,
                 published BOOLEAN DEFAULT 0,
                 allow_comments TINYINT(1) DEFAULT 0,
                 created DATETIME,
                 created_with_precision DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
                 KEY `author_idx` (`author_id`),
-                UNIQUE KEY `length_idx` (`title`(4)),
-                FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT
+                CONSTRAINT `length_idx` UNIQUE KEY(`title`(4)),
+                FOREIGN KEY `author_idx` (`author_id`) REFERENCES `schema_authors`(`id`) ON UPDATE CASCADE ON DELETE RESTRICT,
+                UNIQUE INDEX `unique_id_idx` (`unique_id`)
             ) ENGINE=InnoDB COLLATE=utf8_general_ci
 SQL;
         $connection->execute($table);
@@ -448,7 +450,7 @@ SQL;
         $result = $schema->describe('schema_articles');
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
 
-        $this->assertCount(3, $result->constraints());
+        $this->assertCount(4, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -470,6 +472,13 @@ SQL;
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],
+            'unique_id_idx' => [
+                'type' => 'unique',
+                'columns' => [
+                    'unique_id',
+                ],
+                'length' => [],
+            ],
         ];
 
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
@@ -479,6 +488,7 @@ SQL;
         } else {
             $this->assertEquals($expected['schema_articles_ibfk_1'], $result->getConstraint('schema_articles_ibfk_1'));
         }
+        $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -71,6 +71,7 @@ id BIGINT PRIMARY KEY,
 title VARCHAR(20),
 body TEXT,
 author_id INTEGER NOT NULL,
+unique_id INTEGER NOT NULL,
 published BOOLEAN DEFAULT false,
 views SMALLINT DEFAULT 0,
 readingtime TIME,
@@ -88,6 +89,7 @@ SQL;
         $connection->execute($table);
         $connection->execute('COMMENT ON COLUMN "schema_articles"."title" IS \'a title\'');
         $connection->execute('CREATE INDEX "author_idx" ON "schema_articles" ("author_id")');
+        $connection->execute('CREATE UNIQUE INDEX "unique_id_idx" ON "schema_articles" ("unique_id")');
 
         $table = <<<SQL
 CREATE VIEW schema_articles_v AS
@@ -586,19 +588,8 @@ SQL;
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_articles');
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
-        $expected = [
-            'primary' => [
-                'type' => 'primary',
-                'columns' => ['id'],
-                'length' => [],
-            ],
-            'content_idx' => [
-                'type' => 'unique',
-                'columns' => ['title', 'body'],
-                'length' => [],
-            ],
-        ];
-        $this->assertCount(3, $result->constraints());
+
+        $this->assertCount(4, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -618,10 +609,18 @@ SQL;
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],
+            'unique_id_idx' => [
+                'type' => 'unique',
+                'columns' => [
+                    'unique_id',
+                ],
+                'length' => [],
+            ],
         ];
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals($expected['content_idx'], $result->getConstraint('content_idx'));
         $this->assertEquals($expected['author_idx'], $result->getConstraint('author_idx'));
+        $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -248,6 +248,7 @@ id INTEGER PRIMARY KEY AUTOINCREMENT,
 title VARCHAR(20) DEFAULT 'Let ''em eat cake',
 body TEXT,
 author_id INT(11) NOT NULL,
+unique_id INT(11) NOT NULL,
 published BOOLEAN DEFAULT 0,
 created DATETIME,
 field1 VARCHAR(10) DEFAULT NULL,
@@ -258,6 +259,7 @@ CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("
 SQL;
         $connection->execute($table);
         $connection->execute('CREATE INDEX "created_idx" ON "schema_articles" ("created")');
+        $connection->execute('CREATE UNIQUE INDEX "unique_id_idx" ON "schema_articles" ("unique_id")');
 
         $sql = <<<SQL
 CREATE TABLE schema_composite (
@@ -466,8 +468,15 @@ SQL;
                 'update' => 'cascade',
                 'delete' => 'restrict',
             ],
+            'unique_id_idx' => [
+                'type' => 'unique',
+                'columns' => [
+                    'unique_id',
+                ],
+                'length' => [],
+            ],
         ];
-        $this->assertCount(3, $result->constraints());
+        $this->assertCount(4, $result->constraints());
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals(
             $expected['sqlite_autoindex_schema_articles_1'],
@@ -477,6 +486,7 @@ SQL;
             $expected['author_id_fk'],
             $result->getConstraint('author_id_fk')
         );
+        $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -67,6 +67,7 @@ id BIGINT PRIMARY KEY,
 title NVARCHAR(20) COLLATE Japanese_Unicode_CI_AI DEFAULT N'無題' COLLATE Japanese_Unicode_CI_AI,
 body NVARCHAR(1000) DEFAULT N'本文なし',
 author_id INTEGER NOT NULL,
+unique_id INTEGER NOT NULL,
 published BIT DEFAULT 0,
 views SMALLINT DEFAULT 0,
 created DATETIME,
@@ -78,7 +79,8 @@ field1 VARCHAR(10) DEFAULT NULL,
 field2 VARCHAR(10) DEFAULT 'NULL',
 field3 VARCHAR(10) DEFAULT 'O''hare',
 CONSTRAINT [content_idx] UNIQUE ([title], [body]),
-CONSTRAINT [author_idx] FOREIGN KEY ([author_id]) REFERENCES [schema_authors] ([id]) ON DELETE CASCADE ON UPDATE CASCADE
+CONSTRAINT [author_idx] FOREIGN KEY ([author_id]) REFERENCES [schema_authors] ([id]) ON DELETE CASCADE ON UPDATE CASCADE,
+INDEX [unique_id_idx] UNIQUE ([unique_id])
 )
 SQL;
         $connection->execute($table);
@@ -548,8 +550,9 @@ SQL;
 
         $schema = new SchemaCollection($connection);
         $result = $schema->describe('schema_articles');
+
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);
-        $this->assertCount(3, $result->constraints());
+        $this->assertCount(4, $result->constraints());
         $expected = [
             'primary' => [
                 'type' => 'primary',
@@ -569,10 +572,18 @@ SQL;
                 'update' => 'cascade',
                 'delete' => 'cascade',
             ],
+            'unique_id_idx' => [
+                'type' => 'unique',
+                'columns' => [
+                    'unique_id',
+                ],
+                'length' => [],
+            ],
         ];
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals($expected['content_idx'], $result->getConstraint('content_idx'));
         $this->assertEquals($expected['author_idx'], $result->getConstraint('author_idx'));
+        $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
 
         $this->assertCount(1, $result->indexes());
         $expected = [


### PR DESCRIPTION
This aligns the behavior with that of the other DBMS' schema introspections, where unique indexes are already treated as unique constraints.

SQL Server stores unique indexes in `sys.indexes` as `is_unique = 1` and `is_unique_constraint = 0`.

https://dbfiddle.uk/ZYUiJthc
