### PR TITLE
5.next - Adds support for validating backed enums.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.0@a0a9c27630bcf8301ee78cb06741d2907d8c9fef">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Cache/Engine/FileEngine.php">
     <TooManyTemplateParams>
       <code>$iterator</code>
@@ -163,6 +163,12 @@
   <file src="src/Utility/Hash.php">
     <RedundantCondition>
       <code>is_array($_list)</code>
+    </RedundantCondition>
+  </file>
+  <file src="src/Validation/Validation.php">
+    <RedundantCondition>
+      <code><![CDATA[$check instanceof $enumClassName &&
+            $check instanceof BackedEnum]]></code>
     </RedundantCondition>
   </file>
   <file src="src/View/Exception/MissingCellTemplateException.php">

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -801,21 +801,20 @@ class Validation
             return true;
         }
 
-        if (
-            !is_string($check) &&
-            !is_int($check)
-        ) {
-            return false;
-        }
-
+        $backingType = null;
         try {
             $reflectionEnum = new ReflectionEnum($enumClassName);
-            $backingType = (string)$reflectionEnum->getBackingType();
+            $backingType = $reflectionEnum->getBackingType();
         } catch (ReflectionException) {
-            return false;
         }
 
-        if (get_debug_type($check) !== $backingType) {
+        if ($backingType === null) {
+            throw new InvalidArgumentException(
+                'The `$enumClassName` argument must be the classname of a valid backed enum.'
+            );
+        }
+
+        if (get_debug_type($check) !== (string)$backingType) {
             return false;
         }
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -819,11 +819,7 @@ class Validation
             return false;
         }
 
-        if ($enumClassName::tryFrom($check) !== null) {
-            return true;
-        }
-
-        return false;
+        return $enumClassName::tryFrom($check) !== null;
     }
 
     /**

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -18,6 +18,7 @@ namespace Cake\Validation;
 
 use ArrayAccess;
 use ArrayIterator;
+use BackedEnum;
 use Closure;
 use Countable;
 use InvalidArgumentException;
@@ -2030,6 +2031,45 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
 
         return $this->add($field, 'email', $extra + [
             'rule' => ['email', $checkMX],
+        ]);
+    }
+
+    /**
+     * Add a backed enum validation rule to a field.
+     *
+     * @param string $field The field you want to apply the rule to.
+     * @param class-string<\BackedEnum> $enumClassName The valid backed enum class name.
+     * @param string|null $message The error message when the rule fails.
+     * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
+     *   true when the validation rule should be applied.
+     * @return $this
+     * @see \Cake\Validation\Validation::enum()
+     * @since 5.1.0
+     */
+    public function enum(
+        string $field,
+        string $enumClassName,
+        ?string $message = null,
+        Closure|string|null $when = null
+    ) {
+        if (!in_array(BackedEnum::class, (array)class_implements($enumClassName), true)) {
+            throw new InvalidArgumentException(
+                'The `$enumClassName` argument must be the classname of a valid backed enum.'
+            );
+        }
+
+        if ($message === null) {
+            if (!$this->_useI18n) {
+                $message = sprintf('The provided value must be a `\%s` enum instance or value', $enumClassName);
+            } else {
+                $message = __d('cake', 'The provided value must be a `\{0}` enum instance or value', $enumClassName);
+            }
+        }
+
+        $extra = array_filter(['on' => $when, 'message' => $message]);
+
+        return $this->add($field, 'enum', $extra + [
+            'rule' => ['enum', $enumClassName],
         ]);
     }
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -2059,10 +2059,12 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         }
 
         if ($message === null) {
+            $cases = array_map(fn ($case) => $case->value, $enumClassName::cases());
+            $caseOptions = implode('`, `', $cases);
             if (!$this->_useI18n) {
-                $message = sprintf('The provided value must be a `\%s` enum instance or value', $enumClassName);
+                $message = sprintf('The provided value must be one of `%s`', $caseOptions);
             } else {
-                $message = __d('cake', 'The provided value must be a `\{0}` enum instance or value', $enumClassName);
+                $message = __d('cake', 'The provided value must be one of `{0}`', $caseOptions);
             }
         }
 

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2032,9 +2032,22 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::enum(ArticleStatus::PUBLISHED, Priority::class));
         $this->assertFalse(Validation::enum('wrong type', Priority::class));
         $this->assertFalse(Validation::enum(123, Priority::class));
+    }
 
