### PR TITLE
Allow groupBy to work with enums.

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -292,6 +292,10 @@ trait CollectionTrait
                     'Use a callback to return a default value for that path.'
                 );
             }
+            if ($pathValue instanceof UnitEnum) {
+                $pathValue = $pathValue->value;
+            }
+
             $group[$pathValue][] = $value;
         }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -292,8 +292,10 @@ trait CollectionTrait
                     'Use a callback to return a default value for that path.'
                 );
             }
-            if ($pathValue instanceof UnitEnum) {
+            if ($pathValue instanceof BackedEnum) {
                 $pathValue = $pathValue->value;
+            } elseif ($pathValue instanceof UnitEnum) {
+                $pathValue = $pathValue->name;
             }
 
             $group[$pathValue][] = $value;

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -319,6 +319,12 @@ trait CollectionTrait
                     'Use a callback to return a default value for that path.'
                 );
             }
+            if ($pathValue instanceof BackedEnum) {
+                $pathValue = $pathValue->value;
+            } elseif ($pathValue instanceof UnitEnum) {
+                $pathValue = $pathValue->name;
+            }
+
             $group[$pathValue] = $value;
         }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -623,7 +623,7 @@ trait CollectionTrait
                 if ($mapKey instanceof BackedEnum) {
                     $mapKey = $mapKey->value;
                 } elseif ($mapKey instanceof UnitEnum) {
-                    throw new InvalidArgumentException('Cannot index by path that is a non-backed enum.');
+                    $mapKey = $mapKey->name;
                 }
 
                 $mapReduce->emit($rowVal($value, $key), $mapKey);

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -770,6 +770,7 @@ class CollectionTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot group by path that does not exist or contains a null value.');
+
         $collection->groupBy('missing');
     }
 
@@ -830,6 +831,50 @@ class CollectionTest extends TestCase
     }
 
     /**
+     * Tests indexBy with an enum
+     */
+    public function testIndexByEnum(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
+            ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
+        ];
+        $collection = new Collection($items);
+        $grouped = $collection->indexBy(function ($element) {
+            return $element['id'];
+        });
+        $expected = [
+            1 => ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
+            3 => ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
+            2 => ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+        ];
+        $this->assertEquals($expected, iterator_to_array($grouped));
+    }
+
+    /**
+     * Tests indexBy with a backed enum
+     */
+    public function testIndexByBackedEnum(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
+            ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+            ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
+        ];
+        $collection = new Collection($items);
+        $grouped = $collection->indexBy(function ($element) {
+            return $element['id'];
+        });
+        $expected = [
+            1 => ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
+            3 => ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
+            2 => ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+        ];
+        $this->assertEquals($expected, iterator_to_array($grouped));
+    }
+
+    /**
      * Tests indexBy with a deep property
      */
     public function testIndexByDeep(): void
@@ -862,6 +907,7 @@ class CollectionTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
+
         $collection->indexBy('missing');
     }
 
@@ -879,6 +925,7 @@ class CollectionTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
+
         $collection->indexBy(function ($e) {
             return null;
         });
@@ -1345,6 +1392,7 @@ class CollectionTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
+
         (new Collection($items))->combine('id', 'name');
     }
 
@@ -1358,6 +1406,7 @@ class CollectionTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot group by path that does not exist or contains a null value');
+
         (new Collection($items))->combine('id', 'name', 'parent');
     }
 
@@ -1371,6 +1420,7 @@ class CollectionTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Cannot index by path that does not exist or contains a null value');
+
         (new Collection($items))->combine('id', 'name', 'parent');
     }
 
@@ -2274,8 +2324,10 @@ class CollectionTest extends TestCase
     public function testLastNtWithNegative($data): void
     {
         $collection = new Collection($data);
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The takeLast method requires a number greater than 0.');
+
         $collection->takeLast(-1)->toArray();
     }
 
