### PR TITLE
Fix notice

### DIFF
--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -122,7 +122,7 @@ class ConnectionManager
         }
 
         if (empty($config['driver'])) {
-            $config['driver'] = $config['className'];
+            $config['driver'] = $config['className'] ?? null;
             $config['className'] = Connection::class;
         }
 


### PR DESCRIPTION
```
warning: 2 :: Undefined array key "className" on line 125 of /work/devilbox/data/www/sandbox/vendor/cakephp/cakephp/src/Datasource/ConnectionManager.php
Stack Trace:

Cake\Datasource\ConnectionManager::parseDsn() /work/devilbox/data/www/sandbox/vendor/cakephp/cakephp/src/Core/StaticConfigTrait.php, line 101
Cake\Datasource\ConnectionManager::_setConfig() /work/devilbox/data/www/sandbox/vendor/cakephp/cakephp/src/Datasource/ConnectionManager.php, line 88
```

This can and should be avoided IMO.