### PR TITLE
Fix up CI for deprecation alerts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - '*'
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -125,6 +123,10 @@ jobs:
           vendor/bin/phpunit
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --testsuite=database
         fi
+
+    - name: Run class deprecation aliasing validation script
+      if: always()
+      run: php contrib/validate-deprecation-aliases.php
 
     - name: Prefer lowest check
       if: matrix.prefer-lowest == 'prefer-lowest'

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -325,7 +325,3 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
         return (string)$this->i18nFormat();
     }
 }
-
-// phpcs:disable
-class_alias(Date::class, 'Cake\I18n\FrozenDate');
-// phpcs:enable

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -605,7 +605,3 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
         return (string)$this->i18nFormat();
     }
 }
-
-// phpcs:disable
-class_alias(DateTime::class, 'Cake\I18n\FrozenTime');
-// phpcs:enable


### PR DESCRIPTION
Reintroduces lost validation piece
https://discord.com/channels/525598064984195072/525599108233166858/1163831986545229834
which is critical for proper deprecation handling of classes

Also removed the schedule part as it is counter productive usually - as it can disable the whole CI and requires manual activation afterwards.

Also, now visible with the script running again:
```
Cake\ORM\Query\SelectQuery
 * Missing class_exists() or class_alias() on new file for ORM/Query.php => ORM/Query/SelectQuery.php
```

Seems like there is one missing from the other direction, there is an alias on the SelectQuery, but not on the Query itself.