### PR TITLE
Add missing deprecated annotations

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -422,8 +422,7 @@ class Connection implements ConnectionInterface
      * connection's driver
      *
      * @param \Cake\Database\Query $query The query to be compiled
-     * @param \Cake\Database\ValueBinder $binder Value binder.
-
+     * @param \Cake\Database\ValueBinder $binder Value binder
      * @return string
      * @deprecated 4.5.0 Use getDriver()->compileQuery() instead.
      */

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -315,6 +315,7 @@ class Connection implements ConnectionInterface
      *
      * @throws \Cake\Database\Exception\MissingConnectionException If database connection could not be established.
      * @return bool true, if the connection was already established or the attempt was successful.
+     * @deprecated 4.5.0 Use getDriver()->connect() instead.
      */
     public function connect(): bool
     {
@@ -421,8 +422,10 @@ class Connection implements ConnectionInterface
      * connection's driver
      *
      * @param \Cake\Database\Query $query The query to be compiled
-     * @param \Cake\Database\ValueBinder $binder Value binder
+     * @param \Cake\Database\ValueBinder $binder Value binder.
+
      * @return string
+     * @deprecated 4.5.0 Use getDriver()->compileQuery() instead.
      */
     public function compileQuery(Query $query, ValueBinder $binder): string
     {
@@ -479,6 +482,7 @@ class Connection implements ConnectionInterface
      *
      * @param string $sql The SQL query to execute.
      * @return \Cake\Database\StatementInterface
+     * @deprecated 4.5.0 Use either `selectQuery`, `insertQuery`, `deleteQuery`, `updateQuery` instead.
      */
     public function query(string $sql): StatementInterface
     {
@@ -496,6 +500,7 @@ class Connection implements ConnectionInterface
      * Create a new Query instance for this connection.
      *
      * @return \Cake\Database\Query
+     * @deprecated 4.5.0 Use `insertQuery()`, `deleteQuery()`, `selectQuery()` or `updateQuery()` instead.
      */
     public function newQuery(): Query
     {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -186,6 +186,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      * are enabled.
      *
      * @var bool
+     * @deprecated 4.5.0 Results will always be buffered in 5.0.
      */
     protected $_useBufferedResults = true;
 
@@ -2214,6 +2215,7 @@ class Query implements ExpressionInterface, IteratorAggregate
      *
      * @param bool $enable Whether to enable buffering
      * @return $this
+     * @deprecated 4.5.0 Results will always be buffered in 5.0.
      */
     public function enableBufferedResults(bool $enable = true)
     {
@@ -2235,9 +2237,14 @@ class Query implements ExpressionInterface, IteratorAggregate
      * remembered for future iterations.
      *
      * @return $this
+     * @deprecated 4.5.0 Results will always be buffered in 5.0.
      */
     public function disableBufferedResults()
     {
+        deprecationWarning(
+            '4.5.0 disableBufferedResults() is deprecated. Results will always be buffered in 5.0.'
+        );
+
         $this->_dirty();
         $this->_useBufferedResults = false;
 
@@ -2255,9 +2262,14 @@ class Query implements ExpressionInterface, IteratorAggregate
      * remembered for future iterations.
      *
      * @return bool
+     * @deprecated 4.5.0 Results will always be buffered in 5.0.
      */
     public function isBufferedResultsEnabled(): bool
     {
+        deprecationWarning(
+            '4.5.0 isBufferedResultsEnabled() is deprecated. Results will always be buffered in 5.0.'
+        );
+
         return $this->_useBufferedResults;
     }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2241,10 +2241,6 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function disableBufferedResults()
     {
-        deprecationWarning(
-            '4.5.0 disableBufferedResults() is deprecated. Results will always be buffered in 5.0.'
-        );
-
         $this->_dirty();
         $this->_useBufferedResults = false;
 
@@ -2266,10 +2262,6 @@ class Query implements ExpressionInterface, IteratorAggregate
      */
     public function isBufferedResultsEnabled(): bool
     {
-        deprecationWarning(
-            '4.5.0 isBufferedResultsEnabled() is deprecated. Results will always be buffered in 5.0.'
-        );
-
         return $this->_useBufferedResults;
     }
 


### PR DESCRIPTION
Adds missing deprecated annotations to Database package methods removed in CakePHP 5.0