### PR TITLE
5.x: Convert `addMethods()` to anonymous or test classes or Mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",
         "mikey179/vfsstream": "^1.6.10",
+        "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3",
         "phpunit/phpunit": "^10.1.0"
     },

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -37,6 +37,7 @@ use Cake\Utility\Inflector;
 use Closure;
 use Exception;
 use LogicException;
+use Mockery;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
@@ -225,6 +226,7 @@ abstract class TestCase extends BaseTestCase
         $this->getTableLocator()->clear();
         $this->_configure = [];
         $this->_tableLocator = null;
+        Mockery::close();
     }
 
     /**

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -2606,11 +2606,17 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = (new Collection($items))->lazy();
-        $callable = $this->getMockBuilder(stdClass::class)
-            ->addMethods(['__invoke'])
+        $callable = $this->getMockBuilder(stdMock::class)
             ->getMock();
 
         $callable->expects($this->never())->method('__invoke');
         $collection->filter($callable)->filter($callable);
     }
 }
+
+// phpcs:disable
+class stdMock extends stdClass
+{
+    public function __invoke() {}
+}
+// phpcs:enable

--- a/tests/TestCase/Command/PluginAssetsCommandsTest.php
+++ b/tests/TestCase/Command/PluginAssetsCommandsTest.php
@@ -24,6 +24,7 @@ use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Filesystem;
+use Mockery;
 use SplFileInfo;
 
 /**
@@ -111,10 +112,7 @@ class PluginAssetsCommandsTest extends TestCase
         $this->loadPlugins(['TestTheme']);
 
         $output = new StubConsoleOutput();
-        $io = $this->getMockBuilder(ConsoleIo::class)
-            ->setConstructorArgs([$output, $output, null, null])
-            ->addMethods(['in'])
-            ->getMock();
+        $io = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
         $parser = new ConsoleOptionParser('cake example');
         $parser->addArgument('name', ['required' => false]);
         $parser->addOption('overwrite', ['default' => false, 'boolean' => true]);

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -31,6 +31,7 @@ use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use stdClass;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\DemoCommand;
@@ -531,11 +532,8 @@ class CommandRunnerTest extends TestCase
 
     protected function getMockIo(StubConsoleOutput $output): ConsoleIo
     {
-        $io = $this->getMockBuilder(ConsoleIo::class)
-            ->setConstructorArgs([$output, $output, null, null])
-            ->addMethods(['in'])
-            ->getMock();
-
-        return $io;
+        return Mockery::mock(ConsoleIo::class, [$output, $output, null, null])
+            ->shouldAllowMockingMethod('in')
+            ->makePartial();
     }
 }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -26,6 +26,7 @@ use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use TestApp\Command\AbortCommand;
 use TestApp\Command\AutoLoadModelCommand;
 use TestApp\Command\DemoCommand;
@@ -305,15 +306,10 @@ class CommandTest extends TestCase
 
     /**
      * @param \Cake\Console\ConsoleOutput $output
-     * @return \Cake\Console\ConsoleIo|\PHPUnit\Framework\MockObject\MockObject
+     * @return \Cake\Console\ConsoleIo|\Mockery\MockInterface
      */
     protected function getMockIo($output)
     {
-        $io = $this->getMockBuilder(ConsoleIo::class)
-            ->setConstructorArgs([$output, $output, null, null])
-            ->addMethods(['in'])
-            ->getMock();
-
-        return $io;
+        return Mockery::mock(ConsoleIo::class, [$output, $output, null, null])->makePartial();
     }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1087,10 +1087,10 @@ class ConnectionTest extends TestCase
 
         $newDriver->expects($this->exactly(2))
             ->method('execute')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->throwException(new Exception('server gone away')),
