### PR TITLE
ability to clean WITH clause matching CONTAIN process

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -382,11 +382,11 @@ abstract class Query implements ExpressionInterface, Stringable
      * });
      * ```
      *
-     * @param \Cake\Database\Expression\CommonTableExpression|\Closure $cte The CTE to add.
+     * @param \Cake\Database\Expression\CommonTableExpression|\Closure|null $cte The CTE to add.
      * @param bool $overwrite Whether to reset the list of CTEs.
      * @return $this
      */
-    public function with(CommonTableExpression|Closure $cte, bool $overwrite = false)
+    public function with(CommonTableExpression|Closure|null $cte, bool $overwrite = false)
     {
         if ($overwrite) {
             $this->_parts['with'] = [];
@@ -402,7 +402,10 @@ abstract class Query implements ExpressionInterface, Stringable
             }
         }
 
-        $this->_parts['with'][] = $cte;
+        if ($cte) {
+            $this->_parts['with'][] = $cte;
+        }
+
         $this->_dirty();
 
         return $this;

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -132,7 +132,7 @@ class CommonTableExpressionQueryTest extends TestCase
             ->select('col')
             ->from('cte');
 
-        $query = $query->with(null);
+        $query = $query->with(null, true);
         $this->assertEqualsSql(
             'SELECT col FROM cte',
             $query->sql(new ValueBinder())

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -121,6 +121,25 @@ class CommonTableExpressionQueryTest extends TestCase
     }
 
     /**
+     * Tests calling with(null)  clears other CTEs.
+     */
+    public function testWithCteNullClear(): void
+    {
+        $query = $this->connection->selectQuery()
+            ->with(new CommonTableExpression('cte', function () {
+                return $this->connection->selectQuery(['col' => '1']);
+            }))
+            ->select('col')
+            ->from('cte');
+
+        $query = $query->with(null);
+        $this->assertEqualsSql(
+            'SELECT col FROM cte',
+            $query->sql(new ValueBinder())
+        );
+    }
+
+    /**
      * Tests recursive CTE.
      */
     public function testWithRecursiveCte(): void


### PR DESCRIPTION
Added NULL condition to overwrite and clear SQL WITH clause matching the CONTAIN  process.
