### PR TITLE
[5.x] modified entity getOriginal behavior

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -62,6 +62,21 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getVirtual(): array;
 
     /**
+     * Returns whether a field is an original one
+     *
+     * @return bool
+     */
+    public function isOriginalField(string $name): bool;
+
+    /**
+     * Returns an array of field names previously set using `setOriginalField()`
+     * The entity was initialized with
+     *
+     * @return array<string>
+     */
+    public function getOriginalFields(): array;
+
+    /**
      * Sets the given field or a list of fields to set as original
      *
      * @param array<string>|string $field the name of a field or a list of fields to set as original

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -62,6 +62,30 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getVirtual(): array;
 
     /**
+     * Returns whether a field is an original one
+     *
+     * @return bool
+     */
+    public function isOriginalField(string $name): bool;
+
+    /**
+     * Returns an array of field names previously set using `setOriginalField()`
+     * The entity was initialized with
+     *
+     * @return array<string>
+     */
+    public function getOriginalFields(): array;
+
+    /**
+     * Sets the given field or a list of fields to set as original
+     *
+     * @param array<string>|string $field the name of a field or a list of fields to set as original
+     * @param bool $merge
+     * @return $this
+     */
+    public function setOriginalField(string|array $field, bool $merge = true);
+
+    /**
      * Sets the dirty status of a single field.
      *
      * @param string $field the field to set or check status for
@@ -217,12 +241,21 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function requireFieldPresence(bool $value = true): void;
 
     /**
+     * Returns whether a field has an original value
+     *
+     * @param string $field
+     * @return bool
+     */
+    public function hasOriginal(string $field): bool;
+
+    /**
      * Returns the original value of a field.
      *
      * @param string $field The name of the field.
+     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
      * @return mixed
      */
-    public function getOriginal(string $field): mixed;
+    public function getOriginal(string $field, bool $allowFallback = true): mixed;
 
     /**
      * Gets all original values of the entity.

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -244,7 +244,6 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      * Returns whether a field has an original value
      *
      * @param string $field
-     *
      * @return bool
      */
     public function hasOriginal(string $field): bool;

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -62,6 +62,15 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getVirtual(): array;
 
     /**
+     * Sets the given field or a list of fields to set as original
+     *
+     * @param array<string>|string $field the name of a field or a list of fields to set as original
+     * @param bool $merge
+     * @return $this
+     */
+    public function setOriginalField(string|array $field, bool $merge = true);
+
+    /**
      * Sets the dirty status of a single field.
      *
      * @param string $field the field to set or check status for
@@ -217,12 +226,22 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function requireFieldPresence(bool $value = true): void;
 
     /**
+     * Returns whether a field has an original value
+     *
+     * @param string $field
+     *
+     * @return bool
+     */
+    public function hasOriginal(string $field): bool;
+
+    /**
      * Returns the original value of a field.
      *
      * @param string $field The name of the field.
+     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
      * @return mixed
      */
-    public function getOriginal(string $field): mixed;
+    public function getOriginal(string $field, bool $allowFallback = true): mixed;
 
     /**
      * Gets all original values of the entity.

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -69,21 +69,12 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function isOriginalField(string $name): bool;
 
     /**
-     * Returns an array of field names previously set using `setOriginalField()`
+     * Returns an array of original fields
      * The entity was initialized with
      *
      * @return array<string>
      */
     public function getOriginalFields(): array;
