### PR TITLE
add table schema mapping for sqlite3 UUID_TEXT column type

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -118,7 +118,7 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchema::TYPE_BOOLEAN, 'length' => null];
         }
 
-        if ($col === 'char' && $length === 36) {
+        if (($col === 'char' && $length === 36) || $col === 'uuid') {
             return ['type' => TableSchema::TYPE_UUID, 'length' => null];
         }
         if ($col === 'char') {

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -147,6 +147,10 @@ class SqliteSchemaTest extends TestCase
                 'UNSIGNED DECIMAL(11,2)',
                 ['type' => 'decimal', 'length' => 11, 'precision' => 2, 'unsigned' => true],
             ],
+            [
+                'UUID_TEXT',
+                ['type' => 'uuid', 'length' => null],
+            ],
         ];
     }
 


### PR DESCRIPTION
Sqlite3 column type UUID_TEXT was incorrectly mapped to `text` instead of `uuid` in sqlite3