### PR TITLE
Improve query logging scope

### DIFF
--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -35,7 +35,7 @@ class QueryLogger extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        $this->_defaultConfig['scopes'] = ['queriesLog', 'cake.database.querylogger'];
+        $this->_defaultConfig['scopes'] = ['queriesLog', 'cake.database.queries'];
         $this->_defaultConfig['connection'] = '';
 
         parent::__construct($config);

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -35,7 +35,7 @@ class QueryLogger extends BaseLog
      */
     public function __construct(array $config = [])
     {
-        $this->_defaultConfig['scopes'] = ['queriesLog'];
+        $this->_defaultConfig['scopes'] = ['queriesLog', 'cake.database.querylogger'];
         $this->_defaultConfig['connection'] = '';
 
         parent::__construct($config);
@@ -47,7 +47,7 @@ class QueryLogger extends BaseLog
     public function log($level, string|Stringable $message, array $context = []): void
     {
         $context += [
-            'scope' => $this->scopes() ?: ['queriesLog'],
+            'scope' => $this->scopes() ?: ['queriesLog', 'cake.database.querylogger'],
             'connection' => $this->getConfig('connection'),
             'query' => null,
         ];

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -47,7 +47,7 @@ class QueryLogger extends BaseLog
     public function log($level, string|Stringable $message, array $context = []): void
     {
         $context += [
-            'scope' => $this->scopes() ?: ['queriesLog', 'cake.database.querylogger'],
+            'scope' => $this->scopes() ?: ['queriesLog', 'cake.database.queries'],
             'connection' => $this->getConfig('connection'),
             'query' => null,
         ];

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -277,7 +277,6 @@ abstract class Query implements ExpressionInterface, Stringable
             $binder = $this->getValueBinder();
             $binder->resetCount();
         }
-        $connection = $this->getConnection();
 
         return $this->getConnection()->getDriver()->compileQuery($this, $binder);
     }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1125,7 +1125,7 @@ class ConnectionTest extends TestCase
         try {
             $conn->execute('SELECT 1');
         } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e ?? null);
+            $this->assertInstanceOf(Exception::class, $e);
             $prop->setValue($conn, $oldDriver);
             $conn->rollback();
         }

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -36,6 +36,7 @@ class QueryLoggerTest extends TestCase
         parent::tearDown();
         Log::drop('queryLoggerTest');
         Log::drop('queryLoggerTest2');
+        Log::drop('newScope');
     }
 
     /**
@@ -57,7 +58,7 @@ class QueryLoggerTest extends TestCase
         ]);
         Log::setConfig('newScope', [
             'className' => 'Array',
-            'scopes' => ['cake.database.querylogger'],
+            'scopes' => ['cake.database.queries'],
         ]);
         Log::setConfig('queryLoggerTest2', [
             'className' => 'Array',
@@ -75,9 +76,12 @@ class QueryLoggerTest extends TestCase
      */
     public function testLogFunctionStringable(): void
     {
-        $this->skipIf(version_compare(PHP_VERSION, '8.0', '<'), 'Stringable exists since 8.0');
-
+        Log::setConfig('queryLoggerTest', [
+            'className' => 'Array',
+            'scopes' => ['cake.database.queries'],
+        ]);
         $logger = new QueryLogger(['connection' => '']);
+
         $stringable = new class implements Stringable
         {
             public function __toString(): string
@@ -87,6 +91,8 @@ class QueryLoggerTest extends TestCase
         };
 
         $logger->log(LogLevel::DEBUG, $stringable, ['query' => null]);
+        $logs = Log::engine('queryLoggerTest');
+        $this->assertStringContainsString('FooBar', $logs->read()[0]);
     }
 
     /**

--- a/tests/TestCase/Database/Log/QueryLoggerTest.php
+++ b/tests/TestCase/Database/Log/QueryLoggerTest.php
@@ -55,6 +55,10 @@ class QueryLoggerTest extends TestCase
             'className' => 'Array',
             'scopes' => ['queriesLog'],
         ]);
+        Log::setConfig('newScope', [
+            'className' => 'Array',
+            'scopes' => ['cake.database.querylogger'],
+        ]);
         Log::setConfig('queryLoggerTest2', [
             'className' => 'Array',
             'scopes' => ['foo'],
@@ -62,6 +66,7 @@ class QueryLoggerTest extends TestCase
         $logger->log(LogLevel::DEBUG, $query, compact('query'));
 
         $this->assertCount(1, Log::engine('queryLoggerTest')->read());
+        $this->assertCount(1, Log::engine('newScope')->read());
         $this->assertCount(0, Log::engine('queryLoggerTest2')->read());
     }
 


### PR DESCRIPTION
This has been a long standing personal annoyance that I just re-encountered and wanted to improve. I hate the query logger scope It isn't intuitive or easy to guess. I think this is a step in the right direction. Ideally I can update the documentation to use the new name once we have a decision. We can then deprecate the `queriesLog` scope and remove in 6.x