-
-    /**
-     * Sets the given field or a list of fields to set as original
-     *
-     * @param array<string>|string $field the name of a field or a list of fields to set as original
-     * @param bool $merge
-     * @return $this
-     */
-    public function setOriginalField(string|array $field, bool $merge = true);
 
     /**
      * Sets the dirty status of a single field.

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -62,6 +62,30 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getVirtual(): array;
 
     /**
+     * Returns whether a field is an original one
+     *
+     * @return bool
+     */
+    public function isOriginalField(string $name): bool;
+
+    /**
+     * Returns an array of field names previously set using `setOriginalField()`
+     * The entity was initialized with
+     *
+     * @return array<string>
+     */
+    public function getOriginalFields(): array;
+
+    /**
+     * Sets the given field or a list of fields to set as original
+     *
+     * @param array<string>|string $field the name of a field or a list of fields to set as original
+     * @param bool $merge
+     * @return $this
+     */
+    public function setOriginalField(string|array $field, bool $merge = true);
+
+    /**
      * Sets the dirty status of a single field.
      *
      * @param string $field the field to set or check status for
@@ -217,12 +241,22 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function requireFieldPresence(bool $value = true): void;
 
     /**
+     * Returns whether a field has an original value
+     *
+     * @param string $field
+     *
+     * @return bool
+     */
+    public function hasOriginal(string $field): bool;
+
+    /**
      * Returns the original value of a field.
      *
      * @param string $field The name of the field.
+     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
      * @return mixed
      */
-    public function getOriginal(string $field): mixed;
+    public function getOriginal(string $field, bool $allowFallback = true): mixed;
 
     /**
      * Gets all original values of the entity.

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -62,15 +62,16 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     public function getVirtual(): array;
 
     /**
-     * Returns whether a field is an original one
+     * Returns whether a field is an original one.
+     * Original fields are those that an entity was instantiated with.
      *
      * @return bool
      */
     public function isOriginalField(string $name): bool;
 
     /**
-     * Returns an array of original fields
-     * The entity was initialized with
+     * Returns an array of original fields.
+     * Original fields are those that an entity was initialized with.
      *
      * @return array<string>
      */

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -334,7 +334,6 @@ trait EntityTrait
      * Returns whether a field has an original value
      *
      * @param string $field
-     *
      * @return bool
      */
     public function hasOriginal(string $field): bool
@@ -747,10 +746,9 @@ trait EntityTrait
         foreach ($fields as $field) {
             if ($this->hasOriginal($field)) {
                 $result[$field] = $this->getOriginal($field);
-            }
-            elseif ($this->isOriginalField($field)) {
+            } elseif ($this->isOriginalField($field)) {
                 $result[$field] = $this->get($field);
-            };
+            }
         }
 
         return $result;
@@ -812,7 +810,8 @@ trait EntityTrait
      * @param bool $merge
      * @return $this
      */
