### PR TITLE
5.x: minor test cleanup

### DIFF
--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -62,7 +62,7 @@ class CommandRunnerTest extends TestCase
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
-        $this->config = dirname(dirname(__DIR__));
+        $this->config = dirname(__DIR__, 2);
     }
 
     /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -34,7 +34,7 @@ class MysqlTest extends TestCase
     {
         parent::setUp();
         $config = ConnectionManager::getConfig('test');
-        $this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Not using Mysql for test config');
+        $this->skipIf(!str_contains($config['driver'], 'Mysql'), 'Not using Mysql for test config');
     }
 
     /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -40,7 +40,7 @@ class MysqlSchemaTest extends TestCase
     protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
-        $this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Not using Mysql for test config');
+        $this->skipIf(!str_contains($config['driver'], 'Mysql'), 'Not using Mysql for test config');
     }
 
     /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -36,7 +36,7 @@ class PostgresSchemaTest extends TestCase
     protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
-        $this->skipIf(strpos($config['driver'], 'Postgres') === false, 'Not using Postgres for test config');
+        $this->skipIf(!str_contains($config['driver'], 'Postgres'), 'Not using Postgres for test config');
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -38,7 +38,7 @@ class SqliteSchemaTest extends TestCase
     protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
-        $this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite for test config');
+        $this->skipIf(!str_contains($config['driver'], 'Sqlite'), 'Not using Sqlite for test config');
     }
 
     /**

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -37,7 +37,7 @@ class SqlserverSchemaTest extends TestCase
     protected function _needsConnection(): void
     {
         $config = ConnectionManager::getConfig('test');
-        $this->skipIf(strpos($config['driver'], 'Sqlserver') === false, 'Not using Sqlserver for test config');
+        $this->skipIf(!str_contains($config['driver'], 'Sqlserver'), 'Not using Sqlserver for test config');
     }
 
     /**

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -1208,7 +1208,7 @@ trait PaginatorTestTrait
     public function testPaginateQueryWithBindValue(): void
     {
         $config = ConnectionManager::getConfig('test');
-        $this->skipIf(strpos($config['driver'], 'Sqlserver') !== false, 'Test temporarily broken in SQLServer');
+        $this->skipIf(str_contains($config['driver'], 'Sqlserver'), 'Test temporarily broken in SQLServer');
         $table = $this->getTableLocator()->get('PaginatorPosts');
         $query = $table->find()
             ->where(['PaginatorPosts.author_id BETWEEN :start AND :end'])

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -380,7 +380,7 @@ class OauthTest extends TestCase
             $this->assertSignatureFormat($result);
         } catch (CakeException $e) {
             // Handle 22.04 + OpenSSL bug. This should be safe to remove in the future.
-            if (strpos($e->getMessage(), 'unexpected eof while reading') !== false) {
+            if (str_contains($e->getMessage(), 'unexpected eof while reading')) {
                 $this->markTestSkipped('Skipping because of OpenSSL bug.');
             }
             throw $e;

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -740,10 +740,10 @@ class ResponseTest extends TestCase
         $this->assertEquals(99, $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', false));
-        $this->assertEquals(false, $new->getCookie('testing')['value']);
+        $this->assertSame('', $new->getCookie('testing')['value']);
 
         $new = $response->withCookie(new Cookie('testing', true));
-        $this->assertEquals(true, $new->getCookie('testing')['value']);
+        $this->assertSame('1', $new->getCookie('testing')['value']);
     }
 
     /**

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -63,7 +63,7 @@ class ServerTest extends TestCase
     {
         parent::setUp();
         $this->server = $_SERVER;
-        $this->config = dirname(dirname(__DIR__)) . '/test_app/config';
+        $this->config = dirname(__DIR__, 2) . '/test_app/config';
         $GLOBALS['mockedHeaders'] = [];
         $GLOBALS['mockedHeadersSent'] = true;
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -1283,7 +1283,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $found = false;
         foreach ($association->getConditions() as $key => $value) {
-            if (strpos($key, 'comment_translation.model') !== false) {
+            if (str_contains($key, 'comment_translation.model')) {
                 $found = true;
                 $this->assertSame('Comments', $value);
                 break;
@@ -1311,7 +1311,7 @@ class TranslateBehaviorEavTest extends TestCase
 
         $found = false;
         foreach ($association->getConditions() as $key => $value) {
-            if (strpos($key, 'body_translation.model') !== false) {
+            if (str_contains($key, 'body_translation.model')) {
                 $found = true;
                 $this->assertSame('Posts', $value);
                 break;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -135,7 +135,7 @@ class TableTest extends TestCase
         ]);
 
         $config = $this->connection->config();
-        if (strpos($config['driver'], 'Postgres') !== false) {
+        if (str_contains($config['driver'], 'Postgres')) {
             $this->usersTypeMap = new TypeMap([
                 'Users.id' => 'integer',
                 'id' => 'integer',
@@ -153,7 +153,7 @@ class TableTest extends TestCase
                 'Users__updated' => 'timestampfractional',
                 'updated' => 'timestampfractional',
             ]);
-        } elseif (strpos($config['driver'], 'Sqlserver') !== false) {
+        } elseif (str_contains($config['driver'], 'Sqlserver')) {
             $this->usersTypeMap = new TypeMap([
                 'Users.id' => 'integer',
                 'id' => 'integer',

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -195,7 +195,7 @@ class TestCaseTest extends TestCase
         try {
             $this->deprecated(function () {
                 trigger_error('deprecation message', E_USER_DEPRECATED);
-                $this->assertTrue(false, 'A random message');
+                $this->fail('A random message');
             });
 
             $this->fail();

--- a/tests/test_app/Plugin/TestPlugin/src/Http/Session/TestPluginSession.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Http/Session/TestPluginSession.php
@@ -52,7 +52,7 @@ class TestPluginSession implements SessionHandlerInterface
     /**
      * @inheritDoc
      */
