### PR TITLE
5.x: convert `returnValue()` to `willReturn()`

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -260,7 +260,7 @@ class CacheTest extends TestCase
     public function testConfigFailedInit(): void
     {
         $mock = $this->getMockForAbstractClass('Cake\Cache\CacheEngine', [], '', true, true, true, ['init']);
-        $mock->method('init')->will($this->returnValue(false));
+        $mock->method('init')->willReturn(false);
         Cache::setConfig('tests', [
             'engine' => $mock,
         ]);

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -122,7 +122,7 @@ class PluginAssetsCommandsTest extends TestCase
         $command = $this->getMockBuilder('Cake\Command\PluginAssetsSymlinkCommand')
             ->onlyMethods(['getOptionParser', '_createSymlink', '_copyDirectory'])
             ->getMock();
-        $command->method('getOptionParser')->will($this->returnValue($parser));
+        $command->method('getOptionParser')->willReturn($parser);
 
         $this->assertDirectoryExists($this->wwwRoot . 'test_theme');
 

--- a/tests/TestCase/Command/SchemaCacheCommandsTest.php
+++ b/tests/TestCase/Command/SchemaCacheCommandsTest.php
@@ -106,7 +106,7 @@ class SchemaCacheCommandsTest extends TestCase
     {
         $this->cache->expects($this->atLeastOnce())
             ->method('set')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->exec('schema_cache build --connection test');
         $this->assertExitSuccess();
@@ -120,10 +120,10 @@ class SchemaCacheCommandsTest extends TestCase
         $this->cache->expects($this->once())
             ->method('set')
             ->with('test_articles')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->cache->expects($this->never())
             ->method('delete')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->exec('schema_cache build --connection test articles');
         $this->assertExitSuccess();
@@ -137,12 +137,12 @@ class SchemaCacheCommandsTest extends TestCase
         $this->cache->expects($this->once())
             ->method('set')
             ->with('test_articles')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->cache->expects($this->never())
             ->method('get');
         $this->cache->expects($this->never())
             ->method('delete')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->exec('schema_cache build --connection test articles');
         $this->assertExitSuccess();
@@ -173,7 +173,7 @@ class SchemaCacheCommandsTest extends TestCase
     {
         $this->cache->expects($this->atLeastOnce())
             ->method('delete')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->exec('schema_cache clear --connection test');
         $this->assertExitSuccess();
@@ -186,11 +186,11 @@ class SchemaCacheCommandsTest extends TestCase
     {
         $this->cache->expects($this->never())
             ->method('set')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->cache->expects($this->once())
             ->method('delete')
             ->with('test_articles')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->exec('schema_cache clear --connection test articles');
         $this->assertExitSuccess();

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -520,7 +520,7 @@ class CommandRunnerTest extends TestCase
             ->setConstructorArgs([$this->config])
             ->getMock();
         $collection = new CommandCollection($commands);
-        $app->method('console')->will($this->returnValue($collection));
+        $app->method('console')->willReturn($collection);
 
         return $app;
     }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -197,7 +197,7 @@ class CommandTest extends TestCase
         $parser = new ConsoleOptionParser('cake example');
         $parser->addArgument('name', ['required' => true]);
 
-        $command->method('getOptionParser')->will($this->returnValue($parser));
+        $command->method('getOptionParser')->willReturn($parser);
 
         $output = new StubConsoleOutput();
         $result = $command->run([], $this->getMockIo($output));

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -105,7 +105,7 @@ class ConsoleIoTest extends TestCase
     {
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue('y'));
+            ->willReturn('y');
 
         $result = $this->io->askChoice('Just a test?', $choices);
         $this->assertSame('y', $result);
@@ -121,7 +121,7 @@ class ConsoleIoTest extends TestCase
     {
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue('Y'));
+            ->willReturn('Y');
 
         $result = $this->io->askChoice('Just a test?', $choices);
         $this->assertSame('Y', $result);
@@ -138,7 +138,7 @@ class ConsoleIoTest extends TestCase
 
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue('y'));
+            ->willReturn('y');
 
         $result = $this->io->ask('Just a test?');
         $this->assertSame('y', $result);
@@ -155,7 +155,7 @@ class ConsoleIoTest extends TestCase
 
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue(''));
+            ->willReturn('');
 
         $result = $this->io->ask('Just a test?', 'n');
         $this->assertSame('n', $result);
@@ -711,7 +711,7 @@ class ConsoleIoTest extends TestCase
 
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue('q'));
+            ->willReturn('q');
 
         $this->io->createFile($file, 'some content');
     }
@@ -730,7 +730,7 @@ class ConsoleIoTest extends TestCase
 
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue('n'));
+            ->willReturn('n');
 
         $contents = 'new content';
         $result = $this->io->createFile($file, $contents);
@@ -774,7 +774,7 @@ class ConsoleIoTest extends TestCase
 
         $this->in->expects($this->once())
             ->method('read')
-            ->will($this->returnValue('a'));
+            ->willReturn('a');
 
         $this->io->createFile($file, 'new content');
         $this->assertStringEqualsFile($file, 'new content');

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -625,7 +625,7 @@ class ControllerTest extends TestCase
                     })]
                 )
             )
-            ->will($this->returnValue(new Event('stub')));
+            ->willReturn(new Event('stub'));
 
         $controller->startupProcess();
     }
@@ -643,7 +643,7 @@ class ControllerTest extends TestCase
             ->with($this->callback(function (EventInterface $event) {
                 return $event->getName() === 'Controller.shutdown';
             }))
-            ->will($this->returnValue(new Event('stub')));
+            ->willReturn(new Event('stub'));
 
         $controller->shutdownProcess();
     }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -111,7 +111,7 @@ class ConnectionTest extends TestCase
         $driver = $this->getMockBuilder(Driver::class)->getMock();
         $driver->expects($this->once())
             ->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $driver;
     }

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -119,7 +119,7 @@ class MysqlTest extends TestCase
 
         $driver->expects($this->once())->method('createPdo')
             ->with($dsn, $expected)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
         $driver->connect($config);
     }
 
@@ -180,7 +180,7 @@ class MysqlTest extends TestCase
         $connection->expects($this->once())
             ->method('getAttribute')
             ->with(PDO::ATTR_SERVER_VERSION)
