### PR TITLE
Reverse connection aliasing logic to restore previous behavior

### DIFF
--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -52,7 +52,7 @@ class ConnectionHelper
                 ConnectionManager::alias($connection, $original);
             } else {
                 $test = 'test_' . $connection;
-                ConnectionManager::alias($connection, $test);
+                ConnectionManager::alias($test, $connection);
             }
         }
     }

--- a/tests/TestCase/TestSuite/ConnectionHelperTest.php
+++ b/tests/TestCase/TestSuite/ConnectionHelperTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Database\Connection;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\Exception\MissingDatasourceConfigException;
 use Cake\TestSuite\ConnectionHelper;
 use Cake\TestSuite\TestCase;
 use TestApp\Database\Driver\TestDriver;
@@ -25,7 +26,12 @@ class ConnectionHelperTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         ConnectionManager::drop('query_logging');
+        ConnectionManager::drop('something');
+        ConnectionManager::drop('test_something');
+        ConnectionManager::dropAlias('something');
     }
 
     public function testAliasConnections(): void
@@ -43,14 +49,45 @@ class ConnectionHelperTest extends TestCase
     public function testAliasNonDefaultConnections(): void
     {
         $connection = new Connection(['driver' => TestDriver::class]);
-        ConnectionManager::setConfig('something', $connection);
+        ConnectionManager::setConfig('test_something', $connection);
 
         (new ConnectionHelper())->addTestAliases();
 
+        // Having a test_ alias defined will generate an alias for the unprefixed
+        // connection for simpler CI configuration
         $this->assertSame(
             ConnectionManager::get('test_something'),
             ConnectionManager::get('something')
         );
+    }
+
+    public function testAliasNoTestClass(): void
+    {
+        $connection = new Connection(['driver' => TestDriver::class]);
+        ConnectionManager::setConfig('something', $connection);
+
+        (new ConnectionHelper())->addTestAliases();
+
+        // Should raise as no test connection was defined.
+        $this->expectException(MissingDatasourceConfigException::class);
+        ConnectionManager::get('test_something');
+    }
+
+    public function testAliasNonDefaultConnectionWithTestConnection(): void
+    {
+        $testConnection = new Connection(['driver' => TestDriver::class]);
+        $connection = new Connection(['driver' => TestDriver::class]);
+        ConnectionManager::setConfig('something', $connection);
+        ConnectionManager::setConfig('test_something', $testConnection);
+
+        (new ConnectionHelper())->addTestAliases();
+
+        // Development connections that have test_ prefix connections defined
+        // should have an alias defined for the test_ prefixed name. This allows
+        // access to the development connection to resolve to the test prefixed name
+        // in tests.
+        $this->assertSame($testConnection, ConnectionManager::get('test_something'));
+        $this->assertSame($testConnection, ConnectionManager::get('something'));
     }
 
     public function testEnableQueryLogging(): void


### PR DESCRIPTION
In #17261 we reversed the connection aliasing behavior so that if you had both a test and non test connection defined, and used the `test_` prefixed names in fixtures your local development database would be truncated.

The logic historically was that the framework would require you to define test_ prefixed connections and aliases would be made from live -> test so that accessing the live connection would retrieve the test connections. Having test prefixed connection names resolve to the real connection makes it hard to maintain a persistent development environment.

Fixes #17619