### PR TITLE
Clear output/error on each call to exec()

### DIFF
--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -90,6 +90,8 @@ trait ConsoleIntegrationTestTrait
                 'You can use `$input` only if `$_in` property is null and will be reset.'
             );
         }
+        $this->_out->clear();
+        $this->_err->clear();
 
         $args = $this->commandStringToArgs("cake $command");
         $io = new ConsoleIo($this->_out, $this->_err, $this->_in);

--- a/src/Console/TestSuite/StubConsoleOutput.php
+++ b/src/Console/TestSuite/StubConsoleOutput.php
@@ -73,6 +73,16 @@ class StubConsoleOutput extends ConsoleOutput
     }
 
     /**
+     * Clear buffered output
+     *
+     * @return void
+     */
+    public function clear(): void
+    {
+        $this->_out = [];
+    }
+
+    /**
      * Get the output as a string
      *
      * @return string

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -80,6 +80,21 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     }
 
     /**
+     * tests exec clears output
+     */
+    public function testExecClearsOutput(): void
+    {
+        $this->exec('sample');
+        $this->assertOutputContains('SampleCommand');
+        $this->assertExitCode(CommandInterface::CODE_SUCCESS);
+
+        $this->exec('abort');
+        $this->assertOutputNotContains('SampleCommand');
+        $this->assertErrorContains('Command aborted');
+        $this->assertExitCode(127);
+    }
+
+    /**
      * tests a valid core command
      */
     public function testExecCoreCommand(): void


### PR DESCRIPTION
I think that console integration tests should work more like http integration tests where the output/response is cleared on each request/operation that is performed. Having console output retained between exec() calls makes assertions on output harder to do.

