### PR TITLE
Console Commands: Add default value for arguments

### DIFF
--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -58,7 +58,7 @@ class ConsoleInputArgument
     /**
      * Default value for this argument.
      *
-     * @var string|bool|null
+     * @var string|null
      */
     protected ?string $_default = null;
 
@@ -69,10 +69,15 @@ class ConsoleInputArgument
      * @param string $help The help text for this option
      * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
      * @param list<string> $choices Valid choices for this option.
-     * @param string|bool|null $default The default value for this argument.
+     * @param string|null $default The default value for this argument.
      */
-    public function __construct(array|string $name, string $help = '', bool $required = false, array $choices = [], ?string $default = null)
-    {
+    public function __construct(
+        array|string $name,
+        string $help = '',
+        bool $required = false,
+        array $choices = [],
+        ?string $default = null
+    ) {
         if (is_array($name) && isset($name['name'])) {
             foreach ($name as $key => $value) {
                 $this->{'_' . $key} = $value;

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -216,7 +216,9 @@ class ConsoleInputArgument
         foreach ($this->_choices as $valid) {
             $choices->addChild('choice', $valid);
         }
-        $option->addAttribute('default', $this->_default);
+        if ($this->_default !== null) {
+            $option->addAttribute('default', $this->_default);
+        }
 
         return $parent;
     }

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -56,14 +56,22 @@ class ConsoleInputArgument
     protected array $_choices;
 
     /**
+     * Default value for this argument.
+     *
+     * @var string|bool|null
+     */
+    protected ?string $_default = null;
+
+    /**
      * Make a new Input Argument
      *
      * @param array<string, mixed>|string $name The long name of the option, or an array with all the properties.
      * @param string $help The help text for this option
      * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
      * @param list<string> $choices Valid choices for this option.
+     * @param string|bool|null $default The default value for this argument.
      */
-    public function __construct(array|string $name, string $help = '', bool $required = false, array $choices = [])
+    public function __construct(array|string $name, string $help = '', bool $required = false, array $choices = [], ?string $default = null)
     {
         if (is_array($name) && isset($name['name'])) {
             foreach ($name as $key => $value) {
@@ -75,6 +83,7 @@ class ConsoleInputArgument
             $this->_help = $help;
             $this->_required = $required;
             $this->_choices = $choices;
+            $this->_default = $default;
         }
     }
 
@@ -119,6 +128,9 @@ class ConsoleInputArgument
         if ($this->_choices) {
             $optional .= sprintf(' <comment>(choices: %s)</comment>', implode('|', $this->_choices));
         }
+        if ($this->_default !== null) {
+            $optional .= sprintf(' <comment>default: "%s"</comment>', $this->_default);
+        }
 
         return sprintf('%s%s%s', $name, $this->_help, $optional);
     }
@@ -140,6 +152,16 @@ class ConsoleInputArgument
         }
 
         return $name;
+    }
+
+    /**
+     * Get the default value for this argument
+     *
+     * @return string|null
+     */
+    public function defaultValue(): ?string
+    {
+        return $this->_default;
     }
 
     /**
@@ -194,6 +216,7 @@ class ConsoleInputArgument
         foreach ($this->_choices as $valid) {
             $choices->addChild('choice', $valid);
         }
+        $option->addAttribute('default', $this->_default);
 
         return $parent;
     }

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -581,10 +581,15 @@ class ConsoleOptionParser
         }
 
         foreach ($this->_args as $i => $arg) {
-            if ($arg->isRequired() && !isset($args[$i])) {
-                throw new ConsoleException(
-                    sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
-                );
+            if (!isset($args[$i])) {
+                if ($arg->isRequired()) {
+                    throw new ConsoleException(
+                        sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
+                    );
+                }
+                if ($arg->defaultValue() !== null) {
+                    $args[$i] = $arg->defaultValue();
+                }
             }
         }
         foreach ($this->_options as $option) {

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -895,7 +895,7 @@ TEXT;
         $spec = [
             'command' => 'test',
             'arguments' => [
-                'name' => ['help' => 'The name'],
+                'name' => ['help' => 'The name', 'default' => 'foo'],
                 'other' => ['help' => 'The other arg'],
             ],
             'options' => [

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -607,7 +607,7 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
-     * test addOption with an object.
+     * test addArgument with an object.
      */
     public function testAddArgumentObject(): void
     {
@@ -616,6 +616,18 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->arguments();
         $this->assertCount(1, $result);
         $this->assertSame('test', $result[0]->name());
+    }
+
+    /**
+     * test addArgument with default value with an object.
+     */
+    public function testAddArgumentDefaultObject(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $parser->addArgument(new ConsoleInputArgument('test', '', false, [], 'foo'));
+        $result = $parser->arguments();
+        $this->assertCount(1, $result);
+        $this->assertSame('foo', $result[0]->defaultValue());
     }
 
     /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -580,6 +580,18 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test positional argument with default parsing.
+     */
+    public function testAddArgumentWithDefault(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $result = $parser->addArgument('name', ['help' => 'An argument', 'default' => 'foo']);
+        $args = $parser->arguments();
+        $this->assertEquals($parser, $result, 'Should return this');
+        $this->assertEquals('foo', $args[0]->defaultValue());
+    }
+
+    /**
      * Add arguments that were once considered the same
      */
     public function testAddArgumentDuplicate(): void
@@ -713,6 +725,21 @@ class ConsoleOptionParserTest extends TestCase
     }
 
     /**
+     * test argument with default value.
+     */
+    public function testPositionalArgumentWithDefault(): void
+    {
+        $parser = new ConsoleOptionParser('test', false);
+        $result = $parser->addArgument('name', ['help' => 'An argument', 'default' => 'foo']);
+
+        $result = $parser->parse(['bar'], $this->io);
+        $this->assertEquals(['bar'], $result[1], 'Got the correct value.');
+
+        $result = $parser->parse([], $this->io);
+        $this->assertEquals(['foo'], $result[1], 'Got the correct default value.');
+    }
+
+    /**
      * Test adding multiple arguments.
      */
     public function testAddArguments(): void
