### PR TITLE
4.next: Add __debugInfo to ResultSetDecorator

### DIFF
--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Datasource;
 
 use Cake\Collection\Collection;
+use Cake\Core\Configure;
 use Countable;
 
 /**
@@ -53,7 +54,8 @@ class ResultSetDecorator extends Collection implements ResultSetInterface
     public function __debugInfo(): array
     {
         $parentInfo = parent::__debugInfo();
+        $limit = Configure::read('App.ResultSetDebugLimit', 10);
 
-        return array_merge($parentInfo, ['items' => $this->toArray()]);
+        return array_merge($parentInfo, ['items' => $this->take($limit)->toArray()]);
     }
 }

--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -46,4 +46,14 @@ class ResultSetDecorator extends Collection implements ResultSetInterface
 
         return count($this->toArray());
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function __debugInfo(): array
+    {
+        $parentInfo = parent::__debugInfo();
+
+        return array_merge($parentInfo, ['items' => $this->toArray()]);
+    }
 }

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource;
 
 use ArrayIterator;
+use Cake\Core\Configure;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\TestSuite\TestCase;
 
@@ -95,11 +96,12 @@ class ResultSetDecoratorTest extends TestCase
      */
     public function testDebugInfo(): void
     {
+        Configure::write('App.ResultSetDebugLimit', 2);
         $data = new ArrayIterator([1, 2, 3]);
         $decorator = new ResultSetDecorator($data);
         $this->assertEquals([
             'count' => 3,
-            'items' => [1, 2, 3],
+            'items' => [1, 2],
         ], $decorator->__debugInfo());
     }
 }

--- a/tests/TestCase/Datasource/ResultSetDecoratorTest.php
+++ b/tests/TestCase/Datasource/ResultSetDecoratorTest.php
@@ -89,4 +89,17 @@ class ResultSetDecoratorTest extends TestCase
         $this->assertSame(3, $decorator->count());
         $this->assertCount(3, $decorator);
     }
+
+    /**
+     * Test the __debugInfo() method which is used by DebugKit
+     */
+    public function testDebugInfo(): void
+    {
+        $data = new ArrayIterator([1, 2, 3]);
+        $decorator = new ResultSetDecorator($data);
+        $this->assertEquals([
+            'count' => 3,
+            'items' => [1, 2, 3],
+        ], $decorator->__debugInfo());
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/cakephp/debug_kit/issues/928

This would change the debug_kit variables output from being like this
<img width="761" alt="image" src="https://user-images.githubusercontent.com/9105243/235315182-8a406832-db23-45c3-a326-b5503e700903.png">

to this
<img width="765" alt="image" src="https://user-images.githubusercontent.com/9105243/235315207-4cdf574a-f472-43f9-94d9-f65c1d5bcc4b.png">

