### PR TITLE
Initialize ProgressHelper with defaults

### DIFF
--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -36,6 +36,17 @@ use RuntimeException;
 class ProgressHelper extends Helper
 {
     /**
+     * Default value for progress bar total value.
+     * Percent completion is derived from progress/total
+     */
+    private const DEFAULT_TOTAL = 100;
+
+    /**
+     * Default value for progress bar width
+     */
+    private const DEFAULT_WIDTH = 80;
+
+    /**
      * The current progress.
      *
      * @var float|int
@@ -47,14 +58,14 @@ class ProgressHelper extends Helper
      *
      * @var int
      */
-    protected $_total = 0;
+    protected $_total = self::DEFAULT_TOTAL;
 
     /**
      * The width of the bar.
      *
      * @var int
      */
-    protected $_width = 0;
+    protected $_width = self::DEFAULT_WIDTH;
 
     /**
      * Output a progress bar.
@@ -102,7 +113,7 @@ class ProgressHelper extends Helper
      */
     public function init(array $args = [])
     {
-        $args += ['total' => 100, 'width' => 80];
+        $args += ['total' => self::DEFAULT_TOTAL, 'width' => self::DEFAULT_WIDTH];
         $this->_progress = 0;
         $this->_width = $args['width'];
         $this->_total = $args['total'];

--- a/src/Shell/Helper/ProgressHelper.php
+++ b/src/Shell/Helper/ProgressHelper.php
@@ -39,12 +39,12 @@ class ProgressHelper extends Helper
      * Default value for progress bar total value.
      * Percent completion is derived from progress/total
      */
-    private const DEFAULT_TOTAL = 100;
+    protected const DEFAULT_TOTAL = 100;
 
     /**
      * Default value for progress bar width
      */
-    private const DEFAULT_WIDTH = 80;
+    protected const DEFAULT_WIDTH = 80;
 
     /**
      * The current progress.

--- a/tests/TestCase/Shell/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Shell/Helper/ProgressHelperTest.php
@@ -65,6 +65,17 @@ class ProgressHelperTest extends TestCase
         $this->assertSame($helper, $this->helper, 'Should be chainable');
     }
 
+    public function testIncrementWithoutInit(): void
+    {
+        $this->helper->increment(10);
+        $this->helper->draw();
+        $expected = [
+            '',
+            '======>                                                                      10%',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
     /**
      * Test that a callback is required.
      */


### PR DESCRIPTION
By setting the default values for width and total, we can make ProgressHelper easier to use. I thought this was a better solution over raising an error.

Fixes #17195
