### PR TITLE
Translation behavior: Mark modified fields as clean instead of the entire entity

### DIFF
--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -364,7 +364,7 @@ class EavStrategy implements TranslateStrategyInterface
             if ($row === null) {
                 return $row;
             }
-            $hydrated = !is_array($row);
+            $hydrated = $row instanceof EntityInterface;
 
             foreach ($this->_config['fields'] as $field) {
                 $name = $field . '_translation';
@@ -380,7 +380,6 @@ class EavStrategy implements TranslateStrategyInterface
                     $row[$field] = $content;
 
                     if ($hydrated) {
-                        /** @var \Cake\Datasource\EntityInterface $row */
                         $row->setDirty($field, false);
                     }
                 }
@@ -390,7 +389,6 @@ class EavStrategy implements TranslateStrategyInterface
 
             $row['_locale'] = $locale;
             if ($hydrated) {
-                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->setDirty('_locale', false);
             }
 

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -380,6 +380,7 @@ class EavStrategy implements TranslateStrategyInterface
                     $row[$field] = $content;
 
                     if ($hydrated) {
+                        /** @var \Cake\Datasource\EntityInterface $row */
                         $row->setDirty($field, false);
                     }
                 }
@@ -389,6 +390,7 @@ class EavStrategy implements TranslateStrategyInterface
 
             $row['_locale'] = $locale;
             if ($hydrated) {
+                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->setDirty('_locale', false);
             }
 

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -386,7 +386,8 @@ class EavStrategy implements TranslateStrategyInterface
             $row['_locale'] = $locale;
             if ($hydrated) {
                 /** @var \Cake\Datasource\EntityInterface $row */
-                $row->clean();
+                $row->setDirty($field, false);
+                $row->setDirty('_locale', false);
             }
 
             return $row;
@@ -425,8 +426,8 @@ class EavStrategy implements TranslateStrategyInterface
 
             $options = ['setter' => false, 'guard' => false];
             $row->set('_translations', $result, $options);
+            $row->setDirty('_translations', false);
             unset($row['_i18n']);
-            $row->clean();
 
             return $row;
         });

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -378,6 +378,11 @@ class EavStrategy implements TranslateStrategyInterface
                 $content = $translation['content'] ?? null;
                 if ($content !== null) {
                     $row[$field] = $content;
+
+                    if ($hydrated) {
+                        /** @var \Cake\Datasource\EntityInterface $row */
+                        $row->setDirty($field, false);
+                    }
                 }
 
                 unset($row[$name]);
@@ -386,7 +391,6 @@ class EavStrategy implements TranslateStrategyInterface
             $row['_locale'] = $locale;
             if ($hydrated) {
                 /** @var \Cake\Datasource\EntityInterface $row */
-                $row->setDirty($field, false);
                 $row->setDirty('_locale', false);
             }
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -490,7 +490,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
 
                 if ($hydrated) {
                     /** @var \Cake\Datasource\EntityInterface $row */
-                    $row->clean();
+                    $row->setDirty('_locale', false);
                 }
 
                 return $row;
@@ -516,6 +516,11 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 if ($translation[$field] !== null) {
                     if ($allowEmpty || $translation[$field] !== '') {
                         $row[$field] = $translation[$field];
+
+                        if ($hydrated) {
+                            /** @var \Cake\Datasource\EntityInterface $row */
+                            $row->setDirty($field, false);
+                        }
                     }
                 }
             }
@@ -525,7 +530,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
 
             if ($hydrated) {
                 /** @var \Cake\Datasource\EntityInterface $row */
-                $row->clean();
+                $row->setDirty('_locale', false);
             }
 
             return $row;
@@ -559,7 +564,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             $row['_translations'] = $result;
             unset($row['_i18n']);
             if ($row instanceof EntityInterface) {
-                $row->clean();
+                $row->setDirty('_translations', false);
             }
 
             return $row;

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -489,6 +489,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 unset($row['translation']);
 
                 if ($hydrated) {
+                    /** @var \Cake\Datasource\EntityInterface $row */
                     $row->setDirty('_locale', false);
                 }
 
