### PR TITLE
Make PHPStan see the code better.

### DIFF
--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -191,6 +191,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
             }
 
             if (method_exists($value, 'getOptionParser')) {
+                /** @var \Cake\Console\ConsoleOptionParser $parser */
                 $parser = $value->getOptionParser();
 
                 foreach ($parser->options() as $name => $option) {

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -475,7 +475,9 @@ class BelongsToMany extends Association
 
         $foreignKey = $this->getTargetForeignKey();
         $thisJoin = $query->clause('join')[$this->getName()];
-        $thisJoin['conditions']->add($assoc->_joinCondition(['foreignKey' => $foreignKey]));
+        /** @var \Cake\Database\Expression\QueryExpression $conditions */
+        $conditions = $thisJoin['conditions'];
+        $conditions->add($assoc->_joinCondition(['foreignKey' => $foreignKey]));
     }
 
     /**
@@ -752,7 +754,9 @@ class BelongsToMany extends Association
             // Saving the new linked entity failed, copy errors back into the
             // original entity if applicable and abort.
             if (!empty($options['atomic'])) {
-                $original[$k]->setErrors($entity->getErrors());
+                /** @var \Cake\Datasource\EntityInterface $originalEntity */
+                $originalEntity = $original[$k];
+                $originalEntity->setErrors($entity->getErrors());
             }
 
             return false;

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -234,9 +234,11 @@ class HasMany extends Association
             }
 
             if (!empty($options['atomic'])) {
-                $original[$k]->setErrors($entity->getErrors());
+                /** @var \Cake\ORM\Entity $originEntity */
+                $originEntity = $original[$k];
+                $originEntity->setErrors($entity->getErrors());
                 if ($entity instanceof InvalidPropertyInterface) {
-                    $original[$k]->setInvalid($entity->getInvalid());
+                    $originEntity->setInvalid($entity->getInvalid());
                 }
 
                 return false;

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -171,19 +171,22 @@ class SelectLoader
             $query = $query->find($finderName, ...$opts);
         }
 
+        /** @var \Cake\ORM\Query\SelectQuery $selectQuery */
+        $selectQuery = $options['query'];
+
         $fetchQuery = $query
             ->select($options['fields'])
             ->where($options['conditions'])
             ->eagerLoaded(true)
