### PR TITLE
Deprecate use of query options keys in paginator settings.

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -58,6 +58,8 @@ class NumericPaginator implements PaginatorInterface
         'limit' => 20,
         'maxLimit' => 100,
         'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+        'sortableFields' => null,
+        'finder' => 'all',
     ];
 
     /**
@@ -255,6 +257,20 @@ class NumericPaginator implements PaginatorInterface
     {
         $alias = $object->getAlias();
         $defaults = $this->getDefaults($alias, $settings);
+
+        $validSettings = array_merge(
+            array_keys($this->_defaultConfig),
+            ['whitelist', 'sortWhitelist', 'order', 'scope']
+        );
+        $extraSettings = array_diff_key($defaults, array_flip($validSettings));
+        if ($extraSettings) {
+            deprecationWarning(
+                'Passing query options as paginator settings is deprecated.'
+                . ' Use a custom finder through `finder` config instead.'
+                . ' Extra keys found are: ' . implode(',', array_keys($extraSettings))
+            );
+        }
+
         $options = $this->mergeOptions($params, $defaults);
         $options = $this->validateSort($object, $options);
         $options = $this->checkLimit($options);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -181,7 +181,10 @@ class PaginatorComponentTest extends TestCase
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
             ]);
-        $this->Paginator->paginate($table, $settings);
+
+        $this->deprecated(function () use ($table, $settings) {
+            $this->Paginator->paginate($table, $settings);
+        });
     }
 
     /**
@@ -237,7 +240,6 @@ class PaginatorComponentTest extends TestCase
         $settings = [
             'PaginatorPosts' => [
                 'finder' => 'popular',
-                'fields' => ['id', 'title'],
                 'maxLimit' => 10,
             ],
         ];
@@ -361,7 +363,10 @@ class PaginatorComponentTest extends TestCase
         $result = $this->Paginator->mergeOptions('Silly', $settings);
         $this->assertSame($settings['allowedParameters'], $result['whitelist']);
         unset($result['whitelist']);
-        $this->assertEquals($settings, $result);
+        $this->assertEquals($settings + [
+            'sortableFields' => null,
+            'finder' => 'all',
+        ], $result);
 
         $result = $this->Paginator->mergeOptions('Posts', $settings);
         $expected = [
@@ -370,6 +375,8 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 50,
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -402,6 +409,7 @@ class PaginatorComponentTest extends TestCase
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -421,6 +429,7 @@ class PaginatorComponentTest extends TestCase
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'nonexistent',
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -440,6 +449,7 @@ class PaginatorComponentTest extends TestCase
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'scope',
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -467,6 +477,7 @@ class PaginatorComponentTest extends TestCase
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -492,6 +503,8 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -521,6 +534,8 @@ class PaginatorComponentTest extends TestCase
             'maxLimit' => 100,
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -553,6 +568,8 @@ class PaginatorComponentTest extends TestCase
                 'fields' => ['bad.stuff'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
                 'allowedParameters' => ['limit', 'sort', 'page', 'direction', 'fields'],
+                'sortableFields' => null,
+                'finder' => 'all',
             ];
             $this->assertEquals($expected, $result);
         });
@@ -608,6 +625,8 @@ class PaginatorComponentTest extends TestCase
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
 
@@ -623,6 +642,8 @@ class PaginatorComponentTest extends TestCase
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -650,6 +671,8 @@ class PaginatorComponentTest extends TestCase
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
 
@@ -671,6 +694,8 @@ class PaginatorComponentTest extends TestCase
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1184,30 +1209,32 @@ class PaginatorComponentTest extends TestCase
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
-        $table = $this->getTableLocator()->get('PaginatorPosts');
-        $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
-        $table->save(new Entity($data));
+        $this->deprecated(function () {
+            $table = $this->getTableLocator()->get('PaginatorPosts');
+            $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
+            $table->save(new Entity($data));
 
-        $settings = [
-            'finder' => 'list',
-            'conditions' => ['PaginatorPosts.published' => 'Y'],
-            'limit' => 2,
-        ];
-        $results = $this->Paginator->paginate($table, $settings);
+            $settings = [
+                'finder' => 'list',
+                'conditions' => ['PaginatorPosts.published' => 'Y'],
+                'limit' => 2,
+            ];
+            $results = $this->Paginator->paginate($table, $settings);
 
-        $result = $results->toArray();
-        $expected = [
-            1 => 'First Post',
-            2 => 'Second Post',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $results->toArray();
+            $expected = [
+                1 => 'First Post',
+                2 => 'Second Post',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->controller->getRequest()->getAttribute('paging');
-        $this->assertSame(2, $result['PaginatorPosts']['current']);
-        $this->assertSame(3, $result['PaginatorPosts']['count']);
-        $this->assertSame(2, $result['PaginatorPosts']['pageCount']);
-        $this->assertTrue($result['PaginatorPosts']['nextPage']);
-        $this->assertFalse($result['PaginatorPosts']['prevPage']);
+            $result = $this->controller->getRequest()->getAttribute('paging');
+            $this->assertSame(2, $result['PaginatorPosts']['current']);
+            $this->assertSame(3, $result['PaginatorPosts']['count']);
+            $this->assertSame(2, $result['PaginatorPosts']['pageCount']);
+            $this->assertTrue($result['PaginatorPosts']['nextPage']);
+            $this->assertFalse($result['PaginatorPosts']['prevPage']);
+        });
     }
 
     /**
@@ -1250,9 +1277,7 @@ class PaginatorComponentTest extends TestCase
         );
         $settings = [
             'PaginatorPosts' => [
-                'contain' => ['PaginatorAuthor'],
                 'maxLimit' => 10,
-                'group' => 'PaginatorPosts.published',
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
@@ -1262,8 +1287,6 @@ class PaginatorComponentTest extends TestCase
         $query->expects($this->once())
             ->method('applyOptions')
             ->with([
-                'contain' => ['PaginatorAuthor'],
-                'group' => 'PaginatorPosts.published',
                 'limit' => 10,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
@@ -1304,10 +1327,8 @@ class PaginatorComponentTest extends TestCase
         );
         $settings = [
             'PaginatorPosts' => [
-                'contain' => ['PaginatorAuthor'],
                 'maxLimit' => 10,
                 'limit' => 5,
-                'group' => 'PaginatorPosts.published',
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
@@ -1318,8 +1339,6 @@ class PaginatorComponentTest extends TestCase
         $query->expects($this->once())
             ->method('applyOptions')
             ->with([
-                'contain' => ['PaginatorAuthor'],
-                'group' => 'PaginatorPosts.published',
                 'limit' => 5,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
@@ -100,30 +100,32 @@ class NumericPaginatorTest extends TestCase
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
-        $table = $this->getTableLocator()->get('PaginatorPosts');
-        $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
-        $table->save(new Entity($data));
+        $this->deprecated(function () {
+            $table = $this->getTableLocator()->get('PaginatorPosts');
+            $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
+            $table->save(new Entity($data));
 
-        $settings = [
-            'finder' => 'list',
-            'conditions' => ['PaginatorPosts.published' => 'Y'],
-            'limit' => 2,
-        ];
-        $results = $this->Paginator->paginate($table, [], $settings);
+            $settings = [
+                'finder' => 'list',
+                'conditions' => ['PaginatorPosts.published' => 'Y'],
+                'limit' => 2,
+            ];
+            $results = $this->Paginator->paginate($table, [], $settings);
 
-        $result = $results->toArray();
-        $expected = [
-            1 => 'First Post',
-            2 => 'Second Post',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $results->toArray();
+            $expected = [
+                1 => 'First Post',
+                2 => 'Second Post',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->Paginator->getPagingParams()['PaginatorPosts'];
-        $this->assertSame(2, $result['current']);
-        $this->assertSame(3, $result['count']);
-        $this->assertSame(2, $result['pageCount']);
-        $this->assertTrue($result['nextPage']);
-        $this->assertFalse($result['prevPage']);
+            $result = $this->Paginator->getPagingParams()['PaginatorPosts'];
+            $this->assertSame(2, $result['current']);
+            $this->assertSame(3, $result['count']);
+            $this->assertSame(2, $result['pageCount']);
+            $this->assertTrue($result['nextPage']);
+            $this->assertFalse($result['prevPage']);
+        });
     }
 
     /**
@@ -134,7 +136,6 @@ class NumericPaginatorTest extends TestCase
         $settings = [
             'PaginatorPosts' => [
                 'finder' => 'published',
-                'fields' => ['id', 'title'],
                 'maxLimit' => 10,
             ],
         ];

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -110,7 +110,10 @@ trait PaginatorTestTrait
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
             ]);
-        $this->Paginator->paginate($table, $params, $settings);
+
+        $this->deprecated(function () use ($table, $params, $settings) {
+            $this->Paginator->paginate($table, $params, $settings);
+        });
     }
 
     /**
@@ -273,7 +276,10 @@ trait PaginatorTestTrait
         ];
         $defaults = $this->Paginator->getDefaults('Silly', $settings);
         $result = $this->Paginator->mergeOptions([], $defaults);
-        $this->assertEquals($settings, $result);
+        $this->assertEquals($settings + [
+            'sortableFields' => null,
+            'finder' => 'all',
+        ], $result);
 
         $defaults = $this->Paginator->getDefaults('Posts', $settings);
         $result = $this->Paginator->mergeOptions([], $defaults);
@@ -283,6 +289,8 @@ trait PaginatorTestTrait
             'maxLimit' => 50,
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -316,6 +324,7 @@ trait PaginatorTestTrait
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -336,6 +345,7 @@ trait PaginatorTestTrait
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'nonexistent',
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -356,6 +366,7 @@ trait PaginatorTestTrait
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'scope' => 'scope',
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -384,6 +395,7 @@ trait PaginatorTestTrait
             'finder' => 'myCustomFind',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -410,6 +422,8 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -440,6 +454,8 @@ trait PaginatorTestTrait
             'maxLimit' => 100,
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -473,6 +489,8 @@ trait PaginatorTestTrait
                 'fields' => ['bad.stuff'],
                 'whitelist' => ['limit', 'sort', 'page', 'direction', 'fields'],
                 'allowedParameters' => ['limit', 'sort', 'page', 'direction', 'fields'],
+                'sortableFields' => null,
+                'finder' => 'all',
             ];
             $this->assertEquals($expected, $result);
         });
@@ -496,6 +514,8 @@ trait PaginatorTestTrait
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
 
@@ -512,6 +532,8 @@ trait PaginatorTestTrait
             'paramType' => 'named',
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -540,6 +562,8 @@ trait PaginatorTestTrait
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
 
@@ -562,6 +586,8 @@ trait PaginatorTestTrait
             ],
             'whitelist' => ['limit', 'sort', 'page', 'direction'],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'sortableFields' => null,
+            'finder' => 'all',
         ];
         $this->assertEquals($expected, $result);
     }
@@ -1171,9 +1197,7 @@ trait PaginatorTestTrait
         $params = ['page' => '-1'];
         $settings = [
             'PaginatorPosts' => [
-                'contain' => ['PaginatorAuthor'],
                 'maxLimit' => 10,
-                'group' => 'PaginatorPosts.published',
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
@@ -1183,8 +1207,6 @@ trait PaginatorTestTrait
         $query->expects($this->once())
             ->method('applyOptions')
             ->with([
-                'contain' => ['PaginatorAuthor'],
-                'group' => 'PaginatorPosts.published',
                 'limit' => 10,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
@@ -1222,10 +1244,8 @@ trait PaginatorTestTrait
         $params = ['page' => '-1'];
         $settings = [
             'PaginatorPosts' => [
-                'contain' => ['PaginatorAuthor'],
                 'maxLimit' => 10,
                 'limit' => 5,
-                'group' => 'PaginatorPosts.published',
                 'order' => ['PaginatorPosts.id' => 'ASC'],
             ],
         ];
@@ -1236,8 +1256,6 @@ trait PaginatorTestTrait
         $query->expects($this->once())
             ->method('applyOptions')
             ->with([
-                'contain' => ['PaginatorAuthor'],
-                'group' => 'PaginatorPosts.published',
                 'limit' => 5,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -97,30 +97,32 @@ class SimplePaginatorTest extends NumericPaginatorTest
      */
     public function testPaginateCustomFindFieldsArray(): void
     {
-        $table = $this->getTableLocator()->get('PaginatorPosts');
-        $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
-        $table->save(new Entity($data));
+        $this->deprecated(function () {
+            $table = $this->getTableLocator()->get('PaginatorPosts');
+            $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
+            $table->save(new Entity($data));
 
-        $settings = [
-            'finder' => 'list',
-            'conditions' => ['PaginatorPosts.published' => 'Y'],
-            'limit' => 2,
-        ];
-        $results = $this->Paginator->paginate($table, [], $settings);
+            $settings = [
+                'finder' => 'list',
+                'conditions' => ['PaginatorPosts.published' => 'Y'],
+                'limit' => 2,
+            ];
+            $results = $this->Paginator->paginate($table, [], $settings);
 
-        $result = $results->toArray();
-        $expected = [
-            1 => 'First Post',
-            2 => 'Second Post',
-        ];
-        $this->assertEquals($expected, $result);
+            $result = $results->toArray();
+            $expected = [
+                1 => 'First Post',
+                2 => 'Second Post',
+            ];
+            $this->assertEquals($expected, $result);
 
-        $result = $this->Paginator->getPagingParams()['PaginatorPosts'];
-        $this->assertSame(2, $result['current']);
-        $this->assertNull($result['count']);
-        $this->assertSame(0, $result['pageCount']);
-        $this->assertTrue($result['nextPage']);
-        $this->assertFalse($result['prevPage']);
+            $result = $this->Paginator->getPagingParams()['PaginatorPosts'];
+            $this->assertSame(2, $result['current']);
+            $this->assertNull($result['count']);
+            $this->assertSame(0, $result['pageCount']);
+            $this->assertTrue($result['nextPage']);
+            $this->assertFalse($result['prevPage']);
+        });
     }
 
     /**
@@ -131,7 +133,6 @@ class SimplePaginatorTest extends NumericPaginatorTest
         $settings = [
             'PaginatorPosts' => [
                 'finder' => 'published',
-                'fields' => ['id', 'title'],
                 'maxLimit' => 10,
             ],
         ];


### PR DESCRIPTION
The current mixing of paging setting and query options is ugly. Users should use custom finders instead or pass a query instance to the paginator.

I'll update the tests if the change is approved.