### PR TITLE
Make PHPStan see the code better.

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -18,6 +18,7 @@ namespace Cake\Collection;
 
 use AppendIterator;
 use ArrayIterator;
+use ArrayObject;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;
@@ -695,7 +696,7 @@ trait CollectionTrait
         };
 
         return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer))
-            ->map(fn ($value) => $isObject ? $value : $value->getArrayCopy());
+            ->map(fn (ArrayObject|ArrayIterator $value) => $isObject ? $value : $value->getArrayCopy());
     }
 
     /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -18,7 +18,6 @@ namespace Cake\Collection;
 
 use AppendIterator;
 use ArrayIterator;
-use ArrayObject;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;
@@ -696,7 +695,10 @@ trait CollectionTrait
         };
 
         return $this->newCollection(new MapReduce($this->unwrap(), $mapper, $reducer))
-            ->map(fn (ArrayObject|ArrayIterator $value) => $isObject ? $value : $value->getArrayCopy());
+            ->map(function ($value) use ($isObject) {
+                /** @var \ArrayIterator|\ArrayObject $value */
+                return $isObject ? $value : $value->getArrayCopy();
+            });
     }
 
     /**

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -412,7 +412,7 @@ class Sqlserver extends Driver
 
         $order = new OrderByExpression($distinct);
         $query
-            ->select(function ($q) use ($distinct, $order) {
+            ->select(function (Query $q) use ($distinct, $order) {
                 $over = $q->newExpr('ROW_NUMBER() OVER')
                     ->add('(PARTITION BY')
                     ->add($q->newExpr()->add($distinct)->setConjunction(','))

--- a/src/Database/FieldTypeConverter.php
+++ b/src/Database/FieldTypeConverter.php
@@ -79,13 +79,16 @@ class FieldTypeConverter
         }
 
         foreach ($this->conversions as $conversion) {
+            /** @var \Cake\Database\TypeInterface $type */
+            $type = $conversion['type'];
             if ($conversion['hasBatch']) {
-                $row = $conversion['type']->manyToPHP($row, $conversion['fields'], $this->driver);
+                /** @var \Cake\Database\Type\BatchCastingInterface $type */
+                $row = $type->manyToPHP($row, $conversion['fields'], $this->driver);
                 continue;
             }
 
             foreach ($conversion['fields'] as $field) {
-                $row[$field] = $conversion['type']->toPHP($row[$field], $this->driver);
+                $row[$field] = $type->toPHP($row[$field], $this->driver);
             }
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1296,7 +1296,9 @@ abstract class Query implements ExpressionInterface, Stringable
         if (!$this->_parts['order']) {
             $this->_parts['order'] = new OrderByExpression();
         }
-        $this->_parts['order']->add(new OrderClauseExpression($field, 'ASC'));
+        /** @var \Cake\Database\Expression\QueryExpression $queryExpr */
+        $queryExpr = $this->_parts['order'];
+        $queryExpr->add(new OrderClauseExpression($field, 'ASC'));
 
         return $this;
     }
@@ -1349,7 +1351,10 @@ abstract class Query implements ExpressionInterface, Stringable
         if (!$this->_parts['order']) {
             $this->_parts['order'] = new OrderByExpression();
         }
-        $this->_parts['order']->add(new OrderClauseExpression($field, 'DESC'));
+
+        /** @var \Cake\Database\Expression\QueryExpression $queryExpr */
+        $queryExpr = $this->_parts['order'];
+        $queryExpr->add(new OrderClauseExpression($field, 'DESC'));
 
         return $this;
     }
@@ -1734,6 +1739,7 @@ abstract class Query implements ExpressionInterface, Stringable
         string $conjunction,
         array $types
     ): void {
+        /** @var \Cake\Database\Expression\QueryExpression $expression */
         $expression = $this->_parts[$part] ?: $this->newExpr();
         if (empty($append)) {
             $this->_parts[$part] = $expression;

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -68,7 +68,9 @@ class InsertQuery extends Query
         if (!$this->_parts['values']) {
             $this->_parts['values'] = new ValuesExpression($columns, $this->getTypeMap()->setTypes($types));
         } else {
-            $this->_parts['values']->setColumns($columns);
+            /** @var \Cake\Database\Expression\ValuesExpression $valuesExpr */
+            $valuesExpr = $this->_parts['values'];
+            $valuesExpr->setColumns($columns);
         }
 
         return $this;
@@ -115,7 +117,9 @@ class InsertQuery extends Query
             return $this;
         }
 
-        $this->_parts['values']->add($data);
+        /** @var \Cake\Database\Expression\ValuesExpression $valuesExpr */
+        $valuesExpr = $this->_parts['values'];
+        $valuesExpr->add($data);
 
         return $this;
     }

--- a/src/Database/Query/UpdateQuery.php
+++ b/src/Database/Query/UpdateQuery.php
@@ -109,14 +109,18 @@ class UpdateQuery extends Query
 
         if ($key instanceof Closure) {
             $exp = $this->newExpr()->setConjunction(',');
-            $this->_parts['set']->add($key($exp));
+            /** @var \Cake\Database\Expression\QueryExpression $setExpr */
+            $setExpr = $this->_parts['set'];
+            $setExpr->add($key($exp));
 
             return $this;
         }
 
         if (is_array($key) || $key instanceof ExpressionInterface) {
             $types = (array)$value;
-            $this->_parts['set']->add($key, $types);
+            /** @var \Cake\Database\Expression\QueryExpression $setExpr */
+            $setExpr = $this->_parts['set'];
+            $setExpr->add($key, $types);
 
             return $this;
         }
@@ -124,7 +128,9 @@ class UpdateQuery extends Query
         if (!is_string($types)) {
             $types = null;
         }
