### PR TITLE
Fix #17604 problem formatting milliseconds using i18nFormat in 5.x

### DIFF
--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -101,7 +101,7 @@ trait DateFormatTrait
             static::$formatters[$key] = $formatter;
         }
 
-        return (string)static::$formatters[$key]->format($date->format('U.u'));
+        return (string)static::$formatters[$key]->format($date);
     }
 
     /**

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -101,7 +101,7 @@ trait DateFormatTrait
             static::$formatters[$key] = $formatter;
         }
 
-        return (string)static::$formatters[$key]->format($date->format('U'));
+        return (string)static::$formatters[$key]->format($date->format('U.u'));
     }
 
     /**

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -412,6 +412,12 @@ class DateTimeTest extends TestCase
         $result = $time->i18nFormat(IntlDateFormatter::FULL, 'Asia/Tokyo', 'ja-JP@calendar=japanese');
         $expected = '平成22年1月14日木曜日 22時59分28秒 日本標準時';
         $this->assertTimeFormat($expected, $result);
+
+        // Test with milliseconds
+        $timeMillis = new FrozenTime('2014-07-06T13:09:01.523000+00:00');
+        $result = $timeMillis->i18nFormat("yyyy-MM-dd'T'HH':'mm':'ss.SSSxxx", null, 'en-US');
+        $expected = '2014-07-06T13:09:01.523+00:00';
+        $this->assertSame($expected, $result);
     }
 
     /**

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -414,7 +414,7 @@ class DateTimeTest extends TestCase
         $this->assertTimeFormat($expected, $result);
 
         // Test with milliseconds
-        $timeMillis = new FrozenTime('2014-07-06T13:09:01.523000+00:00');
+        $timeMillis = new DateTime('2014-07-06T13:09:01.523000+00:00');
         $result = $timeMillis->i18nFormat("yyyy-MM-dd'T'HH':'mm':'ss.SSSxxx", null, 'en-US');
         $expected = '2014-07-06T13:09:01.523+00:00';
         $this->assertSame($expected, $result);


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/17604 in branch 5.x relates to https://github.com/cakephp/cakephp/pull/17605