### PR TITLE
Update framework provided property annotations

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -87,6 +87,10 @@ use UnexpectedValueException;
  *
  * @property \Cake\Controller\Component\FlashComponent $Flash
  * @property \Cake\Controller\Component\FormProtectionComponent $FormProtection
+ * @property \Cake\Controller\Component\PaginatorComponent $Paginator
+ * @property \Cake\Controller\Component\RequestHandlerComponent $RequestHandler
+ * @property \Cake\Controller\Component\SecurityComponent $Security
+ * @property \Cake\Controller\Component\AuthComponent $Auth
  * @property \Cake\Controller\Component\CheckHttpCacheComponent $CheckHttpCache
  * @link https://book.cakephp.org/4/en/controllers.html
  */

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -87,10 +87,7 @@ use UnexpectedValueException;
  *
  * @property \Cake\Controller\Component\FlashComponent $Flash
  * @property \Cake\Controller\Component\FormProtectionComponent $FormProtection
- * @property \Cake\Controller\Component\PaginatorComponent $Paginator
- * @property \Cake\Controller\Component\RequestHandlerComponent $RequestHandler
- * @property \Cake\Controller\Component\SecurityComponent $Security
- * @property \Cake\Controller\Component\AuthComponent $Auth
+ * @property \Cake\Controller\Component\CheckHttpCacheComponent $CheckHttpCache
  * @link https://book.cakephp.org/4/en/controllers.html
  */
 #[\AllowDynamicProperties]


### PR DESCRIPTION
Update the components we annotate in `Controller` to no longer include deprecated components and include the `CheckHttpCache` component which was omitted.

Fixes #17247