### PR TITLE
phpdoc: CollectionInterface::sortBy() descending order

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -250,8 +250,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ```
      *
      * @param callable|string $path The column name to use for sorting or callback that returns the value.
-     * @param int $sort The sort type, one of SORT_STRING
-     * SORT_NUMERIC or SORT_NATURAL
+     * @param int $sort The sort type, one of SORT_STRING, SORT_NUMERIC or SORT_NATURAL
      * @see \Cake\Collection\CollectionInterface::sortBy()
      * @return mixed The value of the top element in the collection
      */
@@ -276,8 +275,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ```
      *
      * @param callable|string $path The column name to use for sorting or callback that returns the value.
-     * @param int $sort The sort type, one of SORT_STRING
-     * SORT_NUMERIC or SORT_NATURAL
+     * @param int $sort The sort type, one of SORT_STRING, SORT_NUMERIC or SORT_NATURAL
      * @see \Cake\Collection\CollectionInterface::sortBy()
      * @return mixed The value of the bottom element in the collection
      */
@@ -306,9 +304,9 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * The average of an empty set or 0 rows is `null`. Collections with `null`
      * values are not considered empty.
      *
-     * @param callable|string|null $path The property name to sum or a function
+     * @param callable|string|null $path The property name to compute the average or a function
      * If no value is passed, an identity function will be used.
-     * that will return the value of the property to sum.
+     * that will return the value of the property to compute the average.
      * @return float|int|null
      */
     public function avg($path = null);
@@ -339,18 +337,17 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * The median of an empty set or 0 rows is `null`. Collections with `null`
      * values are not considered empty.
      *
-     * @param callable|string|null $path The property name to sum or a function
+     * @param callable|string|null $path The property name to compute the median or a function
      * If no value is passed, an identity function will be used.
-     * that will return the value of the property to sum.
+     * that will return the value of the property to compute the median.
      * @return float|int|null
      */
     public function median($path = null);
 
     /**
      * Returns a sorted iterator out of the elements in this collection,
-     * ranked in descending order by the results of running each value through a
-     * callback. $callback can also be a string representing the column or property
-     * name.
+     * ranked based on the results of applying a callback function to each value.
+     * The parameter $path can also be a string representing the column or property name.
      *
      * The callback will receive as its first argument each of the elements in $items,
      * the value returned by the callback will be used as the value for sorting such
@@ -378,8 +375,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      *
      * @param callable|string $path The column name to use for sorting or callback that returns the value.
      * @param int $order The sort order, either SORT_DESC or SORT_ASC
-     * @param int $sort The sort type, one of SORT_STRING
-     * SORT_NUMERIC or SORT_NATURAL
+     * @param int $sort The sort type, one of SORT_STRING, SORT_NUMERIC or SORT_NATURAL
      * @return self
      */
     public function sortBy($path, int $order = SORT_DESC, int $sort = \SORT_NUMERIC): CollectionInterface;
@@ -513,7 +509,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ```
      * $items = [
      *  ['invoice' => ['total' => 100]],
-     *  ['invoice' => ['total' => 200]]
+     *  ['invoice' => ['total' => 200]],
      * ];
      *
      * $total = (new Collection($items))->sumOf('invoice.total');
@@ -540,7 +536,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
     public function shuffle(): CollectionInterface;
 
     /**
-     * Returns a new collection with maximum $size random elements
+     * Returns a new collection with maximum $length random elements
      * from this collection
      *
      * @param int $length the maximum number of elements to randomly
@@ -550,7 +546,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
     public function sample(int $length = 10): CollectionInterface;
 
     /**
-     * Returns a new collection with maximum $size elements in the internal
+     * Returns a new collection with maximum $length elements in the internal
      * order this collection was created. If a second parameter is passed, it
      * will determine from what position to start taking elements.
      *
@@ -598,19 +594,19 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * ```
      * $items = [
      *  ['comment' => ['body' => 'cool', 'user' => ['name' => 'Mark']],
-     *  ['comment' => ['body' => 'very cool', 'user' => ['name' => 'Renan']]
+     *  ['comment' => ['body' => 'very cool', 'user' => ['name' => 'Renan']],
      * ];
      *
      * $extracted = (new Collection($items))->match(['user.name' => 'Renan']);
      *
      * // Result will look like this when converted to array
      * [
-     *  ['comment' => ['body' => 'very cool', 'user' => ['name' => 'Renan']]
+     *  ['comment' => ['body' => 'very cool', 'user' => ['name' => 'Renan']]]
      * ]
      * ```
      *
      * @param array $conditions a key-value list of conditions where
-     * the key is a property path as accepted by `Collection::extract,
+     * the key is a property path as accepted by `Collection::extract`,
      * and the value the condition against with each element will be matched
      * @return self
      */
@@ -705,7 +701,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * // Result will look like this when converted to array
      * [
      *  'a' => [1 => 'foo', 3 => 'baz'],
-     *  'b' => [2 => 'bar']
+     *  'b' => [2 => 'bar'],
      * ];
      * ```
      *
@@ -724,9 +720,9 @@ interface CollectionInterface extends Iterator, JsonSerializable
      * based on an id property path and a parent id property path.
      *
      * @param callable|string $idPath the column name path to use for determining
-     * whether an element is parent of another
+     * whether an element is a parent of another
      * @param callable|string $parentPath the column name path to use for determining
-     * whether an element is child of another
+     * whether an element is a child of another
      * @param string $nestingKey The key name under which children are nested
      * @return self
      */
@@ -835,7 +831,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
 
     /**
      * Returns a new collection where any operations chained after it are guaranteed
-     * to be run lazily. That is, elements will be yieleded one at a time.
+     * to be run lazily. That is, elements will be yielded one at a time.
      *
      * A lazy collection can only be iterated once. A second attempt results in an error.
      *
@@ -1162,7 +1158,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
     /**
      * Create a new collection that is the cartesian product of the current collection
      *
-     * In order to create a carteisan product a collection must contain a single dimension
+     * In order to create a cartesian product a collection must contain a single dimension
      * of data.
      *
      * ### Example

--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -348,7 +348,7 @@ interface CollectionInterface extends Iterator, JsonSerializable
 
     /**
      * Returns a sorted iterator out of the elements in this collection,
-     * ranked in ascending order by the results of running each value through a
+     * ranked in descending order by the results of running each value through a
      * callback. $callback can also be a string representing the column or property
      * name.
      *


### PR DESCRIPTION
Because definition is:
```php
public function sortBy($path, int $order = SORT_DESC, int $sort = \SORT_NUMERIC): CollectionInterface;
```
