### PR TITLE
5.x: add command events

### DIFF
--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -190,10 +190,10 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
             $io->setInteractive(false);
         }
 
-        $this->dispatchEvent('Command.executionStarted', ['args' => $args]);
+        $this->dispatchEvent('Command.beforeExecute', ['args' => $args]);
         /** @var int|null $result */
         $result = $this->execute($args, $io);
-        $this->dispatchEvent('Command.executionFinished', ['args' => $args, 'result' => $result]);
+        $this->dispatchEvent('Command.afterExecute', ['args' => $args, 'result' => $result]);
 
         return $result;
     }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -193,7 +193,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
         $this->dispatchEvent('Command.executionStarted', ['args' => $args]);
         /** @var int|null $result */
         $result = $this->execute($args, $io);
-        $this->dispatchEvent('Command.executionFinished', ['args' => $args]);
+        $this->dispatchEvent('Command.executionFinished', ['args' => $args, 'result' => $result]);
 
         return $result;
     }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -20,10 +20,7 @@ use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\StopException;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
-use Cake\Event\EventManager;
-use Cake\Event\EventManagerInterface;
 use Cake\Utility\Inflector;
-use InvalidArgumentException;
 
 /**
  * Base class for console commands.
@@ -288,27 +285,5 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
         } catch (StopException $e) {
             return $e->getCode();
         }
-    }
-
-    /**
-     * Get the global event manager.
-     *
-     * @return \Cake\Event\EventManagerInterface
-     */
-    public function getEventManager(): EventManagerInterface
-    {
-        return EventManager::instance();
-    }
-
-    /**
-     * Set the application's event manager.
-     *
-     * @param \Cake\Event\EventManagerInterface $eventManager The event manager to set.
-     * @return $this
-     * @throws \InvalidArgumentException
-     */
-    public function setEventManager(EventManagerInterface $eventManager)
-    {
-        throw new InvalidArgumentException('You are not allowed to overwrite the global event manager.');
     }
 }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -320,6 +320,10 @@ class CommandRunner implements EventDispatcherInterface
     protected function runCommand(CommandInterface $command, array $argv, ConsoleIo $io): ?int
     {
         try {
+            if ($command instanceof EventDispatcherInterface) {
+                $command->setEventManager($this->getEventManager());
+            }
+
             return $command->run($argv, $io);
         } catch (StopException $e) {
             return $e->getCode();

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -450,12 +450,12 @@ class CommandRunnerTest extends TestCase
         $runner = new CommandRunner($app, 'cake');
 
         $startedEventTriggered = $finishedEventTriggered = false;
-        $runner->getEventManager()->on('Command.executionStarted', function ($event, $args) use (&$startedEventTriggered): void {
+        $runner->getEventManager()->on('Command.beforeExecute', function ($event, $args) use (&$startedEventTriggered): void {
             $this->assertInstanceOf(VersionCommand::class, $event->getSubject());
             $this->assertInstanceOf(Arguments::class, $args);
             $startedEventTriggered = true;
         });
-        $runner->getEventManager()->on('Command.executionFinished', function ($event, $args, $result) use (&$finishedEventTriggered): void {
+        $runner->getEventManager()->on('Command.afterExecute', function ($event, $args, $result) use (&$finishedEventTriggered): void {
             $this->assertInstanceOf(VersionCommand::class, $event->getSubject());
             $this->assertInstanceOf(Arguments::class, $args);
             $this->assertEquals(CommandInterface::CODE_SUCCESS, $result);

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
+use Cake\Command\VersionCommand;
+use Cake\Console\Arguments;
 use Cake\Console\CommandCollection;
 use Cake\Console\CommandFactoryInterface;
 use Cake\Console\CommandInterface;
@@ -432,6 +434,35 @@ class CommandRunnerTest extends TestCase
         });
         $runner->run(['cake', '--version'], $this->getMockIo($output));
         $this->assertTrue($this->eventTriggered, 'Should have triggered event.');
+    }
+
+    /**
+     * Test that run() fires off the Command.started and Command.finished events.
+     */
+    public function testRunTriggersCommandEvents(): void
+    {
+        $app = $this->getMockBuilder(BaseApplication::class)
+            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
+            ->setConstructorArgs([$this->config])
+            ->getMock();
+
+        $output = new StubConsoleOutput();
+        $runner = new CommandRunner($app, 'cake');
+
+        $startedEventTriggered = $finishedEventTriggered = false;
+        $runner->getEventManager()->on('Command.executionStarted', function ($event, $args) use (&$startedEventTriggered): void {
+            $this->assertInstanceOf(VersionCommand::class, $event->getSubject());
+            $this->assertInstanceOf(Arguments::class, $args);
+            $startedEventTriggered = true;
+        });
+        $runner->getEventManager()->on('Command.executionFinished', function ($event, $args) use (&$finishedEventTriggered): void {
+            $this->assertInstanceOf(VersionCommand::class, $event->getSubject());
+            $this->assertInstanceOf(Arguments::class, $args);
+            $finishedEventTriggered = true;
+        });
+        $runner->run(['cake', '--version'], $this->getMockIo($output));
+        $this->assertTrue($startedEventTriggered, 'Should have triggered Command.started event.');
+        $this->assertTrue($finishedEventTriggered, 'Should have triggered Command.finished event.');
     }
 
     /**

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -455,9 +455,10 @@ class CommandRunnerTest extends TestCase
             $this->assertInstanceOf(Arguments::class, $args);
             $startedEventTriggered = true;
         });
-        $runner->getEventManager()->on('Command.executionFinished', function ($event, $args) use (&$finishedEventTriggered): void {
+        $runner->getEventManager()->on('Command.executionFinished', function ($event, $args, $result) use (&$finishedEventTriggered): void {
             $this->assertInstanceOf(VersionCommand::class, $event->getSubject());
             $this->assertInstanceOf(Arguments::class, $args);
+            $this->assertEquals(CommandInterface::CODE_SUCCESS, $result);
             $finishedEventTriggered = true;
         });
         $runner->run(['cake', '--version'], $this->getMockIo($output));


### PR DESCRIPTION
This PR adds 2 new events which will be triggered right before and right after the `execute()` method of the command has been called.

The event-listeners need to be added to the global EventManager.