### PR TITLE
5.x: clarify deep marshalling

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -165,6 +165,16 @@ class Marshaller
      * ]);
      * ```
      *
+     *  ```
+     *  $result = $marshaller->one($data, [
+     *    'associated' => [
+     *      'Tags' => [
+     *        'associated' => ['DeeperAssoc1', 'DeeperAssoc2']
+     *      ]
+     *    ]
+     *  ]);
+     *  ```
+     *
      * @param array<string, mixed> $data The data to hydrate.
      * @param array<string, mixed> $options List of options
      * @return \Cake\Datasource\EntityInterface
@@ -514,6 +524,16 @@ class Marshaller
      * ```
      * $result = $marshaller->merge($entity, $data, [
      *   'associated' => ['Tags' => ['onlyIds' => true]]
+     * ]);
+     * ```
+     *
+     * ```
+     * $result = $marshaller->merge($entity, $data, [
+     *   'associated' => [
+     *     'Tags' => [
+     *       'associated' => ['DeeperAssoc1', 'DeeperAssoc2']
+     *     ]
+     *   ]
      * ]);
      * ```
      *


### PR DESCRIPTION
As just discussed in Slack/Discord it is not clear, that these two method calls don't lead to the same result:

``` 
// works as expected
$entity = $this->patchEntity($entity, $data, ['associated' => ['First.Second', 'First.Third', 'First.Fourth']]);
```
```
// won't patch Second, Third and Four
$entity = $this->patchEntity($entity, $data, ['associated' => ['First' => ['Second', 'Third', 'Fourth']]]); 
```

One would image/expect that this array structure behaves the same as a e.g. `contain()` array structure but it doesn't.

This PR at least adjusts the docs generated for api.cakephp.org including 2 separate tests to make sure this actually works and to link to if someone has questions about it.

We should make this clearer in the Book as well