### PR TITLE
Fix up notice on CLI.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,7 +16,7 @@ parameters:
 			path: src/Console/ConsoleInput.php
 		-
 			message: "#^Property Cake\\\\Console\\\\ConsoleOutput\\:\\:\\$_output \\(resource\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
+			count: 2
 			path: src/Console/ConsoleOutput.php
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14,7 +14,10 @@ parameters:
 			message: "#^Property Cake\\\\Console\\\\ConsoleInput\\:\\:\\$_input \\(resource\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: src/Console/ConsoleInput.php
-
+		-
+			message: "#^Property Cake\\\\Console\\\\ConsoleOutput\\:\\:\\$_output \\(resource\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: src/Console/ConsoleOutput.php
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 2

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -373,7 +373,7 @@ class ConsoleOutput
     public function __destruct()
     {
         /** @psalm-suppress RedundantCondition */
-        if (is_resource($this->_output)) {
+        if (isset($this->_output) && is_resource($this->_output)) {
             fclose($this->_output);
         }
         unset($this->_output);

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -283,6 +283,10 @@ class ConsoleOutput
      */
     protected function _write(string $message): int
     {
+        if (!isset($this->_output)) {
+            return 0;
+        }
+
         return (int)fwrite($this->_output, $message);
     }
 


### PR DESCRIPTION
Recent changes in CLI and resulting issues seem to be not fully resolved yet
Refs https://github.com/cakephp/cakephp/pull/17609

When running dd() in the code somewhere, it throws this after dd output:
```
Warning: Undefined property: Cake\Console\ConsoleOutput::$_output in 
/shared/httpd/app/vendor/cakephp/cakephp/src/Console/ConsoleOutput.php on line 288

Fatal error: Uncaught TypeError: fwrite(): Argument #1 ($stream) must be of type resource, null given in 
/shared/httpd/app/vendor/cakephp/cakephp/src/Console/ConsoleOutput.php:288
```

This fixes it. 

PHP 8.2
