### PR TITLE
Use minimium 1.1 for php-fig/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "psr/container": "^1.1 || ^2.0",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.0.2",
-        "psr/http-message": "^1.0 || ^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
         "psr/log": "^3.0",

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -32,7 +32,7 @@
         "composer/ca-bundle": "^1.2",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.0.2",
-        "psr/http-message": "^1.0 || ^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/http-server-middleware": "^1.0.2",
         "laminas/laminas-diactoros": "^3.0",

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.1",
         "cakephp/core": "^5.0",
         "cakephp/utility": "^5.0",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^1.1 || ^2.0"
     },
     "suggest": {
         "cakephp/i18n": "If you want to use Validation::localizedTime()"


### PR DESCRIPTION
1.1 at least includes scalar param types.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
