### PR TITLE
Fixed ServerShell not using PHP environment variable

### DIFF
--- a/src/Shell/ServerShell.php
+++ b/src/Shell/ServerShell.php
@@ -130,8 +130,10 @@ class ServerShell extends Shell
      */
     public function main()
     {
+        $phpBinary = env('PHP', 'php');
         $command = sprintf(
-            'php -S %s:%d -t %s',
+            '%s -S %s:%d -t %s',
+            $phpBinary,
             $this->_host,
             $this->_port,
             escapeshellarg($this->_documentRoot)


### PR DESCRIPTION
*The Issue*
ServerShell previously ignored the PHP env variable, this fixes that.

See issue: https://github.com/cakephp/cakephp/issues/15116

*Testing*
0. Make sure you have two different php versions. The global `php` executable and another somewhere you know the path.
1. Run `bin/cake server` without any additional flags or ENV variables.
2. Run `PHP=[path-to-php-executable] bin/cake server`, and make sure the prompt displays the correct PHP version.
