### PR TITLE
Fix DashedRoute & InflectedRoute defaults after match()

### DIFF
--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -31,9 +31,9 @@ class DashedRoute extends Route
      * Default values need to be inflected so that they match the inflections that
      * match() will create.
      *
-     * @var bool
+     * @var array|null
      */
-    protected $_inflectedDefaults = false;
+    protected $_inflectedDefaults;
 
     /**
      * Camelizes the previously dashed plugin route taking into account plugin vendors
@@ -97,12 +97,18 @@ class DashedRoute extends Route
     public function match(array $url, array $context = []): ?string
     {
         $url = $this->_dasherize($url);
-        if (!$this->_inflectedDefaults) {
-            $this->_inflectedDefaults = true;
-            $this->defaults = $this->_dasherize($this->defaults);
+        if ($this->_inflectedDefaults === null) {
+            $this->compile();
+            $this->_inflectedDefaults = $this->_dasherize($this->defaults);
         }
+        try {
+            $restore = $this->defaults;
+            $this->defaults = $this->_inflectedDefaults;
 
-        return parent::match($url, $context);
+            return parent::match($url, $context);
+        } finally {
+            $this->defaults = $restore;
+        }
     }
 
     /**

--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -101,8 +101,8 @@ class DashedRoute extends Route
             $this->compile();
             $this->_inflectedDefaults = $this->_dasherize($this->defaults);
         }
+        $restore = $this->defaults;
         try {
-            $restore = $this->defaults;
             $this->defaults = $this->_inflectedDefaults;
 
             return parent::match($url, $context);

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -80,8 +80,8 @@ class InflectedRoute extends Route
             $this->compile();
             $this->_inflectedDefaults = $this->_underscore($this->defaults);
         }
+        $restore = $this->defaults;
         try {
-            $restore = $this->defaults;
             $this->defaults = $this->_inflectedDefaults;
 
             return parent::match($url, $context);

--- a/src/Routing/Route/InflectedRoute.php
+++ b/src/Routing/Route/InflectedRoute.php
@@ -30,9 +30,9 @@ class InflectedRoute extends Route
      * Default values need to be inflected so that they match the inflections that match()
      * will create.
      *
-     * @var bool
+     * @var array|null
      */
-    protected $_inflectedDefaults = false;
+    protected $_inflectedDefaults;
 
     /**
      * Parses a string URL into an array. If it matches, it will convert the prefix, controller and
@@ -76,12 +76,18 @@ class InflectedRoute extends Route
     public function match(array $url, array $context = []): ?string
     {
         $url = $this->_underscore($url);
-        if (!$this->_inflectedDefaults) {
-            $this->_inflectedDefaults = true;
-            $this->defaults = $this->_underscore($this->defaults);
+        if ($this->_inflectedDefaults === null) {
+            $this->compile();
+            $this->_inflectedDefaults = $this->_underscore($this->defaults);
         }
+        try {
+            $restore = $this->defaults;
+            $this->defaults = $this->_inflectedDefaults;
 
-        return parent::match($url, $context);
+            return parent::match($url, $context);
+        } finally {
+            $this->defaults = $restore;
+        }
     }
 
     /**

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -206,4 +206,21 @@ class DashedRouteTest extends TestCase
         $this->assertSame('actionName', $result['action']);
         $this->assertSame('Vendor/PluginName', $result['plugin']);
     }
+
+    public function testMatchDoesNotCorruptDefaults()
+    {
+        $route = new DashedRoute('/user-permissions/edit', [
+            'controller' => 'UserPermissions',
+            'action' => 'edit',
+        ]);
+        $route->match(['controller' => 'UserPermissions', 'action' => 'edit'], []);
+
+        $this->assertSame('UserPermissions', $route->defaults['controller']);
+        $this->assertSame('edit', $route->defaults['action']);
+
+        // Do the match again to ensure that state doesn't become incorrect.
+        $route->match(['controller' => 'UserPermissions', 'action' => 'edit'], []);
+        $this->assertSame('UserPermissions', $route->defaults['controller']);
+        $this->assertSame('edit', $route->defaults['action']);
+    }
 }

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Routing\Route;
 
 use Cake\Routing\Route\InflectedRoute;
-use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Routing\Route;
 
 use Cake\Routing\Route\InflectedRoute;
+use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 
@@ -218,5 +219,19 @@ class InflectedRouteTest extends TestCase
         $this->assertSame('ControllerName', $result['controller']);
         $this->assertSame('action_name', $result['action']);
         $this->assertSame('Vendor/PluginName', $result['plugin']);
+    }
+
+    public function testMatchDoesNotCorruptDefaults()
+    {
+        $route = new InflectedRoute('/user_permissions/edit', ['controller' => 'UserPermissions', 'action' => 'edit']);
+        $route->match(['controller' => 'UserPermissions', 'action' => 'edit'], []);
+
+        $this->assertSame('UserPermissions', $route->defaults['controller']);
+        $this->assertSame('edit', $route->defaults['action']);
+
+        // Do the match again to ensure that state doesn't become incorrect.
+        $route->match(['controller' => 'UserPermissions', 'action' => 'edit'], []);
+        $this->assertSame('UserPermissions', $route->defaults['controller']);
+        $this->assertSame('edit', $route->defaults['action']);
     }
 }


### PR DESCRIPTION
After match() is called, route defaults should not be mutated. I've repurposed the `_inflectedDefaults` attribute to contain the inflected default values so that we can continue to inflect defaults only once.

Fixes #17265
Refs #17269