### PR TITLE
Fix rendering of dev error pages in 8.3

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -617,9 +617,6 @@ class Debugger
      */
     protected static function _highlight(string $str): string
     {
-        if (function_exists('hphp_log') || function_exists('hphp_gettid')) {
-            return htmlentities($str);
-        }
         $added = false;
         if (strpos($str, '<?php') === false) {
             $added = true;
@@ -628,7 +625,7 @@ class Debugger
         $highlight = highlight_string($str, true);
         if ($added) {
             $highlight = str_replace(
-                ['&lt;?php&nbsp;<br/>', '&lt;?php&nbsp;<br />'],
+                ['&lt;?php&nbsp;<br/>', '&lt;?php&nbsp;<br />', '&lt;?php'],
                 '',
                 $highlight
             );

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -625,7 +625,7 @@ class Debugger
         $highlight = highlight_string($str, true);
         if ($added) {
             $highlight = str_replace(
-                ['&lt;?php&nbsp;<br/>', '&lt;?php&nbsp;<br />', '&lt;?php'],
+                ['&lt;?php&nbsp;<br/>', '&lt;?php&nbsp;<br />', '&lt;?php '],
                 '',
                 $highlight
             );

--- a/templates/layout/dev_error.php
+++ b/templates/layout/dev_error.php
@@ -292,6 +292,12 @@ use function Cake\Core\h;
     .excerpt-line {
         padding: 0;
     }
+    /* php 8.3 adds pre around highlighted code */
+    .code-highlight > pre,
+    .excerpt-line > pre {
+        padding: 0;
+        background: none;
+    }
     .excerpt-line > code {
         padding-left: 4px;
     }


### PR DESCRIPTION
- Add PHP8.3 HTML formatting to the list of replacements.
- Update styling to make output visually consistent in 8.3

Fixes #17491
