### PR TITLE
Don't throw an exception for unsupoorted types.

### DIFF
--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -159,17 +159,6 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         $function = new ReflectionFunction($action);
         foreach ($function->getParameters() as $parameter) {
             $type = $parameter->getType();
-            if ($type && !$type instanceof ReflectionNamedType) {
-                // Only single types are supported
-                throw new InvalidParameterException([
-                    'template' => 'unsupported_type',
-                    'parameter' => $parameter->getName(),
-                    'controller' => $this->controller->getName(),
-                    'action' => $this->controller->getRequest()->getParam('action'),
-                    'prefix' => $this->controller->getRequest()->getParam('prefix'),
-                    'plugin' => $this->controller->getRequest()->getParam('plugin'),
-                ]);
-            }
 
             // Check for dependency injection for classes
             if ($type instanceof ReflectionNamedType && !$type->isBuiltin()) {

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -887,7 +887,7 @@ class ControllerFactoryTest extends TestCase
             'params' => [
                 'plugin' => null,
                 'controller' => 'Dependencies',
-                'action' => 'unsupportedTypedUnion',
+                'action' => 'typedUnion',
                 'pass' => ['1'],
             ],
         ]);

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -888,14 +888,15 @@ class ControllerFactoryTest extends TestCase
                 'plugin' => null,
                 'controller' => 'Dependencies',
                 'action' => 'unsupportedTypedUnion',
-                'pass' => ['test'],
+                'pass' => ['1'],
             ],
         ]);
         $controller = $this->factory->create($request);
 
-        $this->expectException(InvalidParameterException::class);
-        $this->expectExceptionMessage('Type declaration for `one` in action `Dependencies::unsupportedTypedUnion()` is unsupported.');
-        $this->factory->invoke($controller);
+        $result = $this->factory->invoke($controller);
+        $data = json_decode((string)$result->getBody(), true);
+
+        $this->assertSame(['one' => '1'], $data);
     }
 
     public function testMiddleware(): void

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -60,7 +60,7 @@ class DependenciesController extends Controller
         return $this->response->withStringBody(json_encode(compact('one')));
     }
 
-    public function unsupportedTypedUnion(string|int $one)
+    public function typedUnion(string|int $one)
     {
         return $this->response->withStringBody(json_encode(compact('one')));
     }


### PR DESCRIPTION
If the ControllerFactory encounters a method argument type like union type which it cannot use for conversion, it no longer throws an exception and passes the value as is.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
