### PR TITLE
Move serialized keys into method.

### DIFF
--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -170,7 +170,7 @@ class JsonView extends SerializedView
                 }
             }
 
-            return !empty($data) ? $data : null;
+            return $data ?: null;
         }
 
         return $this->viewVars[$serialize] ?? null;

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -74,6 +74,27 @@ abstract class SerializedView extends View
      */
     public function render(?string $template = null, string|false|null $layout = null): string
     {
+        $serialize = $this->serializeKeys();
+        if ($serialize !== false) {
+            try {
+                return $this->_serialize($serialize);
+            } catch (Exception | TypeError $e) {
+                throw new SerializationFailureException(
+                    'Serialization of View data failed.',
+                    null,
+                    $e
+                );
+            }
+        }
+
+        return parent::render($template, false);
+    }
+
+    /**
+     * @return array|string|false
+     */
+    protected function serializeKeys(): array|string|false
+    {
         $serialize = $this->getConfig('serialize', false);
 
         if ($serialize === true) {
@@ -89,18 +110,7 @@ abstract class SerializedView extends View
                 $options
             );
         }
-        if ($serialize !== false) {
-            try {
-                return $this->_serialize($serialize);
-            } catch (Exception | TypeError $e) {
-                throw new SerializationFailureException(
-                    'Serialization of View data failed.',
-                    null,
-                    $e
-                );
-            }
-        }
 
-        return parent::render($template, false);
+        return $serialize;
     }
 }

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -115,7 +115,7 @@ class XmlView extends SerializedView
         $rootNode = $this->getConfig('rootNode', 'response');
 
         if (is_array($serialize)) {
-            if (empty($serialize)) {
+            if (!$serialize) {
                 $serialize = '';
             } elseif (count($serialize) === 1) {
                 $serialize = current($serialize);


### PR DESCRIPTION
I looked into CsvView (plugin) and found a dead param

    protected function _serialize(array|string $serialize): string

and the code internally has to ignore it and use
```php
$serialize = $this->getConfig('serialize');

        if ($serialize === true) {
            $serialize = array_keys($this->viewVars);
        }
```

If we moved the keys to serialize into a method, this could potentially be used to overwrite and provide a cleaner interface downstream for other view classes to overwrite, instead of passing a generated set of keys that are then not used and freshly generated anyway.