### PR TITLE
5.x: convert `returnCallback()` to `willReturnCallback()`

### DIFF
--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -485,9 +485,9 @@ class CommandRunnerTest extends TestCase
         $app->expects($this->once())
             ->method('pluginConsole')
             ->with($this->isinstanceOf(CommandCollection::class))
-            ->will($this->returnCallback(function ($commands) {
+            ->willReturnCallback(function ($commands) {
                 return $commands;
-            }));
+            });
         $app->expects($this->once())->method('routes');
         $app->expects($this->once())->method('pluginRoutes');
 

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -179,9 +179,9 @@ class SqliteTest extends TestCase
             ->getMock();
         $mock->expects($this->any())
             ->method('quote')
-            ->will($this->returnCallback(function ($value) {
+            ->willReturnCallback(function ($value) {
                 return '"' . $value . '"';
-            }));
+            });
 
         $driver = $this->getMockBuilder(Sqlite::class)
             ->onlyMethods(['createPdo'])

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1416,9 +1416,9 @@ SQL;
             ->getMock();
             $this->pdo->expects($this->any())
             ->method('quote')
-            ->will($this->returnCallback(function ($value) {
+            ->willReturnCallback(function ($value) {
                 return "'$value'";
-            }));
+            });
 
         $driver = $this->getMockBuilder(Mysql::class)
             ->onlyMethods(['createPdo'])

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -1386,9 +1386,9 @@ SQL;
             ->getMock();
         $mock->expects($this->any())
             ->method('quote')
-            ->will($this->returnCallback(function ($value) {
+            ->willReturnCallback(function ($value) {
                 return "'$value'";
-            }));
+            });
 
         $driver = $this->getMockBuilder(Postgres::class)
             ->setConstructorArgs([$config])

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -1111,9 +1111,9 @@ SQL;
             ->getMock();
         $this->pdo->expects($this->any())
             ->method('quote')
-            ->will($this->returnCallback(function ($value) {
+            ->willReturnCallback(function ($value) {
                 return '"' . $value . '"';
-            }));
+            });
 
         $driver = $this->getMockBuilder(Sqlite::class)
             ->onlyMethods(['createPdo'])

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -1146,9 +1146,9 @@ SQL;
             ->getMock();
         $mock->expects($this->any())
             ->method('quote')
-            ->will($this->returnCallback(function ($value) {
+            ->willReturnCallback(function ($value) {
                 return "'$value'";
-            }));
+            });
 
         $driver = $this->getMockBuilder(Sqlserver::class)
             ->onlyMethods(['createPdo'])

--- a/tests/TestCase/Http/ResponseEmitterTest.php
+++ b/tests/TestCase/Http/ResponseEmitterTest.php
@@ -50,7 +50,7 @@ class ResponseEmitterTest extends TestCase
 
         $this->emitter->expects($this->any())
             ->method('setCookie')
