### PR TITLE
Document the changed behavior of extractOriginal() instead.

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -749,7 +749,7 @@ trait EntityTrait
 
     /**
      * Returns an array with the requested original fields
-     * stored in this entity, indexed by field name.
+     * stored in this entity, indexed by field name, if they exist.
      *
      * Fields that are unchanged from their original value will be included in the
      * return of this method.
@@ -765,8 +765,6 @@ trait EntityTrait
                 $result[$field] = $this->getOriginal($field);
             } elseif ($this->isOriginalField($field)) {
                 $result[$field] = $this->get($field);
-            } else {
-                $result[$field] = null;
             }
         }
 
@@ -775,7 +773,7 @@ trait EntityTrait
 
     /**
      * Returns an array with only the original fields
-     * stored in this entity, indexed by field name.
+     * stored in this entity, indexed by field name, if they exist.
      *
      * This method will only return fields that have been modified since
      * the entity was built. Unchanged fields will be omitted.

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -135,18 +135,17 @@ class EntityTest extends TestCase
             'title' => 'original',
             'body' => 'no',
             'null' => null,
-            'undefined' => null,
         ];
         $this->assertEquals($expected, $result);
 
-        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null']);
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null', 'undefined']);
         $expected = [
             'body' => 'no',
         ];
         $this->assertEquals($expected, $result);
 
         $entity->set('null', 'not null');
-        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null']);
+        $result = $entity->extractOriginalChanged(['id', 'title', 'body', 'null', 'undefined']);
         $expected = [
             'null' => null,
             'body' => 'no',


### PR DESCRIPTION
Amend https://github.com/cakephp/cakephp/pull/17267

It is now kind of inconsistent to extractOriginalChanged()

We could instead just document the non existent fields to be omitted from the result array.
This way it would then also be able to more clearly distinguish between requested field values of null vs undefined.

Reds https://github.com/cakephp/cakephp/issues/17266 discussion