### PR TITLE
Use consistent CamelCase for enum case def.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1365,7 +1365,7 @@ class FormHelper extends Helper
         foreach ($enumClass::cases() as $case) {
             $hasLabel = $case instanceof EnumLabelInterface || method_exists($case, 'label');
             $values[$case->value] = $hasLabel ? $case->label()
-                : Inflector::humanize(mb_strtolower($case->name));
+                : Inflector::humanize(Inflector::underscore($case->name));
         }
 
         return $values;

--- a/tests/TestCase/Database/Type/EnumTypeTest.php
+++ b/tests/TestCase/Database/Type/EnumTypeTest.php
@@ -146,14 +146,14 @@ class EnumTypeTest extends TestCase
     public function testToDatabaseEnum(): void
     {
         $this->assertNull($this->stringType->toDatabase(null, $this->driver));
-        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatus::PUBLISHED, $this->driver));
-        $this->assertSame(3, $this->intType->toDatabase(Priority::HIGH, $this->driver));
+        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatus::Published, $this->driver));
+        $this->assertSame(3, $this->intType->toDatabase(Priority::High, $this->driver));
     }
 
     public function testToDatabaseValidValue(): void
     {
-        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatus::PUBLISHED->value, $this->driver));
-        $this->assertSame(3, $this->intType->toDatabase(Priority::HIGH->value, $this->driver));
+        $this->assertSame('Y', $this->stringType->toDatabase(ArticleStatus::Published->value, $this->driver));
+        $this->assertSame(3, $this->intType->toDatabase(Priority::High->value, $this->driver));
     }
 
     public function testToDatabaseInValidValue(): void
@@ -169,7 +169,7 @@ class EnumTypeTest extends TestCase
     public function testToPHPStringEnum(): void
     {
         $this->assertNull($this->stringType->toPHP(null, $this->driver));
-        $this->assertSame(ArticleStatus::PUBLISHED, $this->stringType->toPHP('Y', $this->driver));
+        $this->assertSame(ArticleStatus::Published, $this->stringType->toPHP('Y', $this->driver));
     }
 
     /**
@@ -178,8 +178,8 @@ class EnumTypeTest extends TestCase
     public function testToPHPIntEnum(): void
     {
         $this->assertNull($this->intType->toPHP(null, $this->driver));
-        $this->assertSame(Priority::HIGH, $this->intType->toPHP(3, $this->driver));
-        $this->assertSame(Priority::HIGH, $this->intType->toPHP('3', $this->driver));
+        $this->assertSame(Priority::High, $this->intType->toPHP(3, $this->driver));
+        $this->assertSame(Priority::High, $this->intType->toPHP('3', $this->driver));
     }
 
     public function testToPHPInvalidEnumValue(): void
@@ -204,8 +204,8 @@ class EnumTypeTest extends TestCase
     {
         $this->assertNull($this->stringType->marshal(null));
         $this->assertNull($this->stringType->marshal(''));
-        $this->assertSame(ArticleStatus::PUBLISHED, $this->stringType->marshal('Y'));
-        $this->assertSame(ArticleStatus::PUBLISHED, $this->stringType->marshal(ArticleStatus::PUBLISHED));
+        $this->assertSame(ArticleStatus::Published, $this->stringType->marshal('Y'));
+        $this->assertSame(ArticleStatus::Published, $this->stringType->marshal(ArticleStatus::Published));
 
         $this->expectException(InvalidArgumentException::class);
         $this->stringType->marshal(1);
@@ -218,9 +218,9 @@ class EnumTypeTest extends TestCase
     {
         $this->assertNull($this->intType->marshal(null));
         $this->assertNull($this->stringType->marshal(''));
-        $this->assertSame(Priority::LOW, $this->intType->marshal(1));
-        $this->assertSame(Priority::LOW, $this->intType->marshal('1'));
-        $this->assertSame(Priority::MEDIUM, $this->intType->marshal(Priority::MEDIUM));
+        $this->assertSame(Priority::Low, $this->intType->marshal(1));
+        $this->assertSame(Priority::Low, $this->intType->marshal('1'));
+        $this->assertSame(Priority::Medium, $this->intType->marshal(Priority::Medium));
 
         $this->expectException(InvalidArgumentException::class);
         $this->intType->marshal('Y');
@@ -236,13 +236,13 @@ class EnumTypeTest extends TestCase
             'author_id' => 1,
             'title' => 'My Title',
             'body' => 'My post',
-            'published' => ArticleStatus::PUBLISHED,
+            'published' => ArticleStatus::Published,
         ]);
         $saved = $this->Articles->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(ArticleStatus::PUBLISHED, $entity->published);
+        $this->assertSame(ArticleStatus::Published, $entity->published);
 
-        $this->assertSame(ArticleStatus::PUBLISHED, $this->Articles->get(4)->published);
+        $this->assertSame(ArticleStatus::Published, $this->Articles->get(4)->published);
     }
 
     /**
@@ -259,9 +259,9 @@ class EnumTypeTest extends TestCase
         ]);
         $saved = $this->Articles->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(ArticleStatus::PUBLISHED, $entity->published);
+        $this->assertSame(ArticleStatus::Published, $entity->published);
 
-        $this->assertSame(ArticleStatus::PUBLISHED, $this->Articles->get(4)->published);
+        $this->assertSame(ArticleStatus::Published, $this->Articles->get(4)->published);
     }
 
     /**
@@ -286,13 +286,13 @@ class EnumTypeTest extends TestCase
         /** @var \Cake\Datasource\EntityInterface $entity */
         $entity = $this->FeaturedTags->newEntity([
             'tag_id' => 4,
-            'priority' => Priority::MEDIUM,
+            'priority' => Priority::Medium,
         ]);
         $saved = $this->FeaturedTags->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(Priority::MEDIUM, $entity->priority);
