### PR TITLE
Better exception output on Type classes.

### DIFF
--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -45,7 +45,8 @@ class BoolType extends BaseType implements BatchCastingInterface
         }
 
         throw new InvalidArgumentException(sprintf(
-            'Cannot convert value of type `%s` to bool',
+            'Cannot convert value `%s` of type `%s` to bool',
+            print_r($value, true),
             get_debug_type($value)
         ));
     }

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -72,7 +72,8 @@ class DecimalType extends BaseType implements BatchCastingInterface
         }
 
         throw new InvalidArgumentException(sprintf(
-            'Cannot convert value of type `%s` to a decimal',
+            'Cannot convert value `%s` of type `%s` to a decimal',
+            print_r($value, true),
             get_debug_type($value)
         ));
     }

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -106,7 +106,8 @@ class EnumType extends BaseType
 
         if (!is_string($value) && !is_int($value)) {
             throw new InvalidArgumentException(sprintf(
-                'Cannot convert value of type `%s` to string or integer',
+                'Cannot convert value `%s` of type `%s` to string or int',
+                print_r($value, true),
                 get_debug_type($value)
             ));
         }

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -38,7 +38,8 @@ class IntegerType extends BaseType implements BatchCastingInterface
     {
         if (!is_numeric($value) && !is_bool($value)) {
             throw new InvalidArgumentException(sprintf(
-                'Cannot convert value of type `%s` to integer',
+                'Cannot convert value `%s` of type `%s` to int',
+                print_r($value, true),
                 get_debug_type($value)
             ));
         }

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -50,7 +50,8 @@ class StringType extends BaseType implements OptionalConvertInterface
         }
 
         throw new InvalidArgumentException(sprintf(
-            'Cannot convert value of type `%s` to string',
+            'Cannot convert value `%s` of type `%s` to string',
+            print_r($value, true),
             get_debug_type($value)
         ));
     }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -3285,7 +3285,7 @@ class MarshallerTest extends TestCase
     public function testInvalidTypesWhenLoadingAssociatedByIds(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
+        $this->expectExceptionMessage('Cannot convert value `foobar` of type `string` to int');
 
         $data = [
             'title' => 'article',
@@ -3305,7 +3305,7 @@ class MarshallerTest extends TestCase
     public function testInvalidTypesWhenLoadingAssociatedByCompositeIds(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot convert value of type `string` to integer');
+        $this->expectExceptionMessage('Cannot convert value `foo` of type `string` to int');
 
         $data = [
             'title' => 'article',


### PR DESCRIPTION
The exceptions logged had a hard to understand issue underneath
Also when debuggin it is easier to follow with the value being tracable

Before:

> InvalidArgumentException: Cannot convert value of type `string` to integer

without any info on the context.

After:

> InvalidArgumentException: Cannot convert value `f777ca65-ee96-4447-b264-606923423b22` of type `string` to integer

