### PR TITLE
Make View::getConfig() public.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -82,9 +82,7 @@ class View implements EventDispatcherInterface
      * @use \Cake\Event\EventDispatcherTrait<\Cake\View\View>
      */
     use EventDispatcherTrait;
-    use InstanceConfigTrait {
-        getConfig as protected;
-    }
+    use InstanceConfigTrait;
     use LogTrait;
 
     /**


### PR DESCRIPTION
The visibility overridding is a relic of the past when `getConfig()` was overridden to show deprecation warnings.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
