### PR TITLE
FIX: Issue creating index on Generated Stored columns in sqlite

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -182,7 +182,7 @@ class SqliteSchemaDialect extends SchemaDialect
     public function describeColumnSql(string $tableName, array $config): array
     {
         $sql = sprintf(
-            'PRAGMA table_info(%s)',
+            'PRAGMA table_xinfo(%s)',
             $this->_driver->quoteIdentifier($tableName)
         );
 


### PR DESCRIPTION
The migrations fail to add index due to PHP checking if the field exists in table.

Because this field is generated on the fly by engine, it's hidden when doing `PRAGMA table_info("tableName");`, it's correctly showing when doing `PRAGMA table_xinfo("tableName");`.

The format of table_xinfo is compatible wih table_info, it does return the field list in the same format but have one additional column and also return hidden and generated columns.

The core differences are:
 table_xinfo - do return hidden and generated fields - so it is returning my "event" field
 table_xinfo - have one more column named "hidden" indicating that the column was hidden or not


This field definition is working with mysql, but not with sqlite due to this bug (as table_info is hidding this column).

    `event` tinyint(1) GENERATED ALWAYS AS (`data_field` IS NOT NULL) STORED NOT NULL,


table_info:
![image](https://github.com/cakephp/cakephp/assets/921517/83fb9535-f877-4097-956c-b20e75b55f62)

table_xinfo:
![image](https://github.com/cakephp/cakephp/assets/921517/d38ea367-6a96-4db1-8d4a-f9667cbc5a84)



New query:
sqlite> PRAGMA table_xinfo("tableName");
0|id|INTEGER|1||1|0
1|created_at|DATETIME_TEXT|1||0|0
2|user_id|INTEGER|0||0|0
3|event_id|VARCHAR(64)|0||0|0
4|type_id|VARCHAR(64)|0||0|0
5|object|VARCHAR(255)|1||0|0
6|target|VARCHAR(150)|1||0|0
7|data|TEXT|1||0|0
8|event|tinyint(1)|1||0|3

Old query:
sqlite> PRAGMA table_info("tableName");
0|id|INTEGER|1||1
1|created_at|DATETIME_TEXT|1||0
2|user_id|INTEGER|0||0
3|event_id|VARCHAR(64)|0||0
4|type_id|VARCHAR(64)|0||0
5|object|VARCHAR(255)|1||0
6|target|VARCHAR(150)|1||0
7|data|TEXT|1||0
sqlite> 

the old one is hidding the event field, due to that I can't make index over that field
