### PR TITLE
[5.x] Word validation error messages more precisely

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1931,9 +1931,24 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must be decimal';
+                if ($places === null) {
+                    $message = 'The provided value must be decimal with any number of decimal places, including none';
+                } else {
+                    $message = sprintf('The provided value must be decimal with `%s` decimal places', $places);
+                }
             } else {
-                $message = __d('cake', 'The provided value must be decimal');
+                if ($places === null) {
+                    $message = __d(
+                        'cake',
+                        'The provided value must be decimal with any number of decimal places, including none'
+                    );
+                } else {
+                    $message = __d(
+                        'cake',
+                        'The provided value must be decimal with `{0}` decimal places',
+                        $places
+                    );
+                }
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1523,7 +1523,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!$this->_useI18n) {
                 $message = sprintf('The provided value must not be same as `%s`', $secondField);
             } else {
-                $message = __d('cake', 'The provided value not must be same as `{0}`', $secondField);
+                $message = __d('cake', 'The provided value must not be same as `{0}`', $secondField);
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1422,9 +1422,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = sprintf('The provided value must be equals to `%s`', $value);
+                $message = sprintf('The provided value must be equal to `%s`', $value);
             } else {
-                $message = __d('cake', 'The provided value must be equals to `{0}`', $value);
+                $message = __d('cake', 'The provided value must be equal to `{0}`', $value);
             }
         }
 