@@ -2628,6 +2680,7 @@ class CollectionTest extends TestCase
     public function testCartesianProductMultidimensionalArray(): void
     {
         $this->expectException(LogicException::class);
+
         $collection = new Collection([
             [
                 'names' => [
@@ -2670,6 +2723,7 @@ class CollectionTest extends TestCase
     public function testTransposeUnEvenLengthShouldThrowException(): void
     {
         $this->expectException(LogicException::class);
+
         $collection = new Collection([
             ['Products', '2012', '2013', '2014'],
             ['Product A', '200', '100', '50'],

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -36,6 +36,7 @@ use TestApp\Collection\CountableIterator;
 use TestApp\Collection\TestCollection;
 use TestApp\Model\Enum\ArticleStatus;
 use TestApp\Model\Enum\NonBacked;
+use TestApp\Model\Enum\Priority;
 use function Cake\Collection\collection;
 
 /**
@@ -702,6 +703,30 @@ class CollectionTest extends TestCase
             ],
             11 => [
                 ['id' => 2, 'name' => 'bar', 'thing' => ['parent_id' => 11]],
+            ],
+        ];
+        $this->assertEquals($expected, iterator_to_array($grouped));
+    }
+
+    /**
+     * Tests grouping by a enum key
+     */
+    public function testGroupByEnum(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
+            ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+            ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
+        ];
+        $collection = new Collection($items);
+        $grouped = $collection->groupBy('thing');
+        $expected = [
+            Priority::Medium->value => [
+                ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
+                ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
+            ],
+            Priority::High->value => [
+                ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
             ],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -838,16 +838,14 @@ class CollectionTest extends TestCase
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
             ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
-            ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
         ];
         $collection = new Collection($items);
         $grouped = $collection->indexBy(function ($element) {
-            return $element['id'];
+            return $element['thing'];
         });
         $expected = [
-            1 => ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
-            3 => ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
-            2 => ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            NonBacked::Basic->name => ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
+            NonBacked::Advanced->name => ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
     }
@@ -860,16 +858,14 @@ class CollectionTest extends TestCase
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
             ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
-            ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
         ];
         $collection = new Collection($items);
         $grouped = $collection->indexBy(function ($element) {
-            return $element['id'];
+            return $element['thing'];
         });
         $expected = [
-            1 => ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
-            3 => ['id' => 3, 'name' => 'baz', 'thing' => Priority::Medium],
-            2 => ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
+            Priority::Medium->value => ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],
+            Priority::High->value => ['id' => 2, 'name' => 'bar', 'thing' => Priority::High],
         ];
         $this->assertEquals($expected, iterator_to_array($grouped));
     }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -709,9 +709,33 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * Tests grouping by a enum key
+     * Tests grouping by an enum key
      */
     public function testGroupByEnum(): void
+    {
+        $items = [
+            ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
+            ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
+        ];
+        $collection = new Collection($items);
+        $grouped = $collection->groupBy('thing');
+        $expected = [
+            NonBacked::Basic->name => [
+                ['id' => 1, 'name' => 'foo', 'thing' => NonBacked::Basic],
+                ['id' => 3, 'name' => 'baz', 'thing' => NonBacked::Basic],
+            ],
+            NonBacked::Advanced->name => [
+                ['id' => 2, 'name' => 'bar', 'thing' => NonBacked::Advanced],
+            ],
+        ];
+        $this->assertEquals($expected, iterator_to_array($grouped));
+    }
+
+    /**
+     * Tests grouping by a backed enum key
+     */
+    public function testGroupByBackedEnum(): void
     {
         $items = [
             ['id' => 1, 'name' => 'foo', 'thing' => Priority::Medium],

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1328,12 +1328,11 @@ class CollectionTest extends TestCase
 
     public function testCombineWithNonBackedEnum(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot index by path that is a non-backed enum.');
-        (new Collection([
+        $collection = (new Collection([
             ['amount' => 10, 'type' => NonBacked::Basic],
-            ['amount' => 2, 'type' => NonBacked::Basic],
+            ['amount' => 2, 'type' => NonBacked::Advanced],
         ]))->combine('type', 'amount');
+        $this->assertEquals(['Basic' => 10, 'Advanced' => 2], $collection->toArray());
     }
 
     public function testCombineNullKey(): void

--- a/tests/test_app/TestApp/Model/Enum/NonBacked.php
+++ b/tests/test_app/TestApp/Model/Enum/NonBacked.php
@@ -17,4 +17,5 @@ namespace TestApp\Model\Enum;
 enum NonBacked
 {
     case Basic;
+    case Advanced;
 }


### PR DESCRIPTION
as per question in the support chat

Other enum support went into 5.x, but we could also do 5.next here.
Since this wasnt functioning so far, I dont see the harm here for 5.x though.

Also combine() seems to work fine with non backed, I dont see why the exception is needed here.

Finally, indexBy() also seems to be fine with the support added.

Completes https://github.com/cakephp/cakephp/pull/17528