### PR TITLE
Avoid Typed property not init exception.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -993,6 +993,10 @@ class BelongsToMany extends Association
      */
     public function getThrough(): Table|string
     {
+        if (!isset($this->_through)) {
+            return '';
+        }
+
         return $this->_through;
     }
 


### PR DESCRIPTION
When running IdeHelper I noticed that it skips a few tables because of an internal exception:

> Typed property Cake\ORM\Association\BelongsToMany::$_through must not be accessed before initialization

When doing

    $through = $association->getThrough();

Normal setup:
```php
        $this->belongsToMany('Articles', [
            'foreignKey' => 'case_id',
            'targetForeignKey' => 'article_id',
            'joinTable' => 'articles_cases',
        ]);
```

Seems like it trips up here as the assoc prop is not defined but then read/checked.
I propose to return empty string here instead.

See dd() output:
```
object(Cake\ORM\Association\BelongsToMany) id:0 {
  protected _joinType => 'INNER'
  protected _strategy => 'select'
  protected _junctionTable => [uninitialized]
  protected _junctionTableName => 'articles_cases'
  protected _junctionAssociationName => [uninitialized]
  protected _junctionProperty => '_joinData'
  protected _saveStrategy => 'replace'
  protected _targetForeignKey => 'article_id'
  protected _through => [uninitialized]
```

The other two [uninitialized] are auto-created on the fly in their methods, so thats why this is only relevant for this one getter
