### PR TITLE
Remove requirement for indexes to have columns

### DIFF
--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -475,13 +475,6 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 $this->_table
             ));
         }
-        if (empty($attrs['columns'])) {
-            throw new DatabaseException(sprintf(
-                'Index "%s" in table "%s" must have at least one column.',
-                $name,
-                $this->_table
-            ));
-        }
         $attrs['columns'] = (array)$attrs['columns'];
         foreach ($attrs['columns'] as $field) {
             if (empty($this->_columns[$field])) {

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -405,9 +405,6 @@ class TableSchemaTest extends TestCase
             [[]],
             // Invalid type
             [['columns' => 'author_id', 'type' => 'derp']],
-            // No columns
-            [['columns' => ''], 'type' => TableSchema::INDEX_INDEX],
-            [['columns' => [], 'type' => TableSchema::INDEX_INDEX]],
             // Missing column
             [['columns' => ['not_there'], 'type' => TableSchema::INDEX_INDEX]],
         ];


### PR DESCRIPTION
Functional indexes in mysql don't have columns. Our validation constraint requiring them to have columns was causing schema reflection to fail.

The error I was able to reproduce was different than reported in #17201 however, the empty column name errors were fixed in #16740.