### PR TITLE
Fix usage of ROOT in deprecationWarning()

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -290,7 +290,7 @@ if (!function_exists('deprecationWarning')) {
             $frame += ['file' => '[internal]', 'line' => '??'];
 
             // Assuming we're installed in vendor/cakephp/cakephp/src/Core/functions.php
-            $root = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+            $root = dirname(__DIR__, 5);
             if (defined('ROOT')) {
                 $root = ROOT;
             }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -289,7 +289,12 @@ if (!function_exists('deprecationWarning')) {
             $frame = $trace[$stackFrame];
             $frame += ['file' => '[internal]', 'line' => '??'];
 
-            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($frame['file'], strlen(ROOT) + 1));
+            // Assuming we're installed in vendor/cakephp/cakephp/src/Core/functions.php
+            $root = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+            if (defined('ROOT')) {
+                $root = ROOT;
+            }
+            $relative = str_replace(DIRECTORY_SEPARATOR, '/', substr($frame['file'], strlen($root) + 1));
             $patterns = (array)Configure::read('Error.ignoredDeprecationPaths');
             foreach ($patterns as $pattern) {
                 $pattern = str_replace(DIRECTORY_SEPARATOR, '/', $pattern);


### PR DESCRIPTION
This should fix errors when cakephp packages are used outside of the framework.

Fixes #17138