-        $this->_parts['set']->eq($key, $value, $types);
+        /** @var \Cake\Database\Expression\QueryExpression $setExpr */
+        $setExpr = $this->_parts['set'];
+        $setExpr->eq($key, $value, $types);
 
         return $this;
     }

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -309,7 +309,11 @@ class QueryCompiler
     {
         $windows = [];
         foreach ($parts as $window) {
-            $windows[] = $window['name']->sql($binder) . ' AS (' . $window['window']->sql($binder) . ')';
+            /** @var \Cake\Database\Expression\IdentifierExpression $expr */
+            $expr = $window['name'];
+            /** @var \Cake\Database\Expression\IdentifierExpression $windowExpr */
+            $windowExpr = $window['window'];
+            $windows[] = $expr->sql($binder) . ' AS (' . $windowExpr->sql($binder) . ')';
         }
 
         return ' WINDOW ' . implode(', ', $windows);
@@ -352,7 +356,9 @@ class QueryCompiler
     protected function _buildUnionPart(array $parts, Query $query, ValueBinder $binder): string
     {
         $parts = array_map(function ($p) use ($binder) {
-            $p['query'] = $p['query']->sql($binder);
+            /** @var \Cake\Database\Expression\IdentifierExpression $expr */
+            $expr = $p['query'];
+            $p['query'] = $expr->sql($binder);
             $p['query'] = $p['query'][0] === '(' ? trim($p['query'], '()') : $p['query'];
             $prefix = $p['all'] ? 'ALL ' : '';
             if ($this->_orderedUnion) {

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -135,6 +135,8 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             $value = new $class('@' . $value);
         }
 
+        assert($value instanceof NativeDateTime || $value instanceof DateTimeImmutable);
+
         if (
             $this->dbTimezone !== null
             && $this->dbTimezone->getName() !== $value->getTimezone()->getName()

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -91,6 +91,8 @@ class DateType extends BaseType implements BatchCastingInterface
             $value = new $class('@' . $value);
         }
 
+        assert(is_object($value) && method_exists($value, 'format'));
+
         return $value->format($this->_format);
     }
 

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -162,6 +162,8 @@ class TimeType extends BaseType implements BatchCastingInterface
             return $value;
         }
 
+        assert(method_exists($value, 'format'));
+
         return $value->format($this->_format);
     }
 

--- a/src/Http/Client/Adapter/Mock.php
+++ b/src/Http/Client/Adapter/Mock.php
@@ -81,7 +81,9 @@ class Mock implements AdapterInterface
         $requestUri = (string)$request->getUri();
 
         foreach ($this->responses as $index => $mock) {
-            if ($method !== $mock['request']->getMethod()) {
+            /** @var \Psr\Http\Message\RequestInterface $request */
+            $request = $mock['request'];
+            if ($method !== $request->getMethod()) {
                 continue;
             }
             if (!$this->urlMatches($requestUri, $mock['request'])) {

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -113,8 +113,10 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
             $time = $time->setTimezone($options['timezone']);
         }
 
-        $now = $options['from']->format('U');
-        $inSeconds = $time->format('U');
+        /** @var \Cake\Chronos\Chronos $from */
+        $from = $options['from'];
+        $now = (int)$from->format('U');
+        $inSeconds = (int)$time->format('U');
         $backwards = ($inSeconds > $now);
 
         $futureTime = $now;
@@ -129,7 +131,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
             return __d('cake', 'just now', 'just now');
         }
 
-        if ($diff > abs($now - (new DateTime($options['end']))->format('U'))) {
+        if ($diff > abs($now - (int)(new DateTime($options['end']))->format('U'))) {
             return sprintf($options['absoluteString'], $time->i18nFormat($options['format']));
         }
 
@@ -335,8 +337,10 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
             $date = $date->setTimezone($options['timezone']);
         }
 
-        $now = $options['from']->format('U');
-        $inSeconds = $date->format('U');
+        /** @var \Cake\Chronos\Chronos $from */
+        $from = $options['from'];
+        $now = (int)$from->format('U');
+        $inSeconds = (int)$date->format('U');
         $backwards = ($inSeconds > $now);
 
         $futureTime = $now;
@@ -351,7 +355,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
             return __d('cake', 'today');
         }
 
-        if ($diff > abs($now - (new Date($options['end']))->format('U'))) {
+        if ($diff > abs($now - (int)(new Date($options['end']))->format('U'))) {
             return sprintf($options['absoluteString'], $date->i18nFormat($options['format']));
         }
 

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -392,8 +392,9 @@ class Xml
         $key = $data['key'];
         $format = $data['format'];
         $value = $data['value'];
+        /** @var \DOMDocument $dom */
         $dom = $data['dom'];
-
+        /** @var \DOMNode $node */
         $node = $data['node'];
 
         $childNS = $childValue = null;

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -644,6 +644,7 @@ class EntityContext implements ContextInterface
         foreach ($normalized as $part) {
             if ($part === '_joinData') {
                 if ($assoc !== null) {
+                    /** @var \Cake\ORM\Association\BelongsToMany $assoc */
                     $table = $assoc->junction();
                     $assoc = null;
                     continue;


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/17443

More fixes as annotations

Issues should be down to 1 now
```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Database/Driver/Sqlserver.php                                                                                                                 
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------- 
  346    Anonymous variable in a `$original->clause('order')->...()` method call can lead to false dead methods. Make sure the variable type is known  
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------- 
```
clause() returns mixed, so chaining directly isnt working here. We could split it up.

I think once we resolve the rest (or whitelist what cannot be easily fixed up), we should enable this stricter PHPSTan config as future protection.