+        $this->assertSame(Priority::Medium, $entity->priority);
 
-        $this->assertSame(Priority::MEDIUM, $this->FeaturedTags->get(4)->priority);
+        $this->assertSame(Priority::Medium, $this->FeaturedTags->get(4)->priority);
     }
 
     /**
@@ -307,9 +307,9 @@ class EnumTypeTest extends TestCase
         ]);
         $saved = $this->FeaturedTags->save($entity);
         $this->assertNotFalse($saved);
-        $this->assertSame(Priority::MEDIUM, $entity->priority);
+        $this->assertSame(Priority::Medium, $entity->priority);
 
-        $this->assertSame(Priority::MEDIUM, $this->FeaturedTags->get(4)->priority);
+        $this->assertSame(Priority::Medium, $this->FeaturedTags->get(4)->priority);
     }
 
     /**
@@ -329,13 +329,13 @@ class EnumTypeTest extends TestCase
      */
     public function testUpdateEnumField(): void
     {
-        $this->assertSame(ArticleStatus::PUBLISHED, $this->Articles->get(1)->published);
+        $this->assertSame(ArticleStatus::Published, $this->Articles->get(1)->published);
 
         $entity = $this->Articles->get(1);
-        $entity->published = ArticleStatus::UNPUBLISHED;
+        $entity->published = ArticleStatus::Unpublished;
         $this->Articles->save($entity);
-        $this->assertSame(ArticleStatus::UNPUBLISHED, $entity->published);
+        $this->assertSame(ArticleStatus::Unpublished, $entity->published);
 
-        $this->assertSame(ArticleStatus::UNPUBLISHED, $this->Articles->get(1)->published);
+        $this->assertSame(ArticleStatus::Unpublished, $this->Articles->get(1)->published);
     }
 }

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2004,17 +2004,17 @@ class ValidationTest extends TestCase
 
     public function testEnum(): void
     {
-        $this->assertTrue(Validation::enum(ArticleStatus::PUBLISHED, ArticleStatus::class));
+        $this->assertTrue(Validation::enum(ArticleStatus::Published, ArticleStatus::class));
         $this->assertTrue(Validation::enum('Y', ArticleStatus::class));
 
-        $this->assertTrue(Validation::enum(Priority::LOW, Priority::class));
+        $this->assertTrue(Validation::enum(Priority::Low, Priority::class));
         $this->assertTrue(Validation::enum(1, Priority::class));
 
-        $this->assertFalse(Validation::enum(Priority::LOW, ArticleStatus::class));
+        $this->assertFalse(Validation::enum(Priority::Low, ArticleStatus::class));
         $this->assertFalse(Validation::enum(1, ArticleStatus::class));
         $this->assertFalse(Validation::enum('non-existent', ArticleStatus::class));
 
-        $this->assertFalse(Validation::enum(ArticleStatus::PUBLISHED, Priority::class));
+        $this->assertFalse(Validation::enum(ArticleStatus::Published, Priority::class));
         $this->assertFalse(Validation::enum('wrong type', Priority::class));
         $this->assertFalse(Validation::enum(123, Priority::class));
     }
@@ -2024,7 +2024,7 @@ class ValidationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The `$enumClassName` argument must be the classname of a valid backed enum.');
 
-        Validation::enum(NonBacked::BASIC, NonBacked::class);
+        Validation::enum(NonBacked::Basic, NonBacked::class);
     }
 
     public function testEnumNonEnum(): void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2714,13 +2714,13 @@ class ValidatorTest extends TestCase
         $validator = new Validator();
         $validator->enum('status', ArticleStatus::class);
 
-        $this->assertEmpty($validator->validate(['status' => ArticleStatus::PUBLISHED]));
+        $this->assertEmpty($validator->validate(['status' => ArticleStatus::Published]));
         $this->assertEmpty($validator->validate(['status' => 'Y']));
 
