### PR TITLE
Fix #17604 problem formatting milliseconds using i18nFormat in 4.x

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -262,7 +262,7 @@ trait DateFormatTrait
             static::$_formatters[$key] = $formatter;
         }
 
-        return static::$_formatters[$key]->format($date->format('U'));
+        return static::$_formatters[$key]->format($date->format('U.u'));
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -262,7 +262,7 @@ trait DateFormatTrait
             static::$_formatters[$key] = $formatter;
         }
 
-        return static::$_formatters[$key]->format($date->format('U.u'));
+        return static::$_formatters[$key]->format($date);
     }
 
     /**

--- a/tests/TestCase/I18n/TimeTest.php
+++ b/tests/TestCase/I18n/TimeTest.php
@@ -463,6 +463,12 @@ class TimeTest extends TestCase
         $result = $time->i18nFormat(IntlDateFormatter::FULL, 'Asia/Tokyo', 'ja-JP@calendar=japanese');
         $expected = '平成22年1月14日木曜日 22時59分28秒 日本標準時';
         $this->assertTimeFormat($expected, $result);
+
+        // Test with milliseconds
+        $timeMillis = new FrozenTime('2014-07-06T13:09:01.523000+00:00');
+        $result = $timeMillis->i18nFormat("yyyy-MM-dd'T'HH':'mm':'ss.SSSxxx", null, 'en-US');
+        $expected = '2014-07-06T13:09:01.523+00:00';
+        $this->assertSame($expected, $result);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/17604 in branch 4.x