### PR TITLE
Local Redis seems to be able to return false

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,6 +6,12 @@
     </TooManyTemplateParams>
   </file>
   <file src="src/Cache/Engine/RedisEngine.php">
+    <InvalidCast>
+      <code><![CDATA[$this->_Redis->del($key)]]></code>
+      <code><![CDATA[$this->_Redis->del($key)]]></code>
+      <code><![CDATA[$this->_Redis->unlink($key)]]></code>
+      <code><![CDATA[$this->_Redis->unlink($key)]]></code>
+    </InvalidCast>
     <InvalidReturnStatement>
       <code><![CDATA[$this->_Redis->set($key, $value)]]></code>
       <code><![CDATA[$this->_Redis->setEx($key, $duration, $value)]]></code>

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -227,7 +227,7 @@ class RedisEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
-        return $this->_Redis->del($key) > 0;
+        return (int)$this->_Redis->del($key) > 0;
     }
 
     /**
@@ -242,7 +242,7 @@ class RedisEngine extends CacheEngine
     {
         $key = $this->_key($key);
 
-        return $this->_Redis->unlink($key) > 0;
+        return (int)$this->_Redis->unlink($key) > 0;
     }
 
     /**
@@ -266,7 +266,7 @@ class RedisEngine extends CacheEngine
             }
 
             foreach ($keys as $key) {
-                $isDeleted = ($this->_Redis->del($key) > 0);
+                $isDeleted = ((int)$this->_Redis->del($key) > 0);
                 $isAllDeleted = $isAllDeleted && $isDeleted;
             }
         }
@@ -297,7 +297,7 @@ class RedisEngine extends CacheEngine
             }
 
             foreach ($keys as $key) {
-                $isDeleted = ($this->_Redis->unlink($key) > 0);
+                $isDeleted = ((int)$this->_Redis->unlink($key) > 0);
                 $isAllDeleted = $isAllDeleted && $isDeleted;
             }
         }


### PR DESCRIPTION
PHPStan locally fails with
```
  230    Comparison operation ">" between (int|Redis|false) and 0 results in an error.          
  245    Comparison operation ">" between (int<0, max>|Redis|false) and 0 results in an error.  
  269    Comparison operation ">" between (int|Redis|false) and 0 results in an error.          
  300    Comparison operation ">" between (int<0, max>|Redis|false) and 0 results in an error.  
```
as it seems to also be able to return false.

It seems to need the case to be silent.