### PR TITLE
Fix message path loading order

### DIFF
--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -174,13 +174,6 @@ class MessagesFileLoader
 
         $searchPaths = [];
 
-        if ($this->_plugin && Plugin::isLoaded($this->_plugin)) {
-            $basePath = App::path('locales', $this->_plugin)[0];
-            foreach ($folders as $folder) {
-                $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR;
-            }
-        }
-
         $localePaths = App::path('locales');
         if (empty($localePaths) && defined('APP')) {
             $localePaths[] = ROOT . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
@@ -188,6 +181,13 @@ class MessagesFileLoader
         foreach ($localePaths as $path) {
             foreach ($folders as $folder) {
                 $searchPaths[] = $path . $folder . DIRECTORY_SEPARATOR;
+            }
+        }
+
+        if ($this->_plugin && Plugin::isLoaded($this->_plugin)) {
+            $basePath = App::path('locales', $this->_plugin)[0];
+            foreach ($folders as $folder) {
+                $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR;
             }
         }
 

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -191,12 +191,26 @@ class I18nTest extends TestCase
     {
         $this->loadPlugins([
             'TestTheme' => [],
+            'TestPluginTwo' => []
         ]);
+
         $translator = I18n::getTranslator('test_theme');
         $this->assertSame(
             'translated',
             $translator->translate('A Message')
         );
+
+        $translator = I18n::getTranslator('test_plugin_two');
+        $this->assertSame(
+            'Test Message (from app)',
+            $translator->translate('Test Message')
+            );
+
+        $translator = I18n::getTranslator('test_plugin_two.custom');
+        $this->assertSame(
+            'Test Custom (from test plugin two)',
+            $translator->translate('Test Custom')
+            );
     }
 
     /**

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -191,7 +191,7 @@ class I18nTest extends TestCase
     {
         $this->loadPlugins([
             'TestTheme' => [],
-            'TestPluginTwo' => []
+            'TestPluginTwo' => [],
         ]);
 
         $translator = I18n::getTranslator('test_theme');
@@ -204,13 +204,13 @@ class I18nTest extends TestCase
         $this->assertSame(
             'Test Message (from app)',
             $translator->translate('Test Message')
-            );
+        );
 
         $translator = I18n::getTranslator('test_plugin_two.custom');
         $this->assertSame(
             'Test Custom (from test plugin two)',
             $translator->translate('Test Custom')
-            );
+        );
     }
 
     /**

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -78,4 +78,45 @@ class MessagesFileLoaderTest extends TestCase
         $package = $loader();
         $this->assertFalse($package);
     }
+    
+    /**
+     * Testing MessagesFileLoader::translationsFilder array sequence
+     */
+    public function testTranslationFoldersSequence(): void
+    {
+        $this->loadPlugins([
+            'TestPluginTwo' => []
+        ]);
+        $loader = new MessagesFileLoader('test_plugin_two', 'en');
+
+        $expected = [
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+        ];
+        $result = $loader->translationsFolders();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Testing plugin override from app
+     */
+    public function testAppOverridesPlugin(): void
+    {
+        $this->loadPlugins([
+            'TestPlugin' => [],
+            'TestPluginTwo' => []
+        ]);
+
+        $loader = new MessagesFileLoader('test_plugin', 'en');
+        $package  = $loader();
+        $messages = $package->getMessages();
+        $this->assertSame('Plural Rule 1 (from plugin)', $messages['Plural Rule 1']['_context']['']);
+        
+        $loader = new MessagesFileLoader('test_plugin_two', 'en');
+        $package  = $loader();
+        $messages = $package->getMessages();
+        $this->assertSame('Test Message (from app)', $messages['Test Message']['_context']['']);
+    }
 }

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -78,14 +78,14 @@ class MessagesFileLoaderTest extends TestCase
         $package = $loader();
         $this->assertFalse($package);
     }
-    
+
     /**
      * Testing MessagesFileLoader::translationsFilder array sequence
      */
     public function testTranslationFoldersSequence(): void
     {
         $this->loadPlugins([
-            'TestPluginTwo' => []
+            'TestPluginTwo' => [],
         ]);
         $loader = new MessagesFileLoader('test_plugin_two', 'en');
 
@@ -106,16 +106,16 @@ class MessagesFileLoaderTest extends TestCase
     {
         $this->loadPlugins([
             'TestPlugin' => [],
-            'TestPluginTwo' => []
+            'TestPluginTwo' => [],
         ]);
 
         $loader = new MessagesFileLoader('test_plugin', 'en');
-        $package  = $loader();
+        $package = $loader();
         $messages = $package->getMessages();
         $this->assertSame('Plural Rule 1 (from plugin)', $messages['Plural Rule 1']['_context']['']);
-        
+
         $loader = new MessagesFileLoader('test_plugin_two', 'en');
-        $package  = $loader();
+        $package = $loader();
         $messages = $package->getMessages();
         $this->assertSame('Test Message (from app)', $messages['Test Message']['_context']['']);
     }

--- a/tests/test_app/Plugin/TestPluginTwo/resources/locales/en/custom.po
+++ b/tests/test_app/Plugin/TestPluginTwo/resources/locales/en/custom.po
@@ -1,0 +1,2 @@
+msgid "Test Custom"
+msgstr "Test Custom (from test plugin two)"

--- a/tests/test_app/Plugin/TestPluginTwo/resources/locales/en/test_plugin_two.po
+++ b/tests/test_app/Plugin/TestPluginTwo/resources/locales/en/test_plugin_two.po
@@ -1,0 +1,2 @@
+msgid "Test Message"
+msgstr "Test Message (from test plugin two)"

--- a/tests/test_app/resources/locales/en/test_plugin_two.po
+++ b/tests/test_app/resources/locales/en/test_plugin_two.po
@@ -1,0 +1,2 @@
+msgid "Test Message"
+msgstr "Test Message (from app)"


### PR DESCRIPTION
Fixes #17423 

* Swapped the search paths order back to app first than plugin.
* Added some tests to check app is able override plugin translations
