### PR TITLE
Issue #17318: Cyclic Recursion while using EntityTrait::getErrors and ::hasErrors

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -119,6 +119,11 @@ trait EntityTrait
     protected $_registryAlias = '';
 
     /**
+     * Storing the current visitation status while recursing through entities getting errors.
+     */
+    private $_hasBeenVisited = false;
+
+    /**
      * Magic getter to access fields that have been set in this entity
      *
      * @param string $field Name of the field to access
@@ -845,6 +850,11 @@ trait EntityTrait
      */
     public function hasErrors(bool $includeNested = true): bool
     {
+        if($this->_hasBeenVisited) {
+            // While recursing through entities, each entity should only be visited once. See https://github.com/cakephp/cakephp/issues/17318
+            return false;
+        }
+
         if (Hash::filter($this->_errors)) {
             return true;
         }
@@ -853,10 +863,15 @@ trait EntityTrait
             return false;
         }
 
-        foreach ($this->_fields as $field) {
-            if ($this->_readHasErrors($field)) {
-                return true;
+        $this->_hasBeenVisited = true;
+        try {
+            foreach ($this->_fields as $field) {
+                if ($this->_readHasErrors($field)) {
+                    return true;
+                }
             }
+        } finally {
+            $this->_hasBeenVisited = false;
         }
 
         return false;
@@ -869,17 +884,29 @@ trait EntityTrait
      */
     public function getErrors(): array
     {
+        if($this->_hasBeenVisited) {
+            // While recursing through entities, each entity should only be visited once. See https://github.com/cakephp/cakephp/issues/17318
+            return [];
+        }
+
         $diff = array_diff_key($this->_fields, $this->_errors);
 
-        return $this->_errors + (new Collection($diff))
-            ->filter(function ($value) {
-                return is_array($value) || $value instanceof EntityInterface;
-            })
-            ->map(function ($value) {
-                return $this->_readError($value);
-            })
-            ->filter()
-            ->toArray();
+        $this->_hasBeenVisited = true;
+        try {
+            $errors = $this->_errors + (new Collection($diff))
+                ->filter(function ($value) {
+                    return is_array($value) || $value instanceof EntityInterface;
+                })
+                ->map(function ($value) {
+                    return $this->_readError($value);
+                })
+                ->filter()
+                ->toArray();
+        } finally {
+            $this->_hasBeenVisited = false;
+        }
+
+        return $errors;
     }
 
     /**

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -123,7 +123,7 @@ trait EntityTrait
      *
      * @var bool
      */
-    private $_hasBeenVisited = false;
+    protected $_hasBeenVisited = false;
 
     /**
      * Magic getter to access fields that have been set in this entity

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -120,6 +120,8 @@ trait EntityTrait
 
     /**
      * Storing the current visitation status while recursing through entities getting errors.
+     *
+     * @var bool
      */
     private $_hasBeenVisited = false;
 
@@ -850,7 +852,7 @@ trait EntityTrait
      */
     public function hasErrors(bool $includeNested = true): bool
     {
-        if($this->_hasBeenVisited) {
+        if ($this->_hasBeenVisited) {
             // While recursing through entities, each entity should only be visited once. See https://github.com/cakephp/cakephp/issues/17318
             return false;
         }
@@ -884,7 +886,7 @@ trait EntityTrait
      */
     public function getErrors(): array
     {
-        if($this->_hasBeenVisited) {
+        if ($this->_hasBeenVisited) {
             // While recursing through entities, each entity should only be visited once. See https://github.com/cakephp/cakephp/issues/17318
             return [];
         }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1654,4 +1654,35 @@ class EntityTest extends TestCase
         $this->assertTrue($entity->hasValue('floatNonZero'));
         $this->assertFalse($entity->hasValue('null'));
     }
+
+    /**
+     * Test infinite recursion in getErrors and hasErrors
+     * See https://github.com/cakephp/cakephp/issues/17318
+     */
+    public function testGetErrorsRecursionError() {
+        $entity = new Entity();
+        $secondEntity = new Entity();
+
+        $entity->set('child', $secondEntity);
+        $secondEntity->set('parent', $entity);
+
+        $expectedErrors = ['name' => ['_required' => 'Must be present.']];
+        $secondEntity->setErrors($expectedErrors);
+
+        $this->assertEquals(['child' => $expectedErrors], $entity->getErrors());
+    }
+
+    /**
+     * Test infinite recursion in getErrors and hasErrors
+     * See https://github.com/cakephp/cakephp/issues/17318
+     */
+    public function testHasErrorsRecursionError() {
+        $entity = new Entity();
+        $secondEntity = new Entity();
+
+        $entity->set('child', $secondEntity);
+        $secondEntity->set('parent', $entity);
+
+        $this->assertFalse($entity->hasErrors());
+    }
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1659,7 +1659,8 @@ class EntityTest extends TestCase
      * Test infinite recursion in getErrors and hasErrors
      * See https://github.com/cakephp/cakephp/issues/17318
      */
-    public function testGetErrorsRecursionError() {
+    public function testGetErrorsRecursionError()
+    {
         $entity = new Entity();
         $secondEntity = new Entity();
 
@@ -1676,7 +1677,8 @@ class EntityTest extends TestCase
      * Test infinite recursion in getErrors and hasErrors
      * See https://github.com/cakephp/cakephp/issues/17318
      */
-    public function testHasErrorsRecursionError() {
+    public function testHasErrorsRecursionError()
+    {
         $entity = new Entity();
         $secondEntity = new Entity();
 


### PR DESCRIPTION
See Issue #17318

To prevent infinite recursion when checking for errors in linked entities (i.e. when there are cyclic references), the methods `getErrors` and `hasErrors` now keep track of being visited in the private property `_hasBeenVisited`, which they set to `true` before recursing into entities linked to them, and set to `false` again afterwards. If it has already been set to `true`, they just return no errors (or `false` in case of `hasErrors`).

Except for removing the possibility of infinite recursion, this change does not change any method signatures, and keeps the existing behavior identical. All tests in `EntityTest.php` were successful and I added two additional tests to check that infinite recusion does in fact not occur.

If this fix is fine for everyone, I'll also write one for 5.x.