### PR TITLE
Show message on successful plugin load.

### DIFF
--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -91,6 +91,8 @@ class PluginLoadCommand extends Command
             $io->err('Failed to update `CONFIG/plugins.php`');
         }
 
+        $io->success('Plugin added successfully to `CONFIG/plugins.php`');
+
         return $result;
     }
 

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -55,6 +55,8 @@ class PluginUnloadCommand extends Command
 
         $result = $this->modifyConfigFile($plugin);
         if ($result === null) {
+            $io->success('Plugin removed from `CONFIG/plugins.php`');
+
             return static::CODE_SUCCESS;
         }
 


### PR DESCRIPTION
Currently no output is shown on successful operation which can be confusing to new users.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
