### PR TITLE
Fix a potentially leaking file descriptor

### DIFF
--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -68,7 +68,6 @@ class ConsoleInput
         /** @psalm-suppress RedundantCondition */
         if (is_resource($this->_input)) {
             fclose($this->_input);
-            unset($this->_input);
         }
         unset($this->_input);
     }

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -59,6 +59,21 @@ class ConsoleInput
     }
 
     /**
+     * Destruct and free resources
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        /** @psalm-suppress RedundantCondition */
+        if (is_resource($this->_input)) {
+            fclose($this->_input);
+            unset($this->_input);
+        }
+        unset($this->_input);
+    }
+
+    /**
      * Read a value from the stream
      *
      * @return string|null The value of the stream. Null on EOF.

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -371,7 +371,7 @@ class ConsoleOutput
         /** @psalm-suppress RedundantCondition */
         if (is_resource($this->_output)) {
             fclose($this->_output);
-            unset($this->_output);
         }
+        unset($this->_output);
     }
 }

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -371,6 +371,7 @@ class ConsoleOutput
         /** @psalm-suppress RedundantCondition */
         if (is_resource($this->_output)) {
             fclose($this->_output);
+            unset($this->_output);
         }
     }
 }

--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -49,6 +49,7 @@ class StubConsoleInput extends ConsoleInput
     {
         parent::__construct();
 
+        unset($this->_input);
         $this->replies = $replies;
     }
 


### PR DESCRIPTION
Calling parent opens a file handle to `php://stdin`. This will leak if not directly unset. I found this while working on migrations.
