### PR TITLE
Document possible types as per 5.x

### DIFF
--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -86,7 +86,7 @@ class Number
      *
      * - `locale`: The locale name to use for formatting the number, e.g. fr_FR
      *
-     * @param string|float $value A floating point number.
+     * @param string|float|int $value A floating point number.
      * @param int $precision The precision of the returned number.
      * @param array<string, mixed> $options Additional options
      * @return string Formatted float.
@@ -102,7 +102,7 @@ class Number
     /**
      * Returns a formatted-for-humans file size.
      *
-     * @param string|int $size Size in bytes
+     * @param string|float|int $size Size in bytes
      * @return string Human readable size
      * @link https://book.cakephp.org/4/en/core-libraries/number.html#interacting-with-human-readable-values
      */
@@ -132,7 +132,7 @@ class Number
      * - `multiply`: Multiply the input value by 100 for decimal percentages.
      * - `locale`: The locale name to use for formatting the number, e.g. fr_FR
      *
-     * @param string|float $value A floating point number
+     * @param string|float|int $value A floating point number
      * @param int $precision The precision of the returned number
      * @param array<string, mixed> $options Options
      * @return string Percentage string

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -99,7 +99,7 @@ class NumberHelper extends Helper
     /**
      * Formats a number with a level of precision.
      *
-     * @param string|float $number A floating point number.
+     * @param string|float|int $number A floating point number.
      * @param int $precision The precision of the returned number.
      * @param array<string, mixed> $options Additional options.
      * @return string Formatted float.
@@ -114,7 +114,7 @@ class NumberHelper extends Helper
     /**
      * Returns a formatted-for-humans file size.
      *
-     * @param string|int $size Size in bytes
+     * @param string|float|int $size Size in bytes
      * @return string Human readable size
      * @see \Cake\I18n\Number::toReadableSize()
      * @link https://book.cakephp.org/4/en/views/helpers/number.html#interacting-with-human-readable-values
@@ -131,7 +131,7 @@ class NumberHelper extends Helper
      *
      * - `multiply`: Multiply the input value by 100 for decimal percentages.
      *
-     * @param string|float $number A floating point number
+     * @param string|float|int $number A floating point number
      * @param int $precision The precision of the returned number
      * @param array<string, mixed> $options Options
      * @return string Percentage string


### PR DESCRIPTION
It seems there are more types allowed, as per actual types added in 5.x.
https://github.com/cakephp/cakephp/blob/5.x/src/View/Helper/NumberHelper.php

So this syncs this back to 4.x