@@ -517,15 +518,18 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                         $row[$field] = $translation[$field];
 
                         if ($hydrated) {
+                            /** @var \Cake\Datasource\EntityInterface $row */
                             $row->setDirty($field, false);
                         }
                     }
                 }
             }
 
+            /** @var array $row */
             unset($row['translation']);
 
             if ($hydrated) {
+                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->setDirty('_locale', false);
             }
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -482,14 +482,13 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 return $row;
             }
 
-            $hydrated = !is_array($row);
+            $hydrated = $row instanceof EntityInterface;
 
             if (empty($row['translation'])) {
                 $row['_locale'] = $locale;
                 unset($row['translation']);
 
                 if ($hydrated) {
-                    /** @var \Cake\Datasource\EntityInterface $row */
                     $row->setDirty('_locale', false);
                 }
 
@@ -518,18 +517,15 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                         $row[$field] = $translation[$field];
 
                         if ($hydrated) {
-                            /** @var \Cake\Datasource\EntityInterface $row */
                             $row->setDirty($field, false);
                         }
                     }
                 }
             }
 
-            /** @var array $row */
             unset($row['translation']);
 
             if ($hydrated) {
-                /** @var \Cake\Datasource\EntityInterface $row */
                 $row->setDirty('_locale', false);
             }
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -2037,4 +2037,21 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertSame('abc', $result->articles[0]->_locale);
         $this->assertSame('xyz', $result->articles[0]->_matchingData['Tags']->_locale);
     }
+
+    /**
+     * Tests that modified entities aren't marked as clean after EavStrategy::rowMapper
+     */
+    public function testModifiedEntityNotCleanAfterTranslationMapping (): void
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $table->setLocale('fra');
+
+        $articles = $table->find()->all();
+        $articles->each(function($article) {
+            $article->published = 'N';
+        });
+
+        $this->assertTrue($articles->first()->isDirty('published'));
+    }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -2041,14 +2041,14 @@ class TranslateBehaviorEavTest extends TestCase
     /**
      * Tests that modified entities aren't marked as clean after EavStrategy::rowMapper
      */
-    public function testModifiedEntityNotCleanAfterTranslationMapping (): void
+    public function testModifiedEntityNotCleanAfterTranslationMapping(): void
     {
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->setLocale('fra');
 
         $articles = $table->find()->all();
-        $articles->each(function($article) {
+        $articles->each(function ($article) {
             $article->published = 'N';
         });
 

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -1129,4 +1129,22 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
             'Title and body are translated values, but don\'t match'
         );
     }
+
+
+    /**
+     * Tests that modified entities aren't marked as clean after ShadowTableStrategy::rowMapper
+     */
+    public function testModifiedEntityNotCleanAfterTranslationMapping(): void
+    {
+        $table = $this->getTableLocator()->get('Articles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+        $table->setLocale('fra');
+
+        $articles = $table->find()->all();
+        $articles->each(function ($article) {
+            $article->published = 'N';
+        });
+
+        $this->assertTrue($articles->first()->isDirty('published'));
+    }
 }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -1130,7 +1130,6 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         );
     }
 
-
     /**
      * Tests that modified entities aren't marked as clean after ShadowTableStrategy::rowMapper
      */


### PR DESCRIPTION
This fixes a bug that occurs when working with entities in a ResultSet when the translate behavior is attached.

Following code works

```php
$records = $this->Articles->find()->all();
$records->each(function(EntityInterface $record) {
  $record->sort++;
  //dump($record->isDirty('sort')); => "true"
});
```

But dumping `$records` will now show that all entities are clean.

```php
//Will do nothing since all records are clean.
$this->Articles->saveMany($records);
```