### PR TITLE
5.x: PHP 8.3 fix

### DIFF
--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -105,7 +105,7 @@ class DebuggerTest extends TestCase
         $this->assertCount(4, $result);
 
         $this->skipIf(defined('HHVM_VERSION'), 'HHVM does not highlight php code');
-        $pattern = '/<code>.*?<span style\="color\: \#\d+">.*?&lt;\?php/';
+        $pattern = '/<code.*?>.*?<span style="color: #[0-9A-F]+">.*?&lt;\?php/';
         $this->assertMatchesRegularExpression($pattern, $result[0]);
 
         $result = Debugger::excerpt(__FILE__, 11, 2);


### PR DESCRIPTION
PHP 8.3 seems to return
```
<pre><code style="color: #000000"><span style="color: #0000BB">&lt;?php</span></code></pre>
```
instead of
```
<code><span style="color: #000000"><span style="color: #0000BB">&lt;?php</span></span></code>
```
so I adjusted (and slightly optimized) the regex to match for both

With that our CI should be green again.