-            ->will($this->returnValue($dbVersion));
+            ->willReturn($dbVersion);
 
         /** @var \PHPUnit\Framework\MockObject\MockObject&\Cake\Database\Driver\Mysql $driver */
         $driver = $this->getMockBuilder(Mysql::class)

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -82,7 +82,7 @@ class PostgresTest extends TestCase
 
         $driver->expects($this->once())->method('createPdo')
             ->with($dsn, $expected)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $driver->connect();
     }
@@ -145,7 +145,7 @@ class PostgresTest extends TestCase
 
         $driver->expects($this->once())->method('createPdo')
             ->with($dsn, $expected)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $driver->connect();
     }
@@ -180,7 +180,7 @@ class PostgresTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -208,7 +208,7 @@ class PostgresTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -108,7 +108,7 @@ class SqliteTest extends TestCase
 
         $driver->expects($this->once())->method('createPdo')
             ->with($dsn, $expected)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $driver->connect($config);
     }

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -180,7 +180,7 @@ class SqlserverTest extends TestCase
 
         $driver->expects($this->once())->method('createPdo')
             ->with($dsn, $expected)
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $driver->connect();
     }
@@ -239,9 +239,9 @@ class SqlserverTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->method('version')
-            ->will($this->returnValue('12'));
+            ->willReturn('12');
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -284,9 +284,9 @@ class SqlserverTest extends TestCase
             ->getMock();
         $driver->expects($this->any())
             ->method('version')
-            ->will($this->returnValue('8'));
+            ->willReturn('8');
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -406,7 +406,7 @@ class SqlserverTest extends TestCase
             ->setConstructorArgs([[]])
             ->getMock();
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $connection = new Connection(['driver' => $driver, 'log' => false]);
         $query = new InsertQuery($connection);
         $query->insert(['title'])
@@ -427,9 +427,9 @@ class SqlserverTest extends TestCase
             ->getMock();
         $driver->expects($this->any())
             ->method('version')
-            ->will($this->returnValue('8'));
+            ->willReturn('8');
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 
@@ -458,9 +458,9 @@ class SqlserverTest extends TestCase
             ->getMock();
         $driver->expects($this->any())
             ->method('version')
-            ->will($this->returnValue('8'));
+            ->willReturn('8');
         $driver->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $connection = new Connection(['driver' => $driver, 'log' => false]);
 

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -138,7 +138,7 @@ class DriverTest extends TestCase
             ->expects($this->once())
             ->method('quote')
             ->with($value, PDO::PARAM_STR)
-            ->will($this->returnValue('string'));
+            ->willReturn('string');
 
         $this->driver->expects($this->any())
             ->method('createPdo')
@@ -235,7 +235,7 @@ class DriverTest extends TestCase
         $query = $this->getMockBuilder(Query::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $query->method('type')->will($this->returnValue('select'));
+        $query->method('type')->willReturn('select');
 
         $driver
             ->expects($this->once())
@@ -318,9 +318,9 @@ class DriverTest extends TestCase
             ->setConstructorArgs([$inner, $this->driver])
             ->onlyMethods(['queryString','rowCount','execute'])
             ->getMock();
-        $statement->expects($this->any())->method('queryString')->will($this->returnValue('SELECT bar FROM foo'));
-        $statement->method('rowCount')->will($this->returnValue(3));
-        $statement->method('execute')->will($this->returnValue(true));
+        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo');
+        $statement->method('rowCount')->willReturn(3);
+        $statement->method('execute')->willReturn(true);
 
         $this->driver->expects($this->any())
             ->method('prepare')
@@ -345,9 +345,9 @@ class DriverTest extends TestCase
             ->setConstructorArgs([$inner, $this->driver])
             ->onlyMethods(['queryString','rowCount','execute'])
             ->getMock();
-        $statement->method('rowCount')->will($this->returnValue(3));
-        $statement->method('execute')->will($this->returnValue(true));
-        $statement->expects($this->any())->method('queryString')->will($this->returnValue('SELECT bar FROM foo WHERE a=:a AND b=:b'));
+        $statement->method('rowCount')->willReturn(3);
+        $statement->method('execute')->willReturn(true);
+        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo WHERE a=:a AND b=:b');
 
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));
         $this->driver->expects($this->any())
@@ -379,8 +379,8 @@ class DriverTest extends TestCase
             ->setConstructorArgs([$inner, $this->driver])
             ->onlyMethods(['queryString','rowCount','execute'])
             ->getMock();
-        $statement->expects($this->any())->method('queryString')->will($this->returnValue('SELECT bar FROM foo'));
-        $statement->method('rowCount')->will($this->returnValue(0));
+        $statement->expects($this->any())->method('queryString')->willReturn('SELECT bar FROM foo');
+        $statement->method('rowCount')->willReturn(0);
         $statement->method('execute')->will($this->throwException(new PDOException()));
 
         $this->driver->setLogger(new QueryLogger(['connection' => 'test']));

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1008,7 +1008,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1057,7 +1057,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1139,12 +1139,12 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $this->pdo
             ->expects($this->any())
             ->method('getAttribute')
-            ->will($this->returnValue('5.6.0'));
+            ->willReturn('5.6.0');
 
         $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
@@ -1207,12 +1207,12 @@ SQL;
             ->getMock();
         $connection->expects($this->any())
             ->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $this->pdo
             ->expects($this->any())
             ->method('getAttribute')
