### PR TITLE
Allow contain back for paginator

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -276,6 +276,9 @@ class NumericPaginator implements PaginatorInterface
         }
 
         $query->applyOptions($queryOptions);
+        if (!empty($data['options']['contain'])) {
+            $query->contain($data['options']['contain']);
+        }
 
         return $query;
     }


### PR DESCRIPTION
Currently, 5.x now silently ignores the contain option now.
This can be quite suprising. I only found it as it was throwing a string vs null type error in one of the helpers in the template.
I would recommend we either trigger a warning here, as currently the silent drop of contained relations is often a overlooked bug in index actions.
Or, the better way probably, to re-add this to avoid this kind of regression and BC breaking behavior in the first place.

Is there any good reason why developers have to rewrite 100 of controllers to use random custom finders or queries for simple contain options? Since all other options and keys are still valid it seems that usually can be passed as options.
Seems like a huge overkill to force devs to do that when it is quite simple to allow - and frankly how the ORM and lookup works across the whole rest of the framework.

4.x code in 5.x:
```php
	$this->paginate['contain'] = ['Countries'];

	if (Plugin::isLoaded('Search')) {
		$query = $this->States->find('search', ['search' => $this->request->getQuery()]);
		$states = $this->paginate($query);
	} else {
		$states = $this->paginate();
	}
```