### PR TITLE
Add new ChainedEngine for Cache to manage fallback config (927 - DebugKit)

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -20,7 +20,6 @@ use Cake\Cache\Engine\NullEngine;
 use Cake\Cache\Exception\CacheWriteException;
 use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\Core\StaticConfigTrait;
-use RuntimeException;
 use function Cake\Core\deprecationWarning;
 
 /**
@@ -156,36 +155,7 @@ class Cache
         /** @var array $config */
         $config = static::$_config[$name];
 
-        try {
-            $registry->load($name, $config);
-        } catch (RuntimeException $e) {
-            if (!array_key_exists('fallback', $config)) {
-                $registry->set($name, new NullEngine());
-                trigger_error($e->getMessage(), E_USER_WARNING);
-
-                return;
-            }
-
-            if ($config['fallback'] === false) {
-                throw $e;
-            }
-
-            if ($config['fallback'] === $name) {
-                throw new InvalidArgumentException(sprintf(
-                    '"%s" cache configuration cannot fallback to itself.',
-                    $name
-                ), 0, $e);
-            }
-
-            /** @var \Cake\Cache\CacheEngine $fallbackEngine */
-            $fallbackEngine = clone static::pool($config['fallback']);
-            $newConfig = $config + ['groups' => [], 'prefix' => null];
-            $fallbackEngine->setConfig('groups', $newConfig['groups'], false);
-            if ($newConfig['prefix']) {
-                $fallbackEngine->setConfig('prefix', $newConfig['prefix'], false);
-            }
-            $registry->set($name, $fallbackEngine);
-        }
+        $registry->load($name, $config);
 
         if ($config['className'] instanceof CacheEngine) {
             $config = $config['className']->getConfig();

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Cache;
 
 use BadMethodCallException;
+use Cake\Cache\Engine\ChainedEngine;
 use Cake\Core\App;
 use Cake\Core\ObjectRegistry;
 use RuntimeException;
@@ -77,6 +78,7 @@ class CacheRegistry extends ObjectRegistry
         } else {
             $instance = new $class($config);
         }
+
         unset($config['className']);
 
         if (!($instance instanceof CacheEngine)) {
@@ -84,6 +86,9 @@ class CacheRegistry extends ObjectRegistry
                 'Cache engines must use Cake\Cache\CacheEngine as a base class.'
             );
         }
+
+        $config['alias'] = $alias;
+        $instance = new ChainedEngine($config, $instance);
 
         if (!$instance->init($config)) {
             throw new RuntimeException(

--- a/src/Cache/Engine/ChainedEngine.php
+++ b/src/Cache/Engine/ChainedEngine.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         4.5.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache\Engine;
+
+use Cake\Cache\Cache;
+use Cake\Cache\CacheEngine;
+use Cake\Cache\Exception\InvalidArgumentException;
+use Cake\Utility\Hash;
+use RuntimeException;
+
+/**
+ * Chained engine for cache.
+ */
+class ChainedEngine extends CacheEngine
+{
+    /**
+     * Main cache engine
+     *
+     * @var \Cake\Cache\CacheEngine
+     */
+    protected CacheEngine $engine;
+
+    /**
+     * Constructor
+     *
+     * @param array $config Engine config
+     * @param \Cake\Cache\CacheEngine $engine Main cache engine
+     */
+    public function __construct(array $config, CacheEngine $engine)
+    {
+        $this->engine = $engine;
+        $this->setConfig($config);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function init(array $config = []): bool
+    {
+        if ($this->engine->init($config)) {
+            return true;
+        }
+        $alias = Hash::get($config, 'alias');
+        if (!array_key_exists('fallback', $config)) {
+            $this->engine = new NullEngine();
+            trigger_error(sprintf(
+                '"%s" does not have a fallback config. Setting NullEngine as fallback.',
+                $alias
+            ), E_USER_WARNING);
+
+            return true;
+        }
+
+        if ($config['fallback'] === $alias) {
+            throw new InvalidArgumentException(sprintf(
+                '"%s" cache configuration cannot fallback to itself.',
+                $alias
+            ), 0);
+        }
+
+        /** @var \Cake\Cache\CacheEngine $fallbackEngine */
+        $fallbackEngine = clone Cache::pool($config['fallback']);
+        $newConfig = $config + ['groups' => [], 'prefix' => null];
+        $fallbackEngine->setConfig('groups', $newConfig['groups'], false);
+        if ($newConfig['prefix']) {
+            $fallbackEngine->setConfig('prefix', $newConfig['prefix'], false);
+        }
+        if (!$fallbackEngine->init($config)) {
+            throw new RuntimeException(sprintf(
+                '"%s" fallback configuration for "%s" cache configuration cannot be initialised.',
+                $config['fallback'],
+                $alias
+            ));
+        }
+
+        $this->engine = $fallbackEngine;
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $default = null)
+    {
+        return $this->engine->get($key, $default);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value, $ttl = null): bool
+    {
+        return $this->engine->set($key, $value, $ttl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function increment(string $key, int $offset = 1)
+    {
+        return $this->engine->increment($key, $offset);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decrement(string $key, int $offset = 1)
+    {
+        return $this->engine->decrement($key, $offset);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($key): bool
+    {
+        return $this->engine->delete($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): bool
+    {
+        return $this->engine->clear();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clearGroup(string $group): bool
+    {
+        return $this->engine->clearGroup($group);
+    }
+}


### PR DESCRIPTION
@ADmad @markstory I have implemented the ChainedEngine to manage the fallback config. In the future we could think about allowing multiple configs instead of main/fallback configs only. 

Please let me know if the approach is correct so I will fix/implement any required tests.

Thank you