### PR TITLE
5.x: fix plugins.php not loading in consecutive tests due to include_once

### DIFF
--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -183,7 +183,7 @@ abstract class BaseApplication implements
         require_once $this->configDir . 'bootstrap.php';
 
         // phpcs:ignore
-        $plugins = @include_once $this->configDir . 'plugins.php';
+        $plugins = @include $this->configDir . 'plugins.php';
         if (is_array($plugins)) {
             $this->plugins->addFromConfig($plugins);
         }

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Command;
 
 use Cake\Console\CommandInterface;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -77,9 +78,13 @@ class PluginLoadCommandTest extends TestCase
         $this->exec('plugin load TestPlugin');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
+        // Needed to not have duplicate named routes
+        Router::reload();
         $this->exec('plugin load TestPluginTwo --no-bootstrap --no-console --no-middleware --no-routes --no-services');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 
+        // Needed to not have duplicate named routes
+        Router::reload();
         $this->exec('plugin load Company/TestPluginThree --only-debug --only-cli');
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
 

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -167,6 +167,19 @@ class BaseApplicationTest extends TestCase
         $this->assertNotEmpty($collection->match($url, []));
     }
 
+    public function testAppBootstrapPlugins(): void
+    {
+        $app = new class (dirname(__DIR__, 2) . DS . 'test_app' . DS . 'config_plugins') extends BaseApplication
+        {
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
+        $app->bootstrap();
+        $this->assertTrue($app->getPlugins()->has('TestPlugin'), 'TestPlugin was not loaded via plugins.php');
+    }
+
     public function testPluginBootstrap(): void
     {
         $app = $this->app;

--- a/tests/test_app/config_plugins/bootstrap.php
+++ b/tests/test_app/config_plugins/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+// Do nothing

--- a/tests/test_app/config_plugins/plugins.php
+++ b/tests/test_app/config_plugins/plugins.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+return ['TestPlugin'];


### PR DESCRIPTION
As can be seen in https://github.com/cakephp/app/pull/971 there is a problem with the current implementation of how `config/plugins.php` is loaded.

`include_once` will only return the contents of that file in the first running test.
But if another test tries load plugins again this doesn't work any more due to how `include_once` works.