### PR TITLE
5.x: skip abstract command being auto discovered

### DIFF
--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -21,6 +21,7 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Utility\Filesystem;
 use Cake\Utility\Inflector;
+use ReflectionClass;
 
 /**
  * Used by CommandCollection and CommandTask to scan the filesystem
@@ -104,7 +105,7 @@ class CommandScanner
         /** @var array<\SplFileInfo> $files */
         $files = $fs->find($path, $classPattern);
 
-        $shells = [];
+        $commands = [];
         foreach ($files as $fileInfo) {
             $file = $fileInfo->getFilename();
 
@@ -117,10 +118,14 @@ class CommandScanner
             if (!is_subclass_of($class, CommandInterface::class)) {
                 continue;
             }
+            $reflection = new ReflectionClass($class);
+            if ($reflection->isAbstract()) {
+                continue;
+            }
             if (is_subclass_of($class, BaseCommand::class)) {
                 $name = $class::defaultName();
             }
-            $shells[$path . $file] = [
+            $commands[$path . $file] = [
                 'file' => $path . $file,
                 'fullName' => $prefix . $name,
                 'name' => $name,
@@ -128,8 +133,8 @@ class CommandScanner
             ];
         }
 
-        ksort($shells);
+        ksort($commands);
 
-        return array_values($shells);
+        return array_values($commands);
     }
 }

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -86,6 +86,10 @@ class HelpCommandTest extends TestCase
             '- test_plugin.sample',
             'only short alias for plugin command.'
         );
+        $this->assertOutputNotContains(
+            ' - abstract',
+            'Abstract command classes should not appear.'
+        );
         $this->assertOutputContains('<info>App</info>', 'app header should appear');
         $this->assertOutputContains('- sample', 'app shell');
         $this->assertOutputContains('<info>CakePHP</info>', 'cakephp header should appear');

--- a/tests/test_app/TestApp/Command/AbstractCommand.php
+++ b/tests/test_app/TestApp/Command/AbstractCommand.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Command;
+
+use Cake\Command\Command;
+
+abstract class AbstractCommand extends Command
+{
+}


### PR DESCRIPTION
Refs: https://github.com/dereuromark/cakephp-ide-helper/blob/cake5/src/Command/AnnotateCommand.php#L13

Since we dropped the ability to create subcommands it would be nice to at least have the ability to create abstract classes without them being auto discovered.