### PR TITLE
Add cast to possible int value

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -666,7 +666,7 @@ trait IntegrationTestTrait
             $fields = array_diff_key($data, array_flip($this->_unlockedFields));
 
             $keys = array_map(function ($field) {
-                return preg_replace('/(\.\d+)+$/', '', (string) $field);
+                return preg_replace('/(\.\d+)+$/', '', (string)$field);
             }, array_keys(Hash::flatten($fields)));
 
             $formProtector = new FormProtector(['unlockedFields' => $this->_unlockedFields]);

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -666,7 +666,7 @@ trait IntegrationTestTrait
             $fields = array_diff_key($data, array_flip($this->_unlockedFields));
 
             $keys = array_map(function ($field) {
-                return preg_replace('/(\.\d+)+$/', '', $field);
+                return preg_replace('/(\.\d+)+$/', '', (string) $field);
             }, array_keys(Hash::flatten($fields)));
 
             $formProtector = new FormProtector(['unlockedFields' => $this->_unlockedFields]);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -831,6 +831,20 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test posting to a secured form action.
+     */
+    public function testPostSecuredFormNumericField(): void
+    {
+        $this->enableSecurityToken();
+        $data = [
+            '123456789' => 'Some text',
+        ];
+        $this->post('/posts/securePost', $data);
+        $this->assertResponseOk();
+        $this->assertResponseContains('Request was accepted');
+    }
+
+    /**
      * Test posting to a secured form action with nested data.
      */
     public function testPostSecuredFormNestedData(): void


### PR DESCRIPTION
IntegrationTestTrait: When using numeric field names in post data \Cake\TestSuite\IntegrationTestTrait::_addTokens throws Error: preg_replace(): Argument #3 ($subject) must be of type array|string, int given.