### PR TITLE
Clarify a less radical fix.

### DIFF
--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -16,9 +16,11 @@ declare(strict_types=1);
  */
 namespace Cake\Datasource;
 
+use AllowDynamicProperties;
 use Cake\Datasource\Exception\MissingModelException;
 use Cake\Datasource\Locator\LocatorInterface;
 use InvalidArgumentException;
+use ReflectionClass;
 use UnexpectedValueException;
 use function Cake\Core\deprecationWarning;
 use function Cake\Core\getTypeName;
@@ -119,10 +121,16 @@ trait ModelAwareTrait
             $modelClass = $alias;
         }
         if (!property_exists($this, $alias)) {
-            deprecationWarning(
-                '4.5.0 - Dynamic properties will be removed in PHP 8.2. ' .
-                "Add `public \${$alias} = null;` to your class definition or use `#[AllowDynamicProperties]` attribute."
-            );
+            $reflection = new ReflectionClass($this);
+            $attributes = method_exists($reflection, 'getAttributes')
+                ? $reflection->getAttributes(AllowDynamicProperties::class)
+                : [];
+            if (!$attributes) {
+                deprecationWarning(
+                    '4.5.0 - Dynamic properties will be removed in PHP 8.2. ' .
+                    "Add `public \${$alias} = null;` to your class definition or use `#[AllowDynamicProperties]` attribute."
+                );
+            }
         }
 
         if (isset($this->{$alias})) {

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -128,7 +128,7 @@ trait ModelAwareTrait
             if (!$attributes) {
                 deprecationWarning(
                     '4.5.0 - Dynamic properties will be removed in PHP 8.2. ' .
-                    "Add `public \${$alias} = null;` to your class definition or use `#[AllowDynamicProperties]` attribute."
+                    "Add `public \${$alias};` to your class definition or use `#[AllowDynamicProperties]` attribute."
                 );
             }
         }


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/17381

Silences the deprecation if not needed due to the usage of the attribute
Works of course only in a more modern PHP version
Otherwise it will output it as usual.

To give context:

Just adding the property results in fatal errors due to the autoloading of it not working anymore.
So thats really not a fix. You would have to fully refactor your code it seems to get rid of it.
This aims to more help keeping things simple.