### PR TITLE
5.1 - Lazy router scopes

### DIFF
--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -948,6 +948,8 @@ class RouteBuilder
             'namePrefix' => $namePrefix,
             'middleware' => $this->middleware,
         ]);
+        $builder->useLazyScopes($this->lazyScopes);
+
         if ($this->lazyScopes) {
             $this->_collection->addScope($builder, $callback);
         } else {
@@ -963,6 +965,9 @@ class RouteBuilder
      * When enabled scopes will not be executed immediately.
      * Instead scopes and the routes they contain will be deferred until
      * CakePHP requires the routes in a scope.
+     *
+     * When a builder uses lazy scopes, any child scopes will also
+     * use lazy scopes.
      *
      * @param bool $value The scope evaluation mode
      * @return $this

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -113,6 +113,13 @@ class RouteBuilder
     protected array $middleware = [];
 
     /**
+     * Whether or not scopes should be evaluated lazily
+     *
+     * @var bool
+     */
+    protected bool $lazyScopes = false;
+
+    /**
      * Constructor
      *
      * ### Options
@@ -941,7 +948,28 @@ class RouteBuilder
             'namePrefix' => $namePrefix,
             'middleware' => $this->middleware,
         ]);
-        $this->_collection->addScope($builder, $callback);
+        if ($this->lazyScopes) {
+            $this->_collection->addScope($builder, $callback);
+        } else {
+            $callback($builder);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Enable or disable lazy scopes
+     *
+     * When enabled scopes will not be executed immediately.
+     * Instead scopes and the routes they contain will be deferred until
+     * CakePHP requires the routes in a scope.
+     *
+     * @param bool $value The scope evaluation mode
+     * @return $this
+     */
+    public function useLazyScopes(bool $value)
+    {
+        $this->lazyScopes = $value;
 
         return $this;
     }

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -948,7 +948,7 @@ class RouteBuilder
             'namePrefix' => $namePrefix,
             'middleware' => $this->middleware,
         ]);
-        $builder->useLazyScopes($this->lazyScopes);
+        $builder->enableLazyScopes($this->lazyScopes);
 
         if ($this->lazyScopes) {
             $this->_collection->addScope($builder, $callback);
@@ -960,7 +960,20 @@ class RouteBuilder
     }
 
     /**
-     * Enable or disable lazy scopes
+     * Disable lazy scopes
+     *
+     * @return $this
+     * @see \Cake\Routing\RouteBuilder::enableLazyScopes()
+     */
+    public function disableLazyScopes()
+    {
+        $this->lazyScopes = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable lazy scopes
      *
      * When enabled scopes will not be executed immediately.
      * Instead scopes and the routes they contain will be deferred until
@@ -972,7 +985,7 @@ class RouteBuilder
      * @param bool $value The scope evaluation mode
      * @return $this
      */
-    public function useLazyScopes(bool $value)
+    public function enableLazyScopes(bool $value = true)
     {
         $this->lazyScopes = $value;
 

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -941,7 +941,7 @@ class RouteBuilder
             'namePrefix' => $namePrefix,
             'middleware' => $this->middleware,
         ]);
-        $callback($builder);
+        $this->_collection->addScope($builder, $callback);
 
         return $this;
     }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -160,7 +160,7 @@ class RouteCollection
         if (empty($this->unresolvedScopes)) {
             return;
         }
-        assert($path === null || $url === null, 'Must provide one of `path` or `url`');
+        assert($path === null || $url === null, 'Provide only one of `path` or `url`');
         assert($path !== false, 'Path = false is undefined behavior');
 
         $resolved = [];

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -66,7 +66,7 @@ class RouteCollection
     /**
      * A mapping of paths to unresolved routing scopes
      *
-     * @var array<string, \Cake\Routing\RouteScope>
+     * @var array<int, \Cake\Routing\RouteScope>
      */
     protected array $unresolvedScopes = [];
 