-            ->will($this->returnValue('5.7.0'));
+            ->willReturn('5.7.0');
 
         $table = (new TableSchema('posts'))->addColumn('id', [
                 'type' => 'integer',
@@ -1253,7 +1253,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false,
@@ -1273,7 +1273,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
@@ -1337,7 +1337,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
@@ -1355,7 +1355,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -1069,7 +1069,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1118,7 +1118,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1167,7 +1167,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
                 'type' => 'integer',
@@ -1238,7 +1238,7 @@ SQL;
             ->getMock();
         $connection->expects($this->any())
             ->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('title', [
             'type' => 'string',
@@ -1258,7 +1258,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false,
@@ -1278,7 +1278,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
@@ -1342,7 +1342,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
@@ -1360,7 +1360,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $table->addColumn('id', 'integer')

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -687,7 +687,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('posts');
 
@@ -705,7 +705,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('posts');
         $result = $table->dropConstraintSql($connection);
@@ -893,7 +893,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('articles'))->addColumn('id', [
                 'type' => 'integer',
@@ -943,7 +943,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
             'type' => 'integer',
             'null' => false,
@@ -963,7 +963,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('articles_tags'))
             ->addColumn('article_id', [
@@ -1029,7 +1029,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('articles');
         $result = $table->dropSql($connection);
@@ -1047,7 +1047,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $statement = $this->getMockBuilder('\PDOStatement')
             ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
@@ -1055,11 +1055,11 @@ SQL;
         $this->pdo->expects($this->once())
             ->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
         $statement->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue(['1']));
-        $statement->method('execute')->will($this->returnValue(true));
+            ->willReturn(['1']);
+        $statement->method('execute')->willReturn(true);
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);
@@ -1078,7 +1078,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $statement = $this->getMockBuilder('\PDOStatement')
             ->onlyMethods(['execute', 'rowCount', 'closeCursor', 'fetch'])
@@ -1086,11 +1086,11 @@ SQL;
         $this->pdo->expects($this->once())
             ->method('prepare')
             ->with('SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
         $statement->expects($this->once())
             ->method('fetch')
-            ->will($this->returnValue(false));
-        $statement->method('execute')->will($this->returnValue(true));
+            ->willReturn(false);
+        $statement->method('execute')->willReturn(true);
 
         $table = new TableSchema('articles');
         $result = $table->truncateSql($connection);

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -925,7 +925,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -974,7 +974,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('posts'))
             ->addColumn('author_id', [
@@ -1023,7 +1023,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = (new TableSchema('schema_articles'))->addColumn('id', [
                 'type' => 'integer',
@@ -1097,7 +1097,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $result = $table->dropSql($connection);
@@ -1115,7 +1115,7 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('getDriver')
-            ->will($this->returnValue($driver));
+            ->willReturn($driver);
 
         $table = new TableSchema('schema_articles');
         $table->addColumn('id', 'integer')

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -65,7 +65,7 @@ class StringTypeTest extends TestCase
         $obj = $this->getMockBuilder('StdClass')
             ->addMethods(['__toString'])
             ->getMock();
-        $obj->method('__toString')->will($this->returnValue('toString called'));
+        $obj->method('__toString')->willReturn('toString called');
 
         $this->assertNull($this->type->toDatabase(null, $this->driver));
         $this->assertSame('word', $this->type->toDatabase('word', $this->driver));

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -86,12 +86,12 @@ trait PaginatorTestTrait
     {
         $this->Post->expects($this->any())
             ->method('getAlias')
-            ->will($this->returnValue('Posts'));
+            ->willReturn('Posts');
 
         $query = $this->_getMockFindQuery();
         $this->Post->expects($this->any())
             ->method('find')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $params = ['page' => '1 " onclick="alert(\'xss\');">'];
         $settings = ['limit' => 1, 'maxLimit' => 10];
@@ -120,7 +120,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('applyOptions')
@@ -195,7 +195,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('applyOptions')
@@ -225,7 +225,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('applyOptions')
@@ -257,7 +257,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('applyOptions')
@@ -615,7 +615,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())->method('applyOptions')
             ->with([
@@ -643,10 +643,10 @@ trait PaginatorTestTrait
         $model = $this->getMockRepository();
         $model->expects($this->any())
             ->method('getAlias')
-            ->will($this->returnValue('model'));
+            ->willReturn('model');
         $model->expects($this->any())
             ->method('hasField')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $options = ['sort' => 'something', 'direction' => 'boogers'];
         $result = $this->Paginator->validateSort($model, $options);
@@ -665,7 +665,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())->method('applyOptions')
             ->with([
@@ -698,7 +698,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())->method('applyOptions')
             ->with([
@@ -740,7 +740,7 @@ trait PaginatorTestTrait
 
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())->method('applyOptions')
             ->with([
@@ -867,9 +867,9 @@ trait PaginatorTestTrait
         $model = $this->getMockRepository();
         $model->expects($this->any())
             ->method('getAlias')
-            ->will($this->returnValue('model'));
+            ->willReturn('model');
         $model->expects($this->once())->method('hasField')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $options = [
             'sort' => 'score',
@@ -929,10 +929,10 @@ trait PaginatorTestTrait
         $model = $this->getMockRepository();
         $model->expects($this->any())
             ->method('getAlias')
-            ->will($this->returnValue($modelAlias));
+            ->willReturn($modelAlias);
         $model->expects($this->any())
             ->method('hasField')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         return $model;
     }
@@ -1297,11 +1297,11 @@ trait PaginatorTestTrait
 
         $query->expects($this->any())
             ->method('count')
-            ->will($this->returnValue(2));
+            ->willReturn(2);
 
         $query->expects($this->any())
             ->method('all')
-            ->will($this->returnValue($results));
+            ->willReturn($results);
 
         if ($table) {
             $query->setRepository($table);

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -103,7 +103,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
                 ->getMock();
             $mock->expects($this->once())
                 ->method('render')
-                ->will($this->returnValue($response));
+                ->willReturn($response);
 
             return $mock;
         };

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -269,7 +269,7 @@ class EventManagerTest extends TestCase
         $listener->expects($this->once())
             ->method('listenerFunction')
             ->with($event)
-            ->will($this->returnValue('something special'));
+            ->willReturn('something special');
         $anotherListener->expects($this->once())
             ->method('listenerFunction')
             ->with($event);
@@ -295,7 +295,7 @@ class EventManagerTest extends TestCase
 
         $listener->expects($this->once())->method('listenerFunction')
             ->with($event)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $anotherListener->expects($this->never())
             ->method('listenerFunction');
         $manager->dispatch($event);
@@ -439,7 +439,7 @@ class EventManagerTest extends TestCase
         $generalManager->expects($this->any())
                 ->method('prioritisedListeners')
                 ->with('fake.event')
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $manager->on('fake.event', [$listener, 'listenerFunction']);
         $manager->on('fake.event', ['priority' => 8], [$listener, 'stopListener']);
@@ -468,11 +468,11 @@ class EventManagerTest extends TestCase
         $generalManager->expects($this->any())
                 ->method('prioritisedListeners')
                 ->with('fake.event')
-                ->will($this->returnValue(
+                ->willReturn(
                     [11 => [
                         ['callable' => [$listener, 'secondListenerFunction']],
                     ]]
-                ));
+                );
 
         $manager->on('fake.event', [$listener, 'listenerFunction']);
         $manager->on('fake.event', ['priority' => 15], [$listener, 'thirdListenerFunction']);
@@ -500,11 +500,11 @@ class EventManagerTest extends TestCase
         $generalManager->expects($this->any())
                 ->method('prioritisedListeners')
                 ->with('fake.event')
-                ->will($this->returnValue(
+                ->willReturn(
                     [10 => [
                         ['callable' => [$listener, 'listenerFunction']],
                     ]]
-                ));
+                );
 
         $manager->on('fake.event', [$listener, 'secondListenerFunction']);
 

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -86,7 +86,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -114,7 +114,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
         $request = $this->auth->authentication($request, $auth);
@@ -137,7 +137,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -160,7 +160,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -181,7 +181,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);
@@ -339,7 +339,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', $method, [], $data);
         $request = $this->auth->authentication($request, $auth);
@@ -357,7 +357,7 @@ class DigestTest extends TestCase
         $response = new Response($headers, '');
         $this->client->expects($this->once())
             ->method('send')
-            ->will($this->returnValue($response));
+            ->willReturn($response);
 
         $auth = ['username' => 'admin', 'password' => '1234'];
         $request = new Request('http://example.com/some/path', Request::METHOD_GET);

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -245,7 +245,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client(['adapter' => $mock, 'protocolVersion' => '2']);
         $result = $http->get('http://cakephp.org/test.html', [], [
@@ -277,7 +277,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -308,7 +308,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -341,7 +341,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -375,7 +375,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -432,7 +432,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -484,7 +484,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -535,7 +535,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -563,7 +563,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -610,7 +610,7 @@ class ClientTest extends TestCase
         $response = new Response($headers, '');
         $adapter->expects($this->once())
             ->method('send')
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -702,7 +702,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client([
             'host' => 'cakephp.org',
@@ -827,7 +827,7 @@ class ClientTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnValue([$response]));
+            ->willReturn([$response]);
 
         $http = new Client(['adapter' => $mock]);
         $request = new LaminasRequest(

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -397,7 +397,7 @@ class MailerTest extends TestCase
             ->with('foo', 'bar');
         $mailer->expects($this->any())
             ->method('deliver')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $mailer->send('test', ['foo', 'bar']);
 
@@ -1113,7 +1113,7 @@ class MailerTest extends TestCase
             ->with('foo', 'bar');
         $mailer->expects($this->any())
             ->method('deliver')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $mailer->send('test', ['foo', 'bar']);
         $this->assertSame('test', $mailer->viewBuilder()->getTemplate());
@@ -1306,7 +1306,7 @@ class MailerTest extends TestCase
             ->with('foo', 'bar');
         $mailer->expects($this->once())
             ->method('deliver')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $mailer->send('test', ['foo', 'bar']);
         $this->assertSame('cakephp', $mailer->viewBuilder()->getTemplate());

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -75,7 +75,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testConnectEhlo(): void
     {
-        $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->any())->method('connect')->willReturn(true);
         $this->socket->expects($this->any())
             ->method('read')
             ->will($this->onConsecutiveCalls("220 Welcome message\r\n", "250 Accepted\r\n"));
@@ -89,7 +89,7 @@ class SmtpTransportTest extends TestCase
     public function testConnectEhloTls(): void
     {
         $this->SmtpTransport->setConfig(['tls' => true]);
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(4))
             ->method('read')
@@ -109,8 +109,7 @@ class SmtpTransportTest extends TestCase
                 )
             );
         $this->socket->expects($this->once())->method('enableCrypto')
-            ->with('tls')
-            ->will($this->returnValue(true));
+            ->with('tls');
 
         $this->SmtpTransport->connect();
     }
@@ -121,7 +120,7 @@ class SmtpTransportTest extends TestCase
     public function testConnectEhloTlsOnNonTlsServer(): void
     {
         $this->SmtpTransport->setConfig(['tls' => true]);
-        $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->any())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(3))
             ->method('read')
@@ -178,14 +177,14 @@ class SmtpTransportTest extends TestCase
                 )
             );
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->SmtpTransport->connect();
     }
 
     public function testConnectEhloWithAuthPlain(): void
     {
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(3))
             ->method('read')
@@ -210,7 +209,7 @@ class SmtpTransportTest extends TestCase
 
     public function testConnectEhloWithAuthLogin(): void
     {
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->any())
             ->method('read')
@@ -258,7 +257,7 @@ class SmtpTransportTest extends TestCase
                 )
             );
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
         $this->SmtpTransport->connect();
     }
 
@@ -282,7 +281,7 @@ class SmtpTransportTest extends TestCase
                     ["HELO localhost\r\n"]
                 )
             );
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $e = null;
         try {
@@ -304,7 +303,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testAuthTypeSet(): void
     {
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(2))
             ->method('read')
@@ -330,7 +329,7 @@ class SmtpTransportTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unsupported auth type. Available types are: PLAIN, LOGIN, XOAUTH2');
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(2))
             ->method('read')
@@ -355,7 +354,7 @@ class SmtpTransportTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unsupported auth type: CRAM-MD5');
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(2))
             ->method('read')
@@ -377,7 +376,7 @@ class SmtpTransportTest extends TestCase
 
     public function testAuthTypeParsingIsSkippedIfNoCredentialsProvided(): void
     {
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->exactly(2))
             ->method('read')
@@ -398,7 +397,7 @@ class SmtpTransportTest extends TestCase
     public function testAuthPlain(): void
     {
         $this->socket->expects($this->once())->method('write')->with("AUTH PLAIN {$this->credentialsEncoded}\r\n");
-        $this->socket->expects($this->once())->method('read')->will($this->returnValue("235 OK\r\n"));
+        $this->socket->expects($this->once())->method('read')->willReturn("235 OK\r\n");
         $this->SmtpTransport->setConfig($this->credentials);
         $this->SmtpTransport->auth();
     }
@@ -624,7 +623,7 @@ class SmtpTransportTest extends TestCase
         $message->setBcc('phpnut@cakephp.org');
         $message->setCc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
 
-        $this->socket->expects($this->any())->method('read')->will($this->returnValue("250 OK\r\n"));
+        $this->socket->expects($this->any())->method('read')->willReturn("250 OK\r\n");
 
         $this->socket->expects($this->exactly(5))
             ->method('write')
@@ -651,7 +650,7 @@ class SmtpTransportTest extends TestCase
         $message->setTo('cake@cakephp.org', 'CakePHP');
         $message->setReturnPath('pleasereply@cakephp.org', 'CakePHP Return');
 
-        $this->socket->expects($this->exactly(2))->method('read')->will($this->returnValue("250 OK\r\n"));
+        $this->socket->expects($this->exactly(2))->method('read')->willReturn("250 OK\r\n");
 
         $this->socket->expects($this->exactly(2))
             ->method('write')
@@ -735,7 +734,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testEmptyClientName(): void
     {
-        $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->any())->method('connect')->willReturn(true);
         $this->socket->expects($this->any())
            ->method('read')
            ->will($this->onConsecutiveCalls("220 Welcome message\r\n", "250 Accepted\r\n"));
@@ -754,7 +753,7 @@ class SmtpTransportTest extends TestCase
     {
         $this->assertEmpty($this->SmtpTransport->getLastResponse());
 
-        $this->socket->expects($this->any())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->any())->method('connect')->willReturn(true);
         $this->socket->expects($this->any())
             ->method('read')
             ->will($this->onConsecutiveCalls(
@@ -808,7 +807,7 @@ class SmtpTransportTest extends TestCase
             );
         $this->socket->expects($this->exactly(2))
             ->method('read')
-            ->will($this->returnValue("250 OK\r\n"));
+            ->willReturn("250 OK\r\n");
 
         $this->SmtpTransport->sendRcpt($message);
 
@@ -921,7 +920,7 @@ class SmtpTransportTest extends TestCase
             ->getMock();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
-        $message->expects($this->exactly(2))->method('getBody')->will($this->returnValue(['First Line']));
+        $message->expects($this->exactly(2))->method('getBody')->willReturn(['First Line']);
 
         $callback = function ($arg) {
             $this->assertNotEquals("QUIT\r\n", $arg);
@@ -965,7 +964,7 @@ class SmtpTransportTest extends TestCase
                 )
             );
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->SmtpTransport->send($message);
         $this->socket->expects($this->once())->method('isConnected')->willReturn(true);
@@ -983,9 +982,9 @@ class SmtpTransportTest extends TestCase
             ->getMock();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
-        $message->expects($this->once())->method('getBody')->will($this->returnValue(['First Line']));
+        $message->expects($this->once())->method('getBody')->willReturn(['First Line']);
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->atLeast(6))
             ->method('read')
@@ -1027,9 +1026,9 @@ class SmtpTransportTest extends TestCase
             ->getMock();
         $message->setFrom('noreply@cakephp.org', 'CakePHP Test');
         $message->setTo('cake@cakephp.org', 'CakePHP');
-        $message->expects($this->once())->method('getBody')->will($this->returnValue(['First Line']));
+        $message->expects($this->once())->method('getBody')->willReturn(['First Line']);
 
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
         $this->socket->expects($this->atLeast(6))
             ->method('read')
@@ -1065,7 +1064,7 @@ class SmtpTransportTest extends TestCase
      */
     public function testSerializeCleanupSocket(): void
     {
-        $this->socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->socket->expects($this->once())->method('connect')->willReturn(true);
         $this->socket->expects($this->exactly(2))
             ->method('read')
             ->will($this->onConsecutiveCalls(

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -259,7 +259,7 @@ class BelongsToManyTest extends TestCase
         $driver = $this->getMockBuilder(Driver::class)->getMock();
         $driver->expects($this->once())
             ->method('enabled')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $mock = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([['name' => 'other_source', 'driver' => $driver]])
@@ -654,7 +654,7 @@ class BelongsToManyTest extends TestCase
         $saveOptions = ['foo' => 'bar'];
 
         $joint->method('getPrimaryKey')
-            ->will($this->returnValue(['article_id', 'tag_id']));
+            ->willReturn(['article_id', 'tag_id']);
 
         $joint->expects($this->exactly(2))
             ->method('save')
@@ -708,7 +708,7 @@ class BelongsToManyTest extends TestCase
         $tags = [new Entity(['id' => 2], $opts)];
 
         $joint->method('getPrimaryKey')
-            ->will($this->returnValue(['article_id', 'tag_id']));
+            ->willReturn(['article_id', 'tag_id']);
 
         $joint->expects($this->once())
             ->method('save')
@@ -1266,7 +1266,7 @@ class BelongsToManyTest extends TestCase
         $assoc->expects($this->once())
             ->method('replaceLinks')
             ->with($entity, [])
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $assoc->expects($this->never())
             ->method('_saveTarget');
@@ -1299,7 +1299,7 @@ class BelongsToManyTest extends TestCase
         $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
         $assoc->expects($this->once())->method('replaceLinks')
             ->with($entity, $entity->tags, $options)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->assertSame($entity, $assoc->saveAssociated($entity, $options));
     }
 
@@ -1328,7 +1328,7 @@ class BelongsToManyTest extends TestCase
         $assoc->setSaveStrategy(BelongsToMany::SAVE_REPLACE);
         $assoc->expects($this->once())->method('replaceLinks')
             ->with($entity, $entity->tags, $options)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $this->assertFalse($assoc->saveAssociated($entity, $options));
     }
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -247,7 +247,7 @@ class HasManyTest extends TestCase
         $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
         $keys = [1, 2, 3, 4];
 
         $callable = $association->eagerLoader(compact('keys', 'query'));
@@ -290,7 +290,7 @@ class HasManyTest extends TestCase
         $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $association->eagerLoader(compact('keys', 'query'));
 
@@ -327,7 +327,7 @@ class HasManyTest extends TestCase
 
         $this->article->method('find')
             ->with('all')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $association->eagerLoader([
             'conditions' => ['Articles.id !=' => 3],
@@ -377,7 +377,7 @@ class HasManyTest extends TestCase
         $query = $this->article->selectQuery();
         $this->article->method('find')
             ->with('all')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $association->eagerLoader([
             'fields' => ['id', 'title'],
@@ -403,7 +403,7 @@ class HasManyTest extends TestCase
         $query = $this->article->query();
         $this->article->method('find')
             ->with('all')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $queryBuilder = function ($query) {
             return $query->select(['author_id'])->join('comments')->where(['comments.id' => 1]);
@@ -455,10 +455,10 @@ class HasManyTest extends TestCase
             ->setConstructorArgs([$this->article])
             ->getMock();
         $query->method('getRepository')
-            ->will($this->returnValue($this->article));
+            ->willReturn($this->article);
         $this->article->method('find')
             ->with('all')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $results = new ResultSet([]);
 
@@ -467,7 +467,7 @@ class HasManyTest extends TestCase
             ['id' => 2, 'title' => 'article 2', 'author_id' => 1, 'site_id' => 20],
         ]);
         $query->method('all')
-            ->will($this->returnValue($results));
+            ->willReturn($results);
 
         $tuple = new TupleComparison(
             ['Articles.author_id', 'Articles.site_id'],

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -274,7 +274,7 @@ class AssociationCollectionTest extends TestCase
         $mockOne->expects($this->once())
             ->method('saveAssociated')
             ->with($entity, $options)
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $mockTwo->expects($this->never())
             ->method('saveAssociated');
@@ -322,7 +322,7 @@ class AssociationCollectionTest extends TestCase
         $mockOne->expects($this->once())
             ->method('saveAssociated')
             ->with($entity, ['atomic' => true, 'associated' => ['Others']])
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $mockTwo->expects($this->never())
             ->method('saveAssociated');
@@ -370,7 +370,7 @@ class AssociationCollectionTest extends TestCase
         $mockOne->expects($this->once())
             ->method('saveAssociated')
             ->with($entity, $options + ['associated' => ['Other']])
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $mockTwo->expects($this->never())
             ->method('saveAssociated');

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -172,7 +172,7 @@ class AssociationProxyTest extends TestCase
 
         $mock->expects($this->once())->method('crazy')
             ->with('a', 'b')
-            ->will($this->returnValue('thing'));
+            ->willReturn('thing');
         $this->assertSame('thing', $articles->authors->crazy('a', 'b'));
     }
 }

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -240,7 +240,7 @@ class AssociationTest extends TestCase
         $this->association
             ->expects($this->once())
             ->method('isOwningSide')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $result = $this->association->getBindingKey();
         $this->assertEquals(['id', 'site_id'], $result);
     }
@@ -258,7 +258,7 @@ class AssociationTest extends TestCase
         $this->association
             ->expects($this->once())
             ->method('isOwningSide')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $result = $this->association->getBindingKey();
         $this->assertEquals(['foo', 'site_id'], $result);
     }

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -267,7 +267,7 @@ class BehaviorRegistryTest extends TestCase
             ->expects($this->once())
             ->method('slugify')
             ->with(['some value'])
-            ->will($this->returnValue('some-thing'));
+            ->willReturn('some-thing');
         $return = $this->Behaviors->call('slugify', [['some value']]);
         $this->assertSame('some-thing', $return);
     }
@@ -303,7 +303,7 @@ class BehaviorRegistryTest extends TestCase
             ->expects($this->once())
             ->method('findNoSlug')
             ->with($query)
-            ->will($this->returnValue($query));
+            ->willReturn($query);
         $return = $this->Behaviors->callFinder('noSlug', $query);
         $this->assertSame($query, $return);
     }

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -265,7 +265,7 @@ class EagerLoaderTest extends TestCase
                     ]
                 )
             )
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $loader = new EagerLoader();
         $loader->contain($contains);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -497,7 +497,7 @@ class EntityTest extends TestCase
             ->addMethods(['_getThings'])
             ->getMock();
         $entity->expects($this->never())->method('_getThings')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
         $this->assertTrue($entity->has('things'));
     }
 
