### PR TITLE
5.next: static ConnectionHelper

### DIFF
--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -39,7 +39,7 @@ class ConnectionHelper
      *
      * @return void
      */
-    public function addTestAliases(): void
+    public static function addTestAliases(): void
     {
         ConnectionManager::alias('test', 'default');
         foreach (ConnectionManager::configured() as $connection) {
@@ -63,7 +63,7 @@ class ConnectionHelper
      * @param array<int, string>|null $connections Connection names or null for all.
      * @return void
      */
-    public function enableQueryLogging(?array $connections = null): void
+    public static function enableQueryLogging(?array $connections = null): void
     {
         $connections ??= ConnectionManager::configured();
         foreach ($connections as $connection) {
@@ -86,7 +86,7 @@ class ConnectionHelper
      * @param array<string>|null $tables List of tables names or null for all.
      * @return void
      */
-    public function dropTables(string $connectionName, ?array $tables = null): void
+    public static function dropTables(string $connectionName, ?array $tables = null): void
     {
         $connection = ConnectionManager::get($connectionName);
         assert($connection instanceof Connection);
@@ -117,7 +117,7 @@ class ConnectionHelper
      * @param array<string>|null $tables List of tables names or null for all.
      * @return void
      */
-    public function truncateTables(string $connectionName, ?array $tables = null): void
+    public static function truncateTables(string $connectionName, ?array $tables = null): void
     {
         $connection = ConnectionManager::get($connectionName);
         assert($connection instanceof Connection);
@@ -128,7 +128,7 @@ class ConnectionHelper
         /** @var array<\Cake\Database\Schema\TableSchema> $schemas Specify type for psalm */
         $schemas = array_map(fn ($table) => $collection->describe($table), $tables);
 
-        $this->runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
+        self::runWithoutConstraints($connection, function (Connection $connection) use ($schemas): void {
             $dialect = $connection->getDriver()->schemaDialect();
             foreach ($schemas as $schema) {
                 foreach ($dialect->truncateTableSql($schema) as $statement) {
@@ -145,7 +145,7 @@ class ConnectionHelper
      * @param \Closure $callback callback
      * @return void
      */
-    public function runWithoutConstraints(Connection $connection, Closure $callback): void
+    public static function runWithoutConstraints(Connection $connection, Closure $callback): void
     {
         if ($connection->getDriver()->supports(DriverFeatureEnum::DISABLE_CONSTRAINT_WITHOUT_TRANSACTION)) {
             $connection->disableConstraints(fn (Connection $connection) => $callback($connection));

--- a/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
+++ b/src/TestSuite/Fixture/Extension/PHPUnitStartedSubscriber.php
@@ -32,12 +32,11 @@ class PHPUnitStartedSubscriber implements PHPUnitStarted
      */
     public function notify(Started $event): void
     {
-        $helper = new ConnectionHelper();
-        $helper->addTestAliases();
+        ConnectionHelper::addTestAliases();
 
         $enableLogging = env('LOG_QUERIES', false);
         if ((int)$enableLogging !== 0) {
-            $helper->enableQueryLogging();
+            ConnectionHelper::enableQueryLogging();
             Log::drop('queries');
             Log::setConfig('queries', [
                 'className' => 'Console',

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -139,8 +139,7 @@ class FixtureHelper
                 if ($sortedFixtures) {
                     $this->insertConnection($connection, $sortedFixtures);
                 } else {
-                    $helper = new ConnectionHelper();
-                    $helper->runWithoutConstraints(
+                    ConnectionHelper::runWithoutConstraints(
                         $connection,
                         fn (Connection $connection) => $this->insertConnection($connection, $groupFixtures)
                     );

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -36,19 +36,6 @@ use InvalidArgumentException;
 class SchemaLoader
 {
     /**
-     * @var \Cake\TestSuite\ConnectionHelper
-     */
-    protected ConnectionHelper $helper;
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->helper = new ConnectionHelper();
-    }
-
-    /**
      * Load and apply schema sql file, or an array of files.
      *
      * @param array<string>|string $paths Schema files to load
@@ -71,7 +58,7 @@ class SchemaLoader
         }
 
         if ($dropTables) {
-            $this->helper->dropTables($connectionName);
+            ConnectionHelper::dropTables($connectionName);
         }
 
         /** @var \Cake\Database\Connection $connection */
@@ -92,7 +79,7 @@ class SchemaLoader
         }
 
         if ($truncateTables) {
-            $this->helper->truncateTables($connectionName);
+            ConnectionHelper::truncateTables($connectionName);
         }
     }
 
@@ -157,7 +144,7 @@ class SchemaLoader
             return;
         }
 
-        $this->helper->dropTables($connectionName);
+        ConnectionHelper::dropTables($connectionName);
 
         $tables = include $file;
 

--- a/tests/TestCase/TestSuite/ConnectionHelperTest.php
+++ b/tests/TestCase/TestSuite/ConnectionHelperTest.php
@@ -31,8 +31,7 @@ class ConnectionHelperTest extends TestCase
     public function testAliasConnections(): void
     {
         ConnectionManager::dropAlias('default');
-
-        (new ConnectionHelper())->addTestAliases();
+        ConnectionHelper::addTestAliases();
 
         $this->assertSame(
             ConnectionManager::get('test'),
@@ -45,7 +44,7 @@ class ConnectionHelperTest extends TestCase
         $connection = new Connection(['driver' => TestDriver::class]);
         ConnectionManager::setConfig('something', $connection);
 
-        (new ConnectionHelper())->addTestAliases();
+        ConnectionHelper::addTestAliases();
 
         $this->assertSame(
             ConnectionManager::get('test_something'),
@@ -59,7 +58,7 @@ class ConnectionHelperTest extends TestCase
         ConnectionManager::setConfig('query_logging', $connection);
         $this->assertFalse($connection->getDriver()->log(''));
 
-        (new ConnectionHelper())->enableQueryLogging(['query_logging']);
+        ConnectionHelper::enableQueryLogging(['query_logging']);
         $this->assertTrue($connection->getDriver()->log(''));
     }
 }

--- a/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
+++ b/tests/TestCase/TestSuite/Fixture/SchemaLoaderTest.php
@@ -52,7 +52,7 @@ class SchemaLoaderTest extends TestCase
         parent::tearDown();
         $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $this->restore;
 
-        (new ConnectionHelper())->dropTables('test', ['schema_loader_test_one', 'schema_loader_test_two']);
+        ConnectionHelper::dropTables('test', ['schema_loader_test_one', 'schema_loader_test_two']);
         ConnectionManager::drop('test_schema_loader');
 
         if (file_exists($this->truncateDbFile)) {


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/issues/17520

The SchemaLoader falls into the same category that it actually doesn't need state so we could make it static as well...

But this would then require users to adjust their app template...