### PR TITLE
Adding the ability to use other resources for Console I/O

### DIFF
--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Console;
 
+use Cake\Console\Exception\ConsoleException;
 use InvalidArgumentException;
 
 /**
@@ -160,11 +161,20 @@ class ConsoleOutput
      * Checks for a pretty console environment. Ansicon and ConEmu allows
      *  pretty consoles on Windows, and is supported.
      *
-     * @param string $stream The identifier of the stream to write output to.
+     * @param string|resource $stream The identifier of the stream to write output to.
+     * @throws \Cake\Console\Exception\ConsoleException If the given stream is not a valid resource.
      */
-    public function __construct(string $stream = 'php://stdout')
+    public function __construct($stream = 'php://stdout')
     {
-        $this->_output = fopen($stream, 'wb');
+        if (is_string($stream)) {
+            $stream = fopen($stream, 'wb');
+        }
+
+        if (!is_resource($stream)) {
+            throw new ConsoleException('Invalid stream in constructor. It is not a valid resource.');
+        }
+
+        $this->_output = $stream;
 
         if (
             (

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\ConsoleOutput;
+use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -244,5 +245,37 @@ class ConsoleOutputTest extends TestCase
             ->with('Bad Regular <b>Left</b> <i>behind</i> <name>');
 
         $this->output->write('<error>Bad</error> Regular <b>Left</b> <i>behind</i> <name>', 0);
+    }
+
+    public function testWithInvalidStreamNum(): void
+    {
+        $this->expectException(\Cake\Console\Exception\ConsoleException::class);
+        $this->expectExceptionMessage('Invalid stream in constructor. It is not a valid resource.');
+        $output = new StubConsoleOutput(1);
+    }
+
+    public function testWithInvalidStreamArray(): void
+    {
+        $this->expectException(\Cake\Console\Exception\ConsoleException::class);
+        $this->expectExceptionMessage('Invalid stream in constructor. It is not a valid resource.');
+        $output = new StubConsoleOutput([]);
+    }
+
+    public function testWorkingWithStub(): void
+    {
+        $output = new StubConsoleOutput();
+        $output->write('Test line 1.');
+        $output->write('Test line 2.');
+
+        $result = $output->messages();
+        $expected = [
+            'Test line 1.',
+            'Test line 2.',
+        ];
+        $this->assertSame($expected, $result);
+
+        $result = $output->output();
+        $expected = "Test line 1.\nTest line 2.";
+        $this->assertSame($expected, $result);
     }
 }


### PR DESCRIPTION
For example, using php's internal streams STDOUT, STDIN, STDERR. Or some other predefined resource.

Specifically, I ran into an issue where php was erroring and saying there were too many streams created.
According to php's website, the stdout, stdin, and stderr are already defined and able to use, so no new streams/resources are need to be created (a new fopen for each `new ConsoleIO()`).
However, I still kept the default of `php://stdout` so it should still work with existing code/userland code.

https://www.php.net/manual/en/features.commandline.io-streams.php

In my specific case, I have a ConsoleIO created in the my Fixture::init() methods to help track when they are (or are not) being used. It was throwing a too many streams error. 

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
