### PR TITLE
4.next: add events to cell action execution

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -170,8 +170,10 @@ abstract class Cell implements EventDispatcherInterface
 
         $render = function () use ($template) {
             try {
+                $this->dispatchEvent('Cell.beforeAction', [$this, $this->action]);
                 $reflect = new ReflectionMethod($this, $this->action);
                 $reflect->invokeArgs($this, $this->args);
+                $this->dispatchEvent('Cell.afterAction', [$this, $this->action]);
             } catch (ReflectionException $e) {
                 throw new BadMethodCallException(sprintf(
                     'Class %s does not have a "%s" method.',

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -450,4 +450,24 @@ class CellTest extends TestCase
         Cache::delete('celltest');
         Cache::drop('default');
     }
+
+    /**
+     * Tests events are dispatched correctly
+     */
+    public function testCellRenderDispatchesEvents(): void
+    {
+        /** @var \TestApp\View\Cell\ArticlesCell $cell */
+        $cell = $this->View->cell('Articles::doEcho', ['msg1' => 'dummy', 'msg2' => ' message']);
+
+        $manager = $this->View->getEventManager();
+        $manager->on('Cell.beforeAction', function ($event, $eventCell, $action) use ($cell) {
+            $this->assertSame($eventCell, $cell);
+            $this->assertEquals('doEcho', $action);
+        });
+        $manager->on('Cell.beforeAction', function ($event, $eventCell, $action) use ($cell) {
+            $this->assertSame($eventCell, $cell);
+            $this->assertEquals('doEcho', $action);
+        });
+        $this->assertStringContainsString('dummy message', $cell->render());
+    }
 }


### PR DESCRIPTION
I need this for my sentry plugin to give a bit more information on what cell is being executed at what time.

Actually... this could go into 5.next for me since the new performance monitoring feature of my plugin requires cake5 anyway...