### PR TITLE
Clarify a less radical fix.

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -121,7 +121,7 @@ trait ModelAwareTrait
         if (!property_exists($this, $alias)) {
             deprecationWarning(
                 '4.5.0 - Dynamic properties will be removed in PHP 8.2. ' .
-                "Add `public \${$alias} = null;` to your class definition."
+                "Add `public \${$alias} = null;` to your class definition or use `#[AllowDynamicProperties]` attribute."
             );
         }
 


### PR DESCRIPTION
It can be helpful to document a less invasive code changing way to fix the issue for existing 4.x apps/plugins.

See e.g. https://github.com/dereuromark/cakephp-queue/issues/388

Refactoring everything can lead to undesired changes/side-effects, so best this is done when doing an actual 5.x upgrade maybe.

I wonder if we could silence the deprecation then if that property is set on the class?

If this is too much of a hazzle, one has to go with adding the actual property everywhere, I guess.