@@ -1454,9 +1454,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = sprintf('The provided value must not be equals to `%s`', $value);
+                $message = sprintf('The provided value must not be equal to `%s`', $value);
             } else {
-                $message = __d('cake', 'The provided value must not be equals to `{0}`', $value);
+                $message = __d('cake', 'The provided value must not be equal to `{0}`', $value);
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2795,9 +2795,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = sprintf('The provided value must have at most `%s`elements', $count);
+                $message = sprintf('The provided value must have at most `%s` elements', $count);
             } else {
-                $message = __d('cake', 'The provided value must have at most `{0}`elements', $count);
+                $message = __d('cake', 'The provided value must have at most `{0}` elements', $count);
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1262,9 +1262,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must be a credit card number';
+                $message = 'The provided value must be a valid credit card number';
             } else {
-                $message = __d('cake', 'The provided value must be a credit card number');
+                $message = __d('cake', 'The provided value must be a valid credit card number');
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2382,11 +2382,17 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function inList(string $field, array $list, ?string $message = null, Closure|string|null $when = null)
     {
+        $listEnumeration = implode(', ', $list);
+
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must be one from the list of allowed values';
+                $message = sprintf('The provided value must be one of: `%s`', $listEnumeration);
             } else {
-                $message = __d('cake', 'The provided value must be one from the list of allowed values');
+                $message = __d(
+                    'cake',
+                    'The provided value must be one of: `{0}`',
+                    $listEnumeration
+                );
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2184,10 +2184,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function array(string $field, ?string $message = null, Closure|string|null $when = null)
     {
-        $message ??= $this->getValidationMessage(
-            'The provided value must be an array',
-            __d('cake', 'The provided value must be an array')
-        );
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an array';
+            } else {
+                $message = __d('cake', 'The provided value must be an array');
+            }
+        }
 
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
@@ -2208,10 +2211,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function scalar(string $field, ?string $message = null, Closure|string|null $when = null)
     {
-        $message ??= $this->getValidationMessage(
-            'The provided value must be scalar',
-            __d('cake', 'The provided value must be scalar')
-        );
+        if ($message === null) {
+            $message = 'The provided value must be scalar';
+            if ($this->_useI18n) {
+                $message = __d('cake', 'The provided value must be scalar');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'scalar', $extra + [
@@ -2388,10 +2394,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return $this->_presenceMessages[$field];
         }
 
-        return $this->getValidationMessage(
-            'This field is required',
-            __d('cake', 'This field is required')
-        );
+        if (!$this->_useI18n) {
+            $message = 'This field is required';
+        } else {
+            $message = __d('cake', 'This field is required');
+        }
+
+        return $message;
     }
 
     /**
@@ -2416,10 +2425,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return $this->_allowEmptyMessages[$field];
         }
 
-        return $this->getValidationMessage(
-            'This field cannot be left empty',
-            __d('cake', 'This field cannot be left empty')
-        );
+        if (!$this->_useI18n) {
+            $message = 'This field cannot be left empty';
+        } else {
+            $message = __d('cake', 'This field cannot be left empty');
+        }
+
+        return $message;
     }
 
     /**
@@ -2540,10 +2552,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         // Loading default provider in case there is none
         $this->getProvider('default');
 
-        $message = $this->getValidationMessage(
-            'The provided value is invalid',
-            __d('cake', 'The provided value is invalid')
-        );
+        if (!$this->_useI18n) {
+            $message = 'The provided value is invalid';
+        } else {
+            $message = __d('cake', 'The provided value is invalid');
+        }
 
         foreach ($rules as $name => $rule) {
             $result = $rule->process($data[$field], $this->_providers, compact('newRecord', 'data', 'field'));
@@ -2592,23 +2605,5 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             '_providers' => array_keys($this->_providers),
             '_fields' => $fields,
         ];
-    }
-
-    /**
-     * Return the untranslated or translated validation message depending on whether I18n is used
-     *
-     * @param string $untranslatedMessage The untranslated validation message to use if I18n is not used.
-     * @param string $translatedMessage The translated validation message to use if I18n is used.
-     * @return string|null Either the untranslated or translated validation message depending on whether I18n is used.
-     */
-    protected function getValidationMessage(
-        string $untranslatedMessage,
-        string $translatedMessage
-    ): ?string {
-        if ($this->_useI18n) {
-            return $translatedMessage;
-        }
-
-        return $untranslatedMessage;
     }
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1071,6 +1071,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function notBlank(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must not be blank';
+            } else {
+                $message = __d('cake', 'The provided value must not be blank');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notBlank', $extra + [
@@ -1090,6 +1098,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function alphaNumeric(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be alphanumeric';
+            } else {
+                $message = __d('cake', 'The provided value must be alphanumeric');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'alphaNumeric', $extra + [
@@ -1109,6 +1125,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function notAlphaNumeric(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must not be alphanumeric';
+            } else {
+                $message = __d('cake', 'The provided value must not be alphanumeric');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notAlphaNumeric', $extra + [
@@ -1128,6 +1152,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function asciiAlphaNumeric(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be ASCII-alphanumeric';
+            } else {
+                $message = __d('cake', 'The provided value must be ASCII-alphanumeric');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'asciiAlphaNumeric', $extra + [
@@ -1147,6 +1179,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function notAsciiAlphaNumeric(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must not be ASCII-alphanumeric';
+            } else {
+                $message = __d('cake', 'The provided value must not be ASCII-alphanumeric');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notAsciiAlphaNumeric', $extra + [
@@ -1175,10 +1215,30 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         if (count($range) !== 2) {
             throw new InvalidArgumentException('The $range argument requires 2 numbers');
         }
+        $lowerBound = array_shift($range);
+        $upperBound = array_shift($range);
+
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf(
+                    'The length of the provided value must be between `%s` and `%s`, inclusively',
+                    $lowerBound,
+                    $upperBound
+                );
+            } else {
+                $message = __d(
+                    'cake',
+                    'The length of the provided value must be between `{0}` and `{1}`, inclusively',
+                    $lowerBound,
+                    $upperBound
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lengthBetween', $extra + [
-            'rule' => ['lengthBetween', array_shift($range), array_shift($range)],
+            'rule' => ['lengthBetween', $lowerBound, $upperBound],
         ]);
     }
 
@@ -1200,6 +1260,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a credit card number';
+            } else {
+                $message = __d('cake', 'The provided value must be a credit card number');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'creditCard', $extra + [
@@ -1224,6 +1292,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be greater than `%s`', $value);
+            } else {
+                $message = __d('cake', 'The provided value must be greater than `{0}`', $value);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThan', $extra + [
@@ -1248,6 +1324,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be greater than or equal to `%s`', $value);
+            } else {
+                $message = __d('cake', 'The provided value must be greater than or equal to `{0}`', $value);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanOrEqual', $extra + [
@@ -1272,6 +1356,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be less than `%s`', $value);
+            } else {
+                $message = __d('cake', 'The provided value must be less than `{0}`', $value);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThan', $extra + [
@@ -1296,6 +1388,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be less than or equal to `%s`', $value);
+            } else {
+                $message = __d('cake', 'The provided value must be less than or equal to `{0}`', $value);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanOrEqual', $extra + [
@@ -1320,6 +1420,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be equals to `%s`', $value);
+            } else {
+                $message = __d('cake', 'The provided value must be equals to `{0}`', $value);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equals', $extra + [
@@ -1344,6 +1452,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must not be equals to `%s`', $value);
+            } else {
+                $message = __d('cake', 'The provided value must not be equals to `{0}`', $value);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notEquals', $extra + [
@@ -1370,6 +1486,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be same as `%s`', $secondField);
+            } else {
+                $message = __d('cake', 'The provided value must be same as `{0}`', $secondField);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'sameAs', $extra + [
@@ -1395,6 +1519,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must not be same as `%s`', $secondField);
+            } else {
+                $message = __d('cake', 'The provided value not must be same as `{0}`', $secondField);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notSameAs', $extra + [
@@ -1420,6 +1552,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be equal to the one of field `%s`', $secondField);
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must be equal to the one of field `0`',
+                    $secondField
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'equalToField', $extra + [
@@ -1445,6 +1589,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must not be equal to the one of field `%s`', $secondField);
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must not be equal to the one of field `0`',
+                    $secondField
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'notEqualToField', $extra + [
@@ -1470,6 +1626,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be greater than the one of field `%s`', $secondField);
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must be greater than the one of field `{0}`',
+                    $secondField
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanField', $extra + [
@@ -1495,6 +1663,21 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf(
+                    'The provided value must be greater than or equal to the one of field `%s`',
+                    $secondField
+                );
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must be greater than or equal to the one of field `{0}`',
+                    $secondField
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'greaterThanOrEqualToField', $extra + [
@@ -1520,6 +1703,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be less than the one of field `%s`', $secondField);
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must be less than the one of field `{0}`',
+                    $secondField
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanField', $extra + [
@@ -1545,6 +1740,18 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be less than or equal to the one of field `%s`', $secondField);
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must be less than or equal to the one of field `{0}`',
+                    $secondField
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'lessThanOrEqualToField', $extra + [
@@ -1569,6 +1776,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a date';
+            } else {
+                $message = __d('cake', 'The provided value must be a date');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'date', $extra + [
@@ -1593,6 +1808,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a date and time';
+            } else {
+                $message = __d('cake', 'The provided value must be a date and time');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'dateTime', $extra + [
@@ -1612,6 +1835,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function time(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a time';
+            } else {
+                $message = __d('cake', 'The provided value must be a time');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'time', $extra + [
@@ -1636,6 +1867,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a localized time, date or date and time';
+            } else {
+                $message = __d('cake', 'The provided value must be a localized time, date or date and time');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'localizedTime', $extra + [
@@ -1655,6 +1894,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function boolean(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a boolean';
+            } else {
+                $message = __d('cake', 'The provided value must be a boolean');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'boolean', $extra + [
@@ -1679,6 +1926,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be decimal';
+            } else {
+                $message = __d('cake', 'The provided value must be decimal');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'decimal', $extra + [
@@ -1703,6 +1958,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an e-mail address';
+            } else {
+                $message = __d('cake', 'The provided value must be an e-mail address');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'email', $extra + [
@@ -1724,6 +1987,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function ip(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an IP address';
+            } else {
+                $message = __d('cake', 'The provided value must be an IP address');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'ip', $extra + [
@@ -1743,6 +2014,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function ipv4(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an IPv4 address';
+            } else {
+                $message = __d('cake', 'The provided value must be an IPv4 address');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'ipv4', $extra + [
@@ -1762,6 +2041,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function ipv6(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an IPv6 address';
+            } else {
+                $message = __d('cake', 'The provided value must be an IPv6 address');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'ipv6', $extra + [
@@ -1782,6 +2069,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function minLength(string $field, int $min, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be at least `%s` characters long', $min);
+            } else {
+                $message = __d('cake', 'The provided value must be at least `{0}` characters long', $min);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'minLength', $extra + [
@@ -1802,6 +2097,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function minLengthBytes(string $field, int $min, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be at least `%s` bytes long', $min);
+            } else {
+                $message = __d('cake', 'The provided value must be at least `{0}` bytes long', $min);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'minLengthBytes', $extra + [
@@ -1822,6 +2125,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function maxLength(string $field, int $max, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be at most `%s` characters long', $max);
+            } else {
+                $message = __d('cake', 'The provided value must be at most `{0}` characters long', $max);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'maxLength', $extra + [
@@ -1842,6 +2153,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function maxLengthBytes(string $field, int $max, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be at be most `%s` bytes long', $max);
+            } else {
+                $message = __d('cake', 'The provided value must be at most `{0}` bytes long', $max);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'maxLengthBytes', $extra + [
@@ -1861,6 +2180,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function numeric(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be numeric';
+            } else {
+                $message = __d('cake', 'The provided value must be numeric');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'numeric', $extra + [
@@ -1880,6 +2207,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function naturalNumber(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a natural number';
+            } else {
+                $message = __d('cake', 'The provided value must be a natural number');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'naturalNumber', $extra + [
@@ -1899,6 +2234,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function nonNegativeInteger(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a non-negative integer';
+            } else {
+                $message = __d('cake', 'The provided value must be a non-negative integer');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'nonNegativeInteger', $extra + [
@@ -1923,10 +2266,30 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         if (count($range) !== 2) {
             throw new InvalidArgumentException('The $range argument requires 2 numbers');
         }
+        $lowerBound = array_shift($range);
+        $upperBound = array_shift($range);
+
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf(
+                    'The provided value must be between `%s` and `%s`, inclusively',
+                    $lowerBound,
+                    $upperBound
+                );
+            } else {
+                $message = __d(
+                    'cake',
+                    'The provided value must be between `{0}` and `{1}`, inclusively',
+                    $lowerBound,
+                    $upperBound
+                );
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'range', $extra + [
-            'rule' => ['range', array_shift($range), array_shift($range)],
+            'rule' => ['range', $lowerBound, $upperBound],
         ]);
     }
 
@@ -1944,6 +2307,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function url(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a URL';
+            } else {
+                $message = __d('cake', 'The provided value must be a URL');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'url', $extra + [
@@ -1965,6 +2336,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function urlWithProtocol(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a URL with protocol';
+            } else {
+                $message = __d('cake', 'The provided value must be a URL with protocol');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'urlWithProtocol', $extra + [
@@ -1985,6 +2364,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function inList(string $field, array $list, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be one from the list of allowed values';
+            } else {
+                $message = __d('cake', 'The provided value must be one from the list of allowed values');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'inList', $extra + [
@@ -2004,6 +2391,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function uuid(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a UUID';
+            } else {
+                $message = __d('cake', 'The provided value must be a UUID');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'uuid', $extra + [
@@ -2028,6 +2423,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an uploaded file';
+            } else {
+                $message = __d('cake', 'The provided value must be an uploaded file');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'uploadedFile', $extra + [
@@ -2049,6 +2452,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function latLong(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a latitude/longitude coordinate';
+            } else {
+                $message = __d('cake', 'The provided value must be a latitude/longitude coordinate');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'latLong', $extra + [
@@ -2068,6 +2479,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function latitude(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a latitude';
+            } else {
+                $message = __d('cake', 'The provided value must be a latitude');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'latitude', $extra + [
@@ -2087,6 +2506,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function longitude(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be a longitude';
+            } else {
+                $message = __d('cake', 'The provided value must be a longitude');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'longitude', $extra + [
@@ -2106,6 +2533,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function ascii(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be ASCII bytes only';
+            } else {
+                $message = __d('cake', 'The provided value must be ASCII bytes only');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'ascii', $extra + [
@@ -2125,6 +2560,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function utf8(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be UTF-8 bytes only';
+            } else {
+                $message = __d('cake', 'The provided value must be UTF-8 bytes only');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'utf8', $extra + [
@@ -2146,6 +2589,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function utf8Extended(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be 3 and 4 byte UTF-8 sequences only';
+            } else {
+                $message = __d('cake', 'The provided value must be 3 and 4 byte UTF-8 sequences only');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'utf8Extended', $extra + [
@@ -2165,6 +2616,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function integer(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = 'The provided value must be an integer';
+            } else {
+                $message = __d('cake', 'The provided value must be an integer');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'integer', $extra + [
@@ -2237,6 +2696,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function hexColor(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            $message = 'The provided value must be a hex color';
+            if ($this->_useI18n) {
+                $message = __d('cake', 'The provided value must be a hex color');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'hexColor', $extra + [
@@ -2262,6 +2728,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if ($message === null) {
+            $message = 'The provided value must be a set of multiple options';
+            if ($this->_useI18n) {
+                $message = __d('cake', 'The provided value must be a set of multiple options');
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
         $caseInsensitive = $options['caseInsensitive'] ?? false;
         unset($options['caseInsensitive']);
@@ -2285,6 +2758,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function hasAtLeast(string $field, int $count, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must have at least `%s` elements', $count);
+            } else {
+                $message = __d('cake', 'The provided value must have at least `{0}` elements', $count);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'hasAtLeast', $extra + [
@@ -2312,6 +2793,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function hasAtMost(string $field, int $count, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must have at most `%s`elements', $count);
+            } else {
+                $message = __d('cake', 'The provided value must have at most `{0}`elements', $count);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'hasAtMost', $extra + [
@@ -2371,6 +2860,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function regex(string $field, string $regex, ?string $message = null, Closure|string|null $when = null)
     {
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must match against the pattern `%s`', $regex);
+            } else {
+                $message = __d('cake', 'The provided value must match against the pattern `{0}`', $regex);
+            }
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'regex', $extra + [

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2184,10 +2184,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function array(string $field, ?string $message = null, Closure|string|null $when = null)
     {
-        $message ??= 'The provided value must be an array';
-        if ($this->_useI18n) {
-            $message = __d('cake', 'The provided value must be an array');
-        }
+        $message ??= $this->getValidationMessage(
+            'The provided value must be an array',
+            __d('cake', 'The provided value must be an array')
+        );
 
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
@@ -2208,11 +2208,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function scalar(string $field, ?string $message = null, Closure|string|null $when = null)
     {
-        $message ??= 'The provided value must be scalar';
-        if ($this->_useI18n) {
-            $message = __d('cake', 'The provided value must be scalar');
-        }
-
+        $message ??= $this->getValidationMessage(
+            'The provided value must be scalar',
+            __d('cake', 'The provided value must be scalar')
+        );
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'scalar', $extra + [
@@ -2389,11 +2388,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return $this->_presenceMessages[$field];
         }
 
-        if ($this->_useI18n) {
-            return __d('cake', 'This field is required');
-        }
-
-        return 'This field is required';
+        return $this->getValidationMessage(
+            'This field is required',
+            __d('cake', 'This field is required')
+        );
     }
 
     /**
@@ -2418,11 +2416,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return $this->_allowEmptyMessages[$field];
         }
 
-        if ($this->_useI18n) {
-            return __d('cake', 'This field cannot be left empty');
-        }
-
-        return 'This field cannot be left empty';
+        return $this->getValidationMessage(
+            'This field cannot be left empty',
+            __d('cake', 'This field cannot be left empty')
+        );
     }
 
     /**
@@ -2542,11 +2539,11 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         $errors = [];
         // Loading default provider in case there is none
         $this->getProvider('default');
-        $message = 'The provided value is invalid';
 
-        if ($this->_useI18n) {
-            $message = __d('cake', 'The provided value is invalid');
-        }
+        $message = $this->getValidationMessage(
+            'The provided value is invalid',
+            __d('cake', 'The provided value is invalid')
+        );
 
         foreach ($rules as $name => $rule) {
             $result = $rule->process($data[$field], $this->_providers, compact('newRecord', 'data', 'field'));
@@ -2595,5 +2592,23 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             '_providers' => array_keys($this->_providers),
             '_fields' => $fields,
         ];
+    }
+
+    /**
+     * Return the untranslated or translated validation message depending on whether I18n is used
+     *
+     * @param string $untranslatedMessage The untranslated validation message to use if I18n is not used.
+     * @param string $translatedMessage The translated validation message to use if I18n is used.
+     * @return string|null Either the untranslated or translated validation message depending on whether I18n is used.
+     */
+    protected function getValidationMessage(
+        string $untranslatedMessage,
+        string $translatedMessage
+    ): ?string {
+        if ($this->_useI18n) {
+            return $translatedMessage;
+        }
+
+        return $untranslatedMessage;
     }
 }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2203,6 +2203,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function scalar(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        $message ??= 'The provided value must be scalar';
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'scalar', $extra + [

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1073,9 +1073,9 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must not be blank';
+                $message = 'This field cannot be left empty';
             } else {
-                $message = __d('cake', 'The provided value must not be blank');
+                $message = __d('cake', 'This field cannot be left empty');
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1835,11 +1835,20 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        $formatEnumeration = implode(', ', $formats);
+
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must be a date and time';
+                $message = sprintf(
+                    'The provided value must be a date and time of one of these formats: `%s`',
+                    $formatEnumeration
+                );
             } else {
-                $message = __d('cake', 'The provided value must be a date and time');
+                $message = __d(
+                    'cake',
+                    'The provided value must be a date and time of one of these formats: `{0}`',
+                    $formatEnumeration
+                );
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1742,7 +1742,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = sprintf('The provided value must be less than or equal to the one of field `%s`', $secondField);
+                $message = sprintf(
+                    'The provided value must be less than or equal to the one of field `%s`',
+                    $secondField
+                );
             } else {
                 $message = __d(
                     'cake',

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1558,7 +1558,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             } else {
                 $message = __d(
                     'cake',
-                    'The provided value must be equal to the one of field `0`',
+                    'The provided value must be equal to the one of field `{0}`',
                     $secondField
                 );
             }
@@ -1595,7 +1595,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             } else {
                 $message = __d(
                     'cake',
-                    'The provided value must not be equal to the one of field `0`',
+                    'The provided value must not be equal to the one of field `{0}`',
                     $secondField
                 );
             }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1246,7 +1246,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a credit card rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param string $type The type of cards you want to allow. Defaults to 'all'.
+     * @param array|string $type The type of cards you want to allow. Defaults to 'all'.
      *   You can also supply an array of accepted card types. e.g `['mastercard', 'visa', 'amex']`
      * @param string|null $message The error message when the rule fails.
      * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
@@ -1256,7 +1256,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function creditCard(
         string $field,
-        string $type = 'all',
+        array|string $type = 'all',
         ?string $message = null,
         Closure|string|null $when = null
     ) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2044,7 +2044,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * @param string|null $message The error message when the rule fails.
      * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
      *   true when the validation rule should be applied.
-     * @see \Cake\Validation\Validation::uuid()
+     * @see \Cake\Validation\Validation::geoCoordinate()
      * @return $this
      */
     public function latLong(string $field, ?string $message = null, Closure|string|null $when = null)

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2184,6 +2184,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function array(string $field, ?string $message = null, Closure|string|null $when = null)
     {
+        $message ??= 'The provided value must be an array';
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'array', $extra + [

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2155,7 +2155,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     {
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = sprintf('The provided value must be at be most `%s` bytes long', $max);
+                $message = sprintf('The provided value must be at most `%s` bytes long', $max);
             } else {
                 $message = __d('cake', 'The provided value must be at most `{0}` bytes long', $max);
             }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2185,6 +2185,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function array(string $field, ?string $message = null, Closure|string|null $when = null)
     {
         $message ??= 'The provided value must be an array';
+        if ($this->_useI18n) {
+            $message = __d('cake', 'The provided value must be an array');
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'array', $extra + [
@@ -2205,6 +2209,10 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     public function scalar(string $field, ?string $message = null, Closure|string|null $when = null)
     {
         $message ??= 'The provided value must be scalar';
+        if ($this->_useI18n) {
+            $message = __d('cake', 'The provided value must be scalar');
+        }
+
         $extra = array_filter(['on' => $when, 'message' => $message]);
 
         return $this->add($field, 'scalar', $extra + [

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1803,11 +1803,20 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        $formatEnumeration = implode(', ', $formats);
+
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must be a date';
+                $message = sprintf(
+                    'The provided value must be a date of one of these formats: `%s`',
+                    $formatEnumeration
+                );
             } else {
-                $message = __d('cake', 'The provided value must be a date');
+                $message = __d(
+                    'cake',
+                    'The provided value must be a date of one of these formats: `{0}`',
+                    $formatEnumeration
+                );
             }
         }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1260,11 +1260,35 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         ?string $message = null,
         Closure|string|null $when = null
     ) {
+        if (is_array($type)) {
+            $typeEnumeration = implode(', ', $type);
+        } else {
+            $typeEnumeration = $type;
+        }
+
         if ($message === null) {
             if (!$this->_useI18n) {
-                $message = 'The provided value must be a valid credit card number';
+                if ($type === 'all') {
+                    $message = 'The provided value must be a valid credit card number of any type';
+                } else {
+                    $message = sprintf(
+                        'The provided value must be a valid credit card number of these types: `%s`',
+                        $typeEnumeration
+                    );
+                }
             } else {
-                $message = __d('cake', 'The provided value must be a valid credit card number');
+                if ($type === 'all') {
+                    $message = __d(
+                        'cake',
+                        'The provided value must be a valid credit card number of any type'
+                    );
+                } else {
+                    $message = __d(
+                        'cake',
+                        'The provided value must be a valid credit card number of these types: `{0}`',
+                        $typeEnumeration
+                    );
+                }
             }
         }
 

--- a/tests/TestCase/Validation/NoI18nValidator.php
+++ b/tests/TestCase/Validation/NoI18nValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cake\Test\TestCase\Validation;
+
+use Cake\Validation\Validator;
+
+/**
+ * Validator without I18n functions available
+ */
+class NoI18nValidator extends Validator
+{
+    /**
+     * Disable the usage of I18n functions
+     */
+    public function __construct()
+    {
+        $this->_useI18n = false;
+        $this->_providers = self::$_defaultProviders;
+    }
+}

--- a/tests/TestCase/Validation/NoI18nValidator.php
+++ b/tests/TestCase/Validation/NoI18nValidator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Cake\Test\TestCase\Validation;
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1497,6 +1497,14 @@ class ValidatorTest extends TestCase
             ],
         ];
         $this->assertEquals($expected, $errors);
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator
+            ->add('email', 'alpha', ['rule' => 'alphanumeric'])
+            ->add('email', 'notBlank', ['rule' => 'notBlank'])
+            ->add('email', 'email', ['rule' => 'email', 'message' => 'Y u no write email?']);
+        $errors = $noI18nValidator->validate(['email' => 'not an email!']);
+        $this->assertEquals($expected, $errors);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -43,6 +43,10 @@ class ValidatorTest extends TestCase
         $validator->requirePresence('field');
         $this->assertSame('This field is required', $validator->getRequiredMessage('field'));
 
+        $validator = new NoI18nValidator();
+        $validator->requirePresence('field');
+        $this->assertSame('This field is required', $validator->getRequiredMessage('field'));
+
         $validator = new Validator();
         $validator->requirePresence('field', true, 'Custom message');
         $this->assertSame('Custom message', $validator->getRequiredMessage('field'));
@@ -57,6 +61,10 @@ class ValidatorTest extends TestCase
         $this->assertNull($validator->getNotEmptyMessage('field'));
 
         $validator = new Validator();
+        $validator->requirePresence('field');
+        $this->assertSame('This field cannot be left empty', $validator->getNotEmptyMessage('field'));
+
+        $validator = new NoI18nValidator();
         $validator->requirePresence('field');
         $this->assertSame('This field cannot be left empty', $validator->getNotEmptyMessage('field'));
 
@@ -1848,6 +1856,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notBlank');
         $this->assertNotEmpty($validator->validate(['username' => '  ']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->notBlank('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'notBlank' => 'This field cannot be left empty',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '  ']));
     }
 
     /**
@@ -1858,6 +1875,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'alphaNumeric');
         $this->assertNotEmpty($validator->validate(['username' => '$']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->alphaNumeric('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'alphaNumeric' => 'The provided value must be alphanumeric',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '$']));
     }
 
     /**
@@ -1868,6 +1894,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notAlphaNumeric');
         $this->assertEmpty($validator->validate(['username' => '$']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->notAlphaNumeric('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'notAlphaNumeric' => 'The provided value must not be alphanumeric',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
     }
 
     /**
@@ -1878,6 +1913,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'asciiAlphaNumeric');
         $this->assertNotEmpty($validator->validate(['username' => '$']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->asciiAlphaNumeric('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'asciiAlphaNumeric' => 'The provided value must be ASCII-alphanumeric',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '$']));
     }
 
     /**
@@ -1888,6 +1932,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notAsciiAlphaNumeric');
         $this->assertEmpty($validator->validate(['username' => '$']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->notAsciiAlphaNumeric('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'notAsciiAlphaNumeric' => 'The provided value must not be ASCII-alphanumeric',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
     }
 
     /**
@@ -1898,6 +1951,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lengthBetween', [5, 7], [5, 7]);
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->lengthBetween('field_name', [5, 7]);
+        $expectedMessage = [
+            'field_name' => [
+                'lengthBetween' => 'The length of the provided value must be between `5` and `7`, inclusively',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo']));
     }
 
     /**
@@ -1918,6 +1980,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'creditCard', 'all', ['all', true], 'creditCard');
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->creditCard('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'creditCard' => 'The provided value must be a credit card number',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo']));
     }
 
     /**
@@ -1928,6 +1999,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThan', 5, [Validation::COMPARE_GREATER, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 2]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->greaterThan('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'greaterThan' => 'The provided value must be greater than `5`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2]));
     }
 
     /**
@@ -1938,6 +2018,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanOrEqual', 5, [Validation::COMPARE_GREATER_OR_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 2]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->greaterThanOrEqual('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'greaterThanOrEqual' => 'The provided value must be greater than or equal to `5`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2]));
     }
 
     /**
@@ -1948,6 +2037,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThan', 5, [Validation::COMPARE_LESS, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 5]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->lessThan('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'lessThan' => 'The provided value must be less than `5`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 5]));
     }
 
     /**
@@ -1958,6 +2056,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanOrEqual', 5, [Validation::COMPARE_LESS_OR_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 6]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->lessThanOrEqual('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'lessThanOrEqual' => 'The provided value must be less than or equal to `5`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 6]));
     }
 
     /**
@@ -1969,6 +2076,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'equals', 5, [Validation::COMPARE_EQUAL, 5], 'comparison');
         $this->assertEmpty($validator->validate(['username' => 5]));
         $this->assertNotEmpty($validator->validate(['username' => 6]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->equals('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'equals' => 'The provided value must be equals to `5`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 6]));
     }
 
     /**
@@ -1979,6 +2095,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notEquals', 5, [Validation::COMPARE_NOT_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 5]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->notEquals('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'notEquals' => 'The provided value must not be equals to `5`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 5]));
     }
 
     /**
@@ -1990,6 +2115,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'sameAs', 'other', ['other', Validation::COMPARE_SAME], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => '1']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->sameAs('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'sameAs' => 'The provided value must be same as `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 2]));
     }
 
     /**
@@ -2000,6 +2134,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', Validation::COMPARE_NOT_SAME], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'foo']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->notSameAs('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'notSameAs' => 'The provided value must not be same as `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 1]));
     }
 
     /**
@@ -2011,6 +2154,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'equalToField', 'other', ['other', Validation::COMPARE_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
         $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'bar']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->equalToField('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'equalToField' => 'The provided value must be equal to the one of field `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo', 'other' => 'bar']));
     }
 
     /**
@@ -2021,6 +2173,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', Validation::COMPARE_NOT_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'foo']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->notEqualToField('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'notEqualToField' => 'The provided value must not be equal to the one of field `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo', 'other' => 'foo']));
     }
 
     /**
@@ -2032,6 +2193,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'greaterThanField', 'other', ['other', Validation::COMPARE_GREATER], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 1]));
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 2]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->greaterThanField('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'greaterThanField' => 'The provided value must be greater than the one of field `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 1]));
     }
 
     /**
@@ -2042,6 +2212,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', Validation::COMPARE_GREATER_OR_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 2]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->greaterThanOrEqualToField('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'greaterThanOrEqualToField' => 'The provided value must be greater than or equal to the one of field `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 2]));
     }
 
     /**
@@ -2053,6 +2232,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'lessThanField', 'other', ['other', Validation::COMPARE_LESS], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 1]));
         $this->assertNotEmpty($validator->validate(['username' => 2, 'other' => 1]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->lessThanField('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'lessThanField' => 'The provided value must be less than the one of field `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2, 'other' => 1]));
     }
 
     /**
@@ -2063,6 +2251,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', Validation::COMPARE_LESS_OR_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 2, 'other' => 1]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->lessThanOrEqualToField('field_name', 'other');
+        $expectedMessage = [
+            'field_name' => [
+                'lessThanOrEqualToField' => 'The provided value must be less than or equal to the one of field `other`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2, 'other' => 1]));
     }
 
     /**
@@ -2073,6 +2270,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'date', ['ymd'], [['ymd']]);
         $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->date('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'date' => 'The provided value must be a date',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a date']));
     }
 
     /**
@@ -2086,6 +2292,15 @@ class ValidatorTest extends TestCase
 
         $validator = (new Validator())->dateTime('thedate', ['iso8601']);
         $this->assertEmpty($validator->validate(['thedate' => '2020-05-01T12:34:56Z']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->dateTime('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'dateTime' => 'The provided value must be a date and time',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a date']));
     }
 
     /**
@@ -2096,6 +2311,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'time');
         $this->assertNotEmpty($validator->validate(['username' => 'not a time']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->time('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'time' => 'The provided value must be a time',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a time']));
     }
 
     /**
@@ -2106,6 +2330,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'localizedTime', 'date', ['date']);
         $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->localizedTime('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'localizedTime' => 'The provided value must be a localized time, date or date and time',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a date']));
     }
 
     /**
@@ -2116,6 +2349,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'boolean');
         $this->assertNotEmpty($validator->validate(['username' => 'not a boolean']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->boolean('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'boolean' => 'The provided value must be a boolean',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a boolean']));
     }
 
     /**
@@ -2126,6 +2368,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'decimal', 2, [2]);
         $this->assertNotEmpty($validator->validate(['username' => 10.1]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->decimal('field_name', 2);
+        $expectedMessage = [
+            'field_name' => [
+                'decimal' => 'The provided value must be decimal'
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 10.1]));
     }
 
     /**
@@ -2142,6 +2393,33 @@ class ValidatorTest extends TestCase
 
         $this->assertProxyMethod($validator, 'ipv6', null, ['ipv6'], 'ip');
         $this->assertNotEmpty($validator->validate(['username' => 'not ip']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->ip('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'ip' => 'The provided value must be an IP address',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an ip']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->ipv4('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'ipv4' => 'The provided value must be an IPv4 address',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an ip']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->ipv6('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'ipv6' => 'The provided value must be an IPv6 address',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an ip']));
     }
 
     /**
@@ -2152,6 +2430,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'minLength', 2, [2]);
         $this->assertNotEmpty($validator->validate(['username' => 'a']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->minLength('field_name', 2);
+        $expectedMessage = [
+            'field_name' => [
+                'minLength' => 'The provided value must be at least `2` characters long',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
     }
 
     /**
@@ -2162,6 +2449,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'minLengthBytes', 11, [11]);
         $this->assertNotEmpty($validator->validate(['username' => 'ÆΔΩЖÇ']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->minLengthBytes('field_name', 11);
+        $expectedMessage = [
+            'field_name' => [
+                'minLengthBytes' => 'The provided value must be at least `11` bytes long',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'ÆΔΩЖÇ']));
     }
 
     /**
@@ -2172,6 +2468,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'maxLength', 2, [2]);
         $this->assertNotEmpty($validator->validate(['username' => 'aaa']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->maxLength('field_name', 2);
+        $expectedMessage = [
+            'field_name' => [
+                'maxLength' => 'The provided value must be at most `2` characters long',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'aaa']));
     }
 
     /**
@@ -2182,6 +2487,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'maxLengthBytes', 9, [9]);
         $this->assertNotEmpty($validator->validate(['username' => 'ÆΔΩЖÇ']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->maxLengthBytes('field_name', 9);
+        $expectedMessage = [
+            'field_name' => [
+                'maxLengthBytes' => 'The provided value must be at most `9` bytes long',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'ÆΔΩЖÇ']));
     }
 
     /**
@@ -2193,6 +2507,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'numeric');
         $this->assertEmpty($validator->validate(['username' => '22']));
         $this->assertNotEmpty($validator->validate(['username' => 'a']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->numeric('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'numeric' => 'The provided value must be numeric',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
     }
 
     /**
@@ -2203,6 +2526,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'naturalNumber', null, [false]);
         $this->assertNotEmpty($validator->validate(['username' => 0]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->naturalNumber('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'naturalNumber' => 'The provided value must be a natural number',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 0]));
     }
 
     /**
@@ -2213,6 +2545,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'nonNegativeInteger', null, [true], 'naturalNumber');
         $this->assertNotEmpty($validator->validate(['username' => -1]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->nonNegativeInteger('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'nonNegativeInteger' => 'The provided value must be a non-negative integer',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => -1]));
     }
 
     /**
@@ -2223,6 +2564,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'range', [1, 4], [1, 4]);
         $this->assertNotEmpty($validator->validate(['username' => 5]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->range('field_name', [1, 4]);
+        $expectedMessage = [
+            'field_name' => [
+                'range' => 'The provided value must be between `1` and `4`, inclusively',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 5]));
     }
 
     /**
@@ -2243,6 +2593,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'url', null, [false]);
         $this->assertNotEmpty($validator->validate(['username' => 'not url']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->url('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'url' => 'The provided value must be a URL',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not url']));
     }
 
     /**
@@ -2253,6 +2612,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'urlWithProtocol', null, [true], 'url');
         $this->assertNotEmpty($validator->validate(['username' => 'google.com']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->urlWithProtocol('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'urlWithProtocol' => 'The provided value must be a URL with protocol',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'google.com']));
     }
 
     /**
@@ -2263,6 +2631,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'inList', ['a', 'b'], [['a', 'b']]);
         $this->assertNotEmpty($validator->validate(['username' => 'c']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->inList('field_name', ['a', 'b']);
+        $expectedMessage = [
+            'field_name' => [
+                'inList' => 'The provided value must be one from the list of allowed values',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'c']));
     }
 
     /**
@@ -2273,6 +2650,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'uuid');
         $this->assertNotEmpty($validator->validate(['username' => 'not uuid']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->uuid('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'uuid' => 'The provided value must be a UUID',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not uuid']));
     }
 
     /**
@@ -2283,6 +2669,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'uploadedFile', ['foo' => 'bar'], [['foo' => 'bar']]);
         $this->assertNotEmpty($validator->validate(['username' => []]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->uploadedFile('field_name', ['foo' => 'bar']);
+        $expectedMessage = [
+            'field_name' => [
+                'uploadedFile' => 'The provided value must be an uploaded file',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => []]));
     }
 
     /**
@@ -2299,6 +2694,33 @@ class ValidatorTest extends TestCase
 
         $this->assertProxyMethod($validator, 'longitude');
         $this->assertNotEmpty($validator->validate(['username' => 2000]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->latLong('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'latLong' => 'The provided value must be a latitude/longitude coordinate',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2000]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->latitude('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'latitude' => 'The provided value must be a latitude',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2000]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->longitude('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'longitude' => 'The provided value must be a longitude',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2000]));
     }
 
     /**
@@ -2309,6 +2731,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'ascii');
         $this->assertNotEmpty($validator->validate(['username' => 'ü']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->ascii('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'ascii' => 'The provided value must be ASCII bytes only',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'ü']));
     }
 
     /**
@@ -2323,6 +2754,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'utf8', null, [['extended' => false]]);
         $this->assertEmpty($validator->validate(['username' => 'ü']));
         $this->assertNotEmpty($validator->validate(['username' => $extended]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->utf8('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'utf8' => 'The provided value must be UTF-8 bytes only',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => "\xf0\x9f\x98\x80"]));
     }
 
     /**
@@ -2337,6 +2777,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'utf8Extended', null, [['extended' => true]], 'utf8');
         $this->assertEmpty($validator->validate(['username' => 'ü']));
         $this->assertEmpty($validator->validate(['username' => $extended]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->utf8Extended('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'utf8Extended' => 'The provided value must be 3 and 4 byte UTF-8 sequences only',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => "\xf0\x9f\x98\x80\x80"]));
     }
 
     /**
@@ -2348,6 +2797,15 @@ class ValidatorTest extends TestCase
         $validator->email('username');
         $this->assertEmpty($validator->validate(['username' => 'test@example.com']));
         $this->assertNotEmpty($validator->validate(['username' => 'not an email']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->email('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'email' => 'The provided value must be an e-mail address',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an email']));
     }
 
     /**
@@ -2358,6 +2816,15 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $this->assertProxyMethod($validator, 'integer', null, [], 'isInteger');
         $this->assertNotEmpty($validator->validate(['username' => 'not integer']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->integer('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'integer' => 'The provided value must be an integer',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not integer']));
     }
 
     /**
@@ -2372,6 +2839,15 @@ class ValidatorTest extends TestCase
             ['username' => ['array' => 'The provided value must be an array']],
             $validator->validate(['username' => 'is not an array'])
         );
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->array('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'array' => 'The provided value must be an array',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'is not an array']));
     }
 
     /**
@@ -2386,6 +2862,15 @@ class ValidatorTest extends TestCase
             ['username' => ['scalar' => 'The provided value must be scalar']],
             $validator->validate(['username' => ['array']])
         );
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->scalar('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'scalar' => 'The provided value must be scalar',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => ['array']]));
     }
 
     /**
@@ -2397,6 +2882,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'hexColor');
         $this->assertEmpty($validator->validate(['username' => '#FFFFFF']));
         $this->assertNotEmpty($validator->validate(['username' => 'FFFFFF']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->hexColor('field_name');
+        $expectedMessage = [
+            'field_name' => [
+                'hexColor' => 'The provided value must be a hex color',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'FFFFFF']));
     }
 
     /**
@@ -2422,6 +2916,18 @@ class ValidatorTest extends TestCase
         );
 
         $this->assertNotEmpty($validator->validate(['username' => '']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->multipleOptions(
+            'field_name',
+            ['min' => 1, 'caseInsensitive' => false]
+        );
+        $expectedMessage = [
+            'field_name' => [
+                'multipleOptions' => 'The provided value must be a set of multiple options',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '']));
     }
 
     /**
@@ -2442,6 +2948,15 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => [1, 2]]]));
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => []]]));
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => 'string']]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->hasAtLeast('field_name', 5);
+        $expectedMessage = [
+            'field_name' => [
+                'hasAtLeast' => 'The provided value must have at least `5` elements',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => ['_ids' => 'string']]));
     }
 
     /**
@@ -2458,6 +2973,15 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3]]]));
         $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2]]]));
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3, 4]]]));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->hasAtMost('field_name', 3);
+        $expectedMessage = [
+            'field_name' => [
+                'hasAtMost' => 'The provided value must have at most `3` elements',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => ['_ids' => [1, 2, 3, 4]]]));
     }
 
     /**
@@ -2469,6 +2993,15 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'regex', '/(?<!\\S)\\d++(?!\\S)/', ['/(?<!\\S)\\d++(?!\\S)/'], 'custom');
         $this->assertEmpty($validator->validate(['username' => '123']));
         $this->assertNotEmpty($validator->validate(['username' => 'Foo']));
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->regex('field_name', '/(?<!\\S)\\d++(?!\\S)/');
+        $expectedMessage = [
+            'field_name' => [
+                'regex' => 'The provided value must match against the pattern `/(?<!\S)\d++(?!\S)/`',
+            ]
+        ];;
+        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'Foo']));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2943,7 +2943,11 @@ class ValidatorTest extends TestCase
         );
 
         $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->{$rule}($fieldName, $additional);
+        if ($additional !== null) {
+            $noI18nValidator->{$rule}($fieldName, $additional);
+        } else {
+            $noI18nValidator->{$rule}($fieldName);
+        }
 
         $this->assertSame(
             $expectedMessage,

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -806,7 +806,7 @@ class ValidatorTest extends TestCase
         ];
         $expected = [
             'photo' => [
-                'uploadedFile' => 'The provided value is invalid',
+                'uploadedFile' => 'The provided value must be an uploaded file',
             ],
         ];
         $result = $validator->validate($data);

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1994,6 +1994,12 @@ class ValidatorTest extends TestCase
         $expectedMessage = 'The provided value must be a valid credit card number of these types: `amex`';
         $cardType = 'amex';
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
+
+        // This should lead to a RangeException or an UnexpectedValueException, instead.
+        // As it could never successfully validate the data.
+        $expectedMessage = 'The provided value must be a valid credit card number of these types: ``';
+        $cardType = [];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
     }
 
     /**
@@ -2247,6 +2253,12 @@ class ValidatorTest extends TestCase
         $expectedMessage = 'The provided value must be a date of one of these formats: `ymd, dmy`';
         $format = ['ymd', 'dmy'];
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
+
+        // This should lead to a RangeException or an UnexpectedValueException, instead.
+        // As it could never successfully validate the data.
+        $expectedMessage = 'The provided value must be a date of one of these formats: ``';
+        $format = [];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
     }
 
     /**
@@ -2273,6 +2285,12 @@ class ValidatorTest extends TestCase
 
         $expectedMessage = 'The provided value must be a date and time of one of these formats: `ymd, dmy`';
         $format = ['ymd', 'dmy'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
+
+        // This should lead to a RangeException or an UnexpectedValueException, instead.
+        // As it could never successfully validate the data.
+        $expectedMessage = 'The provided value must be a date and time of one of these formats: ``';
+        $format = [];
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1983,7 +1983,7 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'creditCard';
-        $expectedMessage = 'The provided value must be a credit card number';
+        $expectedMessage = 'The provided value must be a valid credit card number';
         $cardType = 'all';
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
     }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1872,14 +1872,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'notBlank');
         $this->assertNotEmpty($validator->validate(['username' => '  ']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->notBlank('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'notBlank' => 'This field cannot be left empty',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '  ']));
+        $fieldName = 'field_name';
+        $rule = 'notBlank';
+        $expectedMessage = 'This field cannot be left empty';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -1891,14 +1887,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'alphaNumeric');
         $this->assertNotEmpty($validator->validate(['username' => '$']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->alphaNumeric('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'alphaNumeric' => 'The provided value must be alphanumeric',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '$']));
+        $fieldName = 'field_name';
+        $rule = 'alphaNumeric';
+        $expectedMessage = 'The provided value must be alphanumeric';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -1910,14 +1902,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'notAlphaNumeric');
         $this->assertEmpty($validator->validate(['username' => '$']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->notAlphaNumeric('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'notAlphaNumeric' => 'The provided value must not be alphanumeric',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
+        $fieldName = 'field_name';
+        $rule = 'notAlphaNumeric';
+        $expectedMessage = 'The provided value must not be alphanumeric';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -1929,14 +1917,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'asciiAlphaNumeric');
         $this->assertNotEmpty($validator->validate(['username' => '$']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->asciiAlphaNumeric('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'asciiAlphaNumeric' => 'The provided value must be ASCII-alphanumeric',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '$']));
+        $fieldName = 'field_name';
+        $rule = 'asciiAlphaNumeric';
+        $expectedMessage = 'The provided value must be ASCII-alphanumeric';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -1948,14 +1932,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'notAsciiAlphaNumeric');
         $this->assertEmpty($validator->validate(['username' => '$']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->notAsciiAlphaNumeric('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'notAsciiAlphaNumeric' => 'The provided value must not be ASCII-alphanumeric',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
+        $fieldName = 'field_name';
+        $rule = 'notAsciiAlphaNumeric';
+        $expectedMessage = 'The provided value must not be ASCII-alphanumeric';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -1967,14 +1947,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'lengthBetween', [5, 7], [5, 7]);
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->lengthBetween('field_name', [5, 7]);
-        $expectedMessage = [
-            'field_name' => [
-                'lengthBetween' => 'The length of the provided value must be between `5` and `7`, inclusively',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo']));
+        $fieldName = 'field_name';
+        $rule = 'lengthBetween';
+        $expectedMessage = 'The length of the provided value must be between `5` and `7`, inclusively';
+        $lengthBetween = [5, 7];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $lengthBetween);
     }
 
     /**
@@ -1996,14 +1973,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'creditCard', 'all', ['all', true], 'creditCard');
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->creditCard('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'creditCard' => 'The provided value must be a credit card number',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo']));
+        $fieldName = 'field_name';
+        $rule = 'creditCard';
+        $expectedMessage = 'The provided value must be a credit card number';
+        $cardType = 'all';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
     }
 
     /**
@@ -2015,14 +1989,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'greaterThan', 5, [Validation::COMPARE_GREATER, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 2]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->greaterThan('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'greaterThan' => 'The provided value must be greater than `5`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2]));
+        $fieldName = 'field_name';
+        $rule = 'greaterThan';
+        $expectedMessage = 'The provided value must be greater than `5`';
+        $greaterThan = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $greaterThan);
     }
 
     /**
@@ -2034,14 +2005,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'greaterThanOrEqual', 5, [Validation::COMPARE_GREATER_OR_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 2]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->greaterThanOrEqual('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'greaterThanOrEqual' => 'The provided value must be greater than or equal to `5`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2]));
+        $fieldName = 'field_name';
+        $rule = 'greaterThanOrEqual';
+        $expectedMessage = 'The provided value must be greater than or equal to `5`';
+        $greaterThanOrEqualTo = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $greaterThanOrEqualTo);
     }
 
     /**
@@ -2053,14 +2021,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'lessThan', 5, [Validation::COMPARE_LESS, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 5]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->lessThan('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'lessThan' => 'The provided value must be less than `5`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 5]));
+        $fieldName = 'field_name';
+        $rule = 'lessThan';
+        $expectedMessage = 'The provided value must be less than `5`';
+        $lessThan = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $lessThan);
     }
 
     /**
@@ -2072,14 +2037,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'lessThanOrEqual', 5, [Validation::COMPARE_LESS_OR_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 6]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->lessThanOrEqual('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'lessThanOrEqual' => 'The provided value must be less than or equal to `5`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 6]));
+        $fieldName = 'field_name';
+        $rule = 'lessThanOrEqual';
+        $expectedMessage = 'The provided value must be less than or equal to `5`';
+        $lessThanOrEqualTo = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $lessThanOrEqualTo);
     }
 
     /**
@@ -2092,14 +2054,11 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => 5]));
         $this->assertNotEmpty($validator->validate(['username' => 6]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->equals('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'equals' => 'The provided value must be equals to `5`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 6]));
+        $fieldName = 'field_name';
+        $rule = 'equals';
+        $expectedMessage = 'The provided value must be equals to `5`';
+        $equalTo = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $equalTo);
     }
 
     /**
@@ -2111,14 +2070,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'notEquals', 5, [Validation::COMPARE_NOT_EQUAL, 5], 'comparison');
         $this->assertNotEmpty($validator->validate(['username' => 5]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->notEquals('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'notEquals' => 'The provided value must not be equals to `5`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 5]));
+        $fieldName = 'field_name';
+        $rule = 'notEquals';
+        $expectedMessage = 'The provided value must not be equals to `5`';
+        $notEqualTo = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $notEqualTo);
     }
 
     /**
@@ -2131,14 +2087,11 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => '1']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->sameAs('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'sameAs' => 'The provided value must be same as `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 2]));
+        $fieldName = 'field_name';
+        $rule = 'sameAs';
+        $expectedMessage = 'The provided value must be same as `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2150,14 +2103,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'notSameAs', 'other', ['other', Validation::COMPARE_NOT_SAME], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'foo']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->notSameAs('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'notSameAs' => 'The provided value must not be same as `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 1]));
+        $fieldName = 'field_name';
+        $rule = 'notSameAs';
+        $expectedMessage = 'The provided value must not be same as `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2170,14 +2120,11 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['username' => 'foo']));
         $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'bar']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->equalToField('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'equalToField' => 'The provided value must be equal to the one of field `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo', 'other' => 'bar']));
+        $fieldName = 'field_name';
+        $rule = 'equalToField';
+        $expectedMessage = 'The provided value must be equal to the one of field `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2189,14 +2136,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'notEqualToField', 'other', ['other', Validation::COMPARE_NOT_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 'foo', 'other' => 'foo']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->notEqualToField('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'notEqualToField' => 'The provided value must not be equal to the one of field `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'foo', 'other' => 'foo']));
+        $fieldName = 'field_name';
+        $rule = 'notEqualToField';
+        $expectedMessage = 'The provided value must not be equal to the one of field `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2209,14 +2153,11 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 1]));
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 2]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->greaterThanField('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'greaterThanField' => 'The provided value must be greater than the one of field `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 1]));
+        $fieldName = 'field_name';
+        $rule = 'greaterThanField';
+        $expectedMessage = 'The provided value must be greater than the one of field `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2228,14 +2169,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'greaterThanOrEqualToField', 'other', ['other', Validation::COMPARE_GREATER_OR_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 2]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->greaterThanOrEqualToField('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'greaterThanOrEqualToField' => 'The provided value must be greater than or equal to the one of field `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 1, 'other' => 2]));
+        $fieldName = 'field_name';
+        $rule = 'greaterThanOrEqualToField';
+        $expectedMessage = 'The provided value must be greater than or equal to the one of field `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2248,14 +2186,11 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['username' => 1, 'other' => 1]));
         $this->assertNotEmpty($validator->validate(['username' => 2, 'other' => 1]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->lessThanField('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'lessThanField' => 'The provided value must be less than the one of field `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2, 'other' => 1]));
+        $fieldName = 'field_name';
+        $rule = 'lessThanField';
+        $expectedMessage = 'The provided value must be less than the one of field `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2267,14 +2202,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'lessThanOrEqualToField', 'other', ['other', Validation::COMPARE_LESS_OR_EQUAL], 'compareFields');
         $this->assertNotEmpty($validator->validate(['username' => 2, 'other' => 1]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->lessThanOrEqualToField('field_name', 'other');
-        $expectedMessage = [
-            'field_name' => [
-                'lessThanOrEqualToField' => 'The provided value must be less than or equal to the one of field `other`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2, 'other' => 1]));
+        $fieldName = 'field_name';
+        $rule = 'lessThanOrEqualToField';
+        $expectedMessage = 'The provided value must be less than or equal to the one of field `other`';
+        $otherField = 'other';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $otherField);
     }
 
     /**
@@ -2286,14 +2218,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'date', ['ymd'], [['ymd']]);
         $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->date('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'date' => 'The provided value must be a date',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a date']));
+        $fieldName = 'field_name';
+        $rule = 'date';
+        $expectedMessage = 'The provided value must be a date';
+        $format = ['ymd'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
     }
 
     /**
@@ -2308,14 +2237,11 @@ class ValidatorTest extends TestCase
         $validator = (new Validator())->dateTime('thedate', ['iso8601']);
         $this->assertEmpty($validator->validate(['thedate' => '2020-05-01T12:34:56Z']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->dateTime('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'dateTime' => 'The provided value must be a date and time',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a date']));
+        $fieldName = 'field_name';
+        $rule = 'dateTime';
+        $expectedMessage = 'The provided value must be a date and time';
+        $format = ['ymd'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
     }
 
     /**
@@ -2327,14 +2253,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'time');
         $this->assertNotEmpty($validator->validate(['username' => 'not a time']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->time('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'time' => 'The provided value must be a time',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a time']));
+        $fieldName = 'field_name';
+        $rule = 'time';
+        $expectedMessage = 'The provided value must be a time';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2346,14 +2268,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'localizedTime', 'date', ['date']);
         $this->assertNotEmpty($validator->validate(['username' => 'not a date']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->localizedTime('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'localizedTime' => 'The provided value must be a localized time, date or date and time',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a date']));
+        $fieldName = 'field_name';
+        $rule = 'localizedTime';
+        $expectedMessage = 'The provided value must be a localized time, date or date and time';
+        $type = 'datetime';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $type);
     }
 
     /**
@@ -2365,14 +2284,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'boolean');
         $this->assertNotEmpty($validator->validate(['username' => 'not a boolean']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->boolean('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'boolean' => 'The provided value must be a boolean',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not a boolean']));
+        $fieldName = 'field_name';
+        $rule = 'boolean';
+        $expectedMessage = 'The provided value must be a boolean';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2384,14 +2299,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'decimal', 2, [2]);
         $this->assertNotEmpty($validator->validate(['username' => 10.1]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->decimal('field_name', 2);
-        $expectedMessage = [
-            'field_name' => [
-                'decimal' => 'The provided value must be decimal'
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 10.1]));
+        $fieldName = 'field_name';
+        $rule = 'decimal';
+        $expectedMessage = 'The provided value must be decimal';
+        $places = 2;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $places);
     }
 
     /**
@@ -2409,32 +2321,20 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'ipv6', null, ['ipv6'], 'ip');
         $this->assertNotEmpty($validator->validate(['username' => 'not ip']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->ip('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'ip' => 'The provided value must be an IP address',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an ip']));
+        $fieldName = 'field_name';
+        $rule = 'ip';
+        $expectedMessage = 'The provided value must be an IP address';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->ipv4('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'ipv4' => 'The provided value must be an IPv4 address',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an ip']));
+        $fieldName = 'field_name';
+        $rule = 'ipv4';
+        $expectedMessage = 'The provided value must be an IPv4 address';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->ipv6('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'ipv6' => 'The provided value must be an IPv6 address',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an ip']));
+        $fieldName = 'field_name';
+        $rule = 'ipv6';
+        $expectedMessage = 'The provided value must be an IPv6 address';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2446,14 +2346,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'minLength', 2, [2]);
         $this->assertNotEmpty($validator->validate(['username' => 'a']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->minLength('field_name', 2);
-        $expectedMessage = [
-            'field_name' => [
-                'minLength' => 'The provided value must be at least `2` characters long',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
+        $fieldName = 'field_name';
+        $rule = 'minLength';
+        $expectedMessage = 'The provided value must be at least `2` characters long';
+        $minLength = 2;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $minLength);
     }
 
     /**
@@ -2465,14 +2362,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'minLengthBytes', 11, [11]);
         $this->assertNotEmpty($validator->validate(['username' => 'ÆΔΩЖÇ']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->minLengthBytes('field_name', 11);
-        $expectedMessage = [
-            'field_name' => [
-                'minLengthBytes' => 'The provided value must be at least `11` bytes long',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'ÆΔΩЖÇ']));
+        $fieldName = 'field_name';
+        $rule = 'minLengthBytes';
+        $expectedMessage = 'The provided value must be at least `11` bytes long';
+        $minLengthBytes = 11;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $minLengthBytes);
     }
 
     /**
@@ -2484,14 +2378,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'maxLength', 2, [2]);
         $this->assertNotEmpty($validator->validate(['username' => 'aaa']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->maxLength('field_name', 2);
-        $expectedMessage = [
-            'field_name' => [
-                'maxLength' => 'The provided value must be at most `2` characters long',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'aaa']));
+        $fieldName = 'field_name';
+        $rule = 'maxLength';
+        $expectedMessage = 'The provided value must be at most `2` characters long';
+        $maxLength = 2;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $maxLength);
     }
 
     /**
@@ -2503,14 +2394,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'maxLengthBytes', 9, [9]);
         $this->assertNotEmpty($validator->validate(['username' => 'ÆΔΩЖÇ']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->maxLengthBytes('field_name', 9);
-        $expectedMessage = [
-            'field_name' => [
-                'maxLengthBytes' => 'The provided value must be at most `9` bytes long',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'ÆΔΩЖÇ']));
+        $fieldName = 'field_name';
+        $rule = 'maxLengthBytes';
+        $expectedMessage = 'The provided value must be at most `11` bytes long';
+        $maxLengthBytes = 11;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $maxLengthBytes);
     }
 
     /**
@@ -2523,14 +2411,10 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => '22']));
         $this->assertNotEmpty($validator->validate(['username' => 'a']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->numeric('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'numeric' => 'The provided value must be numeric',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'a']));
+        $fieldName = 'field_name';
+        $rule = 'numeric';
+        $expectedMessage = 'The provided value must be numeric';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2542,14 +2426,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'naturalNumber', null, [false]);
         $this->assertNotEmpty($validator->validate(['username' => 0]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->naturalNumber('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'naturalNumber' => 'The provided value must be a natural number',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 0]));
+        $fieldName = 'field_name';
+        $rule = 'naturalNumber';
+        $expectedMessage = 'The provided value must be a natural number';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2561,14 +2441,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'nonNegativeInteger', null, [true], 'naturalNumber');
         $this->assertNotEmpty($validator->validate(['username' => -1]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->nonNegativeInteger('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'nonNegativeInteger' => 'The provided value must be a non-negative integer',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => -1]));
+        $fieldName = 'field_name';
+        $rule = 'nonNegativeInteger';
+        $expectedMessage = 'The provided value must be a non-negative integer';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2580,14 +2456,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'range', [1, 4], [1, 4]);
         $this->assertNotEmpty($validator->validate(['username' => 5]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->range('field_name', [1, 4]);
-        $expectedMessage = [
-            'field_name' => [
-                'range' => 'The provided value must be between `1` and `4`, inclusively',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 5]));
+        $fieldName = 'field_name';
+        $rule = 'range';
+        $expectedMessage = 'The provided value must be between `1` and `4`, inclusively';
+        $range = [1, 4];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $range);
     }
 
     /**
@@ -2609,14 +2482,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'url', null, [false]);
         $this->assertNotEmpty($validator->validate(['username' => 'not url']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->url('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'url' => 'The provided value must be a URL',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not url']));
+        $fieldName = 'field_name';
+        $rule = 'url';
+        $expectedMessage = 'The provided value must be a URL';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2628,14 +2497,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'urlWithProtocol', null, [true], 'url');
         $this->assertNotEmpty($validator->validate(['username' => 'google.com']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->urlWithProtocol('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'urlWithProtocol' => 'The provided value must be a URL with protocol',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'google.com']));
+        $fieldName = 'field_name';
+        $rule = 'urlWithProtocol';
+        $expectedMessage = 'The provided value must be a URL with protocol';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2647,14 +2512,11 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'inList', ['a', 'b'], [['a', 'b']]);
         $this->assertNotEmpty($validator->validate(['username' => 'c']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->inList('field_name', ['a', 'b']);
-        $expectedMessage = [
-            'field_name' => [
-                'inList' => 'The provided value must be one from the list of allowed values',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'c']));
+        $fieldName = 'field_name';
+        $rule = 'inList';
+        $expectedMessage = 'The provided value must be one from the list of allowed values';
+        $range = ['a', 'b'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $range);
     }
 
     /**
@@ -2666,14 +2528,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'uuid');
         $this->assertNotEmpty($validator->validate(['username' => 'not uuid']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->uuid('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'uuid' => 'The provided value must be a UUID',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not uuid']));
+        $fieldName = 'field_name';
+        $rule = 'uuid';
+        $expectedMessage = 'The provided value must be a UUID';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2685,14 +2543,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'uploadedFile', ['foo' => 'bar'], [['foo' => 'bar']]);
         $this->assertNotEmpty($validator->validate(['username' => []]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->uploadedFile('field_name', ['foo' => 'bar']);
-        $expectedMessage = [
-            'field_name' => [
-                'uploadedFile' => 'The provided value must be an uploaded file',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => []]));
+        $fieldName = 'field_name';
+        $rule = 'uploadedFile';
+        $expectedMessage = 'The provided value must be an uploaded file';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, ['foo' => 'bar']);
     }
 
     /**
@@ -2710,32 +2564,18 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'longitude');
         $this->assertNotEmpty($validator->validate(['username' => 2000]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->latLong('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'latLong' => 'The provided value must be a latitude/longitude coordinate',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2000]));
+        $fieldName = 'field_name';
+        $rule = 'latLong';
+        $expectedMessage = 'The provided value must be a latitude/longitude coordinate';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->latitude('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'latitude' => 'The provided value must be a latitude',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2000]));
+        $rule = 'latitude';
+        $expectedMessage = 'The provided value must be a latitude';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->longitude('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'longitude' => 'The provided value must be a longitude',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 2000]));
+        $rule = 'longitude';
+        $expectedMessage = 'The provided value must be a longitude';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2747,14 +2587,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'ascii');
         $this->assertNotEmpty($validator->validate(['username' => 'ü']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->ascii('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'ascii' => 'The provided value must be ASCII bytes only',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'ü']));
+        $fieldName = 'field_name';
+        $rule = 'ascii';
+        $expectedMessage = 'The provided value must be ASCII bytes only';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2770,14 +2606,10 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => 'ü']));
         $this->assertNotEmpty($validator->validate(['username' => $extended]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->utf8('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'utf8' => 'The provided value must be UTF-8 bytes only',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => "\xf0\x9f\x98\x80"]));
+        $fieldName = 'field_name';
+        $rule = 'utf8';
+        $expectedMessage = 'The provided value must be UTF-8 bytes only';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2793,14 +2625,10 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => 'ü']));
         $this->assertEmpty($validator->validate(['username' => $extended]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->utf8Extended('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'utf8Extended' => 'The provided value must be 3 and 4 byte UTF-8 sequences only',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => "\xf0\x9f\x98\x80\x80"]));
+        $fieldName = 'field_name';
+        $rule = 'utf8Extended';
+        $expectedMessage = 'The provided value must be 3 and 4 byte UTF-8 sequences only';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2813,14 +2641,11 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => 'test@example.com']));
         $this->assertNotEmpty($validator->validate(['username' => 'not an email']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->email('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'email' => 'The provided value must be an e-mail address',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not an email']));
+        $fieldName = 'field_name';
+        $rule = 'email';
+        $expectedMessage = 'The provided value must be an e-mail address';
+        $checkMx = false;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $checkMx);
     }
 
     /**
@@ -2832,14 +2657,10 @@ class ValidatorTest extends TestCase
         $this->assertProxyMethod($validator, 'integer', null, [], 'isInteger');
         $this->assertNotEmpty($validator->validate(['username' => 'not integer']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->integer('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'integer' => 'The provided value must be an integer',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'not integer']));
+        $fieldName = 'field_name';
+        $rule = 'integer';
+        $expectedMessage = 'The provided value must be an integer';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2855,14 +2676,10 @@ class ValidatorTest extends TestCase
             $validator->validate(['username' => 'is not an array'])
         );
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->array('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'array' => 'The provided value must be an array',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'is not an array']));
+        $fieldName = 'field_name';
+        $rule = 'array';
+        $expectedMessage = 'The provided value must be an array';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2878,14 +2695,10 @@ class ValidatorTest extends TestCase
             $validator->validate(['username' => ['array']])
         );
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->scalar('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'scalar' => 'The provided value must be scalar',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => ['array']]));
+        $fieldName = 'field_name';
+        $rule = 'scalar';
+        $expectedMessage = 'The provided value must be scalar';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2898,14 +2711,10 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => '#FFFFFF']));
         $this->assertNotEmpty($validator->validate(['username' => 'FFFFFF']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->hexColor('field_name');
-        $expectedMessage = [
-            'field_name' => [
-                'hexColor' => 'The provided value must be a hex color',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'FFFFFF']));
+        $fieldName = 'field_name';
+        $rule = 'hexColor';
+        $expectedMessage = 'The provided value must be a hex color';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage);
     }
 
     /**
@@ -2932,17 +2741,11 @@ class ValidatorTest extends TestCase
 
         $this->assertNotEmpty($validator->validate(['username' => '']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->multipleOptions(
-            'field_name',
-            ['min' => 1, 'caseInsensitive' => false]
-        );
-        $expectedMessage = [
-            'field_name' => [
-                'multipleOptions' => 'The provided value must be a set of multiple options',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => '']));
+        $fieldName = 'field_name';
+        $rule = 'multipleOptions';
+        $expectedMessage = 'The provided value must be a set of multiple options';
+        $options = ['min' => 1, 'caseInsensitive' => false];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $options);
     }
 
     /**
@@ -2964,14 +2767,11 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => []]]));
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => 'string']]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->hasAtLeast('field_name', 5);
-        $expectedMessage = [
-            'field_name' => [
-                'hasAtLeast' => 'The provided value must have at least `5` elements',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => ['_ids' => 'string']]));
+        $fieldName = 'field_name';
+        $rule = 'hasAtLeast';
+        $expectedMessage = 'The provided value must have at least `5` elements';
+        $atLeast = 5;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $atLeast);
     }
 
     /**
@@ -2989,14 +2789,11 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['things' => ['_ids' => [1, 2]]]));
         $this->assertNotEmpty($validator->validate(['things' => ['_ids' => [1, 2, 3, 4]]]));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->hasAtMost('field_name', 3);
-        $expectedMessage = [
-            'field_name' => [
-                'hasAtMost' => 'The provided value must have at most `3` elements',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => ['_ids' => [1, 2, 3, 4]]]));
+        $fieldName = 'field_name';
+        $rule = 'hasAtMost';
+        $expectedMessage = 'The provided value must have at most `4` elements';
+        $atMost = 4;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $atMost);
     }
 
     /**
@@ -3009,14 +2806,11 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => '123']));
         $this->assertNotEmpty($validator->validate(['username' => 'Foo']));
 
-        $noI18nValidator = new NoI18nValidator();
-        $noI18nValidator->regex('field_name', '/(?<!\\S)\\d++(?!\\S)/');
-        $expectedMessage = [
-            'field_name' => [
-                'regex' => 'The provided value must match against the pattern `/(?<!\S)\d++(?!\S)/`',
-            ]
-        ];;
-        $this->assertSame($expectedMessage, $noI18nValidator->validate(['field_name' => 'Foo']));
+        $fieldName = 'field_name';
+        $rule = 'regex';
+        $expectedMessage = 'The provided value must match against the pattern `/(?<!\S)\d++(?!\S)/`';
+        $regex = '/(?<!\\S)\\d++(?!\\S)/';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $regex);
     }
 
     /**
@@ -3093,5 +2887,41 @@ class ValidatorTest extends TestCase
 
         Validator::addDefaultProvider('test-provider2', 'MyNameSpace\Validation\MySecondProvider');
         $this->assertEquals(Validator::getDefaultProviders(), ['test-provider', 'test-provider2'], 'Default providers incorrect');
+    }
+
+    /**
+     * Assert for the data validation message for a given field's rule for a I18n-enabled & a I18n-disabled validator
+     *
+     * @param string $fieldName The field name.
+     * @param string $rule The rule name.
+     * @param string $expectedMessage The expected data validation message.
+     * @param mixed $additional Additional configuration (optional).
+     * @return void
+     */
+    protected function assertValidationMessage(
+        string $fieldName,
+        string $rule,
+        string $expectedMessage,
+        mixed $additional = null
+    ): void {
+        $validator = new Validator();
+        if ($additional) {
+            $validator->{$rule}($fieldName, $additional);
+        } else {
+            $validator->{$rule}($fieldName);
+        }
+
+        $this->assertSame(
+            $expectedMessage,
+            $validator->field($fieldName)->rule($rule)->get('message')
+        );
+
+        $noI18nValidator = new NoI18nValidator();
+        $noI18nValidator->{$rule}($fieldName, $additional);
+
+        $this->assertSame(
+            $expectedMessage,
+            $noI18nValidator->field($fieldName)->rule($rule)->get('message')
+        );
     }
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2503,6 +2503,7 @@ class ValidatorTest extends TestCase
 
         $rule = $validator->field('username')->rule($method);
         $this->assertNotEmpty($rule, "Rule was not found for $method");
+        $this->assertNotNull($rule->get('message'), 'Message is not present when it should be');
         $this->assertNull($rule->get('on'), 'On clause is present when it should not be');
         $this->assertSame($name, $rule->get('rule'), 'Rule name does not match');
         $this->assertEquals($pass, $rule->get('pass'), 'Passed options are different');

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2526,9 +2526,15 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'inList';
-        $expectedMessage = 'The provided value must be one from the list of allowed values';
-        $range = ['a', 'b'];
-        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $range);
+        $expectedMessage = 'The provided value must be one of: `a, b`';
+        $list = ['a', 'b'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $list);
+
+        // This should lead to a RangeException or an UnexpectedValueException, instead.
+        // As it could never successfully validate the data.
+        $expectedMessage = 'The provided value must be one of: ``';
+        $list = [];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $list);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2379,7 +2379,10 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $validator->scalar('username');
         $this->assertEmpty($validator->validate(['username' => 'scalar']));
-        $this->assertNotEmpty($validator->validate(['username' => ['array']]));
+        $this->assertSame(
+            ['username' => ['scalar' => 'The provided value must be scalar']],
+            $validator->validate(['username' => ['array']])
+        );
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2368,7 +2368,10 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $validator->array('username');
         $this->assertEmpty($validator->validate(['username' => [1, 2, 3]]));
-        $this->assertNotEmpty($validator->validate(['username' => 'is not an array']));
+        $this->assertSame(
+            ['username' => ['array' => 'The provided value must be an array']],
+            $validator->validate(['username' => 'is not an array'])
+        );
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2255,8 +2255,16 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'dateTime';
-        $expectedMessage = 'The provided value must be a date and time';
+        $expectedMessage = 'The provided value must be a date and time of one of these formats: `ymd`';
         $format = ['ymd'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
+
+        $format = null;
+        // Same message expected
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
+
+        $expectedMessage = 'The provided value must be a date and time of one of these formats: `ymd, dmy`';
+        $format = ['ymd', 'dmy'];
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -25,6 +25,7 @@ use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use stdClass;
+use Traversable;
 
 /**
  * Tests Validator class
@@ -1718,7 +1719,7 @@ class ValidatorTest extends TestCase
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
             ->add('title', 'cool', ['rule' => 'isCool', 'provider' => 'thing']);
         $fieldIterator = $validator->getIterator();
-        $this->assertInstanceOf(\Traversable::class, $fieldIterator);
+        $this->assertInstanceOf(Traversable::class, $fieldIterator);
         $this->assertCount(2, $validator);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2309,8 +2309,12 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'decimal';
-        $expectedMessage = 'The provided value must be decimal';
+        $expectedMessage = 'The provided value must be decimal with `2` decimal places';
         $places = 2;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $places);
+
+        $expectedMessage = 'The provided value must be decimal with any number of decimal places, including none';
+        $places = null;
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $places);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2503,7 +2503,6 @@ class ValidatorTest extends TestCase
 
         $rule = $validator->field('username')->rule($method);
         $this->assertNotEmpty($rule, "Rule was not found for $method");
-        $this->assertNull($rule->get('message'), 'Message is present when it should not be');
         $this->assertNull($rule->get('on'), 'On clause is present when it should not be');
         $this->assertSame($name, $rule->get('rule'), 'Rule name does not match');
         $this->assertEquals($pass, $rule->get('pass'), 'Passed options are different');

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1239,7 +1239,7 @@ class ValidatorTest extends TestCase
     public function testNotEmptyDateTimeUpdate(): void
     {
         $validator = new Validator();
-        $validator->notEmptyDatetime('published', 'message', 'update');
+        $validator->notEmptyDateTime('published', 'message', 'update');
         $this->assertTrue($validator->isEmptyAllowed('published', true));
         $this->assertFalse($validator->isEmptyAllowed('published', false));
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2917,7 +2917,7 @@ class ValidatorTest extends TestCase
         mixed $additional = null
     ): void {
         $validator = new Validator();
-        if ($additional) {
+        if ($additional !== null) {
             $validator->{$rule}($fieldName, $additional);
         } else {
             $validator->{$rule}($fieldName);

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2236,8 +2236,16 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'date';
-        $expectedMessage = 'The provided value must be a date';
+        $expectedMessage = 'The provided value must be a date of one of these formats: `ymd`';
         $format = ['ymd'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
+
+        // Same expected message
+        $format = null;
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
+
+        $expectedMessage = 'The provided value must be a date of one of these formats: `ymd, dmy`';
+        $format = ['ymd', 'dmy'];
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $format);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1983,8 +1983,16 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'creditCard';
-        $expectedMessage = 'The provided value must be a valid credit card number';
+        $expectedMessage = 'The provided value must be a valid credit card number of any type';
         $cardType = 'all';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
+
+        $expectedMessage = 'The provided value must be a valid credit card number of these types: `amex, bankcard, maestro`';
+        $cardType = ['amex', 'bankcard', 'maestro'];
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
+
+        $expectedMessage = 'The provided value must be a valid credit card number of these types: `amex`';
+        $cardType = 'amex';
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $cardType);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2064,7 +2064,7 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'equals';
-        $expectedMessage = 'The provided value must be equals to `5`';
+        $expectedMessage = 'The provided value must be equal to `5`';
         $equalTo = 5;
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $equalTo);
     }
@@ -2080,7 +2080,7 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'field_name';
         $rule = 'notEquals';
-        $expectedMessage = 'The provided value must not be equals to `5`';
+        $expectedMessage = 'The provided value must not be equal to `5`';
         $notEqualTo = 5;
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $notEqualTo);
     }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1709,6 +1709,20 @@ class ValidatorTest extends TestCase
     }
 
     /**
+     * Tests the getIterator method
+     */
+    public function testGetIterator(): void
+    {
+        $validator = new Validator();
+        $validator
+            ->add('email', 'alpha', ['rule' => 'alphanumeric'])
+            ->add('title', 'cool', ['rule' => 'isCool', 'provider' => 'thing']);
+        $fieldIterator = $validator->getIterator();
+        $this->assertInstanceOf(\Traversable::class, $fieldIterator);
+        $this->assertCount(2, $validator);
+    }
+
+    /**
      * Tests the countable interface
      */
     public function testCount(): void


### PR DESCRIPTION
Hereby, I propose to improve on the dreaded and very unhelpful `The provided value is invalid` validation error messages.

Wasn't sure whether we can backport this to 4.next, so I implemented it in 5.x to target 5.0.

TODO:
- [x] [There are many more validation methods left](https://github.com/cakephp/cakephp/blob/bd4b99481cfead7d27e876f29291c828b0e3ca04/src/Validation/Validator.php#L1072-L1072)
-  [x] [In case I18n is used, a translated message should be used](https://github.com/cakephp/cakephp/blob/b582d55a3376e9a746f5b904876d0c0fc221ef4e/src/Validation/Validator.php#L2537-L2539)
- [x] Test coverage needs to be updated