### PR TITLE
FIX: exception trap: handle Exception.beforeRender event being stopped or returning no result

### DIFF
--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -240,11 +240,14 @@ class ExceptionTrap
 
         try {
             $event = $this->dispatchEvent('Exception.beforeRender', ['exception' => $exception, 'request' => $request]);
+            if ($event->isStopped()) {
+                return;
+            }
             $exception = $event->getData('exception');
             assert($exception instanceof Throwable);
 
             $renderer = $this->renderer($exception, $request);
-            $renderer->write($event->getResult() ?? $renderer->render());
+            $renderer->write($event->getResult() ?: $renderer->render());
         } catch (Throwable $exception) {
             $this->logInternalError($exception);
         }

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -316,6 +316,23 @@ class ExceptionTrapTest extends TestCase
         $this->assertNotEmpty($out);
     }
 
+    public function testBeforeRenderEventAborted(): void
+    {
+        $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);
+        $trap->getEventManager()->on('Exception.beforeRender', function ($event, Throwable $error, ?ServerRequest $req) {
+            $this->assertEquals(100, $error->getCode());
+            $this->assertStringContainsString('nope', $error->getMessage());
+            $event->stopPropagation();
+        });
+        $error = new InvalidArgumentException('nope', 100);
+
+        ob_start();
+        $trap->handleException($error);
+        $out = ob_get_clean();
+
+        $this->assertSame('', $out);
+    }
+
     public function testBeforeRenderEventExceptionChanged(): void
     {
         $trap = new ExceptionTrap(['exceptionRenderer' => TextExceptionRenderer::class]);

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -306,7 +306,6 @@ class ExceptionTrapTest extends TestCase
         $trap->getEventManager()->on('Exception.beforeRender', function ($event, Throwable $error) {
             $this->assertEquals(100, $error->getCode());
             $this->assertStringContainsString('nope', $error->getMessage());
-            $event->stopPropagation();
         });
         $error = new InvalidArgumentException('nope', 100);
 


### PR DESCRIPTION
Stopping event `Exception.beforeRender` in `ExceptionTrap` is not supported while `Error.beforeRender` is in `ErrorTrap`.

This causes errors when trying to do so, because of a bad comparison operator (`??` instead of `?:`) that means the code ends up passing `false` as first argument of `Renderer::render()` here : https://github.com/cakephp/cakephp/blob/3e4b2b317817c140afd7e7702c27bde20276f48b/src/Error/ExceptionTrap.php#L247

The proposed change is just making the code similar to the implementation of `ErrorTrap::handleError()` : https://github.com/cakephp/cakephp/blob/3e4b2b317817c140afd7e7702c27bde20276f48b/src/Error/ErrorTrap.php#L143-L147