### PR TITLE
only authenticate if username and password are set

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -123,7 +123,6 @@ class SmtpTransport extends AbstractTransport
     {
         if (!$this->connected()) {
             $this->_connect();
-            $this->_auth();
         }
     }
 
@@ -197,7 +196,6 @@ class SmtpTransport extends AbstractTransport
 
         if (!$this->connected()) {
             $this->_connect();
-            $this->_auth();
         } else {
             $this->_smtpSend('RSET');
         }
@@ -327,7 +325,10 @@ class SmtpTransport extends AbstractTransport
             }
         }
 
-        $this->_parseAuthType();
+        if (isset($this->_config['username'], $this->_config['password'])) {
+            $this->_parseAuthType();
+            $this->_auth();
+        }
     }
 
     /**
@@ -338,10 +339,6 @@ class SmtpTransport extends AbstractTransport
      */
     protected function _auth(): void
     {
-        if (!isset($this->_config['username'], $this->_config['password'])) {
-            return;
-        }
-
         $username = $this->_config['username'];
         $password = $this->_config['password'];
 

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -257,7 +257,7 @@ class SmtpTransport extends AbstractTransport
     {
         $auth = '';
         foreach ($this->_lastResponse as $line) {
-            if (strlen($line['message']) === 0 || substr($line['message'], 0, 5) === 'AUTH ') {
+            if (substr($line['message'], 0, 5) === 'AUTH ') {
                 $auth = explode(' ', $line['message'])[1];
                 break;
             }

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -229,11 +229,11 @@ class SmtpTransport extends AbstractTransport
         }
         $this->_lastResponse = array_merge($this->_lastResponse, $response);
     }
-    
+
     /**
      * Checks if the authType is valid and sets $this->authType
-     * 
-     * @throws Cake\Core\Exception\CakeException if authType is invalid
+     *
+     * @throws \Cake\Core\Exception\CakeException if authType is invalid
      * @param string $type Authtype to set
      * @return void
      */
@@ -262,6 +262,7 @@ class SmtpTransport extends AbstractTransport
                 break;
             }
         }
+
         return $auth;
     }
 
@@ -276,7 +277,7 @@ class SmtpTransport extends AbstractTransport
         if (isset($this->_config['authType']) && !isset($this->_config['username'], $this->_config['password'])) {
             throw new CakeException('You must provide username and password for authType ' . $this->_config['authType']);
         }
-        
+
         $this->_generateSocket();
         if (!$this->_socket()->connect()) {
             throw new SocketException('Unable to connect to SMTP server.');

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -275,7 +275,9 @@ class SmtpTransport extends AbstractTransport
     protected function _connect(): void
     {
         if (isset($this->_config['authType']) && !isset($this->_config['username'], $this->_config['password'])) {
-            throw new CakeException('You must provide username and password for authType ' . $this->_config['authType']);
+            throw new CakeException(
+                'You must provide username and password for authType ' . $this->_config['authType']
+            );
         }
 
         $this->_generateSocket();

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -154,7 +154,7 @@ class SmtpTransportTest extends TestCase
     {
         $this->expectException(SocketException::class);
         $this->expectExceptionMessage('SMTP authentication method not allowed, check if SMTP server requires TLS.');
-        $this->SmtpTransport->setConfig(['tls' => false, 'authType' => 'LOGIN'] + $this->credentials);
+        $this->SmtpTransport->setConfig(['tls' => false, 'authType' => SmtpTransport::AUTH_LOGIN] + $this->credentials);
 
         $this->socket->expects($this->exactly(3))
             ->method('read')

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -309,6 +309,15 @@ class SmtpTransportTest extends TestCase
         $this->assertEquals($this->SmtpTransport->getAuthType(), SmtpTransport::AUTH_XOAUTH2);
     }
 
+    public function testExceptionOnlyAuthTypeSet(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('You must provide username and password for authType XOAUTH2');
+
+        $this->SmtpTransport->setConfig(['authType' => SmtpTransport::AUTH_XOAUTH2]);
+        $this->SmtpTransport->connect();
+    }
+
     public function testExceptionInvalidAuthType(): void
     {
         $this->expectException(CakeException::class);

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -305,7 +305,8 @@ class SmtpTransportTest extends TestCase
         $this->SmtpTransport->setConfig(['authType' => SmtpTransport::AUTH_XOAUTH2] + $this->credentials);
         try {
             $this->SmtpTransport->connect();
-        } catch (CakeException $e) {}
+        } catch (CakeException $e) {
+        }
         $this->assertEquals($this->SmtpTransport->getAuthType(), SmtpTransport::AUTH_XOAUTH2);
     }
 


### PR DESCRIPTION
I think the optimal solution would be to revert to the behavior observed prior to version 4.4.14:

- If "authtype," "username," and "password" parameters are set, the provided values will be used for authentication.
- If only "username" and "password" parameters are set, the system will automatically utilize the first available authentication type offered by the server.
- If neither "username" nor "password" parameters are set, no authentication will be performed, regardless of the authentication types offered by the server.