### PR TITLE
5.x: convert `getMockForAbstractClass()` to anonymous class

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -28,6 +28,7 @@ use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\TestSuite\TestCase;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use stdClass;
+use TestApp\Cache\Engine\TestAppCacheEngine;
 
 /**
  * CacheTest class
@@ -259,7 +260,7 @@ class CacheTest extends TestCase
      */
     public function testConfigFailedInit(): void
     {
-        $mock = $this->getMockForAbstractClass('Cake\Cache\CacheEngine', [], '', true, true, true, ['init']);
+        $mock = $this->getMockBuilder(TestAppCacheEngine::class)->getMock();
         $mock->method('init')->willReturn(false);
         Cache::setConfig('tests', [
             'engine' => $mock,

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -20,6 +20,7 @@ use Cake\Console\CommandInterface;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Plugin;
 use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -38,10 +39,13 @@ class HelpCommandTest extends TestCase
         $this->setAppNamespace();
         Plugin::getCollection()->clear();
 
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            ['']
-        );
+        $app = new class ('') extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
         $app->addPlugin('TestPlugin');
     }
 

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -28,6 +28,7 @@ use Cake\Core\Configure;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use stdClass;
@@ -68,10 +69,13 @@ class CommandRunnerTest extends TestCase
      */
     public function testEventManagerProxies(): void
     {
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            [$this->config]
-        );
+        $app = new class ($this->config) extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
 
         $runner = new CommandRunner($app);
         $this->assertSame($app->getEventManager(), $runner->getEventManager());

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database;
 
-use Cake\Database\Driver;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Log\QueryLogger;
@@ -58,15 +57,9 @@ class DriverTest extends TestCase
             'scopes' => ['queriesLog'],
         ]);
 
-        $this->driver = $this->getMockForAbstractClass(
-            StubDriver::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['createPdo', 'prepare']
-        );
+        $this->driver = $this->getMockBuilder(StubDriver::class)
+            ->onlyMethods(['createPdo', 'prepare'])
+            ->getMock();
     }
 
     public function tearDown(): void
