### PR TITLE
[5.x] [WIP] Word validation error messages more precisely

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2203,6 +2203,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function scalar(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        $message ??= 'The provided value must be scalar';
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'scalar', $extra + [

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2379,7 +2379,10 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $validator->scalar('username');
         $this->assertEmpty($validator->validate(['username' => 'scalar']));
-        $this->assertNotEmpty($validator->validate(['username' => ['array']]));
+        $this->assertSame(
+            ['username' => ['scalar' => 'The provided value must be scalar']],
+            $validator->validate(['username' => ['array']])
+        );
     }
 
     /**


### PR DESCRIPTION
Hereby, I propose to improve on the dreaded and very unhelpful `The provided value is invalid` validation error messages.

Wasn't sure whether we can backport this to 4.next, so I implemented it in 5.x to target 5.0.