-                $this->returnValue($statement)
-            ));
+                $statement
+            );
 
         $res = $conn->execute('SELECT 1');
         $this->assertInstanceOf(StatementInterface::class, $res);

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -21,6 +21,7 @@ use Cake\Database\Driver\Sqlite;
 use Cake\Database\DriverFeatureEnum;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use PDO;
 
 /**
@@ -172,14 +173,11 @@ class SqliteTest extends TestCase
      */
     public function testSchemaValue($input, $expected): void
     {
-        $mock = $this->getMockBuilder(PDO::class)
-            ->onlyMethods(['quote'])
-            ->addMethods(['quoteIdentifier'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mock->expects($this->any())
-            ->method('quote')
-            ->willReturnCallback(function ($value) {
+        $mock = Mockery::mock(PDO::class)
+            ->shouldAllowMockingMethod('quoteIdentifier')
+            ->makePartial();
+        $mock->shouldReceive('quote')
+            ->andReturnUsing(function ($value) {
                 return '"' . $value . '"';
             });
 

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -1409,9 +1409,8 @@ SQL;
     {
         $this->_needsConnection();
 
-        $this->pdo = $this->getMockBuilder(PDO::class)
-            ->onlyMethods(['quote', 'getAttribute'])
-            ->addMethods(['quoteIdentifier'])
+        $this->pdo = $this->getMockBuilder(PDOMocked::class)
+            ->onlyMethods(['quote', 'getAttribute', 'quoteIdentifier'])
             ->disableOriginalConstructor()
             ->getMock();
             $this->pdo->expects($this->any())
@@ -1433,3 +1432,10 @@ SQL;
         return $driver;
     }
 }
+
+// phpcs:disable
+class PDOMocked extends PDO
+{
+    public function quoteIdentifier(): void {}
+}
+// phpcs:enable

--- a/tests/TestCase/Database/Type/StringTypeTest.php
+++ b/tests/TestCase/Database/Type/StringTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Driver;
 use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 use PDO;
 
 /**
@@ -62,10 +63,8 @@ class StringTypeTest extends TestCase
      */
     public function testToDatabase(): void
     {
-        $obj = $this->getMockBuilder('StdClass')
-            ->addMethods(['__toString'])
-            ->getMock();
-        $obj->method('__toString')->willReturn('toString called');
+        $obj = Mockery::mock('StdClass')->shouldAllowMockingMethod('__toString');
+        $obj->shouldReceive('__toString')->andReturn('toString called');
 
         $this->assertNull($this->type->toDatabase(null, $this->driver));
         $this->assertSame('word', $this->type->toDatabase('word', $this->driver));

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -1287,7 +1287,6 @@ trait PaginatorTestTrait
         /** @var \Cake\ORM\Query\SelectQuery|\PHPUnit\Framework\MockObject\MockObject $query */
         $query = $this->getMockBuilder(SelectQuery::class)
             ->onlyMethods(['all', 'count', 'applyOptions'])
-            ->addMethods(['total'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/TestCase/Form/FormTest.php
+++ b/tests/TestCase/Form/FormTest.php
@@ -52,12 +52,7 @@ class FormTest extends TestCase
      */
     public function testGetValidator(): void
     {
-        $form = $this->getMockBuilder(Form::class)
-            ->addMethods(['buildValidator'])
-            ->getMock();
-
-        $form->expects($this->once())
-            ->method('buildValidator');
+        $form = new Form();
 
         $this->assertInstanceof(Validator::class, $form->getValidator());
     }

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -30,6 +30,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\Response as LaminasResponse;
 use Laminas\Diactoros\ServerRequest as LaminasServerRequest;
+use Mockery;
 use Psr\Http\Message\ResponseInterface;
 use TestApp\Http\MiddlewareApplication;
 
@@ -127,18 +128,13 @@ class ServerTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withHeader('X-pass', 'request header');
 
-        /** @var \TestApp\Http\MiddlewareApplication|\PHPUnit\Framework\MockObject\MockObject $app */
-        $app = $this->getMockBuilder(MiddlewareApplication::class)
-            ->onlyMethods(['pluginBootstrap', 'pluginMiddleware'])
-            ->addMethods(['pluginEvents'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-        $app->expects($this->once())
-            ->method('pluginBootstrap');
-        $app->expects($this->once())
-            ->method('pluginMiddleware')
-            ->with($this->isInstanceOf(MiddlewareQueue::class))
-            ->willReturnCallback(function ($middleware) {
+        /** @var \TestApp\Http\MiddlewareApplication|\Mockery\MockInterface $app */
+        $app = Mockery::mock(MiddlewareApplication::class, [$this->config])
+            ->shouldAllowMockingMethod('pluginEvents')
+            ->makePartial();
+        $app->shouldReceive('pluginBootstrap', 'pluginMiddleware')
+            ->with(Mockery::type(MiddlewareQueue::class))
+            ->andReturnUsing(function ($middleware) {
                 return $middleware;
             });
 

--- a/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
+++ b/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
@@ -21,7 +21,7 @@ class MailerDefaultProfileRestorationTest extends TestCase
 {
     public function testSendAction(): void
     {
-        $mailer = $this->getMockBuilder(CustomMailer::class)
+        $mailer = $this->getMockBuilder(DefaultProfileRestorationMailer::class)
             ->onlyMethods(['deliver', 'test'])
             ->setConstructorArgs([['template' => 'cakephp']])
             ->getMock();
@@ -38,7 +38,7 @@ class MailerDefaultProfileRestorationTest extends TestCase
 }
 
 // phpcs:disable
-class CustomMailer extends Mailer
+class DefaultProfileRestorationMailer extends Mailer
 {
     public function test($to, $subject)
     {

--- a/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
+++ b/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
@@ -37,9 +37,11 @@ class MailerDefaultProfileRestorationTest extends TestCase
     }
 }
 
+// phpcs:disable
 class CustomMailer extends Mailer
 {
     public function test($to, $subject)
     {
     }
 }
+// phpcs:enable

--- a/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
+++ b/tests/TestCase/Mailer/MailerDefaultProfileRestorationTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Mailer;
+
+use Cake\Mailer\Mailer;
+use Cake\TestSuite\TestCase;
+
+class MailerDefaultProfileRestorationTest extends TestCase
+{
+    public function testSendAction(): void
+    {
+        $mailer = $this->getMockBuilder(CustomMailer::class)
+            ->onlyMethods(['deliver', 'test'])
+            ->setConstructorArgs([['template' => 'cakephp']])
+            ->getMock();
+        $mailer->expects($this->once())
+            ->method('test')
+            ->with('foo', 'bar');
+        $mailer->expects($this->once())
+            ->method('deliver')
+            ->willReturn([]);
+
+        $mailer->send('test', ['foo', 'bar']);
+        $this->assertSame('cakephp', $mailer->viewBuilder()->getTemplate());
+    }
+}
+
+class CustomMailer extends Mailer
+{
+    public function test($to, $subject)
+    {
+    }
+}

--- a/tests/TestCase/Mailer/MailerSendActionTest.php
+++ b/tests/TestCase/Mailer/MailerSendActionTest.php
@@ -21,7 +21,7 @@ class MailerSendActionTest extends TestCase
 {
     public function testSendAction(): void
     {
-        $mailer = $this->getMockBuilder(CustomMailer::class)
+        $mailer = $this->getMockBuilder(SendActionMailer::class)
             ->onlyMethods(['deliver', 'test'])
             ->getMock();
         $mailer->expects($this->once())
@@ -38,7 +38,7 @@ class MailerSendActionTest extends TestCase
 }
 
 // phpcs:disable
-class CustomMailer extends Mailer
+class SendActionMailer extends Mailer
 {
     public function test($to, $subject)
     {

--- a/tests/TestCase/Mailer/MailerSendActionTest.php
+++ b/tests/TestCase/Mailer/MailerSendActionTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Mailer;
+
+use Cake\Mailer\Mailer;
+use Cake\TestSuite\TestCase;
+
+class MailerSendActionTest extends TestCase
+{
+    public function testSendAction(): void
+    {
+        $mailer = $this->getMockBuilder(CustomMailer::class)
+            ->onlyMethods(['deliver', 'test'])
+            ->getMock();
+        $mailer->expects($this->once())
+            ->method('test')
+            ->with('foo', 'bar');
+        $mailer->expects($this->any())
+            ->method('deliver')
+            ->willReturn([]);
+
+        $mailer->send('test', ['foo', 'bar']);
+
+        $this->assertNull($mailer->viewBuilder()->getTemplate());
+    }
+}
+
+class CustomMailer extends Mailer
+{
+    public function test($to, $subject)
+    {
+    }
+}

--- a/tests/TestCase/Mailer/MailerSendActionTest.php
+++ b/tests/TestCase/Mailer/MailerSendActionTest.php
@@ -37,9 +37,11 @@ class MailerSendActionTest extends TestCase
     }
 }
 
+// phpcs:disable
 class CustomMailer extends Mailer
 {
     public function test($to, $subject)
     {
     }
 }
+// phpcs:enable

--- a/tests/TestCase/Mailer/MailerSendFailsEmailIsReset.php
+++ b/tests/TestCase/Mailer/MailerSendFailsEmailIsReset.php
@@ -22,7 +22,7 @@ class MailerSendFailsEmailIsReset extends TestCase
 {
     public function testSendAction(): void
     {
-        $mailer = $this->getMockBuilder(CustomMailer::class)
+        $mailer = $this->getMockBuilder(SendFailsEmailIsResetMailer::class)
             ->onlyMethods(['restore', 'deliver', 'welcome'])
             ->getMock();
 
@@ -43,7 +43,7 @@ class MailerSendFailsEmailIsReset extends TestCase
 }
 
 // phpcs:disable
-class CustomMailer extends Mailer
+class SendFailsEmailIsResetMailer extends Mailer
 {
     public function welcome()
     {

--- a/tests/TestCase/Mailer/MailerSendFailsEmailIsReset.php
+++ b/tests/TestCase/Mailer/MailerSendFailsEmailIsReset.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Mailer;
+
+use Cake\Mailer\Mailer;
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+class MailerSendFailsEmailIsReset extends TestCase
+{
+    public function testSendAction(): void
+    {
+        $mailer = $this->getMockBuilder(CustomMailer::class)
+            ->onlyMethods(['restore', 'deliver', 'welcome'])
+            ->getMock();
+
+        $mailer->expects($this->once())
+            ->method('deliver')
+            ->will($this->throwException(new RuntimeException('kaboom')));
+        // Mailer should be reset even if sending fails.
+        $mailer->expects($this->once())
+            ->method('restore');
+
+        try {
+            $mailer->send('welcome', ['foo', 'bar']);
+            $this->fail('Exception should bubble up.');
+        } catch (RuntimeException $e) {
+            $this->assertTrue(true, 'Exception was raised');
+        }
+    }
+}
+
+class CustomMailer extends Mailer
+{
+    public function welcome()
+    {
+    }
+}

--- a/tests/TestCase/Mailer/MailerSendFailsEmailIsReset.php
+++ b/tests/TestCase/Mailer/MailerSendFailsEmailIsReset.php
@@ -42,9 +42,11 @@ class MailerSendFailsEmailIsReset extends TestCase
     }
 }
 
+// phpcs:disable
 class CustomMailer extends Mailer
 {
     public function welcome()
     {
     }
 }
+// phpcs:enable

--- a/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
+++ b/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Mailer;
+
+use Cake\Mailer\Mailer;
+use Cake\TestSuite\TestCase;
+
+class MailerSendWithUnsetTemplateDefaultsToActionNameTest extends TestCase
+{
+    public function testSendAction(): void
+    {
+        $mailer = $this->getMockBuilder(CustomMailer::class)
+            ->onlyMethods(['deliver', 'restore', 'test'])
+            ->getMock();
+        $mailer->expects($this->once())
+            ->method('test')
+            ->with('foo', 'bar');
+        $mailer->expects($this->any())
+            ->method('deliver')
+            ->willReturn([]);
+
+        $mailer->send('test', ['foo', 'bar']);
+        $this->assertSame('test', $mailer->viewBuilder()->getTemplate());
+    }
+}
+
+class CustomMailer extends Mailer
+{
+    public function test($to, $subject)
+    {
+    }
+}

--- a/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
+++ b/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
@@ -21,7 +21,7 @@ class MailerSendWithUnsetTemplateDefaultsToActionNameTest extends TestCase
 {
     public function testSendAction(): void
     {
-        $mailer = $this->getMockBuilder(CustomMailer::class)
+        $mailer = $this->getMockBuilder(SendWithUnsetTemplateDefaultsToActionNameMailer::class)
             ->onlyMethods(['deliver', 'restore', 'test'])
             ->getMock();
         $mailer->expects($this->once())
@@ -37,7 +37,7 @@ class MailerSendWithUnsetTemplateDefaultsToActionNameTest extends TestCase
 }
 
 // phpcs:disable
-class CustomMailer extends Mailer
+class SendWithUnsetTemplateDefaultsToActionNameMailer extends Mailer
 {
     public function test($to, $subject)
     {

--- a/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
+++ b/tests/TestCase/Mailer/MailerSendWithUnsetTemplateDefaultsToActionNameTest.php
@@ -36,9 +36,11 @@ class MailerSendWithUnsetTemplateDefaultsToActionNameTest extends TestCase
     }
 }
 
+// phpcs:disable
 class CustomMailer extends Mailer
 {
     public function test($to, $subject)
     {
     }
 }
+// phpcs:enable

--- a/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManySaveAssociatedOnlyEntitiesAppendTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM\Association;
+
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Association\BelongsToMany;
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Tests BelongsToManySaveAssociatedOnlyEntitiesAppendTest class
+ */
+class BelongsToManySaveAssociatedOnlyEntitiesAppendTest extends TestCase
+{
+    /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $tag;
+
+    /**
+     * @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $article;
+
+    /**
+     * Set up
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->tag = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['find', 'delete'])
+            ->setConstructorArgs([['alias' => 'Tags', 'table' => 'tags']])
+            ->getMock();
+        $this->tag->setSchema([
+            'id' => ['type' => 'integer'],
+            'name' => ['type' => 'string'],
+            '_constraints' => [
+                'primary' => ['type' => 'primary', 'columns' => ['id']],
+            ],
+        ]);
+        $this->article = $this->getMockBuilder(Table::class)
+            ->onlyMethods(['find', 'delete'])
+            ->setConstructorArgs([['alias' => 'Articles', 'table' => 'articles']])
+            ->getMock();
+        $this->article->setSchema([
+            'id' => ['type' => 'integer'],
+            'name' => ['type' => 'string'],
+            '_constraints' => [
+                'primary' => ['type' => 'primary', 'columns' => ['id']],
+            ],
+        ]);
+    }
+
+    /**
+     * Test that saveAssociated() ignores non entity values.
+     */
+    public function testSaveAssociatedOnlyEntitiesAppend(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $table = $this->getMockBuilder(MockedTable::class)
+            ->setConstructorArgs([['table' => 'tags', 'connection' => $connection]])
+            ->getMock();
+        $table->setPrimaryKey('id');
+
+        $config = [
+            'sourceTable' => $this->article,
+            'targetTable' => $table,
+            'saveStrategy' => BelongsToMany::SAVE_APPEND,
+        ];
+
+        $entity = new Entity([
+            'id' => 1,
+            'title' => 'First Post',
+            'tags' => [
+                ['tag' => 'nope'],
+                new Entity(['tag' => 'cakephp']),
+            ],
+        ]);
+
+        $table->expects($this->never())
+            ->method('saveAssociated');
+
+        $association = new BelongsToMany('Tags', $config);
+        $association->saveAssociated($entity);
+    }
+}
+
+// phpcs:disable
+class MockedTable extends Table
+{
+    public function saveAssociated() {}
+    public function schema() {}
+}
+// phpcs:enable

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1329,41 +1329,6 @@ class BelongsToManyTest extends TestCase
     }
 
     /**
-     * Test that saveAssociated() ignores non entity values.
-     */
-    public function testSaveAssociatedOnlyEntitiesAppend(): void
-    {
-        $connection = ConnectionManager::get('test');
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
-        $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['saveAssociated', 'schema'])
-            ->setConstructorArgs([['table' => 'tags', 'connection' => $connection]])
-            ->getMock();
-        $table->setPrimaryKey('id');
-
-        $config = [
-            'sourceTable' => $this->article,
-            'targetTable' => $table,
-            'saveStrategy' => BelongsToMany::SAVE_APPEND,
-        ];
-
-        $entity = new Entity([
-            'id' => 1,
-            'title' => 'First Post',
-            'tags' => [
-                ['tag' => 'nope'],
-                new Entity(['tag' => 'cakephp']),
-            ],
-        ]);
-
-        $table->expects($this->never())
-            ->method('saveAssociated');
-
-        $association = new BelongsToMany('Tags', $config);
-        $association->saveAssociated($entity);
-    }
-
-    /**
      * Tests that setTargetForeignKey() returns the correct configured value
      */
     public function testSetTargetForeignKey(): void

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -658,26 +658,7 @@ class BelongsToManyTest extends TestCase
 
         $joint->expects($this->exactly(2))
             ->method('save')
-            ->will(
-                $this->onConsecutiveCalls(
-                    $this->returnCallback(function (EntityInterface $e, $opts) use ($entity) {
-                        $expected = ['article_id' => 1, 'tag_id' => 2];
-                        $this->assertEquals($expected, $e->toArray());
-                        $this->assertEquals(['foo' => 'bar'], $opts);
-                        $this->assertTrue($e->isNew());
-
-                        return $entity;
-                    }),
-                    $this->returnCallback(function (EntityInterface $e, $opts) use ($entity) {
-                        $expected = ['article_id' => 1, 'tag_id' => 3];
-                        $this->assertEquals($expected, $e->toArray());
-                        $this->assertEquals(['foo' => 'bar'], $opts);
-                        $this->assertTrue($e->isNew());
-
-                        return $entity;
-                    })
-                )
-            );
+            ->willReturnOnConsecutiveCalls($entity, $entity);
 
         $this->assertTrue($assoc->link($entity, $tags, $saveOptions));
         $this->assertSame($entity->test, $tags);

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -27,6 +27,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query\SelectQuery;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 
 /**
  * Tests BelongsTo class
@@ -314,16 +315,14 @@ class BelongsToTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['saveAssociated'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mock = Mockery::mock('Cake\ORM\Table')
+            ->shouldAllowMockingMethod('saveAssociated')
+            ->makePartial();
         $config = [
             'sourceTable' => $this->client,
             'targetTable' => $mock,
         ];
-        $mock->expects($this->never())
-            ->method('saveAssociated');
+        $mock->shouldNotReceive('saveAssociated');
 
         $entity = new Entity([
             'title' => 'A Title',

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -29,6 +29,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 use function Cake\I18n\__;
 
 /**
@@ -625,10 +626,9 @@ class HasManyTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['saveAssociated'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mock = Mockery::mock('Cake\ORM\Table')
+            ->shouldAllowMockingMethod('saveAssociated')
+            ->makePartial();
         $config = [
             'sourceTable' => $this->author,
             'targetTable' => $mock,
@@ -643,11 +643,11 @@ class HasManyTest extends TestCase
             ],
         ]);
 
-        $mock->expects($this->never())
-            ->method('saveAssociated');
+        $mock->shouldNotReceive('saveAssociated');
 
         $association = new HasMany('Articles', $config);
-        $association->saveAssociated($entity);
+        $result = $association->saveAssociated($entity);
+        $this->assertSame($result, $entity);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -24,6 +24,7 @@ use Cake\Database\TypeMap;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use Mockery;
 
 /**
  * Tests HasOne class
@@ -225,16 +226,14 @@ class HasOneTest extends TestCase
      */
     public function testSaveAssociatedOnlyEntities(): void
     {
-        $mock = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['saveAssociated'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mock = Mockery::mock('Cake\ORM\Table')
+            ->shouldAllowMockingMethod('saveAssociated')
+            ->makePartial();
         $config = [
             'sourceTable' => $this->user,
             'targetTable' => $mock,
         ];
-        $mock->expects($this->never())
-            ->method('saveAssociated');
+        $mock->shouldNotReceive('saveAssociated');
 
         $entity = new Entity([
             'username' => 'Mark',

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM;
 
 use Cake\Database\Exception\DatabaseException;
 use Cake\TestSuite\TestCase;
+use Mockery;
 
 /**
  * Tests the features related to proxying methods from the Association
@@ -163,16 +164,15 @@ class AssociationProxyTest extends TestCase
     public function testAssociationMethodProxy(): void
     {
         $articles = $this->getTableLocator()->get('articles');
-        $mock = $this->getMockBuilder('Cake\ORM\Table')
-            ->addMethods(['crazy'])
-            ->getMock();
+        $mock = Mockery::mock('Cake\ORM\Table')
+            ->shouldAllowMockingMethod('crazy');
         $articles->belongsTo('authors', [
             'targetTable' => $mock,
         ]);
 
-        $mock->expects($this->once())->method('crazy')
+        $mock->shouldReceive('crazy')
             ->with('a', 'b')
-            ->willReturn('thing');
+            ->andReturn('thing');
         $this->assertSame('thing', $articles->authors->crazy('a', 'b'));
     }
 }

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -23,6 +23,7 @@ use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use LogicException;
+use Mockery;
 
 /**
  * Test case for BehaviorRegistry.
@@ -257,17 +258,12 @@ class BehaviorRegistryTest extends TestCase
     public function testCall(): void
     {
         $this->Behaviors->load('Sluggable');
-        $mockedBehavior = $this->getMockBuilder('Cake\ORM\Behavior')
-            ->addMethods(['slugify'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockedBehavior = Mockery::mock('Cake\ORM\Behavior')->makePartial();
         $this->Behaviors->set('Sluggable', $mockedBehavior);
 
-        $mockedBehavior
-            ->expects($this->once())
-            ->method('slugify')
+        $mockedBehavior->shouldReceive('slugify')
             ->with(['some value'])
-            ->willReturn('some-thing');
+            ->andReturn('some-thing');
         $return = $this->Behaviors->call('slugify', [['some value']]);
         $this->assertSame('some-thing', $return);
     }
@@ -292,18 +288,16 @@ class BehaviorRegistryTest extends TestCase
     public function testCallFinder(): void
     {
         $this->Behaviors->load('Sluggable');
-        $mockedBehavior = $this->getMockBuilder('Cake\ORM\Behavior')
-            ->addMethods(['findNoSlug'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockedBehavior = Mockery::mock('Cake\ORM\Behavior')
+            ->shouldAllowMockingMethod('findNoSlug')
+            ->makePartial();
         $this->Behaviors->set('Sluggable', $mockedBehavior);
 
         $query = new SelectQuery($this->Table);
-        $mockedBehavior
-            ->expects($this->once())
-            ->method('findNoSlug')
+        $mockedBehavior->shouldReceive('findNoSlug')
+            ->once()
             ->with($query)
-            ->willReturn($query);
+            ->andReturn($query);
         $return = $this->Behaviors->callFinder('noSlug', $query);
         $this->assertSame($query, $return);
     }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -20,7 +20,6 @@ use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
-use Mockery;
 use stdClass;
 use TestApp\Model\Entity\Extending;
 use TestApp\Model\Entity\NonExtending;

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -614,9 +614,9 @@ class EntityTest extends TestCase
                 return 'Dr. ' . $name;
             }
 
-            protected function _getBar(): string
+            protected function _getBar(string $bar): string
             {
-                return 'Dir. ' . $this->bar;
+                return 'Dir. ' . $bar;
             }
         };
         $entity2 = new class extends Entity {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use Exception;
 use InvalidArgumentException;
 use stdClass;
 use TestApp\Model\Entity\Extending;
@@ -162,16 +163,12 @@ class EntityTest extends TestCase
      */
     public function testSetOneParamWithSetter(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setName'])
-            ->getMock();
-        $entity->expects($this->once())->method('_setName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
-
+        $entity = new class extends Entity {
+            protected function _setName(?string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->name);
     }
@@ -181,24 +178,18 @@ class EntityTest extends TestCase
      */
     public function testMultipleWithSetter(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setName', '_setStuff'])
-            ->getMock();
-        $entity->setAccess('*', true);
-        $entity->expects($this->once())->method('_setName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
-
+        $entity = new class extends Entity {
+            protected function _setName(?string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
-        $entity->expects($this->once())->method('_setStuff')
-            ->with(['a', 'b'])
-            ->willReturnCallback(function ($stuff) {
-                $this->assertEquals(['a', 'b'], $stuff);
+            }
 
+            protected function _setStuff(?array $stuff): array
+            {
                 return ['c', 'd'];
-            });
+            }
+        };
+        $entity->setAccess('*', true);
         $entity->set(['name' => 'Jones', 'stuff' => ['a', 'b']]);
         $this->assertSame('Dr. Jones', $entity->name);
         $this->assertEquals(['c', 'd'], $entity->stuff);
@@ -209,13 +200,18 @@ class EntityTest extends TestCase
      */
     public function testBypassSetters(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setName', '_setStuff'])
-            ->getMock();
-        $entity->setAccess('*', true);
+        $entity = new class extends Entity {
+            protected function _setName(?string $name): string
+            {
+                throw new Exception('_setName should not have been called');
+            }
 
-        $entity->expects($this->never())->method('_setName');
-        $entity->expects($this->never())->method('_setStuff');
+            protected function _setStuff(?array $stuff): array
+            {
+                throw new Exception('_setStuff should not have been called');
+            }
+        };
+        $entity->setAccess('*', true);
 
         $entity->set('name', 'Jones', ['setter' => false]);
         $this->assertSame('Jones', $entity->name);
@@ -303,15 +299,12 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGetters(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
-        $entity->expects($this->any())
-            ->method('_getName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
+        $entity = new class extends Entity {
+            protected function _getName(string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->get('name'));
         $this->assertSame('Dr. Jones', $entity->get('name'));
@@ -322,14 +315,12 @@ class EntityTest extends TestCase
      */
     public function testGetCustomGettersAfterSet(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
-        $entity->expects($this->any())
-            ->method('_getName')
-            ->willReturnCallback(function ($name) {
+        $entity = new class extends Entity {
+            protected function _getName(string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->get('name'));
         $this->assertSame('Dr. Jones', $entity->get('name'));
@@ -344,14 +335,12 @@ class EntityTest extends TestCase
      */
     public function testGetCacheClearedByUnset(): void
     {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
-        $entity->expects($this->any())->method('_getName')
-            ->willReturnCallback(function ($name) {
+        $entity = new class extends Entity {
+            protected function _getName(?string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->get('name'));
 
@@ -364,13 +353,12 @@ class EntityTest extends TestCase
      */
     public function testGetCamelCasedProperties(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getListIdName'])
-            ->getMock();
-        $entity->expects($this->any())->method('_getListIdName')
-            ->willReturnCallback(function () {
+        $entity = new class extends Entity {
+            protected function _getListIdName(): string
+            {
                 return 'A name';
-            });
+            }
+        };
         $entity->setVirtual(['ListIdName']);
         $this->assertSame('A name', $entity->list_id_name, 'underscored virtual field should be accessible');
         $this->assertSame('A name', $entity->listIdName, 'Camelbacked virtual field should be accessible');
@@ -393,16 +381,12 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetter(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setName'])
-            ->getMock();
-        $entity->expects($this->once())->method('_setName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
-
+        $entity = new class extends Entity {
+            protected function _setName(?string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->name = 'Jones';
         $this->assertSame('Dr. Jones', $entity->name);
     }
@@ -412,17 +396,12 @@ class EntityTest extends TestCase
      */
     public function testMagicSetWithSetterTitleCase(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setName'])
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('_setName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
-
+        $entity = new class extends Entity {
+            protected function _setName(?string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->Name = 'Jones';
         $this->assertSame('Dr. Jones', $entity->Name);
     }
@@ -432,16 +411,12 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetter(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
-        $entity->expects($this->once())->method('_getName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
-
+        $entity = new class extends Entity {
+            protected function _getName(string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->set('name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->name);
     }
@@ -451,17 +426,12 @@ class EntityTest extends TestCase
      */
     public function testMagicGetWithGetterTitleCase(): void
     {
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
-        $entity->expects($this->once())
-            ->method('_getName')
-            ->with('Jones')
-            ->willReturnCallback(function ($name) {
-                $this->assertSame('Jones', $name);
-
+        $entity = new class extends Entity {
+            protected function _getName(string $name): string
+            {
                 return 'Dr. ' . $name;
-            });
+            }
+        };
         $entity->set('Name', 'Jones');
         $this->assertSame('Dr. Jones', $entity->Name);
     }
@@ -493,11 +463,12 @@ class EntityTest extends TestCase
         $this->assertTrue($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
 
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getThings'])
-            ->getMock();
-        $entity->expects($this->never())->method('_getThings')
-            ->willReturn(0);
+        $entity = new class extends Entity {
+            protected function _getThings()
+            {
+                throw new Exception('_getThings() should not have been called');
+            }
+        };
         $this->assertTrue($entity->has('things'));
     }
 
@@ -637,21 +608,28 @@ class EntityTest extends TestCase
      */
     public function testMethodCache(): void
     {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setFoo', '_getBar'])
-            ->getMock();
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity2 */
-        $entity2 = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_setBar'])
-            ->getMock();
-        $entity->expects($this->once())->method('_setFoo');
-        $entity->expects($this->once())->method('_getBar');
-        $entity2->expects($this->once())->method('_setBar');
+        $entity = new class extends Entity {
+            protected function _setFoo(?string $name): string
+            {
+                return 'Dr. ' . $name;
+            }
 
-        $entity->set('foo', 1);
-        $entity->get('bar');
-        $entity2->set('bar', 1);
+            protected function _getBar(): string
+            {
+                return 'Dir. ' . $this->bar;
+            }
+        };
+        $entity2 = new class extends Entity {
+            protected function _setBar(?string $name): string
+            {
+                return 'DrDr. ' . $name;
+            }
+        };
+
+        $entity = $entity->set('foo', 'Someone');
+        $this->assertEquals('Dr. Someone', $entity->get('foo'));
+        $entity2 = $entity2->set('bar', 'Someone');
+        $this->assertEquals('DrDr. Someone', $entity2->get('bar'));
     }
 
     /**
@@ -659,14 +637,20 @@ class EntityTest extends TestCase
      */
     public function testSetGetLongPropertyNames(): void
     {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getVeryLongProperty', '_setVeryLongProperty'])
-            ->getMock();
-        $entity->expects($this->once())->method('_getVeryLongProperty');
-        $entity->expects($this->once())->method('_setVeryLongProperty');
-        $entity->get('very_long_property');
-        $entity->set('very_long_property', 1);
+        $entity = new class extends Entity {
+            protected function _setVeryLongProperty(?string $name): string
+            {
+                return 'Dr. ' . $name;
+            }
+
+            protected function _getVeryLongProperty(?string $veryLongProperty): string
+            {
+                return 'Dir. ' . $veryLongProperty;
+            }
+        };
+        $this->assertEquals('Dir. ', $entity->get('very_long_property'));
+        $entity->set('very_long_property', 'Someone');
+        $this->assertEquals('Dir. Dr. Someone', $entity->get('very_long_property'));
     }
 
     /**
@@ -981,16 +965,14 @@ class EntityTest extends TestCase
      */
     public function testToArrayWithAccessor(): void
     {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
+        $entity = new class extends Entity {
+            protected function _getName(?string $name): string
+            {
+                return 'Jose';
+            }
+        };
         $entity->setAccess('*', true);
         $entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
-        $entity->expects($this->any())
-            ->method('_getName')
-            ->willReturn('Jose');
-
         $expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
         $this->assertEquals($expected, $entity->toArray());
     }
@@ -1051,15 +1033,13 @@ class EntityTest extends TestCase
      */
     public function testToArrayVirtualProperties(): void
     {
-        /** @var \Cake\ORM\Entity|\PHPUnit\Framework\MockObject\MockObject $entity */
-        $entity = $this->getMockBuilder(Entity::class)
-            ->addMethods(['_getName'])
-            ->getMock();
+        $entity = new class extends Entity {
+            protected function _getName(?string $name): string
+            {
+                return 'Jose';
+            }
+        };
         $entity->setAccess('*', true);
-
-        $entity->expects($this->any())
-            ->method('_getName')
-            ->willReturn('Jose');
         $entity->set(['email' => 'mark@example.com']);
 
         $entity->setVirtual(['name']);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -20,6 +20,7 @@ use Cake\Datasource\Exception\MissingPropertyException;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 use stdClass;
 use TestApp\Model\Entity\Extending;
 use TestApp\Model\Entity\NonExtending;

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Datasource\ConnectionInterface;
+use Cake\Datasource\ConnectionManager;
+use Cake\ORM\Entity;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+class TableGetWithCustomFinderTest extends TestCase
+{
+    protected ConnectionInterface $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = ConnectionManager::get('test');
+        static::setAppNamespace();
+    }
+
+    public static function providerForTestGetWithCustomFinder(): array
+    {
+        return [
+            [['fields' => ['id'], 'finder' => 'custom']],
+        ];
+    }
+
+    /**
+     * Test that get() will call a custom finder.
+     *
+     * @dataProvider providerForTestGetWithCustomFinder
+     * @param array $options
+     */
+    public function testGetWithCustomFinder($options): void
+    {
+        $table = $this->getMockBuilder(CustomTable::class)
+            ->onlyMethods(['selectQuery', 'findCustom'])
+            ->setConstructorArgs([[
+                'connection' => $this->connection,
+                'schema' => [
+                    'id' => ['type' => 'integer'],
+                    'bar' => ['type' => 'integer'],
+                    '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]],
+                ],
+            ]])
+            ->getMock();
+
+        $query = $this->getMockBuilder(SelectQuery::class)
+            ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache', 'applyOptions'])
+            ->setConstructorArgs([$table])
+            ->getMock();
+
+        $table->expects($this->once())->method('selectQuery')
+            ->willReturn($query);
+        $table->expects($this->any())->method('findCustom')
+            ->willReturn($query);
+
+        $entity = new Entity();
+        $query->expects($this->once())->method('applyOptions')
+            ->with(['fields' => ['id']]);
+        $query->expects($this->once())->method('where')
+            ->with([$table->getAlias() . '.bar' => 10])
+            ->willReturnSelf();
+        $query->expects($this->never())->method('cache');
+        $query->expects($this->once())->method('firstOrFail')
+            ->willReturn($entity);
+
+        $result = $table->get(10, ...$options);
+        $this->assertSame($entity, $result);
+    }
+}
+
+// phpcs:disable
+class CustomTable extends Table
+{
+    public function findCustom($query)
+    {
+        return $query;
+    }
+}
+// phpcs:enable

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -47,7 +47,7 @@ class TableGetWithCustomFinderTest extends TestCase
      */
     public function testGetWithCustomFinder($options): void
     {
-        $table = $this->getMockBuilder(CustomTable::class)
+        $table = $this->getMockBuilder(GetWithCustomFinderTable::class)
             ->onlyMethods(['selectQuery', 'findCustom'])
             ->setConstructorArgs([[
                 'connection' => $this->connection,
@@ -85,7 +85,7 @@ class TableGetWithCustomFinderTest extends TestCase
 }
 
 // phpcs:disable
-class CustomTable extends Table
+class GetWithCustomFinderTable extends Table
 {
     public function findCustom($query)
     {

--- a/tests/TestCase/ORM/TableImplementedEventsTest.php
+++ b/tests/TestCase/ORM/TableImplementedEventsTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+class TableImplementedEventsTest extends TestCase
+{
+    /**
+     * Check that defining methods inside table classes will result in event listeners
+     */
+    public function testImplementedEvents(): void
+    {
+        $table = new CustomTable();
+        $result = $table->implementedEvents();
+        $expected = [
+            'Model.beforeMarshal' => 'beforeMarshal',
+            'Model.buildValidator' => 'buildValidator',
+            'Model.beforeFind' => 'beforeFind',
+            'Model.beforeSave' => 'beforeSave',
+            'Model.afterSave' => 'afterSave',
+            'Model.beforeDelete' => 'beforeDelete',
+            'Model.afterDelete' => 'afterDelete',
+            'Model.afterRules' => 'afterRules',
+        ];
+        $this->assertEquals($expected, $result, 'Events do not match.');
+    }
+}
+
+// phpcs:disable
+class CustomTable extends Table
+{
+    public function buildValidator(): void {}
+    public function beforeMarshal(): void {}
+    public function beforeFind(): void {}
+    public function beforeSave(): void {}
+    public function afterSave(): void {}
+    public function beforeDelete(): void {}
+    public function afterDelete(): void {}
+    public function afterRules(): void {}
+}
+// phpcs:enable

--- a/tests/TestCase/ORM/TableImplementedEventsTest.php
+++ b/tests/TestCase/ORM/TableImplementedEventsTest.php
@@ -24,7 +24,7 @@ class TableImplementedEventsTest extends TestCase
      */
     public function testImplementedEvents(): void
     {
-        $table = new CustomTable();
+        $table = new ImplementedEventsTable();
         $result = $table->implementedEvents();
         $expected = [
             'Model.beforeMarshal' => 'beforeMarshal',
@@ -41,7 +41,7 @@ class TableImplementedEventsTest extends TestCase
 }
 
 // phpcs:disable
-class CustomTable extends Table
+class ImplementedEventsTable extends Table
 {
     public function buildValidator(): void {}
     public function beforeMarshal(): void {}

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2057,38 +2057,6 @@ class TableTest extends TestCase
     }
 
     /**
-     * Test implementedEvents
-     */
-    public function testImplementedEvents(): void
-    {
-        /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject $table */
-        $table = $this->getMockBuilder(Table::class)
-            ->addMethods([
-                'buildValidator',
-                'beforeMarshal',
-                'beforeFind',
-                'beforeSave',
-                'afterSave',
-                'beforeDelete',
-                'afterDelete',
-                'afterRules',
-            ])
-            ->getMock();
-        $result = $table->implementedEvents();
-        $expected = [
-            'Model.beforeMarshal' => 'beforeMarshal',
-            'Model.buildValidator' => 'buildValidator',
-            'Model.beforeFind' => 'beforeFind',
-            'Model.beforeSave' => 'beforeSave',
-            'Model.afterSave' => 'afterSave',
-            'Model.beforeDelete' => 'beforeDelete',
-            'Model.afterDelete' => 'afterDelete',
-            'Model.afterRules' => 'afterRules',
-        ];
-        $this->assertEquals($expected, $result, 'Events do not match.');
-    }
-
-    /**
      * Tests that it is possible to insert a new row using the save method
      *
      * @group save
@@ -3514,42 +3482,6 @@ class TableTest extends TestCase
     }
 
     /**
-     * Tests that it is possible to define custom validator methods
-     */
-    public function testValidationWithDefiner(): void
-    {
-        $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['validationForOtherStuff'])
-            ->getMock();
-        $table->expects($this->once())->method('validationForOtherStuff')
-            ->will($this->returnArgument(0));
-        $other = $table->getValidator('forOtherStuff');
-        $this->assertInstanceOf('Cake\Validation\Validator', $other);
-        $this->assertNotSame($other, $table->getValidator());
-        $this->assertSame($table, $other->getProvider('table'));
-    }
-
-    /**
-     * Tests that a InvalidArgumentException is thrown if the custom validator does not return an Validator instance
-     */
-    public function testValidationWithBadDefiner(): void
-    {
-        $table = $this->getMockBuilder(Table::class)
-            ->addMethods(['validationBad'])
-            ->getMock();
-        $table->expects($this->once())
-            ->method('validationBad');
-
-        $this->expectException(AssertionError::class);
-        $this->expectExceptionMessage(sprintf(
-            'The `%s::validationBad()` validation method must return an instance of `Cake\Validation\Validator`.',
-            $table::class
-        ));
-
-        $table->getValidator('bad');
-    }
-
-    /**
      * Tests that a InvalidArgumentException is thrown if the custom validator method does not exist.
      */
     public function testValidatorWithMissingMethod(): void
@@ -4184,7 +4116,6 @@ class TableTest extends TestCase
             ->getMock();
         $supervisors = $this->getMockBuilder(Table::class)
             ->onlyMethods(['_insert'])
-            ->addMethods(['validate'])
             ->setConstructorArgs([[
                 'table' => 'authors',
                 'alias' => 'supervisors',
@@ -5430,58 +5361,6 @@ class TableTest extends TestCase
             ->getMock();
 
         $table->expects($this->once())->method('selectQuery')
-            ->willReturn($query);
-
-        $entity = new Entity();
-        $query->expects($this->once())->method('applyOptions')
-            ->with(['fields' => ['id']]);
-        $query->expects($this->once())->method('where')
-            ->with([$table->getAlias() . '.bar' => 10])
-            ->willReturnSelf();
-        $query->expects($this->never())->method('cache');
-        $query->expects($this->once())->method('firstOrFail')
-            ->willReturn($entity);
-
-        $result = $table->get(10, ...$options);
-        $this->assertSame($entity, $result);
-    }
-
-    public static function providerForTestGetWithCustomFinder(): array
-    {
-        return [
-            [['fields' => ['id'], 'finder' => 'custom']],
-        ];
-    }
-
-    /**
-     * Test that get() will call a custom finder.
-     *
-     * @dataProvider providerForTestGetWithCustomFinder
-     * @param array $options
-     */
-    public function testGetWithCustomFinder($options): void
-    {
-        $table = $this->getMockBuilder(Table::class)
-            ->onlyMethods(['selectQuery'])
-            ->addMethods(['findCustom'])
-            ->setConstructorArgs([[
-                'connection' => $this->connection,
-                'schema' => [
-                    'id' => ['type' => 'integer'],
-                    'bar' => ['type' => 'integer'],
-                    '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]],
-                ],
-            ]])
-            ->getMock();
-
-        $query = $this->getMockBuilder(SelectQuery::class)
-            ->onlyMethods(['addDefaultTypes', 'firstOrFail', 'where', 'cache', 'applyOptions'])
-            ->setConstructorArgs([$table])
-            ->getMock();
-
-        $table->expects($this->once())->method('selectQuery')
-            ->willReturn($query);
-        $table->expects($this->any())->method('findCustom')
             ->willReturn($query);
 
         $entity = new Entity();

--- a/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
@@ -25,7 +25,7 @@ class TableValidationWithBadDefinerTest extends TestCase
      */
     public function testValidationWithBadDefiner(): void
     {
-        $table = new CustomTable();
+        $table = new ValidationWithBadDefinerTable();
         $this->expectException(AssertionError::class);
         $this->expectExceptionMessage(sprintf(
             'The `%s::validationBad()` validation method must return an instance of `Cake\Validation\Validator`.',
@@ -37,7 +37,7 @@ class TableValidationWithBadDefinerTest extends TestCase
 }
 
 // phpcs:disable
-class CustomTable extends Table
+class ValidationWithBadDefinerTable extends Table
 {
     public function validationBad($validator)
     {

--- a/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use AssertionError;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+class TableValidationWithBadDefinerTest extends TestCase
+{
+    /**
+     * Tests that a InvalidArgumentException is thrown if the custom validator does not return an Validator instance
+     */
+    public function testValidationWithBadDefiner(): void
+    {
+        $table = new CustomTable();
+        $this->expectException(AssertionError::class);
+        $this->expectExceptionMessage(sprintf(
+            'The `%s::validationBad()` validation method must return an instance of `Cake\Validation\Validator`.',
+            $table::class
+        ));
+
+        $table->getValidator('bad');
+    }
+}
+
+// phpcs:disable
+class CustomTable extends Table
+{
+    public function validationBad($validator)
+    {
+        return '';
+    }
+}
+// phpcs:enable

--- a/tests/TestCase/ORM/TableValidationWithDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithDefinerTest.php
@@ -24,7 +24,7 @@ class TableValidationWithDefinerTest extends TestCase
      */
     public function testValidationWithDefinerTest(): void
     {
-        $table = new CustomTable();
+        $table = new ValidationWithDefinerTable();
         $other = $table->getValidator('forOtherStuff');
         $this->assertNotSame($other, $table->getValidator());
         $this->assertSame($table, $other->getProvider('table'));
@@ -32,7 +32,7 @@ class TableValidationWithDefinerTest extends TestCase
 }
 
 // phpcs:disable
-class CustomTable extends Table
+class ValidationWithDefinerTable extends Table
 {
     public function validationForOtherStuff($validator)
     {

--- a/tests/TestCase/ORM/TableValidationWithDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithDefinerTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+class TableValidationWithDefinerTest extends TestCase
+{
+    /**
+     * Tests that it is possible to define custom validator methods
+     */
+    public function testValidationWithDefinerTest(): void
+    {
+        $table = new CustomTable();
+        $other = $table->getValidator('forOtherStuff');
+        $this->assertNotSame($other, $table->getValidator());
+        $this->assertSame($table, $other->getProvider('table'));
+    }
+}
+
+// phpcs:disable
+class CustomTable extends Table
+{
+    public function validationForOtherStuff($validator)
+    {
+        return $validator;
+    }
+}
+// phpcs:enable

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -1518,9 +1518,7 @@ class ValidatorTest extends TestCase
             ->add('email', 'alpha', ['rule' => 'alphanumeric'])
             ->add('title', 'cool', ['rule' => 'isCool', 'provider' => 'thing']);
 
-        $thing = $this->getMockBuilder('\stdClass')
-            ->addMethods(['isCool'])
-            ->getMock();
+        $thing = $this->getMockBuilder(stdMock::class)->getMock();
         $thing->expects($this->once())->method('isCool')
             ->willReturnCallback(function ($data, $context) use ($thing) {
                 $this->assertSame('bar', $data);
@@ -1562,9 +1560,7 @@ class ValidatorTest extends TestCase
             'rule' => ['isCool', 'and', 'awesome'],
             'provider' => 'thing',
         ]);
-        $thing = $this->getMockBuilder('\stdClass')
-            ->addMethods(['isCool'])
-            ->getMock();
+        $thing = $this->getMockBuilder(stdMock::class)->getMock();
         $thing->expects($this->once())->method('isCool')
             ->willReturnCallback(function ($data, $a, $b, $context) use ($thing) {
                 $this->assertSame('bar', $data);
@@ -2989,3 +2985,10 @@ class ValidatorTest extends TestCase
         );
     }
 }
+
+// phpcs:disable
+class stdMock extends stdClass
+{
+    public function isCool() {}
+}
+// phpcs:enable


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17236

Well, here we go...

There is no real alternative to `->addMethods()` in PHPUnit 10 (and going forward) any more, so this is my attempt to move as many of these calls to Mockery as possible (which we already decided internally to do in the long run for all mocking purposes).

But I have already run into some limitations how Mockery works and how it creates method call expectations. There may be other ways of how to solve the problems I have ran into since I am not very used to Mockery but lets see what you say about the current situation 😁 

---

E.g. in the MailerTest we currently do something like
``` php
$mailer = $this->getMockBuilder(Mailer::class)
    ->onlyMethods(['deliver'])
    ->addMethods(['test'])
    ->getMock();
$mailer->expects($this->once())
    ->method('test')
    ->with('foo', 'bar');
$mailer->expects($this->any())
    ->method('deliver')
    ->willReturn([]);

$mailer->send('test', ['foo', 'bar']);
```

because we expect the user to define their own Mailer methods on the extended class (here `test`)

Now if we wanna do the same in Mockery it would look like this:
``` php
$mailer = Mockery::mock(Mailer::class)
    ->shouldAllowMockingMethod('test')
    ->makePartial();
$mailer->shouldReceive('test')->once()
    ->with('foo', 'bar');
$mailer->shouldReceive('deliver')->once()
    ->andReturn([]);

$mailer->send('test', ['foo', 'bar']);
```

BUT this doesn't work with how we check for available methods inside the `send()` [method](https://github.com/cakephp/cakephp/blob/5.x/src/Mailer/Mailer.php#L319) via
``` php
method_exists($this, $action)
```

Since the mocked mailer object doesn't actually have that `test` method present (it seems to be done via a `__call()` method as explained [here](https://stackoverflow.com/questions/51364884/mockery-and-method-exists)) we can't test this (as far as I can tell)

---

We also have a similar situation in the `EntityTest` because in the [EntityTrait](https://github.com/cakephp/cakephp/blob/5.x/src/Datasource/EntityTrait.php#L668) we do
``` php
get_class_methods($class)
```
which (again) doesn't contain methods which are indirectly callable via `__call()`

Therefore, (as far as I can tell) we can't do something like this in mockery:
``` php
$entity = $this->getMockBuilder(Entity::class)
    ->addMethods(['_getName'])
    ->getMock();
$entity->expects($this->any())
    ->method('_getName')
    ->with('Jones')
    ->willReturnCallback(function ($name) {
        return 'Dr. ' . $name;
    });
$entity->set('name', 'Jones');
$this->assertSame('Dr. Jones', $entity->get('name'));
```

Looking forward to your feedback 😁 