### PR TITLE
Run 5.x also against PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1']
+        php-version: ['8.1', '8.2']
         db-type: [sqlite, pgsql]
         prefer-lowest: ['']
         include:


### PR DESCRIPTION
As locally this has some errors for me:
```
7) Cake\Test\TestCase\ORM\TableTest::testValidationWithBadDefiner
Failed asserting that exception of type "TypeError" matches expected exception "AssertionError". Message was: "Cake\ORM\Table::createValidator(): Return value must be of type Cake\Validation\Validator, null returned" at
/work/git/cakephp/src/Validation/ValidatorAwareTrait.php:139
/work/git/cakephp/src/Validation/ValidatorAwareTrait.php:95
/work/git/cakephp/tests/TestCase/ORM/TableTest.php:3549
```
etc