### PR TITLE
5.x: convert `returnSelf()` to `willReturnSelf()`

### DIFF
--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -477,7 +477,7 @@ class HasManyTest extends TestCase
         );
         $query->expects($this->once())->method('andWhere')
             ->with($tuple)
-            ->will($this->returnSelf());
+            ->willReturnSelf();
 
         $callable = $association->eagerLoader(compact('keys', 'query'));
         $row = ['Authors__id' => 2, 'Authors__site_id' => 10, 'username' => 'author 1'];

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -612,10 +612,7 @@ class EntityTest extends TestCase
             ->with(
                 ...self::withConsecutive(['foo', 1], ['bar', 2])
             )
-            ->will($this->onConsecutiveCalls(
-                $this->returnSelf(),
-                $this->returnSelf()
-            ));
+            ->willReturnSelf();
 
         $entity['foo'] = 1;
         $entity['bar'] = 2;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1262,7 +1262,7 @@ class TableTest extends TestCase
         $options = ['fields' => ['a', 'b']];
         $query->expects($this->any())
             ->method('select')
-            ->will($this->returnSelf());
+            ->willReturnSelf();
 
         $query->expects($this->once())->method('getOptions')
             ->will($this->returnValue([]));
@@ -5437,7 +5437,7 @@ class TableTest extends TestCase
             ->with(['fields' => ['id']]);
         $query->expects($this->once())->method('where')
             ->with([$table->getAlias() . '.bar' => 10])
-            ->will($this->returnSelf());
+            ->willReturnSelf();
         $query->expects($this->never())->method('cache');
         $query->expects($this->once())->method('firstOrFail')
             ->will($this->returnValue($entity));
@@ -5489,7 +5489,7 @@ class TableTest extends TestCase
             ->with(['fields' => ['id']]);
         $query->expects($this->once())->method('where')
             ->with([$table->getAlias() . '.bar' => 10])
-            ->will($this->returnSelf());
+            ->willReturnSelf();
         $query->expects($this->never())->method('cache');
         $query->expects($this->once())->method('firstOrFail')
             ->will($this->returnValue($entity));
@@ -5557,10 +5557,10 @@ class TableTest extends TestCase
             ->with(['fields' => ['id']]);
         $query->expects($this->once())->method('where')
             ->with([$table->getAlias() . '.bar' => $primaryKey])
-            ->will($this->returnSelf());
+            ->willReturnSelf();
         $query->expects($this->once())->method('cache')
             ->with($cacheKey, $cacheConfig)
-            ->will($this->returnSelf());
+            ->willReturnSelf();
         $query->expects($this->once())->method('firstOrFail')
             ->will($this->returnValue($entity));
 

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -179,12 +179,12 @@ class TestFixtureTest extends TestCase
         $query->expects($this->once())
             ->method('insert')
             ->with(['author_id', 'title', 'body', 'published'], ['author_id' => 'integer', 'title' => 'string', 'body' => 'text', 'published' => 'string'])
-            ->will($this->returnSelf());
+            ->willReturnSelf();
 
         $query->expects($this->once())
             ->method('into')
             ->with('articles')
-            ->will($this->returnSelf());
+            ->willReturnSelf();
 
         $expected = [
             ['author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
@@ -200,7 +200,7 @@ class TestFixtureTest extends TestCase
                     [$expected[2]]
                 )
             )
-            ->will($this->returnSelf());
+            ->willReturnSelf();
 
         $statement = $this->createMock(StatementInterface::class);
 


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17236
As mentioned by Sebastian himself in the linked PHPUnit Issue:

use `$double->willReturnSelf()` instead of `$double->will($this->returnSelf())`