### PR TITLE
Add an assertion for cookie presence

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1249,6 +1249,23 @@ trait IntegrationTestTrait
     }
 
     /**
+     * Asserts that a cookie is set.
+     *
+     * Useful when you're working with cookies that have obfuscated values
+     * but the cookie being set is important.
+     *
+     * @param mixed $expected The expected contents.
+     * @param string $name The cookie name.
+     * @param string $message The failure message that will be appended to the generated message.
+     * @return void
+     */
+    public function assertCookieIsSet(string $name, string $message = ''): void
+    {
+        $verboseMessage = $this->extractVerboseMessage($message);
+        $this->assertThat($name, new CookieSet($this->_response), $verboseMessage);
+    }
+
+    /**
      * Asserts a cookie has not been set in the response
      *
      * @param string $cookie The cookie name to check

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1254,7 +1254,6 @@ trait IntegrationTestTrait
      * Useful when you're working with cookies that have obfuscated values
      * but the cookie being set is important.
      *
-     * @param mixed $expected The expected contents.
      * @param string $name The cookie name.
      * @param string $message The failure message that will be appended to the generated message.
      * @return void

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -769,6 +769,37 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Tests assertCookieIsSet assertion
+     */
+    public function testAssertCookieIsSet(): void
+    {
+        $this->get('/posts/secretCookie');
+        $this->assertCookieIsSet('secrets');
+    }
+
+    /**
+     * Tests the failure message for assertCookieIsSet
+     */
+    public function testCookieIsSetFailure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that \'not-secrets\' cookie is set');
+        $this->post('/posts/secretCookie');
+        $this->assertCookieIsSet('not-secrets');
+    }
+
+    /**
+     * Tests the failure message for assertCookieIsSet when no
+     * response whas generated
+     */
+    public function testCookieIsSetFailureNoResponse(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('No response set, cannot assert content.');
+        $this->assertCookieIsSet('secrets');
+    }
+
+    /**
      * Test error handling and error page rendering.
      */
     public function testPostAndErrorHandling(): void


### PR DESCRIPTION
I have found myself needing this in a few scenarios. The first is when dealing with session tokens, or obfuscated state like 'remember me' cookies. I don't know or don't care what the value is, only that the controller action has set that cookie.
