### PR TITLE
Allow setting finder and options for existsIn and isUnique rules

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -135,9 +135,11 @@ interface RepositoryInterface
      * conditions.
      *
      * @param array $conditions list of conditions to pass to the query
+     * @param array $options list of options to apply to the query
+     *
      * @return bool
      */
-    public function exists($conditions): bool;
+    public function exists($conditions, array $options = []): bool;
 
     /**
      * Persists an entity based on the fields that are marked as dirty and

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -136,7 +136,6 @@ interface RepositoryInterface
      *
      * @param array $conditions list of conditions to pass to the query
      * @param array $options list of options to apply to the query
-     *
      * @return bool
      */
     public function exists($conditions, array $options = []): bool;

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -135,10 +135,9 @@ interface RepositoryInterface
      * conditions.
      *
      * @param array $conditions list of conditions to pass to the query
-     * @param array $options list of options to apply to the query
      * @return bool
      */
-    public function exists($conditions, array $options = []): bool;
+    public function exists($conditions): bool;
 
     /**
      * Persists an entity based on the fields that are marked as dirty and

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -881,16 +881,17 @@ abstract class Association
      *
      * @param \Cake\Database\ExpressionInterface|\Closure|array|string|null $conditions The conditions to use
      * for checking if any record matches.
+     * @param array $options list of options to apply to the query
      * @see \Cake\ORM\Table::exists()
      * @return bool
      */
-    public function exists($conditions): bool
+    public function exists($conditions, array $options = []): bool
     {
         $conditions = $this->find()
             ->where($conditions)
             ->clause('where');
 
-        return $this->getTarget()->exists($conditions);
+        return $this->getTarget()->exists($conditions, $options);
     }
 
     /**

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -46,7 +46,9 @@ class ExistsIn
      *
      * @var array<string, mixed>
      */
-    protected $_options = [];
+    protected $_options = [
+        'allowNullableNulls' => FALSE,
+    ];
 
     /**
      * Constructor.
@@ -63,10 +65,8 @@ class ExistsIn
      */
     public function __construct($fields, $repository, array $options = [])
     {
-        $options += ['allowNullableNulls' => false];
-        $this->_options = $options;
-
         $this->_fields = (array)$fields;
+        $this->_options = $options + $this->_options;
         $this->_repository = $repository;
     }
 
@@ -143,7 +143,10 @@ class ExistsIn
             $entity->extract($fields)
         );
 
