### PR TITLE
[4.5] TLS Support for RedisEngine

### DIFF
--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -45,6 +45,7 @@ class RedisEngine extends CacheEngine
      * - `password` Redis server password.
      * - `persistent` Connect to the Redis server with a persistent connection
      * - `port` port number to the Redis server.
+     * - `tls` connect to the Redis server using TLS.
      * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
      *    with either another cache config or another application.
      * - `scanCount` Number of keys to ask for each scan (default: 10)
@@ -61,6 +62,7 @@ class RedisEngine extends CacheEngine
         'password' => false,
         'persistent' => true,
         'port' => 6379,
+        'tls' => false,
         'prefix' => 'cake_',
         'host' => null,
         'server' => '127.0.0.1',
@@ -99,24 +101,29 @@ class RedisEngine extends CacheEngine
      */
     protected function _connect(): bool
     {
+        $tls = $this->_config['tls'] === true ? 'tls://' : '';
+
+        $map = [
+            'ssl_ca' => 'cafile',
+            'ssl_key' => 'local_pk',
+            'ssl_cert' => 'local_cert',
+        ];
+
+        $ssl = [];
+        foreach ($map as $key => $context) {
+            if (!empty($this->_config[$key])) {
+                $ssl[$context] = $this->_config[$key];
+            }
+        }
+
         try {
-            $this->_Redis = new Redis();
+            $this->_Redis = $this->_createRedisInstance();
             if (!empty($this->_config['unix_socket'])) {
                 $return = $this->_Redis->connect($this->_config['unix_socket']);
             } elseif (empty($this->_config['persistent'])) {
-                $return = $this->_Redis->connect(
-                    $this->_config['server'],
-                    (int)$this->_config['port'],
-                    (int)$this->_config['timeout']
-                );
+                $return = $this->_connectTransient($tls . $this->_config['server'], $ssl);
             } else {
-                $persistentId = $this->_config['port'] . $this->_config['timeout'] . $this->_config['database'];
-                $return = $this->_Redis->pconnect(
-                    $this->_config['server'],
-                    (int)$this->_config['port'],
-                    (int)$this->_config['timeout'],
-                    $persistentId
-                );
+                $return = $this->_connectPersistent($tls . $this->_config['server'], $ssl);
             }
         } catch (RedisException $e) {
             if (class_exists(Log::class)) {
@@ -133,6 +140,67 @@ class RedisEngine extends CacheEngine
         }
 
         return $return;
+    }
+
+    /**
+     * Connects to a Redis server using a new connection.
+     *
+     * @param string $server Server to connect to.
+     * @param array $ssl SSL context options.
+     * @throws \RedisException
+     * @return bool True if Redis server was connected
+     */
+    protected function _connectTransient($server, array $ssl): bool
+    {
+        if (empty($ssl)) {
+            return $this->_Redis->connect(
+                $server,
+                (int)$this->_config['port'],
+                (int)$this->_config['timeout']
+            );
+        }
+
+        return $this->_Redis->connect(
+            $server,
+            (int)$this->_config['port'],
+            (int)$this->_config['timeout'],
+            null,
+            0,
+            0.0,
+            ['ssl' => $ssl]
+        );
+    }
+
+    /**
+     * Connects to a Redis server using a persistent connection.
+     *
+     * @param string $server Server to connect to.
+     * @param array $ssl SSL context options.
+     * @throws \RedisException
+     * @return bool True if Redis server was connected
+     */
+    protected function _connectPersistent($server, array $ssl): bool
+    {
+        $persistentId = $this->_config['port'] . $this->_config['timeout'] . $this->_config['database'];
+
+        if (empty($ssl)) {
+            return $this->_Redis->pconnect(
+                $server,
+                (int)$this->_config['port'],
+                (int)$this->_config['timeout'],
+                $persistentId
+            );
+        }
+
+        return $this->_Redis->pconnect(
+            $server,
+            (int)$this->_config['port'],
+            (int)$this->_config['timeout'],
+            $persistentId,
+            0,
+            0.0,
+            ['ssl' => $ssl]
+        );
     }
 
     /**
@@ -392,6 +460,16 @@ class RedisEngine extends CacheEngine
         }
 
         return unserialize($value);
+    }
+
+    /**
+     * Create new Redis instance.
+     *
+     * @return \Redis
+     */
+    protected function _createRedisInstance(): Redis
+    {
+        return new Redis();
     }
 
     /**

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -92,6 +92,7 @@ class RedisEngineTest extends TestCase
             'groups' => [],
             'server' => '127.0.0.1',
             'port' => $this->port,
+            'tls' => false,
             'timeout' => 0,
             'persistent' => true,
             'password' => false,
@@ -119,6 +120,7 @@ class RedisEngineTest extends TestCase
             'groups' => [],
             'server' => 'localhost',
             'port' => $this->port,
+            'tls' => false,
             'timeout' => 0,
             'persistent' => true,
             'password' => false,
@@ -134,12 +136,269 @@ class RedisEngineTest extends TestCase
     }
 
     /**
+     * testConfigDsnSSLContext method
+     */
+    public function testConfigDsnSSLContext(): void
+    {
+        $url = 'redis://localhost:' . $this->port;
+
+        $url .= '?ssl_ca=/tmp/cert.crt';
+        $url .= '&ssl_key=/tmp/local.key';
+        $url .= '&ssl_cert=/tmp/local.crt';
+
+        Cache::setConfig('redis_dsn', compact('url'));
+
+        $config = Cache::pool('redis_dsn')->getConfig();
+        $expecting = [
+            'prefix' => 'cake_',
+            'duration' => 3600,
+            'groups' => [],
+            'server' => 'localhost',
+            'port' => $this->port,
+            'tls' => false,
+            'timeout' => 0,
+            'persistent' => true,
+            'password' => false,
+            'database' => 0,
+            'unix_socket' => false,
+            'host' => 'localhost',
+            'scheme' => 'redis',
+            'scanCount' => 10,
+            'ssl_ca' => '/tmp/cert.crt',
+            'ssl_key' => '/tmp/local.key',
+            'ssl_cert' => '/tmp/local.crt',
+        ];
+        $this->assertEquals($expecting, $config);
+
+        Cache::drop('redis_dsn');
+    }
+
+    /**
      * testConnect method
      */
     public function testConnect(): void
     {
         $Redis = new RedisEngine();
         $this->assertTrue($Redis->init(Cache::pool('redis')->getConfig()));
+    }
+
+    /**
+     * testConnectTransient method
+     */
+    public function testConnectTransient(): void
+    {
+        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $phpredis = $this->createMock(\Redis::class);
+
+        $phpredis->expects($this->once())
+            ->method('select')
+            ->with((int)$Redis->getConfig('database'))
+            ->willReturn(true);
+
+        $phpredis->expects($this->once())
+            ->method('connect')
+            ->with(
+                $Redis->getConfig('server'),
+                (int)$this->port,
+                (int)$Redis->getConfig('timeout'),
+            )
+            ->willReturn(true);
+
+        $Redis->expects($this->once())
+            ->method('_createRedisInstance')
+            ->willReturn($phpredis);
+
+        $config = [
+            'port' => $this->port,
+            'persistent' => false,
+        ];
+        $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
+
+        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $phpredis = $this->createMock(\Redis::class);
+
+        $phpredis->expects($this->once())
+            ->method('select')
+            ->with((int)$Redis->getConfig('database'))
+            ->willReturn(true);
+
+        $phpredis->expects($this->once())
+            ->method('connect')
+            ->with(
+                'tls://' . $Redis->getConfig('server'),
+                (int)$this->port,
+                (int)$Redis->getConfig('timeout'),
+            )
+            ->willReturn(true);
+
+        $Redis->expects($this->once())
+            ->method('_createRedisInstance')
+            ->willReturn($phpredis);
+
+        $config = [
+            'port' => $this->port,
+            'persistent' => false,
+            'tls' => true,
+        ];
+        $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
+    }
+
+    /**
+     * testConnectTransientContext method
+     */
+    public function testConnectTransientContext(): void
+    {
+        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $phpredis = $this->createMock(\Redis::class);
+
+        $cafile = ROOT . DS . 'vendor' . DS . 'composer' . DS . 'ca-bundle' . DS . 'res' . DS . 'cacert.pem';
+
+        $context = [
+            'ssl' => [
+                'cafile' => $cafile,
+            ],
+        ];
+
+        $phpredis->expects($this->once())
+            ->method('select')
+            ->with((int)$Redis->getConfig('database'))
+            ->willReturn(true);
+
+        $phpredis->expects($this->once())
+            ->method('connect')
+            ->with(
+                $Redis->getConfig('server'),
+                (int)$this->port,
+                (int)$Redis->getConfig('timeout'),
+                null,
+                0,
+                0.0,
+                $context
+            )
+            ->willReturn(true);
+
+        $Redis->expects($this->once())
+            ->method('_createRedisInstance')
+            ->willReturn($phpredis);
+
+        $config = [
+            'port' => $this->port,
+            'persistent' => false,
+            'ssl_ca' => $cafile,
+        ];
+
+        $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
+    }
+
+    /**
+     * testConnectPersistent method
+     */
+    public function testConnectPersistent(): void
+    {
+        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $phpredis = $this->createMock(\Redis::class);
+
+        $expectedPersistentId = $this->port . $Redis->getConfig('timeout') . $Redis->getConfig('database');
+
+        $phpredis->expects($this->once())
+            ->method('select')
+            ->with((int)$Redis->getConfig('database'))
+            ->willReturn(true);
+
+        $phpredis->expects($this->once())
+            ->method('pconnect')
+            ->with(
+                $Redis->getConfig('server'),
+                (int)$this->port,
+                (int)$Redis->getConfig('timeout'),
+                $expectedPersistentId
+            )
+            ->willReturn(true);
+
+        $Redis->expects($this->once())
+            ->method('_createRedisInstance')
+            ->willReturn($phpredis);
+
+        $config = [
+            'port' => $this->port,
+        ];
+        $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
+
+        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $phpredis = $this->createMock(\Redis::class);
+
+        $phpredis->expects($this->once())
+            ->method('select')
+            ->with((int)$Redis->getConfig('database'))
+            ->willReturn(true);
+
+        $phpredis->expects($this->once())
+            ->method('pconnect')
+            ->with(
+                'tls://' . $Redis->getConfig('server'),
+                (int)$this->port,
+                (int)$Redis->getConfig('timeout'),
+                $expectedPersistentId
+            )
+            ->willReturn(true);
+
+        $Redis->expects($this->once())
+            ->method('_createRedisInstance')
+            ->willReturn($phpredis);
+
+        $config = [
+            'port' => $this->port,
+            'tls' => true,
+        ];
+        $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
+    }
+
+    /**
+     * testConnectPersistentContext method
+     */
+    public function testConnectPersistentContext(): void
+    {
+        $Redis = $this->createPartialMock(RedisEngine::class, ['_createRedisInstance']);
+        $phpredis = $this->createMock(\Redis::class);
+
+        $expectedPersistentId = $this->port . $Redis->getConfig('timeout') . $Redis->getConfig('database');
+
+        $cafile = ROOT . DS . 'vendor' . DS . 'composer' . DS . 'ca-bundle' . DS . 'res' . DS . 'cacert.pem';
+
+        $context = [
+            'ssl' => [
+                'cafile' => $cafile,
+            ],
+        ];
+
+        $phpredis->expects($this->once())
+            ->method('select')
+            ->with((int)$Redis->getConfig('database'))
+            ->willReturn(true);
+
+        $phpredis->expects($this->once())
+            ->method('pconnect')
+            ->with(
+                $Redis->getConfig('server'),
+                (int)$this->port,
+                (int)$Redis->getConfig('timeout'),
+                $expectedPersistentId,
+                0,
+                0.0,
+                $context
+            )
+            ->willReturn(true);
+
+        $Redis->expects($this->once())
+            ->method('_createRedisInstance')
+            ->willReturn($phpredis);
+
+        $config = [
+            'port' => $this->port,
+            'persistent' => true,
+            'ssl_ca' => $cafile,
+        ];
+        $this->assertTrue($Redis->init($config + Cache::pool('redis')->getConfig()));
     }
 
     /**


### PR DESCRIPTION
Pull request for  #17130.

- Adds option `'tls' => true` and can be used in the DSN as `tls=true`.
- Adds SSL context options `ssl_ca`, `ssl_cert`, `ssl_key` exactly as the MySQL driver has (to keep the API consistent).
- Other context options are now also supported.

I put the `connect()` and `pconnect()` calls in seperate methods to avoid nesting. Earlier versions of `php-redis` don't have that last `$context` parameter. It was introduced in `v5.3.0`. However, PHP 7.4 support was fixed in `v5.0.2`, so it is possible people are running older versions of the extension. I maintained the old signature unless a context is given to accommodate the different versions.

You also see `new Redis()` wrapped in a method. This is to mock it, otherwise it's a bit difficult to test.

Anyone an idea how to fix that PHPStan error? I think the rules are outdated. It complains `Redis::connect()` is called with too many (7) parameters, though it really has [7 parameters ](https://phpredis.github.io/phpredis/Redis.html#method_connect) (in later versions).