### PR TITLE
5.x: fix exception render tagging private plugin frames as vendor frames

### DIFF
--- a/templates/element/dev_error_stacktrace.php
+++ b/templates/element/dev_error_stacktrace.php
@@ -89,7 +89,7 @@ foreach ($exceptions as $level => $exc):
 
         $frameId = "{$level}-{$i}";
         $activeFrame = $i == 0;
-        $vendorFrame = isset($stack['file']) && !str_contains($stack['file'], APP) ? 'vendor-frame' : '';
+        $vendorFrame = isset($stack['file']) && str_starts_with($stack['file'], ROOT . DS . 'vendor') ? 'vendor-frame' : '';
     ?>
         <li id="stack-frame-<?= $frameId ?>" class="stack-frame <?= $vendorFrame ?>">
             <div class="stack-frame-header">


### PR DESCRIPTION
This PR changes the exception renderer to do

<img width="1708" alt="image" src="https://github.com/cakephp/cakephp/assets/9105243/47cff81c-75c6-4949-95fd-a03f32b72030">

instead of

<img width="1708" alt="image" src="https://github.com/cakephp/cakephp/assets/9105243/224b0ec2-62f6-4a6a-8796-65ab112c2bb0">

So private plugin frames are not marked as `vendor frames`

There is no test because I haven't found an easy way to reproduce this in a test environment.