### PR TITLE
5.x: prevent CollectionTrait::combine keypath being used with non-backed enums

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -617,7 +617,7 @@ trait CollectionTrait
                 if ($mapKey instanceof BackedEnum) {
                     $mapKey = $mapKey->value;
                 } elseif ($mapKey instanceof UnitEnum) {
-                    throw new InvalidArgumentException('Cannot index by path on a non-backed enum.');
+                    throw new InvalidArgumentException('Cannot index by path that is a non-backed enum.');
                 }
 
                 $mapReduce->emit($rowVal($value, $key), $mapKey);

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -40,6 +40,7 @@ use LogicException;
 use OuterIterator;
 use RecursiveIteratorIterator;
 use Traversable;
+use UnitEnum;
 use const SORT_ASC;
 use const SORT_DESC;
 use const SORT_NUMERIC;
@@ -615,6 +616,8 @@ trait CollectionTrait
 
                 if ($mapKey instanceof BackedEnum) {
                     $mapKey = $mapKey->value;
+                } elseif ($mapKey instanceof UnitEnum) {
+                    throw new InvalidArgumentException('Cannot index by path on a non-backed enum.');
                 }
 
                 $mapReduce->emit($rowVal($value, $key), $mapKey);

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -35,6 +35,7 @@ use stdClass;
 use TestApp\Collection\CountableIterator;
 use TestApp\Collection\TestCollection;
 use TestApp\Model\Enum\ArticleStatus;
+use TestApp\Model\Enum\NonBacked;
 use function Cake\Collection\collection;
 
 /**
@@ -1274,6 +1275,16 @@ class CollectionTest extends TestCase
             ['amount' => 2, 'article_status' => ArticleStatus::from('N')],
         ]))->combine('article_status', 'amount');
         $this->assertEquals(['Y' => 10, 'N' => 2], $collection->toArray());
+    }
+
+    public function testCombineWithNonBackedEnum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot index by path on a non-backed enum.');
+        (new Collection([
+            ['amount' => 10, 'type' => NonBacked::Basic],
+            ['amount' => 2, 'type' => NonBacked::Basic],
+        ]))->combine('type', 'amount');
     }
 
     public function testCombineNullKey(): void

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1280,7 +1280,7 @@ class CollectionTest extends TestCase
     public function testCombineWithNonBackedEnum(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot index by path on a non-backed enum.');
+        $this->expectExceptionMessage('Cannot index by path that is a non-backed enum.');
         (new Collection([
             ['amount' => 10, 'type' => NonBacked::Basic],
             ['amount' => 2, 'type' => NonBacked::Basic],


### PR DESCRIPTION
Refs: https://github.com/cakephp/cakephp/pull/17528 & https://github.com/cakephp/cakephp/issues/17527