### PR TITLE
Fix  engine class loading

### DIFF
--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -69,7 +69,11 @@ class NumberHelper extends Helper
         $config = $this->_config;
 
         /** @psalm-var class-string<\Cake\I18n\Number>|null $engineClass */
-        $engineClass = App::className($config['engine'], 'Utility');
+        $engineClass = App::className($config['engine'], 'I18n');
+        if ($engineClass === null) {
+            // Legacy namespace lookup
+            $engineClass = App::className($config['engine'], 'Utility');
+        }
         if ($engineClass === null) {
             throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
         }

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -75,7 +75,7 @@ class NumberHelper extends Helper
             $engineClass = App::className($config['engine'], 'Utility');
         }
         if ($engineClass === null) {
-            throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
+            throw new CakeException(sprintf('Class for `%s` could not be found', $config['engine']));
         }
         if ($engineClass !== Number::class) {
             deprecationWarning('4.5.0 - The `engine` option for NumberHelper will be removed in 5.0');

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -88,7 +88,7 @@ class TextHelper extends Helper
         /** @psalm-var class-string<\Cake\Utility\Text>|null $engineClass */
         $engineClass = App::className($config['engine'], 'Utility');
         if ($engineClass === null) {
-            throw new CakeException(sprintf('Class for %s could not be found', $config['engine']));
+            throw new CakeException(sprintf('Class for `%s` could not be found', $config['engine']));
         }
         if ($engineClass != Text::class) {
             deprecationWarning('4.5.0 - The `engine` option for TextHelper will be removed in 5.0');

--- a/src/View/Helper/UrlHelper.php
+++ b/src/View/Helper/UrlHelper.php
@@ -59,7 +59,7 @@ class UrlHelper extends Helper
         /** @psalm-var class-string<\Cake\Routing\Asset>|null $engineClass */
         $engineClass = App::className($engineClassConfig, 'Routing');
         if ($engineClass === null) {
-            throw new CakeException(sprintf('Class for %s could not be found', $engineClassConfig));
+            throw new CakeException(sprintf('Class for `%s` could not be found', $engineClassConfig));
         }
 
         $this->_assetUrlClassName = $engineClass;

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -24,10 +24,11 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Helper\NumberHelper;
 use Cake\View\View;
 use ReflectionMethod;
-use TestApp\Utility\NumberMock;
-use TestApp\Utility\TestAppEngine;
+use TestApp\I18n\NumberMock;
+use TestApp\I18n\TestAppI18nEngine;
+use TestApp\Utility\TestAppUtilityEngine;
 use TestApp\View\Helper\NumberHelperTestObject;
-use TestPlugin\Utility\TestPluginEngine;
+use TestPlugin\I18n\TestPluginEngine;
 
 /**
  * NumberHelperTest class
@@ -126,8 +127,24 @@ class NumberHelperTest extends TestCase
     public function testEngineOverride(): void
     {
         $this->deprecated(function () {
-            $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestAppEngine']);
-            $this->assertInstanceOf(TestAppEngine::class, $Number->engine());
+            $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestAppI18nEngine']);
+            $this->assertInstanceOf(TestAppI18nEngine::class, $Number->engine());
+
+            $this->loadPlugins(['TestPlugin']);
+            $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);
+            $this->assertInstanceOf(TestPluginEngine::class, $Number->engine());
+            $this->removePlugins(['TestPlugin']);
+        });
+    }
+
+    /**
+     * test engine override for legacy namespace Utility instead of I18n
+     */
+    public function testEngineOverrideLegacy(): void
+    {
+        $this->deprecated(function () {
+            $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestAppUtilityEngine']);
+            $this->assertInstanceOf(TestAppUtilityEngine::class, $Number->engine());
 
             $this->loadPlugins(['TestPlugin']);
             $Number = new NumberHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -20,7 +20,7 @@ use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\TextHelper;
 use Cake\View\View;
-use TestApp\Utility\TestAppEngine;
+use TestApp\Utility\TestAppUtilityEngine;
 use TestApp\Utility\TextMock;
 use TestApp\View\Helper\TextHelperTestObject;
 use TestPlugin\Utility\TestPluginEngine;
@@ -134,8 +134,8 @@ class TextHelperTest extends TestCase
     public function testEngineOverride(): void
     {
         $this->deprecated(function () {
-            $Text = new TextHelperTestObject($this->View, ['engine' => 'TestAppEngine']);
-            $this->assertInstanceOf(TestAppEngine::class, $Text->engine());
+            $Text = new TextHelperTestObject($this->View, ['engine' => 'TestAppUtilityEngine']);
+            $this->assertInstanceOf(TestAppUtilityEngine::class, $Text->engine());
 
             $this->loadPlugins(['TestPlugin']);
             $Text = new TextHelperTestObject($this->View, ['engine' => 'TestPlugin.TestPluginEngine']);

--- a/tests/test_app/Plugin/TestPlugin/src/I18n/TestPluginEngine.php
+++ b/tests/test_app/Plugin/TestPlugin/src/I18n/TestPluginEngine.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace TestPlugin\I18n;
+
+class TestPluginEngine
+{
+}

--- a/tests/test_app/TestApp/I18n/NumberMock.php
+++ b/tests/test_app/TestApp/I18n/NumberMock.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace TestApp\Utility;
+namespace TestApp\I18n;
 
 class NumberMock
 {

--- a/tests/test_app/TestApp/I18n/TestAppI18nEngine.php
+++ b/tests/test_app/TestApp/I18n/TestAppI18nEngine.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\I18n;
+
+class TestAppI18nEngine
+{
+}

--- a/tests/test_app/TestApp/Utility/TestAppUtilityEngine.php
+++ b/tests/test_app/TestApp/Utility/TestAppUtilityEngine.php
@@ -3,6 +3,6 @@ declare(strict_types=1);
 
 namespace TestApp\Utility;
 
-class TestAppEngine
+class TestAppUtilityEngine
 {
 }

--- a/tests/test_app/TestApp/View/Helper/NumberHelperTestObject.php
+++ b/tests/test_app/TestApp/View/Helper/NumberHelperTestObject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace TestApp\View\Helper;
 
 use Cake\View\Helper\NumberHelper;
-use TestApp\Utility\NumberMock;
+use TestApp\I18n\NumberMock;
 
 /**
  * NumberHelperTestObject class


### PR DESCRIPTION
Using "Number" instead of FQCN results in

    Cake\Core\Exception\CakeException: Class for Number could not be found
    
This can be potentially bc breaking if someone uses custom classes inside the not expected Utility namespace
I wonder if we could shim this somehow to both find the core helper but also custom ones in this legacy "Utility" folder of people.