### PR TITLE
Relax types on Validator comparison methods

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1307,7 +1307,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a equal to comparison rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param float|int $value The value user data must be equal to.
+     * @param mixed $value The value user data must be equal to.
      * @param string|null $message The error message when the rule fails.
      * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
      *   true when the validation rule should be applied.
@@ -1316,7 +1316,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function equals(
         string $field,
-        float|int $value,
+        mixed $value,
         ?string $message = null,
         Closure|string|null $when = null
     ) {
@@ -1331,7 +1331,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a not equal to comparison rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param float|int $value The value user data must be not be equal to.
+     * @param mixed $value The value user data must be not be equal to.
      * @param string|null $message The error message when the rule fails.
      * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
      *   true when the validation rule should be applied.
@@ -1340,7 +1340,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      */
     public function notEquals(
         string $field,
-        float|int $value,
+        mixed $value,
         ?string $message = null,
         Closure|string|null $when = null
     ) {


### PR DESCRIPTION
Equality can be done on any value as we support custom types and enums. Relax validator methods to allow this again.

Fixes #17199
