### PR TITLE
Add trailing newline for generated file

### DIFF
--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -118,7 +118,7 @@ class PluginLoadCommand extends Command
         } else {
             $array = var_export($config, true);
         }
-        $contents = '<?php' . PHP_EOL . 'return ' . $array . ';' . PHP_EOL;
+        $contents = '<?php' . "\n\n" . 'return ' . $array . ';' . "\n";
 
         if (file_put_contents($this->configFile, $contents)) {
             return static::CODE_SUCCESS;

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -114,7 +114,7 @@ class PluginLoadCommand extends Command
         $config[$plugin] = $options;
 
         if (class_exists(VarExporter::class)) {
-            $array = VarExporter::export($config);
+            $array = VarExporter::export($config, VarExporter::TRAILING_COMMA_IN_ARRAY);
         } else {
             $array = var_export($config, true);
         }

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -118,7 +118,7 @@ class PluginLoadCommand extends Command
         } else {
             $array = var_export($config, true);
         }
-        $contents = '<?php' . "\n" . 'return ' . $array . ';';
+        $contents = '<?php' . PHP_EOL . 'return ' . $array . ';' . PHP_EOL;
 
         if (file_put_contents($this->configFile, $contents)) {
             return static::CODE_SUCCESS;


### PR DESCRIPTION
The generated file is usually flagged by CS right away as the trailing new line is missing
This fixes it

Technically, the comma is also missing in the last line of the array:
```php
<?php
return [
    'Foo/Bar' => []
];
```
Added that too.

```
 2 | ERROR | [x] Expected 1 line before "return", found 0.
   |       |     (SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing.IncorrectLinesCountBeforeControlStructure)
 3 | ERROR | [x] Multi-line arrays must have a trailing comma after the last element. (SlevomatCodingStandard.Arrays.TrailingArrayComma.MissingTrailingComma)
 4 | ERROR | [x] Expected 1 newline at end of file; 0 found (PSR2.Files.EndFileNewline.NoneFound)
```