### PR TITLE
TimeType allow overwriting default Time class

### DIFF
--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -182,6 +182,16 @@ class TimeType extends BaseType implements BatchCastingInterface
     }
 
     /**
+     * Get the classname used for building objects.
+     *
+     * @return class-string<\Cake\Chronos\ChronosTime>
+     */
+    public function getTimeClassName(): string
+    {
+        return $this->_className;
+    }
+
+    /**
      * Converts a string into a Time object
      *
      * @param string $value The value to parse and convert to an object.

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -66,6 +66,14 @@ class DateTypeTest extends TestCase
     }
 
     /**
+     * Test getDateClassName
+     */
+    public function testGetDateClassName(): void
+    {
+        $this->assertSame(Date::class, $this->type->getDateClassName());
+    }
+
+    /**
      * Test toPHP
      */
     public function testToPHP(): void

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -61,6 +61,14 @@ class TimeTypeTest extends TestCase
     }
 
     /**
+     * Test getTimeClassName
+     */
+    public function testGetTimeClassName(): void
+    {
+        $this->assertSame(Time::class, $this->type->getTimeClassName());
+    }
+
+    /**
      * Test toPHP
      */
     public function testToPHP(): void


### PR DESCRIPTION
Like DateType allow getting $_className.
It should be used in bake annotation to allow overwriting default Time class.
Related change in bake library: https://github.com/cakephp/bake/pull/948