### PR TITLE
Add Server.terminate event.

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -142,6 +142,24 @@ class Server implements EventDispatcherInterface
     }
 
     /**
+     * Trigger the Server.terminate event.
+     *
+     * The event is used to do potentially heavy tasks after the response is sent
+     * to the client. Only the PHP FPM server API is able to send a response to
+     * the client while the server's PHP process still performs some tasks. For
+     * other environments the event will be triggered before the response is flushed
+     * to the client and will have no benefit.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request Request instance.
+     * @param \Psr\Http\Message\ResponseInterface $response Response instance.
+     * @return void
+     */
+    public function terminate(ServerRequestInterface $request, ResponseInterface $response): void
+    {
+        $this->dispatchEvent('Server.terminate', compact('request', 'response'));
+    }
+
+    /**
      * Get the current application.
      *
      * @return \Cake\Core\HttpApplicationInterface The application that will be run.

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -22,6 +22,7 @@ use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
 use Cake\Http\CallbackStream;
 use Cake\Http\MiddlewareQueue;
+use Cake\Http\Response;
 use Cake\Http\ResponseEmitter;
 use Cake\Http\Server;
 use Cake\Http\ServerRequest;
@@ -32,6 +33,7 @@ use Laminas\Diactoros\Response as LaminasResponse;
 use Laminas\Diactoros\ServerRequest as LaminasServerRequest;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\MiddlewareApplication;
 
 require_once __DIR__ . '/server_mocks.php';
@@ -352,5 +354,24 @@ class ServerTest extends TestCase
 
         $request = new ServerRequest();
         $this->assertInstanceOf(ResponseInterface::class, $server->run($request));
+    }
+
+    public function testTerminate(): void
+    {
+        /** @var \Cake\Core\HttpApplicationInterface|\PHPUnit\Framework\MockObject\MockObject $app */
+        $app = $this->createMock(HttpApplicationInterface::class);
+        $server = new Server($app);
+
+        $triggered = false;
+        $server->getEventManager()->on(
+            'Server.terminate',
+            function (EventInterface $event, ServerRequestInterface $request, ResponseInterface $response) use (&$triggered) {
+                $triggered = true;
+            }
+        );
+
+        $server->terminate(new ServerRequest(), new Response());
+
+        $this->assertTrue($triggered);
     }
 }


### PR DESCRIPTION
The app's `webroot/index.php` would be modified as follows to take advantage of this event.

```diff
diff --git a/webroot/index.php b/webroot/index.php
index 544b479..a8d4fcd 100644
--- a/webroot/index.php
+++ b/webroot/index.php
@@ -29,9 +29,13 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 
 use App\Application;
 use Cake\Http\Server;
+use Cake\Http\ServerRequestFactory;
 
 // Bind your application to the server.
 $server = new Server(new Application(dirname(__DIR__) . '/config'));
 
-// Run the request/response through the application and emit the response.
-$server->emit($server->run());
+$request = ServerRequestFactory::fromGlobals();
+$response = $server->run($request);
+
+$server->emit($response);
+$server->terminate($request, $response);
```