### PR TITLE
5.x: add deprecation warning to `getMockForModel` if `addMethods` is used

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -307,6 +307,9 @@ abstract class TestCase extends BaseTestCase
      */
     public function loadPlugins(array $plugins = []): BaseApplication
     {
+        /**
+         * @psalm-suppress MissingTemplateParam
+         */
         $app = new class ('') extends BaseApplication
         {
             /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -23,6 +23,7 @@ use Cake\Error\Debugger;
 use Cake\Error\PhpError;
 use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
+use Cake\Http\MiddlewareQueue;
 use Cake\ORM\Entity;
 use Cake\ORM\Exception\MissingTableClassException;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -306,11 +307,17 @@ abstract class TestCase extends BaseTestCase
      */
     public function loadPlugins(array $plugins = []): BaseApplication
     {
-        /** @var \Cake\Http\BaseApplication $app */
-        $app = $this->getMockForAbstractClass(
-            BaseApplication::class,
-            ['']
-        );
+        $app = new class ('') extends BaseApplication
+        {
+            /**
+             * @param \Cake\Http\MiddlewareQueue $middlewareQueue
+             * @return \Cake\Http\MiddlewareQueue
+             */
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
 
         foreach ($plugins as $pluginName => $config) {
             if (is_array($config)) {
@@ -935,6 +942,8 @@ abstract class TestCase extends BaseTestCase
         }
 
         if ($nonExistingMethods) {
+            trigger_error('Adding non existent methods to your model ' .
+                'via testing will not work in future PHPUnit versions.', E_USER_DEPRECATED);
             $builder->addMethods($nonExistingMethods);
         }
 


### PR DESCRIPTION
as we know PHPUnit 10 has deprecated `->addMethods()` and will remove it in the future.

We also provide users to leverage this system via doing 
```
$this->getMockForModel('TableAlias', ['unknownMethod']);
```

Therefore this PR adds a deprecation notice if this functionality is used by users

I also replaced the (also deprecated) `getMockForAbstractClass()` with an anonymous class so we got rid of all known deprecations in our code base at this moment.