### PR TITLE
Add __debugInfo to ValueBinder

### DIFF
--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -148,4 +148,16 @@ class ValueBinder
             $statement->bindValue($b['placeholder'], $b['value'], $b['type']);
         }
     }
+
+    /**
+     * Get verbose debugging data.
+     *
+     * @return array
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'bindings' => $this->bindings(),
+        ];
+    }
 }

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -159,4 +159,19 @@ class ValueBinderTest extends TestCase
         $valueBinder->bind(':c1', 'value1', 'string');
         $valueBinder->attachTo($statementMock);
     }
+
+    /**
+     * test the __debugInfo method
+     */
+    public function testDebugInfo(): void
+    {
+        $valueBinder = new ValueBinder();
+
+        $valueBinder->bind(':c0', 'value0');
+        $valueBinder->bind(':c1', 'value1');
+
+        $data = $valueBinder->__debugInfo();
+        $this->assertArrayHasKey('bindings', $data);
+        $this->assertArrayHasKey(':c0', $data['bindings']);
+    }
 }


### PR DESCRIPTION
When inspecting queries in a repl or test environment being able to see the bindings data with as small effort is helpful in evaluating queries that are being executed.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
