### PR TITLE
Fix up better exceptions for CLI prod

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Console;
 
+use Cake\Console\Exception\ConsoleException;
+
 /**
  * Provides an interface for interacting with
  * a command's options and arguments.
@@ -145,6 +147,13 @@ class Arguments
     public function getOption(string $name): string|bool|null
     {
         $value = $this->options[$name] ?? null;
+        if (is_array($value)) {
+            throw new ConsoleException(sprintf(
+                'Cannot get multiple values for option `%s`, use `getMultipleOption()` instead.',
+                $name
+            ));
+        }
+
         assert($value === null || is_string($value) || is_bool($value));
 
         return $value;
@@ -158,7 +167,12 @@ class Arguments
     public function getBooleanOption(string $name): ?bool
     {
         $value = $this->options[$name] ?? null;
-        assert($value === null || is_bool($value));
+        if ($value !== null && !is_bool($value)) {
+            throw new ConsoleException(sprintf(
+                'Option `%s` is not of type `bool`, use `getOption()` instead.',
+                $name
+            ));
+        }
 
         return $value;
     }
@@ -171,7 +185,12 @@ class Arguments
     public function getMultipleOption(string $name): ?array
     {
         $value = $this->options[$name] ?? null;
-        assert($value === null || is_array($value));
+        if ($value !== null && !is_array($value)) {
+            throw new ConsoleException(sprintf(
+                'Option `%s` is not of type `array`, use `getOption()` instead.',
+                $name
+            ));
+        }
 
         return $value;
     }


### PR DESCRIPTION
assert() can easily be deactivated on systems, especially on prod.
And CLI commands are also still executed on prod systems.

So using assert() here seems like an anti pattern for critical feedback and should never be used as such IMO.
The following fixes make sure that the developer as well as user gets proper feedback on what is wrong instead of a fatal type error without info on what is going on.

We are over using asserts a bit it seems, but in other places, it is often just theoretical or definitely bound to local system development, whereas here it can be a critical issue people very easily can run into on prod systems, if the local system hasnt been fully covered with unit tests.