### PR TITLE
Console Commands: Add default value for arguments

### DIFF
--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -56,9 +56,9 @@ class ConsoleInputArgument
     protected $_choices;
 
     /**
-     * Default value for this argument.
+     * Default value for the argument.
      *
-     * @var mixed
+     * @var string|null
      */
     protected $_default;
 
@@ -69,8 +69,9 @@ class ConsoleInputArgument
      * @param string $help The help text for this option
      * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
      * @param array<string> $choices Valid choices for this option.
+     * @param string|null $default The default value for this argument.
      */
-    public function __construct($name, $help = '', $required = false, $choices = [])
+    public function __construct($name, $help = '', $required = false, $choices = [], $default = null)
     {
         if (is_array($name) && isset($name['name'])) {
             foreach ($name as $key => $value) {
@@ -82,6 +83,7 @@ class ConsoleInputArgument
             $this->_help = $help;
             $this->_required = $required;
             $this->_choices = $choices;
+            $this->_default = $default;
         }
     }
 
@@ -126,6 +128,9 @@ class ConsoleInputArgument
         if ($this->_choices) {
             $optional .= sprintf(' <comment>(choices: %s)</comment>', implode('|', $this->_choices));
         }
+        if ($this->_default !== null) {
+            $optional .= sprintf(' <comment>default: "%s"</comment>', $this->_default);
+        }
 
         return sprintf('%s%s%s', $name, $this->_help, $optional);
     }
@@ -147,6 +152,16 @@ class ConsoleInputArgument
         }
 
         return $name;
+    }
+
+    /**
+     * Get the default value for this argument
+     *
+     * @return string|null
+     */
+    public function defaultValue()
+    {
+        return $this->_default;
     }
 
     /**
@@ -201,6 +216,7 @@ class ConsoleInputArgument
         foreach ($this->_choices as $valid) {
             $choices->addChild('choice', $valid);
         }
+        $option->addAttribute('default', $this->_default);
 
         return $parent;
     }

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -56,6 +56,13 @@ class ConsoleInputArgument
     protected $_choices;
 
     /**
+     * Default value for this argument.
+     *
+     * @var mixed
+     */
+    protected $_default;
+
+    /**
      * Make a new Input Argument
      *
      * @param array<string, mixed>|string $name The long name of the option, or an array with all the properties.

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -216,7 +216,9 @@ class ConsoleInputArgument
         foreach ($this->_choices as $valid) {
             $choices->addChild('choice', $valid);
         }
-        $option->addAttribute('default', $this->_default);
+        if ($this->_default !== null) {
+            $option->addAttribute('default', $this->_default);
+        }
 
         return $parent;
     }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -725,10 +725,15 @@ class ConsoleOptionParser
         }
 
         foreach ($this->_args as $i => $arg) {
-            if ($arg->isRequired() && !isset($args[$i])) {
-                throw new ConsoleException(
-                    sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
-                );
+            if (!isset($args[$i])) {
+                if ($arg->isRequired()) {
+                    throw new ConsoleException(
+                        sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
+                    );
+                }
+                if ($arg->defaultValue() !== null) {
+                    $args[$i] = $arg->defaultValue();
+                }
             }
         }
         foreach ($this->_options as $option) {

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -1218,7 +1218,7 @@ TEXT;
         $spec = [
             'command' => 'test',
             'arguments' => [
-                'name' => ['help' => 'The name'],
+                'name' => ['help' => 'The name', 'default' => 'foo'],
                 'other' => ['help' => 'The other arg'],
             ],
             'options' => [

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -581,6 +581,18 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test positional argument parsing.
+     */
+    public function testAddArgumentWithDefault(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $result = $parser->addArgument('name', ['help' => 'An argument', 'default' => 'foo']);
+        $args = $parser->arguments();
+        $this->assertEquals($parser, $result, 'Should return this');
+        $this->assertEquals('foo', $args[0]->defaultValue());
+    }
+
+    /**
      * Add arguments that were once considered the same
      */
     public function testAddArgumentDuplicate(): void
@@ -711,6 +723,21 @@ class ConsoleOptionParserTest extends TestCase
         $this->assertEquals($expected, $result[1], 'Got the correct value.');
 
         $result = $parser->parse(['jose', 'coder'], $this->io);
+    }
+
+    /**
+     * test argument with default value.
+     */
+    public function testPositionalArgumentWithDefault(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $result = $parser->addArgument('name', ['help' => 'An argument', 'default' => 'foo']);
+
+        $result = $parser->parse(['bar'], $this->io);
+        $this->assertEquals(['bar'], $result[1], 'Got the correct value.');
+
+        $result = $parser->parse([], $this->io);
+        $this->assertEquals(['foo'], $result[1], 'Got the correct default value.');
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -957,7 +957,7 @@ TEXT;
         ])->addOption('connection', [
             'help' => 'Db connection.',
             'short' => 'c',
-        ])->addArgument('name', ['required' => false]);
+        ])->addArgument('name', ['required' => false, 'default' => 'foo']);
 
         $result = $parser->help('build');
         $expected = <<<TEXT
@@ -975,7 +975,7 @@ cake mycommand build [-c] [-h] [-q] [-v] [<name>]
 
 <info>Arguments:</info>
 
-name   <comment>(optional)</comment>
+name   <comment>(optional)</comment> <comment>default: "foo"</comment>
 
 TEXT;
         $this->assertTextEquals($expected, $result, 'Help is not correct.');

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -310,7 +310,7 @@ xml;
                 'choices' => ['aco', 'aro'],
                 'required' => true,
             ])
-            ->addArgument('other_longer', ['help' => 'Another argument.']);
+            ->addArgument('other_longer', ['help' => 'Another argument.', 'default' => 'foo']);
 
         $formatter = new HelpFormatter($parser);
         $result = $formatter->xml();
@@ -340,7 +340,7 @@ xml;
 			<choice>aro</choice>
 		</choices>
 	</argument>
-	<argument name="other_longer" help="Another argument." required="0">
+	<argument name="other_longer" help="Another argument." required="0" default="foo">
 		<choices></choices>
 	</argument>
 </arguments>


### PR DESCRIPTION
Notice: Creation of dynamic property Cake\Console\ConsoleInputArgument::$_default is deprecated
