### PR TITLE
Drop unneeded alias.

### DIFF
--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -162,10 +162,3 @@ class TypeFactory
         static::$_builtTypes = [];
     }
 }
-
-// phpcs:disable
-class_alias(
-    'Cake\Database\TypeFactory',
-    'Cake\Database\Type'
-);
-// phpcs:enable


### PR DESCRIPTION
Cake\Database\Type has been removed in 5.0.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
