### PR TITLE
5.x: fix undefined property warning

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Collection/Iterator/NoChildrenIterator.php
 
 		-
+			message: "#^Property Cake\\\\Console\\\\ConsoleInput\\:\\:\\$_input \\(resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: src/Console/ConsoleInput.php
+
+		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2
 			path: src/Console/ConsoleOptionParser.php

--- a/src/Console/ConsoleInput.php
+++ b/src/Console/ConsoleInput.php
@@ -66,7 +66,7 @@ class ConsoleInput
     public function __destruct()
     {
         /** @psalm-suppress RedundantCondition */
-        if (is_resource($this->_input)) {
+        if (isset($this->_input) && is_resource($this->_input)) {
             fclose($this->_input);
         }
         unset($this->_input);


### PR DESCRIPTION
it seems the change in #17600 caused the following warning to pop up

```
warning: 2 :: Undefined property: Cake\Console\TestSuite\StubConsoleInput::$_input on line 69 of /myapp/vendor/cakephp/cakephp/src/Console/ConsoleInput.php
```

as the `_input` could not be initialized for some reason (haven't really tracked down what calls the destructor here)

In the end this removes the warning.