### PR TITLE
Fix up int and string enum types

### DIFF
--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -167,7 +167,7 @@ class EnumType extends BaseType
      */
     public function marshal(mixed $value): ?BackedEnum
     {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
         }
 
@@ -191,9 +191,10 @@ class EnumType extends BaseType
         $enumInstance = $this->enumClassName::tryFrom($value);
         if ($enumInstance === null) {
             throw new InvalidArgumentException(sprintf(
-                'Unable to marshal value to %s, got %s',
-                $this->enumClassName,
+                'Unable to marshal value `%s` of type `%s` to `%s`',
+                print_r($value, true),
                 get_debug_type($value),
+                $this->enumClassName,
             ));
         }
 

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -95,9 +95,10 @@ class EnumType extends BaseType
         if ($value instanceof BackedEnum) {
             if (!$value instanceof $this->enumClassName) {
                 throw new InvalidArgumentException(sprintf(
-                    'Given value type `%s` does not match associated `%s` backed enum',
+                    'Given value type `%s` does not match associated `%s` backed enum in `%s`',
                     get_debug_type($value),
-                    $this->backingType
+                    $this->backingType,
+                    $this->enumClassName
                 ));
             }
 
@@ -174,11 +175,16 @@ class EnumType extends BaseType
             return $value;
         }
 
+        if ($this->backingType === 'int' && is_numeric($value) && is_string($value)) {
+            $value = (int)$value;
+        }
+
         if (get_debug_type($value) !== $this->backingType) {
             throw new InvalidArgumentException(sprintf(
-                'Given value type `%s` does not match associated `%s` backed enum',
+                'Given value type `%s` does not match associated `%s` backed enum in `%s`',
                 get_debug_type($value),
-                $this->backingType
+                $this->backingType,
+                $this->enumClassName
             ));
         }
 

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -203,8 +203,10 @@ class EnumTypeTest extends TestCase
     public function testMarshalString(): void
     {
         $this->assertNull($this->stringType->marshal(null));
+        $this->assertNull($this->stringType->marshal(''));
         $this->assertSame(ArticleStatus::PUBLISHED, $this->stringType->marshal('Y'));
         $this->assertSame(ArticleStatus::PUBLISHED, $this->stringType->marshal(ArticleStatus::PUBLISHED));
+
         $this->expectException(InvalidArgumentException::class);
         $this->stringType->marshal(1);
     }
@@ -215,8 +217,11 @@ class EnumTypeTest extends TestCase
     public function testMarshalInteger(): void
     {
         $this->assertNull($this->intType->marshal(null));
+        $this->assertNull($this->stringType->marshal(''));
         $this->assertSame(Priority::LOW, $this->intType->marshal(1));
+        $this->assertSame(Priority::LOW, $this->intType->marshal('1'));
         $this->assertSame(Priority::MEDIUM, $this->intType->marshal(Priority::MEDIUM));
+
         $this->expectException(InvalidArgumentException::class);
         $this->intType->marshal('Y');
     }


### PR DESCRIPTION
When using int backed enums and form posting, the value is of type string, even if int.
It then fails inside the EnumType with

> InvalidArgumentException
Given value type `string` does not match associated `int` backed enum in `App\Model\Enum\TestEnumStatus`

For backingType int we need to cast here for it to work out.

```php
enum TestEnumStatus: int implements EnumLabelInterface
{
    case INACTIVE = 0;
    case ACTIVE = 1;

    /**
     * @return string
     */
    public function label(): string
    {
        return Inflector::humanize(mb_strtolower($this->name));
    }
}
```
and posted value of

    echo $this->Form->control('status');

is `'1'`


For string enums there is also a bug with marshalling on nullable column.
This is also addressed here.