-    public function setOriginalField(string|array $field, bool $merge = true) {
+    public function setOriginalField(string|array $field, bool $merge = true)
+    {
         if (!$merge) {
             $this->_originalFields = (array)$field;
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -260,10 +260,10 @@ trait EntityTrait
             $this->setDirty($name, true);
 
             if ($options['setter']) {
-            $setter = static::_accessor($name, 'set');
-            if ($setter) {
-                $value = $this->{$setter}($value);
-            }
+                $setter = static::_accessor($name, 'set');
+                if ($setter) {
+                    $value = $this->{$setter}($value);
+                }
             }
 
             if (

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -45,7 +45,7 @@ trait EntityTrait
     protected array $_original = [];
 
     /**
-     * Holds all fields that have been initially set on instantiation resp. after marking it clean
+     * Holds all fields that have been initially set on instantiation, or after marking as clean
      *
      * @var array<string>
      */
@@ -226,12 +226,25 @@ trait EntityTrait
      * $entity->set('name', 'Andrew');
      * ```
      *
+     * You can use the `asOriginal` option to set the given field as original, if it wasn't
+     * present when the entity was instantiated.
+     *
+     * ```
+     * $entity = new Entity(['name' => 'andrew', 'id' => 1]);
+     *
+     * $entity->set('phone_number', '555-0134');
+     * print_r($entity->getOriginalFields()) // prints ['name', 'id']
+     *
+     * $entity->set('phone_number', '555-0134', ['asOriginal' => true]);
+     * print_r($entity->getOriginalFields()) // prints ['name', 'id', 'phone_number']
+     * ```
+     *
      * @param array<string, mixed>|string $field the name of field to set or a list of
      * fields with their respective values
      * @param mixed $value The value to set to the field or an array if the
      * first argument is also an array, in which case will be treated as $options
      * @param array<string, mixed> $options Options to be used for setting the field. Allowed option
-     * keys are `setter` and `guard`
+     * keys are `setter`, `guard` and `asOriginal`
      * @return $this
      * @throws \InvalidArgumentException
      */
@@ -796,8 +809,8 @@ trait EntityTrait
     }
 
     /**
-     * Returns an array of original fields
-     * The entity was initialized with
+     * Returns an array of original fields.
+     * Original fields are those that the entity was initialized with.
      *
      * @return array<string>
      */

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -45,6 +45,13 @@ trait EntityTrait
     protected array $_original = [];
 
     /**
+     * Holds all fields that have been initially set on instantiation resp. after marking it clean
+     *
+     * @var array<string, mixed>
+     */
+    protected array $_originalFields = [];
+
+    /**
      * List of field names that should **not** be included in JSON or Array
      * representations of this Entity.
      *
@@ -252,23 +259,22 @@ trait EntityTrait
 
             $this->setDirty($name, true);
 
-            if (
-                !array_key_exists($name, $this->_original) &&
-                array_key_exists($name, $this->_fields) &&
-                $this->_fields[$name] !== $value
-            ) {
-                $this->_original[$name] = $this->_fields[$name];
-            }
-
-            if (!$options['setter']) {
-                $this->_fields[$name] = $value;
-                continue;
-            }
-
+            if ($options['setter']) {
             $setter = static::_accessor($name, 'set');
             if ($setter) {
                 $value = $this->{$setter}($value);
             }
+            }
+
+            if (
+                !array_key_exists($name, $this->_original) &&
+                in_array($name, $this->_originalFields) &&
+                in_array($name, $this->_fields) &&
+                $value !== $this->_fields[$name]
+            ) {
+                $this->_original[$name] = $this->_fields[$name];
+            }
+
             $this->_fields[$name] = $value;
         }
 
@@ -325,19 +331,36 @@ trait EntityTrait
     }
 
     /**
+     * Returns whether a field has an original value
+     *
+     * @param string $field
+     *
+     * @return bool
+     */
+    public function hasOriginal(string $field): bool
+    {
+        return array_key_exists($field, $this->_original);
+    }
+
+    /**
      * Returns the value of an original field by name
      *
      * @param string $field the name of the field for which original value is retrieved.
+     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
      * @return mixed
      * @throws \InvalidArgumentException if an empty field name is passed.
      */
-    public function getOriginal(string $field): mixed
+    public function getOriginal(string $field, bool $allowFallback = true): mixed
     {
         if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');
         }
         if (array_key_exists($field, $this->_original)) {
             return $this->_original[$field];
+        }
+
+        if (!$allowFallback) {
+            throw new InvalidArgumentException(sprintf('Could not retrieve original value for field `%s`', $field));
         }
 
         return $this->get($field);
@@ -353,7 +376,10 @@ trait EntityTrait
         $originals = $this->_original;
         $originalKeys = array_keys($originals);
         foreach ($this->_fields as $key => $value) {
-            if (!in_array($key, $originalKeys, true)) {
+            if (
+                !in_array($key, $originalKeys, true) &&
+                in_array($key, $this->_originalFields)
+            ) {
                 $originals[$key] = $value;
             }
         }
@@ -468,7 +494,7 @@ trait EntityTrait
     {
         $field = (array)$field;
         foreach ($field as $p) {
-            unset($this->_fields[$p], $this->_original[$p], $this->_dirty[$p]);
+            unset($this->_fields[$p], $this->_dirty[$p]);
         }
 
         return $this;
@@ -719,7 +745,12 @@ trait EntityTrait
     {
         $result = [];
         foreach ($fields as $field) {
+            if ($this->hasOriginal($field)) {
             $result[$field] = $this->getOriginal($field);
+        }
+            elseif (in_array($field, $this->_originalFields)) {
+                $result[$field] = $this->get($field);
+            };
         }
 
         return $result;
@@ -739,6 +770,10 @@ trait EntityTrait
     {
         $result = [];
         foreach ($fields as $field) {
+            if (!$this->hasOriginal($field)) {
+                continue;
+            }
+
             $original = $this->getOriginal($field);
             if ($original !== $this->get($field)) {
                 $result[$field] = $original;
@@ -746,6 +781,36 @@ trait EntityTrait
         }
 
         return $result;
+    }
+
+    /**
+     * Sets the given field or a list of fields to set as original
+     *
+     * @param array<string>|string $field the name of a field or a list of fields to set as original
+     * @param bool $merge
+     * @return $this
+     */
+    public function setOriginalField(string|array $field, bool $merge = true) {
+        if (!$merge) {
+            $this->_originalFields = (array)$field;
+
+            //WIP? Tests with assertEqual fail as long as the values of $this->_originalFields aren't in the same order.
+            //sort($this->_originalFields);
+
+            return $this;
+        }
+
+        $fields = (array)$field;
+        foreach ($fields as $field) {
+            if (!in_array($field, $this->_originalFields)) {
+                $this->_originalFields[] = $field;
+            }
+        }
+
+        //WIP? Tests with assertEqual fail as long as the values of $this->_originalFields aren't in the same order.
+        //sort($this->_originalFields);
+
+        return $this;
     }
 
     /**
@@ -759,7 +824,9 @@ trait EntityTrait
     public function setDirty(string $field, bool $isDirty = true)
     {
         if ($isDirty === false) {
-            unset($this->_dirty[$field]);
+            $this->setOriginalField($field);
+
+            unset($this->_dirty[$field], $this->_original[$field]);
 
             return $this;
         }
@@ -808,6 +875,7 @@ trait EntityTrait
         $this->_errors = [];
         $this->_invalid = [];
         $this->_original = [];
+        $this->setOriginalField(array_keys($this->_fields), false);
     }
 
     /**
@@ -1249,6 +1317,7 @@ trait EntityTrait
             '[accessible]' => $this->_accessible,
             '[dirty]' => $this->_dirty,
             '[original]' => $this->_original,
+            '[originalFields]' => $this->_originalFields,
             '[virtual]' => $this->_virtual,
             '[hasErrors]' => $this->hasErrors(),
             '[errors]' => $this->_errors,

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -47,7 +47,7 @@ trait EntityTrait
     /**
      * Holds all fields that have been initially set on instantiation resp. after marking it clean
      *
-     * @var array<string, mixed>
+     * @var array<string>
      */
     protected array $_originalFields = [];
 
@@ -334,7 +334,6 @@ trait EntityTrait
      * Returns whether a field has an original value
      *
      * @param string $field
-     *
      * @return bool
      */
     public function hasOriginal(string $field): bool
@@ -747,10 +746,9 @@ trait EntityTrait
         foreach ($fields as $field) {
             if ($this->hasOriginal($field)) {
                 $result[$field] = $this->getOriginal($field);
-            }
-            elseif ($this->isOriginalField($field)) {
+            } elseif ($this->isOriginalField($field)) {
                 $result[$field] = $this->get($field);
-            };
+            }
         }
 
         return $result;
@@ -812,7 +810,8 @@ trait EntityTrait
      * @param bool $merge
      * @return $this
      */
-    public function setOriginalField(string|array $field, bool $merge = true) {
+    public function setOriginalField(string|array $field, bool $merge = true)
+    {
         if (!$merge) {
             $this->_originalFields = (array)$field;
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -248,7 +248,11 @@ trait EntityTrait
         if (!is_array($field)) {
             throw new InvalidArgumentException('Cannot set an empty field');
         }
-        $options += ['setter' => true, 'guard' => $guard];
+        $options += ['setter' => true, 'guard' => $guard, 'asOriginal' => false];
+
+        if ($options['asOriginal'] === true) {
+            $this->setOriginalField(array_keys($field));
+        }
 
         foreach ($field as $name => $value) {
             /** @psalm-suppress RedundantCastGivenDocblockType */
@@ -792,7 +796,7 @@ trait EntityTrait
     }
 
     /**
-     * Returns an array of field names previously set using `setOriginalField()`
+     * Returns an array of original fields
      * The entity was initialized with
      *
      * @return array<string>
@@ -810,26 +814,21 @@ trait EntityTrait
      * @param bool $merge
      * @return $this
      */
-    public function setOriginalField(string|array $field, bool $merge = true)
+    protected function setOriginalField(string|array $field, bool $merge = true)
     {
         if (!$merge) {
             $this->_originalFields = (array)$field;
-
-            //WIP? Tests with assertEqual fail as long as the values of $this->_originalFields aren't in the same order.
-            sort($this->_originalFields);
 
             return $this;
         }
 
         $fields = (array)$field;
         foreach ($fields as $field) {
+            $field = (string)$field;
             if (!$this->isOriginalField($field)) {
                 $this->_originalFields[] = $field;
             }
         }
-
-        //WIP? Tests with assertEqual fail as long as the values of $this->_originalFields aren't in the same order.
-        sort($this->_originalFields);
 
         return $this;
     }

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -45,6 +45,13 @@ trait EntityTrait
     protected array $_original = [];
 
     /**
+     * Holds all fields that have been initially set on instantiation resp. after marking it clean
+     *
+     * @var array<string, mixed>
+     */
+    protected array $_originalFields = [];
+
+    /**
      * List of field names that should **not** be included in JSON or Array
      * representations of this Entity.
      *
@@ -252,23 +259,22 @@ trait EntityTrait
 
             $this->setDirty($name, true);
 
-            if (
-                !array_key_exists($name, $this->_original) &&
-                array_key_exists($name, $this->_fields) &&
-                $this->_fields[$name] !== $value
-            ) {
-                $this->_original[$name] = $this->_fields[$name];
-            }
-
-            if (!$options['setter']) {
-                $this->_fields[$name] = $value;
-                continue;
-            }
-
+            if ($options['setter']) {
             $setter = static::_accessor($name, 'set');
             if ($setter) {
                 $value = $this->{$setter}($value);
             }
+            }
+
+            if (
+                $this->isOriginalField($name) &&
+                !array_key_exists($name, $this->_original) &&
+                array_key_exists($name, $this->_fields) &&
+                $value !== $this->_fields[$name]
+            ) {
+                $this->_original[$name] = $this->_fields[$name];
+            }
+
             $this->_fields[$name] = $value;
         }
 
@@ -325,19 +331,36 @@ trait EntityTrait
     }
 
     /**
+     * Returns whether a field has an original value
+     *
+     * @param string $field
+     *
+     * @return bool
+     */
+    public function hasOriginal(string $field): bool
+    {
+        return array_key_exists($field, $this->_original);
+    }
+
+    /**
      * Returns the value of an original field by name
      *
      * @param string $field the name of the field for which original value is retrieved.
+     * @param bool $allowFallback whether to allow falling back to the current field value if no original exists
      * @return mixed
      * @throws \InvalidArgumentException if an empty field name is passed.
      */
-    public function getOriginal(string $field): mixed
+    public function getOriginal(string $field, bool $allowFallback = true): mixed
     {
         if ($field === '') {
             throw new InvalidArgumentException('Cannot get an empty field');
         }
         if (array_key_exists($field, $this->_original)) {
             return $this->_original[$field];
+        }
+
+        if (!$allowFallback) {
+            throw new InvalidArgumentException(sprintf('Cannot retrieve original value for field `%s`', $field));
         }
 
         return $this->get($field);
@@ -353,7 +376,10 @@ trait EntityTrait
         $originals = $this->_original;
         $originalKeys = array_keys($originals);
         foreach ($this->_fields as $key => $value) {
-            if (!in_array($key, $originalKeys, true)) {
+            if (
+                !in_array($key, $originalKeys, true) &&
+                $this->isOriginalField($key)
+            ) {
                 $originals[$key] = $value;
             }
         }
@@ -468,7 +494,7 @@ trait EntityTrait
     {
         $field = (array)$field;
         foreach ($field as $p) {
-            unset($this->_fields[$p], $this->_original[$p], $this->_dirty[$p]);
+            unset($this->_fields[$p], $this->_dirty[$p]);
         }
 
         return $this;
@@ -719,7 +745,12 @@ trait EntityTrait
     {
         $result = [];
         foreach ($fields as $field) {
-            $result[$field] = $this->getOriginal($field);
+            if ($this->hasOriginal($field)) {
+                $result[$field] = $this->getOriginal($field);
+            }
+            elseif ($this->isOriginalField($field)) {
+                $result[$field] = $this->get($field);
+            };
         }
 
         return $result;
@@ -739,6 +770,10 @@ trait EntityTrait
     {
         $result = [];
         foreach ($fields as $field) {
+            if (!$this->hasOriginal($field)) {
+                continue;
+            }
+
             $original = $this->getOriginal($field);
             if ($original !== $this->get($field)) {
                 $result[$field] = $original;
@@ -746,6 +781,58 @@ trait EntityTrait
         }
 
         return $result;
+    }
+
+    /**
+     * Returns whether a field is an original one
+     *
+     * @return bool
+     */
+    public function isOriginalField(string $name): bool
+    {
+        return in_array($name, $this->_originalFields);
+    }
+
+    /**
+     * Returns an array of field names previously set using `setOriginalField()`
+     * The entity was initialized with
+     *
+     * @return array
+     */
+    public function getOriginalFields(): array
+    {
+        return $this->_originalFields;
+    }
+
+    /**
+     * Sets the given field or a list of fields to as original.
+     * Normally there is no need to call this method manually.
+     *
+     * @param array<string>|string $field the name of a field or a list of fields to set as original
+     * @param bool $merge
+     * @return $this
+     */
+    public function setOriginalField(string|array $field, bool $merge = true) {
+        if (!$merge) {
+            $this->_originalFields = (array)$field;
+
+            //WIP? Tests with assertEqual fail as long as the values of $this->_originalFields aren't in the same order.
+            sort($this->_originalFields);
+
+            return $this;
+        }
+
+        $fields = (array)$field;
+        foreach ($fields as $field) {
+            if (!$this->isOriginalField($field)) {
+                $this->_originalFields[] = $field;
+            }
+        }
+
+        //WIP? Tests with assertEqual fail as long as the values of $this->_originalFields aren't in the same order.
+        sort($this->_originalFields);
+
+        return $this;
     }
 
     /**
@@ -759,7 +846,9 @@ trait EntityTrait
     public function setDirty(string $field, bool $isDirty = true)
     {
         if ($isDirty === false) {
-            unset($this->_dirty[$field]);
+            $this->setOriginalField($field);
+
+            unset($this->_dirty[$field], $this->_original[$field]);
 
             return $this;
         }
@@ -808,6 +897,7 @@ trait EntityTrait
         $this->_errors = [];
         $this->_invalid = [];
         $this->_original = [];
+        $this->setOriginalField(array_keys($this->_fields), false);
     }
 
     /**
@@ -1249,6 +1339,7 @@ trait EntityTrait
             '[accessible]' => $this->_accessible,
             '[dirty]' => $this->_dirty,
             '[original]' => $this->_original,
+            '[originalFields]' => $this->_originalFields,
             '[virtual]' => $this->_virtual,
             '[hasErrors]' => $this->hasErrors(),
             '[errors]' => $this->_errors,

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -65,13 +65,16 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             $this->setNew($options['markNew']);
         }
 
-        if (!empty($properties) && $options['markClean'] && !$options['useSetters']) {
-            $this->_fields = $properties;
-
-            return;
-        }
-
         if (!empty($properties)) {
+            //Remember the original field names here.
+            $this->setOriginalField(array_keys($properties));
+
+            if ($options['markClean'] && !$options['useSetters']) {
+                $this->_fields = $properties;
+
+                return;
+            }
+
             $this->set($properties, [
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -65,16 +65,16 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             $this->setNew($options['markNew']);
         }
 
-        //Remember the original field names here.
-        $this->setOriginalField(array_keys($properties));
-
-        if (!empty($properties) && $options['markClean'] && !$options['useSetters']) {
-            $this->_fields = $properties;
-
-            return;
-        }
-
         if (!empty($properties)) {
+            //Remember the original field names here.
+            $this->setOriginalField(array_keys($properties));
+
+            if ($options['markClean'] && !$options['useSetters']) {
+                $this->_fields = $properties;
+
+                return;
+            }
+
             $this->set($properties, [
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -65,6 +65,9 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             $this->setNew($options['markNew']);
         }
 
+        //Remember the original field names here.
+        $this->setOriginalField(array_keys($properties));
+
         if (!empty($properties) && $options['markClean'] && !$options['useSetters']) {
             $this->_fields = $properties;
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -213,12 +213,14 @@ class Marshaller
         }
 
         if (isset($options['fields'])) {
+            $entity->setOriginalField($options['fields'], false);
             foreach ((array)$options['fields'] as $field) {
                 if (array_key_exists($field, $properties)) {
                     $entity->set($field, $properties[$field]);
                 }
             }
         } else {
+            $entity->setOriginalField(array_keys($properties), false);
             $entity->set($properties);
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -213,15 +213,13 @@ class Marshaller
         }
 
         if (isset($options['fields'])) {
-            $entity->setOriginalField($options['fields'], false);
             foreach ((array)$options['fields'] as $field) {
                 if (array_key_exists($field, $properties)) {
-                    $entity->set($field, $properties[$field]);
+                    $entity->set($field, $properties[$field], ['asOriginal' => true]);
                 }
             }
         } else {
-            $entity->setOriginalField(array_keys($properties), false);
-            $entity->set($properties);
+            $entity->set($properties, ['asOriginal' => true]);
         }
 
         // Don't flag clean association entities as

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -790,7 +790,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertNotEmpty($entity->author->name);
 
         $expected = $table->get(1, ...['contain' => ['Authors']]);
-        $this->assertEquals($expected, $result);
+        $this->assertEqualsCanonicalizing($expected, $result);
         $this->assertNotEmpty($entity->author);
         $this->assertNotEmpty($entity->author->name);
     }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -36,10 +36,9 @@ class EntityTest extends TestCase
     public function testSetOneParamNoSetters(): void
     {
         $entity = new Entity();
-        $entity->setOriginalField(['id', 'foo']);
 
         $this->assertNull($entity->getOriginal('foo'));
-        $entity->set('foo', 'bar');
+        $entity->set('foo', 'bar', ['asOriginal' => true]);
         $this->assertSame('bar', $entity->foo);
         $this->assertSame('bar', $entity->getOriginal('foo'));
 
@@ -47,7 +46,7 @@ class EntityTest extends TestCase
         $this->assertSame('baz', $entity->foo);
         $this->assertSame('bar', $entity->getOriginal('foo'));
 
-        $entity->set('id', 1);
+        $entity->set('id', 1, ['asOriginal' => true]);
         $this->assertSame(1, $entity->id);
         $this->assertSame(1, $entity->getOriginal('id'));
         $this->assertSame('bar', $entity->getOriginal('foo'));
@@ -60,9 +59,8 @@ class EntityTest extends TestCase
     {
         $entity = new Entity();
         $entity->setAccess('*', true);
-        $entity->setOriginalField(['id', 'foo']);
 
-        $entity->set(['foo' => 'bar', 'id' => 1]);
+        $entity->set(['foo' => 'bar', 'id' => 1], ['asOriginal' => true]);
         $this->assertSame('bar', $entity->foo);
         $this->assertSame(1, $entity->id);
 
@@ -1703,41 +1701,14 @@ class EntityTest extends TestCase
         $entity = new Entity(['foo' => 'foo', 'bar' => 'bar']);
         $entity->set('baz', 'baz');
         $return = $entity->getOriginalFields();
-        $this->assertEqualsCanonicalizing(['foo', 'bar'], $return);
-        $this->assertNotEqualsCanonicalizing(['foo', 'bar', 'baz'], $return);
+        $this->assertEquals(['foo', 'bar'], $return);
 
         $entity = new Entity([]);
         $entity->set('foo', 'foo');
         $entity->set('bar', 'bar');
         $entity->set('baz', 'baz');
         $return = $entity->getOriginalFields();
-        $this->assertEqualsCanonicalizing([], $return);
-        $this->assertNotEqualsCanonicalizing(['foo', 'bar', 'baz'], $return);
-    }
-
-    /**
-     * Test setOriginalField()
-     */
-    public function testSetOriginalField(): void
-    {
-        $entity = new Entity([]);
-        $entity->set('foo', 'bar');
-        $return = $entity->isOriginalField('foo');
-        $this->assertSame(false, $return);
-        $return = $entity->getOriginalFields();
-        $this->assertSame([], $return);
-
-        $entity->setOriginalField('foo');
-        $return = $entity->getOriginalFields();
-        $this->assertSame(['foo'], $return);
-
-        $entity->setOriginalField('bar');
-        $return = $entity->getOriginalFields();
-        $this->assertEqualsCanonicalizing(['foo', 'bar'], $return);
-
-        $entity->setOriginalField('baz', false);
-        $return = $entity->getOriginalFields();
-        $this->assertEqualsCanonicalizing(['baz'], $return);
+        $this->assertEquals([], $return);
     }
 
     /**

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -509,7 +509,8 @@ class QueryRegressionTest extends TestCase
             ->contain(['Authors', 'ArticlesTags.Authors'])
             ->first();
 
-        $this->assertEquals($resultA, $resultB);
+        $this->assertEquals($resultA->author, $resultB->author);
+        $this->assertEquals($resultA->articles_tag, $resultB->articles_tag);
         $this->assertNotEmpty($resultA->author);
         $this->assertNotEmpty($resultA->articles_tag->author);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -4384,7 +4384,7 @@ class TableTest extends TestCase
 
         $article = $table->find('all')->where(['id' => 1])->contain(['Tags'])->first();
         $this->assertEquals($article->tags[2]->id, $tags[0]->id);
-        $this->assertEquals($article->tags[3], $tags[1]);
+        $this->assertEqualsCanonicalizing($article->tags[3], $tags[1]);
     }
 
     /**
@@ -6413,7 +6413,8 @@ class TableTest extends TestCase
         $this->assertSame($entity, $result);
 
         $expected = $table->get(1, contain: ['SiteArticles', 'Articles.Tags']);
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected->site_articles, $result->site_articles);
+        $this->assertEquals($expected->articles, $result->articles);
     }
 
     /**
@@ -6436,7 +6437,10 @@ class TableTest extends TestCase
         $result = $table->loadInto($entity, $options);
         $this->assertSame($entity, $result);
         $expected = $table->get(1, contain: $options);
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected->site_articles, $result->site_articles);
+        $this->assertEquals(['title', 'author_id'], $expected->site_articles[0]->getOriginalFields());
+        $this->assertEquals($expected->articles, $result->articles);
+        $this->assertSame('tag2', $expected->articles[0]->tags[0]->name);
     }
 
     /**
@@ -6474,8 +6478,11 @@ class TableTest extends TestCase
             $this->assertSame($v, $result[$k]);
         }
 
-        $expected = $table->find()->contain($contain)->toArray();
-        $this->assertEquals($expected, $result);
+        $entities = $table->find()->contain($contain)->toArray();
+        foreach ($entities as $k => $v) {
+            $this->assertEquals($v->site_articles, $result[$k]->site_articles);
+            $this->assertEquals($v->articles, $result[$k]->articles);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes https://github.com/cakephp/cakephp/issues/17200

It maintains BC*, while making it a bit more clear what "original" means. These points are my interprations of "original" (feel free to correct me):
- fields which are present when instantiating an entity class (manually or when fetching a row from the db)
- all fields that are present when `clean()` gets called, creating a new "original"-state
- all fields that are present when an entity was successfully saved (the same as calling `clean()` manually)
- fields that were manually marked as clean (`setDirty('field', false)`)

*The BC exception being that it breaks when one implemented `EntityInterface` without using `EntityTrait`, since additional method signatures were introduced (and one changed), and that `getOriginal()` returns no original values for entities created with an empty array as argument (`newEntity([])`/`newEmptyEntity()`).

An additional second argument for `getOriginal()` allows to bypass the fallback to the current value, resulting in an InvalidArgumentException when called on a new field.