### PR TITLE
Fix up Date regression

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -136,6 +136,10 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             $value = new $class('@' . $value);
         }
 
+        if ($value instanceof ChronosDate) {
+            return $value->format($this->_format);
+        }
+
         if (!$value instanceof DateTimeInterface) {
             return null;
         }

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Database\Type;
 
 use Cake\Chronos\ChronosDate;
 use Cake\Database\Type\DateTimeType;
+use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
@@ -200,6 +201,10 @@ class DateTimeTypeTest extends TestCase
         $date = 1401906995;
         $result = $this->type->toDatabase($date, $this->driver);
         $this->assertSame('2014-06-04 18:36:35', $result);
+
+        $date = new Date();
+        $result = $this->type->toDatabase($date, $this->driver);
+        $this->assertSame('2024-01-27 00:00:00', $result);
     }
 
     /**


### PR DESCRIPTION
Reverts the regression introduced in https://github.com/cakephp/cakephp/issues/17565
(specifically https://github.com/cakephp/cakephp/pull/17448/files#diff-5c48d7aa764ea35cd91bcefaf29a3f34e93664b98a0c75eb10b8ed7c76b93967R139-R140 )

Apparently, Date is part of DateTimeType behavior handling, and we do not have a test case for it..

Now, 

    'OR' => [
        'Events.end >=' => new Date(), 
        'AND' => ['Events.end IS' => null, 'Events.beginning >=' => new Date()]
    ]

works again.

It seems historically Date has always been also possible to inject into DateTime conditions, and as such it needs to stay.