### PR TITLE
Fix Validation::utf8 to fail on invalid bytes

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -1614,7 +1614,7 @@ class Validation
         }
         $options += ['extended' => false];
         if ($options['extended']) {
-            return true;
+            return preg_match('//u', $value) === 1;
         }
 
         return preg_match('/[\x{10000}-\x{10FFFF}]/u', $value) === 0;

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2993,6 +2993,9 @@ class ValidationTest extends TestCase
 
         // Grinning face
         $this->assertFalse(Validation::utf8('some' . "\xf0\x9f\x98\x80" . 'value'));
+
+        // incomplete character
+        $this->assertFalse(Validation::utf8("\xfe\xfe"));
     }
 
     /**
@@ -3019,6 +3022,9 @@ class ValidationTest extends TestCase
 
         // Grinning face
         $this->assertTrue(Validation::utf8('some' . "\xf0\x9f\x98\x80" . 'value', ['extended' => true]));
+
+        // incomplete characters
+        $this->assertFalse(Validation::utf8("\xfe\xfe", ['extended' => true]));
     }
 
     /**


### PR DESCRIPTION
The extended mode for utf8 validation should not accept partial unicode bytes.

I've not changed the behavior around null bytes as I don't want to risk breaking potential usage in userland code.

Fixes #17121