### PR TITLE
5.next: rename `_cake_core_` to `_cake_translations_`

### DIFF
--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -199,7 +199,7 @@ trait StaticConfigTrait
      * $dsn = 'file:///?className=\My\Cache\Engine\FileEngine';
      * $config = Cache::parseDsn($dsn);
      *
-     * $dsn = 'File://?prefix=myapp_cake_core_&serialize=true&duration=+2 minutes&path=/tmp/persistent/';
+     * $dsn = 'File://?prefix=myapp_cake_translations_&serialize=true&duration=+2 minutes&path=/tmp/persistent/';
      * $config = Cache::parseDsn($dsn);
      * ```
      *

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\I18n;
 
 use Cake\Cache\Cache;
+use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\I18n\Exception\I18nException;
 use Cake\I18n\Formatter\IcuFormatter;
 use Cake\I18n\Formatter\SprintfFormatter;
@@ -71,7 +72,12 @@ class I18n
         );
 
         if (class_exists(Cache::class)) {
-            static::$_collection->setCacher(Cache::pool('_cake_translations_'));
+            try {
+                $pool = Cache::pool('_cake_translations_');
+            } catch (InvalidArgumentException) {
+                $pool = Cache::pool('_cake_core_');
+            }
+            static::$_collection->setCacher($pool);
         }
 
         return static::$_collection;

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -71,7 +71,7 @@ class I18n
         );
 
         if (class_exists(Cache::class)) {
-            static::$_collection->setCacher(Cache::pool('_cake_core_'));
+            static::$_collection->setCacher(Cache::pool('_cake_translations_'));
         }
 
         return static::$_collection;

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -575,7 +575,7 @@ class CacheTest extends TestCase
     {
         Cache::drop('default');
         $result = Cache::configured();
-        $this->assertContains('_cake_core_', $result);
+        $this->assertContains('_cake_translations_', $result);
         $this->assertNotContains('default', $result, 'Unconnected engines should not display.');
     }
 

--- a/tests/TestCase/Command/CacheCommandsTest.php
+++ b/tests/TestCase/Command/CacheCommandsTest.php
@@ -80,7 +80,7 @@ class CacheCommandsTest extends TestCase
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertOutputContains('- test');
-        $this->assertOutputContains('- _cake_core_');
+        $this->assertOutputContains('- _cake_translations_');
         $this->assertOutputContains('- _cake_model_');
     }
 
@@ -123,7 +123,7 @@ class CacheCommandsTest extends TestCase
     public function testClearIgnoresOtherCaches(): void
     {
         Cache::add('key', 'value', 'test');
-        $this->exec('cache clear _cake_core_');
+        $this->exec('cache clear _cake_translations_');
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertSame('value', Cache::read('key', 'test'));
@@ -135,12 +135,12 @@ class CacheCommandsTest extends TestCase
     public function testClearAll(): void
     {
         Cache::add('key', 'value1', 'test');
-        Cache::add('key', 'value3', '_cake_core_');
+        Cache::add('key', 'value3', '_cake_translations_');
         $this->exec('cache clear_all');
 
         $this->assertExitCode(CommandInterface::CODE_SUCCESS);
         $this->assertNull(Cache::read('key', 'test'));
-        $this->assertNull(Cache::read('key', '_cake_core_'));
+        $this->assertNull(Cache::read('key', '_cake_translations_'));
     }
 
     public function testClearGroup(): void

--- a/tests/TestCase/Core/StaticConfigTraitTest.php
+++ b/tests/TestCase/Core/StaticConfigTraitTest.php
@@ -180,12 +180,12 @@ class StaticConfigTraitTest extends TestCase
         ];
         $this->assertEquals($expected, TestEmailStaticConfig::parseDsn($dsn));
 
-        $dsn = 'file:///?prefix=myapp_cake_core_&serialize=true&duration=%2B2 minutes';
+        $dsn = 'file:///?prefix=myapp_cake_translations_&serialize=true&duration=%2B2 minutes';
         $expected = [
             'className' => 'Cake\Log\Engine\FileLog',
             'duration' => '+2 minutes',
             'path' => '/',
-            'prefix' => 'myapp_cake_core_',
+            'prefix' => 'myapp_cake_translations_',
             'scheme' => 'file',
             'serialize' => true,
         ];

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -36,7 +36,7 @@ class DateTest extends TestCase
     {
         parent::setUp();
 
-        Cache::clear('_cake_core_');
+        Cache::clear('_cake_translations_');
         I18n::setTranslator('cake', function () {
             $package = new Package();
             $package->setMessages([

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -54,7 +54,7 @@ class I18nTest extends TestCase
         I18n::setDefaultFormatter('default');
         I18n::setLocale(I18n::getDefaultLocale());
         $this->clearPlugins();
-        Cache::clear('_cake_core_');
+        Cache::clear('_cake_translations_');
     }
 
     /**
@@ -649,10 +649,10 @@ class I18nTest extends TestCase
         $english = I18n::getTranslator();
         $spanish = I18n::getTranslator('default', 'es_ES');
 
-        $cached = Cache::read('translations.default.en_US', '_cake_core_');
+        $cached = Cache::read('translations.default.en_US', '_cake_translations_');
         $this->assertEquals($english, $cached);
 
-        $cached = Cache::read('translations.default.es_ES', '_cake_core_');
+        $cached = Cache::read('translations.default.es_ES', '_cake_translations_');
         $this->assertEquals($spanish, $cached);
 
         $this->assertSame($english, I18n::getTranslator());

--- a/tests/TestCase/I18n/Parser/PoFileParserTest.php
+++ b/tests/TestCase/I18n/Parser/PoFileParserTest.php
@@ -55,7 +55,7 @@ class PoFileParserTest extends TestCase
         parent::tearDown();
         I18n::clear();
         I18n::setLocale(I18n::getDefaultLocale());
-        Cache::clear('_cake_core_');
+        Cache::clear('_cake_translations_');
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,7 +89,7 @@ Configure::write('App', [
 ]);
 
 Cache::setConfig([
-    '_cake_core_' => [
+    '_cake_translations_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
         'serialize' => true,


### PR DESCRIPTION
don't know if we can put this into `5.next` since this technically changes behavior here but I think the naming of `_cake_core_` is misleading and should be renamed to `_cake_translations_` since thats all we do with that pool

`_cake_core_` indicates we cache different parts of the framework as well which doesn't happen with that specific pool.