### PR TITLE
Fix BasePlugin.php enable hook typo

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -210,7 +210,7 @@ class BasePlugin implements PluginInterface
     public function enable(string $hook)
     {
         $this->checkHook($hook);
-        $this->{"{$hook}Enabled}"} = true;
+        $this->{"{$hook}Enabled"} = true;
 
         return $this;
     }


### PR DESCRIPTION
Typo fix, based on tag 4.4.15 as a common base for 4.x, 4.next and 5.x. So It can be merged however is desired.

The Common base for 3.x is way too old, so for 3.x needs to be separate => https://github.com/cakephp/cakephp/pull/17234
