### PR TITLE
Always store touched entity field value in _original.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -254,8 +254,7 @@ trait EntityTrait
 
             if (
                 !array_key_exists($name, $this->_original) &&
-                array_key_exists($name, $this->_fields) &&
-                $this->_fields[$name] !== $value
+                array_key_exists($name, $this->_fields)
             ) {
                 $this->_original[$name] = $this->_fields[$name];
             }


### PR DESCRIPTION
I want to see if the tests all pass, and if this could be done.
The changes seem to be a requirement for logic like https://github.com/dereuromark/cakephp-shim/pull/107 to work it seems.
Maybe there is also a different way, just proposing to take a look at this.

It sure would add a bit more memory consumption to the duplicating of touched field values with the same value being rewritten.