### PR TITLE
5.x Make deprecation warnings log at debug

### DIFF
--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -64,12 +64,12 @@ class ErrorLogger implements ErrorLoggerInterface
         if ($includeTrace) {
             $message .= "\nTrace:\n" . $error->getTraceAsString() . "\n";
         }
-        $logMap = [
+        $label = $error->getLabel();
+        $level = match ($label) {
             'strict' => LOG_NOTICE,
-            'deprecated' => LOG_NOTICE,
-        ];
-        $level = $error->getLabel();
-        $level = $logMap[$level] ?? $level;
+            'deprecated' => LOG_DEBUG,
+            default => $label,
+        };
 
         Log::write($level, $message);
     }

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -104,7 +104,8 @@ class ErrorTrapTest extends TestCase
             // PHP error level, expected log level
             [E_USER_WARNING, 'warning'],
             [E_USER_NOTICE, 'notice'],
-            [E_USER_DEPRECATED, 'debug'],
+            // Log level is notice on windows because windows log levels are different.
+            [E_USER_DEPRECATED, DS === '\\' ?  'notice' : 'debug'],
         ];
     }
 

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -105,7 +105,7 @@ class ErrorTrapTest extends TestCase
             [E_USER_WARNING, 'warning'],
             [E_USER_NOTICE, 'notice'],
             // Log level is notice on windows because windows log levels are different.
-            [E_USER_DEPRECATED, DS === '\\' ?  'notice' : 'debug'],
+            [E_USER_DEPRECATED, DS === '\\' ? 'notice' : 'debug'],
         ];
     }
 

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -104,7 +104,7 @@ class ErrorTrapTest extends TestCase
             // PHP error level, expected log level
             [E_USER_WARNING, 'warning'],
             [E_USER_NOTICE, 'notice'],
-            [E_USER_DEPRECATED, 'notice'],
+            [E_USER_DEPRECATED, 'debug'],
         ];
     }
 


### PR DESCRIPTION
It is often useful to have info logging on in production. However, you can't do that with the default CakePHP logging as we log deprecation warnings at info. Moving deprecations to debug allows us to have easier to control logging.
