### PR TITLE
5.next: fix `PluginConfig` not returning an array on non existent config file

### DIFF
--- a/src/Core/PluginConfig.php
+++ b/src/Core/PluginConfig.php
@@ -67,6 +67,8 @@ class PluginConfig
         $pluginLoadConfig = @include CONFIG . 'plugins.php';
         if (is_array($pluginLoadConfig)) {
             $pluginLoadConfig = Hash::normalize($pluginLoadConfig);
+        } else {
+            $pluginLoadConfig = [];
         }
 
         $result = [];

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -55,9 +55,7 @@ class PluginConfigTest extends TestCase
         if (file_exists($this->pluginsListPath)) {
             unlink($this->pluginsListPath);
         }
-        if (file_exists($this->pluginsConfigPath)) {
-            file_put_contents($this->pluginsConfigPath, $this->originalPluginsConfigContent);
-        }
+        file_put_contents($this->pluginsConfigPath, $this->originalPluginsConfigContent);
     }
 
     public function testSimpleConfig(): void
@@ -230,6 +228,30 @@ PHP;
             'UnknownPlugin' => [
                 'isLoaded' => false,
                 'isUnknown' => true,
+            ],
+        ], PluginConfig::getAppConfig());
+    }
+
+    public function testNoPluginConfig(): void
+    {
+        $file = <<<PHP
+<?php
+return [
+    'plugins' => [
+        'TestPlugin' => '/config/path',
+        'OtherPlugin' => '/config/path',
+    ]
+];
+PHP;
+        file_put_contents($this->pluginsListPath, $file);
+        unlink($this->pluginsConfigPath);
+
+        $this->assertSame([
+            'TestPlugin' => [
+                'isLoaded' => false,
+            ],
+            'OtherPlugin' => [
+                'isLoaded' => false,
             ],
         ], PluginConfig::getAppConfig());
     }


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/17334 and https://github.com/cakephp/debug_kit/pull/963