### PR TITLE
Use associative array / named args when invoking cell methods.

### DIFF
--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -73,9 +73,6 @@ trait CellTrait
             throw new MissingCellException(['className' => $pluginAndCell . 'Cell']);
         }
 
-        if (!empty($data)) {
-            $data = array_values($data);
-        }
         $options = ['action' => $action, 'args' => $data] + $options;
 
         return $this->_createCell($className, $action, $plugin, $options);

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -121,9 +121,20 @@ class CellTest extends TestCase
      */
     public function testCellWithArguments(): void
     {
+        $cell = $this->View->cell('Articles::doEcho', ['dummy', ' message']);
+        $render = "{$cell}";
+        $this->assertStringContainsString('dummy message', $render);
+    }
+
+    public function testCellWithNamedArguments(): void
+    {
         $cell = $this->View->cell('Articles::doEcho', ['msg1' => 'dummy', 'msg2' => ' message']);
         $render = "{$cell}";
         $this->assertStringContainsString('dummy message', $render);
+
+        $cell = $this->View->cell('Articles::doEcho', ['msg2' => ' dummy', 'msg1' => 'message']);
+        $render = "{$cell}";
+        $this->assertStringContainsString('message dummy', $render);
     }
 
     /**
@@ -207,7 +218,7 @@ class CellTest extends TestCase
     public function testCellRenderThemed(): void
     {
         $this->View->setTheme('TestTheme');
-        $cell = $this->View->cell('Articles', ['msg' => 'hello world!']);
+        $cell = $this->View->cell('Articles');
 
         $this->assertEquals($this->View->getTheme(), $cell->viewBuilder()->getTheme());
         $this->assertStringContainsString('Themed cell content.', $cell->render());


### PR DESCRIPTION
This allows passing args out of order.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
