### PR TITLE
Fix cookie parsing when value is undefined

### DIFF
--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -284,7 +284,10 @@ class Cookie implements CookieInterface
             $parts = preg_split('/\;[ \t]*/', $cookie);
         }
 
-        [$name, $value] = explode('=', array_shift($parts), 2);
+        $nameValue = explode('=', array_shift($parts), 2);
+        $name = array_shift($nameValue);
+        $value = array_shift($nameValue) ?? '';
+
         $data = [
                 'name' => urldecode($name),
                 'value' => urldecode($value),

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -465,7 +465,7 @@ class CookieTest extends TestCase
         $this->assertSame('test;example.com;/path', $cookie->getId());
     }
 
-    public function testCreateFromHeaderString(): void
+    public function testCreateFromHeaderStringInvalidSamesite(): void
     {
         $header = 'cakephp=cakephp-rocks; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org; samesite=invalid; secure; httponly';
         $result = Cookie::createFromHeaderString($header);
@@ -473,6 +473,14 @@ class CookieTest extends TestCase
         // Ignore invalid value when parsing headers
         // https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-4.1
         $this->assertNull($result->getSameSite());
+    }
+
+    public function testCreateFromHeaderStringEmptyValue(): void
+    {
+        $header = 'cakephp; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org;';
+        $result = Cookie::createFromHeaderString($header);
+
+        $this->assertSame('', $result->getValue());
     }
 
     public function testDefaults(): void

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -477,6 +477,7 @@ class CookieTest extends TestCase
 
     public function testCreateFromHeaderStringEmptyValue(): void
     {
+        // Invalid cookie with no = separator or value.
         $header = 'cakephp; expires=Wed, 01-Dec-2027 12:00:00 GMT; path=/; domain=cakephp.org;';
         $result = Cookie::createFromHeaderString($header);
 
@@ -502,7 +503,7 @@ class CookieTest extends TestCase
         $this->expectExceptionMessage('Invalid type `array` for expire');
 
         Cookie::setDefaults(['expires' => ['ompalompa']]);
-        $cookie = new Cookie('cakephp', 'cakephp-rocks');
+        new Cookie('cakephp', 'cakephp-rocks');
     }
 
     public function testInvalidSameSiteForDefaults(): void


### PR DESCRIPTION
Some server send malformed cookie name/value pairs that lack both the value and are missing an `=`.

Fixes #17296
