### PR TITLE
5.next: add plugin versions to `plugin list` command

### DIFF
--- a/src/Command/PluginListCommand.php
+++ b/src/Command/PluginListCommand.php
@@ -46,10 +46,11 @@ class PluginListCommand extends Command
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
         $loadedPluginsCollection = Plugin::getCollection();
-        $config = PluginConfig::getAppConfig();
+        $path = (string)$args->getOption('composer-path');
+        $config = PluginConfig::getAppConfig($path ?: null);
 
         $table = [
-            ['Plugin', 'Is Loaded', 'Only Debug', 'Only CLI', 'Optional'],
+            ['Plugin', 'Is Loaded', 'Only Debug', 'Only CLI', 'Optional', 'Version'],
         ];
 
         if (empty($config)) {
@@ -63,12 +64,14 @@ class PluginListCommand extends Command
             $onlyDebug = $options['onlyDebug'] ?? false;
             $onlyCli = $options['onlyCli'] ?? false;
             $optional = $options['optional'] ?? false;
+            $version = $options['version'] ?? '';
             $table[] = [
                 $pluginName,
                 $isLoaded ? 'X' : '',
                 $onlyDebug ? 'X' : '',
                 $onlyCli ? 'X' : '',
                 $optional ? 'X' : '',
+                $version,
             ];
         }
         $io->helper('Table')->output($table);
@@ -85,6 +88,9 @@ class PluginListCommand extends Command
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription('Displays all currently available plugins.');
+        $parser->addOption('composer-path', [
+            'help' => 'The absolute path to the composer.lock file to retrieve the versions from',
+        ]);
 
         return $parser;
     }

--- a/tests/TestCase/Command/PluginListCommandTest.php
+++ b/tests/TestCase/Command/PluginListCommandTest.php
@@ -176,4 +176,37 @@ PHP;
 
         $this->exec('plugin list');
     }
+
+    /**
+     * Test listing vendor plugins with versions
+     */
+    public function testListWithVersions(): void
+    {
+        $file = <<<PHP
+<?php
+declare(strict_types=1);
+return [
+    'plugins' => [
+        'Chronos' => ROOT . '/vendor/cakephp/chronos',
+        'CodeSniffer' => ROOT . '/vendor/cakephp/cakephp-codesniffer'
+    ]
+];
+PHP;
+        file_put_contents($this->pluginsListPath, $file);
+
+        $config = <<<PHP
+<?php
+declare(strict_types=1);
+return [
+    'Chronos',
+    'CodeSniffer'
+];
+PHP;
+        file_put_contents($this->pluginsConfigPath, $config);
+
+        $path = ROOT . DS . 'tests' . DS . 'composer.lock';
+        $this->exec(sprintf('plugin list --composer-path="%s"', $path));
+        $this->assertOutputContains('| Chronos     | X         |            |          |          | 3.0.4   |');
+        $this->assertOutputContains('| CodeSniffer | X         |            |          |          | 5.1.1   |');
+    }
 }

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -1,0 +1,314 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "8ba86848f9797e948641be63f29d81bf",
+    "packages": [
+        {
+            "name": "cakephp/chronos",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/chronos.git",
+                "reference": "9cb035acd10152a6b74df936986f15c4e6015bd3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/chronos/zipball/9cb035acd10152a6b74df936986f15c4e6015bd3",
+                "reference": "9cb035acd10152a6b74df936986f15c4e6015bd3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^5.0",
+                "phpunit/phpunit": "^10.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Chronos\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "The CakePHP Team",
+                    "homepage": "https://cakephp.org"
+                }
+            ],
+            "description": "A simple API extension for DateTime.",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/cakephp/chronos/issues",
+                "source": "https://github.com/cakephp/chronos"
+            },
+            "time": "2023-10-17T07:41:48+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "cakephp/cakephp-codesniffer",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/cakephp-codesniffer.git",
+                "reference": "3227936e698774025a16fb808c28f92688672306"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/cakephp-codesniffer/zipball/3227936e698774025a16fb808c28f92688672306",
+                "reference": "3227936e698774025a16fb808c28f92688672306",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "phpstan/phpdoc-parser": "^1.4.5",
+                "slevomat/coding-standard": "^8.4",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "CakePHP\\": "CakePHP/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/cakephp-codesniffer/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP CodeSniffer Standards",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "codesniffer",
+                "framework"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp-codesniffer/issues",
+                "source": "https://github.com/cakephp/cakephp-codesniffer"
+            },
+            "time": "2023-04-09T13:00:25+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-01-11T20:47:48+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-20T00:12:19+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.1",
+        "ext-intl": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17541

