### PR TITLE
Update query logging for PHPUnit changes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -45,6 +45,9 @@
         <ini name="error_reporting" value="32767"/>
         <env name="FIXTURE_SCHEMA_METADATA" value="./tests/schema.php"/>
 
+        <!-- Enable query logging output for the testrun.
+        <env name="LOG_QUERIES" value="1" />
+        -->
         <!-- SQLite
         <env name="DB_URL" value="sqlite:///:memory:"/>
         -->

--- a/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
+++ b/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
@@ -20,6 +20,7 @@ use Cake\Log\Log;
 use Cake\TestSuite\ConnectionHelper;
 use PHPUnit\Event\TestSuite\Started;
 use PHPUnit\Event\TestSuite\StartedSubscriber as PHPUnitStarted;
+use function Cake\Core\env;
 
 class PHPUnitStartedSubscriber implements PHPUnitStarted
 {
@@ -34,8 +35,8 @@ class PHPUnitStartedSubscriber implements PHPUnitStarted
         $helper = new ConnectionHelper();
         $helper->addTestAliases();
 
-        $enableLogging = in_array('--debug', $_SERVER['argv'] ?? [], true);
-        if ($enableLogging) {
+        $enableLogging = env('LOG_QUERIES') ?? 0;
+        if ((int)$enableLogging !== 0) {
             $helper->enableQueryLogging();
             Log::drop('queries');
             Log::setConfig('queries', [

--- a/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
+++ b/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
@@ -35,7 +35,7 @@ class PHPUnitStartedSubscriber implements PHPUnitStarted
         $helper = new ConnectionHelper();
         $helper->addTestAliases();
 
-        $enableLogging = env('LOG_QUERIES') ?? 0;
+        $enableLogging = env('LOG_QUERIES', false);
         if ((int)$enableLogging !== 0) {
             $helper->enableQueryLogging();
             Log::drop('queries');


### PR DESCRIPTION
Because PHPUnit no longer has a `--debug` option, we need to change how query logging works in test runs. Instead of reading the PHPUnit flag, we read an environment variable. This can either be set in the phpunit.xml file or in the execution environment.

Once we're happy with this, I'll update the app skeleton, and migration guide.
