### PR TITLE
Less cloaking and more strict comparison where possible.

### DIFF
--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -190,7 +190,7 @@ class ApcuEngine extends CacheEngine
      */
     public function groups(): array
     {
-        if (empty($this->_compiledGroupNames)) {
+        if (!$this->_compiledGroupNames) {
             foreach ($this->_config['groups'] as $group) {
                 $this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
             }

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -471,7 +471,7 @@ class MemcachedEngine extends CacheEngine
      */
     public function groups(): array
     {
-        if (empty($this->_compiledGroupNames)) {
+        if (!$this->_compiledGroupNames) {
             foreach ($this->_config['groups'] as $group) {
                 $this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
             }

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -181,7 +181,7 @@ class MapReduce implements IteratorAggregate
             $mapper($val, $key, $this);
         }
 
-        if (!empty($this->_intermediate) && empty($this->_reducer)) {
+        if ($this->_intermediate && $this->_reducer === null) {
             throw new LogicException('No reducer function was provided');
         }
 

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -261,7 +261,7 @@ class I18nExtractCommand extends Command
 
         $this->_markerError = (bool)$args->getOption('marker-error');
 
-        if (empty($this->_files)) {
+        if (!$this->_files) {
             $this->_searchFiles();
         }
 
@@ -816,7 +816,7 @@ class I18nExtractCommand extends Command
     protected function _searchFiles(): void
     {
         $pattern = false;
-        if (!empty($this->_exclude)) {
+        if ($this->_exclude) {
             $exclude = [];
             foreach ($this->_exclude as $e) {
                 if (DIRECTORY_SEPARATOR !== '\\' && $e[0] !== DIRECTORY_SEPARATOR) {

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -136,7 +136,7 @@ class ServerCommand extends Command
             escapeshellarg($this->_documentRoot)
         );
 
-        if (!empty($this->_iniPath)) {
+        if ($this->_iniPath) {
             $command = sprintf('%s -c %s', $command, $this->_iniPath);
         }
 

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -161,7 +161,7 @@ class ConsoleInputArgument
      */
     public function validChoice(string $value): bool
     {
-        if (empty($this->_choices)) {
+        if (!$this->_choices) {
             return true;
         }
         if (!in_array($value, $this->_choices, true)) {

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -265,7 +265,7 @@ class ConsoleInputOption
      */
     public function validChoice(string|bool $value): bool
     {
-        if (empty($this->_choices)) {
+        if (!$this->_choices) {
             return true;
         }
         if (!in_array($value, $this->_choices, true)) {

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -787,7 +787,7 @@ class ConsoleOptionParser
      */
     protected function _parseArg(string $argument, array $args): array
     {
-        if (empty($this->_args)) {
+        if (!$this->_args) {
             $args[] = $argument;
 
             return $args;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -288,7 +288,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function __get(string $name): mixed
     {
-        if (!empty($this->defaultTable)) {
+        if ($this->defaultTable) {
             if (str_contains($this->defaultTable, '\\')) {
                 $class = App::shortName($this->defaultTable, 'Model/Table', 'Table');
             } else {

--- a/src/Core/TestSuite/ContainerStubTrait.php
+++ b/src/Core/TestSuite/ContainerStubTrait.php
@@ -91,7 +91,7 @@ trait ContainerStubTrait
         $appArgs = $this->_appArgs ?: [CONFIG];
 
         $app = new $appClass(...$appArgs);
-        if (!empty($this->containerServices) && method_exists($app, 'getEventManager')) {
+        if ($this->containerServices && method_exists($app, 'getEventManager')) {
             $app->getEventManager()->on('Application.buildContainer', [$this, 'modifyContainer']);
         }
 
@@ -142,7 +142,7 @@ trait ContainerStubTrait
      */
     public function modifyContainer(EventInterface $event, ContainerInterface $container): void
     {
-        if (empty($this->containerServices)) {
+        if (!$this->containerServices) {
             return;
         }
         foreach ($this->containerServices as $key => $factory) {

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -521,7 +521,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
             throw new LogicException('Case expression has incomplete when clause. Missing `then()` after `when()`.');
         }
 
-        if (empty($this->when)) {
+        if (!$this->when) {
             throw new LogicException('Case expression must have at least one when statement.');
         }
 

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -213,7 +213,7 @@ class ValuesExpression implements ExpressionInterface
      */
     public function sql(ValueBinder $binder): string
     {
-        if (empty($this->_values) && empty($this->_query)) {
+        if (!$this->_values && $this->_query === null) {
             return '';
         }
 

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -184,7 +184,7 @@ class LoggedQuery implements JsonSerializable, Stringable
     public function __toString(): string
     {
         $sql = $this->query;
-        if (!empty($this->params)) {
+        if ($this->params) {
             $sql = $this->interpolate();
         }
 

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -85,7 +85,7 @@ class CorsBuilder
     public function build(): ResponseInterface
     {
         $response = $this->_response;
-        if (empty($this->_origin)) {
+        if (!$this->_origin) {
             return $response;
         }
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -532,7 +532,7 @@ class Mailer implements EventListenerInterface
      */
     protected function logDelivery(array $contents): void
     {
-        if (empty($this->logConfig)) {
+        if (!$this->logConfig) {
             return;
         }
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -324,7 +324,7 @@ class Message implements JsonSerializable
             $this->charset = $this->appCharset;
         }
         $this->domain = (string)preg_replace('/\:\d+$/', '', (string)env('HTTP_HOST'));
-        if (empty($this->domain)) {
+        if (!$this->domain) {
             $this->domain = php_uname('n');
         }
 
@@ -1257,7 +1257,7 @@ class Message implements JsonSerializable
      */
     public function getBody(): array
     {
-        if (empty($this->message)) {
+        if (!$this->message) {
             $this->message = $this->generateMessage();
         }
 

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -342,7 +342,7 @@ class Socket
      */
     public function lastError(): ?string
     {
-        if (empty($this->lastError)) {
+        if (!$this->lastError) {
             return null;
         }
 

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -232,7 +232,7 @@ abstract class Association
             }
         }
 
-        if (empty($this->_className)) {
+        if (!$this->_className) {
             $this->_className = $alias;
         }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1470,7 +1470,7 @@ class BelongsToMany extends Association
     protected function _junctionTableName(?string $name = null): string
     {
         if ($name === null) {
-            if (empty($this->_junctionTableName)) {
+            if (!$this->_junctionTableName) {
                 $tablesNames = array_map('Cake\Utility\Inflector::underscore', [
                     $this->getSource()->getTable(),
                     $this->getTarget()->getTable(),

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -400,7 +400,7 @@ class EagerLoader
      */
     public function attachAssociations(SelectQuery $query, Table $repository, bool $includeFields): void
     {
-        if (empty($this->_containments) && $this->_matching === null) {
+        if (!$this->_containments && $this->_matching === null) {
             return;
         }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -736,7 +736,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     {
         $decorator = $this->_decoratorClass();
 
-        if (!empty($this->_mapReduce)) {
+        if ($this->_mapReduce) {
             foreach ($this->_mapReduce as $functions) {
                 $result = new MapReduce($result, $functions['mapper'], $functions['reducer']);
             }
@@ -747,7 +747,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             $result = new $decorator($result);
         }
 
-        if (!empty($this->_formatters)) {
+        if ($this->_formatters) {
             foreach ($this->_formatters as $formatter) {
                 $result = $formatter($result, $this);
             }

--- a/src/Routing/Route/EntityRoute.php
+++ b/src/Routing/Route/EntityRoute.php
@@ -43,7 +43,7 @@ class EntityRoute extends Route
      */
     public function match(array $url, array $context = []): ?string
     {
-        if (empty($this->_compiledRoute)) {
+        if (!$this->_compiledRoute) {
             $this->compile();
         }
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -309,7 +309,7 @@ class Route
      */
     protected function _writeRoute(): void
     {
-        if (empty($this->template) || ($this->template === '/')) {
+        if (!$this->template || ($this->template === '/')) {
             $this->_compiledRoute = '#^/*$#';
             $this->keys = [];
 
@@ -375,7 +375,7 @@ class Route
      */
     public function getName(): string
     {
-        if (!empty($this->_name)) {
+        if ($this->_name) {
             return $this->_name;
         }
         $name = '';
@@ -619,7 +619,7 @@ class Route
      */
     public function match(array $url, array $context = []): ?string
     {
-        if (empty($this->_compiledRoute)) {
+        if (!$this->_compiledRoute) {
             $this->compile();
         }
         $defaults = $this->defaults;
@@ -731,7 +731,7 @@ class Route
         }
 
         // check patterns for routed params
-        if (!empty($this->options)) {
+        if ($this->options) {
             foreach ($this->options as $key => $pattern) {
                 if (isset($url[$key]) && !preg_match('#^' . $pattern . '$#u', (string)$url[$key])) {
                     return null;

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -71,7 +71,7 @@ class TestFixture implements FixtureInterface
      */
     public function __construct()
     {
-        if (!empty($this->connection)) {
+        if ($this->connection) {
             $connection = $this->connection;
             if (!str_starts_with($connection, 'test')) {
                 $message = sprintf(
@@ -109,7 +109,7 @@ class TestFixture implements FixtureInterface
      */
     public function init(): void
     {
-        if (empty($this->table)) {
+        if (!$this->table) {
             $this->table = $this->_tableFromClass();
         }
 
@@ -169,7 +169,7 @@ class TestFixture implements FixtureInterface
     public function insert(ConnectionInterface $connection): bool
     {
         assert($connection instanceof Connection);
-        if (!empty($this->records)) {
+        if ($this->records) {
             [$fields, $values, $types] = $this->_getRecords();
             $query = $connection->insertQuery()
                 ->insert($fields, $types)

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -231,7 +231,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
      */
     protected function _cacheConfig(string $action, ?string $template = null): array
     {
-        if (empty($this->_cache)) {
+        if (!$this->_cache) {
             return [];
         }
         $template = $template ?: 'default';

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -95,15 +95,15 @@ trait CellTrait
         $builder = $instance->viewBuilder();
         $builder->setTemplate(Inflector::underscore($action));
 
-        if (!empty($plugin)) {
+        if ($plugin) {
             $builder->setPlugin($plugin);
         }
-        if (!empty($this->helpers)) {
+        if ($this->helpers) {
             $builder->addHelpers($this->helpers);
         }
 
         if ($this instanceof View) {
-            if (!empty($this->theme)) {
+            if ($this->theme) {
                 $builder->setTheme($this->theme);
             }
 

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -137,7 +137,7 @@ class StringTemplate
      */
     public function pop(): void
     {
-        if (empty($this->_configStack)) {
+        if (!$this->_configStack) {
             return;
         }
         [$this->_config, $this->_compiled] = array_pop($this->_configStack);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -786,7 +786,7 @@ class View implements EventDispatcherInterface
         $this->dispatchEvent('View.afterRender', [$templateFileName]);
 
         if ($this->autoLayout) {
-            if (empty($this->layout)) {
+            if (!$this->layout) {
                 throw new CakeException(
                     'View::$layout must be a non-empty string.' .
                     'To disable layout rendering use method `View::disableAutoLayout()` instead.'
@@ -1451,7 +1451,7 @@ class View implements EventDispatcherInterface
     protected function _getLayoutFileName(?string $name = null): string
     {
         if ($name === null) {
-            if (empty($this->layout)) {
+            if (!$this->layout) {
                 throw new CakeException(
                     'View::$layout must be a non-empty string.' .
                     'To disable layout rendering use method `View::disableAutoLayout()` instead.'
@@ -1590,7 +1590,7 @@ class View implements EventDispatcherInterface
             $pluginPaths[] = Plugin::templatePath($plugin);
         }
 
-        if (!empty($this->theme)) {
+        if ($this->theme) {
             $themePath = Plugin::templatePath(Inflector::camelize($this->theme));
 
             if ($plugin) {

--- a/tests/test_app/TestApp/Auth/TestAuthenticate.php
+++ b/tests/test_app/TestApp/Auth/TestAuthenticate.php
@@ -59,7 +59,7 @@ class TestAuthenticate extends BaseAuthenticate
         $this->callStack[] = __FUNCTION__;
         $this->authenticationProvider = $event->getData('1');
 
-        if (!empty($this->modifiedUser)) {
+        if ($this->modifiedUser) {
             return $user + ['extra' => 'foo'];
         }
     }


### PR DESCRIPTION
With more strict typing/properties, it is now safer to to do more identical null checks or removal the cloaking "maybe not defined" checks for a syntax that allows to see undefined props more easily.
The empty() one should usually only be used if the key e.g. in an array might be undefined.