### PR TITLE
Skip SMTP auth type parsing if no credentials are provided.

### DIFF
--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -252,6 +252,10 @@ class SmtpTransport extends AbstractTransport
             return;
         }
 
+        if (!isset($this->_config['username'], $this->_config['password'])) {
+            return;
+        }
+
         $auth = '';
         foreach ($this->_lastResponse as $line) {
             if (strlen($line['message']) === 0 || substr($line['message'], 0, 5) === 'AUTH ') {

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -351,8 +351,28 @@ class SmtpTransportTest extends TestCase
                 ["EHLO localhost\r\n"],
             );
 
+        $this->SmtpTransport->setConfig($this->credentials);
         $this->SmtpTransport->connect();
-        $this->assertEquals($this->SmtpTransport->getAuthType(), SmtpTransport::AUTH_XOAUTH2);
+    }
+
+    public function testAuthTypeParsingIsSkippedIfNoCredentialsProvided(): void
+    {
+        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+
+        $this->socket->expects($this->exactly(2))
+            ->method('read')
+            ->will($this->onConsecutiveCalls(
+                "220 Welcome message\r\n",
+                "250 Accepted\r\n250 AUTH CRAM-MD5\r\n",
+            ));
+        $this->socket->expects($this->exactly(1))
+            ->method('write')
+            ->withConsecutive(
+                ["EHLO localhost\r\n"],
+            );
+
+        $this->SmtpTransport->connect();
+        $this->assertNull($this->SmtpTransport->getAuthType());
     }
 
     public function testAuthPlain(): void


### PR DESCRIPTION
Closes #17151

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
