### PR TITLE
[5.0] ValidationSet::$_allowEmpty set to null by default

### DIFF
--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -146,7 +146,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
         }
         $this->_rules[$name] = $rule;
 
-        if (null === $this->_allowEmpty) {
+        if ($this->_allowEmpty === null) {
             $this->_allowEmpty = false;
         }
 

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -48,9 +48,9 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
     /**
      * Denotes if a field is allowed to be empty
      *
-     * @var callable|string|bool
+     * @var callable|string|bool|null
      */
-    protected $_allowEmpty = false;
+    protected $_allowEmpty;
 
     /**
      * Returns whether a field can be left out.
@@ -82,7 +82,7 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      */
     public function isEmptyAllowed(): callable|string|bool
     {
-        return $this->_allowEmpty;
+        return $this->_allowEmpty ?? true;
     }
 
     /**
@@ -145,6 +145,10 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
             $rule = new ValidationRule($rule);
         }
         $this->_rules[$name] = $rule;
+
+        if (null === $this->_allowEmpty) {
+            $this->_allowEmpty = false;
+        }
 
         return $this;
     }

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -215,7 +215,7 @@ class ValidationSetTest extends TestCase
     {
         $set = new ValidationSet();
 
-        $this->assertFalse($set->isEmptyAllowed());
+        $this->assertTrue($set->isEmptyAllowed());
 
         $set->allowEmpty(true);
         $this->assertTrue($set->isEmptyAllowed());

--- a/tests/TestCase/Validation/ValidationSetTest.php
+++ b/tests/TestCase/Validation/ValidationSetTest.php
@@ -217,10 +217,10 @@ class ValidationSetTest extends TestCase
 
         $this->assertTrue($set->isEmptyAllowed());
 
-        $set->allowEmpty(true);
-        $this->assertTrue($set->isEmptyAllowed());
-
         $set->allowEmpty(false);
         $this->assertFalse($set->isEmptyAllowed());
+
+        $set->allowEmpty(true);
+        $this->assertTrue($set->isEmptyAllowed());
     }
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -202,7 +202,7 @@ class ValidatorTest extends TestCase
     public function testAddNestedManyWithExtra(): void
     {
         $inner = new Validator();
-        $inner->requirePresence('body');
+        $inner->notEmptyString('body');
 
         $validator = new Validator();
         $validator->addNestedMany('comments', $inner, 'errors found', 'create');
@@ -1792,7 +1792,7 @@ class ValidatorTest extends TestCase
                 ],
                 'body' => [
                     'isPresenceRequired' => true,
-                    'isEmptyAllowed' => false,
+                    'isEmptyAllowed' => true,
                     'rules' => [],
                 ],
                 'published' => [

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -943,8 +943,8 @@ class EntityContextTest extends TestCase
             'table' => 'Articles',
         ]);
 
-        $this->assertTrue($context->isRequired('tags.0._joinData.article_id'));
-        $this->assertTrue($context->isRequired('tags.0._joinData.tag_id'));
+        $this->assertFalse($context->isRequired('tags.0._joinData.article_id'));
+        $this->assertFalse($context->isRequired('tags.0._joinData.tag_id'));
     }
 
     /**

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -140,7 +140,7 @@ class FormContextTest extends TestCase
         $context = new FormContext([
             'entity' => $form,
         ]);
-        $this->assertTrue($context->isRequired('name'));
+        $this->assertFalse($context->isRequired('name'));
         $this->assertTrue($context->isRequired('email'));
         $this->assertNull($context->isRequired('body'));
         $this->assertNull($context->isRequired('Prefix.body'));


### PR DESCRIPTION
Fix for #15699

`ValidationSet::$_allowEmpty` is set to `null` by default.

It means that no any rule added and `isEmptyAllowed()` will return `true` in this case.
But once the first rule is added, `ValidationSet::$_allowEmpty` is set to `false`, if it was not changed earlier by `notEmpty*()` call.