### PR TITLE
Fix up CI for deprecation alerts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - '*'
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -125,6 +123,10 @@ jobs:
           vendor/bin/phpunit
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --testsuite=database
         fi
+
+    - name: Run class deprecation aliasing validation script
+      if: always()
+      run: php contrib/validate-deprecation-aliases.php
 
     - name: Prefer lowest check
       if: matrix.prefer-lowest == 'prefer-lowest'

--- a/contrib/validate-deprecation-aliases.php
+++ b/contrib/validate-deprecation-aliases.php
@@ -1,42 +1,47 @@
 #!/usr/bin/php -q
 <?php
+declare(strict_types=1);
+
+/*
+ * Validate that each deprecation of a class is followed by class_alias() and class_exists()
+ * in each relevant file complementing each other.
+ */
 
 $options = [
-	__DIR__ . '/../vendor/autoload.php',
-	__DIR__ . '/vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/vendor/autoload.php',
 ];
 if (!empty($_SERVER['PWD'])) {
-	array_unshift($options, $_SERVER['PWD'] . '/vendor/autoload.php');
+    array_unshift($options, $_SERVER['PWD'] . '/vendor/autoload.php');
 }
 
 foreach ($options as $file) {
-	if (file_exists($file)) {
-		define('COMPOSER_INSTALL', $file);
+    if (file_exists($file)) {
+        define('COMPOSER_INSTALL', $file);
 
-		break;
-	}
+        break;
+    }
 }
 require COMPOSER_INSTALL;
 
 $path = dirname(__DIR__) . DS . 'src' . DS;
-$di = new RecursiveDirectoryIterator($path, (RecursiveDirectoryIterator::SKIP_DOTS));
-/** @var \SplFileInfo[] $iterator */
+$di = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
+/** @var array<\SplFileInfo> $iterator */
 $iterator = new RecursiveIteratorIterator($di);
 
-$issues = [];
 $code = 0;
 foreach ($iterator as $file) {
-    if (pathinfo($file, PATHINFO_EXTENSION) !== 'php') {
+    if (pathinfo((string)$file, PATHINFO_EXTENSION) !== 'php') {
         continue;
     }
-    if (pathinfo($file, PATHINFO_FILENAME) === 'functions') {
+    if (pathinfo((string)$file, PATHINFO_FILENAME) === 'functions') {
         continue;
     }
     if (strpos($file->getRealPath(), '/TestSuite/')) {
         continue;
     }
 
-    $content = file_get_contents($file);
+    $content = file_get_contents((string)$file);
     if (!strpos($content, 'class_alias(')) {
         continue;
     }
@@ -53,7 +58,7 @@ foreach ($iterator as $file) {
     $filePath = str_replace('Cake/', $path, $filePath);
     $filePath .= '.php';
     if (!file_exists($filePath)) {
-        throw new RuntimeException('Cannot find path for ' . $matches[1]);
+        throw new RuntimeException('Cannot find path for `' . $matches[1] . '`');
     }
 
     $newFileContent = file_get_contents($filePath);
@@ -61,7 +66,7 @@ foreach ($iterator as $file) {
     if (strpos($newFileContent, 'class_exists(') === false && !str_contains($newFileContent, 'class_alias(')) {
         $oldPath = str_replace($path, '', $file->getRealPath());
         $newPath = str_replace($path, '', $filePath);
-        echo "\033[31m" . ' * Missing class_exists() or class_alias() on new file for ' . $oldPath . ' => ' . $newPath . "\033[0m" . PHP_EOL;
+        echo "\033[31m" . ' * Missing `class_exists()` or `class_alias()` on new file for `' . $oldPath . '` => `' . $newPath . '`' .  "\033[0m" . PHP_EOL;
         $code = 1;
     } else {
         echo ' * OK' . PHP_EOL;

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -327,5 +327,5 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
 }
 
 // phpcs:disable
-class_alias(Date::class, 'Cake\I18n\FrozenDate');
+class_alias('Cake\I18n\Date', 'Cake\I18n\FrozenDate');
 // phpcs:enable

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -607,5 +607,5 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
 }
 
 // phpcs:disable
-class_alias(DateTime::class, 'Cake\I18n\FrozenTime');
+class_alias('Cake\I18n\DateTime', 'Cake\I18n\FrozenTime');
 // phpcs:enable

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1795,3 +1795,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         return $this->_autoFields;
     }
 }
+
+// phpcs:disable
+class_exists('Cake\ORM\Query');
+// phpcs:enable


### PR DESCRIPTION
Reopen https://github.com/cakephp/cakephp/pull/17357

Also, now visible with the script running again:
```
Cake\ORM\Query\SelectQuery
 * Missing class_exists() or class_alias() on new file for ORM/Query.php => ORM/Query/SelectQuery.php
```

Seems like there is one missing from the other direction, there is an alias on the SelectQuery, but not on the Query itself.