### PR TITLE
Fix creating fixture tables in postgres schemas

### DIFF
--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -642,6 +642,10 @@ class PostgresSchemaDialect extends SchemaDialect
         $content = array_merge($columns, $constraints);
         $content = implode(",\n", array_filter($content));
         $tableName = $this->_driver->quoteIdentifier($schema->name());
+        $dbSchema = $this->_driver->schema();
+        if ($dbSchema != 'public') {
+            $tableName = $this->_driver->quoteIdentifier($dbSchema) . '.' . $tableName;
+        }
         $temporary = $schema->isTemporary() ? ' TEMPORARY ' : ' ';
         $out = [];
         $out[] = sprintf("CREATE%sTABLE %s (\n%s\n)", $temporary, $tableName, $content);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -1228,6 +1228,27 @@ SQL;
     }
 
     /**
+     * Tests creating tables in postgres schema
+     */
+    public function testCreateInSchema(): void
+    {
+        $driver = $this->_getMockedDriver(['schema' => 'notpublic']);
+        $connection = $this->getMockBuilder('Cake\Database\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $connection->expects($this->any())
+            ->method('getDriver')
+            ->will($this->returnValue($driver));
+
+        $table = (new TableSchema('schema_articles'))->addColumn('title', [
+            'type' => 'string',
+            'length' => 255,
+        ]);
+        $sql = $table->createSql($connection);
+        $this->assertStringContainsString('CREATE TABLE "notpublic"."schema_articles"', $sql[0]);
+    }
+
+    /**
      * Tests creating temporary tables
      */
     public function testCreateTemporary(): void
@@ -1355,9 +1376,9 @@ SQL;
     /**
      * Get a schema instance with a mocked driver/pdo instances
      */
-    protected function _getMockedDriver(): Driver
+    protected function _getMockedDriver(array $config = []): Driver
     {
-        $driver = new Postgres();
+        $driver = new Postgres($config);
         $mock = $this->getMockBuilder(PDO::class)
             ->onlyMethods(['quote'])
             ->disableOriginalConstructor()


### PR DESCRIPTION
When creating fixture tables we should generate tables into the configured database schema instead of `public`

Fixes cakephp/debug_kit#863
