### PR TITLE
Fix BasePlugin.php enable hook typo for 3.x

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -175,7 +175,7 @@ class BasePlugin implements PluginInterface
     public function enable($hook)
     {
         $this->checkHook($hook);
-        $this->{"{$hook}Enabled}"} = true;
+        $this->{"{$hook}Enabled"} = true;
 
         return $this;
     }


### PR DESCRIPTION
Based on 3.x

PR for 4.x, 4.next, 5.x => https://github.com/cakephp/cakephp/pull/17233