### PR TITLE
Make assertion requirement for testing env more explicit.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -58,6 +58,7 @@
         <env name="DB_URL" value="sqlserver://localhost/cake_test?timezone=UTC"/>
         -->
 
+        <const name="PHPUNIT_TESTSUITE" value="true"/>
         <!-- Constants used by Http Interop's Http Factory tests -->
         <const name="REQUEST_FACTORY" value="Cake\Http\RequestFactory"/>
         <const name="RESPONSE_FACTORY" value="Cake\Http\ResponseFactory"/>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,7 @@ define('CONFIG', TEST_APP . 'config' . DS);
 @mkdir(CACHE . 'models');
 // phpcs:enable
 
+require_once 'check.php';
 require_once CORE_PATH . 'config/bootstrap.php';
 
 date_default_timezone_set('UTC');

--- a/tests/check.php
+++ b/tests/check.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+if (!defined('PHPUNIT_TESTSUITE') || !PHPUNIT_TESTSUITE) {
+    return;
+}
+
+$assertions = (int)ini_get('zend.assertions');
+if ($assertions !== 1) {
+    throw new RuntimeException('Assertions are not activated, but needed for tests to run. Please set respective directives in your php.ini (`zend.assertions = 1`).');
+}


### PR DESCRIPTION
Took me a while to figure out why I had 7-9 fails on my local system.
Turns out the zend.assertion was turned off by default for some reason locally.

This aims to make it more clear to developers what needs to be done to have the tests working.

```
> phpunit
PHPUnit 10.2.6 by Sebastian Bergmann and contributors.

Error in bootstrap script: RuntimeException:
Assertions are not activated, but needed for tests to run. Please set respective directives in your php.ini (`zend.assertions = 1`).
```


But how can we skip this for static analyzers?
Is there a config to know that we run phpunit?