I have adjusted the PluginConfig class to also contain the logic to parse the `composer.json` for the package name as well as the `composer.lock` to get the exact version which is being used for a specific package.

So this can easily be reused to create a `bin/cake plugin show DebugKit` command if so desired (or adjust the already existing packages panel of debug_kit)

Using this branch on my current app this currently looks like this:
```
+-------------------------+-----------+------------+----------+----------+---------+
| Plugin                  | Is Loaded | Only Debug | Only CLI | Optional | Version |
+-------------------------+-----------+------------+----------+----------+---------+
| ADmad/Sequence          | X         |            |          |          | 4.0.0   |
| AlfredCovid             | X         |            |          |          |         |
| AlfredDashboard         | X         |            |          |          |         |
| AlfredDbIntegrity       | X         |            |          |          |         |
| AlfredDeploy            | X         |            |          |          |         |
| AlfredDns               | X         |            |          |          |         |
| AlfredDocumentations    | X         |            |          |          |         |
| AlfredDriversLogbook    | X         |            |          |          |         |
| AlfredEasybill          | X         |            |          |          |         |
| AlfredGoogle            | X         |            |          |          |         |
| AlfredMaintenances      | X         |            |          |          |         |
| AlfredMealOrders        | X         |            |          |          |         |
| AlfredProjects          | X         |            |          |          |         |
| AlfredStaffMembers      | X         |            |          |          |         |
| AlfredStandBy           | X         |            |          |          |         |
| AlfredTemplates         | X         | X          |          |          |         |
| AlfredTools             | X         |            |          |          |         |
| Authentication          |           |            |          |          | 3.0.3   |
| Authorization           |           |            |          |          | 3.1.1   |
| Bake                    | X         |            | X        | X        | 3.0.5   |
| CakeDC/Auth             |           |            |          |          | 8.0.3   |
| CakeDC/Users            | X         |            |          |          | 12.0.0  |
| CakeDumpSql             | X         |            |          |          | 2.0.0   |
| CakeSentry              | X         |            |          |          | 3.x-dev |
| Cake/TwigView           | X         |            |          |          | 2.0.1   |
| CakephpFixtureFactories | X         |            | X        | X        | v3.0.1  |
| CakephpTestSuiteLight   |           |            |          |          | v3.0    |
| DebugKit                | X         | X          |          |          | 5.0.5   |
| Duplicatable            | X         |            |          |          | 5.0.0   |
| IdeHelper               | X         |            | X        | X        | 2.2.0   |
| IdeHelperExtra          | X         |            | X        | X        | 0.2.0   |
| Migrations              | X         |            | X        | X        | 4.1.1   |
| Muffin/Footprint        | X         |            |          |          | 4.0.1   |
| Queue                   | X         |            |          |          | 7.1.2   |
| Search                  | X         |            |          |          | 7.0.0   |
| Setup                   | X         | X          |          |          | 3.2.1   |
| Shim                    |           |            |          |          | 3.2.1   |
| Tools                   | X         |            |          |          | 3.3.0   |
| LordSimal/CakephpDbml   |           |            |          |          |         |
+-------------------------+-----------+------------+----------+----------+---------+
```

we could of course add another column at the end to see if that specific plugin/package is a base requirement or a dev requirement in the `composer.json` but I guess this isn't that much of a usefull information so I left it out.

Same goes for the composer package name