### PR TITLE
Fix backed int validation for forms.

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -808,7 +808,16 @@ class Validation
         $backingType = null;
         try {
             $reflectionEnum = new ReflectionEnum($enumClassName);
-            $backingType = $reflectionEnum->getBackingType();
+
+            /** @var \ReflectionNamedType|\ReflectionUnionType|null $reflectionBackingType */
+            $reflectionBackingType = $reflectionEnum->getBackingType();
+            if ($reflectionBackingType) {
+                if (method_exists($reflectionBackingType, 'getName')) {
+                    $backingType = $reflectionBackingType->getName();
+                } else {
+                    $backingType = (string)$reflectionBackingType;
+                }
+            }
         } catch (ReflectionException) {
         }
 
@@ -816,6 +825,13 @@ class Validation
             throw new InvalidArgumentException(
                 'The `$enumClassName` argument must be the classname of a valid backed enum.'
             );
+        }
+
+        if ($backingType === 'int') {
+            if (!is_numeric($check)) {
+                return false;
+            }
+            $check = (int)$check;
         }
 
         if (get_debug_type($check) !== (string)$backingType) {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2022,6 +2022,9 @@ class ValidationTest extends TestCase
         $this->assertFalse(Validation::enum(ArticleStatus::Published, Priority::class));
         $this->assertFalse(Validation::enum('wrong type', Priority::class));
         $this->assertFalse(Validation::enum(123, Priority::class));
+
+        $this->assertTrue(Validation::enum('1', Priority::class));
+        $this->assertFalse(Validation::enum('a1', Priority::class));
     }
 
     public function testEnumNonBacked(): void


### PR DESCRIPTION
While working on 5.next and https://github.com/cakephp/cakephp/pull/17632 and building a sandbox example for different enum validations, I noticed that there is a bug in our current 5.x enum validation.

So this needs to be fixed first here for int backed to work when coming from form input, and thus being strings of ints.

Two things:
- (string) cast of reflection type is apparently deprecated, and the ->getName() should be used moving forward.
But only for one of the possible types - I used the fallback for now ( see https://www.php.net/manual/en/class.reflectiontype.php )
- the int case is now happening for numeric input, making a match possible.

Test cases added, should be all good now.