### PR TITLE
Shim binary16 support for migration based testing

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -110,7 +110,7 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
         }
 
-        if (($col === 'binary' && $length === 16) || (str_contains(strtolower($column), 'blob') && $col === 'uuid')) {
+        if (($col === 'binary' && $length === 16) || strtolower($column) === 'uuid_blob') {
             return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
         }
         if (($col === 'char' && $length === 36) || $col === 'uuid') {

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -48,11 +48,6 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
         }
 
-        // For now to shim binary(16)
-        if ($column === 'UUID_BLOB') {
-            $column = 'BINARYUUID';
-        }
-
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -48,6 +48,11 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
         }
 
+        // For now to shim binary(16)
+        if ($column === 'UUID_BLOB') {
+            $column = 'BINARYUUID';
+        }
+
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
@@ -120,6 +125,9 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => $length];
         }
 
+        if ($col === 'binaryuuid') {
+            return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
+        }
         if ($col === 'binary' && $length === 16) {
             return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
         }

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -48,6 +48,10 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
         }
 
+        if ($column === 'UUID_BLOB') {
+            $column = 'BINARYUUID';
+        }
+
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
         if (empty($matches)) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -110,7 +110,7 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
         }
 
-        if (($col === 'binary' && $length === 16) || (str_contains($column, 'blob') && $col === 'uuid')) {
+        if (($col === 'binary' && $length === 16) || (str_contains(strtolower($column), 'blob') && $col === 'uuid')) {
             return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
         }
         if (($col === 'char' && $length === 36) || $col === 'uuid') {

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -48,12 +48,8 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
         }
 
-        if ($column === 'UUID_BLOB') {
-            $column = 'BINARYUUID';
-        }
-
         preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
-        if (empty($matches)) {
+        if (!$matches) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
@@ -114,6 +110,9 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_BOOLEAN, 'length' => null];
         }
 
+        if (($col === 'binary' && $length === 16) || (str_contains($column, 'blob') && $col === 'uuid')) {
+            return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
+        }
         if (($col === 'char' && $length === 36) || $col === 'uuid') {
             return ['type' => TableSchemaInterface::TYPE_UUID, 'length' => null];
         }
@@ -124,12 +123,6 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => $length];
         }
 
-        if ($col === 'binaryuuid') {
-            return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
-        }
-        if ($col === 'binary' && $length === 16) {
-            return ['type' => TableSchemaInterface::TYPE_BINARY_UUID, 'length' => null];
-        }
         if (in_array($col, ['blob', 'clob', 'binary', 'varbinary'])) {
             return ['type' => TableSchemaInterface::TYPE_BINARY, 'length' => $length];
         }

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -153,6 +153,10 @@ class SqliteSchemaTest extends TestCase
                 'UUID_TEXT',
                 ['type' => 'uuid', 'length' => null],
             ],
+            [
+                'UUID_BLOB',
+                ['type' => 'binaryuuid', 'length' => null],
+            ],
         ];
     }
 


### PR DESCRIPTION
This seems to fix the issue inside CakePHP test harness for https://github.com/cakephp/cakephp/issues/17420

The main issue is that the incoming type inside the schema column data for SQLite is
```php
  'name' => 'uuid',
  'type' => 'UUID_BLOB',
  'notnull' => (int) 1,
  'dflt_value' => null,
```
And the `preg_match('/(unsigned)?\s*([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);` in line 56 of SqliteSchemaDialect doesnt like the underscore, so removes the blob data
As such it always defaults to the normal UUID and loses the binary info, and cannot properly use the type class it should be using.

To shim this by correcting the name first seems to fix it for now
We still would want to look into migrations/phinx for a root fix, but it seems to be necessary here for all existing versions that are using UUID_BLOB as detected type string.
