### PR TITLE
5.x paginator cleanup

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -48,6 +48,10 @@ class NumericPaginator implements PaginatorInterface
      *   have to explicity specify them (along with other fields). Using an empty
      *   array will disable sorting alltogether.
      * - `finder` - The table finder to use. Defaults to `all`.
+     * - `scope` - If specified this scope will be used as get the paging options
+     *   form the query params passed to paginate(). Scope allow namespacing the
+     *   paging options and allows paginating multiple models in the same action.
+     *   Default `null`.
      *
      * @var array<string, mixed>
      */
@@ -58,6 +62,7 @@ class NumericPaginator implements PaginatorInterface
         'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
         'sortableFields' => null,
         'finder' => 'all',
+        'scope' => null,
     ];
 
     /**
@@ -267,7 +272,6 @@ class NumericPaginator implements PaginatorInterface
         $options = $this->validateSort($object, $options);
         $options = $this->checkLimit($options);
 
-        $options += ['page' => 1, 'scope' => null];
         $options['page'] = max((int)$options['page'], 1);
 
         return compact('defaults', 'options');

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -48,8 +48,8 @@ class NumericPaginator implements PaginatorInterface
      *   have to explicity specify them (along with other fields). Using an empty
      *   array will disable sorting alltogether.
      * - `finder` - The table finder to use. Defaults to `all`.
-     * - `scope` - If specified this scope will be used as get the paging options
-     *   form the query params passed to paginate(). Scope allow namespacing the
+     * - `scope` - If specified this scope will be used to get the paging options
+     *   from the query params passed to paginate(). Scopes allow namespacing the
      *   paging options and allows paginating multiple models in the same action.
      *   Default `null`.
      *

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -418,7 +418,7 @@ class NumericPaginator implements PaginatorInterface
      * @param array $settings The settings to merge with the request data.
      * @return array<string, mixed> Array of merged options.
      */
