### PR TITLE
Use consistent uppercase for enum case def.

### DIFF
--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2024,7 +2024,7 @@ class ValidationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
 
-        Validation::enum(NonBacked::Basic, NonBacked::class);
+        Validation::enum(NonBacked::BASIC, NonBacked::class);
     }
 
     public function testEnumNonEnum(): void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2720,7 +2720,7 @@ class ValidatorTest extends TestCase
         $this->assertNotEmpty($validator->validate(['status' => Priority::LOW]));
         $this->assertNotEmpty($validator->validate(['status' => 'wrong type']));
         $this->assertNotEmpty($validator->validate(['status' => 123]));
-        $this->assertNotEmpty($validator->validate(['status' => NonBacked::Basic]));
+        $this->assertNotEmpty($validator->validate(['status' => NonBacked::BASIC]));
 
         $fieldName = 'status';
         $rule = 'enum';

--- a/tests/test_app/TestApp/Model/Enum/NonBacked.php
+++ b/tests/test_app/TestApp/Model/Enum/NonBacked.php
@@ -16,5 +16,5 @@ namespace TestApp\Model\Enum;
 
 enum NonBacked
 {
-    case Basic;
+    case BASIC;
 }


### PR DESCRIPTION
Refs https://github.com/cakephp/bake/pull/972

So far all the core code is UPPER_CASE, if we wanted to use CamelCase, we could switch it probably with only minor BC issues.

Either way we should also introduce a code sniffer to verify it consistently.