@@ -785,20 +812,26 @@ class ConsoleOptionParserTest extends TestCase
         $parser->setDescription('A command!')
             ->setRootName('tool')
             ->addOption('test', ['help' => 'A test option.'])
-            ->addOption('reqd', ['help' => 'A required option.', 'required' => true]);
+            ->addOption('reqd', ['help' => 'A required option.', 'required' => true])
+            ->addArgument('name', ['help' => 'An argument', 'default' => 'foo']);
 
         $result = $parser->help();
         $expected = <<<TEXT
 A command!
 
 <info>Usage:</info>
-tool sample [-h] --reqd [--test]
+tool sample [-h] --reqd [--test] [<name>]
 
 <info>Options:</info>
 
 --help, -h  Display this help.
 --reqd      A required option. <comment>(required)</comment>
 --test      A test option.
+
+<info>Arguments:</info>
+
+name  An argument <comment>(optional)</comment> <comment>default:
+      "foo"</comment>
 
 TEXT;
         $this->assertTextEquals($expected, $result, 'Help is not correct.');

--- a/tests/TestCase/Console/HelpFormatterTest.php
+++ b/tests/TestCase/Console/HelpFormatterTest.php
@@ -266,7 +266,7 @@ xml;
                 'choices' => ['aco', 'aro'],
                 'required' => true,
             ])
-            ->addArgument('other_longer', ['help' => 'Another argument.']);
+            ->addArgument('other_longer', ['help' => 'Another argument.', 'default' => 'foo']);
 
         $formatter = new HelpFormatter($parser);
         $result = $formatter->xml();
@@ -295,7 +295,7 @@ xml;
 			<choice>aro</choice>
 		</choices>
 	</argument>
-	<argument name="other_longer" help="Another argument." required="0">
+	<argument name="other_longer" help="Another argument." required="0" default="foo">
 		<choices></choices>
 	</argument>
 </arguments>


### PR DESCRIPTION
Add an optional parameter "default" to arguments.

Calling the command without the argument is the same as calling the command with the argument with the value specified as "default".

Example:
```php
    public function buildOptionParser (ConsoleOptionParser $parser): ConsoleOptionParser {
	$parser = parent::buildOptionParser($parser);
	$parser->addArgument('date', [
		'help' => __('Date to query'),
		'default' => 'yesterday',
		'required' => false,
	]);

	return $parser;
    }
```
Getting the argument:
```php
    $date = $args->getArgument('date');
```
Instead of:
```php
    $date = $args->getArgument('date')  ?: 'yesterday';
```


