### PR TITLE
FormHelper Backed Enum support

### DIFF
--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -204,7 +204,7 @@ class EnumType extends BaseType
     }
 
     /**
-     * @return string
+     * @return class-string<\BackedEnum>
      */
     public function getEnumClassName(): string
     {

--- a/src/Database/TypeFactory.php
+++ b/src/Database/TypeFactory.php
@@ -88,12 +88,11 @@ class TypeFactory
      */
     public static function buildAll(): array
     {
-        $result = [];
         foreach (static::$_types as $name => $type) {
-            $result[$name] = static::$_builtTypes[$name] ?? static::build($name);
+            static::$_builtTypes[$name] ??= static::build($name);
         }
 
-        return $result;
+        return static::$_builtTypes;
     }
 
     /**
@@ -106,7 +105,6 @@ class TypeFactory
     public static function set(string $name, TypeInterface $instance): void
     {
         static::$_builtTypes[$name] = $instance;
-        static::$_types[$name] = $instance::class;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -19,6 +19,8 @@ namespace Cake\View\Helper;
 use BackedEnum;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
+use Cake\Database\Type\EnumType;
+use Cake\Database\TypeFactory;
 use Cake\Form\FormProtector;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
@@ -1313,6 +1315,20 @@ class FormHelper extends Helper
             return $options;
         }
 
+        $internalType = $this->_getContext()->type($fieldName);
+        if ($internalType && str_starts_with($internalType, 'enum-')) {
+            $dbType = TypeFactory::build($internalType);
+            if ($dbType instanceof EnumType) {
+                if ($options['type'] !== 'radio') {
+                    $options['type'] = 'select';
+                }
+
+                $options['options'] = $this->enumOptions($dbType->getEnumClassName());
+
+                return $options;
+            }
+        }
+
         $pluralize = true;
         if (str_ends_with($fieldName, '._ids')) {
             $fieldName = substr($fieldName, 0, -5);
@@ -1335,6 +1351,24 @@ class FormHelper extends Helper
         $options['options'] = $varOptions;
 
         return $options;
+    }
+
+    /**
+     * Get map of enum value => label for select/radio options.
+     *
+     * @param class-string<\BackedEnum> $enumClass Enum class name.
+     * @return array<int|string, string>
+     */
+    protected function enumOptions(string $enumClass): array
+    {
+        assert(is_subclass_of($enumClass, BackedEnum::class));
+
+        $values = [];
+        foreach ($enumClass::cases() as $case) {
+            $values[$case->value] = method_exists($case, 'label') ? $case->label() : $case->name;
+        }
+
+        return $values;
     }
 
     /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1365,6 +1365,7 @@ class FormHelper extends Helper
 
         $values = [];
         foreach ($enumClass::cases() as $case) {
+            /** @phpstan-ignore-next-line */
             $values[$case->value] = method_exists($case, 'label') ? $case->label() : $case->name;
         }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\View\Helper;
 
+use BackedEnum;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Form\FormProtector;
@@ -2344,6 +2345,10 @@ class FormHelper extends Helper
             $options['val'] = $options['default'];
         }
         unset($options['value'], $options['default']);
+
+        if ($options['val'] instanceof BackedEnum) {
+            $options['val'] = $options['val']->value;
+        }
 
         if ($context->hasError($field)) {
             $options = $this->addClass($options, $this->_config['errorClass']);

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -14,14 +14,12 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
         'core.ColumnSchemaAwareTypeValues',
     ];
 
-    /**
-     * @var \Cake\Database\TypeInterface|null
-     */
-    public $textType;
+    protected array $typeMap;
 
     public function setUp(): void
     {
-        $this->textType = TypeFactory::build('text');
+        $this->typeMap = TypeFactory::getMap();
+
         TypeFactory::map('text', ColumnSchemaAwareType::class);
         // For SQLServer.
         TypeFactory::map('nvarchar', ColumnSchemaAwareType::class);
@@ -32,11 +30,8 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        TypeFactory::set('text', $this->textType);
 
-        $map = TypeFactory::getMap();
-        unset($map['nvarchar']);
-        TypeFactory::setMap($map);
+        TypeFactory::setMap($this->typeMap);
     }
 
     public function testCustomTypesCanBeUsedInFixtures(): void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -37,6 +37,7 @@ use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
+use TestApp\Model\Enum\ArticleStatus;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
 use TestApp\View\Form\StubContext;
@@ -4490,6 +4491,24 @@ class FormHelperTest extends TestCase
             '/label',
         ];
         $this->assertHtml($expected, $result);
