### PR TITLE
Skip adding security tokens to GET requests in IntegrationTests

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -643,7 +643,9 @@ trait IntegrationTestTrait
         ) {
             $props['input'] = http_build_query($data);
         } else {
-            $data = $this->_addTokens($tokenUrl, $data);
+            if ($method !== 'GET' || !empty($data)) {
+                $data = $this->_addTokens($tokenUrl, $data);
+            }
             $props['post'] = $this->_castToString($data);
         }
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -233,6 +233,28 @@ class IntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * Test for issue #17612 - skip adding tokens for GET without data.
+     */
+    public function testAddTokenInGetRequest(): void
+    {
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+        $requestWithoutTokens = $this->_buildRequest('tasks/view', 'GET');
+
+        $this->assertArrayNotHasKey('_Token', $requestWithoutTokens['post']);
+        $this->assertArrayNotHasKey('_csrfToken', $requestWithoutTokens['post']);
+        $this->assertArrayNotHasKey('csrfToken', $requestWithoutTokens['cookies']);
+
+        $this->enableCsrfToken();
+        $this->enableSecurityToken();
+        $requestWithTokens = $this->_buildRequest('tasks/view', 'GET', ['lorem' => 'ipsum']);
+
+        $this->assertArrayHasKey('_Token', $requestWithTokens['post']);
+        $this->assertArrayHasKey('_csrfToken', $requestWithTokens['post']);
+        $this->assertArrayHasKey('csrfToken', $requestWithTokens['cookies']);
+    }
+
+    /**
      * Test building a request, with query parameters
      */
     public function testRequestBuildingQueryParameters(): void


### PR DESCRIPTION
Described in #17612