### PR TITLE
Update FormHelper.php

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -636,12 +636,12 @@ class FormHelper extends Helper
         return $this->formatTemplate('hiddenBlock', ['content' => $out]);
     }
 
-   /**
-    * Get Session id for FormProtector
-    * Must be the same as in FormProtectionComponent
-    *
-    * @return string
-    */
+    /**
+     * Get Session id for FormProtector
+     * Must be the same as in FormProtectionComponent
+     *
+     * @return string
+     */
     protected function _getFormProtectorSessionId(): string
     {
         return $this->_View->getRequest()->getSession()->id();

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -636,6 +636,12 @@ class FormHelper extends Helper
         return $this->formatTemplate('hiddenBlock', ['content' => $out]);
     }
 
+   /**
+    * Get Session id for FormProtector
+    * Must be the same as in FormProtectionComponent
+    *
+    * @return string
+    */
     protected function _getFormProtectorSessionId(): string
     {
         return $this->_View->getRequest()->getSession()->id();

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -616,7 +616,7 @@ class FormHelper extends Helper
 
         $tokenData = $this->formProtector->buildTokenData(
             $this->_lastAction,
-            $this->_View->getRequest()->getSession()->id()
+            $this->_getFormProtectorSessionId()
         );
         $tokenFields = array_merge($secureAttributes, [
             'value' => $tokenData['fields'],
@@ -634,6 +634,11 @@ class FormHelper extends Helper
         }
 
         return $this->formatTemplate('hiddenBlock', ['content' => $out]);
+    }
+
+    protected function _getFormProtectorSessionId(): string
+    {
+        return $this->_View->getRequest()->getSession()->id();
     }
 
     /**


### PR DESCRIPTION
Allow changing the logic to allow using and empty string instead of the session id or use the user id of the logged in user. It would prefer to have a form protection against html manipulation independent of the current user session to avoid false positive errors if the session id rotates in a bad moment.
it should be combined with updating the FormProtectionComponent #17263 
