### PR TITLE
4.5 Add deprecations to Connection methods

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -318,7 +318,9 @@ class Connection implements ConnectionInterface
      */
     public function connect(): bool
     {
-        deprecationWarning('If you cannot use automatic connection management, use $connection->getDriver()->connect() instead.');
+        deprecationWarning(
+            'If you cannot use automatic connection management, use $connection->getDriver()->connect() instead.'
+        );
 
         $connected = true;
         foreach ([self::ROLE_READ, self::ROLE_WRITE] as $role) {
@@ -349,7 +351,9 @@ class Connection implements ConnectionInterface
      */
     public function disconnect(): void
     {
-        deprecationWarning('If you cannot use automatic connection management, use $connection->getDriver()->disconnect() instead.');
+        deprecationWarning(
+            'If you cannot use automatic connection management, use $connection->getDriver()->disconnect() instead.'
+        );
 
         $this->getDriver(self::ROLE_READ)->disconnect();
         $this->getDriver(self::ROLE_WRITE)->disconnect();

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -318,6 +318,8 @@ class Connection implements ConnectionInterface
      */
     public function connect(): bool
     {
+        deprecationWarning('If you cannot use automatic connection management, use $connection->getDriver()->connect() instead.');
+
         $connected = true;
         foreach ([self::ROLE_READ, self::ROLE_WRITE] as $role) {
             try {
@@ -343,9 +345,12 @@ class Connection implements ConnectionInterface
      * Disconnects from database server.
      *
      * @return void
+     * @deprecated 4.5.0 Use getDriver()->disconnect() instead.
      */
     public function disconnect(): void
     {
+        deprecationWarning('If you cannot use automatic connection management, use $connection->getDriver()->disconnect() instead.');
+
         $this->getDriver(self::ROLE_READ)->disconnect();
         $this->getDriver(self::ROLE_WRITE)->disconnect();
     }
@@ -354,9 +359,12 @@ class Connection implements ConnectionInterface
      * Returns whether connection to database server was already established.
      *
      * @return bool
+     * @deprecated 4.5.0 Use getDriver()->isConnected() instead.
      */
     public function isConnected(): bool
     {
+        deprecationWarning('Use $connection->getDriver()->isConnected() instead.');
+
         return $this->getDriver(self::ROLE_READ)->isConnected() && $this->getDriver(self::ROLE_WRITE)->isConnected();
     }
 
@@ -365,6 +373,7 @@ class Connection implements ConnectionInterface
      *
      * @param \Cake\Database\Query|string $query The SQL to convert into a prepared statement.
      * @return \Cake\Database\StatementInterface
+     * @deprecated 4.5.0 Use getDriver()->prepare() instead.
      */
     public function prepare($query): StatementInterface
     {
@@ -413,6 +422,8 @@ class Connection implements ConnectionInterface
      */
     public function compileQuery(Query $query, ValueBinder $binder): string
     {
+        deprecationWarning('Use getDriver()->compileQuery() instead.');
+
         return $this->getDriver($query->getConnectionRole())->compileQuery($query, $binder)[1];
     }
 
@@ -467,6 +478,8 @@ class Connection implements ConnectionInterface
      */
     public function query(string $sql): StatementInterface
     {
+        deprecationWarning('Use either `selectQuery`, `insertQuery`, `deleteQuery`, `updateQuery` instead.');
+
         return $this->getDisconnectRetry()->run(function () use ($sql) {
             $statement = $this->prepare($sql);
             $statement->execute();
@@ -940,9 +953,11 @@ class Connection implements ConnectionInterface
      * @param mixed $value The value to quote.
      * @param \Cake\Database\TypeInterface|string|int $type Type to be used for determining kind of quoting to perform
      * @return string Quoted value
+     * @deprecated 4.5.0 Use getDriver()->quote() instead.
      */
     public function quote($value, $type = 'string'): string
     {
+        deprecationWarning('Use getDriver()->quote() instead.');
         [$value, $type] = $this->cast($value, $type);
 
         return $this->getDriver()->quote($value, $type);
@@ -954,9 +969,12 @@ class Connection implements ConnectionInterface
      * This is not required to use `quoteIdentifier()`.
      *
      * @return bool
+     * @deprecated 4.5.0 Use getDriver()->supportsQuoting() instead.
      */
     public function supportsQuoting(): bool
     {
+        deprecationWarning('Use getDriver()->supportsQuoting() instead.');
+
         return $this->getDriver()->supports(DriverInterface::FEATURE_QUOTE);
     }
 
@@ -968,9 +986,12 @@ class Connection implements ConnectionInterface
      *
      * @param string $identifier The identifier to quote.
      * @return string
+     * @deprecated 4.5.0 Use getDriver()->quoteIdentifier() instead.
      */
     public function quoteIdentifier(string $identifier): string
     {
+        deprecationWarning('Use getDriver()->quoteIdentifier() instead.');
+
         return $this->getDriver()->quoteIdentifier($identifier);
     }
 
@@ -1031,6 +1052,7 @@ class Connection implements ConnectionInterface
      *
      * @param bool $enable Enable/disable query logging
      * @return $this
+     * @deprecated 4.5.0 Connection logging is moving to the driver in 5.x
      */
     public function enableQueryLogging(bool $enable = true)
     {
@@ -1043,6 +1065,7 @@ class Connection implements ConnectionInterface
      * Disable query logging
      *
      * @return $this
+     * @deprecated 4.5.0 Connection logging is moving to the driver in 5.x
      */
     public function disableQueryLogging()
     {
@@ -1055,6 +1078,7 @@ class Connection implements ConnectionInterface
      * Check if query logging is enabled.
      *
      * @return bool
+     * @deprecated 4.5.0 Connection logging is moving to the driver in 5.x
      */
     public function isQueryLoggingEnabled(): bool
     {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -329,8 +329,9 @@ class Query implements ExpressionInterface, IteratorAggregate
             $binder = $this->getValueBinder();
             $binder->resetCount();
         }
+        $connection = $this->getConnection();
 
-        return $this->getConnection()->compileQuery($this, $binder);
+        return $connection->getDriver($this->getConnectionRole())->compileQuery($this, $binder)[1];
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -92,10 +92,8 @@ class ConnectionTest extends TestCase
         $this->connection = ConnectionManager::get('test');
         $this->defaultLogger = $this->connection->getLogger();
 
-        $this->deprecated(function () {
-            $this->logState = $this->connection->isQueryLoggingEnabled();
-            $this->connection->disableQueryLogging();
-        });
+        $this->logState = $this->connection->isQueryLoggingEnabled();
+        $this->connection->disableQueryLogging();
 
         static::setAppNamespace();
     }
@@ -105,9 +103,7 @@ class ConnectionTest extends TestCase
         parent::tearDown();
         $this->connection->disableSavePoints();
         $this->connection->setLogger($this->defaultLogger);
-        $this->deprecated(function () {
-            $this->connection->enableQueryLogging($this->logState);
-        });
+        $this->connection->enableQueryLogging($this->logState);
 
         Log::reset();
         unset($this->connection);
@@ -298,18 +294,16 @@ class ConnectionTest extends TestCase
      */
     public function testPrepare(): void
     {
-        $this->deprecated(function () {
-            $sql = 'SELECT 1 + 1';
-            $result = $this->connection->prepare($sql);
-            $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-            $this->assertEquals($sql, $result->queryString);
+        $sql = 'SELECT 1 + 1';
+        $result = $this->connection->prepare($sql);
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $this->assertEquals($sql, $result->queryString);
 
-            $query = $this->connection->selectQuery('1 + 1');
-            $result = $this->connection->prepare($query);
-            $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-            $sql = '#SELECT [`"\[]?1 \+ 1[`"\]]?#';
-            $this->assertMatchesRegularExpression($sql, $result->queryString);
-        });
+        $query = $this->connection->selectQuery('1 + 1');
+        $result = $this->connection->prepare($query);
+        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+        $sql = '#SELECT [`"\[]?1 \+ 1[`"\]]?#';
+        $this->assertMatchesRegularExpression($sql, $result->queryString);
     }
 
     /**
@@ -856,37 +850,35 @@ class ConnectionTest extends TestCase
      */
     public function testInTransactionWithSavePoints(): void
     {
-        $this->deprecated(function () {
-            $this->skipIf(
-                $this->connection->getDriver() instanceof Sqlserver,
-                'SQLServer fails when this test is included.'
-            );
+        $this->skipIf(
+            $this->connection->getDriver() instanceof Sqlserver,
+            'SQLServer fails when this test is included.'
+        );
 
-            $this->connection->enableSavePoints(true);
-            $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
+        $this->connection->enableSavePoints(true);
+        $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
 
-            $this->connection->begin();
-            $this->assertTrue($this->connection->inTransaction());
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
 
-            $this->connection->begin();
-            $this->assertTrue($this->connection->inTransaction());
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
 
-            $this->connection->commit();
-            $this->assertTrue($this->connection->inTransaction());
+        $this->connection->commit();
+        $this->assertTrue($this->connection->inTransaction());
 
-            $this->connection->commit();
-            $this->assertFalse($this->connection->inTransaction());
+        $this->connection->commit();
+        $this->assertFalse($this->connection->inTransaction());
 
-            $this->connection->begin();
-            $this->assertTrue($this->connection->inTransaction());
+        $this->connection->begin();
+        $this->assertTrue($this->connection->inTransaction());
 
-            $this->connection->begin();
-            $this->connection->rollback();
-            $this->assertTrue($this->connection->inTransaction());
+        $this->connection->begin();
+        $this->connection->rollback();
+        $this->assertTrue($this->connection->inTransaction());
 
-            $this->connection->rollback();
-            $this->assertFalse($this->connection->inTransaction());
-        });
+        $this->connection->rollback();
+        $this->assertFalse($this->connection->inTransaction());
     }
 
     /**
@@ -1047,18 +1039,16 @@ class ConnectionTest extends TestCase
      */
     public function testLoggerDecorator(): void
     {
-        $this->deprecated(function () {
-            $logger = new QueryLogger();
-            $this->connection->enableQueryLogging(true);
-            $this->connection->setLogger($logger);
-            $st = $this->connection->prepare('SELECT 1');
-            $this->assertInstanceOf(LoggingStatement::class, $st);
-            $this->assertSame($logger, $st->getLogger());
+        $logger = new QueryLogger();
+        $this->connection->enableQueryLogging(true);
+        $this->connection->setLogger($logger);
+        $st = $this->connection->prepare('SELECT 1');
+        $this->assertInstanceOf(LoggingStatement::class, $st);
+        $this->assertSame($logger, $st->getLogger());
 
-            $this->connection->enableQueryLogging(false);
-            $st = $this->connection->prepare('SELECT 1');
-            $this->assertNotInstanceOf('Cake\Database\Log\LoggingStatement', $st);
-        });
+        $this->connection->enableQueryLogging(false);
+        $st = $this->connection->prepare('SELECT 1');
+        $this->assertNotInstanceOf('Cake\Database\Log\LoggingStatement', $st);
     }
 
     /**
@@ -1066,13 +1056,11 @@ class ConnectionTest extends TestCase
      */
     public function testEnableQueryLogging(): void
     {
-        $this->deprecated(function () {
-            $this->connection->enableQueryLogging(true);
-            $this->assertTrue($this->connection->isQueryLoggingEnabled());
+        $this->connection->enableQueryLogging(true);
+        $this->assertTrue($this->connection->isQueryLoggingEnabled());
 
-            $this->connection->disableQueryLogging();
-            $this->assertFalse($this->connection->isQueryLoggingEnabled());
-        });
+        $this->connection->disableQueryLogging();
+        $this->assertFalse($this->connection->isQueryLoggingEnabled());
     }
 
     /**
@@ -1081,14 +1069,12 @@ class ConnectionTest extends TestCase
     public function testLogFunction(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
-        $this->deprecated(function () {
-            $this->connection->enableQueryLogging();
-            $this->connection->log('SELECT 1');
+        $this->connection->enableQueryLogging();
+        $this->connection->log('SELECT 1');
 
-            $messages = Log::engine('queries')->read();
-            $this->assertCount(1, $messages);
-            $this->assertSame('debug: connection=test role= duration=0 rows=0 SELECT 1', $messages[0]);
-        });
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(1, $messages);
+        $this->assertSame('debug: connection=test role= duration=0 rows=0 SELECT 1', $messages[0]);
     }
 
     /**
@@ -1097,32 +1083,30 @@ class ConnectionTest extends TestCase
     public function testLoggerDecoratorDoesNotPrematurelyFetchRecords(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
-        $this->deprecated(function () {
-            $logger = new QueryLogger();
-            $this->connection->enableQueryLogging(true);
-            $this->connection->setLogger($logger);
-            $st = $this->connection->execute('SELECT * FROM things');
-            $this->assertInstanceOf(LoggingStatement::class, $st);
+        $logger = new QueryLogger();
+        $this->connection->enableQueryLogging(true);
+        $this->connection->setLogger($logger);
+        $st = $this->connection->execute('SELECT * FROM things');
+        $this->assertInstanceOf(LoggingStatement::class, $st);
 
-            $messages = Log::engine('queries')->read();
-            $this->assertCount(0, $messages);
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(0, $messages);
 
-            $expected = [
-                [1, 'a title', 'a body'],
-                [2, 'another title', 'another body'],
-            ];
-            $results = $st->fetchAll();
-            $this->assertEquals($expected, $results);
+        $expected = [
+            [1, 'a title', 'a body'],
+            [2, 'another title', 'another body'],
+        ];
+        $results = $st->fetchAll();
+        $this->assertEquals($expected, $results);
 
-            $messages = Log::engine('queries')->read();
-            $this->assertCount(1, $messages);
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(1, $messages);
 
-            $st = $this->connection->execute('SELECT * FROM things WHERE id = 0');
-            $this->assertSame(0, $st->rowCount());
+        $st = $this->connection->execute('SELECT * FROM things WHERE id = 0');
+        $this->assertSame(0, $st->rowCount());
 
-            $messages = Log::engine('queries')->read();
-            $this->assertCount(2, $messages, 'Select queries without any matching rows should also be logged.');
-        });
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(2, $messages, 'Select queries without any matching rows should also be logged.');
     }
 
     /**
@@ -1132,28 +1116,26 @@ class ConnectionTest extends TestCase
     {
         Log::setConfig('queries', ['className' => 'Array']);
 
-        $this->deprecated(function () {
-            $connection = $this
-                ->getMockBuilder(Connection::class)
-                ->onlyMethods(['connect'])
-                ->disableOriginalConstructor()
-                ->getMock();
-            $connection->enableQueryLogging(true);
+        $connection = $this
+            ->getMockBuilder(Connection::class)
+            ->onlyMethods(['connect'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $connection->enableQueryLogging(true);
 
-            $this->deprecated(function () use ($connection) {
-                $driver = $this->getMockFormDriver();
-                $connection->setDriver($driver);
-            });
-
-            $connection->begin();
-            $connection->begin(); //This one will not be logged
-            $connection->rollback();
-
-            $messages = Log::engine('queries')->read();
-            $this->assertCount(2, $messages);
-            $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
-            $this->assertSame('debug: connection= role= duration=0 rows=0 ROLLBACK', $messages[1]);
+        $this->deprecated(function () use ($connection) {
+            $driver = $this->getMockFormDriver();
+            $connection->setDriver($driver);
         });
+
+        $connection->begin();
+        $connection->begin(); //This one will not be logged
+        $connection->rollback();
+
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(2, $messages);
+        $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
+        $this->assertSame('debug: connection= role= duration=0 rows=0 ROLLBACK', $messages[1]);
     }
 
     /**
@@ -1161,23 +1143,21 @@ class ConnectionTest extends TestCase
      */
     public function testLogCommitTransaction(): void
     {
-        $this->deprecated(function () {
-            $driver = $this->getMockFormDriver();
-            $connection = $this->getMockBuilder(Connection::class)
-                ->onlyMethods(['connect'])
-                ->setConstructorArgs([['driver' => $driver]])
-                ->getMock();
+        $driver = $this->getMockFormDriver();
+        $connection = $this->getMockBuilder(Connection::class)
+            ->onlyMethods(['connect'])
+            ->setConstructorArgs([['driver' => $driver]])
+            ->getMock();
 
-            Log::setConfig('queries', ['className' => 'Array']);
-            $connection->enableQueryLogging(true);
-            $connection->begin();
-            $connection->commit();
+        Log::setConfig('queries', ['className' => 'Array']);
+        $connection->enableQueryLogging(true);
+        $connection->begin();
+        $connection->commit();
 
-            $messages = Log::engine('queries')->read();
-            $this->assertCount(2, $messages);
-            $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
-            $this->assertSame('debug: connection= role= duration=0 rows=0 COMMIT', $messages[1]);
-        });
+        $messages = Log::engine('queries')->read();
+        $this->assertCount(2, $messages);
+        $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
+        $this->assertSame('debug: connection= role= duration=0 rows=0 COMMIT', $messages[1]);
     }
 
     /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -92,8 +92,10 @@ class ConnectionTest extends TestCase
         $this->connection = ConnectionManager::get('test');
         $this->defaultLogger = $this->connection->getLogger();
 
-        $this->logState = $this->connection->isQueryLoggingEnabled();
-        $this->connection->disableQueryLogging();
+        $this->deprecated(function () {
+            $this->logState = $this->connection->isQueryLoggingEnabled();
+            $this->connection->disableQueryLogging();
+        });
 
         static::setAppNamespace();
     }
@@ -103,7 +105,9 @@ class ConnectionTest extends TestCase
         parent::tearDown();
         $this->connection->disableSavePoints();
         $this->connection->setLogger($this->defaultLogger);
-        $this->connection->enableQueryLogging($this->logState);
+        $this->deprecated(function () {
+            $this->connection->enableQueryLogging($this->logState);
+        });
 
         Log::reset();
         unset($this->connection);
@@ -130,8 +134,10 @@ class ConnectionTest extends TestCase
      */
     public function testConnect(): void
     {
-        $this->assertTrue($this->connection->connect());
-        $this->assertTrue($this->connection->isConnected());
+        $this->deprecated(function () {
+            $this->assertTrue($this->connection->connect());
+            $this->assertTrue($this->connection->isConnected());
+        });
     }
 
     /**
@@ -249,25 +255,27 @@ class ConnectionTest extends TestCase
      */
     public function testWrongCredentials(): void
     {
-        $config = ConnectionManager::getConfig('test');
-        $this->skipIf(isset($config['url']), 'Datasource has dsn, skipping.');
-        $connection = new Connection(['database' => '/dev/nonexistent'] + ConnectionManager::getConfig('test'));
+        $this->deprecated(function () {
+            $config = ConnectionManager::getConfig('test');
+            $this->skipIf(isset($config['url']), 'Datasource has dsn, skipping.');
+            $connection = new Connection(['database' => '/dev/nonexistent'] + ConnectionManager::getConfig('test'));
 
-        $e = null;
-        try {
-            $connection->connect();
-        } catch (MissingConnectionException $e) {
-        }
+            $e = null;
+            try {
+                $connection->connect();
+            } catch (MissingConnectionException $e) {
+            }
 
-        $this->assertNotNull($e);
-        $this->assertStringStartsWith(
-            sprintf(
-                'Connection to %s could not be established:',
-                App::shortName(get_class($connection->getDriver()), 'Database/Driver')
-            ),
-            $e->getMessage()
-        );
-        $this->assertInstanceOf('PDOException', $e->getPrevious());
+            $this->assertNotNull($e);
+            $this->assertStringStartsWith(
+                sprintf(
+                    'Connection to %s could not be established:',
+                    App::shortName(get_class($connection->getDriver()), 'Database/Driver')
+                ),
+                $e->getMessage()
+            );
+            $this->assertInstanceOf('PDOException', $e->getPrevious());
+        });
     }
 
     public function testConnectRetry(): void
@@ -290,16 +298,18 @@ class ConnectionTest extends TestCase
      */
     public function testPrepare(): void
     {
-        $sql = 'SELECT 1 + 1';
-        $result = $this->connection->prepare($sql);
-        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $this->assertEquals($sql, $result->queryString);
+        $this->deprecated(function () {
+            $sql = 'SELECT 1 + 1';
+            $result = $this->connection->prepare($sql);
+            $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+            $this->assertEquals($sql, $result->queryString);
 
-        $query = $this->connection->selectQuery('1 + 1');
-        $result = $this->connection->prepare($query);
-        $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
-        $sql = '#SELECT [`"\[]?1 \+ 1[`"\]]?#';
-        $this->assertMatchesRegularExpression($sql, $result->queryString);
+            $query = $this->connection->selectQuery('1 + 1');
+            $result = $this->connection->prepare($query);
+            $this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+            $sql = '#SELECT [`"\[]?1 \+ 1[`"\]]?#';
+            $this->assertMatchesRegularExpression($sql, $result->queryString);
+        });
     }
 
     /**
@@ -351,18 +361,20 @@ class ConnectionTest extends TestCase
             'Only required for SQLite driver which does not support buffered results natively'
         );
 
-        $statement = $this->connection->query('SELECT * FROM things LIMIT 3');
+        $this->deprecated(function () {
+            $statement = $this->connection->query('SELECT * FROM things LIMIT 3');
 
-        $collection = new Collection($statement);
-        $result = $collection->extract('id')->toArray();
-        $this->assertEquals(['1', '2'], $result);
+            $collection = new Collection($statement);
+            $result = $collection->extract('id')->toArray();
+            $this->assertEquals(['1', '2'], $result);
 
-        // Check iteration after extraction
-        $result = [];
-        foreach ($collection as $v) {
-            $result[] = $v['id'];
-        }
-        $this->assertEquals(['1', '2'], $result);
+            // Check iteration after extraction
+            $result = [];
+            foreach ($collection as $v) {
+                $result[] = $v['id'];
+            }
+            $this->assertEquals(['1', '2'], $result);
+        });
     }
 
     /**
@@ -844,35 +856,37 @@ class ConnectionTest extends TestCase
      */
     public function testInTransactionWithSavePoints(): void
     {
-        $this->skipIf(
-            $this->connection->getDriver() instanceof Sqlserver,
-            'SQLServer fails when this test is included.'
-        );
+        $this->deprecated(function () {
+            $this->skipIf(
+                $this->connection->getDriver() instanceof Sqlserver,
+                'SQLServer fails when this test is included.'
+            );
 
-        $this->connection->enableSavePoints(true);
-        $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
+            $this->connection->enableSavePoints(true);
+            $this->skipIf(!$this->connection->isSavePointsEnabled(), 'Database driver doesn\'t support save points');
 
-        $this->connection->begin();
-        $this->assertTrue($this->connection->inTransaction());
+            $this->connection->begin();
+            $this->assertTrue($this->connection->inTransaction());
 
-        $this->connection->begin();
-        $this->assertTrue($this->connection->inTransaction());
+            $this->connection->begin();
+            $this->assertTrue($this->connection->inTransaction());
 
-        $this->connection->commit();
-        $this->assertTrue($this->connection->inTransaction());
+            $this->connection->commit();
+            $this->assertTrue($this->connection->inTransaction());
 
-        $this->connection->commit();
-        $this->assertFalse($this->connection->inTransaction());
+            $this->connection->commit();
+            $this->assertFalse($this->connection->inTransaction());
 
-        $this->connection->begin();
-        $this->assertTrue($this->connection->inTransaction());
+            $this->connection->begin();
+            $this->assertTrue($this->connection->inTransaction());
 
-        $this->connection->begin();
-        $this->connection->rollback();
-        $this->assertTrue($this->connection->inTransaction());
+            $this->connection->begin();
+            $this->connection->rollback();
+            $this->assertTrue($this->connection->inTransaction());
 
-        $this->connection->rollback();
-        $this->assertFalse($this->connection->inTransaction());
+            $this->connection->rollback();
+            $this->assertFalse($this->connection->inTransaction());
+        });
     }
 
     /**
@@ -880,18 +894,20 @@ class ConnectionTest extends TestCase
      */
     public function testQuote(): void
     {
-        $this->skipIf(!$this->connection->supportsQuoting());
-        $expected = "'2012-01-01'";
-        $result = $this->connection->quote(new DateTime('2012-01-01'), 'date');
-        $this->assertEquals($expected, $result);
+        $this->deprecated(function () {
+            $this->skipIf(!$this->connection->supportsQuoting());
+            $expected = "'2012-01-01'";
+            $result = $this->connection->quote(new DateTime('2012-01-01'), 'date');
+            $this->assertEquals($expected, $result);
 
-        $expected = "'1'";
-        $result = $this->connection->quote(1, 'string');
-        $this->assertEquals($expected, $result);
+            $expected = "'1'";
+            $result = $this->connection->quote(1, 'string');
+            $this->assertEquals($expected, $result);
 
-        $expected = "'hello'";
-        $result = $this->connection->quote('hello', 'string');
-        $this->assertEquals($expected, $result);
+            $expected = "'hello'";
+            $result = $this->connection->quote('hello', 'string');
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -899,109 +915,111 @@ class ConnectionTest extends TestCase
      */
     public function testQuoteIdentifier(): void
     {
-        $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')
-            ->onlyMethods(['enabled'])
-            ->getMock();
-        $driver->expects($this->once())
-            ->method('enabled')
-            ->will($this->returnValue(true));
-        $connection = new Connection(['driver' => $driver]);
+        $this->deprecated(function () {
+            $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlite')
+                ->onlyMethods(['enabled'])
+                ->getMock();
+            $driver->expects($this->once())
+                ->method('enabled')
+                ->will($this->returnValue(true));
+            $connection = new Connection(['driver' => $driver]);
 
-        $result = $connection->quoteIdentifier('name');
-        $expected = '"name"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('name');
+            $expected = '"name"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Model.*');
-        $expected = '"Model".*';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Model.*');
+            $expected = '"Model".*';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Items.No_ 2');
-        $expected = '"Items"."No_ 2"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Items.No_ 2');
+            $expected = '"Items"."No_ 2"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Items.No_ 2 thing');
-        $expected = '"Items"."No_ 2 thing"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Items.No_ 2 thing');
+            $expected = '"Items"."No_ 2 thing"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Items.No_ 2 thing AS thing');
-        $expected = '"Items"."No_ 2 thing" AS "thing"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Items.No_ 2 thing AS thing');
+            $expected = '"Items"."No_ 2 thing" AS "thing"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Items.Item Category Code = :c1');
-        $expected = '"Items"."Item Category Code" = :c1';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Items.Item Category Code = :c1');
+            $expected = '"Items"."Item Category Code" = :c1';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('MTD()');
-        $expected = 'MTD()';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('MTD()');
+            $expected = 'MTD()';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('(sm)');
-        $expected = '(sm)';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('(sm)');
+            $expected = '(sm)';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('name AS x');
-        $expected = '"name" AS "x"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('name AS x');
+            $expected = '"name" AS "x"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Model.name AS x');
-        $expected = '"Model"."name" AS "x"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Model.name AS x');
+            $expected = '"Model"."name" AS "x"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Function(Something.foo)');
-        $expected = 'Function("Something"."foo")';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Function(Something.foo)');
+            $expected = 'Function("Something"."foo")';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Function(SubFunction(Something.foo))');
-        $expected = 'Function(SubFunction("Something"."foo"))';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Function(SubFunction(Something.foo))');
+            $expected = 'Function(SubFunction("Something"."foo"))';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Function(Something.foo) AS x');
-        $expected = 'Function("Something"."foo") AS "x"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Function(Something.foo) AS x');
+            $expected = 'Function("Something"."foo") AS "x"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('name-with-minus');
-        $expected = '"name-with-minus"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('name-with-minus');
+            $expected = '"name-with-minus"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('my-name');
-        $expected = '"my-name"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('my-name');
+            $expected = '"my-name"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Foo-Model.*');
-        $expected = '"Foo-Model".*';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Foo-Model.*');
+            $expected = '"Foo-Model".*';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Team.P%');
-        $expected = '"Team"."P%"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Team.P%');
+            $expected = '"Team"."P%"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Team.G/G');
-        $expected = '"Team"."G/G"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Team.G/G');
+            $expected = '"Team"."G/G"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Model.name as y');
-        $expected = '"Model"."name" AS "y"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Model.name as y');
+            $expected = '"Model"."name" AS "y"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('nämé');
-        $expected = '"nämé"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('nämé');
+            $expected = '"nämé"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('aßa.nämé');
-        $expected = '"aßa"."nämé"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('aßa.nämé');
+            $expected = '"aßa"."nämé"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('aßa.*');
-        $expected = '"aßa".*';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('aßa.*');
+            $expected = '"aßa".*';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Modeß.nämé as y');
-        $expected = '"Modeß"."nämé" AS "y"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Modeß.nämé as y');
+            $expected = '"Modeß"."nämé" AS "y"';
+            $this->assertEquals($expected, $result);
 