@@ -81,9 +74,8 @@ class DriverTest extends TestCase
      */
     public function testConstructorException(): void
     {
-        $arg = ['login' => 'Bear'];
         try {
-            $this->getMockForAbstractClass(Driver::class, [$arg]);
+            new StubDriver(['login' => 'Bear']);
         } catch (Exception $e) {
             $this->assertStringContainsString(
                 'Please pass "username" instead of "login" for connecting to the database',
@@ -97,14 +89,10 @@ class DriverTest extends TestCase
      */
     public function testConstructor(): void
     {
-        $arg = ['quoteIdentifiers' => true];
-        $driver = $this->getMockForAbstractClass(Driver::class, [$arg]);
-
+        $driver = new StubDriver(['quoteIdentifiers' => true]);
         $this->assertTrue($driver->isAutoQuotingEnabled());
 
-        $arg = ['username' => 'GummyBear'];
-        $driver = $this->getMockForAbstractClass(Driver::class, [$arg]);
-
+        $driver = new StubDriver(['username' => 'GummyBear']);
         $this->assertFalse($driver->isAutoQuotingEnabled());
     }
 
@@ -223,9 +211,9 @@ class DriverTest extends TestCase
             ->method('compile')
             ->willReturn('1');
 
-        $driver = $this->getMockBuilder(Driver::class)
+        $driver = $this->getMockBuilder(StubDriver::class)
             ->onlyMethods(['newCompiler', 'transformQuery'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $driver
             ->expects($this->once())
@@ -400,26 +388,15 @@ class DriverTest extends TestCase
 
     public function testGetLoggerDefault(): void
     {
-        $driver = $this->getMockForAbstractClass(
-            StubDriver::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['createPdo', 'prepare']
-        );
+        $driver = $this->getMockBuilder(StubDriver::class)
+            ->onlyMethods(['createPdo', 'prepare'])
+            ->getMock();
         $this->assertNull($driver->getLogger());
 
-        $driver = $this->getMockForAbstractClass(
-            StubDriver::class,
-            [['log' => true]],
-            '',
-            true,
-            true,
-            true,
-            ['createPdo']
-        );
+        $driver = $this->getMockBuilder(StubDriver::class)
+            ->setConstructorArgs([['log' => true]])
+            ->onlyMethods(['createPdo'])
+            ->getMock();
 
         $logger = $driver->getLogger();
         $this->assertInstanceOf(QueryLogger::class, $logger);
@@ -460,15 +437,10 @@ class DriverTest extends TestCase
                 true,
             );
 
-        $driver = $this->getMockForAbstractClass(
-            StubDriver::class,
-            [['log' => true]],
-            '',
-            true,
-            true,
-            true,
-            ['getPdo']
-        );
+        $driver = $this->getMockBuilder(StubDriver::class)
+            ->setConstructorArgs([['log' => true]])
+            ->onlyMethods(['getPdo'])
+            ->getMock();
 
         $driver->expects($this->any())
             ->method('getPdo')

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -23,7 +23,6 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
 use Cake\Database\Statement\Statement;
-use Cake\Database\StatementInterface;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\Test\TestCase\Database\QueryAssertsTrait;

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -22,12 +22,14 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query\SelectQuery;
 use Cake\Database\Query\UpdateQuery;
+use Cake\Database\Statement\Statement;
 use Cake\Database\StatementInterface;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
 use Cake\Test\TestCase\Database\QueryAssertsTrait;
 use Cake\TestSuite\TestCase;
 use DateTime;
+use PDOStatement;
 
 /**
  * Tests UpdateQuery class
@@ -329,9 +331,12 @@ class UpdateQueryTest extends TestCase
      */
     public function testRowCountAndClose(): void
     {
-        $statementMock = $this->getMockBuilder(StatementInterface::class)
+        $inner = $this->getMockBuilder(PDOStatement::class)->getMock();
+
+        $statementMock = $this->getMockBuilder(Statement::class)
+            ->setConstructorArgs([$inner, $this->connection->getDriver()])
             ->onlyMethods(['rowCount', 'closeCursor'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $statementMock->expects($this->once())
             ->method('rowCount')

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -86,7 +86,9 @@ class QueryTest extends TestCase
 
     protected function newQuery()
     {
-        return $this->getMockForAbstractClass(Query::class, [$this->connection]);
+        return new class ($this->connection) extends Query
+        {
+        };
     }
 
     /**

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -39,9 +39,9 @@ use TestPlugin\Plugin as TestPlugin;
 class BaseApplicationTest extends TestCase
 {
     /**
-     * @var string
+     * @var \Cake\Http\BaseApplication
      */
-    protected $path;
+    protected BaseApplication $app;
 
     /**
      * Setup
@@ -50,13 +50,23 @@ class BaseApplicationTest extends TestCase
     {
         parent::setUp();
         static::setAppNamespace();
-        $this->path = dirname(dirname(__DIR__));
+        $this->app = new class (dirname(__DIR__, 2)) extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
     }
 
+    /**
+     * @return void
+     */
     public function tearDown(): void
     {
         parent::tearDown();
         $this->clearPlugins();
+        unset($this->app);
     }
 
     /**
@@ -72,7 +82,7 @@ class BaseApplicationTest extends TestCase
             'pass' => [],
         ]);
 
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $result = $app->handle($request);
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertSame('Hello Jane', '' . $result->getBody());
@@ -87,7 +97,7 @@ class BaseApplicationTest extends TestCase
      */
     public function testAddPluginUnknownClass(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $app->addPlugin('PluginJs');
         $plugin = $app->getPlugins()->get('PluginJs');
         $this->assertInstanceOf(BasePlugin::class, $plugin);
@@ -108,7 +118,7 @@ class BaseApplicationTest extends TestCase
 
     public function testAddPluginValidShortName(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $app->addPlugin('TestPlugin');
 
         $this->assertCount(1, $app->getPlugins());
@@ -121,7 +131,7 @@ class BaseApplicationTest extends TestCase
 
     public function testAddPluginValid(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $app->addPlugin(TestPlugin::class);
 
         $this->assertCount(1, $app->getPlugins());
@@ -131,10 +141,7 @@ class BaseApplicationTest extends TestCase
     public function testPluginMiddleware(): void
     {
         $start = new MiddlewareQueue();
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            [$this->path]
-        );
+        $app = $this->app;
         $app->addPlugin(TestPlugin::class);
 
         $after = $app->pluginMiddleware($start);
@@ -146,10 +153,7 @@ class BaseApplicationTest extends TestCase
     {
         $collection = new RouteCollection();
         $routes = new RouteBuilder($collection, '/');
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            [$this->path]
-        );
+        $app = $this->app;
         $app->addPlugin(TestPlugin::class);
 
         $result = $app->pluginRoutes($routes);
@@ -165,10 +169,7 @@ class BaseApplicationTest extends TestCase
 
     public function testPluginBootstrap(): void
     {
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            [$this->path]
-        );
+        $app = $this->app;
         $app->addPlugin(TestPlugin::class);
 
         $this->assertFalse(Configure::check('PluginTest.test_plugin.bootstrap'));
@@ -182,10 +183,7 @@ class BaseApplicationTest extends TestCase
      */
     public function testPluginBootstrapRecursivePlugins(): void
     {
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            [$this->path]
-        );
+        $app = $this->app;
         $app->addPlugin('Named');
         $app->pluginBootstrap();
         $this->assertTrue(
@@ -209,7 +207,7 @@ class BaseApplicationTest extends TestCase
      */
     public function testAddOptionalPluginLoadingNonExistentPlugin(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $pluginCountBefore = count($app->getPlugins());
         $nonExistingPlugin = 'NonExistentPlugin';
         $app->addOptionalPlugin($nonExistingPlugin);
@@ -224,7 +222,7 @@ class BaseApplicationTest extends TestCase
      */
     public function testAddOptionalPluginLoadingNonExistentPluginValid(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $app->addOptionalPlugin(TestPlugin::class);
 
         $this->assertCount(1, $app->getPlugins());
@@ -233,7 +231,7 @@ class BaseApplicationTest extends TestCase
 
     public function testGetContainer(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $container = $app->getContainer();
 
         $this->assertInstanceOf(ContainerInterface::class, $container);
@@ -242,7 +240,7 @@ class BaseApplicationTest extends TestCase
 
     public function testBuildContainerEvent(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $called = false;
         $app->getEventManager()->on('Application.buildContainer', function ($event, $container) use (&$called): void {
             $this->assertInstanceOf(BaseApplication::class, $event->getSubject());
@@ -257,7 +255,7 @@ class BaseApplicationTest extends TestCase
 
     public function testBuildContainerEventReplaceContainer(): void
     {
-        $app = $this->getMockForAbstractClass(BaseApplication::class, [$this->path]);
+        $app = $this->app;
         $app->getEventManager()->on('Application.buildContainer', function (EventInterface $event) {
             $new = new Container();
             $new->add('testing', 'yes');

--- a/tests/TestCase/Http/MiddlewareApplicationTest.php
+++ b/tests/TestCase/Http/MiddlewareApplicationTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Http;
 
 use Cake\Http\MiddlewareApplication;
+use Cake\Http\MiddlewareQueue;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -48,7 +49,16 @@ class MiddlewareApplicationTest extends TestCase
             'pass' => [],
         ]);
 
-        $app = $this->getMockForAbstractClass(MiddlewareApplication::class);
+        $app = new class extends MiddlewareApplication {
+            public function bootstrap(): void
+            {
+            }
+
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
         $result = $app->handle($request);
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertSame('Not found', '' . $result->getBody());

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -305,11 +305,13 @@ class ServerTest extends TestCase
      */
     public function testEventManagerProxies(): void
     {
-        /** @var \Cake\Http\BaseApplication|\PHPUnit\Framework\MockObject\MockObject $app */
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            [$this->config]
-        );
+        $app = new class ($this->config) extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
 
         $server = new Server($app);
         $this->assertSame($app->getEventManager(), $server->getEventManager());

--- a/tests/TestCase/I18n/TranslatorRegistryTest.php
+++ b/tests/TestCase/I18n/TranslatorRegistryTest.php
@@ -24,6 +24,7 @@ use Cake\I18n\PackageLocator;
 use Cake\I18n\Translator;
 use Cake\I18n\TranslatorRegistry;
 use Cake\TestSuite\TestCase;
+use TestApp\Cache\Engine\TestAppCacheEngine;
 
 class TranslatorRegistryTest extends TestCase
 {
@@ -36,7 +37,7 @@ class TranslatorRegistryTest extends TestCase
         $package = $this->getMockBuilder(Package::class)->getMock();
         $formatter = $this->getMockBuilder(SprintfFormatter::class)->getMock();
         $formatterLocator = $this->getMockBuilder(FormatterLocator::class)->getMock();
-        $cacheEngineNullPackage = $this->getMockForAbstractClass('Cake\Cache\CacheEngine', [], '', true, true, true, ['read']);
+        $cacheEngineNullPackage = $this->getMockBuilder(TestAppCacheEngine::class)->getMock();
         $translatorNullPackage = $this->getMockBuilder(Translator::class)->disableOriginalConstructor()->getMock();
 
         $translatorNonNullPackage = $this->getMockBuilder(Translator::class)->disableOriginalConstructor()->getMock();
@@ -56,7 +57,7 @@ class TranslatorRegistryTest extends TestCase
             ->willReturn($package);
 
         $cacheEngineNullPackage
-            ->method('read')
+            ->method('get')
             ->willReturn($translatorNullPackage);
 
         $registry = new TranslatorRegistry($packageLocator, $formatterLocator, 'en_CA');

--- a/tests/test_app/TestApp/Database/Driver/StubDriver.php
+++ b/tests/test_app/TestApp/Database/Driver/StubDriver.php
@@ -16,11 +16,39 @@ declare(strict_types=1);
 namespace TestApp\Database\Driver;
 
 use Cake\Database\Driver;
+use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Schema\SchemaDialect;
+use Cake\Database\Schema\SqliteSchemaDialect;
 
-abstract class StubDriver extends Driver
+class StubDriver extends Driver
 {
     public function connect(): void
     {
         $this->pdo = $this->createPdo('', []);
+    }
+
+    public function enabled(): bool
+    {
+        return true;
+    }
+
+    public function disableForeignKeySQL(): string
+    {
+        return '';
+    }
+
+    public function enableForeignKeySQL(): string
+    {
+        return '';
+    }
+
+    public function schemaDialect(): SchemaDialect
+    {
+        return new SqliteSchemaDialect($this);
+    }
+
+    public function supports(DriverFeatureEnum $feature): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17236

Haven't touched the DriverTest yet because it has the majority of the remaining `getMockForAbstractClass()` calls.
Besides that there are a few others remaining which get a mock for `CacheEngine` or `StatementInterface` which I haven't looked at yet.