### PR TITLE
5.x: don't require mockery via TestCase::teardown

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -226,7 +226,9 @@ abstract class TestCase extends BaseTestCase
         $this->getTableLocator()->clear();
         $this->_configure = [];
         $this->_tableLocator = null;
-        Mockery::close();
+        if (class_exists(Mockery::class)) {
+            Mockery::close();
+        }
     }
 
     /**


### PR DESCRIPTION
Refs: #17246 

putting `Mockery::close();` inside the TestCase::teardown now implicitly requires every plugin and app to at least have mockery installed although we don't (yet) fully require it.