-        $result = $connection->quoteIdentifier('Model.näme Datum as y');
-        $expected = '"Model"."näme Datum" AS "y"';
-        $this->assertEquals($expected, $result);
+            $result = $connection->quoteIdentifier('Model.näme Datum as y');
+            $expected = '"Model"."näme Datum" AS "y"';
+            $this->assertEquals($expected, $result);
+        });
     }
 
     /**
@@ -1029,16 +1047,18 @@ class ConnectionTest extends TestCase
      */
     public function testLoggerDecorator(): void
     {
-        $logger = new QueryLogger();
-        $this->connection->enableQueryLogging(true);
-        $this->connection->setLogger($logger);
-        $st = $this->connection->prepare('SELECT 1');
-        $this->assertInstanceOf(LoggingStatement::class, $st);
-        $this->assertSame($logger, $st->getLogger());
+        $this->deprecated(function () {
+            $logger = new QueryLogger();
+            $this->connection->enableQueryLogging(true);
+            $this->connection->setLogger($logger);
+            $st = $this->connection->prepare('SELECT 1');
+            $this->assertInstanceOf(LoggingStatement::class, $st);
+            $this->assertSame($logger, $st->getLogger());
 
-        $this->connection->enableQueryLogging(false);
-        $st = $this->connection->prepare('SELECT 1');
-        $this->assertNotInstanceOf('Cake\Database\Log\LoggingStatement', $st);
+            $this->connection->enableQueryLogging(false);
+            $st = $this->connection->prepare('SELECT 1');
+            $this->assertNotInstanceOf('Cake\Database\Log\LoggingStatement', $st);
+        });
     }
 
     /**
@@ -1046,11 +1066,13 @@ class ConnectionTest extends TestCase
      */
     public function testEnableQueryLogging(): void
     {
-        $this->connection->enableQueryLogging(true);
-        $this->assertTrue($this->connection->isQueryLoggingEnabled());
+        $this->deprecated(function () {
+            $this->connection->enableQueryLogging(true);
+            $this->assertTrue($this->connection->isQueryLoggingEnabled());
 
-        $this->connection->disableQueryLogging();
-        $this->assertFalse($this->connection->isQueryLoggingEnabled());
+            $this->connection->disableQueryLogging();
+            $this->assertFalse($this->connection->isQueryLoggingEnabled());
+        });
     }
 
     /**
@@ -1059,12 +1081,14 @@ class ConnectionTest extends TestCase
     public function testLogFunction(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
-        $this->connection->enableQueryLogging();
-        $this->connection->log('SELECT 1');
+        $this->deprecated(function () {
+            $this->connection->enableQueryLogging();
+            $this->connection->log('SELECT 1');
 
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(1, $messages);
-        $this->assertSame('debug: connection=test role= duration=0 rows=0 SELECT 1', $messages[0]);
+            $messages = Log::engine('queries')->read();
+            $this->assertCount(1, $messages);
+            $this->assertSame('debug: connection=test role= duration=0 rows=0 SELECT 1', $messages[0]);
+        });
     }
 
     /**
@@ -1073,30 +1097,32 @@ class ConnectionTest extends TestCase
     public function testLoggerDecoratorDoesNotPrematurelyFetchRecords(): void
     {
         Log::setConfig('queries', ['className' => 'Array']);
-        $logger = new QueryLogger();
-        $this->connection->enableQueryLogging(true);
-        $this->connection->setLogger($logger);
-        $st = $this->connection->execute('SELECT * FROM things');
-        $this->assertInstanceOf(LoggingStatement::class, $st);
+        $this->deprecated(function () {
+            $logger = new QueryLogger();
+            $this->connection->enableQueryLogging(true);
+            $this->connection->setLogger($logger);
+            $st = $this->connection->execute('SELECT * FROM things');
+            $this->assertInstanceOf(LoggingStatement::class, $st);
 
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(0, $messages);
+            $messages = Log::engine('queries')->read();
+            $this->assertCount(0, $messages);
 
-        $expected = [
-            [1, 'a title', 'a body'],
-            [2, 'another title', 'another body'],
-        ];
-        $results = $st->fetchAll();
-        $this->assertEquals($expected, $results);
+            $expected = [
+                [1, 'a title', 'a body'],
+                [2, 'another title', 'another body'],
+            ];
+            $results = $st->fetchAll();
+            $this->assertEquals($expected, $results);
 
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(1, $messages);
+            $messages = Log::engine('queries')->read();
+            $this->assertCount(1, $messages);
 
-        $st = $this->connection->execute('SELECT * FROM things WHERE id = 0');
-        $this->assertSame(0, $st->rowCount());
+            $st = $this->connection->execute('SELECT * FROM things WHERE id = 0');
+            $this->assertSame(0, $st->rowCount());
 
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(2, $messages, 'Select queries without any matching rows should also be logged.');
+            $messages = Log::engine('queries')->read();
+            $this->assertCount(2, $messages, 'Select queries without any matching rows should also be logged.');
+        });
     }
 
     /**
@@ -1106,26 +1132,28 @@ class ConnectionTest extends TestCase
     {
         Log::setConfig('queries', ['className' => 'Array']);
 
-        $connection = $this
-            ->getMockBuilder(Connection::class)
-            ->onlyMethods(['connect'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $connection->enableQueryLogging(true);
+        $this->deprecated(function () {
+            $connection = $this
+                ->getMockBuilder(Connection::class)
+                ->onlyMethods(['connect'])
+                ->disableOriginalConstructor()
+                ->getMock();
+            $connection->enableQueryLogging(true);
 
-        $this->deprecated(function () use ($connection) {
-            $driver = $this->getMockFormDriver();
-            $connection->setDriver($driver);
+            $this->deprecated(function () use ($connection) {
+                $driver = $this->getMockFormDriver();
+                $connection->setDriver($driver);
+            });
+
+            $connection->begin();
+            $connection->begin(); //This one will not be logged
+            $connection->rollback();
+
+            $messages = Log::engine('queries')->read();
+            $this->assertCount(2, $messages);
+            $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
+            $this->assertSame('debug: connection= role= duration=0 rows=0 ROLLBACK', $messages[1]);
         });
-
-        $connection->begin();
-        $connection->begin(); //This one will not be logged
-        $connection->rollback();
-
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(2, $messages);
-        $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
-        $this->assertSame('debug: connection= role= duration=0 rows=0 ROLLBACK', $messages[1]);
     }
 
     /**
@@ -1133,21 +1161,23 @@ class ConnectionTest extends TestCase
      */
     public function testLogCommitTransaction(): void
     {
-        $driver = $this->getMockFormDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['connect'])
-            ->setConstructorArgs([['driver' => $driver]])
-            ->getMock();
+        $this->deprecated(function () {
+            $driver = $this->getMockFormDriver();
+            $connection = $this->getMockBuilder(Connection::class)
+                ->onlyMethods(['connect'])
+                ->setConstructorArgs([['driver' => $driver]])
+                ->getMock();
 
-        Log::setConfig('queries', ['className' => 'Array']);
-        $connection->enableQueryLogging(true);
-        $connection->begin();
-        $connection->commit();
+            Log::setConfig('queries', ['className' => 'Array']);
+            $connection->enableQueryLogging(true);
+            $connection->begin();
+            $connection->commit();
 
-        $messages = Log::engine('queries')->read();
-        $this->assertCount(2, $messages);
-        $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
-        $this->assertSame('debug: connection= role= duration=0 rows=0 COMMIT', $messages[1]);
+            $messages = Log::engine('queries')->read();
+            $this->assertCount(2, $messages);
+            $this->assertSame('debug: connection= role= duration=0 rows=0 BEGIN', $messages[0]);
+            $this->assertSame('debug: connection= role= duration=0 rows=0 COMMIT', $messages[1]);
+        });
     }
 
     /**
@@ -1420,28 +1450,30 @@ class ConnectionTest extends TestCase
      */
     public function testAutomaticReconnect2(): void
     {
-        $conn = clone $this->connection;
-        $statement = $conn->query('SELECT 1');
-        $statement->execute();
-        $statement->closeCursor();
+        $this->deprecated(function () {
+            $conn = clone $this->connection;
+            $statement = $conn->query('SELECT 1');
+            $statement->execute();
+            $statement->closeCursor();
 
-        $newDriver = $this->getMockBuilder(Driver::class)->getMock();
-        $prop = new ReflectionProperty($conn, 'readDriver');
-        $prop->setAccessible(true);
-        $prop->setValue($conn, $newDriver);
-        $prop = new ReflectionProperty($conn, 'writeDriver');
-        $prop->setAccessible(true);
-        $prop->setValue($conn, $newDriver);
+            $newDriver = $this->getMockBuilder(Driver::class)->getMock();
+            $prop = new ReflectionProperty($conn, 'readDriver');
+            $prop->setAccessible(true);
+            $prop->setValue($conn, $newDriver);
+            $prop = new ReflectionProperty($conn, 'writeDriver');
+            $prop->setAccessible(true);
+            $prop->setValue($conn, $newDriver);
 
-        $newDriver->expects($this->exactly(2))
-            ->method('prepare')
-            ->will($this->onConsecutiveCalls(
-                $this->throwException(new Exception('server gone away')),
-                $this->returnValue($statement)
-            ));
+            $newDriver->expects($this->exactly(2))
+                ->method('prepare')
+                ->will($this->onConsecutiveCalls(
+                    $this->throwException(new Exception('server gone away')),
+                    $this->returnValue($statement)
+                ));
 
-        $res = $conn->query('SELECT 1');
-        $this->assertInstanceOf(StatementInterface::class, $res);
+            $res = $conn->query('SELECT 1');
+            $this->assertInstanceOf(StatementInterface::class, $res);
+        });
     }
 
     /**
@@ -1450,99 +1482,105 @@ class ConnectionTest extends TestCase
      */
     public function testNoAutomaticReconnect(): void
     {
-        $conn = clone $this->connection;
-        $statement = $conn->query('SELECT 1');
-        $statement->execute();
-        $statement->closeCursor();
+        $this->deprecated(function () {
+            $conn = clone $this->connection;
+            $statement = $conn->query('SELECT 1');
+            $statement->execute();
+            $statement->closeCursor();
 
-        $conn->begin();
+            $conn->begin();
 
-        $newDriver = $this->getMockBuilder(Driver::class)->getMock();
-        $prop = new ReflectionProperty($conn, 'readDriver');
-        $prop->setAccessible(true);
-        $prop->setValue($conn, $newDriver);
-        $prop = new ReflectionProperty($conn, 'writeDriver');
-        $prop->setAccessible(true);
-        $oldDriver = $prop->getValue($conn);
-        $prop->setValue($conn, $newDriver);
+            $newDriver = $this->getMockBuilder(Driver::class)->getMock();
+            $prop = new ReflectionProperty($conn, 'readDriver');
+            $prop->setAccessible(true);
+            $prop->setValue($conn, $newDriver);
+            $prop = new ReflectionProperty($conn, 'writeDriver');
+            $prop->setAccessible(true);
+            $oldDriver = $prop->getValue($conn);
+            $prop->setValue($conn, $newDriver);
 
-        $newDriver->expects($this->once())
-            ->method('prepare')
-            ->will($this->throwException(new Exception('server gone away')));
+            $newDriver->expects($this->once())
+                ->method('prepare')
+                ->will($this->throwException(new Exception('server gone away')));
 
-        try {
-            $conn->query('SELECT 1');
-        } catch (Exception $e) {
-        }
-        $this->assertInstanceOf(Exception::class, $e ?? null);
+            try {
+                $conn->query('SELECT 1');
+            } catch (Exception $e) {
+            }
+            $this->assertInstanceOf(Exception::class, $e ?? null);
 
-        $prop->setValue($conn, $oldDriver);
-        $conn->rollback();
+            $prop->setValue($conn, $oldDriver);
+            $conn->rollback();
+        });
     }
 
     public function testAutomaticReconnectWithoutQueryLogging(): void
     {
-        $conn = clone $this->connection;
+        $this->deprecated(function () {
+            $conn = clone $this->connection;
 
-        $logger = new TestBaseLog();
-        $conn->setLogger($logger);
-        $conn->disableQueryLogging();
+            $logger = new TestBaseLog();
+            $conn->setLogger($logger);
+            $conn->disableQueryLogging();
 
-        $statement = $conn->query('SELECT 1');
-        $statement->execute();
-        $statement->closeCursor();
+            $statement = $conn->query('SELECT 1');
+            $statement->execute();
+            $statement->closeCursor();
 
-        $newDriver = $this->getMockBuilder(Driver::class)->getMock();
-        $prop = new ReflectionProperty($conn, 'readDriver');
-        $prop->setAccessible(true);
-        $prop->setValue($conn, $newDriver);
-        $prop = new ReflectionProperty($conn, 'writeDriver');
-        $prop->setAccessible(true);
-        $prop->setValue($conn, $newDriver);
+            $newDriver = $this->getMockBuilder(Driver::class)->getMock();
+            $prop = new ReflectionProperty($conn, 'readDriver');
+            $prop->setAccessible(true);
+            $prop->setValue($conn, $newDriver);
+            $prop = new ReflectionProperty($conn, 'writeDriver');
+            $prop->setAccessible(true);
+            $prop->setValue($conn, $newDriver);
 
-        $newDriver->expects($this->exactly(2))
-            ->method('prepare')
-            ->will($this->onConsecutiveCalls(
-                $this->throwException(new Exception('server gone away')),
-                $this->returnValue($statement)
-            ));
+            $newDriver->expects($this->exactly(2))
+                ->method('prepare')
+                ->will($this->onConsecutiveCalls(
+                    $this->throwException(new Exception('server gone away')),
+                    $this->returnValue($statement)
+                ));
 
-        $conn->query('SELECT 1');
+            $conn->query('SELECT 1');
 
-        $this->assertEmpty($logger->getMessage());
+            $this->assertEmpty($logger->getMessage());
+        });
     }
 
     public function testAutomaticReconnectWithQueryLogging(): void
     {
-        $conn = clone $this->connection;
+        $this->deprecated(function () {
+            $conn = clone $this->connection;
 
-        $logger = new TestBaseLog();
-        $conn->setLogger($logger);
-        $conn->enableQueryLogging();
+            $logger = new TestBaseLog();
+            $conn->setLogger($logger);
+            $conn->enableQueryLogging();
 
-        $statement = $conn->query('SELECT 1');
-        $statement->execute();
-        $statement->closeCursor();
+            $statement = $conn->query('SELECT 1');
+            $statement->execute();
+            $statement->closeCursor();
 
-        $newDriver = $this->getMockBuilder(Driver::class)->getMock();
-        $prop = new ReflectionProperty($conn, 'readDriver');
-        $prop->setAccessible(true);
-        $prop->setValue($conn, $newDriver);
-        $prop = new ReflectionProperty($conn, 'writeDriver');
-        $prop->setAccessible(true);
-        $oldDriver = $prop->getValue($conn);
-        $prop->setValue($conn, $newDriver);
+            $newDriver = $this->getMockBuilder(Driver::class)->getMock();
+            $prop = new ReflectionProperty($conn, 'readDriver');
+            $prop->setAccessible(true);
+            $prop->setValue($conn, $newDriver);
+            $prop = new ReflectionProperty($conn, 'writeDriver');
+            $prop->setAccessible(true);
+            $oldDriver = $prop->getValue($conn);
+            $prop->setValue($conn, $newDriver);
 
-        $newDriver->expects($this->exactly(2))
-            ->method('prepare')
-            ->will($this->onConsecutiveCalls(
-                $this->throwException(new Exception('server gone away')),
-                $this->returnValue($statement)
-            ));
+            $newDriver->expects($this->exactly(2))
+                ->method('prepare')
+                ->will($this->onConsecutiveCalls(
+                    $this->throwException(new Exception('server gone away')),
+                    $this->returnValue($statement)
+                ));
 
-        $conn->query('SELECT 1');
+            $conn->query('SELECT 1');
 
-        $this->assertSame('[RECONNECT]', $logger->getMessage());
+            $this->assertSame('[RECONNECT]', $logger->getMessage());
+        });
     }
 
     public function testNewQuery()

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -278,15 +278,17 @@ class ConnectionTest extends TestCase
     {
         $this->skipIf(!ConnectionManager::get('test')->getDriver() instanceof Sqlserver);
 
-        $connection = new Connection(['driver' => 'RetryDriver']);
-        $this->assertInstanceOf('TestApp\Database\Driver\RetryDriver', $connection->getDriver());
+        $this->deprecated(function () {
+            $connection = new Connection(['driver' => 'RetryDriver']);
+            $this->assertInstanceOf('TestApp\Database\Driver\RetryDriver', $connection->getDriver());
 
-        try {
-            $connection->connect();
-        } catch (MissingConnectionException $e) {
-        }
+            try {
+                $connection->connect();
+            } catch (MissingConnectionException $e) {
+            }
 
-        $this->assertSame(4, $connection->getDriver()->getConnectRetries());
+            $this->assertSame(4, $connection->getDriver()->getConnectRetries());
+        });
     }
 
     /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -141,22 +141,26 @@ class MysqlTest extends TestCase
      */
     public function testIsConnected(): void
     {
-        $connection = ConnectionManager::get('test');
-        $connection->disconnect();
-        $this->assertFalse($connection->isConnected(), 'Not connected now.');
+        $this->deprecated(function () {
+            $connection = ConnectionManager::get('test');
+            $connection->disconnect();
+            $this->assertFalse($connection->isConnected(), 'Not connected now.');
 
-        $connection->connect();
-        $this->assertTrue($connection->isConnected(), 'Should be connected.');
+            $connection->connect();
+            $this->assertTrue($connection->isConnected(), 'Should be connected.');
+        });
     }
 
     public function testRollbackTransactionAutoConnect(): void
     {
-        $connection = ConnectionManager::get('test');
-        $connection->disconnect();
+        $this->deprecated(function () {
+            $connection = ConnectionManager::get('test');
+            $connection->disconnect();
 
-        $driver = $connection->getDriver();
-        $this->assertFalse($driver->rollbackTransaction());
-        $this->assertTrue($driver->isConnected());
+            $driver = $connection->getDriver();
+            $this->assertFalse($driver->rollbackTransaction());
+            $this->assertTrue($driver->isConnected());
+        });
     }
 
     public function testCommitTransactionAutoConnect(): void

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -125,7 +125,7 @@ class SqliteTest extends TestCase
         $connection = ConnectionManager::get('test_shared_cache');
         $this->assertSame([], $connection->getSchemaCollection()->listTables());
 
