### PR TITLE
Avoid inflecting URL parts when matching routes.

### DIFF
--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -26,16 +26,6 @@ use Cake\Utility\Inflector;
 class DashedRoute extends Route
 {
     /**
-     * Flag for tracking whether the defaults have been inflected.
-     *
-     * Default values need to be inflected so that they match the inflections that
-     * match() will create.
-     *
-     * @var bool
-     */
-    protected bool $_inflectedDefaults = false;
-
-    /**
      * Camelizes the previously dashed plugin route taking into account plugin vendors
      *
      * @param string $plugin Plugin name
@@ -85,24 +75,11 @@ class DashedRoute extends Route
     }
 
     /**
-     * Dasherizes the controller, action and plugin params before passing them on
-     * to the parent class.
-     *
-     * @param array $url Array of parameters to convert to a string.
-     * @param array $context An array of the current request context.
-     *   Contains information such as the current host, scheme, port, and base
-     *   directory.
-     * @return string|null Either a string URL or null.
+     * @inheritDoc
      */
-    public function match(array $url, array $context = []): ?string
+    protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $url = $this->_dasherize($url);
-        if (!$this->_inflectedDefaults) {
-            $this->_inflectedDefaults = true;
-            $this->defaults = $this->_dasherize($this->defaults);
-        }
-
-        return parent::match($url, $context);
+        return parent::_writeUrl($this->_dasherize($params), $pass, $query);
     }
 
     /**

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -25,16 +25,6 @@ use Cake\Utility\Inflector;
 class InflectedRoute extends Route
 {
     /**
-     * Flag for tracking whether the defaults have been inflected.
-     *
-     * Default values need to be inflected so that they match the inflections that match()
-     * will create.
-     *
-     * @var bool
-     */
-    protected bool $_inflectedDefaults = false;
-
-    /**
      * Parses a string URL into an array. If it matches, it will convert the prefix, controller and
      * plugin keys to their camelized form.
      *
@@ -64,24 +54,11 @@ class InflectedRoute extends Route
     }
 
     /**
-     * Underscores the prefix, controller and plugin params before passing them on to the
-     * parent class
-     *
-     * @param array $url Array of parameters to convert to a string.
-     * @param array $context An array of the current request context.
-     *   Contains information such as the current host, scheme, port, and base
-     *   directory.
-     * @return string|null Either a string URL for the parameters if they match or null.
+     * @inheritDoc
      */
-    public function match(array $url, array $context = []): ?string
+    protected function _writeUrl(array $params, array $pass = [], array $query = []): string
     {
-        $url = $this->_underscore($url);
-        if (!$this->_inflectedDefaults) {
-            $this->_inflectedDefaults = true;
-            $this->defaults = $this->_underscore($this->defaults);
-        }
-
-        return parent::match($url, $context);
+        return parent::_writeUrl($this->_underscore($params), $pass, $query);
     }
 
     /**

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -59,6 +59,7 @@ class DashedRouteTest extends TestCase
 
         $route = new DashedRoute('/blog/{action}', ['controller' => 'Posts']);
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView']);
+        $this->assertSame(['controller' => 'Posts'], $route->defaults);
         $this->assertSame('/blog/my-view', $result);
 
         $result = $route->match(['controller' => 'Posts', 'action' => 'myView', '?' => ['id' => 2]]);

--- a/tests/TestCase/Routing/Route/PluginShortRouteTest.php
+++ b/tests/TestCase/Routing/Route/PluginShortRouteTest.php
@@ -57,7 +57,7 @@ class PluginShortRouteTest extends TestCase
      */
     public function testMatch(): void
     {
-        $route = new PluginShortRoute('/{plugin}', ['action' => 'index'], ['plugin' => 'foo|bar']);
+        $route = new PluginShortRoute('/{plugin}', ['action' => 'index'], ['plugin' => 'Foo|Bar']);
 
         $result = $route->match(['plugin' => 'Foo', 'controller' => 'Posts', 'action' => 'index']);
         $this->assertNull($result, 'plugin controller mismatch was converted. %s');


### PR DESCRIPTION
Inflect parts only when generating URL string.
Closes #17265

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
