### PR TITLE
Increase session gc lifetime

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -220,8 +220,14 @@ class Session
             'handler' => [],
         ];
 
-        if ($config['timeout']) {
-            $config['ini']['session.gc_maxlifetime'] = 60 * $config['timeout'];
+        if (isset($config['timeout']) && !isset($config['ini']['session.gc_maxlifetime'])) {
+            $maxlifetime = $config['timeout'] * 60;
+            if ($maxlifetime === 0) {
+                // If sessions are set to have no idle timeout, extend the
+                // gc_maxlifetime to 30 days so that sessions don't get reaped immediately
+                $maxlifetime = 60 * 60 * 24 * 30;
+            }
+            $config['ini']['session.gc_maxlifetime'] = $maxlifetime;
         }
 
         if ($config['cookie']) {

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -223,7 +223,7 @@ class Session
 
         $lifetime = 0;
         if (isset($config['timeout'])) {
-            $lifetime = $config['timeout'] * 60;
+            $lifetime = (int)$config['timeout'] * 60;
         }
         if ($lifetime !== 0) {
             $config['ini']['session.gc_maxlifetime'] = $lifetime;

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -70,17 +70,38 @@ class SessionTest extends TestCase
      * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
-    public function testSessionConfigTimeout(): void
+    public function testSessionConfigTimeoutZero(): void
     {
         $_SESSION = null;
 
+        ini_set('session.gc_maxlifetime', 86400);
         $config = [
             'defaults' => 'php',
             'timeout' => 0,
         ];
 
         Session::create($config);
-        $this->assertEquals(60 * 60 * 24 * 30, ini_get('session.gc_maxlifetime'), 'Ini value is incorrect');
+        $this->assertEquals(86400, ini_get('session.gc_maxlifetime'), 'ini value unchanged when timeout disabled');
+    }
+
+    /**
+     * test setting ini properties with Session configuration.
+     *
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function testSessionConfigTimeout(): void
+    {
+        $_SESSION = null;
+
+        ini_set('session.gc_maxlifetime', 86400);
+        $config = [
+            'defaults' => 'php',
+            'timeout' => 30,
+        ];
+
+        Session::create($config);
+        $this->assertEquals(30 * 60, ini_get('session.gc_maxlifetime'), 'timeout should set gc maxlifetime');
     }
 
     /**

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -65,6 +65,25 @@ class SessionTest extends TestCase
     }
 
     /**
+     * test setting ini properties with Session configuration.
+     *
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
+    public function testSessionConfigTimeout(): void
+    {
+        $_SESSION = null;
+
+        $config = [
+            'defaults' => 'php',
+            'timeout' => 0,
+        ];
+
+        Session::create($config);
+        $this->assertEquals(60 * 60 * 24 * 30, ini_get('session.gc_maxlifetime'), 'Ini value is incorrect');
+    }
+
+    /**
      * test session cookie path setting
      *
      * @preserveGlobalState disabled


### PR DESCRIPTION
When sessions have serverside timeouts disabled we should set a longer session.gc_maxlifetime option as using 0 could result in all sessions being reaped when a GC sweep is done.

Refs #17513