-        $this->assertFalse(Validation::enum(NonBacked::Basic, NonBacked::class));
-        $this->assertFalse(Validation::enum('non-enum class', TestCase::class));
+    public function testEnumNonBacked(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
+
+        Validation::enum(NonBacked::Basic, NonBacked::class);
+    }
+
+    public function testEnumNonEnum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
+
+        Validation::enum('non-enum class', TestCase::class);
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -30,6 +30,9 @@ use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Locale;
 use stdClass;
+use TestApp\Model\Enum\ArticleStatus;
+use TestApp\Model\Enum\NonBacked;
+use TestApp\Model\Enum\Priority;
 
 require_once __DIR__ . '/stubs.php';
 
@@ -2012,6 +2015,26 @@ class ValidationTest extends TestCase
     {
         $this->assertTrue(Validation::email('abc.efg@cakephp.org', null, '/^[A-Z0-9._%-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i'));
         $this->assertFalse(Validation::email('abc.efg@com.caphpkeinvalid', null, '/^[A-Z0-9._%-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i'));
+    }
+
+    public function testEnum(): void
+    {
+        $this->assertTrue(Validation::enum(ArticleStatus::PUBLISHED, ArticleStatus::class));
+        $this->assertTrue(Validation::enum('Y', ArticleStatus::class));
+
+        $this->assertTrue(Validation::enum(Priority::LOW, Priority::class));
+        $this->assertTrue(Validation::enum(1, Priority::class));
+
+        $this->assertFalse(Validation::enum(Priority::LOW, ArticleStatus::class));
+        $this->assertFalse(Validation::enum(1, ArticleStatus::class));
+        $this->assertFalse(Validation::enum('non-existent', ArticleStatus::class));
+
+        $this->assertFalse(Validation::enum(ArticleStatus::PUBLISHED, Priority::class));
+        $this->assertFalse(Validation::enum('wrong type', Priority::class));
+        $this->assertFalse(Validation::enum(123, Priority::class));
+
+        $this->assertFalse(Validation::enum(NonBacked::Basic, NonBacked::class));
+        $this->assertFalse(Validation::enum('non-enum class', TestCase::class));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2722,7 +2722,7 @@ class ValidatorTest extends TestCase
 
         $fieldName = 'status';
         $rule = 'enum';
-        $expectedMessage = 'The provided value must be a `\TestApp\Model\Enum\ArticleStatus` enum instance or value';
+        $expectedMessage = 'The provided value must be one of `Y`, `N`';
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, ArticleStatus::class);
     }
 

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -25,6 +25,9 @@ use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use stdClass;
+use TestApp\Model\Enum\ArticleStatus;
+use TestApp\Model\Enum\NonBacked;
+use TestApp\Model\Enum\Priority;
 use Traversable;
 
 /**
@@ -2702,6 +2705,43 @@ class ValidatorTest extends TestCase
         $expectedMessage = 'The provided value must be an e-mail address';
         $checkMx = false;
         $this->assertValidationMessage($fieldName, $rule, $expectedMessage, $checkMx);
+    }
+
+    public function testEnum(): void
+    {
+        $validator = new Validator();
+        $validator->enum('status', ArticleStatus::class);
+
+        $this->assertEmpty($validator->validate(['status' => ArticleStatus::PUBLISHED]));
+        $this->assertEmpty($validator->validate(['status' => 'Y']));
+
+        $this->assertNotEmpty($validator->validate(['status' => Priority::LOW]));
+        $this->assertNotEmpty($validator->validate(['status' => 'wrong type']));
+        $this->assertNotEmpty($validator->validate(['status' => 123]));
+        $this->assertNotEmpty($validator->validate(['status' => NonBacked::Basic]));
+
+        $fieldName = 'status';
+        $rule = 'enum';
+        $expectedMessage = 'The provided value must be a `\TestApp\Model\Enum\ArticleStatus` enum instance or value';
+        $this->assertValidationMessage($fieldName, $rule, $expectedMessage, ArticleStatus::class);
+    }
+
+    public function testEnumNonBacked(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
+
+        $validator = new Validator();
+        $validator->enum('status', NonBacked::class);
+    }
+
+    public function testEnumNonEnum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
+
+        $validator = new Validator();
+        $validator->enum('status', TestCase::class);
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Enum/NonBacked.php
+++ b/tests/test_app/TestApp/Model/Enum/NonBacked.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Enum;
+
+enum NonBacked
+{
+    case Basic;
+}


### PR DESCRIPTION
The docs only talk about backend enums in the context of the database layer, validation however isn't tied to the database layer, so maybe one would like to see support for basic, unbacked enums too, that would however be nothing more than a simple `instanceof` check, so I'm not sure how useful that would be.