### PR TITLE
ability to clean WITH clause matching CONTAIN process

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -457,7 +457,10 @@ class Query implements ExpressionInterface, IteratorAggregate
             }
         }
 
-        $this->_parts['with'][] = $cte;
+        if ($cte) {
+            $this->_parts['with'][] = $cte;
+        }
+
         $this->_dirty();
 
         return $this;


### PR DESCRIPTION
Added NULL condition to overwrite and clear SQL WITH clause matching the CONTAIN  process.