@@ -158,6 +158,8 @@ class RouteCollection
     protected function resolveScopes(string|bool|null $path = null, ?array $url = null): void
     {
         assert($path === null || $url === null, 'Must provide one of `path` or `url`');
+        assert($path !== false, 'Path = false is undefined behavior');
+
         $resolved = [];
         $start = 0;
         $length = count($this->unresolvedScopes);

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -18,7 +18,6 @@ namespace Cake\Routing;
 
 use Cake\Routing\Exception\DuplicateNamedRouteException;
 use Cake\Routing\Exception\MissingRouteException;
-use Cake\Routing\RouteBuilder;
 use Cake\Routing\Route\Route;
 use Closure;
 use InvalidArgumentException;
@@ -154,9 +153,13 @@ class RouteCollection
      *
      * @param string|bool|null $path The path to match or true to resolve all scopes
      * @param array $url The url array to match with.
+     * @return void
      */
     protected function resolveScopes(string|bool|null $path = null, ?array $url = null): void
     {
+        if (empty($this->unresolvedScopes)) {
+            return;
+        }
         assert($path === null || $url === null, 'Must provide one of `path` or `url`');
         assert($path !== false, 'Path = false is undefined behavior');
 

--- a/src/Routing/RouteScope.php
+++ b/src/Routing/RouteScope.php
@@ -16,7 +16,7 @@ class RouteScope
     /**
      * Constructor
      *
-     * @param \Cake\Routing\RouterBuilder $builder The route builder to be used when resolving this scope.
+     * @param \Cake\Routing\RouteBuilder $builder The route builder to be used when resolving this scope.
      * @param \Closure $callback The closure containing the routes in a scope.
      */
     public function __construct(

--- a/src/Routing/RouteScope.php
+++ b/src/Routing/RouteScope.php
@@ -56,7 +56,17 @@ class RouteScope
             return true;
         }
 
-        return array_intersect_key($url, $defaults) === $defaults;
+        $fullMatch = array_intersect_key($url, $defaults) === $defaults;
+        if ($fullMatch) {
+            return $fullMatch;
+        }
+        // If there is no prefix key bail,
+        // The prefix key is special in that it can have partial matches.
+        if (!isset($url['prefix']) || !isset($defaults['prefix'])) {
+            return false;
+        }
+
+        return str_starts_with($url['prefix'], $defaults['prefix']);
     }
 
     /**

--- a/src/Routing/RouteScope.php
+++ b/src/Routing/RouteScope.php
@@ -33,8 +33,9 @@ class RouteScope
      */
     public function matchesPath(string $path): bool
     {
-        // TODO implement this.
-        return true;
+        $scopePath = $this->builder->path();
+
+        return str_starts_with($path, $scopePath);
     }
 
     /**

--- a/src/Routing/RouteScope.php
+++ b/src/Routing/RouteScope.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Routing;
+
+use Closure;
+
+/**
+ * Builder for routing scopes that allows deferred evaluation
+ * of scope callbacks.
+ *
+ * @internal
+ */
+class RouteScope
+{
+    /**
+     * Constructor
+     *
+     * @param \Cake\Routing\RouterBuilder $builder The route builder to be used when resolving this scope.
+     * @param \Closure $callback The closure containing the routes in a scope.
+     */
+    public function __construct(
+        private RouteBuilder $builder,
+        private Closure $callback,
+    ) {
+    }
+
+    /**
+     * Check if this scope matches the provided path
+     *
+     * @param string $path The path to compare with
+     * @return bool
+     */
+    public function matchesPath(string $path): bool
+    {
+        // TODO implement this.
+        return true;
+    }
+
+    /**
+     * Get the path prefix for this scope
+     *
+     * @return string
+     */
+    public function path(): string
+    {
+        return $this->builder->path();
+    }
+
+    /**
+     * Resolve the deferred scope and add all routes
+     * contained in the scope callback
+     */
+    public function resolve(): void
+    {
+        $callback = $this->callback;
+        $callback($this->builder);
+    }
+}

--- a/src/Routing/RouteScope.php
+++ b/src/Routing/RouteScope.php
@@ -39,6 +39,27 @@ class RouteScope
     }
 
     /**
+     * Check if this scope's builder defaults matches the provided URL array.
+     *
+     * Scopes with no parameters match every scope as the routes within the scope
+     * are undefined and thus the scope could create routes that match.
+     *
+     * @array $url The url array being checked.
+     * @return bool
+     */
+    public function matchesUrl(array $url): bool
+    {
+        $defaults = $this->builder->params();
+        // If the defaults are empty, the URL could match routes
+        // defined by the scope.
+        if (empty($defaults)) {
+            return true;
+        }
+
+        return array_intersect_key($url, $defaults) === $defaults;
+    }
+
+    /**
      * Get the path prefix for this scope
      *
      * @return string

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -58,6 +58,17 @@ class RouteBuilderTest extends TestCase
     }
 
     /**
+     * Data provider for lazy scope modes.
+     */
+    public static function scopeModeProvider(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
      * Test path()
      */
     public function testPath(): void
@@ -698,10 +709,13 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test connecting resources.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testResourcesInScope(): void
+    public function testResourcesInScope($scopeMode): void
     {
         $builder = Router::createRouteBuilder('/');
+        $builder->useLazyScopes($scopeMode);
         $builder->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
@@ -896,10 +910,13 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test adding a scope.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testScope(): void
+    public function testScope($scopeMode): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/v1', ['version' => 1], function (RouteBuilder $routes): void {
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'Api', 'version' => 1], $routes->params());
@@ -909,10 +926,13 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test adding a scope with action in the scope
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testScopeWithAction(): void
+    public function testScopeWithAction($scopeMode): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function (RouteBuilder $routes): void {
             $routes->connect('/shared', ['shared' => true]);
             $routes->get('/exclusive', ['exclusive' => true]);
@@ -1161,10 +1181,13 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Integration test for http method helpers and route fluent method
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testHttpMethodIntegration(): void
+    public function testHttpMethodIntegration($scopeMode): void
     {
         $routes = new RouteBuilder($this->collection, '/');
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/', function (RouteBuilder $routes): void {
             $routes->get('/faq/{page}', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
                 ->setPatterns(['page' => '[a-z0-9_]+'])

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -715,7 +715,7 @@ class RouteBuilderTest extends TestCase
     public function testResourcesInScope($scopeMode): void
     {
         $builder = Router::createRouteBuilder('/');
-        $builder->useLazyScopes($scopeMode);
+        $builder->enableLazyScopes($scopeMode);
         $builder->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
@@ -916,7 +916,7 @@ class RouteBuilderTest extends TestCase
     public function testScope($scopeMode): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/v1', ['version' => 1], function (RouteBuilder $routes): void {
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'Api', 'version' => 1], $routes->params());
@@ -932,7 +932,7 @@ class RouteBuilderTest extends TestCase
     public function testScopeWithAction($scopeMode): void
     {
         $routes = new RouteBuilder($this->collection, '/api', ['prefix' => 'Api']);
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/prices', ['controller' => 'Prices', 'action' => 'view'], function (RouteBuilder $routes): void {
             $routes->connect('/shared', ['shared' => true]);
             $routes->get('/exclusive', ['exclusive' => true]);
@@ -1187,7 +1187,7 @@ class RouteBuilderTest extends TestCase
     public function testHttpMethodIntegration($scopeMode): void
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/', function (RouteBuilder $routes): void {
             $routes->get('/faq/{page}', ['controller' => 'Pages', 'action' => 'faq'], 'faq')
                 ->setPatterns(['page' => '[a-z0-9_]+'])
@@ -1243,7 +1243,7 @@ class RouteBuilderTest extends TestCase
     public function testUseLazyScopeInheritance(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->useLazyScopes(true);
+        $routes->enableLazyScopes(true);
         $routes->scope('/admin', function ($builder) {
             $builder->connect('/home');
             $builder->scope('/pages', function ($builder) {

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -502,6 +502,7 @@ class RouteBuilderTest extends TestCase
             $this->assertSame('/b/people', $r->path());
             $this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
         });
+        $this->collection->routes();
     }
 
     /**
@@ -513,12 +514,14 @@ class RouteBuilderTest extends TestCase
         $routes->plugin('Contacts', ['_namePrefix' => 'contacts.'], function (RouteBuilder $r): void {
             $this->assertEquals('contacts.', $r->namePrefix());
         });
+        $this->collection->routes();
 
         $routes = new RouteBuilder($this->collection, '/b', ['key' => 'value']);
         $routes->namePrefix('default.');
         $routes->plugin('Blog', ['_namePrefix' => 'blog.'], function (RouteBuilder $r): void {
             $this->assertEquals('default.blog.', $r->namePrefix(), 'Should combine nameprefix');
         });
+        $this->collection->routes();
     }
 
     /**
@@ -845,9 +848,9 @@ class RouteBuilderTest extends TestCase
             $this->assertEquals(['prefix' => 'Api'], $routes->params());
 
             $routes->resources('Comments');
-            $route = $this->collection->routes()[3];
-            $this->assertSame('/api/articles/{article_id}/comments', $route->template);
         });
+        $route = $this->collection->routes()[3];
+        $this->assertSame('/api/articles/{article_id}/comments', $route->template);
     }
 
     /**
@@ -901,6 +904,7 @@ class RouteBuilderTest extends TestCase
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'Api', 'version' => 1], $routes->params());
         });
+        $this->collection->routes();
     }
 
     /**
@@ -950,6 +954,7 @@ class RouteBuilderTest extends TestCase
             $this->assertSame('/api/v1', $routes->path());
             $this->assertEquals(['prefix' => 'Api'], $routes->params());
         });
+        $this->collection->routes();
     }
 
     /**

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -832,6 +832,7 @@ class RouteCollectionTest extends TestCase
     public function testScopeResolution(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
+        $routes->useLazyScopes(true);
         $routes->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $builder) {
             $builder->connect('/version', 'Versions::current');
         });

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -832,7 +832,7 @@ class RouteCollectionTest extends TestCase
     public function testScopeResolution(): void
     {
         $routes = new RouteBuilder($this->collection, '/');
-        $routes->useLazyScopes(true);
+        $routes->enableLazyScopes(true);
         $routes->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $builder) {
             $builder->connect('/version', 'Versions::current');
         });

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1738,6 +1738,7 @@ class RouterTest extends TestCase
                 $routes->connect('/docs', ['controller' => 'ApiDocs', 'action' => 'index']);
             });
         });
+        Router::routes();
 
         $this->assertEquals(['json', 'rss', 'xml'], array_values(Router::extensions()));
     }
@@ -3090,6 +3091,7 @@ class RouterTest extends TestCase
 
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
+        Router::routes();
     }
 
     /**
@@ -3111,7 +3113,7 @@ class RouterTest extends TestCase
             );
             $routes->connect('/home', []);
         });
-
+        Router::routes();
         $this->assertEquals(['json', 'rss'], array_values(Router::extensions()));
 
         $routes->scope('/api', function (RouteBuilder $routes): void {
@@ -3124,6 +3126,7 @@ class RouterTest extends TestCase
                 $this->assertEquals(['json', 'csv'], $routes->getExtensions());
             });
         });
+        Router::routes();
 
         $this->assertEquals(['json', 'rss', 'csv'], array_values(Router::extensions()));
     }
@@ -3141,6 +3144,7 @@ class RouterTest extends TestCase
             $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
         });
+        Router::routes();
     }
 
     /**
@@ -3157,6 +3161,7 @@ class RouterTest extends TestCase
 
             $routes->connect('/articles', ['controller' => 'Articles']);
         });
+        Router::routes();
     }
 
     /**
@@ -3175,6 +3180,7 @@ class RouterTest extends TestCase
             $this->assertSame('admin:', $routes->namePrefix());
             $this->assertEquals(['prefix' => 'Admin'], $routes->params());
         });
+        Router::routes();
     }
 
     /**
@@ -3193,6 +3199,7 @@ class RouterTest extends TestCase
             $this->assertSame('/custom-path', $routes->path());
             $this->assertEquals(['prefix' => 'CustomPath'], $routes->params());
         });
+        Router::routes();
     }
 
     /**
@@ -3205,6 +3212,7 @@ class RouterTest extends TestCase
             $this->assertSame('/debug-kit', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
         });
+        Router::routes();
     }
 
     /**
@@ -3222,6 +3230,7 @@ class RouterTest extends TestCase
         $routes->plugin('Contacts', ['_namePrefix' => 'contacts:'], function (RouteBuilder $routes): void {
             $this->assertSame('contacts:', $routes->namePrefix());
         });
+        Router::routes();
     }
 
     /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1742,7 +1742,7 @@ class RouterTest extends TestCase
         Router::extensions(['json']);
 
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/', function (RouteBuilder $routes): void {
             $routes->setExtensions('rss');
             $routes->connect('/', ['controller' => 'Pages', 'action' => 'index']);
@@ -1765,7 +1765,7 @@ class RouterTest extends TestCase
     public function testResourcesInScope($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
@@ -3103,7 +3103,7 @@ class RouterTest extends TestCase
     public function testScope($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/path', ['param' => 'value'], function (RouteBuilder $routes): void {
             $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
@@ -3124,7 +3124,7 @@ class RouterTest extends TestCase
     {
         Router::extensions(['json']);
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/', function (RouteBuilder $routes): void {
             $this->assertEquals(['json'], $routes->getExtensions(), 'Should default to global extensions.');
             $routes->setExtensions(['rss']);
@@ -3163,7 +3163,7 @@ class RouterTest extends TestCase
     {
         $options = ['param' => 'value'];
         $routes = Router::createRouteBuilder('/', ['routeClass' => 'InflectedRoute', 'extensions' => ['json']]);
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->scope('/path', $options, function (RouteBuilder $routes): void {
             $this->assertSame('InflectedRoute', $routes->getRouteClass());
             $this->assertSame(['json'], $routes->getExtensions());
@@ -3181,7 +3181,7 @@ class RouterTest extends TestCase
     public function testScopeNamePrefix($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
 
         $routes->scope('/path', ['param' => 'value', '_namePrefix' => 'path:'], function (RouteBuilder $routes): void {
             $this->assertSame('/path', $routes->path());
@@ -3196,7 +3196,7 @@ class RouterTest extends TestCase
     public function testLazyScopeEvaluation(): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes(true);
+        $routes->enableLazyScopes(true);
         $routes->scope('/path', function (RouteBuilder $builder) {
             $builder->connect('/articles', ['controller' => 'Articles']);
         });
@@ -3214,7 +3214,7 @@ class RouterTest extends TestCase
     public function testLazyScopeEvaluationNested(): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes(true);
+        $routes->enableLazyScopes(true);
         $routes->scope('/path', function (RouteBuilder $builder) {
             $builder->scope('/other', function (RouteBuilder $builder) {
                 $builder->connect('/articles', ['controller' => 'Articles']);
@@ -3239,7 +3239,7 @@ class RouterTest extends TestCase
     public function testPrefix($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
 
         $routes->prefix('admin', function (RouteBuilder $routes): void {
             $this->assertSame('/admin', $routes->path());
@@ -3261,7 +3261,7 @@ class RouterTest extends TestCase
     public function testPrefixOptions($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
 
         $routes->prefix('admin', ['param' => 'value'], function (RouteBuilder $routes): void {
             $this->assertSame('/admin', $routes->path());
@@ -3283,7 +3283,7 @@ class RouterTest extends TestCase
     public function testPlugin($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
         $routes->plugin('DebugKit', function (RouteBuilder $routes): void {
             $this->assertSame('/debug-kit', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
@@ -3299,7 +3299,7 @@ class RouterTest extends TestCase
     public function testPluginOptions($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->useLazyScopes($scopeMode);
+        $routes->enableLazyScopes($scopeMode);
 
         $routes->plugin('DebugKit', ['path' => '/debugger'], function (RouteBuilder $routes): void {
             $this->assertSame('/debugger', $routes->path());

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -3175,7 +3175,7 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() method
- *
+     *
      * @dataProvider scopeModeProvider
      */
     public function testScopeNamePrefix($scopeMode): void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -60,6 +60,17 @@ class RouterTest extends TestCase
     }
 
     /**
+     * Data provider for lazy scope modes.
+     */
+    public static function scopeModeProvider(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
      * testFullBaseUrl method
      */
     public function testBaseUrl(): void
@@ -1723,12 +1734,15 @@ class RouterTest extends TestCase
 
     /**
      * Test that route builders propagate extensions to the top.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testExtensionsWithScopedRoutes(): void
+    public function testExtensionsWithScopedRoutes($scopeMode): void
     {
         Router::extensions(['json']);
 
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/', function (RouteBuilder $routes): void {
             $routes->setExtensions('rss');
             $routes->connect('/', ['controller' => 'Pages', 'action' => 'index']);
@@ -1745,10 +1759,13 @@ class RouterTest extends TestCase
 
     /**
      * Test connecting resources.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testResourcesInScope(): void
+    public function testResourcesInScope($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/api', ['prefix' => 'Api'], function (RouteBuilder $routes): void {
             $routes->setExtensions(['json']);
             $routes->resources('Articles');
@@ -3080,10 +3097,13 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() method
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testScope(): void
+    public function testScope($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/path', ['param' => 'value'], function (RouteBuilder $routes): void {
             $this->assertSame('/path', $routes->path());
             $this->assertEquals(['param' => 'value'], $routes->params());
@@ -3097,11 +3117,14 @@ class RouterTest extends TestCase
     /**
      * Test to ensure that extensions defined in scopes don't leak.
      * And that global extensions are propagated.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testScopeExtensionsContained(): void
+    public function testScopeExtensionsContained($scopeMode): void
     {
         Router::extensions(['json']);
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/', function (RouteBuilder $routes): void {
             $this->assertEquals(['json'], $routes->getExtensions(), 'Should default to global extensions.');
             $routes->setExtensions(['rss']);
@@ -3133,11 +3156,14 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() options
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testScopeOptions(): void
+    public function testScopeOptions($scopeMode): void
     {
         $options = ['param' => 'value'];
         $routes = Router::createRouteBuilder('/', ['routeClass' => 'InflectedRoute', 'extensions' => ['json']]);
+        $routes->useLazyScopes($scopeMode);
         $routes->scope('/path', $options, function (RouteBuilder $routes): void {
             $this->assertSame('InflectedRoute', $routes->getRouteClass());
             $this->assertSame(['json'], $routes->getExtensions());
@@ -3149,10 +3175,13 @@ class RouterTest extends TestCase
 
     /**
      * Test the scope() method
+ *
+     * @dataProvider scopeModeProvider
      */
-    public function testScopeNamePrefix(): void
+    public function testScopeNamePrefix($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
 
         $routes->scope('/path', ['param' => 'value', '_namePrefix' => 'path:'], function (RouteBuilder $routes): void {
             $this->assertSame('/path', $routes->path());
@@ -3167,6 +3196,7 @@ class RouterTest extends TestCase
     public function testLazyScopeEvaluation(): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes(true);
         $routes->scope('/path', function (RouteBuilder $builder) {
             $builder->connect('/articles', ['controller' => 'Articles']);
         });
@@ -3184,6 +3214,7 @@ class RouterTest extends TestCase
     public function testLazyScopeEvaluationNested(): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes(true);
         $routes->scope('/path', function (RouteBuilder $builder) {
             $builder->scope('/other', function (RouteBuilder $builder) {
                 $builder->connect('/articles', ['controller' => 'Articles']);
@@ -3202,10 +3233,13 @@ class RouterTest extends TestCase
 
     /**
      * Test that prefix() creates a scope.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testPrefix(): void
+    public function testPrefix($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
 
         $routes->prefix('admin', function (RouteBuilder $routes): void {
             $this->assertSame('/admin', $routes->path());
@@ -3221,10 +3255,13 @@ class RouterTest extends TestCase
 
     /**
      * Test that prefix() accepts options
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testPrefixOptions(): void
+    public function testPrefixOptions($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
 
         $routes->prefix('admin', ['param' => 'value'], function (RouteBuilder $routes): void {
             $this->assertSame('/admin', $routes->path());
@@ -3240,10 +3277,13 @@ class RouterTest extends TestCase
 
     /**
      * Test that plugin() creates a scope.
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testPlugin(): void
+    public function testPlugin($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
         $routes->plugin('DebugKit', function (RouteBuilder $routes): void {
             $this->assertSame('/debug-kit', $routes->path());
             $this->assertEquals(['plugin' => 'DebugKit'], $routes->params());
@@ -3253,10 +3293,13 @@ class RouterTest extends TestCase
 
     /**
      * Test that plugin() accepts options
+     *
+     * @dataProvider scopeModeProvider
      */
-    public function testPluginOptions(): void
+    public function testPluginOptions($scopeMode): void
     {
         $routes = Router::createRouteBuilder('/');
+        $routes->useLazyScopes($scopeMode);
 
         $routes->plugin('DebugKit', ['path' => '/debugger'], function (RouteBuilder $routes): void {
             $this->assertSame('/debugger', $routes->path());
@@ -3544,8 +3587,6 @@ class RouterTest extends TestCase
     }
 
     /**
-<<<<<<< HEAD
-=======
      * Test the url() function which wraps Router::url()
      *
      * @return void
@@ -3566,7 +3607,6 @@ class RouterTest extends TestCase
     }
 
     /**
->>>>>>> origin/4.next
      * Helper to create a request for a given URL and method.
      *
      * @param string $url The URL to create a request for


### PR DESCRIPTION
This is an experiment that I had on recent travels. I spent a small amount of time with SPX profiling a simple 'hello world' template render. I wanted to see if there were any opportunities for quick wins. I found some interesting overhead in route generation. We've long known that route parsing can be a non-trivial amount of framework overhead.

I used routes from an application I have. It includes 65 routes organized into 10 scopes. I was interested in the performance of two functions. First, h `loadRoutes` method is responsible for loading application and plugin routes. Next, the `RoutingMiddleware::process` function is a great signal of the framework overhead, as it concludes with the controller being created and invoked. Currently in `5.x` we see:

`loadRoutes`

![before` loadroutes](https://github.com/cakephp/cakephp/assets/24086/653bacc4-c920-4cef-b37b-6f1400f6e6a1)

`RoutingMiddleware::process`
![before routingmiddleware](https://github.com/cakephp/cakephp/assets/24086/fb419654-94d1-44b5-a09e-f95f8cc98069)

My idea was that for applications that use routing scopes/prefixes/plugins we have a really simple way to defer route generation. Each of these concepts introduces a static prefix. When a request is processed we only need to load the scope that matches. The other scopes don't matter, and might not ever be needed. This could allow us to shave a measurable amount of time off the 'framework time'. 

I've implemented this theory and measured the inclusive time of `loadRoutes` and `RoutingMiddleware::process` again:

`loadRoutes`
![after loadroutes](https://github.com/cakephp/cakephp/assets/24086/e624274b-e47a-4e58-999d-5e33bb872e1c)

`RoutingMiddleware::process`
![after routingmiddleware](https://github.com/cakephp/cakephp/assets/24086/fc0f5c50-b4de-4afc-a53e-5e7c14fa678e)

By deferring route construction response times fell from 4ms to 3.2ms. The time spent in `process` went from 2.12ms to 1.6ms, which I think is decent savings.

I consider this a prototype and not yet production ready, but it 'works' and is measurably faster for the 'hello world' scenario. However, it creates some interesting tradeoffs. Those tradeoffs are:

1. While there are no 'breaks' in the API, there could be semantically different behavior in applications that access and manipulate routes directly. Applications that only use `Router` to generate URLs should not be impacted.
2. While we've optimized the simple scenario where a view generates 0 URLs, most responses *do* generate URLs. This means that when we go to generate URL strings we need to build **all** routes as `RouteCollection` doesn't have a good way to skip route scopes *yet*.
3. It is an overall increase incomplexity. This is another behavior that increases complexity with questionable value for real-world applications. Sure they may 'startup' faster, but we've not eliminated any work yet.

If we can find a reasonable solution to skipping scopes during URL matching we could deliver improved performance for more applications. One potential solution could be to use scope `params` as a way to fast-forward scopes that won't create routes that match anyways. This would work well with plugin based applications.

I also think this needs to be an opt-in change that applications enable. If it gets traction and doesn't generate many issues we can consider making it the default in the future.

So does this seem like it would be worth pursuing further? 
