### PR TITLE
Fix argument type.

### DIFF
--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http;
 
-use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * A builder object that assists in defining Cross Origin Request related
@@ -26,7 +26,7 @@ use Psr\Http\Message\MessageInterface;
  * set all the headers you want to use, the `build()` method can be used to return
  * a modified Response.
  *
- * It is most convenient to get this object via `Request::cors()`.
+ * It is most convenient to get this object via `Response::cors()`.
  *
  * @see \Cake\Http\Response::cors()
  */
@@ -35,9 +35,9 @@ class CorsBuilder
     /**
      * The response object this builder is attached to.
      *
-     * @var \Psr\Http\Message\MessageInterface
+     * @var \Psr\Http\Message\ResponseInterface
      */
-    protected MessageInterface $_response;
+    protected ResponseInterface $_response;
 
     /**
      * The request's Origin header value
@@ -63,11 +63,11 @@ class CorsBuilder
     /**
      * Constructor.
      *
-     * @param \Psr\Http\Message\MessageInterface $response The response object to add headers onto.
+     * @param \Psr\Http\Message\ResponseInterface $response The response object to add headers onto.
      * @param string $origin The request's Origin header.
      * @param bool $isSsl Whether the request was over SSL.
      */
-    public function __construct(MessageInterface $response, string $origin, bool $isSsl = false)
+    public function __construct(ResponseInterface $response, string $origin, bool $isSsl = false)
     {
         $this->_origin = $origin;
         $this->_isSsl = $isSsl;
@@ -80,9 +80,9 @@ class CorsBuilder
      * If the builder has no Origin, or if there are no allowed domains,
      * or if the allowed domains do not match the Origin header no headers will be applied.
      *
-     * @return \Psr\Http\Message\MessageInterface A new instance of the response with new headers.
+     * @return \Psr\Http\Message\ResponseInterface A new instance of the response with new headers.
      */
-    public function build(): MessageInterface
+    public function build(): ResponseInterface
     {
         $response = $this->_response;
         if (empty($this->_origin)) {


### PR DESCRIPTION
Using an unnecessarily wide type causes static analysis errors when consuming the built object. Also manipulating CORS headers for a request object would have no practical value.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
