### PR TITLE
Fix for SortIterator with support for Chronos instances

### DIFF
--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -18,6 +18,7 @@ namespace Cake\Collection\Iterator;
 
 use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
+use Cake\Chronos\ChronosTime;
 use Cake\Collection\Collection;
 use DateTimeInterface;
 use Iterator;
@@ -77,7 +78,11 @@ class SortIterator extends Collection
         $results = [];
         foreach ($items as $key => $val) {
             $val = $callback($val);
-            $isDateTime = $val instanceof DateTimeInterface || $val instanceof Chronos || $val instanceof ChronosDate;
+            $isDateTime =
+                $val instanceof DateTimeInterface ||
+                $val instanceof Chronos ||
+                $val instanceof ChronosDate ||
+                $val instanceof ChronosTime;
             if ($isDateTime && $type === SORT_NUMERIC) {
                 $val = $val->format('U');
             }

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Collection\Iterator;
 
+use Cake\Chronos\Chronos;
+use Cake\Chronos\ChronosDate;
 use Cake\Collection\Collection;
 use DateTimeInterface;
 use Iterator;
@@ -75,7 +77,8 @@ class SortIterator extends Collection
         $results = [];
         foreach ($items as $key => $val) {
             $val = $callback($val);
-            if ($val instanceof DateTimeInterface && $type === SORT_NUMERIC) {
+            $isDateTime = $val instanceof DateTimeInterface || $val instanceof Chronos || $val instanceof ChronosDate;
+            if ($isDateTime && $type === SORT_NUMERIC) {
                 $val = $val->format('U');
             }
             $results[$key] = $val;

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Collection\Iterator;
 use ArrayObject;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
+use Cake\Chronos\ChronosTime;
 use Cake\Collection\Iterator\SortIterator;
 use Cake\TestSuite\TestCase;
 use DateInterval;
@@ -256,6 +257,40 @@ class SortIteratorTest extends TestCase
             new DateTimeImmutable('2013-08-12'),
             new Chronos('2014-07-21'),
             new ChronosDate('2015-06-30'),
+        ];
+        $this->assertEquals($expected, $sorted->toList());
+    }
+
+    /**
+     * Tests sorting with Chronos time instances
+     */
+    public function testSortWithChronosTime(): void
+    {
+        $items = new ArrayObject([
+            new ChronosTime('12:00:00'),
+            new ChronosTime('10:00:01'),
+            new ChronosTime('11:00:00'),
+        ]);
+        $callback = fn ($d) => $d;
+        $sorted = new SortIterator($items, $callback);
+        $expected = [
+            new ChronosTime('12:00:00'),
+            new ChronosTime('11:00:00'),
+            new ChronosTime('10:00:01'),
+        ];
+        $this->assertEquals($expected, $sorted->toList());
+
+        $items = new ArrayObject([
+            new ChronosTime('12:00:00'),
+            new ChronosTime('10:00:01'),
+            new ChronosTime('11:00:00'),
+        ]);
+
+        $sorted = new SortIterator($items, $callback, SORT_ASC);
+        $expected = [
+            new ChronosTime('10:00:01'),
+            new ChronosTime('11:00:00'),
+            new ChronosTime('12:00:00'),
         ];
         $this->assertEquals($expected, $sorted->toList());
     }

--- a/tests/TestCase/Collection/Iterator/SortIteratorTest.php
+++ b/tests/TestCase/Collection/Iterator/SortIteratorTest.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Collection\Iterator;
 
 use ArrayObject;
+use Cake\Chronos\Chronos;
+use Cake\Chronos\ChronosDate;
 use Cake\Collection\Iterator\SortIterator;
 use Cake\TestSuite\TestCase;
 use DateInterval;
@@ -220,6 +222,40 @@ class SortIteratorTest extends TestCase
             new DateTimeImmutable('2013-08-12'),
             new DateTime('2015-07-21'),
             new DateTime('2016-06-30'),
+        ];
+        $this->assertEquals($expected, $sorted->toList());
+    }
+
+    /**
+     * Tests sorting with Chronos datetime
+     */
+    public function testSortWithChronosDateTime(): void
+    {
+        $items = new ArrayObject([
+            new Chronos('2014-07-21'),
+            new ChronosDate('2015-06-30'),
+            new DateTimeImmutable('2013-08-12'),
+        ]);
+        $callback = fn ($d) => $d;
+        $sorted = new SortIterator($items, $callback);
+        $expected = [
+            new ChronosDate('2015-06-30'),
+            new Chronos('2014-07-21'),
+            new DateTimeImmutable('2013-08-12'),
+        ];
+        $this->assertEquals($expected, $sorted->toList());
+
+        $items = new ArrayObject([
+            new Chronos('2014-07-21'),
+            new ChronosDate('2015-06-30'),
+            new DateTimeImmutable('2013-08-12'),
+        ]);
+
+        $sorted = new SortIterator($items, $callback, SORT_ASC);
+        $expected = [
+            new DateTimeImmutable('2013-08-12'),
+            new Chronos('2014-07-21'),
+            new ChronosDate('2015-06-30'),
         ];
         $this->assertEquals($expected, $sorted->toList());
     }


### PR DESCRIPTION
This pull request addresses an issue where the `SortIterator` was not functioning correctly with instances of Chronos. Currently, the class only handles DateTimeImmutable instances, while Chronos and ChronosDate no longer extend this native class.

The problem was observed when migrating a project to version 5.0. This correction aims to resolve this issue, allowing the SortIterator to work properly with Chronos instances.

How to reproduce the bug:
```php
$table = TableRegistry::getTableLocator()->get('Posts');
$table->find()->all()->sortBy('created_at');
// Error: Object of class Cake\I18n\DateTime could not be converted to float
```
OR
```php
$items =[Chronos::now(), Chronos::yesterday()];
$sorted = (new SortIterator($items, fn ($d) => $d))->toList();
// Error: Object of class Cake\Chronos\Chronos could not be converted to float
```
Error:
```
src/Collection/Iterator/SortIterator.php, line 84: 
Object of class Cake\I18n\DateTime could not be converted to float on line 84
```

Even if the Chronos class is updated to inherit from DateTimeImmutable again (#17279), I still have concerns that this bug may affect instances of ChronosDate and ChronosTime.