### PR TITLE
Add test for int backed in Form control().

### DIFF
--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -42,6 +42,7 @@ use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
 use TestApp\Model\Enum\ArticleStatusLabel;
 use TestApp\Model\Enum\ArticleStatusLabelInterface;
+use TestApp\Model\Enum\Priority;
 use TestApp\Model\Table\ContactsTable;
 use TestApp\Model\Table\ValidateUsersTable;
 use TestApp\View\Form\StubContext;
@@ -3678,20 +3679,36 @@ class FormHelperTest extends TestCase
             EnumType::from(ArticleStatusLabelInterface::class)
         );
 
-        $article = $articlesTable->newEmptyEntity();
-        $this->Form->create($article);
+        $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published');
+        $this->assertHtml($expected, $result);
+
+        $articlePriosTable = $this->getTableLocator()->get('ArticlePrios');
+        $articlePriosTable->getSchema()->setColumnType(
+            'priority',
+            EnumType::from(Priority::class)
+        );
+
+        $this->Form->create($articlePriosTable->newEmptyEntity());
+        // Select empty by default
+        $result = $this->Form->control('priority', ['empty' => ['' => ' - please select - '], 'default' => '']);
         $expected = [
             'div' => ['class' => 'input select'],
-            'label' => ['for' => 'published'],
-            'Published',
+            'label' => ['for' => 'priority'],
+            'Priority',
             '/label',
-            'select' => ['name' => 'published', 'id' => 'published'],
-            ['option' => ['value' => 'Y']],
-            'Is Published',
+            'select' => ['name' => 'priority', 'id' => 'priority'],
+            ['option' => ['value' => '', 'selected' => 'selected']],
+            ' - please select - ',
             '/option',
-            ['option' => ['value' => 'N', 'selected' => 'selected']],
-            'Is Unpublished',
+            ['option' => ['value' => '1']],
+            'Is Low',
+            '/option',
+            ['option' => ['value' => '2']],
+            'Is Medium',
+            '/option',
+            ['option' => ['value' => '3']],
+            'Is High',
             '/option',
             '/select',
             '/div',

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -487,6 +487,26 @@ return [
             ],
         ],
     ],
+    'article_prios' => [
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+            'priority' => [
+                'type' => 'integer',
+                'length' => 2,
+                'default' => 2, // Medium
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id',
+                ],
+            ],
+        ],
+    ],
     'articles_translations' => [
         'columns' => [
             'id' => [

--- a/tests/test_app/TestApp/Model/Enum/Priority.php
+++ b/tests/test_app/TestApp/Model/Enum/Priority.php
@@ -14,9 +14,20 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Enum;
 
-enum Priority: int
+use Cake\Database\Type\EnumLabelInterface;
+use Cake\Utility\Inflector;
+
+enum Priority: int implements EnumLabelInterface
 {
     case Low = 1;
     case Medium = 2;
     case High = 3;
+
+    /**
+     * @return string
+     */
+    public function label(): string
+    {
+        return 'Is ' . Inflector::humanize(Inflector::underscore($this->name));
+    }
 }


### PR DESCRIPTION
Shows that defaulting to empty option works even if DB column has a value set - as long as manual empty string is set as default.