### PR TITLE
5.x: fix CollectionTrait::combine not working with BackedEnums in keyfield

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -18,6 +18,7 @@ namespace Cake\Collection;
 
 use AppendIterator;
 use ArrayIterator;
+use BackedEnum;
 use Cake\Collection\Iterator\BufferedIterator;
 use Cake\Collection\Iterator\ExtractIterator;
 use Cake\Collection\Iterator\FilterIterator;
@@ -610,6 +611,10 @@ trait CollectionTrait
                         'Cannot index by path that does not exist or contains a null value. ' .
                         'Use a callback to return a default value for that path.'
                     );
+                }
+
+                if ($mapKey instanceof BackedEnum) {
+                    $mapKey = $mapKey->value;
                 }
 
                 $mapReduce->emit($rowVal($value, $key), $mapKey);

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -34,6 +34,7 @@ use NoRewindIterator;
 use stdClass;
 use TestApp\Collection\CountableIterator;
 use TestApp\Collection\TestCollection;
+use TestApp\Model\Enum\ArticleStatus;
 use function Cake\Collection\collection;
 
 /**
@@ -1267,6 +1268,12 @@ class CollectionTest extends TestCase
 
         $collection = (new Collection($items))->combine('id', 'crazy');
         $this->assertEquals([1 => null, 2 => null, 3 => null], $collection->toArray());
+
+        $collection = (new Collection([
+            ['amount' => 10, 'article_status' => ArticleStatus::from('Y')],
+            ['amount' => 2, 'article_status' => ArticleStatus::from('N')],
+        ]))->combine('article_status', 'amount');
+        $this->assertEquals(['Y' => 10, 'N' => 2], $collection->toArray());
     }
 
     public function testCombineNullKey(): void


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17527

How would we react to collections which have a "non-backed" enum - and therefore no scalar value which can be used as a key field - in this situation?. Do we want to specifically catch that?