### PR TITLE
5.x event result

### DIFF
--- a/src/Core/TestSuite/ContainerStubTrait.php
+++ b/src/Core/TestSuite/ContainerStubTrait.php
@@ -138,12 +138,12 @@ trait ContainerStubTrait
      *
      * @param \Cake\Event\EventInterface $event The event
      * @param \Cake\Core\ContainerInterface $container The container to wrap.
-     * @return \Cake\Core\ContainerInterface|null
+     * @return void
      */
-    public function modifyContainer(EventInterface $event, ContainerInterface $container): ?ContainerInterface
+    public function modifyContainer(EventInterface $event, ContainerInterface $container): void
     {
         if (empty($this->containerServices)) {
-            return null;
+            return;
         }
         foreach ($this->containerServices as $key => $factory) {
             if ($container->has($key)) {
@@ -157,7 +157,7 @@ trait ContainerStubTrait
             }
         }
 
-        return $container;
+        $event->setResult($container);
     }
 
     /**

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -90,10 +90,10 @@ class TimestampBehavior extends Behavior
      * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event Event instance.
      * @param \Cake\Datasource\EntityInterface $entity Entity instance.
      * @throws \UnexpectedValueException if a field's when value is misdefined
-     * @return true Returns true irrespective of the behavior logic, the save will not be prevented.
+     * @return void
      * @throws \UnexpectedValueException When the value for an event is not 'always', 'new' or 'existing'
      */
-    public function handleEvent(EventInterface $event, EntityInterface $entity): bool
+    public function handleEvent(EventInterface $event, EntityInterface $entity): void
     {
         $eventName = $event->getName();
         $events = $this->_config['events'];
@@ -122,8 +122,6 @@ class TimestampBehavior extends Behavior
                 $this->_updateField($entity, $field, $refresh);
             }
         }
-
-        return true;
     }
 
     /**

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -21,6 +21,7 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\Container;
 use Cake\Core\ContainerInterface;
+use Cake\Event\EventInterface;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequest;
@@ -259,11 +260,11 @@ class BaseApplicationTest extends TestCase
     public function testBuildContainerEventReplaceContainer(): void
     {
         $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
-        $app->getEventManager()->on('Application.buildContainer', function () {
+        $app->getEventManager()->on('Application.buildContainer', function (EventInterface $event) {
             $new = new Container();
             $new->add('testing', 'yes');
 
-            return $new;
+            $event->setResult($new);
         });
 
         $container = $app->getContainer();

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -91,8 +91,7 @@ class TimestampBehaviorTest extends TestCase
         $event = new Event('Model.beforeSave');
         $entity = new Entity(['name' => 'Foo']);
 
-        $return = $this->Behavior->handleEvent($event, $entity);
-        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf(DateTime::class, $entity->created);
         $this->assertSame($ts->format('c'), $entity->created->format('c'), 'Created timestamp is not the same');
     }
@@ -113,8 +112,7 @@ class TimestampBehaviorTest extends TestCase
         $existingValue = new NativeDateTime('2011-11-11');
         $entity = new Entity(['name' => 'Foo', 'created' => $existingValue]);
 
-        $return = $this->Behavior->handleEvent($event, $entity);
-        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->Behavior->handleEvent($event, $entity);
         $this->assertSame($existingValue, $entity->created, 'Created timestamp is expected to be unchanged');
     }
 
@@ -134,8 +132,7 @@ class TimestampBehaviorTest extends TestCase
         $entity = new Entity(['name' => 'Foo']);
         $entity->setNew(false);
 
-        $return = $this->Behavior->handleEvent($event, $entity);
-        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->Behavior->handleEvent($event, $entity);
         $this->assertNull($entity->created, 'Created timestamp is expected to be untouched if the entity is not new');
     }
 
@@ -155,8 +152,7 @@ class TimestampBehaviorTest extends TestCase
         $entity = new Entity(['name' => 'Foo']);
         $entity->setNew(false);
 
-        $return = $this->Behavior->handleEvent($event, $entity);
-        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf(DateTime::class, $entity->modified);
         $this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is not the same');
     }
@@ -179,8 +175,7 @@ class TimestampBehaviorTest extends TestCase
         $entity->clean();
         $entity->setNew(false);
 
-        $return = $this->Behavior->handleEvent($event, $entity);
-        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->Behavior->handleEvent($event, $entity);
         $this->assertInstanceOf(DateTime::class, $entity->modified);
         $this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is expected to be updated');
     }
@@ -199,8 +194,7 @@ class TimestampBehaviorTest extends TestCase
         $event = new Event('Model.beforeSave');
         $entity = new Entity(['name' => 'Foo']);
 
-        $return = $this->Behavior->handleEvent($event, $entity);
-        $this->assertTrue($return, 'Handle Event is expected to always return true');
+        $this->Behavior->handleEvent($event, $entity);
         $this->assertNull($entity->created);
         $this->assertNull($entity->modified);
     }


### PR DESCRIPTION
This removes returns from event callbacks and uses `EventInterface::setResult()` instead. The return in `TimestampBehavior` seems to be a redundant relic from 2.x days as it always returned `true`.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
