### PR TITLE
Allow both psr/http-message constraint versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "psr/container": "^2.0",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.0.2",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
         "psr/log": "^3.0",

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -32,7 +32,7 @@
         "composer/ca-bundle": "^1.2",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.0.2",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
         "laminas/laminas-diactoros": "^3.0",

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.1",
         "cakephp/core": "^5.0",
         "cakephp/utility": "^5.0",
-        "psr/http-message": "^1.0.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "suggest": {
         "cakephp/i18n": "If you want to use Validation::localizedTime()"


### PR DESCRIPTION
Part 2 of https://github.com/cakephp/cakephp/issues/17358

Some packages declared 2.0, others 1.0. This is now fixed by allowing both.

It seems that we are not directly using the libraries in a way that would conflict from allowing a wider range and thus a better compatibility to other vendor libraries or packages.