### PR TITLE
5.x: convert `getObjectForTrait()` to anonymous class

### DIFF
--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -38,7 +38,9 @@ class StaticConfigTraitTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->subject = $this->getObjectForTrait(StaticConfigTrait::class);
+        $this->subject = new class {
+            use StaticConfigTrait;
+        };
     }
 
     /**
@@ -85,20 +87,19 @@ class StaticConfigTraitTest extends TestCase
     public function testGetConfigOrFail(): void
     {
         $className = get_class($this->subject);
-        $className::setConfig('foo', ['bar' => true]);
+        $className::setConfig('foo2', ['bar' => true]);
 
-        $result = $className::getConfigOrFail('foo');
+        $result = $className::getConfigOrFail('foo2');
         $this->assertSame(['bar' => true], $result);
     }
 
     public function testGetConfigOrFailException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected configuration `foo` not found.');
+        $this->expectExceptionMessage('Expected configuration `unknown` not found.');
 
         $className = get_class($this->subject);
-        $result = $className::getConfigOrFail('foo');
-        $this->assertSame('bar', $result);
+        $className::getConfigOrFail('unknown');
     }
 
     /**

--- a/tests/TestCase/Event/EventDispatcherTraitTest.php
+++ b/tests/TestCase/Event/EventDispatcherTraitTest.php
@@ -37,7 +37,9 @@ class EventDispatcherTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = $this->getObjectForTrait(EventDispatcherTrait::class);
+        $this->subject = new class {
+            use EventDispatcherTrait;
+        };
     }
 
     /**

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Log;
 
 use Cake\Log\Log;
+use Cake\Log\LogTrait;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -45,7 +46,9 @@ class LogTraitTest extends TestCase
             );
 
         Log::setConfig('trait_test', ['engine' => $mock]);
-        $subject = $this->getObjectForTrait('Cake\Log\LogTrait');
+        $subject = new class {
+            use LogTrait;
+        };
 
         $subject->log('Testing');
         $subject->log('message', 'debug');

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -41,7 +41,9 @@ class LocatorAwareTraitTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = $this->getObjectForTrait(LocatorAwareTrait::class);
+        $this->subject = new class {
+            use LocatorAwareTrait;
+        };
     }
 
     /**


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17236