@@ -588,10 +588,7 @@ class EntityTest extends TestCase
             ->with(
                 ...self::withConsecutive(['foo'], ['bar'])
             )
-            ->will($this->onConsecutiveCalls(
-                $this->returnValue('worked'),
-                $this->returnValue('worked too')
-            ));
+            ->willReturn('worked', 'worked too');
 
         $this->assertSame('worked', $entity['foo']);
         $this->assertSame('worked too', $entity['bar']);
@@ -705,7 +702,7 @@ class EntityTest extends TestCase
         $phone = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['jsonSerialize'])
             ->getMock();
-        $phone->expects($this->once())->method('jsonSerialize')->will($this->returnValue(['something']));
+        $phone->expects($this->once())->method('jsonSerialize')->willReturn(['something']);
         $data = ['name' => 'James', 'age' => 20, 'phone' => $phone];
         $entity = new Entity($data);
         $expected = ['name' => 'James', 'age' => 20, 'phone' => ['something']];
@@ -995,7 +992,7 @@ class EntityTest extends TestCase
         $entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
         $entity->expects($this->any())
             ->method('_getName')
-            ->will($this->returnValue('Jose'));
+            ->willReturn('Jose');
 
         $expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
         $this->assertEquals($expected, $entity->toArray());
@@ -1065,7 +1062,7 @@ class EntityTest extends TestCase
 
         $entity->expects($this->any())
             ->method('_getName')
