### PR TITLE
Revert for case when cell is not part of view.

### DIFF
--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -98,7 +98,7 @@ trait CellTrait
         if ($plugin) {
             $builder->setPlugin($plugin);
         }
-        if ($this->helpers) {
+        if (!empty($this->helpers)) {
             $builder->addHelpers($this->helpers);
         }
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17538

Apparently your case is not yet part of the tests
In your case the Cell seems not to be part of the view class, as such the helpers array needs to be defined manually

        protected array $helpers = [];
        
Lets revert this then for this case to avoid this breaking change.