### PR TITLE
Cleanup static application state before executing each integration test.

### DIFF
--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\TestSuite;
 
 use Cake\Core\HttpApplicationInterface;
+use Cake\Core\Plugin;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Http\FlashMessage;
 use Cake\Http\Server;
@@ -91,6 +92,7 @@ class MiddlewareDispatcher
 
         $out = Router::url($url);
         Router::resetRoutes();
+        Plugin::getCollection()->clear();
 
         return $out;
     }
@@ -136,6 +138,9 @@ class MiddlewareDispatcher
      */
     public function execute(array $requestSpec): ResponseInterface
     {
+        Router::resetRoutes();
+        Plugin::getCollection()->clear();
+
         $server = new Server($this->app);
 
         return $server->run($this->_createRequest($requestSpec));


### PR DESCRIPTION
Running the application bootstrapping multiple times causes issues like plugins being added to the statically maintained plugin collection multiple times causing exceptions.

Refs #17628

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
