### PR TITLE
5.x: fix aliasing non default test datasource

### DIFF
--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -52,7 +52,7 @@ class ConnectionHelper
                 ConnectionManager::alias($connection, $original);
             } else {
                 $test = 'test_' . $connection;
-                ConnectionManager::alias($test, $connection);
+                ConnectionManager::alias($connection, $test);
             }
         }
     }

--- a/tests/TestCase/TestSuite/ConnectionHelperTest.php
+++ b/tests/TestCase/TestSuite/ConnectionHelperTest.php
@@ -40,6 +40,19 @@ class ConnectionHelperTest extends TestCase
         );
     }
 
+    public function testAliasNonDefaultConnections(): void
+    {
+        $connection = new Connection(['driver' => TestDriver::class]);
+        ConnectionManager::setConfig('something', $connection);
+
+        (new ConnectionHelper())->addTestAliases();
+
+        $this->assertSame(
+            ConnectionManager::get('test_something'),
+            ConnectionManager::get('something')
+        );
+    }
+
     public function testEnableQueryLogging(): void
     {
         $connection = new Connection(['driver' => TestDriver::class]);


### PR DESCRIPTION
Refs: https://github.com/cakephp/elastic-search/pull/315

Via the PR above I noticed that aliasing test datasources which are not `test` or `default` didn't work as expected.