-        $connection->query('CREATE TABLE test (test int);');
+        $connection->execute('CREATE TABLE test (test int);');
         $this->assertSame(['test'], $connection->getSchemaCollection()->listTables());
 
         ConnectionManager::setConfig('test_shared_cache2', [

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -68,6 +68,10 @@ class QueryLoggerTest extends TestCase
     public function testLogFunctionStringable(): void
     {
         $this->skipIf(version_compare(PHP_VERSION, '8.0', '<'), 'Stringable exists since 8.0');
+        Log::setConfig('queryLoggerTest', [
+            'className' => 'Array',
+            'scopes' => ['queriesLog'],
+        ]);
 
         $logger = new QueryLogger(['connection' => '']);
         $stringable = new class implements \Stringable
@@ -79,6 +83,9 @@ class QueryLoggerTest extends TestCase
         };
 
         $logger->log(LogLevel::DEBUG, $stringable, ['query' => null]);
+        $logs = Log::engine('queryLoggerTest')->read();
+        $this->assertCount(1, $logs);
+        $this->assertStringContainsString('FooBar', $logs[0]);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -786,9 +786,9 @@ class HasManyTest extends TestCase
     protected function assertSelectClause($expected, $query): void
     {
         if ($this->autoQuote) {
-            $connection = $query->getConnection();
+            $driver = $query->getConnection()->getDriver();
             foreach ($expected as $key => $value) {
-                $expected[$connection->quoteIdentifier($key)] = $connection->quoteIdentifier($value);
+                $expected[$driver->quoteIdentifier($key)] = $driver->quoteIdentifier($value);
                 unset($expected[$key]);
             }
         }

--- a/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
@@ -112,7 +112,7 @@ class SchemaLoaderTest extends TestCase
         $result = $connection->getSchemaCollection()->listTables();
         $this->assertEquals(['schema_loader_second'], $result);
 
-        $statement = $connection->query('SELECT * FROM schema_loader_second');
+        $statement = $connection->execute('SELECT * FROM schema_loader_second');
         $result = $statement->fetchAll();
         $this->assertCount(0, $result, 'Table should be empty.');
     }


### PR DESCRIPTION
I didn't add runtime deprecations to a few methods as I think they are mostly used internally and adding 'new' code paths for them will result in more conflicts for us, with little benefit to userland code.