### PR TITLE
Use stricter PHPStan checking for better coverage.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,10 @@ end_of_line = crlf
 [*.yml]
 indent_size = 2
 
-[*.xml]
+[psalm-baseline.xml]
+indent_size = 2
+
+[phars.xml]
 indent_size = 2
 
 [Makefile]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,22 +122,6 @@ jobs:
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --testsuite=database
         fi
 
-    - name: Run class deprecation aliasing validation script
-      if: always()
-      run: php contrib/validate-deprecation-aliases.php
-
-    - name: Run composer.json validation for split packages
-      if: always()
-      run: php contrib/validate-split-packages.php
-
-    - name: Run PHPStan for split packages
-      if: always()
-      run: php contrib/validate-split-packages-phpstan.php
-
-    - name: Prefer lowest check
-      if: matrix.prefer-lowest == 'prefer-lowest'
-      run: composer require --dev dereuromark/composer-prefer-lowest && vendor/bin/validate-prefer-lowest -m
-
     - name: Submit code coverage
       if: matrix.php-version == '8.1'
       uses: codecov/codecov-action@v3
@@ -217,7 +201,56 @@ jobs:
           vendor/bin/phpunit --display-incomplete --display-skipped --testsuite=database
 
   cs-stan:
-    uses: cakephp/.github/.github/workflows/cs-stan.yml@5.x
-    secrets: inherit
-    with:
-      check_tests: true
+    name: Coding Standard & Static Analysis
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mbstring, intl
+          coverage: none
+          tools: phive, cs2pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Composer install
+        uses: ramsey/composer-install@v2
+
+      - name: Install PHP tools with phive.
+        run: "phive install --trust-gpg-keys '${{ inputs.phive_keys }}'"
+
+      - name: Run phpcs
+        if: always()
+        run: vendor/bin/phpcs --report=checkstyle | cs2pr
+
+      - name: Run psalm
+        if: always()
+        run: tools/psalm --output-format=github
+
+      - name: Run phpstan
+        if: always()
+        run: vendor/bin/phpstan analyse --error-format=github
+
+      - name: Run phpstan for tests
+        if: ${{ inputs.check_tests }}
+        run: vendor/bin/phpstan analyse -c tests/phpstan.neon --error-format=github
+
+      - name: Run class deprecation aliasing validation script
+        if: always()
+        run: php contrib/validate-deprecation-aliases.php
+
+      - name: Run composer.json validation for split packages
+        if: always()
+        run: php contrib/validate-split-packages.php
+
+      - name: Run PHPStan for split packages
+        if: always()
+        run: php contrib/validate-split-packages-phpstan.php
+
+      - name: Prefer lowest check
+        if: matrix.prefer-lowest == 'prefer-lowest'
+        run: composer require --dev dereuromark/composer-prefer-lowest && vendor/bin/validate-prefer-lowest -m

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="1.10.38" installed="1.10.38" location="./tools/phpstan" copy="false"/>
   <phar name="psalm" version="5.15.0" installed="5.15.0" location="./tools/psalm" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,8 @@
         "process-timeout": 900,
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
         }
     },
     "autoload": {
@@ -130,7 +131,7 @@
         "phpstan-tests": "tools/phpstan analyze -c tests/phpstan.neon",
         "phpstan-baseline": "tools/phpstan --generate-baseline",
         "psalm-baseline": "tools/psalm  --set-baseline=psalm-baseline.xml",
-        "stan-setup": "phive install",
+        "stan-setup": "phive install && cp composer.json composer.backup && composer require --dev phpstan/extension-installer symplify/phpstan-rules && mv composer.backup composer.json",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -123,8 +123,8 @@
             "@cs-check",
             "@test"
         ],
-        "cs-check": "phpcs --colors --parallel=16 -p src/ tests/",
-        "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
+        "cs-check": "phpcs --colors --parallel=16 -p",
+        "cs-fix": "phpcbf --colors --parallel=16 -p",
         "phpstan": "phpstan analyse",
         "psalm": "tools/psalm --show-info=false",
         "stan": [

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
         "mikey179/vfsstream": "^1.6.10",
         "mockery/mockery": "^1.6",
         "paragonie/csp-builder": "^2.3 || ^3.0",
+        "phpstan/phpstan": "^1.10.30",
+        "phpstan/extension-installer": "^1.3",
+        "symplify/phpstan-rules": "^12.4",
         "phpunit/phpunit": "^10.1.0 <=10.5.3"
     },
     "suggest": {
@@ -122,16 +125,16 @@
         ],
         "cs-check": "phpcs --colors --parallel=16 -p src/ tests/",
         "cs-fix": "phpcbf --colors --parallel=16 -p src/ tests/",
-        "phpstan": "tools/phpstan analyse",
+        "phpstan": "phpstan analyse",
         "psalm": "tools/psalm --show-info=false",
         "stan": [
             "@phpstan",
             "@psalm"
         ],
-        "phpstan-tests": "tools/phpstan analyze -c tests/phpstan.neon",
-        "phpstan-baseline": "tools/phpstan --generate-baseline",
+        "phpstan-tests": "phpstan analyze -c tests/phpstan.neon",
+        "phpstan-baseline": "phpstan --generate-baseline",
         "psalm-baseline": "tools/psalm  --set-baseline=psalm-baseline.xml",
-        "stan-setup": "phive install && cp composer.json composer.backup && composer require --dev phpstan/extension-installer symplify/phpstan-rules && mv composer.backup composer.json",
+        "stan-setup": "phive install",
         "lowest": "validate-prefer-lowest",
         "lowest-setup": "composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction && cp composer.json composer.backup && composer require --dev dereuromark/composer-prefer-lowest && mv composer.backup composer.json",
         "test": "phpunit",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,10 @@
 <ruleset name="CakePHP Core">
     <config name="installed_paths" value="../../cakephp/cakephp-codesniffer" />
 
+    <file>config/</file>
+    <file>src/</file>
+    <file>tests/</file>
+
     <rule ref="CakePHP" />
 
     <arg value="s"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,10 @@
 includes:
 	- phpstan-baseline.neon
 
+rules:
+    - Symplify\PHPStanRules\Rules\Explicit\NoMixedPropertyFetcherRule
+    - Symplify\PHPStanRules\Rules\Explicit\NoMixedMethodCallerRule
+
 parameters:
 	level: 8
 	checkMissingIterableValueType: false

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -133,8 +133,11 @@ class DateTimeType extends BaseType implements BatchCastingInterface
         }
         if (is_int($value)) {
             $class = $this->_className;
-            /** @var \DateTime|\DateTimeImmutable $value */
             $value = new $class('@' . $value);
+        }
+
+        if (!$value instanceof DateTimeInterface) {
+            return null;
         }
 
         if (

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1624,7 +1624,7 @@ class View implements EventDispatcherInterface
      * @param string $name Element name
      * @param array $data Data
      * @param array<string, mixed> $options Element options
-     * @return array Element Cache configuration.
+     * @return array<string, mixed> Element Cache configuration.
      * @psalm-return array{key:string, config:string}
      */
     protected function _elementCache(string $name, array $data, array $options): array


### PR DESCRIPTION
Completes protection discussed and finalized in https://github.com/cakephp/cakephp/pull/17443 etc

I wonder how we can make PHPStan in CI work with this, though
Since we are using this split off task

I still think we should undo that and move CI validation back here directly, it would also help with https://github.com/cakephp/cakephp/pull/17439
There is no need in trying to keep this too agnostic IMO