-            ->enableHydration($options['query']->isHydrationEnabled());
-        if ($options['query']->isResultsCastingEnabled()) {
+            ->enableHydration($selectQuery->isHydrationEnabled());
+        if ($selectQuery->isResultsCastingEnabled()) {
             $fetchQuery->enableResultsCasting();
         } else {
             $fetchQuery->disableResultsCasting();
         }
 
         if ($useSubquery) {
-            $filter = $this->_buildSubquery($options['query']);
+            $filter = $this->_buildSubquery($selectQuery);
             $fetchQuery = $this->_addFilteringJoin($fetchQuery, $key, $filter);
         } else {
             $fetchQuery = $this->_addFilteringCondition($fetchQuery, $key, $filter);
@@ -449,6 +452,7 @@ class SelectLoader
         $fields = $query->aliasFields($keys, $this->sourceAlias);
         $group = $fields = array_values($fields);
 
+        /** @var \Cake\Database\Expression\QueryExpression $order */
         $order = $query->clause('order');
         if ($order) {
             $columns = $query->clause('select');

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -94,6 +94,7 @@ class SelectWithPivotLoader extends SelectLoader
         $query = parent::_buildQuery($options);
 
         if ($queryBuilder) {
+            /** @var \Cake\ORM\Query\SelectQuery $query */
             $query = $queryBuilder($query);
         }
 

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -136,12 +136,14 @@ class CounterCacheBehavior extends Behavior
 
                 $registryAlias = $assoc->getTarget()->getRegistryAlias();
                 $entityAlias = $assoc->getProperty();
+                /** @var \Cake\Datasource\EntityInterface $assocEntity */
+                $assocEntity = $entity->$entityAlias;
 
                 if (
                     !is_callable($config) &&
                     isset($config['ignoreDirty']) &&
                     $config['ignoreDirty'] === true &&
-                    $entity->$entityAlias->isDirty($field)
+                    $assocEntity->isDirty($field)
                 ) {
                     $this->_ignoreDirty[$registryAlias][$field] = true;
                 }

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -402,6 +402,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         if ($id) {
             $where['id'] = $id;
 
+            /** @var \Cake\Datasource\EntityInterface|null $translation */
             $translation = $this->translationTable->find()
                 ->select(array_merge(['id', 'locale'], $fields))
                 ->where($where)

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -82,7 +82,10 @@ class ExistsIn
     public function __invoke(EntityInterface $entity, array $options): bool
     {
         if (is_string($this->_repository)) {
-            if (!$options['repository']->hasAssociation($this->_repository)) {
+            /** @var \Cake\ORM\Table $table */
+            $table = $options['repository'];
+
+            if (!$table->hasAssociation($this->_repository)) {
                 throw new DatabaseException(sprintf(
                     'ExistsIn rule for `%s` is invalid. `%s` is not associated with `%s`.',
                     implode(', ', $this->_fields),
@@ -90,7 +93,7 @@ class ExistsIn
                     get_class($options['repository'])
                 ));
             }
-            $repository = $options['repository']->getAssociation($this->_repository);
+            $repository = $table->getAssociation($this->_repository);
             $this->_repository = $repository;
         }
 
@@ -124,6 +127,7 @@ class ExistsIn
         }
 
         if ($this->_options['allowNullableNulls']) {
+            /** @var \Cake\ORM\Table $source */
             $schema = $source->getSchema();
             foreach ($fields as $i => $field) {
                 if ($schema->getColumn($field) && $schema->isNullable($field) && $entity->get($field) === null) {

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -75,17 +75,20 @@ class IsUnique
             return true;
         }
 
-        $alias = $options['repository']->getAlias();
+        /** @var \Cake\ORM\Table $repository */
+        $repository = $options['repository'];
+
+        $alias = $repository->getAlias();
         $conditions = $this->_alias($alias, $fields);
         if ($entity->isNew() === false) {
-            $keys = (array)$options['repository']->getPrimaryKey();
+            $keys = (array)$repository->getPrimaryKey();
             $keys = $this->_alias($alias, $entity->extract($keys));
             if (Hash::filter($keys)) {
                 $conditions['NOT'] = $keys;
             }
         }
 
-        return !$options['repository']->exists($conditions);
+        return !$repository->exists($conditions);
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -338,6 +338,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
         $this->_eventManager = $eventManager ?: new EventManager();
+        /** @var \Cake\ORM\BehaviorRegistry $behaviors */
         $this->_behaviors = $behaviors ?: new BehaviorRegistry();
         $this->_behaviors->setTable($this);
         $this->_associations = $associations ?: new AssociationCollection();
@@ -2327,6 +2328,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         /** @var array<bool> $isNew */
         $isNew = [];
         $cleanupOnFailure = function ($entities) use (&$isNew): void {
+            /** @var iterable<\Cake\Datasource\EntityInterface> $entities */
             foreach ($entities as $key => $entity) {
                 if (isset($isNew[$key]) && $isNew[$key]) {
                     $entity->unset($this->getPrimaryKey());


### PR DESCRIPTION
Refs https://github.com/CakeDC/cakephp-phpstan/issues/20

When looking into what PHPStan actually completely ignores for some reason makes you see where you are vulnerable or have a false sense of security.

There are about 75 issues left after these small fixes here.
Most of them are valid as in: PHPStan just doesnt provide help here because it cannot see the type.

The list of leftovers is as follows:
```
  ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Collection)                                           
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  698    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Iterator\TreeIterator)                                
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  698    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Iterator\TreePrinter)                                 
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  698    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\Collection\Iterator\ZipIterator)                                 
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  698    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Collection/CollectionTrait.php (in context of class Cake\ORM\ResultSet)                                                   
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  698    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Driver/Sqlserver.php                                                                                                                                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  346    Anonymous variable in a `$original->clause('order')->...()` method call can lead to false dead methods. Make sure the variable type is known                                                                                   
  416    Anonymous variable in a `$q->...()` method call can lead to false dead methods. Make sure the variable type is known                                                                                                           
  416    Anonymous variable in a `$q->newExpr('ROW_NUMBER() OVER')->...()` method call can lead to false dead methods. Make sure the variable type is known                                                                             
  416    Anonymous variable in a `$q->newExpr('ROW_NUMBER() OVER')->add('(PARTITION BY')->...()` method call can lead to false dead methods. Make sure the variable type is known                                                       
  416    Anonymous variable in a `$q->newExpr('ROW_NUMBER() OVER')->add('(PARTITION BY')->add($q->newExpr()->add($distinct)->setConjunction(','))->...()` method call can lead to false dead methods. Make sure the variable type is    
         known                                                                                                                                                                                                                          
  416    Anonymous variable in a `$q->newExpr('ROW_NUMBER() OVER')->add('(PARTITION BY')->add($q->newExpr()->add($distinct)->setConjunction(','))->add($order)->...()` method call can lead to false dead methods. Make sure the        
         variable type is known                                                                                                                                                                                                         
  416    Anonymous variable in a `$q->newExpr('ROW_NUMBER() OVER')->add('(PARTITION BY')->add($q->newExpr()->add($distinct)->setConjunction(','))->add($order)->add(')')->...()` method call can lead to false dead methods. Make sure  
         the variable type is known                                                                                                                                                                                                     
  418    Anonymous variable in a `$q->...()` method call can lead to false dead methods. Make sure the variable type is known                                                                                                           
  418    Anonymous variable in a `$q->newExpr()->...()` method call can lead to false dead methods. Make sure the variable type is known                                                                                                
  418    Anonymous variable in a `$q->newExpr()->add($distinct)->...()` method call can lead to false dead methods. Make sure the variable type is known                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/FieldTypeConverter.php                                                                                                        
 ------ --------------------------------------------------------------------------------------------------------------------------------------- 
  83     Anonymous variable in a `$conversion['type']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  88     Anonymous variable in a `$conversion['type']->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ --------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   Database/Query.php                                                                                                                        
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  1299   Anonymous variable in a `$this->_parts['order']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  1352   Anonymous variable in a `$this->_parts['order']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  1748   Anonymous variable in a `$expression->...()` method call can lead to false dead methods. Make sure the variable type is known             
  1749   Anonymous variable in a `$expression->...()` method call can lead to false dead methods. Make sure the variable type is known             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Query/InsertQuery.php                                                                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  71     Anonymous variable in a `$this->_parts['values']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  118    Anonymous variable in a `$this->_parts['values']->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Query/UpdateQuery.php                                                                                                          
 ------ ---------------------------------------------------------------------------------------------------------------------------------------- 
  112    Anonymous variable in a `$this->_parts['set']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  119    Anonymous variable in a `$this->_parts['set']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  127    Anonymous variable in a `$this->_parts['set']->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/QueryCompiler.php                                                                                                           
 ------ ------------------------------------------------------------------------------------------------------------------------------------- 
  312    Anonymous variable in a `$window['name']->...()` method call can lead to false dead methods. Make sure the variable type is known    
  312    Anonymous variable in a `$window['window']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  355    Anonymous variable in a `$p['query']->...()` method call can lead to false dead methods. Make sure the variable type is known        
 ------ ------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Type/DateTimeType.php                                                                                                           
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 
  140    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  140    Anonymous variable in a `$value->getTimezone()->...()` method call can lead to false dead methods. Make sure the variable type is known  
  145    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  148    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known                 
 ------ ----------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Type/DateType.php                                                                                                
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  94     Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Type/TimeType.php                                                                                                
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  165    Anonymous variable in a `$value->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
  Line   Http/Client/Adapter/Mock.php                                                                                                        
 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
  84     Anonymous variable in a `$mock['request']->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ ------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
  Line   I18n/RelativeTimeFormatter.php                                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------ 
  116    Anonymous variable in a `$options['from']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  338    Anonymous variable in a `$options['from']->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ ------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Association/BelongsToMany.php                                                                                                          
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  478    Anonymous variable in a `$thisJoin['conditions']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  755    Anonymous variable in a `$original[$k]->...()` method call can lead to false dead methods. Make sure the variable type is known            
  1285   Anonymous variable in a `$existingLink->...()` method call can lead to false dead methods. Make sure the variable type is known            
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Association/HasMany.php                                                                                                      
 ------ --------------------------------------------------------------------------------------------------------------------------------- 
  237    Anonymous variable in a `$original[$k]->...()` method call can lead to false dead methods. Make sure the variable type is known  
  239    Anonymous variable in a `$original[$k]->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ --------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Association/Loader/SelectLoader.php                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------- 
  178    Anonymous variable in a `$options['query']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  179    Anonymous variable in a `$options['query']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  455    Anonymous variable in a `$order->...()` method call can lead to false dead methods. Make sure the variable type is known             
 ------ ------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   ORM/Association/Loader/SelectWithPivotLoader.php                                                                                                            
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  100    Anonymous variable in a `$query->...()` method call can lead to false dead methods. Make sure the variable type is known                                    
  101    Anonymous variable in a `$query->...()` method call can lead to false dead methods. Make sure the variable type is known                                    
  101    Anonymous variable in a `$query->...()` method call can lead to false dead methods. Make sure the variable type is known                                    
  117    Anonymous variable in a `$query->...()` method call can lead to false dead methods. Make sure the variable type is known                                    
  117    Anonymous variable in a `$query->where($this->junctionConditions)->...()` method call can lead to false dead methods. Make sure the variable type is known  
  121    Anonymous variable in a `$query->...()` method call can lead to false dead methods. Make sure the variable type is known                                    
  121    Anonymous variable in a `$query->getEagerLoader()->...()` method call can lead to false dead methods. Make sure the variable type is known                  
  130    Anonymous variable in a `$query->...()` method call can lead to false dead methods. Make sure the variable type is known                                    
  130    Anonymous variable in a `$query->getTypeMap()->...()` method call can lead to false dead methods. Make sure the variable type is known                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Behavior/CounterCacheBehavior.php                                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  144    Anonymous variable in a `$entity->{$entityAlias}->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Behavior/Translate/ShadowTableStrategy.php                                                                                  
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  412    Anonymous variable in a `$translation->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ -------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   ORM/Rule/ExistsIn.php                                                                                                                     
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  85     Anonymous variable in a `$options['repository']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  93     Anonymous variable in a `$options['repository']->...()` method call can lead to false dead methods. Make sure the variable type is known  
  103    Anonymous variable in a `$target->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  127    Anonymous variable in a `$source->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  129    Anonymous variable in a `$schema->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  129    Anonymous variable in a `$schema->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  136    Anonymous variable in a `$target->...()` method call can lead to false dead methods. Make sure the variable type is known                 
  144    Anonymous variable in a `$target->...()` method call can lead to false dead methods. Make sure the variable type is known                 
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------- 
  Line   ORM/Table.php                                                                                                                        
 ------ ------------------------------------------------------------------------------------------------------------------------------------- 
  342    Anonymous variable in a `$this->_behaviors->...()` method call can lead to false dead methods. Make sure the variable type is known  
  2332   Anonymous variable in a `$entity->...()` method call can lead to false dead methods. Make sure the variable type is known            
  2333   Anonymous variable in a `$entity->...()` method call can lead to false dead methods. Make sure the variable type is known            
 ------ ------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Utility/Xml.php                                                                                                           
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  416    Anonymous variable in a `$dom->...()` method call can lead to false dead methods. Make sure the variable type is known    
  418    Anonymous variable in a `$child->...()` method call can lead to false dead methods. Make sure the variable type is known  
  418    Anonymous variable in a `$dom->...()` method call can lead to false dead methods. Make sure the variable type is known    
  421    Anonymous variable in a `$child->...()` method call can lead to false dead methods. Make sure the variable type is known  
  425    Anonymous variable in a `$node->...()` method call can lead to false dead methods. Make sure the variable type is known   
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   View/Form/EntityContext.php                                                                                                               
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 
  647    Anonymous variable in a `$assoc->...()` method call can lead to false dead methods. Make sure the variable type is known                  
  653    Anonymous variable in a `$associationCollection->...()` method call can lead to false dead methods. Make sure the variable type is known  
  664    Anonymous variable in a `$assoc->...()` method call can lead to false dead methods. Make sure the variable type is known                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------ 

```