-        return $target->exists($conditions);
+        $options = $this->_options;
+        unset($options['allowNullableNulls']);
+
+        return $target->exists($conditions, $options);
     }
 
     /**

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -47,7 +47,7 @@ class ExistsIn
      * @var array<string, mixed>
      */
     protected $_options = [
-        'allowNullableNulls' => FALSE,
+        'allowNullableNulls' => false,
     ];
 
     /**

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -85,7 +85,12 @@ class IsUnique
             }
         }
 
-        return !$options['repository']->exists($conditions);
+        $repository = $options['repository'];
+
+        $options = $this->_options;
+        unset($options['allowNullableNulls']);
+
+        return !$repository->exists($conditions, $options);
     }
 
     /**

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -103,7 +103,7 @@ class RulesChecker extends BaseRulesChecker
     public function existsIn($field, $table, $message = null): RuleInvoker
     {
         $options = is_array($message) ? $message : ['message' => $message];
-        $message = $options['message'] ?? NULL;
+        $message = $options['message'] ?? null;
         unset($options['message']);
 
         if (!$message) {

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -46,6 +46,8 @@ class RulesChecker extends BaseRulesChecker
      * ### Options
      *
      * - `allowMultipleNulls` Allows any field to have multiple null values. Defaults to false.
+     * - 'message' sets a custom error message.
+     * Other options will be applied to the query in `\Cake\ORM\Table::exists()`
      *
      * @param array<string> $fields The list of fields to check for uniqueness.
      * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can
@@ -85,9 +87,11 @@ class RulesChecker extends BaseRulesChecker
      * $rules->add($rules->existsIn('site_id', new SitesTable(), 'Invalid Site'));
      * ```
      *
-     * Available $options are error 'message' and 'allowNullableNulls' flag.
-     * 'message' sets a custom error message.
-     * Set 'allowNullableNulls' to true to accept composite foreign keys where one or more nullable columns are null.
+     * ### Options
+     *
+     * - `allowMultipleNulls` Allows any field to have multiple null values. Defaults to false.
+     * - 'message' sets a custom error message.
+     * Other options will be applied to the query in `\Cake\ORM\Table::exists()`
      *
      * @param array<string>|string $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
@@ -98,12 +102,9 @@ class RulesChecker extends BaseRulesChecker
      */
     public function existsIn($field, $table, $message = null): RuleInvoker
     {
-        $options = [];
-        if (is_array($message)) {
-            $options = $message + ['message' => null];
-            $message = $options['message'];
-            unset($options['message']);
-        }
+        $options = is_array($message) ? $message : ['message' => $message];
+        $message = $options['message'] ?? NULL;
+        unset($options['message']);
 
         if (!$message) {
             if ($this->_useI18n) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1743,10 +1743,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * @inheritDoc
      */
-    public function exists($conditions): bool
+    public function exists($conditions, array $options = []): bool
     {
+        $finder = $options['finder'] ?? 'all';
+
         return (bool)count(
-            $this->find('all')
+            $this->find($finder)
+            ->applyOptions($options)
             ->select(['existing' => 1])
             ->where($conditions)
             ->limit(1)

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1741,7 +1741,12 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     }
 
     /**
-     * @inheritDoc
+     * Returns true if there is any record in this repository matching the specified
+     * conditions.
+     *
+     * @param array $conditions list of conditions to pass to the query
+     * @param array $options list of options to apply to the query
+     * @return bool
      */
     public function exists($conditions, array $options = []): bool
     {

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1850,6 +1850,7 @@ class TableTest extends TestCase
         $this->assertTrue($table->exists(['id' => 1]));
         $this->assertFalse($table->exists(['id' => 3]));
         $this->assertTrue($table->exists(['id' => 3], ['skipCreatedCondition' => TRUE]));
+        $table->removeBehavior('Test4');
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1842,6 +1842,17 @@ class TableTest extends TestCase
     }
 
     /**
+     * Tests the exists function with options
+     */
+    public function testExistsWithQueryOptions (): void {
+        $table = $this->getTableLocator()->get('users');
+        $table->addBehavior('Test4');
+        $this->assertTrue($table->exists(['id' => 1]));
+        $this->assertFalse($table->exists(['id' => 3]));
+        $this->assertTrue($table->exists(['id' => 3], ['skipCreatedCondition' => TRUE]));
+    }
+
+    /**
      * Test implementedEvents
      */
     public function testImplementedEvents(): void

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1844,12 +1844,13 @@ class TableTest extends TestCase
     /**
      * Tests the exists function with options
      */
-    public function testExistsWithQueryOptions (): void {
+    public function testExistsWithQueryOptions(): void
+    {
         $table = $this->getTableLocator()->get('users');
         $table->addBehavior('Test4');
         $this->assertTrue($table->exists(['id' => 1]));
         $this->assertFalse($table->exists(['id' => 3]));
-        $this->assertTrue($table->exists(['id' => 3], ['skipCreatedCondition' => TRUE]));
+        $this->assertTrue($table->exists(['id' => 3], ['skipCreatedCondition' => true]));
         $table->removeBehavior('Test4');
     }
 

--- a/tests/test_app/TestApp/Model/Behavior/Test4Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test4Behavior.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace TestApp\Model\Behavior;
@@ -9,7 +8,8 @@ use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
 use Cake\ORM\Query;
 
-class Test4Behavior extends Behavior {
+class Test4Behavior extends Behavior
+{
     /**
      * Test for event bindings.
      */

--- a/tests/test_app/TestApp/Model/Behavior/Test4Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test4Behavior.php
@@ -11,7 +11,7 @@ use Cake\ORM\Query;
 class Test4Behavior extends Behavior
 {
     /**
-     * Test for event bindings.
+     * Add a where-clause to the query unless a truthy `skipCreatedCondition` option was provided
      */
     public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void
     {
@@ -27,28 +27,10 @@ class Test4Behavior extends Behavior
     /**
      * implementedEvents
      *
-     * This class does pretend to implement beforeFind
-     *
      * @return array<string, mixed>
      */
     public function implementedEvents(): array
     {
         return ['Model.beforeFind' => 'beforeFind'];
-    }
-
-    /**
-     * implementedFinders
-     */
-    public function implementedFinders(): array
-    {
-        return [];
-    }
-
-    /**
-     * implementedMethods
-     */
-    public function implementedMethods(): array
-    {
-        return [];
     }
 }

--- a/tests/test_app/TestApp/Model/Behavior/Test4Behavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/Test4Behavior.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestApp\Model\Behavior;
+
+use ArrayObject;
+use Cake\Event\EventInterface;
+use Cake\ORM\Behavior;
+use Cake\ORM\Query;
+
+class Test4Behavior extends Behavior {
+    /**
+     * Test for event bindings.
+     */
+    public function beforeFind(EventInterface $event, Query $query, ArrayObject $options, $primary): void
+    {
+        if (!empty($options['skipCreatedCondition'])) {
+            return;
+        }
+
+        $query->where([
+            'created <' => '2010-05-10 01:20:23',
+        ]);
+    }
+
+    /**
+     * implementedEvents
+     *
+     * This class does pretend to implement beforeFind
+     *
+     * @return array<string, mixed>
+     */
+    public function implementedEvents(): array
+    {
+        return ['Model.beforeFind' => 'beforeFind'];
+    }
+
+    /**
+     * implementedFinders
+     */
+    public function implementedFinders(): array
+    {
+        return [];
+    }
+
+    /**
+     * implementedMethods
+     */
+    public function implementedMethods(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
These changes allow setting additional query options as well as a custom finder for the `existsIn` and the `isUnique`-rule.

This way, a specific finder can be used for a single rule without the need to have it set in the association.

The provided options are available in the `beforeFind`-methods of behaviors as well. See the new `Test4Behavior` which skips an additional check.