### PR TITLE
5.x: remove `addMethods(['table'])` from tests

### DIFF
--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1218,7 +1218,6 @@ class BelongsToManyTest extends TestCase
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
         $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         /** @var \Cake\ORM\Association\BelongsToMany|\PHPUnit\Framework\MockObject\MockObject $assoc */
@@ -1249,7 +1248,6 @@ class BelongsToManyTest extends TestCase
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
         $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         /** @var \Cake\ORM\Association\BelongsToMany|\PHPUnit\Framework\MockObject\MockObject $assoc */
@@ -1281,7 +1279,6 @@ class BelongsToManyTest extends TestCase
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         $assoc = $this->getMockBuilder(BelongsToMany::class)
@@ -1310,7 +1307,6 @@ class BelongsToManyTest extends TestCase
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
         $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         $assoc = $this->getMockBuilder(BelongsToMany::class)

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -126,7 +126,6 @@ class AssociationCollectionTest extends TestCase
     public function testGetByProperty(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         $belongsTo = new BelongsTo('Users', [
@@ -246,7 +245,6 @@ class AssociationCollectionTest extends TestCase
     public function testSaveParents(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         $mockOne = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
@@ -294,7 +292,6 @@ class AssociationCollectionTest extends TestCase
     public function testSaveParentsFiltered(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         $mockOne = $this->getMockBuilder('Cake\ORM\Association\BelongsTo')
@@ -342,7 +339,6 @@ class AssociationCollectionTest extends TestCase
     public function testSaveChildrenFiltered(): void
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['table'])
             ->getMock();
         $table->setSchema([]);
         $mockOne = $this->getMockBuilder('Cake\ORM\Association\HasMany')


### PR DESCRIPTION
not really sure why this mocked method was added here anyway. Maybe it was needed in an earlier version.

Refs: https://github.com/cakephp/cakephp/issues/17236