### PR TITLE
Fix source line for dd() functions

### DIFF
--- a/src/Error/functions.php
+++ b/src/Error/functions.php
@@ -98,7 +98,7 @@ function dd(mixed $var, ?bool $showHtml = null): void
         return;
     }
 
-    $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
+    $trace = Debugger::trace(['start' => 0, 'depth' => 2, 'format' => 'array']);
     /** @psalm-suppress PossiblyInvalidArrayOffset */
     $location = [
         'line' => $trace[0]['line'],

--- a/src/Error/functions_global.php
+++ b/src/Error/functions_global.php
@@ -101,7 +101,7 @@ if (!function_exists('dd')) {
             return;
         }
 
-        $trace = Debugger::trace(['start' => 1, 'depth' => 2, 'format' => 'array']);
+        $trace = Debugger::trace(['start' => 0, 'depth' => 2, 'format' => 'array']);
         /** @psalm-suppress PossiblyInvalidArrayOffset */
         $location = [
             'line' => $trace[0]['line'],


### PR DESCRIPTION
Align the source line with debug().

Fixes #17299
