### PR TITLE
Add logging to error rendering failures

### DIFF
--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -162,7 +162,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             $request = $request->withAttribute('params', $routerRequest->getAttribute('params'));
         }
 
-        $class = "";
+        $class = '';
         try {
             $params = $request->getAttribute('params');
             $params['controller'] = 'Error';

--- a/templates/Error/missing_controller.php
+++ b/templates/Error/missing_controller.php
@@ -22,6 +22,7 @@ $pluginDot = empty($plugin) ? null : $plugin . '.';
 $namespace = Configure::read('App.namespace');
 $prefixNs = $prefixPath = '';
 
+$controller = (string)$controller;
 $incompleteInflection = (str_contains($controller, '_') || str_contains($controller, '-'));
 $originalClass = $controller;
 

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -260,7 +260,8 @@ class ExceptionTrapTest extends TestCase
         ob_get_clean();
 
         $logs = Log::engine('test_error')->read();
-        $this->assertEmpty($logs);
+        $this->assertCount(1, $logs);
+        $this->assertStringContainsString('MissingTemplateException - Failed to render', $logs[0]);
         $this->assertTrue($this->triggered, 'Should have triggered event when skipping logging.');
     }
 

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -318,7 +318,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $request = ServerRequestFactory::fromGlobals();
         $middleware = new ErrorHandlerMiddleware(['log' => true]);
         $handler = new TestRequestHandler(function (): void {
-            throw new MissingControllerException(['class' => 'Articles']);
+            throw new MissingControllerException(['controller' => 'Articles']);
         });
         $result = $middleware->process($request, $handler);
         $this->assertSame(404, $result->getStatusCode());
@@ -329,7 +329,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             $logs[0]
         );
         $this->assertStringContainsString('Exception Attributes:', $logs[0]);
-        $this->assertStringContainsString("'class' => 'Articles'", $logs[0]);
+        $this->assertStringContainsString("'controller' => 'Articles'", $logs[0]);
         $this->assertStringContainsString('Request URL:', $logs[0]);
     }
 


### PR DESCRIPTION
When error rendering fails it can be tedious to diagnose what the problem is. Having some logging when rendering fails could help triage the problem and get to a solution quicker.

Refs #17603
