### PR TITLE
5.x: remove ComponentRegistry from DIC

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace Cake\Http;
 
 use Cake\Console\CommandCollection;
-use Cake\Controller\ComponentRegistry;
 use Cake\Controller\ControllerFactory;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\Container;
@@ -329,9 +328,6 @@ abstract class BaseApplication implements
         }
 
         $controller = $this->controllerFactory->create($request);
-
-        // This is needed for auto-wiring. Should be removed in 5.x
-        $container->add(ComponentRegistry::class, $controller->components());
 
         return $this->controllerFactory->invoke($controller);
     }

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Http;
 
-use Cake\Controller\ComponentRegistry;
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\Container;
@@ -80,7 +79,6 @@ class BaseApplicationTest extends TestCase
         $container = $app->getContainer();
         $this->assertSame($request, $container->get(ServerRequest::class));
         $this->assertSame($container, $container->get(ContainerInterface::class));
-        $this->assertInstanceOf(ComponentRegistry::class, $container->get(ComponentRegistry::class));
     }
 
     /**


### PR DESCRIPTION
Thanks @ADmad for catching that.

I tested this change with my app which uses the auto-wiring feature and everything is fine for me.