### PR TITLE
Add missing method to interface as soft-req

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -26,6 +26,7 @@ use Stringable;
  *
  * @property mixed $id Alias for commonly used primary key.
  * @template-extends \ArrayAccess<string, mixed>
+ * @method bool hasValue(string $field)
  */
 interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
 {


### PR DESCRIPTION
Did we forget to put hasValue() in the entity interface in 5.x? 🙂
We should put this on the 6.x roadmap to not forget it again

For now this will at least make PHPStan happy for cases where the concrete object wouldnt need to be typed.