### PR TITLE
[5.x] Functions to access Request parameters with specific data types

### DIFF
--- a/src/Controller/RequestParamController.php
+++ b/src/Controller/RequestParamController.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Controller;
+
+class RequestParamController extends Controller
+{
+    use RequestParamTrait;
+}

--- a/src/Controller/RequestParamTrait.php
+++ b/src/Controller/RequestParamTrait.php
@@ -1,0 +1,241 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Controller;
+
+/**
+ * @mixin \Cake\Controller\Controller
+ */
+trait RequestParamTrait
+{
+    /**
+     * Provides a safe accessor for retrieving an integer value (int|null) from the Request->query.
+     * Validates value as int, and converts to int on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * String values are trimmed using trim().
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return int|null
+     */
+    public function getQueryInt(string $paramName): ?int
+    {
+        return $this->filterInt($this->request->getQuery($paramName, ''));
+    }
+
+    /**
+     * Provides a safe accessor for retrieving an integer value (int|null) from the Request->data.
+     * Validates value as int, and converts to int on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * String values are trimmed using trim().
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return int|null
+     */
+    public function getDataInt(string $paramName): ?int
+    {
+        return $this->filterInt($this->request->getData($paramName, ''));
+    }
+
+    /**
+     * Provides a safe accessor for retrieving an integer value (int|null) from the Request->params.
+     * Validates value as int, and converts to int on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * String values are trimmed using trim().
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return int|null
+     */
+    public function getParamInt(string $paramName): ?int
+    {
+        return $this->filterInt($this->request->getParam($paramName, ''));
+    }
+
+    /**
+     * Provides a safe accessor for retrieving an integer value (int|null) from the Request->cookies.
+     * Validates value as int, and converts to int on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * String values are trimmed using trim().
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return int|null
+     */
+    public function getCookieInt(string $paramName): ?int
+    {
+        return $this->filterInt($this->request->getCookie($paramName, ''));
+    }
+
+    /**
+     * Validates value as int, and converts to int on success, null on failure.
+     * String values are trimmed using trim().
+     *
+     * @param mixed $rawValue
+     * @return int|null
+     */
+    protected function filterInt(mixed $rawValue): ?int
+    {
+        return filter_var($rawValue, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a string value (string|null) from the Request->query.
+     * Validates the value as a string, and converts it to a string on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return string|null
+     */
+    public function getQueryString(string $paramName): ?string
+    {
+        $rawValue = $this->request->getQuery($paramName);
+
+        return is_string($rawValue) ? $rawValue : null;
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a string value (string|null) from the Request->data.
+     * Validates the value as a string, and converts it to a string on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return string|null
+     */
+    public function getDataString(string $paramName): ?string
+    {
+        $rawValue = $this->request->getData($paramName);
+
+        return is_string($rawValue) ? $rawValue : null;
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a string value (string|null) from the Request->params.
+     * Validates the value as a string, and converts it to a string on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return string|null
+     */
+    public function getParamString(string $paramName): ?string
+    {
+        $rawValue = $this->request->getParam($paramName);
+
+        return is_string($rawValue) ? $rawValue : null;
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a string value (string|null) from the Request->cookies.
+     * Validates the value as a string, and converts it to a string on success.
+     * Returns null on failure or if the value is missing.
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return string|null
+     */
+    public function getCookieString(string $paramName): ?string
+    {
+        $rawValue = $this->request->getCookie($paramName);
+
+        return is_string($rawValue) ? $rawValue : null;
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a bool value (bool|null) from the Request->query.
+     *
+     * 1 | '1' | 1.0 | true values returns as true
+     * 0 | '0' | 0.0 | false values returns as false
+     * Other values or missing values returns as null
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return bool|null
+     */
+    public function getQueryBool(string $paramName): ?bool
+    {
+        return $this->filterBool($this->request->getQuery($paramName, ''));
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a bool value (bool|null) from the Request->data.
+     *
+     * 1 | '1' | 1.0 | true values returns as true
+     * 0 | '0' | 0.0 | false values returns as false
+     * Other values or missing values returns as null
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return bool|null
+     */
+    public function getDataBool(string $paramName): ?bool
+    {
+        return $this->filterBool($this->request->getData($paramName, ''));
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a bool value (bool|null) from the Request->params.
+     *
+     * 1 | '1' | 1.0 | true values returns as true
+     * 0 | '0' | 0.0 | false values returns as false
+     * Other values or missing values returns as null
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return bool|null
+     */
+    public function getParamBool(string $paramName): ?bool
+    {
+        return $this->filterBool($this->request->getParam($paramName, ''));
+    }
+
+    /**
+     * Provides a safe accessor for retrieving a bool value (bool|null) from the Request->cookies.
+     *
+     * 1 | '1' | 1.0 | true values returns as true
+     * 0 | '0' | 0.0 | false values returns as false
+     * Other values or missing values returns as null
+     *
+     * Allows you to use Hash::get() compatible paths.
+     *
+     * @param string $paramName Dot separated name of the value to read.
+     * @return bool|null
+     */
+    public function getCookieBool(string $paramName): ?bool
+    {
+        return $this->filterBool($this->request->getCookie($paramName, ''));
+    }
+
+    /**
+     * 1 | '1' | 1.0 | true values returns as true
+     * 0 | '0' | 0.0 | false values returns as false
+     * Other values or missing values returns as null
+     *
+     * @param mixed $rawValue
+     * @return bool|null
+     */
+    protected function filterBool(mixed $rawValue): ?bool
+    {
+        if ($rawValue === '1' || $rawValue === 1 || $rawValue === 1.0 || $rawValue === true) {
+            return true;
+        } elseif ($rawValue === '0' || $rawValue === 0 || $rawValue === 0.0 || $rawValue === false) {
+            return false;
+        } else {
+            return null;
+        }
+    }
+}

--- a/tests/TestCase/Controller/RequestParamTraitTest.php
+++ b/tests/TestCase/Controller/RequestParamTraitTest.php
@@ -1,0 +1,328 @@
+<?php
+declare(strict_types=1);
+
+namespace Controller;
+
+use Cake\Controller\RequestParamController;
+use Cake\Http\Cookie\Cookie;
+use Cake\Http\Cookie\CookieCollection;
+use Cake\Http\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+class RequestParamTraitTest extends TestCase
+{
+    /**
+     * @dataProvider getQueryIntProvider
+     */
+    public function testGetQueryInt(string $query, ?int $expected): void
+    {
+        $result = $this->getControllerWithQuery($query)->getQueryInt('test');
+        $this->assertSame($expected, $result);
+    }
+
+    public static function getQueryIntProvider(): array
+    {
+        return [
+            'empty query' => ['', null],
+            'missing' => ['other-test=', null],
+            'empty' => ['test=', null],
+            'space' => ['test= ', null],
+            'null' => ['test=null', null],
+            'dash' => ['test=-', null],
+            'ctz' => ['test=čťž', null],
+            'hex' => ['test=0x539', null],
+            'binary' => ['test=0b10100111001', null],
+            'zero' => ['test=0', 0],
+            'number' => ['test=55', 55],
+            'number_space_before' => ['test= 55', 55],
+            'number_space_after' => ['test=55 ', 55],
+            'negative number' => ['test=-5', -5],
+            'float round' => ['test=5.0', null],
+            'float real' => ['test=5.1', null],
+            'float round slovak' => ['test=5,0', null],
+            'int ok-overflow' => ['test=9223372036854775807', 9223372036854775807],
+            'int overflow' => ['test=9223372036854775808', null],
+            'int-negative ok-overflow' => ['test=-9223372036854775807', -9223372036854775807],
+            //-9223372036854775808 - PHP inconsistency (once float, once int)
+            'int-negative overflow' => ['test=-9223372036854775809', null],
+            'string' => ['test=f', null],
+            'partially1 number' => ['test=5 5', null],
+            'partially2 number' => ['test=5x', null],
+            'partially3 number' => ['test=x4', null],
+            'empty-array' => ['test[]=', null],
+            'int-array' => ['test[]=5', null],
+            'int-one-array' => ['test[1]=5', null],
+            'string-one-array' => ['test[1]=h', null],
+        ];
+    }
+
+    /**
+     * @dataProvider getIntProvider
+     */
+    public function testGetDataInt(mixed $rawValue, ?int $expected): void
+    {
+        $result = $this->getControllerWithData('test', $rawValue)->getDataInt('test');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider getIntProvider
+     */
+    public function testGetParamInt(mixed $rawValue, ?int $expected): void
+    {
+        $result = $this->getControllerWithParam('test', $rawValue)->getParamInt('test');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider getIntProvider
+     */
+    public function testGetCookieInt(mixed $rawValue, ?int $expected): void
+    {
+        $result = $this->getControllerWithCookie('test', $rawValue)->getCookieInt('test');
+        $this->assertSame($expected, $result);
+    }
+
+    public static function getIntProvider(): array
+    {
+        return [
+            // like string
+            '(string) empty' => ['', null],
+            '(string) space' => [' ', null],
+            '(string) null' => ['null', null],
+            '(string) dash' => ['-', null],
+            '(string) ctz' => ['čťž', null],
+            '(string) hex' => ['0x539', null],
+            '(string) binary' => ['0b10100111001', null],
+            '(string) zero' => ['0', 0],
+            '(string) number' => ['55', 55],
+            '(string) number_space_before' => [' 55', 55],
+            '(string) number_space_after' => ['55 ', 55],
+            '(string) negative number' => ['-5', -5],
+            '(string) float round' => ['5.0', null],
+            '(string) float real' => ['5.1', null],
+            '(string) float round slovak' => ['5,0', null],
+            '(string) int ok-overflow' => ['9223372036854775807', 9223372036854775807],
+            '(string) int overflow' => ['9223372036854775808', null],
+            '(string) int-negative ok-overflow' => ['-9223372036854775807', -9223372036854775807],
+            // -9223372036854775808 - PHP inconsistency (once float, once int)
+            '(string) int-negative overflow' => ['-9223372036854775809', null],
+            '(string) string' => ['f', null],
+            '(string) partially1 number' => ['5 5', null],
+            '(string) partially2 number' => ['5x', null],
+            '(string) partially3 number' => ['x4', null],
+            // like int
+            '(int) number' => [55, 55],
+            '(int) negative number' => [-5, -5],
+            '(int) int ok-overflow' => [9223372036854775807, 9223372036854775807],
+            '(int) int overflow' => [9223372036854775808, null],
+            '(int) int-negative ok-overflow' => [-9223372036854775807, -9223372036854775807],
+            '(int) int-negative overflow' => [-9223372036854775809, null],
+            // other
+            'empty-array' => [[], null],
+            'int-array' => [[5], null],
+            'int-one-array' => [[1 => 5], null],
+            'string-one-array' => [[1 => 'h'], null],
+            'float' => [5.5, null],
+            'float round' => [5.0, 5],
+            'float negative' => [-5.5, null],
+            'float round negative' => [-5.0, -5],
+        ];
+    }
+
+    /**
+     * @dataProvider getQueryStringProvider
+     */
+    public function testGetQueryString(string $query, ?string $expected): void
+    {
+        $result = $this->getControllerWithQuery($query)->getQueryString('test');
+        $this->assertSame($expected, $result);
+    }
+
+    public static function getQueryStringProvider(): array
+    {
+        return [
+            'empty query' => ['', null],
+            'missing' => ['other-test=', null],
+            'empty' => ['test=', ''],
+            'space' => ['test= ', ' '],
+            'null' => ['test=null', 'null'],
+            'dash' => ['test=-', '-'],
+            'ctz' => ['test=čťž', 'čťž'],
+            'hex' => ['test=0x539', '0x539'],
+            'binary' => ['test=0b10100111001', '0b10100111001'],
+            'zero' => ['test=0', '0'],
+            'number' => ['test=55', '55'],
+            'number_space_before' => ['test= 55', ' 55'],
+            'number_space_after' => ['test=55 ', '55 '],
+            'negative number' => ['test=-5', '-5'],
+            'float round' => ['test=5.0', '5.0'],
+            'float real' => ['test=5.1', '5.1'],
+            'float round slovak' => ['test=5,0', '5,0'],
+            'int ok-overflow' => ['test=9223372036854775807', '9223372036854775807'],
+            'int overflow' => ['test=9223372036854775808', '9223372036854775808'],
+            'int-negative ok-overflow' => ['test=-9223372036854775807', '-9223372036854775807'],
+            'int-negative overflow' => ['test=-9223372036854775809', '-9223372036854775809'],
+            'string' => ['test=f', 'f'],
+            'partially1 number' => ['test=5 5', '5 5'],
+            'partially2 number' => ['test=5x', '5x'],
+            'partially3 number' => ['test=x4', 'x4'],
+            'empty-array' => ['test[]=', null],
+            'int-array' => ['test[]=5', null],
+            'int-one-array' => ['test[1]=5', null],
+            'string-one-array' => ['test[1]=h', null],
+        ];
+    }
+
+    /**
+     * @dataProvider getStringProvider
+     */
+    public function testGetDataString(mixed $value, ?string $expected): void
+    {
+        $result = $this->getControllerWithData('test', $value)->getDataString('test');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider getStringProvider
+     */
+    public function testGetParamString(mixed $value, ?string $expected): void
+    {
+        $result = $this->getControllerWithParam('test', $value)->getParamString('test');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider getStringProvider
+     */
+    public function testGetCookieString(mixed $value, ?string $expected): void
+    {
+        $result = $this->getControllerWithCookie('test', $value)->getCookieString('test');
+        $this->assertSame($expected, $result);
+    }
+
+    public static function getStringProvider(): array
+    {
+        return [
+            'empty' => ['', ''],
+            'space' => [' ', ' '],
+            'dash' => ['-', '-'],
+            'zero' => ['0', '0'],
+            'number' => ['55', '55'],
+            'partially2 number' => ['5x', '5x'],
+            'string-array' => [['5'], null],
+        ];
+    }
+
+    /**
+     * @dataProvider getQueryBoolProvider
+     */
+    public function testGetQueryBool(string $query, ?bool $expected): void
+    {
+        $result = $this->getControllerWithQuery($query)->getQueryBool('test');
+        $this->assertSame($expected, $result, 'query: ' . $query);
+    }
+
+    public static function getQueryBoolProvider(): array
+    {
+        return [
+            'empty string' => ['test=', null],
+            'space' => ['test= ', null],
+            'some word' => ['test=abc', null],
+            'double 0' => ['test=00', null],
+            'single 0' => ['test=0', false],
+            'false' => ['test=false', null],
+            'double 1' => ['test=11', null],
+            'single 1' => ['test=1', true],
+            'true' => ['test=true', null],
+            'empty-array' => ['test[]=', null],
+            'int-array' => ['test[]=1', null],
+            'int-one-array' => ['test[1]=true', null],
+            'string-one-array' => ['test[1]=0', null],
+        ];
+    }
+
+    /**
+     * @dataProvider getBoolProvider
+     */
+    public function testGetDataBool(mixed $rawValue, ?bool $expected): void
+    {
+        $result = $this->getControllerWithData('test', $rawValue)->getDataBool('test');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider getBoolProvider
+     */
+    public function testGetParamBool(mixed $rawValue, ?bool $expected): void
+    {
+        $result = $this->getControllerWithParam('test', $rawValue)->getParamBool('test');
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @dataProvider getBoolProvider
+     */
+    public function testGetCookieBool(mixed $rawValue, ?bool $expected): void
+    {
+        $result = $this->getControllerWithCookie('test', $rawValue)->getCookieBool('test');
+        $this->assertSame($expected, $result);
+    }
+
+    public static function getBoolProvider(): array
+    {
+        return [
+            'empty string' => ['', null],
+            'space' => [' ', null],
+            'some word' => ['abc', null],
+            'double 0' => ['00', null],
+            'single 0' => ['0', false],
+            'false' => ['false', null],
+            'double 1' => ['11', null],
+            'single 1' => ['1', true],
+            'true-string' => ['true', null],
+            'true' => [true, true],
+            'int 0' => [0, false],
+            'int 1' => [1, true],
+            'int -1' => [-1, null],
+            'int 55' => [55, null],
+            'negative number' => [-5, null],
+            'empty-array' => [[], null],
+            'int-array' => [[5], null],
+            'int-one-array' => [[1 => 5], null],
+            'string-one-array' => [[1 => 'h'], null],
+            'float' => [5.5, null],
+            'float round' => [5.0, null],
+            'float 0.0' => [0.0, false],
+            'float 1.0' => [1.0, true],
+        ];
+    }
+
+    private function getControllerWithQuery(string $query): RequestParamController
+    {
+        $request = new ServerRequest(['url' => '/some/url?' . $query]);
+
+        return new RequestParamController($request);
+    }
+
+    private function getControllerWithData(string $name, mixed $value): RequestParamController
+    {
+        $request = (new ServerRequest())->withData($name, $value);
+
+        return new RequestParamController($request);
+    }
+
+    private function getControllerWithParam(string $name, mixed $value): RequestParamController
+    {
+        $request = (new ServerRequest())->withParam($name, $value);
+
+        return new RequestParamController($request);
+    }
+
+    private function getControllerWithCookie(string $name, array|string|float|int|bool $value): RequestParamController
+    {
+        $request = (new ServerRequest())->withCookieCollection(new CookieCollection([new Cookie($name, $value)]));
+
+        return new RequestParamController($request);
+    }
+}


### PR DESCRIPTION
These functions solve the problem with functions like Request->getQuery() that return a mixed type.

Many programmers overlook the possibility of receiving an unexpected array instead of a string, which can occur, for example, when bots are searching for security vulnerabilities. In certain cases, script execution may fail due to input validation occurring deeper in the code.

PHP is becoming more type-oriented, and tools like PhpStan encourage documenting mixed type through PhpDocs comments.

These functions prevent potentially dangerous typecasting of mixed type, so we enhance the overall security.

The development process becomes more efficient as programmers no longer need to focus on handling multiple input types. And no need to add comments/suppressions for Psalm and PhpStan.

Before:
```php
$token = $this->request->getCookie($this->_config['cookie']);
if ($token !== null) {
    /** @psalm-suppress PossiblyInvalidCast */
    $token = (string)$token;
}

return $token;
```

After:
```php
return $this->request->getCookieString($this->_config['cookie']);
```

The new functions cover the "get" operations from:
 - $request->cookies
 - $request->query
 - $request->params
 - $request->data

For types:
 - int
 - string
 - bool

Q: Is the `$default` parameter missing?
A: No, instead of `$default`, the `??` operator is now used, starting from PHP 7 :)