-            ->will($this->returnCallback(function ($cookie) {
+            ->willReturnCallback(function ($cookie) {
                 if (is_string($cookie)) {
                     $cookie = Cookie::createFromHeaderString($cookie, ['path' => '']);
                 }
@@ -59,7 +59,7 @@ class ResponseEmitterTest extends TestCase
                     + $cookie->getOptions();
 
                 return true;
-            }));
+            });
     }
 
     /**

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -138,9 +138,9 @@ class ServerTest extends TestCase
         $app->expects($this->once())
             ->method('pluginMiddleware')
             ->with($this->isInstanceOf(MiddlewareQueue::class))
-            ->will($this->returnCallback(function ($middleware) {
+            ->willReturnCallback(function ($middleware) {
                 return $middleware;
-            }));
+            });
 
         $server = new Server($app);
         $res = $server->run($request);

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -902,7 +902,7 @@ class SmtpTransportTest extends TestCase
         $callback = function ($arg): void {
             $this->assertNotEquals("QUIT\r\n", $arg);
         };
-        $this->socket->expects($this->any())->method('write')->will($this->returnCallback($callback));
+        $this->socket->expects($this->any())->method('write')->willReturnCallback($callback);
         $this->socket->expects($this->never())->method('disconnect');
         $this->SmtpTransport->disconnect();
     }
@@ -927,7 +927,7 @@ class SmtpTransportTest extends TestCase
 
             return 1;
         };
-        $this->socket->expects($this->any())->method('write')->will($this->returnCallback($callback));
+        $this->socket->expects($this->any())->method('write')->willReturnCallback($callback);
         $this->socket->expects($this->never())->method('disconnect');
 
         $this->socket->expects($this->exactly(11))

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -712,11 +712,11 @@ class BelongsToManyTest extends TestCase
 
         $joint->expects($this->once())
             ->method('save')
-            ->will($this->returnCallback(function (EntityInterface $e) {
+            ->willReturnCallback(function (EntityInterface $e) {
                 $this->assertSame('Plugin.ArticlesTags', $e->getSource());
 
                 return $e;
-            }));
+            });
 
         $this->assertTrue($assoc->link($entity, $tags));
         $this->assertSame($entity->tags, $tags);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -167,11 +167,11 @@ class EntityTest extends TestCase
             ->getMock();
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->name);
     }
@@ -187,18 +187,18 @@ class EntityTest extends TestCase
         $entity->setAccess('*', true);
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->expects($this->once())->method('_setStuff')
             ->with(['a', 'b'])
-            ->will($this->returnCallback(function ($stuff) {
+            ->willReturnCallback(function ($stuff) {
                 $this->assertEquals(['a', 'b'], $stuff);
 
                 return ['c', 'd'];
-            }));
+            });
         $entity->set(['name' => 'Jones', 'stuff' => ['a', 'b']]);
         $this->assertSame('Dr. Jones', $entity->name);
         $this->assertEquals(['c', 'd'], $entity->stuff);
@@ -309,9 +309,9 @@ class EntityTest extends TestCase
         $entity->expects($this->any())
             ->method('_getName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->get('name'));
         $this->assertSame('Dr. Jones', $entity->get('name'));
@@ -327,9 +327,9 @@ class EntityTest extends TestCase
             ->getMock();
         $entity->expects($this->any())
             ->method('_getName')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->get('name'));
         $this->assertSame('Dr. Jones', $entity->get('name'));
@@ -349,9 +349,9 @@ class EntityTest extends TestCase
             ->addMethods(['_getName'])
             ->getMock();
         $entity->expects($this->any())->method('_getName')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->get('name'));
 
@@ -368,9 +368,9 @@ class EntityTest extends TestCase
             ->addMethods(['_getListIdName'])
             ->getMock();
         $entity->expects($this->any())->method('_getListIdName')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function () {
                 return 'A name';
-            }));
+            });
         $entity->setVirtual(['ListIdName']);
         $this->assertSame('A name', $entity->list_id_name, 'underscored virtual field should be accessible');
         $this->assertSame('A name', $entity->listIdName, 'Camelbacked virtual field should be accessible');
@@ -398,11 +398,11 @@ class EntityTest extends TestCase
             ->getMock();
         $entity->expects($this->once())->method('_setName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->name = 'Jones';
         $this->assertSame('Dr. Jones', $entity->name);
     }
@@ -418,11 +418,11 @@ class EntityTest extends TestCase
         $entity->expects($this->once())
             ->method('_setName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->Name = 'Jones';
         $this->assertSame('Dr. Jones', $entity->Name);
     }
@@ -437,11 +437,11 @@ class EntityTest extends TestCase
             ->getMock();
         $entity->expects($this->once())->method('_getName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->name);
     }
@@ -457,11 +457,11 @@ class EntityTest extends TestCase
         $entity->expects($this->once())
             ->method('_getName')
             ->with('Jones')
-            ->will($this->returnCallback(function ($name) {
+            ->willReturnCallback(function ($name) {
                 $this->assertSame('Jones', $name);
 
                 return 'Dr. ' . $name;
-            }));
+            });
         $entity->set('Name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->Name);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3389,11 +3389,11 @@ class TableTest extends TestCase
         $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->any())
             ->method('dispatch')
-            ->will($this->returnCallback(function (EventInterface $event) {
+            ->willReturnCallback(function (EventInterface $event) {
                 $event->stopPropagation();
 
                 return $event;
-            }));
+            });
 
         $table = $this->getTableLocator()->get('users', ['eventManager' => $mock]);
         $entity->setNew(false);
@@ -3411,12 +3411,12 @@ class TableTest extends TestCase
         $mock = $this->getMockBuilder('Cake\Event\EventManager')->getMock();
         $mock->expects($this->any())
             ->method('dispatch')
-            ->will($this->returnCallback(function (EventInterface $event) {
+            ->willReturnCallback(function (EventInterface $event) {
                 $event->stopPropagation();
                 $event->setResult('got stopped');
 
                 return $event;
-            }));
+            });
 
         $table = $this->getTableLocator()->get('users', ['eventManager' => $mock]);
         $entity->setNew(false);

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -487,13 +487,13 @@ class RoutingMiddlewareTest extends TestCase
     {
         $mock = $this->createMock(Application::class);
         $mock->method('routes')
-            ->will($this->returnCallback(function (RouteBuilder $routes) {
+            ->willReturnCallback(function (RouteBuilder $routes) {
                 return $routes;
-            }));
+            });
 
         if ($handleCallback) {
             $mock->method('handle')
-                ->will($this->returnCallback($handleCallback));
+                ->willReturnCallback($handleCallback);
         }
 
         return $mock;

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1505,7 +1505,7 @@ class ValidatorTest extends TestCase
             ->addMethods(['isCool'])
             ->getMock();
         $thing->expects($this->once())->method('isCool')
-            ->will($this->returnCallback(function ($data, $context) use ($thing) {
+            ->willReturnCallback(function ($data, $context) use ($thing) {
                 $this->assertSame('bar', $data);
                 $expected = [
                     'default' => new RulesProvider(),
@@ -1523,7 +1523,7 @@ class ValidatorTest extends TestCase
                 $this->assertEquals($expected, $context);
 
                 return "That ain't cool, yo";
-            }));
+            });
 
         $validator->setProvider('thing', $thing);
         $errors = $validator->validate(['email' => '!', 'title' => 'bar']);
@@ -1549,7 +1549,7 @@ class ValidatorTest extends TestCase
             ->addMethods(['isCool'])
             ->getMock();
         $thing->expects($this->once())->method('isCool')
-            ->will($this->returnCallback(function ($data, $a, $b, $context) use ($thing) {
+            ->willReturnCallback(function ($data, $a, $b, $context) use ($thing) {
                 $this->assertSame('bar', $data);
                 $this->assertSame('and', $a);
                 $this->assertSame('awesome', $b);
@@ -1569,7 +1569,7 @@ class ValidatorTest extends TestCase
                 $this->assertEquals($expected, $context);
 
                 return "That ain't cool, yo";
-            }));
+            });
         $validator->setProvider('thing', $thing);
         $errors = $validator->validate(['email' => '!', 'title' => 'bar']);
         $expected = [


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17236
As mentioned by Sebastian himself in the linked PHPUnit Issue:

use `$double->willReturnCallback()` instead of `$double->will($this->returnCallback())`