-        $this->assertNotEmpty($validator->validate(['status' => Priority::LOW]));
+        $this->assertNotEmpty($validator->validate(['status' => Priority::Low]));
         $this->assertNotEmpty($validator->validate(['status' => 'wrong type']));
         $this->assertNotEmpty($validator->validate(['status' => 123]));
-        $this->assertNotEmpty($validator->validate(['status' => NonBacked::BASIC]));
+        $this->assertNotEmpty($validator->validate(['status' => NonBacked::Basic]));
 
         $fieldName = 'status';
         $rule = 'enum';

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3663,10 +3663,10 @@ class FormHelperTest extends TestCase
             '/label',
             'select' => ['name' => 'published', 'id' => 'published'],
             ['option' => ['value' => 'Y']],
-            'Is published',
+            'Is Published',
             '/option',
             ['option' => ['value' => 'N', 'selected' => 'selected']],
-            'Is unpublished',
+            'Is Unpublished',
             '/option',
             '/select',
             '/div',
@@ -3688,10 +3688,10 @@ class FormHelperTest extends TestCase
             '/label',
             'select' => ['name' => 'published', 'id' => 'published'],
             ['option' => ['value' => 'Y']],
-            'Is published',
+            'Is Published',
             '/option',
             ['option' => ['value' => 'N', 'selected' => 'selected']],
-            'Is unpublished',
+            'Is Unpublished',
             '/option',
             '/select',
             '/div',
@@ -4569,7 +4569,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $article = new Article([
-            'status' => ArticleStatus::UNPUBLISHED,
+            'status' => ArticleStatus::Unpublished,
         ]);
         $this->Form->create($article);
         $result = $this->Form->radio('status', ['Y' => 'Published', 'N' => 'Unpublished']);
@@ -4994,7 +4994,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $article = new Article([
-            'status' => ArticleStatus::UNPUBLISHED,
+            'status' => ArticleStatus::Unpublished,
         ]);
         $this->Form->create($article);
         $result = $this->Form->select('status', ['Y' => 'Published', 'N' => 'Unpublished']);
@@ -6577,7 +6577,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $article = new Article([
-            'status' => ArticleStatus::UNPUBLISHED,
+            'status' => ArticleStatus::Unpublished,
         ]);
         $this->Form->create($article);
         $result = $this->Form->hidden('status');

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatus.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatus.php
@@ -16,6 +16,6 @@ namespace TestApp\Model\Enum;
 
 enum ArticleStatus: string
 {
-    case PUBLISHED = 'Y';
-    case UNPUBLISHED = 'N';
+    case Published = 'Y';
+    case Unpublished = 'N';
 }

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusLabel.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusLabel.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Enum;
 
+use Cake\Utility\Inflector;
+
 enum ArticleStatusLabel: string
 {
-    case PUBLISHED = 'Y';
-    case UNPUBLISHED = 'N';
+    case Published = 'Y';
+    case Unpublished = 'N';
 
     public function label(): string
     {
-        return 'Is ' . strtolower($this->name);
+        return 'Is ' . Inflector::humanize(Inflector::underscore($this->name));
     }
 }

--- a/tests/test_app/TestApp/Model/Enum/ArticleStatusLabelInterface.php
+++ b/tests/test_app/TestApp/Model/Enum/ArticleStatusLabelInterface.php
@@ -15,17 +15,18 @@ declare(strict_types=1);
 namespace TestApp\Model\Enum;
 
 use Cake\Database\Type\EnumLabelInterface;
+use Cake\Utility\Inflector;
 
 enum ArticleStatusLabelInterface: string implements EnumLabelInterface
 {
-    case PUBLISHED = 'Y';
-    case UNPUBLISHED = 'N';
+    case Published = 'Y';
+    case Unpublished = 'N';
 
     /**
      * @return string
      */
     public function label(): string
     {
-        return 'Is ' . strtolower($this->name);
+        return 'Is ' . Inflector::humanize(Inflector::underscore($this->name));
     }
 }

--- a/tests/test_app/TestApp/Model/Enum/NonBacked.php
+++ b/tests/test_app/TestApp/Model/Enum/NonBacked.php
@@ -16,5 +16,5 @@ namespace TestApp\Model\Enum;
 
 enum NonBacked
 {
-    case BASIC;
+    case Basic;
 }

--- a/tests/test_app/TestApp/Model/Enum/Priority.php
+++ b/tests/test_app/TestApp/Model/Enum/Priority.php
@@ -16,7 +16,7 @@ namespace TestApp\Model\Enum;
 
 enum Priority: int
 {
-    case LOW = 1;
-    case MEDIUM = 2;
-    case HIGH = 3;
+    case Low = 1;
+    case Medium = 2;
+    case High = 3;
 }


### PR DESCRIPTION
I am afraid we cannot switch the core enums to this casing, for BC reasons.
So those have to wait till 5.1 or 6.0

But we can already make sure all form based and especially user generated enums will have the new convention then.

Refs https://github.com/cakephp/bake/pull/972