-            ->will($this->returnValue('Jose'));
+            ->willReturn('Jose');
         $entity->set(['email' => 'mark@example.com']);
 
         $entity->setVirtual(['name']);

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -1864,7 +1864,7 @@ class SelectQueryTest extends TestCase
         $cacher->expects($this->once())
             ->method('get')
             ->with('my_key')
-            ->will($this->returnValue($resultSet));
+            ->willReturn($resultSet);
 
         $query->cache('my_key', $cacher)
             ->where(['id' => 1]);
@@ -2342,7 +2342,7 @@ class SelectQueryTest extends TestCase
 
         $query->expects($this->once())
             ->method('_performCount')
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $result = $query->count();
         $this->assertSame(1, $result, 'The result of the sql query should be returned');

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -181,7 +181,7 @@ class ResultSetFactoryTest extends TestCase
         $row = ['Other__field' => 'test'];
         $statement = $this->createMock(StatementInterface::class);
         $statement->method('fetchAll')
-            ->will($this->returnValue([$row]));
+            ->willReturn([$row]);
 
         $results = $this->factory->createResultSet($query, $statement->fetchAll());
         $this->assertNotEmpty($results);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1174,7 +1174,7 @@ class TableTest extends TestCase
             ->getMock();
         $table->expects($this->once())
             ->method('updateQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('execute')
@@ -1234,7 +1234,7 @@ class TableTest extends TestCase
             ->getMock();
         $table->expects($this->once())
             ->method('deleteQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('execute')
@@ -1257,7 +1257,7 @@ class TableTest extends TestCase
             ->getMock();
         $table->expects($this->once())
             ->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $options = ['fields' => ['a', 'b']];
         $query->expects($this->any())
@@ -1265,7 +1265,7 @@ class TableTest extends TestCase
             ->will($this->returnSelf());
 
         $query->expects($this->once())->method('getOptions')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
         $query->expects($this->once())
             ->method('applyOptions')
             ->with($options);
@@ -1442,12 +1442,12 @@ class TableTest extends TestCase
         $table->expects($this->once())
             ->method('find')
             ->with('threaded', ['order' => ['name' => 'ASC']])
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $table->expects($this->once())
             ->method('findList')
             ->with($query, 'id')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $result = $table
             ->find('threaded', ['order' => ['name' => 'ASC']])
@@ -2477,13 +2477,13 @@ class TableTest extends TestCase
         ]);
 
         $table->expects($this->once())->method('insertQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())->method('execute')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
 
         $statement->expects($this->once())->method('rowCount')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
 
         $called = false;
         $listener = function ($e, $entity, $options) use (&$called): void {
@@ -2576,7 +2576,7 @@ class TableTest extends TestCase
 
         $connection->expects($this->once())->method('begin');
         $connection->expects($this->once())->method('commit');
-        $connection->expects($this->any())->method('inTransaction')->will($this->returnValue(true));
+        $connection->expects($this->any())->method('inTransaction')->willReturn(true);
         $data = new Entity([
             'username' => 'superuser',
             'created' => new DateTime('2013-10-10 00:00'),
@@ -2609,10 +2609,10 @@ class TableTest extends TestCase
             ->setConstructorArgs([$table])
             ->getMock();
         $table->expects($this->any())->method('getConnection')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $table->expects($this->once())->method('insertQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $connection->expects($this->once())->method('begin');
         $connection->expects($this->once())->method('rollback');
@@ -2651,20 +2651,20 @@ class TableTest extends TestCase
             ->getMock();
 
         $table->expects($this->any())->method('getConnection')
-            ->will($this->returnValue($connection));
+            ->willReturn($connection);
 
         $table->expects($this->once())->method('insertQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $statement = $this->createMock(StatementInterface::class);
         $statement->expects($this->once())
             ->method('rowCount')
-            ->will($this->returnValue(0));
+            ->willReturn(0);
         $connection->expects($this->once())->method('begin');
         $connection->expects($this->once())->method('rollback');
         $query->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
 
         $data = new Entity([
             'username' => 'superuser',
@@ -2828,10 +2828,10 @@ class TableTest extends TestCase
         $statement = $this->getMockBuilder(StatementInterface::class)->getMock();
         $statement->expects($this->once())
             ->method('errorCode')
-            ->will($this->returnValue('00000'));
+            ->willReturn('00000');
 
         $connection->expects($this->once())->method('run')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
 
         $entity = new Entity([
             'id' => 2,
@@ -4218,17 +4218,17 @@ class TableTest extends TestCase
         $articles->expects($this->once())
             ->method('_insert')
             ->with($entity, ['title' => 'bar'])
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $authors->expects($this->once())
             ->method('_insert')
             ->with($entity->author, ['name' => 'Juan'])
-            ->will($this->returnValue($entity->author));
+            ->willReturn($entity->author);
 
         $supervisors->expects($this->once())
             ->method('_insert')
             ->with($entity->author->supervisor, ['name' => 'Marc'])
-            ->will($this->returnValue($entity->author->supervisor));
+            ->willReturn($entity->author->supervisor);
 
         $tags->expects($this->never())->method('_insert');
 
@@ -5430,7 +5430,7 @@ class TableTest extends TestCase
             ->getMock();
 
         $table->expects($this->once())->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $entity = new Entity();
         $query->expects($this->once())->method('applyOptions')
@@ -5440,7 +5440,7 @@ class TableTest extends TestCase
             ->will($this->returnSelf());
         $query->expects($this->never())->method('cache');
         $query->expects($this->once())->method('firstOrFail')
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $result = $table->get(10, ...$options);
         $this->assertSame($entity, $result);
@@ -5480,7 +5480,7 @@ class TableTest extends TestCase
             ->getMock();
 
         $table->expects($this->once())->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
         $table->expects($this->any())->method('findCustom')
             ->willReturn($query);
 
@@ -5492,7 +5492,7 @@ class TableTest extends TestCase
             ->will($this->returnSelf());
         $query->expects($this->never())->method('cache');
         $query->expects($this->once())->method('firstOrFail')
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $result = $table->get(10, ...$options);
         $this->assertSame($entity, $result);
@@ -5550,7 +5550,7 @@ class TableTest extends TestCase
             ->getMock();
 
         $table->expects($this->once())->method('selectQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $entity = new Entity();
         $query->expects($this->once())->method('applyOptions')
@@ -5562,7 +5562,7 @@ class TableTest extends TestCase
             ->with($cacheKey, $cacheConfig)
             ->will($this->returnSelf());
         $query->expects($this->once())->method('firstOrFail')
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
 
         $result = $table->get($primaryKey, ...$options);
         $this->assertSame($entity, $result);
@@ -5642,14 +5642,14 @@ class TableTest extends TestCase
         $table->belongsTo('users');
         $table->hasMany('articles');
         $table->expects($this->once())->method('marshaller')
-            ->will($this->returnValue($marshaller));
+            ->willReturn($marshaller);
 
         $entity = new Entity();
         $data = ['foo' => 'bar'];
         $marshaller->expects($this->once())
             ->method('merge')
             ->with($entity, $data, ['associated' => ['users', 'articles']])
-            ->will($this->returnValue($entity));
+            ->willReturn($entity);
         $table->patchEntity($entity, $data);
     }
 
@@ -5683,14 +5683,14 @@ class TableTest extends TestCase
         $table->belongsTo('users');
         $table->hasMany('articles');
         $table->expects($this->once())->method('marshaller')
-            ->will($this->returnValue($marshaller));
+            ->willReturn($marshaller);
 
         $entities = [new Entity()];
         $data = [['foo' => 'bar']];
         $marshaller->expects($this->once())
             ->method('mergeMany')
             ->with($entities, $data, ['associated' => ['users', 'articles']])
-            ->will($this->returnValue($entities));
+            ->willReturn($entities);
         $table->patchEntities($entities, $data);
     }
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1046,7 +1046,7 @@ class RouteTest extends TestCase
         $route->expects($this->once())
             ->method('parse')
             ->with('/forward', 'GET')
-            ->will($this->returnValue(['works!']));
+            ->willReturn(['works!']);
 
         $request = new ServerRequest([
             'environment' => [

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2999,7 +2999,7 @@ class RouterTest extends TestCase
             ->getMock();
         $route->expects($this->any())
             ->method('match')
-            ->will($this->returnValue($url));
+            ->willReturn($url);
 
         Router::createRouteBuilder('/')->connect($route);
 

--- a/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
+++ b/tests/TestCase/TestSuite/Fixture/FixtureHelperTest.php
@@ -109,12 +109,12 @@ class FixtureHelperTest extends TestCase
         $fixture1 = $this->createMock(TestFixture::class);
         $fixture1->expects($this->once())
             ->method('connection')
-            ->will($this->returnValue('test1'));
+            ->willReturn('test1');
 
         $fixture2 = $this->createMock(TestFixture::class);
         $fixture2->expects($this->once())
             ->method('connection')
-            ->will($this->returnValue('test2'));
+            ->willReturn('test2');
 
         ConnectionManager::alias('test', 'test1');
         ConnectionManager::alias('test', 'test2');
@@ -155,7 +155,7 @@ class FixtureHelperTest extends TestCase
         $fixture = $this->getMockBuilder(TestFixture::class)->getMock();
         $fixture->expects($this->once())
             ->method('connection')
-            ->will($this->returnValue('test'));
+            ->willReturn('test');
         $fixture->expects($this->once())
             ->method('insert')
             ->will($this->throwException(new PDOException('Missing key')));
@@ -165,7 +165,7 @@ class FixtureHelperTest extends TestCase
             ->getMock();
         $helper->expects($this->any())
             ->method('sortByConstraint')
-            ->will($this->returnValue([$fixture]));
+            ->willReturn([$fixture]);
 
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to insert rows for table ``');
@@ -200,7 +200,7 @@ class FixtureHelperTest extends TestCase
         $fixture = $this->getMockBuilder(TestFixture::class)->getMock();
         $fixture->expects($this->once())
             ->method('connection')
-            ->will($this->returnValue('test'));
+            ->willReturn('test');
         $fixture->expects($this->once())
             ->method('truncate')
             ->will($this->throwException(new PDOException('Missing key')));
@@ -210,7 +210,7 @@ class FixtureHelperTest extends TestCase
             ->getMock();
         $helper->expects($this->any())
             ->method('sortByConstraint')
-            ->will($this->returnValue([$fixture]));
+            ->willReturn([$fixture]);
 
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage('Unable to truncate table ``');

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -371,7 +371,7 @@ class TestCaseTest extends TestCase
         $Posts = $this->getMockForModel('Posts', ['save']);
         $Posts->expects($this->once())
             ->method('save')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
         $this->assertSame(false, $Posts->save($entity));
         $this->assertSame('Cake\ORM\Entity', $Posts->getEntityClass());
         $this->assertInstanceOf('Cake\Database\Connection', $Posts->getConnection());
@@ -384,14 +384,14 @@ class TestCaseTest extends TestCase
         $SluggedPosts->expects($this->once())
             ->method('slugify')
             ->with('some value')
-            ->will($this->returnValue('mocked'));
+            ->willReturn('mocked');
         $this->assertSame('mocked', $SluggedPosts->slugify('some value'));
 
         $SluggedPosts = $this->getMockForModel('SluggedPosts', ['save', 'slugify']);
         $SluggedPosts->expects($this->once())
             ->method('slugify')
             ->with('some value two')
-            ->will($this->returnValue('mocked'));
+            ->willReturn('mocked');
         $this->assertSame('mocked', $SluggedPosts->slugify('some value two'));
     }
 
@@ -425,7 +425,7 @@ class TestCaseTest extends TestCase
         $this->assertSame('Cake\ORM\Entity', $TestPluginComment->getEntityClass());
         $TestPluginComment->expects($this->exactly(1))
             ->method('save')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $entity = new Entity([]);
         $this->assertFalse($TestPluginComment->save($entity));
@@ -453,7 +453,7 @@ class TestCaseTest extends TestCase
 
         $Mock->expects($this->exactly(1))
             ->method('save')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $entity = new Entity([]);
         $this->assertFalse($Mock->save($entity));

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -174,7 +174,7 @@ class TestFixtureTest extends TestCase
             ->getMock();
         $db->expects($this->once())
             ->method('insertQuery')
-            ->will($this->returnValue($query));
+            ->willReturn($query);
 
         $query->expects($this->once())
             ->method('insert')
@@ -206,7 +206,7 @@ class TestFixtureTest extends TestCase
 
         $query->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue($statement));
+            ->willReturn($statement);
 
         $this->assertSame(true, $fixture->insert($db));
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -212,7 +212,7 @@ class FormHelperTest extends TestCase
         $mock->expects($this->once())
             ->method('render')
             ->with($data)
-            ->will($this->returnValue('HTML'));
+            ->willReturn('HTML');
         $result = $this->Form->widget('test', $data);
         $this->assertSame('HTML', $result);
     }
@@ -237,12 +237,12 @@ class FormHelperTest extends TestCase
         $mock->expects($this->once())
             ->method('render')
             ->with($data)
-            ->will($this->returnValue('HTML'));
+            ->willReturn('HTML');
 
         $mock->expects($this->once())
             ->method('secureFields')
             ->with($data)
-            ->will($this->returnValue(['test']));
+            ->willReturn(['test']);
 
         $this->Form->create();
         $result = $this->Form->widget('test', $data + ['secure' => true]);


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17236
As mentioned by Sebastian himself in the linked PHPUnit Issue:

use `$double->willReturn()` instead of `$double->will($this->returnValue())`