### PR TITLE
Fix plugin helper loading conflict error

### DIFF
--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -75,7 +75,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         } catch (MissingHelperException $exception) {
             $plugin = $this->_View->getPlugin();
             if (!empty($plugin)) {
-                $this->load($plugin . '.' . $helper);
+                $this->load($helper, ['className' => $plugin . '.' . $helper]);
 
                 return true;
             }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -910,6 +910,17 @@ class ViewTest extends TestCase
     }
 
     /**
+     * Test lazy loading helpers in plugins
+     */
+    public function testLazyLoadHelpersPlugin(): void
+    {
+        $view = new View(null, null, null, ['plugin' => 'TestPlugin']);
+
+        $this->assertEquals('hello other', $view->OtherHelper->hello());
+        $this->assertEquals('hello plugged, hello other', $view->PluggedHelper->hello());
+    }
+
+    /**
      * Test manipulating class properties in initialize()
      */
     public function testInitialize(): void

--- a/tests/test_app/Plugin/TestPlugin/src/View/Helper/OtherHelperHelper.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Helper/OtherHelperHelper.php
@@ -23,4 +23,8 @@ use Cake\View\Helper;
  */
 class OtherHelperHelper extends Helper
 {
+    public function hello(): string
+    {
+        return 'hello other';
+    }
 }

--- a/tests/test_app/Plugin/TestPlugin/src/View/Helper/PluggedHelperHelper.php
+++ b/tests/test_app/Plugin/TestPlugin/src/View/Helper/PluggedHelperHelper.php
@@ -25,4 +25,9 @@ use Cake\View\Helper;
 class PluggedHelperHelper extends Helper
 {
     public array $helpers = ['TestPlugin.OtherHelper'];
+
+    public function hello(): string
+    {
+        return 'hello plugged, ' . $this->OtherHelper->hello();
+    }
 }


### PR DESCRIPTION
When plugin helpers are lazy-loaded with a non-prefixed name we shouldn't raise errors when those helpers are also loaded via fallback helper loading. Thanks to @kolorafa for providing a simple application that helps reproduce this issue.

Fixes #17268