+
+        $article = new Article([
+            'status' => ArticleStatus::UNPUBLISHED,
+        ]);
+        $this->Form->create($article);
+        $result = $this->Form->radio('status', ['Y' => 'Published', 'N' => 'Unpublished']);
+        $expected = [
+            'input' => ['type' => 'hidden', 'name' => 'status', 'value' => '', 'id' => 'status'],
+            ['label' => ['for' => 'status-y']],
+            ['input' => ['type' => 'radio', 'name' => 'status', 'value' => 'Y', 'id' => 'status-y']],
+            'Published',
+            '/label',
+            ['label' => ['for' => 'status-n']],
+            ['input' => ['type' => 'radio', 'name' => 'status', 'value' => 'N', 'id' => 'status-n', 'checked' => 'checked']],
+            'Unpublished',
+            '/label',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -4872,6 +4891,19 @@ class FormHelperTest extends TestCase
             'select' => ['name' => 'Model[field]'],
             ['option' => ['value' => '0', 'selected' => 'selected']], 'No', '/option',
             ['option' => ['value' => '1']], 'Yes', '/option',
+            '/select',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $article = new Article([
+            'status' => ArticleStatus::UNPUBLISHED,
+        ]);
+        $this->Form->create($article);
+        $result = $this->Form->select('status', ['Y' => 'Published', 'N' => 'Unpublished']);
+        $expected = [
+            'select' => ['name' => 'status'],
+            ['option' => ['value' => 'Y']], 'Published', '/option',
+            ['option' => ['value' => 'N', 'selected' => 'selected']], 'Unpublished', '/option',
             '/select',
         ];
         $this->assertHtml($expected, $result);
@@ -6429,6 +6461,16 @@ class FormHelperTest extends TestCase
         $result = $this->Form->hidden('field', ['value' => 'my value']);
         $expected = [
             'input' => ['type' => 'hidden', 'class' => 'form-error', 'name' => 'field', 'value' => 'my value'],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $article = new Article([
+            'status' => ArticleStatus::UNPUBLISHED,
+        ]);
+        $this->Form->create($article);
+        $result = $this->Form->hidden('status');
+        $expected = [
+            'input' => ['type' => 'hidden', 'name' => 'status', 'value' => 'N'],
         ];
         $this->assertHtml($expected, $result);
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -20,6 +20,7 @@ use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
+use Cake\Database\Type\EnumType;
 use Cake\Form\Form;
 use Cake\Http\ServerRequest;
 use Cake\I18n\Date;
@@ -38,6 +39,7 @@ use InvalidArgumentException;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
+use TestApp\Model\Enum\ArticleStatusLabel;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
 use TestApp\View\Form\StubContext;
@@ -3621,6 +3623,53 @@ class FormHelperTest extends TestCase
             '/div',
         ];
         $this->assertHtml($expected, $result);
+
+        $articlesTable = $this->getTableLocator()->get('Articles');
+        $articlesTable->getSchema()->setColumnType(
+            'published',
+            EnumType::from(ArticleStatus::class)
+        );
+        $this->Form->create($articlesTable->newEmptyEntity());
+        $result = $this->Form->control('published');
+        $expected = [
+            'div' => ['class' => 'input select'],
+            'label' => ['for' => 'published'],
+            'Published',
+            '/label',
+            'select' => ['name' => 'published', 'id' => 'published'],
+            ['option' => ['value' => 'Y']],
+            'PUBLISHED',
+            '/option',
+            ['option' => ['value' => 'N', 'selected' => 'selected']],
+            'UNPUBLISHED',
+            '/option',
+            '/select',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $articlesTable->getSchema()->setColumnType(
+            'published',
+            EnumType::from(ArticleStatusLabel::class)
+        );
+        $this->Form->create($articlesTable->newEmptyEntity());
+        $result = $this->Form->control('published');
+        $expected = [
+            'div' => ['class' => 'input select'],
+            'label' => ['for' => 'published'],
+            'Published',
+            '/label',
+            'select' => ['name' => 'published', 'id' => 'published'],
+            ['option' => ['value' => 'Y']],
+            'Is published',
+            '/option',
+            ['option' => ['value' => 'N', 'selected' => 'selected']],
+            'Is unpublished',
+            '/option',
+            '/select',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
     }
 
     /**
@@ -4697,6 +4746,28 @@ class FormHelperTest extends TestCase
                     'id' => 'accept--1',
                 ]],
                 'negative',
+                '/label',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
+        $articlesTable = $this->getTableLocator()->get('Articles');
+        $articlesTable->getSchema()->setColumnType(
+            'published',
+            EnumType::from(ArticleStatus::class)
+        );
+        $this->Form->create($articlesTable->newEmptyEntity());
+        $result = $this->Form->control('published', ['type' => 'radio', 'label' => false,]);
+        $expected = [
+            ['div' => ['class' => 'input radio']],
+                'input' => ['type' => 'hidden', 'name' => 'published', 'value' => '', 'id' => 'published'],
+                ['label' => ['for' => 'published-y']],
+                ['input' => ['type' => 'radio', 'name' => 'published', 'value' => 'Y', 'id' => 'published-y']],
+                'PUBLISHED',
+                '/label',
+                ['label' => ['for' => 'published-n']],
+                ['input' => ['type' => 'radio', 'name' => 'published', 'value' => 'N', 'id' => 'published-n', 'checked' => 'checked']],
+                'UNPUBLISHED',
                 '/label',
             '/div',
         ];

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusLabel.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusLabel.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Model\Enum;
+
+enum ArticleStatusLabel: string
+{
+    case PUBLISHED = 'Y';
+    case UNPUBLISHED = 'N';
+
+    public function label(): string
+    {
+        return 'Is ' . strtolower($this->name);
+    }
+}


### PR DESCRIPTION
- Coerce enum instances into their string/int values so that form widgets can property populate the input values.
- For table columns mapped to enum types auto set the form control type to `select` and auto generate the options list using the enum cases.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