-    public function mergeOptions(array $params, array $settings): array
+    protected function mergeOptions(array $params, array $settings): array
     {
         if (!empty($settings['scope'])) {
             $scope = $settings['scope'];
@@ -438,7 +438,7 @@ class NumericPaginator implements PaginatorInterface
      * @return array<string, mixed> An array of pagination settings for a model,
      *   or the general settings.
      */
-    public function getDefaults(string $alias, array $settings): array
+    protected function getDefaults(string $alias, array $settings): array
     {
         if (isset($settings[$alias])) {
             $settings = $settings[$alias];
@@ -485,7 +485,7 @@ class NumericPaginator implements PaginatorInterface
      * @return array<string, mixed> An array of options with sort + direction removed and
      *   replaced with order if possible.
      */
-    public function validateSort(RepositoryInterface $object, array $options): array
+    protected function validateSort(RepositoryInterface $object, array $options): array
     {
         if (isset($options['sort'])) {
             $direction = null;
@@ -622,7 +622,7 @@ class NumericPaginator implements PaginatorInterface
      * @param array<string, mixed> $options An array of options with a limit key to be checked.
      * @return array<string, mixed> An array of options for pagination.
      */
-    public function checkLimit(array $options): array
+    protected function checkLimit(array $options): array
     {
         $options['limit'] = (int)$options['limit'];
         if ($options['limit'] < 1) {

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
@@ -96,39 +96,6 @@ class NumericPaginatorTest extends TestCase
     }
 
     /**
-     * test paginate() and custom find with fields array, to make sure the correct count is returned.
-     */
-    public function testPaginateCustomFindFieldsArray(): void
-    {
-        $this->deprecated(function () {
-            $table = $this->getTableLocator()->get('PaginatorPosts');
-            $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
-            $table->save(new Entity($data));
-
-            $settings = [
-                'finder' => 'list',
-                'conditions' => ['PaginatorPosts.published' => 'Y'],
-                'limit' => 2,
-            ];
-            $results = $this->Paginator->paginate($table, [], $settings);
-
-            $result = $results->toArray();
-            $expected = [
-                1 => 'First Post',
-                2 => 'Second Post',
-            ];
-            $this->assertEquals($expected, $result);
-
-            $result = $results->pagingParams();
-            $this->assertSame(2, $result['count']);
-            $this->assertSame(3, $result['totalCount']);
-            $this->assertSame(2, $result['pageCount']);
-            $this->assertTrue($result['hasNextPage']);
-            $this->assertFalse($result['hasPrevPage']);
-        });
-    }
-
-    /**
      * Test that special paginate types are called and that the type param doesn't leak out into defaults or options.
      */
     public function testPaginateCustomFinder(): void
@@ -141,14 +108,15 @@ class NumericPaginatorTest extends TestCase
         ];
 
         $table = $this->getTableLocator()->get('PaginatorPosts');
+        $this->assertSame(3, $table->find('published')->count());
         $table->updateAll(['published' => 'N'], ['id' => 2]);
 
         $result = $this->Paginator->paginate($table, [], $settings);
         $pagingParams = $result->pagingParams();
-        $this->assertSame('published', $pagingParams['finder']);
 
         $this->assertSame(1, $pagingParams['start']);
         $this->assertSame(2, $pagingParams['end']);
+        $this->assertSame(2, $pagingParams['totalCount']);
         $this->assertFalse($pagingParams['hasNextPage']);
     }
 

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -81,7 +81,7 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test that unknown keys in the default settings are
+     * test that unknown keys in the default settings are **not**
      * passed to the find operations.
      */
     public function testPaginateExtraParams(): void
@@ -105,16 +105,12 @@ trait PaginatorTestTrait
         $query->expects($this->once())
             ->method('applyOptions')
             ->with([
-                'contain' => ['PaginatorAuthor'],
-                'group' => 'PaginatorPosts.published',
                 'limit' => 10,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
             ]);
 
-        $this->deprecated(function () use ($table, $params, $settings) {
-            $this->Paginator->paginate($table, $params, $settings);
-        });
+        $this->Paginator->paginate($table, $params, $settings);
     }
 
     /**
@@ -1125,21 +1121,20 @@ trait PaginatorTestTrait
     }
 
     /**
-     * test paginate() and custom finders to ensure the count + find
-     * use the custom type.
+     * test the `finder` is unused if paginate() is called with a query instance.
      */
-    public function testPaginateCustomFindCount(): void
+    public function testPaginateQueryUnusedFinder(): void
     {
         $settings = [
             'finder' => 'published',
             'limit' => 2,
         ];
-        $table = $this->_getMockPosts(['selectQuery']);
+        $table = $this->_getMockPosts(['find']);
         $query = $this->_getMockFindQuery();
+        $query->setRepository($table);
 
-        $table->expects($this->once())
-            ->method('selectQuery')
-            ->will($this->returnValue($query));
+        $table->expects($this->never())
+            ->method('find');
 
         $query->expects($this->once())->method('applyOptions')
             ->with([
@@ -1147,9 +1142,7 @@ trait PaginatorTestTrait
                 'page' => 1,
                 'order' => [],
             ]);
-        $result = $this->Paginator->paginate($table, [], $settings)->pagingParams();
-
-        $this->assertEquals('published', $result['finder']);
+        $this->Paginator->paginate($query, [], $settings)->pagingParams();
     }
 
     /**

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -45,7 +45,27 @@ trait PaginatorTestTrait
 
         Configure::write('App.namespace', 'TestApp');
 
-        $this->Paginator = new NumericPaginator();
+        $this->Paginator = new class extends NumericPaginator {
+            public function getDefaults(string $alias, array $settings): array
+            {
+                return parent::getDefaults($alias, $settings);
+            }
+
+            public function mergeOptions(array $params, array $settings): array
+            {
+                return parent::mergeOptions($params, $settings);
+            }
+
+            public function validateSort(RepositoryInterface $object, array $options): array
+            {
+                return parent::validateSort($object, $options);
+            }
+
+            public function checkLimit(array $options): array
+            {
+                return parent::checkLimit($options);
+            }
+        };
 
         $this->Post = $this->getMockRepository();
     }

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -268,6 +268,7 @@ trait PaginatorTestTrait
                 'maxLimit' => 50,
             ],
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
+            'scope' => null,
         ];
         $defaults = $this->Paginator->getDefaults('Silly', $settings);
         $result = $this->Paginator->mergeOptions([], $defaults);
@@ -285,6 +286,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -318,6 +320,7 @@ trait PaginatorTestTrait
             'finder' => 'myCustomFind',
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -386,6 +389,7 @@ trait PaginatorTestTrait
             'finder' => 'myCustomFind',
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -413,6 +417,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -444,6 +449,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -478,6 +484,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction', 'fields'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -501,6 +508,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -518,6 +526,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }
@@ -547,6 +556,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
 
@@ -570,6 +580,7 @@ trait PaginatorTestTrait
             'allowedParameters' => ['limit', 'sort', 'page', 'direction'],
             'sortableFields' => null,
             'finder' => 'all',
+            'scope' => null,
         ];
         $this->assertEquals($expected, $result);
     }

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Datasource\Paging;
 
 use Cake\Core\Configure;
 use Cake\Datasource\Paging\SimplePaginator;
+use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Entity;
 
 class SimplePaginatorTest extends NumericPaginatorTest
@@ -28,7 +29,27 @@ class SimplePaginatorTest extends NumericPaginatorTest
 
         Configure::write('App.namespace', 'TestApp');
 
-        $this->Paginator = new SimplePaginator();
+        $this->Paginator = new class extends SimplePaginator {
+            public function getDefaults(string $alias, array $settings): array
+            {
+                return parent::getDefaults($alias, $settings);
+            }
+
+            public function mergeOptions(array $params, array $settings): array
+            {
+                return parent::mergeOptions($params, $settings);
+            }
+
+            public function validateSort(RepositoryInterface $object, array $options): array
+            {
+                return parent::validateSort($object, $options);
+            }
+
+            public function checkLimit(array $options): array
+            {
+                return parent::checkLimit($options);
+            }
+        };
     }
 
     /**

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -93,39 +93,6 @@ class SimplePaginatorTest extends NumericPaginatorTest
     }
 
     /**
-     * test paginate() and custom find with fields array, to make sure the correct count is returned.
-     */
-    public function testPaginateCustomFindFieldsArray(): void
-    {
-        $this->deprecated(function () {
-            $table = $this->getTableLocator()->get('PaginatorPosts');
-            $data = ['author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N'];
-            $table->save(new Entity($data));
-
-            $settings = [
-                'finder' => 'list',
-                'conditions' => ['PaginatorPosts.published' => 'Y'],
-                'limit' => 2,
-            ];
-            $results = $this->Paginator->paginate($table, [], $settings);
-
-            $result = $results->toArray();
-            $expected = [
-                1 => 'First Post',
-                2 => 'Second Post',
-            ];
-            $this->assertEquals($expected, $result);
-
-            $result = $results->pagingParams();
-            $this->assertSame(1, $result['currentPage']);
-            $this->assertNull($result['totalCount']);
-            $this->assertNull($result['pageCount']);
-            $this->assertTrue($result['hasNextPage']);
-            $this->assertFalse($result['hasPrevPage']);
-        });
-    }
-
-    /**
      * Test that special paginate types are called and that the type param doesn't leak out into defaults or options.
      */
     public function testPaginateCustomFinder(): void
@@ -138,11 +105,11 @@ class SimplePaginatorTest extends NumericPaginatorTest
         ];
 
         $table = $this->getTableLocator()->get('PaginatorPosts');
+        $this->assertSame(3, $table->find('published')->count());
         $table->updateAll(['published' => 'N'], ['id' => 2]);
 
         $result = $this->Paginator->paginate($table, [], $settings);
         $pagingParams = $result->pagingParams();
-        $this->assertSame('published', $pagingParams['finder']);
 
         $this->assertSame(1, $pagingParams['start']);
         $this->assertSame(2, $pagingParams['end']);


### PR DESCRIPTION
- Cleaned up deprecated code
- Made various method for options munging protected as there isn't any use case for them be publicly accessible.
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