-    public function gc($maxlifetime): int|false
+    public function gc($max_lifetime): int|false
     {
         return 0;
     }

--- a/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
+++ b/tests/test_app/TestApp/ApplicationWithDefaultRoutes.php
@@ -40,10 +40,10 @@ class ApplicationWithDefaultRoutes extends BaseApplication
         // Do nothing.
     }
 
-    public function middleware(MiddlewareQueue $middlewareQueueQueue): MiddlewareQueue
+    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueueQueue->add(new RoutingMiddleware($this));
+        $middlewareQueue->add(new RoutingMiddleware($this));
 
-        return $middlewareQueueQueue;
+        return $middlewareQueue;
     }
 }

--- a/tests/test_app/TestApp/ApplicationWithExceptionsInMiddleware.php
+++ b/tests/test_app/TestApp/ApplicationWithExceptionsInMiddleware.php
@@ -37,9 +37,9 @@ class ApplicationWithExceptionsInMiddleware extends BaseApplication
         // Do nothing.
     }
 
-    public function middleware(MiddlewareQueue $middlewareQueueQueue): MiddlewareQueue
+    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
-        $middlewareQueueQueue
+        $middlewareQueue
             // Catch any exceptions in the lower layers,
             // and make an error page/response
             ->add(ErrorHandlerMiddleware::class)
@@ -50,6 +50,6 @@ class ApplicationWithExceptionsInMiddleware extends BaseApplication
             // Add routing middleware.
             ->add(new RoutingMiddleware($this));
 
-        return $middlewareQueueQueue;
+        return $middlewareQueue;
     }
 }

--- a/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
+++ b/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
@@ -17,7 +17,7 @@ class OrderedUuidType extends BaseType implements ExpressionTypeInterface
     /**
      * @inheritDoc
      */
-    public function toPHP(mixed $value, Driver $d): mixed
+    public function toPHP(mixed $value, Driver $driver): mixed
     {
         return new UuidValue($value);
     }
@@ -55,7 +55,7 @@ class OrderedUuidType extends BaseType implements ExpressionTypeInterface
     /**
      * @inheritDoc
      */
-    public function toDatabase(mixed $value, Driver $d): mixed
+    public function toDatabase(mixed $value, Driver $driver): mixed
     {
         return $value;
     }

--- a/tests/test_app/TestApp/Http/MiddlewareApplication.php
+++ b/tests/test_app/TestApp/Http/MiddlewareApplication.php
@@ -39,7 +39,7 @@ class MiddlewareApplication extends BaseApplication
     /**
      * @param \Psr\Http\Message\ServerRequestInterface $request The request
      */
-    public function handle(ServerRequestInterface $req): ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $res = new Response(['status' => 200]);
 

--- a/tests/test_app/TestApp/Http/Session/TestAppLibSession.php
+++ b/tests/test_app/TestApp/Http/Session/TestAppLibSession.php
@@ -59,7 +59,7 @@ class TestAppLibSession implements SessionHandlerInterface
     /**
      * @inheritDoc
      */
-    public function gc($maxlifetime): int|false
+    public function gc($max_lifetime): int|false
     {
         return 0;
     }

--- a/tests/test_app/TestApp/Model/Entity/ProtectedUser.php
+++ b/tests/test_app/TestApp/Model/Entity/ProtectedUser.php
@@ -10,5 +10,5 @@ use Cake\ORM\Entity;
  */
 class ProtectedUser extends Entity
 {
-    protected $_hidden = ['password'];
+    protected array $_hidden = ['password'];
 }

--- a/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
+++ b/tests/test_app/TestApp/TestCase/Event/CustomTestEventListenerInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace TestApp\TestCase\Event;
 
 use Cake\Event\EventListenerInterface;
-use Closure;
 
 /**
  * Mock used for testing the subscriber objects
@@ -19,10 +18,10 @@ class CustomTestEventListenerInterface extends EventTestListener implements Even
         return [
             'fake.event' => 'listenerFunction',
             'another.event' => ['callable' => 'secondListenerFunction'],
-            'closure.event' => Closure::fromCallable([$this, 'thirdlistenerFunction']),
+            'closure.event' => $this->thirdlistenerFunction(...),
             'multiple.handlers' => [
                 ['callable' => 'listenerFunction'],
-                ['callable' => Closure::fromCallable([$this, 'secondListenerFunction'])],
+                ['callable' => $this->secondListenerFunction(...)],
             ],
         ];
     }

--- a/tests/test_app/templates/Posts/json/index.php
+++ b/tests/test_app/templates/Posts/json/index.php
@@ -1,5 +1,5 @@
 <?php
-$paging = isset($this->Paginator->options['url']) ? $this->Paginator->options['url'] : null;
+$paging = $this->Paginator->options['url'] ?? null;
 
 $formatted = [
     'user' => $user['User']['username'],

--- a/tests/test_app/templates/TestsApps/index.php
+++ b/tests/test_app/templates/TestsApps/index.php
@@ -1,1 +1,1 @@
-This is the TestsAppsController index view <?= isset($var) ? $var : ''; ?>
+This is the TestsAppsController index view <?= $var ?? ''; ?>


### PR DESCRIPTION
Some of these changes are related to use modern PHP features like `str_contains` or [first-class callable syntax](https://www.php.net/manual/en/functions.first_class_callable_syntax.php)

Others are just param renames so they inherit the same name from their parent