### PR TITLE
5.x: fix behavior change introduced by PHPUnit 10.5.5

### DIFF
--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -21,6 +21,7 @@ use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**
  * LogTest class
@@ -395,6 +396,8 @@ class LogTest extends TestCase
 
         Log::drop('shops');
     }
+
+    #[WithoutErrorHandler]
 
     /**
      * Test scoped logging backwards compat

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\Association;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Model\Table\AuthorsTable;
 use TestApp\Model\Table\TestTable;
 
@@ -492,6 +493,7 @@ class AssociationTest extends TestCase
         );
     }
 
+    #[WithoutErrorHandler]
     public function testCustomFinderWithOptions(): void
     {
         $this->association->setFinder('withOptions');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -57,6 +57,7 @@ use Cake\Validation\Validator;
 use Exception;
 use InvalidArgumentException;
 use PDOException;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use RuntimeException;
 use TestApp\Model\Entity\ProtectedEntity;
 use TestApp\Model\Entity\Tag;
@@ -608,6 +609,8 @@ class TableTest extends TestCase
         $result = $table->getSchema();
         $this->assertSame('foobar', $result->getColumnType('username'));
     }
+
+    #[WithoutErrorHandler]
 
     /**
      * Undocumented function
@@ -1573,6 +1576,8 @@ class TableTest extends TestCase
         $this->assertSame($expected, $query->toArray());
     }
 
+    #[WithoutErrorHandler]
+
     /**
      * Tests find(list) with backwards compatibile options
      */
@@ -1649,6 +1654,8 @@ class TableTest extends TestCase
         ];
         $this->assertSame($expected, $query->toArray());
     }
+
+    #[WithoutErrorHandler]
 
     /**
      * Test find('list') called with option array instead of named args for backwards compatility
@@ -5446,6 +5453,8 @@ class TableTest extends TestCase
         $result = $table->get($primaryKey, ...$options);
         $this->assertSame($entity, $result);
     }
+
+    #[WithoutErrorHandler]
 
     /**
      * Test get() with options array.

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -29,6 +29,7 @@ use Cake\Test\Fixture\FixturizedTestCase;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestStatus\Skipped;
 use PHPUnit\Framework\TestStatus\Success;
 use TestApp\Model\Table\SecondaryPostsTable;
@@ -218,6 +219,8 @@ class TestCaseTest extends TestCase
             $this->assertStringStartsWith('Should have at least one deprecation warning', $e->getMessage());
         }
     }
+
+    #[WithoutErrorHandler]
 
     /**
      * test deprecated() with duplicate deprecation with same messsage and line


### PR DESCRIPTION
Refs: https://github.com/sebastianbergmann/phpunit/pull/5619

All our tests which use e.g `$this->deprecated()` need to have this attribute added to that test.