### PR TITLE
Allow reading Mysql int length from comment metadata

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -119,7 +119,7 @@ class MysqlSchemaDialect extends SchemaDialect
         if ($length === null && $comment && str_starts_with($comment, '[schema]')) {
             $lengthDefinitionString = trim(mb_substr($comment, strpos($comment, '[schema]') + 8));
             if (str_contains($lengthDefinitionString, ';')) {
-                $separatorPos = strpos($lengthDefinitionString, ';');
+                $separatorPos = (int)strpos($lengthDefinitionString, ';');
                 $lengthDefinitionString = trim(mb_substr($lengthDefinitionString, 0, $separatorPos));
             }
 


### PR DESCRIPTION
This resolves the problematic Mysql upgrade from v5 to v8 in regards to ints.
All int types lose the length which so far was an important part of metadata.
See https://github.com/cakephp/migrations/issues/502

It is used for input validation on forms (maxlength) as well as for presentation/precision/scale based on that length.

This resolves it in a similar way we did for [baked enums](https://github.com/cakephp/bake/compare/3.0.6...3.1.0#diff-b2a7f0a392cef7628e2952ea340e286e957a809321cbe9cb98047925b2e83e8bR1483-R1492).
It reads the comment for length metadata and adds it if it is null.

tinyint(2) aka "enum" before in v5 is now tinyint with v8 and comment
```
[schema] length:2
```
and same behavior as before.

int(10) before in v5 is now int with v8 and comment
```
[schema] length:10
```
and same behavior as before.

Meta comment needs to be at the beginning, but it can have other non-relevant text afterwards, e.g.

```
[schema] length:2; This is sth important
```
