### PR TITLE
FormHelper - attribute aria-required

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1071,7 +1071,6 @@ class FormHelper extends Helper
         if ($options['type'] !== 'hidden' && ($options['type'] !== 'select' && !isset($options['multiple']))) {
             $isFieldError = $this->isFieldError($fieldName);
             $options += [
-                'aria-required' => $options['required'] ? 'true' : null,
                 'aria-invalid' => $isFieldError ? 'true' : null,
             ];
             // Don't include aria-describedby unless we have a good chance of

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -506,7 +506,6 @@ class FormHelperTest extends TestCase
                 'data-validity-message' => 'This field cannot be left empty',
                 'oninvalid' => 'this.setCustomValidity(&#039;&#039;); if (!this.value) this.setCustomValidity(this.dataset.validityMessage)',
                 'oninput' => 'this.setCustomValidity(&#039;&#039;)',
-                'aria-required' => 'true',
             ],
             '/div',
         ];
@@ -2563,7 +2562,6 @@ class FormHelperTest extends TestCase
                 'data-validity-message' => 'This field cannot be left empty',
                 'oninvalid' => 'this.setCustomValidity(&#039;&#039;); if (!this.value) this.setCustomValidity(this.dataset.validityMessage)',
                 'oninput' => 'this.setCustomValidity(&#039;&#039;)',
-                'aria-required' => 'true',
                 'aria-invalid' => 'true',
                 'aria-describedby' => 'title-error',
             ],
@@ -2586,7 +2584,6 @@ class FormHelperTest extends TestCase
                 'type' => 'text',
                 'name' => 'title',
                 'id' => 'title',
-                'aria-required' => 'true',
                 'aria-invalid' => 'true',
                 'aria-describedby' => 'title-error',
                 'class' => 'form-error',
@@ -6366,7 +6363,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'type' => 'text',
                 'required' => 'required',
                 'placeholder' => 'Add title',
@@ -6393,7 +6389,6 @@ class FormHelperTest extends TestCase
         $expected = [
             'div' => ['class' => 'input text required'],
             'input' => [
-                'aria-required' => 'true',
                 'type' => 'text',
                 'required' => 'required',
                 'id' => 'title',
@@ -7702,7 +7697,6 @@ class FormHelperTest extends TestCase
                 '/label',
                 'textarea' => [
                     'name',
-                    'aria-required' => 'true',
                     'required' => 'required',
                     'id' => '0-comments-1-comment',
                     'rows' => 5,
@@ -7808,7 +7802,6 @@ class FormHelperTest extends TestCase
             'Password',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id' => 'password',
                 'name' => 'password',
                 'type' => 'password',
@@ -7827,7 +7820,6 @@ class FormHelperTest extends TestCase
             'Phone',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id' => 'phone',
                 'name' => 'phone',
                 'type' => 'tel',
@@ -7847,7 +7839,6 @@ class FormHelperTest extends TestCase
             'Email',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id' => 'email',
                 'name' => 'email',
                 'type' => 'email',
@@ -7892,7 +7883,6 @@ class FormHelperTest extends TestCase
             'Password',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id' => 'password',
                 'name' => 'password',
                 'type' => 'password',
@@ -7909,7 +7899,6 @@ class FormHelperTest extends TestCase
             'Phone',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id' => 'phone',
                 'name' => 'phone',
                 'type' => 'tel',
@@ -7931,7 +7920,6 @@ class FormHelperTest extends TestCase
             'Email',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id' => 'email',
                 'name' => 'email',
                 'type' => 'email',
@@ -7970,7 +7958,6 @@ class FormHelperTest extends TestCase
                 'type' => 'text',
                 'name' => 'title',
                 'id' => 'title',
-                'aria-required' => 'true',
                 'required' => 'required',
                 'data-validity-message' => 'This field cannot be left empty',
                 'oninvalid' => 'this.setCustomValidity(&#039;&#039;); if (!this.value) this.setCustomValidity(this.dataset.validityMessage)',
@@ -8847,7 +8834,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id',
                 'name' => 'title',
                 'type' => 'text',
@@ -8892,7 +8878,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id',
                 'name' => 'title',
                 'type' => 'text',
@@ -8929,7 +8914,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id',
                 'name' => 'title',
                 'type' => 'text',
@@ -8966,7 +8950,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id',
                 'name' => 'title',
                 'type' => 'text',
@@ -9009,7 +8992,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id',
                 'name' => 'title',
                 'type' => 'text',
@@ -9044,7 +9026,6 @@ class FormHelperTest extends TestCase
             'Title',
             '/label',
             'input' => [
-                'aria-required' => 'true',
                 'id',
                 'name' => 'title',
                 'type' => 'text',


### PR DESCRIPTION
Attribute aria-required is unnecessary for elements that have attribute required.

According to https://validator.w3.org, a warning is issued for these items. So I removed the mandatory fields where the required attribute is - aria-required.

![obrazek](https://github.com/cakephp/cakephp/assets/59865811/6ce38933-c80b-4986-b7af-ad11650811c7)
