### PR TITLE
Improve output of cache clear_group command

### DIFF
--- a/src/Command/CacheClearGroupCommand.php
+++ b/src/Command/CacheClearGroupCommand.php
@@ -98,7 +98,7 @@ class CacheClearGroupCommand extends Command
                 ));
                 $this->abort();
             } else {
-                $io->success(sprintf('Group "%s" was cleared.', $groupConfig));
+                $io->success(sprintf('Cache "%s" was cleared.', $groupConfig));
             }
         }
 

--- a/src/Command/CacheClearGroupCommand.php
+++ b/src/Command/CacheClearGroupCommand.php
@@ -98,7 +98,7 @@ class CacheClearGroupCommand extends Command
                 ));
                 $this->abort();
             } else {
-                $io->success(sprintf('Group "%s" was cleared.', $group));
+                $io->success(sprintf('Group "%s" was cleared.', $groupConfig));
             }
         }
 


### PR DESCRIPTION
Prefer this when I clear a group named `default` containing these cache configs:

```console
/srv/app $ bin/cake cache clear_group default
Cache "_cake_core_" was cleared.
Cache "_cake_model_" was cleared.
Cache "_cake_routes_" was cleared.
Cache "default" was cleared.
Cache "fallback" was cleared.

```

Over this:

```console
/srv/app $ bin/cake cache clear_group default
Group "default" was cleared.
Group "default" was cleared.
Group "default" was cleared.
Group "default" was cleared.
Group "default" was cleared.
```