### PR TITLE
Allow both psr/container versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "laminas/laminas-diactoros": "^3.0",
         "laminas/laminas-httphandlerrunner": "^2.6",
         "league/container": "^4.2",
-        "psr/container": "^2.0",
+        "psr/container": "^1.1 || ^2.0",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.0.2",
         "psr/http-message": "^2.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.1",
         "cakephp/utility": "^5.0",
         "league/container": "^4.2",
-        "psr/container": "^2.0"
+        "psr/container": "^1.1 || ^2.0"
     },
     "provide": {
         "psr/container-implementation": "^2.0"


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17355 and other similar issues reported
https://github.com/cakephp/phinx/issues/2227 for example

Given that we only pull psr/container because of league, and league allows both, it seems only logical that we dont artifically limit it either.

Now:
```
cakephp/cakephp  5.x requires psr/container (^1.1 || ^2.0) 
league/container 4.2.0       requires psr/container (^1.1 || ^2.0) 
```

Which seems correct.