### PR TITLE
Fix handling of enums as selected for SelectBoxWidget.

### DIFF
--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\View\Widget;
 
 use ArrayAccess;
+use BackedEnum;
 use Cake\View\Form\ContextInterface;
 use Traversable;
 use function Cake\Core\h;
@@ -319,7 +320,11 @@ class SelectBoxWidget extends BasicWidget
             return false;
         }
         if (!is_array($selected)) {
-            $selected = $selected === false ? '0' : $selected;
+            if ($selected === false) {
+                $selected = '0';
+            } elseif ($selected instanceof BackedEnum) {
+                $selected = $selected->value;
+            }
 
             return $key === (string)$selected;
         }

--- a/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxWidgetTest.php
@@ -22,6 +22,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\SelectBoxWidget;
+use TestApp\Model\Enum\ArticleStatus;
 
 /**
  * SelectBox test case
@@ -241,6 +242,28 @@ class SelectBoxWidgetTest extends TestCase
             ['option' => ['value' => '1x']], 'one x', '/option',
             ['option' => ['value' => '2', 'selected' => 'selected']], 'two', '/option',
             ['option' => ['value' => '2x']], 'two x', '/option',
+            '/select',
+        ];
+        $this->assertHtml($expected, $result);
+    }
+
+    public function testRenderSelectedEnum(): void
+    {
+        $select = new SelectBoxWidget($this->templates);
+        $data = [
+            'id' => 'status',
+            'name' => 'status',
+            'val' => ArticleStatus::PUBLISHED,
+            'options' => [
+                'Y' => 'Published',
+                'N' => 'Unpublished',
+            ],
+        ];
+        $result = $select->render($data, $this->context);
+        $expected = [
+            'select' => ['name' => 'status', 'id' => 'status'],
+            ['option' => ['value' => 'Y', 'selected' => 'selected']], 'Published', '/option',
+            ['option' => ['value' => 'N']], 'Unpublished', '/option',
             '/select',
         ];
         $this->assertHtml($expected, $result);


### PR DESCRIPTION
When a column is mapped to a enum type in the table schema the entity passed as form context would contain the field as enum.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
