### PR TITLE
Add query to LoggedQuery::getContext()

### DIFF
--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -131,6 +131,7 @@ class LoggedQuery implements JsonSerializable, Stringable
     public function getContext(): array
     {
         return [
+            'query' => $this->query,
             'numRows' => $this->numRows,
             'took' => $this->took,
             'role' => $this->driver ? $this->driver->getRole() : '',

--- a/tests/TestCase/Database/Log/LoggedQueryTest.php
+++ b/tests/TestCase/Database/Log/LoggedQueryTest.php
@@ -172,6 +172,7 @@ class LoggedQueryTest extends TestCase
         ]);
 
         $expected = [
+            'query' => 'SELECT a FROM b where a = :p1',
             'numRows' => 10,
             'took' => 15.0,
             'role' => '',


### PR DESCRIPTION
As discussed on Discord, this allows access to the executed parameterized SQL query.