### PR TITLE
Fix up test suite constraint messages.

### DIFF
--- a/src/Console/TestSuite/Constraint/ContentsContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsContain.php
@@ -40,7 +40,7 @@ class ContentsContain extends ContentsBase
      */
     public function toString(): string
     {
-        return sprintf('is in %s,' . PHP_EOL . 'actual result:' . PHP_EOL, $this->output) . $this->contents;
+        return sprintf('is in %s,' . PHP_EOL . 'actual result:' . PHP_EOL . '`%s`', $this->output, $this->contents);
     }
 }
 

--- a/src/Console/TestSuite/Constraint/ExitCode.php
+++ b/src/Console/TestSuite/Constraint/ExitCode.php
@@ -57,7 +57,12 @@ class ExitCode extends Constraint
      */
     public function toString(): string
     {
-        return sprintf('matches exit code %s', $this->exitCode ?? 'null');
+        return sprintf('matches exit code `%s`', $this->exitCode ?? 'null');
+    }
+
+    public function failureDescription(mixed $other): string
+    {
+        return '`' . $other . '` ' . $this->toString();
     }
 }
 

--- a/src/Console/TestSuite/Constraint/ExitCode.php
+++ b/src/Console/TestSuite/Constraint/ExitCode.php
@@ -60,6 +60,12 @@ class ExitCode extends Constraint
         return sprintf('matches exit code `%s`', $this->exitCode ?? 'null');
     }
 
+    /**
+     * Returns the description of the failure.
+     *
+     * @param mixed $other Expected
+     * @return string
+     */
     public function failureDescription(mixed $other): string
     {
         return '`' . $other . '` ' . $this->toString();

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -228,7 +228,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     public static function assertionFailureMessagesProvider(): array
     {
         return [
-            'assertExitCode' => ['assertExitCode', 'Failed asserting that 1 matches exit code 0', 'routes', CommandInterface::CODE_ERROR],
+            'assertExitCode' => ['assertExitCode', 'Failed asserting that `1` matches exit code `0`', 'routes', CommandInterface::CODE_ERROR],
             'assertOutputEmpty' => ['assertOutputEmpty', 'Failed asserting that output is empty', 'routes'],
             'assertOutputContains' => ['assertOutputContains', 'Failed asserting that \'missing\' is in output', 'routes', 'missing'],
             'assertOutputNotContains' => ['assertOutputNotContains', 'Failed asserting that \'controller\' is not in output', 'routes', 'controller'],


### PR DESCRIPTION
When rewriting shell to command tests, I noticed this confusing message:
```
1) Setup\Test\TestCase\Command\MaintenanceModeStatusCommandTest::testStatus
Failed asserting that 'Maintenance mode not active.' is in output,
actual result:
Maintenance mode not active.
```

Turns out the dot is part of the PHPUnit addition after the actual element output.

To avoid confusion I fixed up the messages using proper code fencing.
This makes it more clear:
```
1) Setup\Test\TestCase\Command\MaintenanceModeStatusCommandTest::testStatus
Failed asserting that 'Maintenance mode not active.' is in output,
actual result:
`Maintenance mode not active`.
```