### PR TITLE
Remove exception where not needed

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -142,10 +142,6 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
 
         $failure = null;
         foreach ($config as $key => $value) {
-            if (!array_key_exists($key, $existingConfig)) {
-                $failure = " The `{$key}` was not defined in the previous configuration data.";
-                break;
-            }
             if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
                 $failure = sprintf(
                     ' The `%s` key has a value of `%s` but previously had a value of `%s`',

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -142,6 +142,10 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
 
         $failure = null;
         foreach ($config as $key => $value) {
+            if ($key !== 'className' && !array_key_exists($key, $existingConfig)) {
+                $failure = " The `{$key}` was not defined in the previous configuration data.";
+                break;
+            }
             if (isset($existingConfig[$key]) && $existingConfig[$key] !== $value) {
                 $failure = sprintf(
                     ' The `%s` key has a value of `%s` but previously had a value of `%s`',

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -75,7 +75,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
         } catch (MissingHelperException $exception) {
             $plugin = $this->_View->getPlugin();
             if (!empty($plugin)) {
-                $this->load($helper, ['className' => $plugin . '.' . $helper]);
+                $this->load($plugin . '.' . $helper);
 
                 return true;
             }


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/17274#issuecomment-1729524448

Is there any reason this is needed?
It seems to make it trip up when setting components inside components in my case where before it didnt throw an exception in 4.x

The alternative would be to always create at least className key when setting it directly via

    protected array $components = ['TinyAuth.Auth'];
    
and

    $this->loadComponent('TinyAuth.Auth');
    
since it would then not fail on such an avoidable issue as "The className was not defined in the previous configuration data"