### PR TITLE
[5.x] Keep contain key when defining associations through $this->paginate()

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -261,7 +261,7 @@ class NumericPaginator implements PaginatorInterface
         $options = $data['options'];
         $queryOptions = array_intersect_key(
             $options,
-            ['order' => null, 'page' => null, 'limit' => null],
+            ['order' => null, 'page' => null, 'limit' => null, 'contain' => null],
         );
 
         if ($query === null) {

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -128,6 +128,7 @@ trait PaginatorTestTrait
                 'limit' => 10,
                 'order' => ['PaginatorPosts.id' => 'ASC'],
                 'page' => 1,
+                'contain' => ['PaginatorAuthor'],
             ]);
 
         $this->Paginator->paginate($table, $params, $settings);


### PR DESCRIPTION
Relates to https://github.com/cakephp/cakephp/issues/17308
