### PR TITLE
Refactor cloaking checks

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -677,7 +677,7 @@ trait CollectionTrait
                 $isObject = is_object(current($parents));
                 $foundOutType = true;
             }
-            if (empty($key) || !isset($parents[$key])) {
+            if (!$key || !isset($parents[$key])) {
                 foreach ($values as $id) {
                     /** @psalm-suppress PossiblyInvalidArgument */
                     $parents[$id] = $isObject ? $parents[$id] : new ArrayIterator($parents[$id], 1);

--- a/src/Command/Helper/TableHelper.php
+++ b/src/Command/Helper/TableHelper.php
@@ -142,7 +142,7 @@ class TableHelper extends Helper
      */
     public function output(array $args): void
     {
-        if (empty($args)) {
+        if (!$args) {
             return;
         }
 
@@ -157,7 +157,7 @@ class TableHelper extends Helper
             $this->_rowSeparator($widths);
         }
 
-        if (empty($args)) {
+        if (!$args) {
             return;
         }
 

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -97,7 +97,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
         foreach ($invert as $class => $names) {
             preg_match('/^(.+)\\\\Command\\\\/', $class, $matches);
             // Probably not a useful class
-            if (empty($matches)) {
+            if (!$matches) {
                 continue;
             }
             $namespace = str_replace('\\', '/', $matches[1]);

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -135,7 +135,7 @@ class ConsoleInputOption
                 sprintf('Short option `%s` is invalid, short options must be one letter.', $this->_short)
             );
         }
-        if (isset($this->_default) && $this->prompt) {
+        if ($this->_default !== null && $this->prompt) {
             throw new ConsoleException(
                 'You cannot set both `prompt` and `default` options. ' .
                 'Use either a static `default` or interactive `prompt`'

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -514,7 +514,7 @@ class ConsoleIo
         }
 
         $optionsText = '';
-        if (isset($options)) {
+        if ($options !== null) {
             $optionsText = " $options ";
         }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -254,7 +254,7 @@ class ConsoleOutput
     protected function _replaceTags(array $matches): string
     {
         $style = $this->getStyle($matches['tag']);
-        if (empty($style)) {
+        if (!$style) {
             return '<' . $matches['tag'] . '>' . $matches['text'] . '</' . $matches['tag'] . '>';
         }
 

--- a/src/Console/HelpFormatter.php
+++ b/src/Console/HelpFormatter.php
@@ -90,7 +90,7 @@ class HelpFormatter
         $parser = $this->_parser;
         $out = [];
         $description = $parser->getDescription();
-        if (!empty($description)) {
+        if ($description) {
             $out[] = Text::wrap($description, $width);
             $out[] = '';
         }
@@ -114,7 +114,7 @@ class HelpFormatter
         }
 
         $arguments = $parser->arguments();
-        if (!empty($arguments)) {
+        if ($arguments) {
             $max = $this->_getMaxLength($arguments) + 2;
             $out[] = '<info>Arguments:</info>';
             $out[] = '';
@@ -128,7 +128,7 @@ class HelpFormatter
             $out[] = '';
         }
         $epilog = $parser->getEpilog();
-        if (!empty($epilog)) {
+        if ($epilog) {
             $out[] = Text::wrap($epilog, $width);
             $out[] = '';
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -749,7 +749,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     protected function chooseViewClass(): ?string
     {
         $possibleViewClasses = $this->viewClasses();
-        if (empty($possibleViewClasses)) {
+        if (!$possibleViewClasses) {
             return null;
         }
         // Controller or component has already made a view class decision.

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -139,7 +139,7 @@ class Configure
      */
     public static function check(string $var): bool
     {
-        if (empty($var)) {
+        if (!$var) {
             return false;
         }
 
@@ -390,7 +390,7 @@ class Configure
             throw new CakeException(sprintf('There is no `%s` config engine.', $config));
         }
         $values = static::$_values;
-        if (!empty($keys)) {
+        if ($keys) {
             $values = array_intersect_key($values, array_flip($keys));
         }
 

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -134,7 +134,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
         if (!$hasConfig) {
             throw new CakeException($msg);
         }
-        if (empty($config)) {
+        if (!$config) {
             return;
         }
         $existingConfig = $existing->getConfig();

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -214,7 +214,7 @@ trait StaticConfigTrait
      */
     public static function parseDsn(string $dsn): array
     {
-        if (empty($dsn)) {
+        if (!$dsn) {
             return [];
         }
 

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -763,7 +763,7 @@ abstract class Driver
      */
     public function isConnected(): bool
     {
-        if (isset($this->pdo)) {
+        if ($this->pdo !== null) {
             try {
                 $connected = (bool)$this->pdo->query('SELECT 1');
             } catch (PDOException $e) {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -276,7 +276,7 @@ abstract class Driver
     public function execute(string $sql, array $params = [], array $types = []): StatementInterface
     {
         $statement = $this->prepare($sql);
-        if (!empty($params)) {
+        if ($params) {
             $statement->bind($params, $types);
         }
         $this->executeStatement($statement);

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -111,7 +111,7 @@ class Mysql extends Driver
      */
     public function connect(): void
     {
-        if (isset($this->pdo)) {
+        if ($this->pdo !== null) {
             return;
         }
         $config = $this->_config;

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -77,7 +77,7 @@ class Postgres extends Driver
      */
     public function connect(): void
     {
-        if (isset($this->pdo)) {
+        if ($this->pdo !== null) {
             return;
         }
         $config = $this->_config;

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -111,7 +111,7 @@ class Sqlite extends Driver
      */
     public function connect(): void
     {
-        if (isset($this->pdo)) {
+        if ($this->pdo !== null) {
             return;
         }
         $config = $this->_config;

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -112,7 +112,7 @@ class Sqlserver extends Driver
      */
     public function connect(): void
     {
-        if (isset($this->pdo)) {
+        if ($this->pdo !== null) {
             return;
         }
         $config = $this->_config;

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -277,7 +277,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
             }
         }
 
-        if (!empty($value)) {
+        if ($value) {
             $parts += $binder->generateManyNamed($value, $type);
         }
 

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -72,7 +72,7 @@ class QueryExpression implements ExpressionInterface, Countable
     ) {
         $this->setTypeMap($types);
         $this->setConjunction(strtoupper($conjunction));
-        if (!empty($conditions)) {
+        if ($conditions) {
             $this->add($conditions, $this->getTypeMap()->getTypes());
         }
     }

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -139,7 +139,7 @@ class TupleComparison extends ComparisonExpression
 
             $type = $this->types;
             $isMultiOperation = $this->isMulti();
-            if (empty($type)) {
+            if (!$type) {
                 $type = null;
             }
 

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -310,7 +310,7 @@ class ValuesExpression implements ExpressionInterface
 
         $types = $this->_requiresToExpressionCasting($types);
 
-        if (empty($types)) {
+        if (!$types) {
             return;
         }
 

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -121,7 +121,7 @@ class WhenThenExpression implements ExpressionInterface
     public function when(object|array|string|float|int|bool $when, array|string|null $type = null)
     {
         if (is_array($when)) {
-            if (empty($when)) {
+            if (!$when) {
                 throw new InvalidArgumentException('The `$when` argument must be a non-empty array');
             }
 

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -164,7 +164,7 @@ class IdentifierQuoter
             }
 
             $result = $this->_basicQuoter($contents);
-            if (!empty($result)) {
+            if ($result) {
                 $query->{$part}($result, true);
             }
         }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1736,7 +1736,7 @@ abstract class Query implements ExpressionInterface, Stringable
     ): void {
         /** @var \Cake\Database\Expression\QueryExpression $expression */
         $expression = $this->_parts[$part] ?: $this->newExpr();
-        if (empty($append)) {
+        if (!$append) {
             $this->_parts[$part] = $expression;
 
             return;
@@ -1785,7 +1785,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $this->_valueBinder = clone $this->_valueBinder;
         }
         foreach ($this->_parts as $name => $part) {
-            if (empty($part)) {
+            if (!$part) {
                 continue;
             }
             if (is_array($part)) {

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -60,7 +60,7 @@ class InsertQuery extends Query
      */
     public function insert(array $columns, array $types = [])
     {
-        if (empty($columns)) {
+        if (!$columns) {
             throw new InvalidArgumentException('At least 1 column is required to perform an insert.');
         }
         $this->_dirty();

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -149,7 +149,7 @@ class Collection implements CollectionInterface
         $convertMethod = "convert{$stage}Description";
 
         [$sql, $params] = $this->_dialect->{$describeMethod}($name, $config);
-        if (empty($sql)) {
+        if (!$sql) {
             return;
         }
         try {

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -100,7 +100,7 @@ class MysqlSchemaDialect extends SchemaDialect
     protected function _convertColumn(string $column): array
     {
         preg_match('/([a-z]+)(?:\(([0-9,]+)\))?\s*([a-z]+)?/i', $column, $matches);
-        if (empty($matches)) {
+        if (!$matches) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 
@@ -257,7 +257,7 @@ class MysqlSchemaDialect extends SchemaDialect
         }
 
         // MySQL multi column indexes come back as multiple rows.
-        if (!empty($existing)) {
+        if ($existing) {
             $columns = array_merge($existing['columns'], $columns);
             $length = array_merge($existing['length'], $length);
         }

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -101,7 +101,7 @@ class PostgresSchemaDialect extends SchemaDialect
     protected function _convertColumn(string $column): array
     {
         preg_match('/([a-z\s]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
-        if (empty($matches)) {
+        if (!$matches) {
             throw new DatabaseException(sprintf('Unable to parse column type from `%s`', $column));
         }
 

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -314,7 +314,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         }
 
         $columns = [$row['column_name']];
-        if (!empty($existing)) {
+        if ($existing) {
             $columns = array_merge($existing['columns'], $columns);
         }
 

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -79,7 +79,7 @@ class Statement implements StatementInterface
      */
     public function bind(array $params, array $types): void
     {
-        if (empty($params)) {
+        if (!$params) {
             return;
         }
 

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -140,7 +140,7 @@ class ValueBinder
     public function attachTo(StatementInterface $statement): void
     {
         $bindings = $this->bindings();
-        if (empty($bindings)) {
+        if (!$bindings) {
             return;
         }
 

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -53,7 +53,7 @@ abstract class AbstractLocator implements LocatorInterface
         unset($storeOptions['allowFallbackClass']);
 
         if (isset($this->instances[$alias])) {
-            if (!empty($storeOptions) && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
+            if ($storeOptions && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
                 throw new CakeException(sprintf(
                     'You cannot configure `%s`, it already exists in the registry.',
                     $alias

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -94,7 +94,7 @@ trait ModelAwareTrait
     public function fetchModel(?string $modelClass = null, ?string $modelType = null): RepositoryInterface
     {
         $modelClass ??= $this->modelClass;
-        if (empty($modelClass)) {
+        if (!$modelClass) {
             throw new UnexpectedValueException('Default modelClass is empty');
         }
         $modelType ??= $this->getModelType();

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -70,7 +70,7 @@ class QueryCacher
         $key = $this->_resolveKey($query);
         $storage = $this->_resolveCacher();
         $result = $storage->get($key);
-        if (empty($result)) {
+        if (!$result) {
             return null;
         }
 

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -95,7 +95,7 @@ class Debugger
     public function __construct()
     {
         $docRef = ini_get('docref_root');
-        if (empty($docRef) && function_exists('ini_set')) {
+        if (!$docRef && function_exists('ini_set')) {
             ini_set('docref_root', 'https://secure.php.net/');
         }
         if (!defined('E_RECOVERABLE_ERROR')) {
@@ -480,7 +480,7 @@ class Debugger
             return [];
         }
         $data = file_get_contents($file);
-        if (empty($data)) {
+        if (!$data) {
             return $lines;
         }
         if (str_contains($data, "\n")) {

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -208,10 +208,10 @@ class EventManager implements EventManagerInterface
     protected function _detachSubscriber(EventListenerInterface $subscriber, ?string $eventKey = null): void
     {
         $events = $subscriber->implementedEvents();
-        if (!empty($eventKey) && empty($events[$eventKey])) {
+        if ($eventKey && empty($events[$eventKey])) {
             return;
         }
-        if (!empty($eventKey)) {
+        if ($eventKey) {
             $events = [$eventKey => $events[$eventKey]];
         }
         foreach ($events as $key => $handlers) {
@@ -296,7 +296,7 @@ class EventManager implements EventManagerInterface
             static::instance()->addEventToList($event);
         }
 
-        if (empty($listeners)) {
+        if (!$listeners) {
             return $event;
         }
 

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -164,7 +164,7 @@ class FormProtector
      */
     protected function getFieldNameArray(string $name): array
     {
-        if (!$name && $name !== '0') {
+        if ($name === '') {
             return [];
         }
 

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -66,7 +66,7 @@ class FormProtector
         $this->debugMessage = null;
 
         $extractedToken = $this->extractToken($formData);
-        if (empty($extractedToken)) {
+        if (!$extractedToken) {
             return false;
         }
 
@@ -120,7 +120,7 @@ class FormProtector
             $field = $this->getFieldNameArray($field);
         }
 
-        if (empty($field)) {
+        if (!$field) {
             return $this;
         }
 
@@ -164,7 +164,7 @@ class FormProtector
      */
     protected function getFieldNameArray(string $name): array
     {
-        if (empty($name) && $name !== '0') {
+        if (!$name && $name !== '0') {
             return [];
         }
 
@@ -317,7 +317,7 @@ class FormProtector
                 $fieldList[$i] = (string)$key;
             }
         }
-        if (!empty($multi)) {
+        if ($multi) {
             $fieldList += array_unique($multi);
         }
 
@@ -332,7 +332,7 @@ class FormProtector
         foreach ($fieldList as $i => $key) {
             $isLocked = in_array($key, $locked, true);
 
-            if (!empty($unlockedFields)) {
+            if ($unlockedFields) {
                 foreach ($unlockedFields as $off) {
                     $off = explode('.', $off);
                     $field = array_values(array_intersect(explode('.', $key), $off));
@@ -366,7 +366,7 @@ class FormProtector
     protected function sortedUnlockedFields(array $formData): array
     {
         $unlocked = urldecode($formData['_Token']['unlocked']);
-        if (empty($unlocked)) {
+        if (!$unlocked) {
             return [];
         }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -572,7 +572,7 @@ class Client implements ClientInterface
      */
     public function buildUrl(string $url, array|string $query = [], array $options = []): string
     {
-        if (empty($options) && empty($query)) {
+        if (!$options && !$query) {
             return $url;
         }
         $defaults = [

--- a/src/Http/ContentTypeNegotiation.php
+++ b/src/Http/ContentTypeNegotiation.php
@@ -71,10 +71,10 @@ class ContentTypeNegotiation
     public function preferredType(RequestInterface $request, array $choices = []): ?string
     {
         $parsed = $this->parseAccept($request);
-        if (empty($parsed)) {
+        if (!$parsed) {
             return null;
         }
-        if (empty($choices)) {
+        if (!$choices) {
             $preferred = array_shift($parsed);
 
             return $preferred[0];

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -413,7 +413,7 @@ class Cookie implements CookieInterface
             );
         }
 
-        if (empty($name)) {
+        if (!$name) {
             throw new InvalidArgumentException('The cookie name cannot be empty.');
         }
     }

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -276,7 +276,7 @@ class CookieCollection implements IteratorAggregate, Countable
             $cookiePairs[] = $cookie;
         }
 
-        if (empty($cookiePairs)) {
+        if (!$cookiePairs) {
             return $request;
         }
 

--- a/src/Http/Exception/BadRequestException.php
+++ b/src/Http/Exception/BadRequestException.php
@@ -35,7 +35,7 @@ class BadRequestException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Bad Request';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/ConflictException.php
+++ b/src/Http/Exception/ConflictException.php
@@ -35,7 +35,7 @@ class ConflictException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Conflict';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/ForbiddenException.php
+++ b/src/Http/Exception/ForbiddenException.php
@@ -35,7 +35,7 @@ class ForbiddenException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Forbidden';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/GoneException.php
+++ b/src/Http/Exception/GoneException.php
@@ -35,7 +35,7 @@ class GoneException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Gone';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/InternalErrorException.php
+++ b/src/Http/Exception/InternalErrorException.php
@@ -30,7 +30,7 @@ class InternalErrorException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Internal Server Error';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/InvalidCsrfTokenException.php
+++ b/src/Http/Exception/InvalidCsrfTokenException.php
@@ -35,7 +35,7 @@ class InvalidCsrfTokenException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Invalid CSRF Token';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/MethodNotAllowedException.php
+++ b/src/Http/Exception/MethodNotAllowedException.php
@@ -35,7 +35,7 @@ class MethodNotAllowedException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Method Not Allowed';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/NotAcceptableException.php
+++ b/src/Http/Exception/NotAcceptableException.php
@@ -35,7 +35,7 @@ class NotAcceptableException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Not Acceptable';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/NotFoundException.php
+++ b/src/Http/Exception/NotFoundException.php
@@ -35,7 +35,7 @@ class NotFoundException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Not Found';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/ServiceUnavailableException.php
+++ b/src/Http/Exception/ServiceUnavailableException.php
@@ -35,7 +35,7 @@ class ServiceUnavailableException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Service Unavailable';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/UnauthorizedException.php
+++ b/src/Http/Exception/UnauthorizedException.php
@@ -35,7 +35,7 @@ class UnauthorizedException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Unauthorized';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Exception/UnavailableForLegalReasonsException.php
+++ b/src/Http/Exception/UnavailableForLegalReasonsException.php
@@ -35,7 +35,7 @@ class UnavailableForLegalReasonsException extends HttpException
      */
     public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
     {
-        if (empty($message)) {
+        if (!$message) {
             $message = 'Unavailable For Legal Reasons';
         }
         parent::__construct($message, $code, $previous);

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -172,7 +172,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
         $this->checkValues($option, [self::DENY, self::SAMEORIGIN, self::ALLOW_FROM]);
 
         if ($option === self::ALLOW_FROM) {
-            if (empty($url)) {
+            if (!$url) {
                 throw new InvalidArgumentException('The 2nd arg $url can not be empty when `allow-from` is used');
             }
             $option .= ' ' . $url;

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -438,7 +438,7 @@ class ServerRequest implements ServerRequestInterface
         $ref = $this->getEnv('HTTP_REFERER');
 
         $base = Configure::read('App.fullBaseUrl') . $this->webroot;
-        if (empty($ref) || empty($base)) {
+        if (!$ref || !$base) {
             return null;
         }
 
@@ -1065,7 +1065,7 @@ class ServerRequest implements ServerRequestInterface
     public function domain(int $tldLength = 1): string
     {
         $host = $this->host();
-        if (empty($host)) {
+        if (!$host) {
             return '';
         }
 
@@ -1085,7 +1085,7 @@ class ServerRequest implements ServerRequestInterface
     public function subdomains(int $tldLength = 1): array
     {
         $host = $this->host();
-        if (empty($host)) {
+        if (!$host) {
             return [];
         }
 
@@ -1772,7 +1772,7 @@ class ServerRequest implements ServerRequestInterface
             $target .= '?' . $this->uri->getQuery();
         }
 
-        if (empty($target)) {
+        if (!$target) {
             $target = '/';
         }
 

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -483,7 +483,7 @@ class Session
      */
     public function consume(string $name): mixed
     {
-        if (empty($name)) {
+        if (!$name) {
             return null;
         }
         $value = $this->read($name);

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -121,7 +121,7 @@ class DatabaseSession implements SessionHandlerInterface
             ->disableHydration()
             ->first();
 
-        if (empty($result)) {
+        if (!$result) {
             return '';
         }
 

--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -87,7 +87,7 @@ class UriFactory implements UriFactoryInterface
         if ($path === '/index.php' && $uri->getQuery()) {
             $path = $uri->getQuery();
         }
-        if (empty($path) || $path === '/' || $path === '//' || $path === '/index.php') {
+        if (!$path || $path === '/' || $path === '//' || $path === '/index.php') {
             $path = '/';
         }
         $endsWithIndex = '/' . (Configure::read('App.webroot') ?: 'webroot') . '/index.php';

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -164,7 +164,7 @@ class MessagesFileLoader
         $searchPaths = [];
 
         $localePaths = App::path('locales');
-        if (empty($localePaths) && defined('APP')) {
+        if (!$localePaths && defined('APP')) {
             $localePaths[] = ROOT . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
         }
         foreach ($localePaths as $path) {

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -134,7 +134,7 @@ class Translator
             unset($tokensValues['_context']);
         }
 
-        if (empty($tokensValues)) {
+        if (!$tokensValues) {
             // Fallback for plurals that were using the singular key
             if (is_array($message)) {
                 return array_values($message + [''])[0];

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -130,7 +130,7 @@ abstract class BaseLog extends AbstractLogger
             $message,
             $matches
         );
-        if (empty($matches)) {
+        if (!$matches) {
             return $message;
         }
 

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -392,7 +392,7 @@ class Mailer implements EventListenerInterface
         if (is_string($config)) {
             $name = $config;
             $config = static::getConfig($name);
-            if (empty($config)) {
+            if (!$config) {
                 throw new InvalidArgumentException(sprintf('Unknown email configuration `%s`.', $name));
             }
             unset($name);

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -978,7 +978,7 @@ class Message implements JsonSerializable
 
         $headers = [];
         foreach ($lines as $key => $value) {
-            if (empty($value) && $value !== '0') {
+            if (!$value && $value !== '0') {
                 continue;
             }
 
@@ -1621,7 +1621,7 @@ class Message implements JsonSerializable
         $cut = ($wrapLength === static::LINE_LENGTH_MUST);
 
         foreach ($lines as $line) {
-            if (empty($line) && $line !== '0') {
+            if (!$line && $line !== '0') {
                 $formatted[] = '';
                 continue;
             }
@@ -1703,7 +1703,7 @@ class Message implements JsonSerializable
                     }
                 }
             }
-            if (!empty($tmpLine)) {
+            if ($tmpLine) {
                 $formatted[] = $tmpLine;
             }
         }

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -978,7 +978,7 @@ class Message implements JsonSerializable
 
         $headers = [];
         foreach ($lines as $key => $value) {
-            if (!$value && $value !== '0') {
+            if ($value === '') {
                 continue;
             }
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1621,7 +1621,7 @@ class Message implements JsonSerializable
         $cut = ($wrapLength === static::LINE_LENGTH_MUST);
 
         foreach ($lines as $line) {
-            if (!$line && $line !== '0') {
+            if ($line === '') {
                 $formatted[] = '';
                 continue;
             }

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -58,7 +58,7 @@ class Renderer
     {
         $rendered = [];
         $template = $this->viewBuilder()->getTemplate();
-        if (empty($template)) {
+        if (!$template) {
             foreach ($types as $type) {
                 $rendered[$type] = $content;
             }

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -504,7 +504,7 @@ class SmtpTransport extends AbstractTransport
         $lines = $message->getBody();
         $messages = [];
         foreach ($lines as $line) {
-            if ($line && ($line[0] === '.')) {
+            if (str_starts_with($line, '.')) {
                 $messages[] = '.' . $line;
             } else {
                 $messages[] = $line;

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -471,7 +471,7 @@ class SmtpTransport extends AbstractTransport
     protected function _prepareFromAddress(Message $message): array
     {
         $from = $message->getReturnPath();
-        if (empty($from)) {
+        if (!$from) {
             $from = $message->getFrom();
         }
 
@@ -504,7 +504,7 @@ class SmtpTransport extends AbstractTransport
         $lines = $message->getBody();
         $messages = [];
         foreach ($lines as $line) {
-            if (!empty($line) && ($line[0] === '.')) {
+            if ($line && ($line[0] === '.')) {
                 $messages[] = '.' . $line;
             } else {
                 $messages[] = $line;

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -458,9 +458,9 @@ class Socket
      */
     public function reset(?array $state = null): void
     {
-        if (empty($state)) {
+        if (!$state) {
             static $initialState = [];
-            if (empty($initialState)) {
+            if (!$initialState) {
                 $initialState = get_class_vars(self::class);
             }
             $state = $initialState;

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -1079,7 +1079,7 @@ abstract class Association
         $bindingKey = (array)$this->getBindingKey();
 
         if (count($foreignKey) !== count($bindingKey)) {
-            if (empty($bindingKey)) {
+            if (!$bindingKey) {
                 $table = $this->getTarget()->getTable();
                 if ($this->isOwningSide($this->getSource())) {
                     $table = $this->getSource()->getTable();

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -137,7 +137,7 @@ class BelongsTo extends Association
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
-        if (empty($targetEntity) || !($targetEntity instanceof EntityInterface)) {
+        if (!$targetEntity || !($targetEntity instanceof EntityInterface)) {
             return $entity;
         }
 
@@ -176,7 +176,7 @@ class BelongsTo extends Association
         $bindingKey = (array)$this->getBindingKey();
 
         if (count($foreignKey) !== count($bindingKey)) {
-            if (empty($bindingKey)) {
+            if (!$bindingKey) {
                 $msg = 'The `%s` table does not define a primary key. Please set one.';
                 throw new DatabaseException(sprintf($msg, $this->getTarget()->getTable()));
             }

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -137,7 +137,7 @@ class BelongsTo extends Association
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
-        if (!$targetEntity || !($targetEntity instanceof EntityInterface)) {
+        if (!$targetEntity instanceof EntityInterface) {
             return $entity;
         }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -1410,7 +1410,7 @@ class BelongsToMany extends Association
             $result[] = $joint;
         }
 
-        if (empty($missing)) {
+        if (!$missing) {
             return $result;
         }
 

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -121,7 +121,7 @@ class HasOne extends Association
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
-        if (empty($targetEntity) || !($targetEntity instanceof EntityInterface)) {
+        if (!$targetEntity || !($targetEntity instanceof EntityInterface)) {
             return $entity;
         }
 

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -121,7 +121,7 @@ class HasOne extends Association
     public function saveAssociated(EntityInterface $entity, array $options = []): EntityInterface|false
     {
         $targetEntity = $entity->get($this->getProperty());
-        if (!$targetEntity || !($targetEntity instanceof EntityInterface)) {
+        if (!$targetEntity instanceof EntityInterface) {
             return $entity;
         }
 

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -253,7 +253,7 @@ class SelectLoader
         }
 
         $select = $fetchQuery->aliasFields($fetchQuery->clause('select'));
-        if (empty($select)) {
+        if (!$select) {
             return;
         }
         $missingKey = function ($fieldList, $key) {

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -216,7 +216,7 @@ class AssociationCollection implements IteratorAggregate
      */
     public function saveParents(Table $table, EntityInterface $entity, array $associations, array $options = []): bool
     {
-        if (empty($associations)) {
+        if (!$associations) {
             return true;
         }
 
@@ -238,7 +238,7 @@ class AssociationCollection implements IteratorAggregate
      */
     public function saveChildren(Table $table, EntityInterface $entity, array $associations, array $options): bool
     {
-        if (empty($associations)) {
+        if (!$associations) {
             return true;
         }
 
@@ -308,7 +308,7 @@ class AssociationCollection implements IteratorAggregate
         if (!$entity->isDirty($association->getProperty())) {
             return true;
         }
-        if (!empty($nested)) {
+        if ($nested) {
             $options = $nested + $options;
         }
 
@@ -361,7 +361,7 @@ class AssociationCollection implements IteratorAggregate
             $keys = $this->keys();
         }
 
-        if (empty($keys)) {
+        if (!$keys) {
             return [];
         }
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -325,7 +325,7 @@ class Behavior implements EventListenerInterface
     public function implementedFinders(): array
     {
         $methods = $this->getConfig('implementedFinders');
-        if ($methods !== null) {
+        if (!$methods) {
             return $methods;
         }
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -357,7 +357,7 @@ class Behavior implements EventListenerInterface
     public function implementedMethods(): array
     {
         $methods = $this->getConfig('implementedMethods');
-        if ($methods !== null) {
+        if (!$methods) {
             return $methods;
         }
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -325,8 +325,8 @@ class Behavior implements EventListenerInterface
     public function implementedFinders(): array
     {
         $methods = $this->getConfig('implementedFinders');
-        if (!$methods) {
-            return [];
+        if ($methods) {
+            return $methods;
         }
 
         return $this->_reflectionCache()['finders'];
@@ -357,8 +357,8 @@ class Behavior implements EventListenerInterface
     public function implementedMethods(): array
     {
         $methods = $this->getConfig('implementedMethods');
-        if (!$methods) {
-            return [];
+        if ($methods) {
+            return $methods;
         }
 
         return $this->_reflectionCache()['methods'];

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -326,7 +326,7 @@ class Behavior implements EventListenerInterface
     {
         $methods = $this->getConfig('implementedFinders');
         if (!$methods) {
-            return $methods;
+            return [];
         }
 
         return $this->_reflectionCache()['finders'];
@@ -358,7 +358,7 @@ class Behavior implements EventListenerInterface
     {
         $methods = $this->getConfig('implementedMethods');
         if (!$methods) {
-            return $methods;
+            return [];
         }
 
         return $this->_reflectionCache()['methods'];

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -325,7 +325,7 @@ class Behavior implements EventListenerInterface
     public function implementedFinders(): array
     {
         $methods = $this->getConfig('implementedFinders');
-        if (isset($methods)) {
+        if ($methods !== null) {
             return $methods;
         }
 
@@ -357,7 +357,7 @@ class Behavior implements EventListenerInterface
     public function implementedMethods(): array
     {
         $methods = $this->getConfig('implementedMethods');
-        if (isset($methods)) {
+        if ($methods !== null) {
             return $methods;
         }
 

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -325,7 +325,7 @@ class Behavior implements EventListenerInterface
     public function implementedFinders(): array
     {
         $methods = $this->getConfig('implementedFinders');
-        if ($methods) {
+        if ($methods !== null) {
             return $methods;
         }
 
@@ -357,7 +357,7 @@ class Behavior implements EventListenerInterface
     public function implementedMethods(): array
     {
         $methods = $this->getConfig('implementedMethods');
-        if ($methods) {
+        if ($methods !== null) {
             return $methods;
         }
 

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -407,7 +407,7 @@ class EavStrategy implements TranslateStrategyInterface
                 return $row;
             }
             $translations = (array)$row->get('_i18n');
-            if (empty($translations) && $row->get('_translations')) {
+            if (!$translations && $row->get('_translations')) {
                 return $row;
             }
             $grouped = new Collection($translations);
@@ -445,7 +445,7 @@ class EavStrategy implements TranslateStrategyInterface
         /** @var array<string, \Cake\Datasource\EntityInterface> $translations */
         $translations = (array)$entity->get('_translations');
 
-        if (empty($translations) && !$entity->isDirty('_translations')) {
+        if (!$translations && !$entity->isDirty('_translations')) {
             return;
         }
 
@@ -467,7 +467,7 @@ class EavStrategy implements TranslateStrategyInterface
             }
         }
 
-        if (empty($find)) {
+        if (!$find) {
             return;
         }
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -546,7 +546,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 return $row;
             }
             $translations = (array)$row->get('_i18n');
-            if (empty($translations) && $row->get('_translations')) {
+            if (!$translations && $row->get('_translations')) {
                 return $row;
             }
 
@@ -579,7 +579,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         /** @var array<string, \Cake\ORM\Entity> $translations */
         $translations = (array)$entity->get('_translations');
 
-        if (empty($translations) && !$entity->isDirty('_translations')) {
+        if (!$translations && !$entity->isDirty('_translations')) {
             return;
         }
 

--- a/src/ORM/Behavior/Translate/TranslateTrait.php
+++ b/src/ORM/Behavior/Translate/TranslateTrait.php
@@ -42,7 +42,7 @@ trait TranslateTrait
         $i18n = $this->get('_translations');
         $created = false;
 
-        if (empty($i18n)) {
+        if (!$i18n) {
             $i18n = [];
             $created = true;
         }

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -387,7 +387,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     {
         $name = namespaceSplit($table::class);
         $name = substr((string)end($name), 0, -5);
-        if (empty($name)) {
+        if (!$name) {
             $name = $table->getTable() ?: $table->getAlias();
             $name = Inflector::camelize($name);
         }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -614,13 +614,13 @@ class EagerLoader
      */
     public function loadExternal(SelectQuery $query, array $results): array
     {
-        if (empty($results)) {
+        if (!$results) {
             return $results;
         }
 
         $table = $query->getRepository();
         $external = $this->externalAssociations($table);
-        if (empty($external)) {
+        if (!$external) {
             return $results;
         }
 
@@ -792,7 +792,7 @@ class EagerLoader
             }
             $collectKeys[$meta->aliasPath()] = [$alias, $pkFields, count($pkFields) === 1];
         }
-        if (empty($collectKeys)) {
+        if (!$collectKeys) {
             return [];
         }
 

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -65,7 +65,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
             $this->setNew($options['markNew']);
         }
 
-        if (!empty($properties)) {
+        if ($properties) {
             //Remember the original field names here.
             $this->setOriginalField(array_keys($properties));
 

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -87,7 +87,7 @@ trait LocatorAwareTrait
     public function fetchTable(?string $alias = null, array $options = []): Table
     {
         $alias ??= $this->defaultTable;
-        if (empty($alias)) {
+        if (!$alias) {
             throw new UnexpectedValueException(
                 'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
             );

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -59,7 +59,7 @@ trait LocatorAwareTrait
      */
     public function getTableLocator(): LocatorInterface
     {
-        if (isset($this->_tableLocator)) {
+        if ($this->_tableLocator !== null) {
             return $this->_tableLocator;
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -403,7 +403,7 @@ class Marshaller
             }
         }
 
-        if (!empty($conditions)) {
+        if ($conditions) {
             /** @var \Traversable<\Cake\Datasource\EntityInterface> $results */
             $results = $target->find()
                 ->andWhere(fn (QueryExpression $exp) => $exp->or($conditions))
@@ -460,7 +460,7 @@ class Marshaller
      */
     protected function _loadAssociatedByIds(Association $assoc, array $ids): array
     {
-        if (empty($ids)) {
+        if (!$ids) {
             return [];
         }
 
@@ -694,7 +694,7 @@ class Marshaller
             }, ['OR' => []]);
         $maybeExistentQuery = $this->_table->find()->where($conditions);
 
-        if (!empty($indexed) && count($maybeExistentQuery->clause('where'))) {
+        if ($indexed && count($maybeExistentQuery->clause('where'))) {
             /** @var \Traversable<\Cake\Datasource\EntityInterface> $existent */
             $existent = $maybeExistentQuery->all();
             foreach ($existent as $entity) {
@@ -795,7 +795,7 @@ class Marshaller
             return [];
         }
 
-        if (!empty($associated) && !in_array('_joinData', $associated, true) && !isset($associated['_joinData'])) {
+        if ($associated && !in_array('_joinData', $associated, true) && !isset($associated['_joinData'])) {
             return $this->mergeMany($original, $value, $options);
         }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1078,10 +1078,10 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             $association = $table->getAssociation($name);
             $target = $association->getTarget();
             $primary = (array)$target->getPrimaryKey();
-            if (empty($primary) || $typeMap->type($target->aliasField($primary[0])) === null) {
+            if (!$primary || $typeMap->type($target->aliasField($primary[0])) === null) {
                 $this->addDefaultTypes($target);
             }
-            if (!empty($nested)) {
+            if ($nested) {
                 $this->_addAssociationsToTypeMap($target, $typeMap, $nested);
             }
         }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2138,7 +2138,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected function _insert(EntityInterface $entity, array $data): EntityInterface|false
     {
         $primary = (array)$this->getPrimaryKey();
-        if (empty($primary)) {
+        if (!$primary) {
             $msg = sprintf(
                 'Cannot insert row in `%s` table, it has no primary key.',
                 $this->getTable()
@@ -2172,7 +2172,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             }
         }
 
-        if (empty($data)) {
+        if (!$data) {
             return false;
         }
 
@@ -2239,7 +2239,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $primaryKey = $entity->extract($primaryColumns);
 
         $data = array_diff_key($data, $primaryKey);
-        if (empty($data)) {
+        if (!$data) {
             return $entity;
         }
 
@@ -2748,7 +2748,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     {
         $method = Inflector::underscore($method);
         preg_match('/^find_([\w]+)_by_/', $method, $matches);
-        if (empty($matches)) {
+        if (!$matches) {
             // find_by_ is 8 characters.
             $fields = substr($method, 8);
             $findType = 'all';

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -495,7 +495,7 @@ class Route
             unset($route['_trailing_']);
         }
 
-        if (!empty($ext)) {
+        if ($ext) {
             $route['_ext'] = $ext;
         }
 
@@ -575,7 +575,7 @@ class Route
         $urldecode = $this->options['_urldecode'] ?? true;
 
         foreach ($args as $param) {
-            if (empty($param) && $param !== '0') {
+            if (!$param && $param !== '0') {
                 continue;
             }
             $pass[] = $urldecode ? rawurldecode($param) : $param;
@@ -844,7 +844,7 @@ class Route
         if (!empty($params['_ext'])) {
             $out .= '.' . $params['_ext'];
         }
-        if (!empty($query)) {
+        if ($query) {
             $out .= rtrim('?' . http_build_query($query), '?');
         }
 

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -389,7 +389,7 @@ class RouteBuilder
         $resourceMap = array_merge(static::$_resourceMap, $options['map']);
 
         $only = (array)$options['only'];
-        if (empty($only)) {
+        if (!$only) {
             $only = array_keys($resourceMap);
         }
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -383,7 +383,7 @@ class Router
         $context = static::$_requestContext;
         $context['_base'] ??= '';
 
-        if (empty($url)) {
+        if (!$url) {
             $here = static::getRequest()?->getRequestTarget() ?? '/';
             $output = $context['_base'] . $here;
             if ($full) {
@@ -693,7 +693,7 @@ class Router
         }
         $url = preg_replace('/(?:(\/$))/', '', $url);
 
-        if (empty($url)) {
+        if (!$url) {
             return '/';
         }
 

--- a/src/TestSuite/Constraint/Email/MailContainsAttachment.php
+++ b/src/TestSuite/Constraint/Email/MailContainsAttachment.php
@@ -36,10 +36,10 @@ class MailContainsAttachment extends MailContains
         $messages = $this->getMessages();
         foreach ($messages as $message) {
             foreach ($message->getAttachments() as $filename => $fileInfo) {
-                if ($filename === $expectedFilename && empty($expectedFileInfo)) {
+                if ($filename === $expectedFilename && !$expectedFileInfo) {
                     return true;
                 }
-                if (!empty($expectedFileInfo) && array_intersect($expectedFileInfo, $fileInfo) === $expectedFileInfo) {
+                if ($expectedFileInfo && array_intersect($expectedFileInfo, $fileInfo) === $expectedFileInfo) {
                     return true;
                 }
             }

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -50,7 +50,7 @@ class TransactionStrategy implements FixtureStrategyInterface
      */
     public function setupTest(array $fixtureNames): void
     {
-        if (empty($fixtureNames)) {
+        if (!$fixtureNames) {
             return;
         }
 

--- a/src/TestSuite/Fixture/TruncateStrategy.php
+++ b/src/TestSuite/Fixture/TruncateStrategy.php
@@ -44,7 +44,7 @@ class TruncateStrategy implements FixtureStrategyInterface
      */
     public function setupTest(array $fixtureNames): void
     {
-        if (empty($fixtureNames)) {
+        if (!$fixtureNames) {
             return;
         }
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -574,7 +574,7 @@ trait IntegrationTestTrait
     protected function _handleError(Throwable $exception): void
     {
         $class = Configure::read('Error.exceptionRenderer');
-        if (empty($class) || !class_exists($class)) {
+        if (!$class || !class_exists($class)) {
             $class = WebExceptionRenderer::class;
         }
         /** @var \Cake\Error\Renderer\WebExceptionRenderer $instance */

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -671,7 +671,7 @@ abstract class TestCase extends BaseTestCase
                     ];
                     continue;
                 }
-                if (!empty($tags) && preg_match('/^preg\:\/(.+)\/$/i', $tags, $matches)) {
+                if ($tags && preg_match('/^preg\:\/(.+)\/$/i', $tags, $matches)) {
                     $tags = $matches[1];
                     $type = 'Regex matches';
                 } else {
@@ -698,7 +698,7 @@ abstract class TestCase extends BaseTestCase
                 $explanations = [];
                 $i = 1;
                 foreach ($attributes as $attr => $val) {
-                    if (is_numeric($attr) && preg_match('/^preg\:\/(.+)\/$/i', (string)$val, $matches)) {
+                    if (is_numeric($attr) && preg_match('/^preg:\/(.+)\/$/i', (string)$val, $matches)) {
                         $attrs[] = $matches[1];
                         $explanations[] = sprintf('Regex `%s` matches', $matches[1]);
                         continue;
@@ -710,7 +710,7 @@ abstract class TestCase extends BaseTestCase
                         $attr = $val;
                         $val = '.+?';
                         $explanations[] = sprintf('Attribute `%s` present', $attr);
-                    } elseif (!empty($val) && preg_match('/^preg\:\/(.+)\/$/i', $val, $matches)) {
+                    } elseif ($val && preg_match('/^preg:\/(.+)\/$/i', $val, $matches)) {
                         $val = str_replace(
                             ['.*', '.+'],
                             ['.*?', '.+?'],

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -54,7 +54,7 @@ class Hash
      */
     public static function get(ArrayAccess|array $data, array|string|int|null $path, mixed $default = null): mixed
     {
-        if (empty($data) || $path === null) {
+        if (!$data || $path === null) {
             return $default;
         }
 
@@ -118,7 +118,7 @@ class Hash
      */
     public static function extract(ArrayAccess|array $data, string $path): ArrayAccess|array
     {
-        if (empty($path)) {
+        if (!$path) {
             return $data;
         }
 
@@ -238,7 +238,7 @@ class Hash
             $val = $cond['val'] ?? null;
 
             // Presence test.
-            if (empty($op) && empty($val) && !isset($data[$attr])) {
+            if (!$op && !$val && !isset($data[$attr])) {
                 return false;
             }
 
@@ -456,7 +456,7 @@ class Hash
         array|string|null $valuePath = null,
         ?string $groupPath = null
     ): array {
-        if (empty($data)) {
+        if (!$data) {
             return [];
         }
 
@@ -476,15 +476,15 @@ class Hash
         }
 
         $vals = null;
-        if (!empty($valuePath) && is_array($valuePath)) {
+        if ($valuePath && is_array($valuePath)) {
             $format = array_shift($valuePath);
             $vals = static::format($data, $valuePath, $format);
             assert(is_array($vals));
-        } elseif (!empty($valuePath)) {
+        } elseif ($valuePath) {
             $vals = static::extract($data, $valuePath);
             assert(is_array($vals));
         }
-        if (empty($vals)) {
+        if (!$vals) {
             $vals = array_fill(0, $keys === null ? count($data) : count($keys), null);
         }
 
@@ -496,7 +496,7 @@ class Hash
 
         if ($groupPath !== null) {
             $group = static::extract($data, $groupPath);
-            if (!empty($group)) {
+            if ($group) {
                 $c = is_array($keys) ? count($keys) : count($vals);
                 $out = [];
                 for ($i = 0; $i < $c; $i++) {
@@ -512,7 +512,7 @@ class Hash
                 return $out;
             }
         }
-        if (empty($vals)) {
+        if (!$vals) {
             return [];
         }
 
@@ -581,12 +581,12 @@ class Hash
      */
     public static function contains(array $data, array $needle): bool
     {
-        if (empty($data) || empty($needle)) {
+        if (!$data || !$needle) {
             return false;
         }
         $stack = [];
 
-        while (!empty($needle)) {
+        while ($needle) {
             $key = key($needle);
             $val = $needle[$key];
             unset($needle[$key]);
@@ -595,14 +595,14 @@ class Hash
                 $next = $data[$key];
                 unset($data[$key]);
 
-                if (!empty($val)) {
+                if ($val) {
                     $stack[] = [$val, $next];
                 }
             } elseif (!array_key_exists($key, $data) || $data[$key] != $val) {
                 return false;
             }
 
-            if (empty($needle) && !empty($stack)) {
+            if (!$needle && $stack) {
                 [$needle, $data] = array_pop($stack);
             }
         }
@@ -687,7 +687,7 @@ class Hash
             unset($data[$key]);
 
             if (is_array($element) && !empty($element)) {
-                if (!empty($data)) {
+                if ($data) {
                     $stack[] = [$data, $path];
                 }
                 $data = $element;
@@ -697,7 +697,7 @@ class Hash
                 $result[$path . $key] = $element;
             }
 
-            if (empty($data) && !empty($stack)) {
+            if (!$data && $stack) {
                 [$data, $path] = array_pop($stack);
                 reset($data);
             }
@@ -818,7 +818,7 @@ class Hash
      */
     public static function numeric(array $data): bool
     {
-        if (empty($data)) {
+        if (!$data) {
             return false;
         }
 
@@ -838,7 +838,7 @@ class Hash
      */
     public static function dimensions(array $data): int
     {
-        if (empty($data)) {
+        if (!$data) {
             return 0;
         }
         reset($data);
@@ -866,7 +866,7 @@ class Hash
     public static function maxDimensions(array $data): int
     {
         $depth = [];
-        if (!empty($data)) {
+        if ($data) {
             foreach ($data as $value) {
                 if (is_array($value)) {
                     $depth[] = static::maxDimensions($value) + 1;
@@ -983,7 +983,7 @@ class Hash
         string|int $dir = 'asc',
         array|string $type = 'regular'
     ): array {
-        if (empty($data)) {
+        if (!$data) {
             return [];
         }
         $originalKeys = array_keys($data);
@@ -1101,10 +1101,10 @@ class Hash
      */
     public static function diff(array $data, array $compare): array
     {
-        if (empty($data)) {
+        if (!$data) {
             return $compare;
         }
-        if (empty($compare)) {
+        if (!$compare) {
             return $data;
         }
         $intersection = array_intersect_key($data, $compare);
@@ -1128,10 +1128,10 @@ class Hash
      */
     public static function mergeDiff(array $data, array $compare): array
     {
-        if (empty($data) && !empty($compare)) {
+        if (!$data && !empty($compare)) {
             return $compare;
         }
-        if (empty($compare)) {
+        if (!$compare) {
             return $data;
         }
         foreach ($compare as $key => $value) {

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -62,7 +62,7 @@ class Security
      */
     public static function hash(string $string, ?string $algorithm = null, string|bool $salt = false): string
     {
-        if (empty($algorithm)) {
+        if (!$algorithm) {
             $algorithm = static::$hashType;
         }
         $algorithm = strtolower($algorithm);
@@ -240,7 +240,7 @@ class Security
     public static function decrypt(string $cipher, string $key, ?string $hmacSalt = null): ?string
     {
         self::_checkKey($key, 'decrypt()');
-        if (empty($cipher)) {
+        if (!$cipher) {
             throw new InvalidArgumentException('The data to decrypt cannot be empty.');
         }
         $hmacSalt ??= static::getSalt();

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -101,7 +101,7 @@ class Text
         string $leftBound = '(',
         string $rightBound = ')'
     ): array {
-        if (empty($data)) {
+        if (!$data) {
             return [];
         }
 
@@ -158,11 +158,11 @@ class Text
                 $offset = $length + 1;
             }
         }
-        if (empty($results) && !empty($buffer)) {
+        if (!$results && $buffer) {
             $results[] = $buffer;
         }
 
-        if (!empty($results)) {
+        if ($results) {
             return array_map('trim', $results);
         }
 
@@ -199,7 +199,7 @@ class Text
             'before' => ':', 'after' => '', 'escape' => '\\', 'format' => null, 'clean' => false,
         ];
         $options += $defaults;
-        if (empty($data)) {
+        if (!$data) {
             return $options['clean'] ? static::cleanInsert($str, $options) : $str;
         }
 
@@ -479,7 +479,7 @@ class Text
      */
     public static function highlight(string $text, array|string $phrase, array $options = []): string
     {
-        if (empty($phrase)) {
+        if (!$phrase) {
             return $text;
         }
 
@@ -855,7 +855,7 @@ class Text
      */
     public static function excerpt(string $text, string $phrase, int $radius = 100, string $ellipsis = '...'): string
     {
-        if (empty($text) || empty($phrase)) {
+        if (!$text || !$phrase) {
             return static::truncate($text, $radius * 2, ['ellipsis' => $ellipsis]);
         }
 
@@ -946,7 +946,7 @@ class Text
             if ($value < 128) {
                 $map[] = $value;
             } else {
-                if (empty($values)) {
+                if (!$values) {
                     $find = $value < 224 ? 2 : 3;
                 }
                 $values[] = $value;
@@ -1095,7 +1095,7 @@ class Text
      */
     public static function transliterate(string $string, Transliterator|string|null $transliterator = null): string
     {
-        if (empty($transliterator)) {
+        if (!$transliterator) {
             $transliterator = static::$_defaultTransliterator ?: static::$_defaultTransliteratorId;
         }
 

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -315,7 +315,7 @@ class Xml
         mixed $data,
         string $format
     ): void {
-        if (empty($data) || !is_array($data)) {
+        if (!$data || !is_array($data)) {
             return;
         }
         foreach ($data as $key => $value) {
@@ -410,7 +410,7 @@ class Xml
                 $childNS = $value['xmlns:'];
                 unset($value['xmlns:']);
             }
-        } elseif (!empty($value) || $value === 0 || $value === '0') {
+        } elseif ($value || $value === 0 || $value === '0') {
             $childValue = (string)$value;
         }
 
@@ -468,7 +468,7 @@ class Xml
             $attributes = $xml->attributes($namespace, true);
             /** @var string $key */
             foreach ($attributes as $key => $value) {
-                if (!empty($namespace)) {
+                if ($namespace) {
                     $key = $namespace . ':' . $key;
                 }
                 $data['@' . $key] = (string)$value;
@@ -480,13 +480,13 @@ class Xml
         }
 
         $asString = trim((string)$xml);
-        if (empty($data)) {
+        if (!$data) {
             $data = $asString;
         } elseif ($asString !== '') {
             $data['@'] = $asString;
         }
 
-        if (!empty($ns)) {
+        if ($ns) {
             $ns .= ':';
         }
         $name = $ns . $xml->getName();

--- a/src/Validation/README.md
+++ b/src/Validation/README.md
@@ -27,7 +27,7 @@ $validator
     ->notEmptyString('comment', 'You need to give a comment.');
 
 $errors = $validator->validate($_POST);
-if (!empty($errors)) {
+if ($errors) {
     // display errors.
 }
 ```

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -147,7 +147,7 @@ class Validation
      */
     public static function notBlank(mixed $check): bool
     {
-        if (empty($check) && !is_bool($check) && !is_numeric($check)) {
+        if (!$check && !is_bool($check) && !is_numeric($check)) {
             return false;
         }
 
@@ -856,7 +856,7 @@ class Validation
             return static::extension(array_shift($check), $extensions);
         }
 
-        if (empty($check)) {
+        if (!$check) {
             return false;
         }
 
@@ -1000,7 +1000,7 @@ class Validation
         $check = array_filter((array)$check, function ($value) {
             return $value || is_numeric($value);
         });
-        if (empty($check)) {
+        if (!$check) {
             return false;
         }
         if ($options['max'] && count($check) > $options['max']) {

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -193,7 +193,7 @@ class ValidationRule
     protected function _addValidatorProps(array $validator = []): void
     {
         foreach ($validator as $key => $value) {
-            if (empty($value)) {
+            if (!$value) {
                 continue;
             }
             if ($key === 'rule' && is_array($value) && !is_callable($value)) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -596,7 +596,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                     return false;
                 }
                 $check = $validator->validate($row, $context['newRecord']);
-                if (!empty($check)) {
+                if ($check) {
                     $errors[$i] = $check;
                 }
             }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -129,7 +129,7 @@ class EntityContext implements ContextInterface
         $entity = $this->_context['entity'];
         $this->_isCollection = is_iterable($entity);
 
-        if (empty($table)) {
+        if (!$table) {
             if ($this->_isCollection) {
                 /** @var iterable<\Cake\Datasource\EntityInterface|array> $entity */
                 foreach ($entity as $e) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2481,7 +2481,7 @@ class FormHelper extends Helper
      */
     protected function _getContext(mixed $data = []): ContextInterface
     {
-        if (isset($this->_context) && empty($data)) {
+        if ($this->_context !== null && !$data) {
             return $this->_context;
         }
         $data += ['entity' => null];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -474,7 +474,7 @@ class FormHelper extends Helper
             $append .= $this->_csrfField();
         }
 
-        if (!empty($append)) {
+        if ($append) {
             $append = $templater->format('hiddenBlock', ['content' => $append]);
         }
 
@@ -1653,7 +1653,7 @@ class FormHelper extends Helper
      */
     public function __call(string $method, array $params): string
     {
-        if (empty($params)) {
+        if (!$params) {
             throw new CakeException(sprintf('Missing field name for `FormHelper::%s`.', $method));
         }
         $options = $params[1] ?? [];

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -218,7 +218,7 @@ class HtmlHelper extends Helper
      */
     public function charset(?string $charset = null): string
     {
-        if (empty($charset)) {
+        if (!$charset) {
             $charset = strtolower((string)Configure::read('App.encoding'));
         }
 
@@ -890,7 +890,7 @@ class HtmlHelper extends Helper
      */
     public function div(?string $class = null, ?string $text = null, array $options = []): string
     {
-        if (!empty($class)) {
+        if ($class) {
             $options['class'] = $class;
         }
 
@@ -1024,7 +1024,7 @@ class HtmlHelper extends Helper
             $options['text'] = $sourceTags . $options['text'];
             unset($options['fullBase']);
         } else {
-            if (empty($path) && !empty($options['src'])) {
+            if (!$path && !empty($options['src'])) {
                 $path = $options['src'];
             }
             /** @psalm-suppress PossiblyNullArgument */

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -390,7 +390,7 @@ class PaginatorHelper extends Helper
         $url = $options['url'];
         unset($options['url']);
 
-        if (empty($title)) {
+        if (!$title) {
             $title = $key;
 
             if (str_contains($title, '.')) {
@@ -527,7 +527,7 @@ class PaginatorHelper extends Helper
             $options = [$scope => $options];
         }
 
-        if (!empty($baseUrl)) {
+        if ($baseUrl) {
             $url = Hash::merge($url, $baseUrl);
         }
 

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -74,7 +74,7 @@ class HelperRegistry extends ObjectRegistry implements EventDispatcherInterface
             $this->load($helper);
         } catch (MissingHelperException $exception) {
             $plugin = $this->_View->getPlugin();
-            if (!empty($plugin)) {
+            if ($plugin) {
                 $this->load($helper, ['className' => $plugin . '.' . $helper]);
 
                 return true;

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -174,7 +174,7 @@ class StringTemplate
      */
     protected function _compileTemplates(array $templates = []): void
     {
-        if (empty($templates)) {
+        if (!$templates) {
             $templates = array_keys($this->_config);
         }
         foreach ($templates as $name) {
@@ -357,7 +357,7 @@ class StringTemplate
         string $useIndex = 'class'
     ): array|string|null {
         // NOOP
-        if (empty($newClass)) {
+        if (!$newClass) {
             return $input;
         }
 

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -821,7 +821,7 @@ class View implements EventDispatcherInterface
     {
         $layoutFileName = $this->_getLayoutFileName($layout);
 
-        if (!empty($content)) {
+        if ($content) {
             $this->Blocks->set('content', $content);
         }
 
@@ -1134,7 +1134,7 @@ class View implements EventDispatcherInterface
      */
     protected function _render(string $templateFile, array $data = []): string
     {
-        if (empty($data)) {
+        if (!$data) {
             $data = $this->viewVars;
         }
         $this->_current = $templateFile;
@@ -1347,7 +1347,7 @@ class View implements EventDispatcherInterface
 
         $name ??= $this->template;
 
-        if (empty($name)) {
+        if (!$name) {
             throw new CakeException('Template name not provided');
         }
 
@@ -1579,7 +1579,7 @@ class View implements EventDispatcherInterface
         }
         $templatePaths = App::path(static::NAME_TEMPLATE);
         $pluginPaths = $themePaths = [];
-        if (!empty($plugin)) {
+        if ($plugin) {
             foreach ($templatePaths as $templatePath) {
                 $pluginPaths[] = $templatePath
                     . static::PLUGIN_TEMPLATE_FOLDER

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1433,7 +1433,7 @@ class View implements EventDispatcherInterface
             $name = $second;
             $plugin = $first;
         }
-        if (isset($this->plugin) && !$plugin && $fallback) {
+        if ($this->plugin !== null && !$plugin && $fallback) {
             $plugin = $this->plugin;
         }
 

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -162,7 +162,7 @@ class SelectBoxWidget extends BasicWidget
         if (!empty($data['empty'])) {
             $options = $this->_emptyValue($data['empty']) + (array)$options;
         }
-        if (empty($options)) {
+        if (!$options) {
             return [];
         }
 
@@ -290,7 +290,7 @@ class SelectBoxWidget extends BasicWidget
             if ($this->_isDisabled((string)$key, $disabled)) {
                 $optAttrs['disabled'] = true;
             }
-            if (!empty($templateVars)) {
+            if ($templateVars) {
                 $optAttrs['templateVars'] = array_merge($templateVars, $optAttrs['templateVars']);
             }
             $optAttrs['escape'] = $escape;


### PR DESCRIPTION
to non-cloaking ones where clearly defined.

This leaves empty() and isset() checks in place now where they are specifically
needed
In a separate PR one could check if those could or should be resolved in a var that is initialized before if/else checks
and then could also be !== null etc.
  