### PR TITLE
Simplify the terminate event

### DIFF
--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -129,6 +129,14 @@ class Server implements EventDispatcherInterface
     /**
      * Emit the response using the PHP SAPI.
      *
+     * After the response has been emitted, the `Server.terminate` event will be triggered.
+     *
+     * The `Server.terminate` event can be used to do potentially heavy tasks after the
+     * response is sent to the client. Only the PHP FPM server API is able to send a
+     * response to the client while the server's PHP process still performs some tasks.
+     * For other environments the event will be triggered before the response is flushed
+     * to the client and will have no benefit.
+     *
      * @param \Psr\Http\Message\ResponseInterface $response The response to emit
      * @param \Cake\Http\ResponseEmitter|null $emitter The emitter to use.
      *   When null, a SAPI Stream Emitter will be used.
@@ -144,7 +152,7 @@ class Server implements EventDispatcherInterface
             $container = $this->app->getContainer();
             if ($container && $container->has(ServerRequest::class)) {
                 $request = $container->get(ServerRequest::class);
-            }        
+            }
         }
         if (!$request) {
             $request = Router::getRequest();

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -139,14 +139,12 @@ class Server implements EventDispatcherInterface
         $emitter ??= new ResponseEmitter();
         $emitter->emit($response);
 
-        $container = null;
         $request = null;
-        $app = $this->app;
-        if ($app instanceof ContainerApplicationInterface) {
-            $container = $app->getContainer();
-        }
-        if ($container && $container->has(ServerRequest::class)) {
-            $request = $container->get(ServerRequest::class);
+        if ($this->app instanceof ContainerApplicationInterface) {
+            $container = $this->app->getContainer();
+            if ($container && $container->has(ServerRequest::class)) {
+                $request = $container->get(ServerRequest::class);
+            }        
         }
         if (!$request) {
             $request = Router::getRequest();

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -150,7 +150,7 @@ class Server implements EventDispatcherInterface
         $request = null;
         if ($this->app instanceof ContainerApplicationInterface) {
             $container = $this->app->getContainer();
-            if ($container && $container->has(ServerRequest::class)) {
+            if ($container->has(ServerRequest::class)) {
                 $request = $container->get(ServerRequest::class);
             }
         }

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -33,7 +33,6 @@ use Laminas\Diactoros\Response as LaminasResponse;
 use Laminas\Diactoros\ServerRequest as LaminasServerRequest;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use TestApp\Http\MiddlewareApplication;
 
 require_once __DIR__ . '/server_mocks.php';

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -356,21 +356,29 @@ class ServerTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $server->run($request));
     }
 
-    public function testTerminate(): void
+    public function testTerminateEvent(): void
     {
-        /** @var \Cake\Core\HttpApplicationInterface|\PHPUnit\Framework\MockObject\MockObject $app */
-        $app = $this->createMock(HttpApplicationInterface::class);
+        $request = new ServerRequest();
+        $app = new MiddlewareApplication($this->config);
+        $app->getContainer()->add(ServerRequest::class, $request);
         $server = new Server($app);
 
         $triggered = false;
         $server->getEventManager()->on(
             'Server.terminate',
-            function (EventInterface $event, ServerRequestInterface $request, ResponseInterface $response) use (&$triggered) {
+            function ($event, $request, $response) use (&$triggered) {
                 $triggered = true;
+                $this->assertInstanceOf(ServerRequest::class, $request);
+                $this->assertInstanceOf(Response::class, $response);
             }
         );
 
-        $server->terminate(new ServerRequest(), new Response());
+        $emitter = $this->getMockBuilder(ResponseEmitter::class)->getMock();
+        $emitter->expects($this->once())
+            ->method('emit')
+            ->willReturn(true);
+
+        $server->emit(new Response(), $emitter);
 
         $this->assertTrue($triggered);
     }


### PR DESCRIPTION
I would like to get a solution that requires userland code to not need to be aware of concerns like where to find the request. If we can abstract that away we can improve it over time more easily.
