### PR TITLE
Fix Array to String warning in EventFiredWith constraint

### DIFF
--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -112,6 +112,6 @@ class EventFiredWith extends Constraint
      */
     public function toString(): string
     {
-        return 'was fired with ' . $this->_dataKey . ' matching ' . (string)$this->_dataValue;
+        return "was fired with `{$this->_dataKey}` matching `" . json_encode($this->_dataValue) . '`';
     }
 }

--- a/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
+++ b/tests/TestCase/TestSuite/Constraint/EventFiredWithTest.php
@@ -78,4 +78,24 @@ class EventFiredWithTest extends TestCase
 
         $constraint->matches('my.event');
     }
+
+    /**
+     * tests assertions on events with non-scalar data
+     */
+    public function testMatchesArrayData(): void
+    {
+        $manager = EventManager::instance();
+        $manager->setEventList(new EventList());
+        $manager->trackEvents(true);
+
+        $myEvent = new Event('my.event', $this, [
+            'data' => ['one' => 1],
+        ]);
+
+        $manager->getEventList()->add($myEvent);
+
+        $constraint = new EventFiredWith($manager, 'data', ['one' => 1]);
+        $constraint->matches('my.event');
+        $this->assertEquals('was fired with `data` matching `{"one":1}`', $constraint->toString());
+    }
 }


### PR DESCRIPTION
Improve formatting of message and use json_encode to avoid Array to string warning

Fixes #17524
