### PR TITLE
Fix up nullable type on protected method. 

### DIFF
--- a/src/Database/Expression/BetweenExpression.php
+++ b/src/Database/Expression/BetweenExpression.php
@@ -117,10 +117,10 @@ class BetweenExpression implements ExpressionInterface, FieldInterface
      *
      * @param mixed $value The value to bind
      * @param \Cake\Database\ValueBinder $binder The value binder to use
-     * @param string $type The type of $value
+     * @param string|null $type The type of $value
      * @return string generated placeholder
      */
-    protected function _bindValue(mixed $value, ValueBinder $binder, string $type): string
+    protected function _bindValue(mixed $value, ValueBinder $binder, ?string $type): string
     {
         $placeholder = $binder->placeholder('c');
         $binder->bind($placeholder, $value, $type);


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17402

It is true that the nullable part is not checked and blindly passed on into a not compatible signature in the protected method
The following code allows null again.

Interesting that no test picked up on this so far.