### PR TITLE
Prefer defined vars over undefined checks.

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -162,6 +162,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
     {
         $this->ensureValidType($values, self::CHECK_KEY);
 
+        $restore = null;
         if ($ttl !== null) {
             $restore = $this->getConfig('duration');
             $this->setConfig('duration', $ttl);
@@ -176,7 +177,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
 
             return true;
         } finally {
-            if (isset($restore)) {
+            if ($restore !== null) {
                 $this->setConfig('duration', $restore);
             }
         }

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -185,9 +185,10 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             $controller = new $class($request);
             $controller->startupProcess();
         } catch (Throwable $e) {
+            $controller = null;
         }
 
-        if (!isset($controller)) {
+        if ($controller === null) {
             return new Controller($request);
         }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -548,10 +548,11 @@ class Client implements ClientInterface
      */
     protected function _sendRequest(RequestInterface $request, array $options): Response
     {
+        $responses = [];
         if (static::$_mockAdapter) {
             $responses = static::$_mockAdapter->send($request, $options);
         }
-        if (empty($responses)) {
+        if (!$responses) {
             $responses = $this->_adapter->send($request, $options);
         }
         foreach ($responses as $response) {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1373,13 +1373,14 @@ class Response implements ResponseInterface, Stringable
         if ($options['download']) {
             $agent = (string)env('HTTP_USER_AGENT');
 
+            $contentType = null;
             if ($agent && preg_match('%Opera([/ ])([0-9].[0-9]{1,2})%', $agent)) {
                 $contentType = 'application/octet-stream';
             } elseif ($agent && preg_match('/MSIE ([0-9].[0-9]{1,2})/', $agent)) {
                 $contentType = 'application/force-download';
             }
 
-            if (isset($contentType)) {
+            if ($contentType !== null) {
                 $new = $new->withType($contentType);
             }
             $name = $options['name'] ?: $file->getFileName();

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -140,6 +140,7 @@ class I18n
     {
         $translators = static::translators();
 
+        $currentLocale = null;
         if ($locale) {
             $currentLocale = $translators->getLocale();
             $translators->setLocale($locale);
@@ -153,7 +154,7 @@ class I18n
             ));
         }
 
-        if (isset($currentLocale)) {
+        if ($currentLocale !== null) {
             $translators->setLocale($currentLocale);
         }
 

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -236,6 +236,7 @@ class CounterCacheBehavior extends Behavior
         $updateConditions = array_combine($primaryKeys, $countConditions);
 
         $countOriginalConditions = $entity->extractOriginalChanged($foreignKeys);
+        $updateOriginalConditions = null;
         if ($countOriginalConditions !== []) {
             $updateOriginalConditions = array_combine($primaryKeys, $countOriginalConditions);
         }
@@ -264,7 +265,7 @@ class CounterCacheBehavior extends Behavior
                 }
             }
 
-            if (isset($updateOriginalConditions) && $this->_shouldUpdateCount($updateOriginalConditions)) {
+            if ($updateOriginalConditions && $this->_shouldUpdateCount($updateOriginalConditions)) {
                 if ($config instanceof Closure) {
                     $count = $config($event, $entity, $this->_table, true);
                 } else {

--- a/src/Routing/Asset.php
+++ b/src/Routing/Asset.php
@@ -154,6 +154,7 @@ class Asset
             return ltrim(Router::url($path), '/');
         }
 
+        $plugin = null;
         if (!array_key_exists('plugin', $options) || $options['plugin'] !== false) {
             [$plugin, $path] = static::pluginSplit($path);
         }
@@ -162,7 +163,7 @@ class Asset
             $placeHolderVal = '';
             if (!empty($options['theme'])) {
                 $placeHolderVal = static::inflectString($options['theme']) . '/';
-            } elseif (isset($plugin)) {
+            } elseif ($plugin !== null) {
                 $placeHolderVal = static::inflectString($plugin) . '/';
             }
 
@@ -181,7 +182,7 @@ class Asset
             return Router::url($path);
         }
 
-        if (isset($plugin)) {
+        if ($plugin !== null) {
             $path = static::inflectString($plugin) . '/' . $path;
         }
 

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -142,6 +142,7 @@ class ContextFactory
     {
         $data += ['entity' => null];
 
+        $context = null;
         foreach ($this->providers as $provider) {
             $check = $provider['callable'];
             $context = $check($request, $data);
@@ -150,7 +151,7 @@ class ContextFactory
             }
         }
 
-        if (!isset($context)) {
+        if ($context === null) {
             throw new CakeException(sprintf(
                 'No context provider found for value of type `%s`.'
                 . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.',

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -1250,10 +1250,10 @@ HTML;
     {
         $message = new Message(['transport' => 'debug']);
 
-        if (!empty($charset)) {
+        if ($charset) {
             $message->setCharset($charset);
         }
-        if (!empty($headerCharset)) {
+        if ($headerCharset) {
             $message->setHeaderCharset($headerCharset);
         }
 
@@ -1274,10 +1274,10 @@ HTML;
     {
         $message = new Message();
 
-        if (!empty($charset)) {
+        if ($charset) {
             $message->setCharset($charset);
         }
-        if (!empty($headerCharset)) {
+        if ($headerCharset) {
             $message->setHeaderCharset($headerCharset);
         }
 

--- a/tests/test_app/TestApp/Model/Entity/NonExtending.php
+++ b/tests/test_app/TestApp/Model/Entity/NonExtending.php
@@ -23,7 +23,7 @@ class NonExtending implements EntityInterface
             'source' => null,
         ];
 
-        if (!empty($properties)) {
+        if ($properties) {
             $this->set($properties, [
                 'setter' => $options['useSetters'],
                 'guard' => $options['guard'],

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -33,12 +33,12 @@ class AuthorsTable extends Table
 
     /**
      * @param \Cake\ORM\Query\SelectQuery $query
-     * @param array<string, mixed> $options
+     * @param int|null $authorId
      * @return \Cake\ORM\Query\SelectQuery
      */
     public function findByAuthor(SelectQuery $query, ?int $authorId = null): SelectQuery
     {
-        if (isset($authorId)) {
+        if ($authorId !== null) {
             $query->where(['Articles.id' => $authorId]);
         }
 
@@ -66,7 +66,7 @@ class AuthorsTable extends Table
     /**
      * Finder that accepts an option via a typed parameter.
      *
-     * @param \Cake\ORM\SelectQuery $query The query
+     * @param \Cake\ORM\Query\SelectQuery $query The query
      * @param int $id Author ID
      * @return \Cake\ORM\Query\SelectQuery
      */


### PR DESCRIPTION
Refs also https://github.com/cakephp/cakephp/pull/17539

In general, having vars defined as null before partially/conditionally assigning means that checking on it laters
is a bit cleaner and does not need cloaking checks on possibly undefined content.
