### PR TITLE
4.5 - Add opt-in path for EntityTrait::has()

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -120,6 +120,16 @@ trait EntityTrait
     protected $_registryAlias = '';
 
     /**
+     * Set to true in your entity's class definition or
+     * via application logic. When true. has() and related
+     * methods will use `array_key_exists` instead of `isset`
+     * to decide if fields are 'defined' in an entity.
+     *
+     * @var bool
+     */
+    protected $_hasAllowsNull = false;
+
+    /**
      * Magic getter to access fields that have been set in this entity
      *
      * @param string $field Name of the field to access
@@ -362,7 +372,11 @@ trait EntityTrait
     public function has($field): bool
     {
         foreach ((array)$field as $prop) {
-            if ($this->get($prop) === null) {
+            if ($this->_hasAllowsNull) {
+                if (!array_key_exists($prop, $this->_fields) && !static::_accessor($prop, 'get')) {
+                    return false;
+                }
+            } elseif ($this->get($prop) === null) {
                 return false;
             }
         }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -21,6 +21,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use stdClass;
 use TestApp\Model\Entity\Extending;
+use TestApp\Model\Entity\ForwardsCompatHas;
 use TestApp\Model\Entity\NonExtending;
 
 /**
@@ -466,6 +467,30 @@ class EntityTest extends TestCase
         $this->assertTrue($entity->has(['id']));
         $this->assertTrue($entity->has(['id', 'name']));
         $this->assertFalse($entity->has(['id', 'foo']));
+        $this->assertFalse($entity->has(['id', 'nope']));
+
+        $entity = $this->getMockBuilder(Entity::class)
+            ->addMethods(['_getThings'])
+            ->getMock();
+        $entity->expects($this->once())->method('_getThings')
+            ->will($this->returnValue(0));
+        $this->assertTrue($entity->has('things'));
+    }
+
+    /**
+     * Tests has() method with 5.x behavior
+     */
+    public function testHasForwardsCompat(): void
+    {
+        $entity = new ForwardsCompatHas(['id' => 1, 'name' => 'Juan', 'foo' => null]);
+        $this->assertTrue($entity->has('id'));
+        $this->assertTrue($entity->has('name'));
+        $this->assertTrue($entity->has('foo'));
+        $this->assertFalse($entity->has('last_name'));
+
+        $this->assertTrue($entity->has(['id']));
+        $this->assertTrue($entity->has(['id', 'name']));
+        $this->assertTrue($entity->has(['id', 'foo']));
         $this->assertFalse($entity->has(['id', 'nope']));
 
         $entity = $this->getMockBuilder(Entity::class)

--- a/tests/test_app/TestApp/Model/Entity/ForwardsCompatHas.php
+++ b/tests/test_app/TestApp/Model/Entity/ForwardsCompatHas.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * Tests entity class used for asserting correct loading
+ */
+class ForwardsCompatHas extends Entity
+{
+    protected $_hasAllowsNull = true;
+}


### PR DESCRIPTION
Give applications a way to gradually opt-in to the breaking changes being made to EntityTrait::has() in 5.x. This should help smooth out upgrades for large applications a bit.