### PR TITLE
Refactor paginator.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,11 +29,6 @@
       <code>InvalidArrayOffset</code>
     </UnusedPsalmSuppress>
   </file>
-  <file src="src/Datasource/Paging/PaginatedResultSet.php">
-    <MethodSignatureMustProvideReturnType>
-      <code>://cakephp.org)</code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="src/Event/EventDispatcherTrait.php">
     <MoreSpecificImplementedParamType>
       <code>$subject</code>

--- a/src/Datasource/Paging/PaginatedResultSet.php
+++ b/src/Datasource/Paging/PaginatedResultSet.php
@@ -16,13 +16,12 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource\Paging;
 
-use Cake\Datasource\ResultSetInterface;
 use IteratorIterator;
+use Traversable;
 
 /**
  * Paginated resultset.
  *
- * @method \Cake\Datasource\ResultSetInterface getInnerIterator()
  * @template-extends \IteratorIterator<mixed, mixed, \Traversable<mixed>>
  * @template T
  */
@@ -38,10 +37,10 @@ class PaginatedResultSet extends IteratorIterator implements PaginatedInterface
     /**
      * Constructor
      *
-     * @param \Cake\Datasource\ResultSetInterface<T> $results Resultset instance.
+     * @param \Traversable<T> $results Resultset instance.
      * @param array $params Paging params.
      */
-    public function __construct(ResultSetInterface $results, array $params)
+    public function __construct(Traversable $results, array $params)
     {
         parent::__construct($results);
 
@@ -53,15 +52,15 @@ class PaginatedResultSet extends IteratorIterator implements PaginatedInterface
      */
     public function count(): int
     {
-        return $this->getInnerIterator()->count();
+        return $this->params['count'];
     }
 
     /**
      * Get paginated items.
      *
-     * @return \Cake\Datasource\ResultSetInterface<T> The paginated items result set.
+     * @return \Traversable<T> The paginated items result set.
      */
-    public function items(): ResultSetInterface
+    public function items(): Traversable
     {
         return $this->getInnerIterator();
     }

--- a/src/Datasource/Paging/SimplePaginator.php
+++ b/src/Datasource/Paging/SimplePaginator.php
@@ -17,17 +17,68 @@ declare(strict_types=1);
 namespace Cake\Datasource\Paging;
 
 use Cake\Datasource\QueryInterface;
+use Cake\Datasource\ResultSetInterface;
 
 /**
  * Simplified paginator which avoids potentially expensives queries
  * to get the total count of records.
  *
  * When using a simple paginator you will not be able to generate page numbers.
- * Instead use only the prev/next pagination controls, and handle 404 errors
- * when pagination goes past the available result set.
+ * Instead use only the prev/next pagination controls.
  */
 class SimplePaginator extends NumericPaginator
 {
+    /**
+     * Get paginated items.
+     *
+     * Get one additional record than the limit. This helps deduce if next page exits.
+     *
+     * @param \Cake\Datasource\QueryInterface $query Query to fetch items.
+     * @param array $data Paging data.
+     * @return \Cake\Datasource\ResultSetInterface
+     */
+    protected function getItems(QueryInterface $query, array $data): ResultSetInterface
+    {
+        return $query->limit($data['options']['limit'] + 1)->all();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function buildParams(array $data): array
+    {
+        $hasNextPage = false;
+        if ($this->pagingParams['count'] > $data['options']['limit']) {
+            $hasNextPage = true;
+            $this->pagingParams['count'] -= 1;
+        }
+
+        parent::buildParams($data);
+
+        $this->pagingParams['hasNextPage'] = $hasNextPage;
+
+        return $this->pagingParams;
+    }
+
+    /**
+     * Build paginated resultset.
+     *
+     * Since the query fetches an extra record, drop the last record if records
+     * fetched exceeds the limit/per page.
+     *
+     * @param \Cake\Datasource\ResultSetInterface $items
+     * @param array $pagingParams
+     * @return \Cake\Datasource\Paging\PaginatedInterface
+     */
+    protected function buildPaginated(ResultSetInterface $items, array $pagingParams): PaginatedInterface
+    {
+        if (count($items) > $this->pagingParams['perPage']) {
+            $items = $items->take($this->pagingParams['perPage']);
+        }
+
+        return new PaginatedResultSet($items, $pagingParams);
+    }
+
     /**
      * Simple pagination does not perform any count query, so this method returns `null`.
      *

--- a/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/SimplePaginatorTest.php
@@ -134,7 +134,8 @@ class SimplePaginatorTest extends NumericPaginatorTest
 
         $this->assertSame(1, $pagingParams['start']);
         $this->assertSame(2, $pagingParams['end']);
-        // nextPage will be always true for SimplePaginator
-        $this->assertTrue($pagingParams['hasNextPage']);
+        $this->assertSame(2, count($result));
+        $this->assertSame(2, $pagingParams['count']);
+        $this->assertFalse($pagingParams['hasNextPage']);
     }
 }


### PR DESCRIPTION
Make the options/params array passing easier to understand by adding the $pagingParams property which has all required keys.

**SimplePaginator's "hasNextPage" param now accurately indicates whether a next page exists. Earlier it always returned `true` causing devs to handle the potential PageOutOfBounds exception at the app level.**

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
