### PR TITLE
4.next: fix DateType not properly handling ChronosDate instances with different timezones

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Chronos\Chronos;
 use Cake\Database\DriverInterface;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\I18nDateTimeInterface;
@@ -319,10 +318,6 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      */
     public function marshal($value): ?DateTimeInterface
     {
-        if ($value instanceof Chronos) {
-            return $value;
-        }
-
         if ($value instanceof DateTimeInterface) {
             if ($value instanceof DateTime) {
                 $value = clone $value;

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
+use Cake\Chronos\Chronos;
 use Cake\Database\DriverInterface;
 use Cake\I18n\FrozenTime;
 use Cake\I18n\I18nDateTimeInterface;
@@ -318,6 +319,10 @@ class DateTimeType extends BaseType implements BatchCastingInterface
      */
     public function marshal($value): ?DateTimeInterface
     {
+        if ($value instanceof Chronos) {
+            return $value;
+        }
+
         if ($value instanceof DateTimeInterface) {
             if ($value instanceof DateTime) {
                 $value = clone $value;

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
+use Cake\Chronos\ChronosDate;
 use Cake\I18n\Date;
 use Cake\I18n\FrozenDate;
 use Cake\I18n\I18nDateTimeInterface;
@@ -104,6 +105,10 @@ class DateType extends DateTimeType
      */
     public function marshal($value): ?DateTimeInterface
     {
+        if ($value instanceof ChronosDate) {
+            return $value;
+        }
+
         if ($value instanceof DateTimeInterface) {
             return new FrozenDate('@' . $value->getTimestamp());
         }

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Type;
 
-use Cake\Chronos\ChronosDate;
 use Cake\I18n\Date;
 use Cake\I18n\FrozenDate;
 use Cake\I18n\I18nDateTimeInterface;
@@ -105,12 +104,8 @@ class DateType extends DateTimeType
      */
     public function marshal($value): ?DateTimeInterface
     {
-        if ($value instanceof ChronosDate) {
-            return $value;
-        }
-
         if ($value instanceof DateTimeInterface) {
-            return new FrozenDate('@' . $value->getTimestamp());
+            return new FrozenDate($value);
         }
 
         /** @var class-string<\Cake\Chronos\ChronosDate> $class */

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -46,6 +46,11 @@ class DateTimeTypeTest extends TestCase
     protected $_originalMap = [];
 
     /**
+     * @var string
+     */
+    protected $originalTimeZone;
+
+    /**
      * Setup
      */
     public function setUp(): void
@@ -59,6 +64,18 @@ class DateTimeTypeTest extends TestCase
             'src/I18n/Time.php',
             'tests/TestCase/Database/Type/DateTimeTypeTest.php',
         ]);
+        $this->originalTimeZone = date_default_timezone_get();
+    }
+
+    /**
+     * Reset timezone to its initial value
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        date_default_timezone_set($this->originalTimeZone);
     }
 
     /**
@@ -203,78 +220,7 @@ class DateTimeTypeTest extends TestCase
             'src/I18n/Time.php',
         ]);
 
-        $data = $this->dateTimeArray();
-
-        Configure::delete('Error.ignoredDeprecationPaths');
-
-        return $data;
-    }
-
-    /**
-     * Data provider for marshal()
-     *
-     * @return array
-     */
-    public function marshalWithTimezoneProvider(): array
-    {
-        Configure::write('Error.ignoredDeprecationPaths', [
-            'src/I18n/Time.php',
-        ]);
-
-        $defaultTimezone = date_default_timezone_get();
-        date_default_timezone_set('Europe/Vienna');
-        $data = $this->dateTimeArray();
-        Configure::delete('Error.ignoredDeprecationPaths');
-        date_default_timezone_set($defaultTimezone);
-
-        return $data;
-    }
-
-    /**
-     * test marshalling data.
-     *
-     * @dataProvider marshalProvider
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testMarshal($value, $expected): void
-    {
-        $result = $this->type->marshal($value);
-        if (is_object($expected)) {
-            $this->assertEquals($expected, $result);
-        } else {
-            $this->assertSame($expected, $result);
-        }
-    }
-
-    /**
-     * test marshalling data with different timezone
-     *
-     * @dataProvider marshalWithTimezoneProvider
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testMarshalWithTimezone($value, $expected): void
-    {
-        $defaultTimezone = date_default_timezone_get();
-        date_default_timezone_set('Europe/Vienna');
-        $result = $this->type->marshal($value);
-        if (is_object($expected)) {
-            $this->assertEquals($expected, $result);
-        } else {
-            $this->assertSame($expected, $result);
-        }
-        date_default_timezone_set($defaultTimezone);
-    }
-
-    /**
-     * Helper method which is used by both marshalProvider and marshalWithTimezoneProvider
-     *
-     * @return array
-     */
-    protected function dateTimeArray(): array
-    {
-        return [
+        $data = [
             // invalid types.
             [null, null],
             [false, null],
@@ -360,6 +306,39 @@ class DateTimeTypeTest extends TestCase
                 Time::now(),
             ],
         ];
+
+        Configure::delete('Error.ignoredDeprecationPaths');
+
+        return $data;
+    }
+
+    /**
+     * test marshalling data.
+     *
+     * @dataProvider marshalProvider
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testMarshal($value, $expected): void
+    {
+        $result = $this->type->marshal($value);
+        if (is_object($expected)) {
+            $this->assertEquals($expected, $result);
+        } else {
+            $this->assertSame($expected, $result);
+        }
+    }
+
+    /**
+     * test marshalling data with different timezone
+     */
+    public function testMarshalWithTimezone(): void
+    {
+        date_default_timezone_set('Europe/Vienna');
+        $value = Time::now();
+        $expected = Time::now();
+        $result = $this->type->marshal($value);
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -203,7 +203,78 @@ class DateTimeTypeTest extends TestCase
             'src/I18n/Time.php',
         ]);
 
-        $data = [
+        $data = $this->dateTimeArray();
+
+        Configure::delete('Error.ignoredDeprecationPaths');
+
+        return $data;
+    }
+
+    /**
+     * Data provider for marshal()
+     *
+     * @return array
+     */
+    public function marshalWithTimezoneProvider(): array
+    {
+        Configure::write('Error.ignoredDeprecationPaths', [
+            'src/I18n/Time.php',
+        ]);
+
+        $defaultTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Vienna');
+        $data = $this->dateTimeArray();
+        Configure::delete('Error.ignoredDeprecationPaths');
+        date_default_timezone_set($defaultTimezone);
+
+        return $data;
+    }
+
+    /**
+     * test marshalling data.
+     *
+     * @dataProvider marshalProvider
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testMarshal($value, $expected): void
+    {
+        $result = $this->type->marshal($value);
+        if (is_object($expected)) {
+            $this->assertEquals($expected, $result);
+        } else {
+            $this->assertSame($expected, $result);
+        }
+    }
+
+    /**
+     * test marshalling data with different timezone
+     *
+     * @dataProvider marshalWithTimezoneProvider
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testMarshalWithTimezone($value, $expected): void
+    {
+        $defaultTimezone = date_default_timezone_get();
+        date_default_timezone_set('Europe/Vienna');
+        $result = $this->type->marshal($value);
+        if (is_object($expected)) {
+            $this->assertEquals($expected, $result);
+        } else {
+            $this->assertSame($expected, $result);
+        }
+        date_default_timezone_set($defaultTimezone);
+    }
+
+    /**
+     * Helper method which is used by both marshalProvider and marshalWithTimezoneProvider
+     *
+     * @return array
+     */
+    protected function dateTimeArray(): array
+    {
+        return [
             // invalid types.
             [null, null],
             [false, null],
@@ -289,27 +360,6 @@ class DateTimeTypeTest extends TestCase
                 Time::now(),
             ],
         ];
-
-        Configure::delete('Error.ignoredDeprecationPaths');
-
-        return $data;
-    }
-
-    /**
-     * test marshalling data.
-     *
-     * @dataProvider marshalProvider
-     * @param mixed $value
-     * @param mixed $expected
-     */
-    public function testMarshal($value, $expected): void
-    {
-        $result = $this->type->marshal($value);
-        if (is_object($expected)) {
-            $this->assertEquals($expected, $result);
-        } else {
-            $this->assertSame($expected, $result);
-        }
     }
 
     /**

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -131,78 +131,7 @@ class DateTypeTest extends TestCase
         Configure::write('Error.ignoredDeprecationPaths', [
             'src/I18n/Date.php',
         ]);
-
-        $date = new ChronosDate('@1392387900');
-
-        $data = [
-            // invalid types.
-            [null, null],
-            [false, null],
-            [true, null],
-            ['', null],
-            ['derpy', null],
-            ['2013-nope!', null],
-            ['2014-02-14 13:14:15', null],
-
-            // valid string types
-            ['1392387900', $date],
-            [1392387900, $date],
-            ['2014-02-14', new ChronosDate('2014-02-14')],
-
-            // valid array types
-            [
-                ['year' => '', 'month' => '', 'day' => ''],
-                null,
-            ],
-            [
-                ['year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 13, 'minute' => 14, 'second' => 15],
-                new ChronosDate('2014-02-14'),
-            ],
-            [
-                [
-                    'year' => 2014, 'month' => 2, 'day' => 14,
-                    'hour' => 1, 'minute' => 14, 'second' => 15,
-                    'meridian' => 'am',
-                ],
-                new ChronosDate('2014-02-14'),
-            ],
-            [
-                [
-                    'year' => 2014, 'month' => 2, 'day' => 14,
-                    'hour' => 1, 'minute' => 14, 'second' => 15,
-                    'meridian' => 'pm',
-                ],
-                new ChronosDate('2014-02-14'),
-            ],
-            [
-                [
-                    'year' => 2014, 'month' => 2, 'day' => 14,
-                ],
-                new ChronosDate('2014-02-14'),
-            ],
-            [
-                new FrozenDate('2023-04-26'),
-                new ChronosDate('2023-04-26'),
-            ],
-
-            // Invalid array types
-            [
-                ['year' => 'farts', 'month' => 'derp'],
-                null,
-            ],
-            [
-                ['year' => 'farts', 'month' => 'derp', 'day' => 'farts'],
-                null,
-            ],
-            [
-                [
-                    'year' => '2014', 'month' => '02', 'day' => '14',
-                    'hour' => 'farts', 'minute' => 'farts',
-                ],
-                new ChronosDate('2014-02-14'),
-            ],
-        ];
-
+        $data = $this->dateArray();
         Configure::delete('Error.ignoredDeprecationPaths');
 
         return $data;
@@ -221,9 +150,23 @@ class DateTypeTest extends TestCase
 
         $defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Vienna');
+        $data = $this->dateArray();
+        Configure::delete('Error.ignoredDeprecationPaths');
+        date_default_timezone_set($defaultTimezone);
+
+        return $data;
+    }
+
+    /**
+     * Helper method which is used by both marshalProvider and marshalWithTimezoneProvider
+     *
+     * @return array
+     */
+    protected function dateArray(): array
+    {
         $date = new ChronosDate('@1392387900');
 
-        $data = [
+        return [
             // invalid types.
             [null, null],
             [false, null],
@@ -291,11 +234,6 @@ class DateTypeTest extends TestCase
                 new ChronosDate('2014-02-14'),
             ],
         ];
-
-        Configure::delete('Error.ignoredDeprecationPaths');
-        date_default_timezone_set($defaultTimezone);
-
-        return $data;
     }
 
     /**


### PR DESCRIPTION
After upgrading to current `4.next` one of my tests was broken because one of the dates was offset by one day.

After some debugging I realized, that these 2 entities would result in 2 different dates being saved
``` php
$table = $this->fetchTable('AlfredStandBy.StandByEntries');
$currentDate = new FrozenDate();

$entity1 = $table->newEmptyEntity();
$entity1 = $table->patchEntity($entity1, ['date' => $currentDate]);
$table->save($entity1);

$entity2 = $table->newEmptyEntity();
$entity2 = $table->patchEntity($entity2, ['date' => $currentDate->format('Y-m-d')]);
$table->save($entity2);

var_dump($entity1->date); (wrong date, yesterday)
var_dump($entity2->date); (correct date, today)
```

To be clear this is only the case if you set your php datetime zone to something different than UTC like I have
``` php
date_default_timezone_set('Europe/Vienna');
```

In the end it comes down to this line in the DateType marshal method:
``` php
if ($value instanceof DateTimeInterface) {
    return new FrozenDate('@' . $value->getTimestamp());
}
```

In this scenario if `$value` is a FrozenDate object containing a timezone like this one
``` php
class Cake\I18n\FrozenDate#345 (3) {
  public $date =>
  string(26) "2023-04-26 00:00:00.000000"
  public $timezone_type =>
  int(3)
  public $timezone =>
  string(13) "Europe/Vienna"
}
```

it leads to this new FrozenDate object 
``` php
class Cake\I18n\FrozenDate#264 (3) {
  public $date =>
  string(26) "2023-04-25 00:00:00.000000"
  public $timezone_type =>
  int(3)
  public $timezone =>
  string(13) "Europe/Vienna"
}
```

Therefore my proposal is to just directly return the $value inside the marshal if it is an instance of `ChronosDate` since it doesn't need to be processed.