### PR TITLE
5.x: date validation

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Validation;
 
+use Cake\Chronos\Chronos;
+use Cake\Chronos\ChronosDate;
 use Cake\Core\Exception\CakeException;
 use Cake\I18n\DateTime;
 use Cake\Utility\Text;
@@ -446,7 +448,7 @@ class Validation
      */
     public static function date(mixed $check, array|string $format = 'ymd', ?string $regex = null): bool
     {
-        if ($check instanceof DateTimeInterface) {
+        if ($check instanceof DateTimeInterface || $check instanceof ChronosDate || $check instanceof Chronos) {
             return true;
         }
         if (is_object($check)) {
@@ -524,7 +526,7 @@ class Validation
      */
     public static function datetime(mixed $check, array|string $dateFormat = 'ymd', ?string $regex = null): bool
     {
-        if ($check instanceof DateTimeInterface) {
+        if ($check instanceof DateTimeInterface || $check instanceof Chronos) {
             return true;
         }
         if (is_object($check)) {
@@ -592,7 +594,7 @@ class Validation
      */
     public static function time(mixed $check): bool
     {
-        if ($check instanceof DateTimeInterface) {
+        if ($check instanceof DateTimeInterface || $check instanceof Chronos) {
             return true;
         }
         if (is_array($check)) {
@@ -624,7 +626,7 @@ class Validation
      */
     public static function localizedTime(mixed $check, string $type = 'datetime', string|int|null $format = null): bool
     {
-        if ($check instanceof DateTimeInterface) {
+        if ($check instanceof DateTimeInterface || $check instanceof Chronos) {
             return true;
         }
         if (!is_string($check)) {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -19,6 +19,8 @@ namespace Cake\Test\TestCase\Validation;
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime as CakeDateTime;
 use Cake\I18n\I18n;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validation;
@@ -961,6 +963,18 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::date(new stdClass()));
         $this->assertFalse(Validation::dateTime(new stdClass()));
         $this->assertFalse(Validation::localizedTime(new stdClass()));
+
+        $cakeDate = new Date();
+        $this->assertTrue(Validation::date($cakeDate));
+        $this->assertFalse(Validation::time($cakeDate));
+        $this->assertFalse(Validation::dateTime($cakeDate));
+        $this->assertFalse(Validation::localizedTime($cakeDate));
+
+        $cakeDateTime = new CakeDateTime();
+        $this->assertTrue(Validation::date($cakeDateTime));
+        $this->assertTrue(Validation::time($cakeDateTime));
+        $this->assertTrue(Validation::dateTime($cakeDateTime));
+        $this->assertTrue(Validation::localizedTime($cakeDateTime));
     }
 
     /**


### PR DESCRIPTION
The validation methods which are used in table classes like `$validator->dateTime('myDateTimeCol')` use these methods.

These haven't been adjusted to accept the new Chronos classes, therefore preventing entities from being saved if the field has been provided a Chronos or ChronosDate instance.