### PR TITLE
Update FormProtectionComponent.php

### DIFF
--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -77,7 +77,7 @@ class FormProtectionComponent extends Component
     {
         $session = $this->getController()->getRequest()->getSession();
         $session->start();
-        
+
         return $session->id();
     }
 

--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -67,6 +67,14 @@ class FormProtectionComponent extends Component
         'validationFailureCallback' => null,
     ];
 
+    protected function _getSessionId(): string
+    {
+        $session = $this->getController()->getRequest()->getSession();
+        $session->start();
+        
+        return $session->id();
+    }
+
     /**
      * Component startup.
      *
@@ -86,12 +94,11 @@ class FormProtectionComponent extends Component
             && $hasData
             && $this->_config['validate']
         ) {
-            $session = $request->getSession();
-            $session->start();
+            $sessionId = $this->_getSessionId();
             $url = Router::url($request->getRequestTarget());
 
             $formProtector = new FormProtector($this->_config);
-            $isValid = $formProtector->validate($data, $url, $session->id());
+            $isValid = $formProtector->validate($data, $url, $sessionId);
 
             if (!$isValid) {
                 return $this->validationFailure($formProtector);

--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -69,7 +69,7 @@ class FormProtectionComponent extends Component
 
     /**
      * Get Session id for FormProtector
-     * Must be the same as in FormHelper()
+     * Must be the same as in FormHelper
      *
      * @return string
      */

--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -67,6 +67,12 @@ class FormProtectionComponent extends Component
         'validationFailureCallback' => null,
     ];
 
+    /**
+     * Get Session id for FormProtector
+     * Must be the same as in FormHelper()
+     *
+     * @return string
+     */
     protected function _getSessionId(): string
     {
         $session = $this->getController()->getRequest()->getSession();


### PR DESCRIPTION
Allow changing the logic to allow using and empty string instead of the session id or use the user id of the logged in user. It would prefer to have a form protection against html manipulation independent of the current user session to avoid false positive errors if the session id rotates in a bad moment.
it should be combined with updating the form helper #17264
