### PR TITLE
Allow using _translations.{locale}.field_name style naming for default locale.

### DIFF
--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Behavior;
 
+use ArrayObject;
 use Cake\Datasource\QueryInterface;
+use Cake\Event\EventInterface;
 use Cake\I18n\I18n;
 use Cake\ORM\Behavior;
 use Cake\ORM\Behavior\Translate\ShadowTableStrategy;
@@ -211,9 +213,40 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     {
         return [
             'Model.beforeFind' => 'beforeFind',
+            'Model.beforeMarshal' => 'beforeMarshal',
             'Model.beforeSave' => 'beforeSave',
             'Model.afterSave' => 'afterSave',
         ];
+    }
+
+    /**
+     * Hoist fields for the default locale under `_translations` key to the root
+     * in the data.
+     *
+     * This allows `_translations.{locale}.field_name` type naming even for the
+     * default locale in forms.
+     *
+     * @param \Cake\Event\EventInterface $event
+     * @param \ArrayObject $data
+     * @param \ArrayObject $options
+     * @return void
+     */
+    public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void
+    {
+        if (isset($options['translations']) && !$options['translations']) {
+            return;
+        }
+
+        $defaultLocale = $this->getConfig('defaultLocale');
+        if (!isset($data['_translations'][$defaultLocale])) {
+            return;
+        }
+
+        foreach ($data['_translations'][$defaultLocale] as $field => $value) {
+            $data[$field] = $value;
+        }
+
+        unset($data['_translations'][$defaultLocale]);
     }
 
     /**

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -880,9 +880,21 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table = $this->getTableLocator()->get('Articles');
         $table->getValidator()->add('title', 'notBlank', ['rule' => 'notBlank']);
         $table->addBehavior('Translate', [
+            'defaultLocale' => 'en',
             'fields' => ['title'],
         ]);
         $table->setEntityClass(TranslateArticle::class);
+
+        $article = $table->patchEntity(
+            $table->newEmptyEntity(),
+            [
+                '_translations' => ['en' => ['title' => '']],
+            ],
+        );
+        $this->assertSame(
+            ['notBlank' => 'The provided value is invalid'],
+            $article->getError('title')
+        );
 
         $data = [
             'author_id' => 1,
@@ -895,6 +907,9 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
                 'es' => [
                     'title' => 'Title ES',
                 ],
+                'fr' => [
+                    'title' => 'Title FR',
+                ],
             ],
         ];
 
@@ -905,10 +920,10 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
 
         $expected = [
             [
-                'en' => [
-                    'title' => 'Title EN',
-                    'locale' => 'en',
-                    'body' => 'Body EN',
+                'fr' => [
+                    'title' => 'Title FR',
+                    'locale' => 'fr',
+                    'body' => null,
                 ],
                 'es' => [
                     'title' => 'Title ES',
@@ -917,8 +932,12 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
                 ],
             ],
         ];
-        $result = $table->find('translations')->where(['id' => $result->id]);
+        $result = $table->find('translations')->where(['Articles.id' => $result->id])->all();
         $this->assertEquals($expected, $this->_extractTranslations($result)->toArray());
+
+        $entity = $result->first();
+        $this->assertSame('Title EN', $entity->title);
+        $this->assertSame('Body EN', $entity->body);
     }
 
     /**


### PR DESCRIPTION
This allows consistently naming the translated fields for all locales in forms. Refs https://discourse.cakephp.org/t/translate-behavior-in-cakephp-5-x/11530.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
