### PR TITLE
5.1 unbuffered queries

### DIFF
--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -35,6 +35,7 @@ use Cake\Database\Schema\SchemaDialect;
 use Cake\Database\Schema\TableSchema;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\Database\Statement\Statement;
+use Closure;
 use InvalidArgumentException;
 use PDO;
 use PDOException;
@@ -391,13 +392,17 @@ abstract class Driver
             );
         }
 
-        $typeMap = null;
-        if ($query instanceof SelectQuery && $query->isResultsCastingEnabled()) {
-            $typeMap = $query->getSelectTypeMap();
+        $decorators = [];
+        if ($query instanceof SelectQuery) {
+            $decorators = $query->getResultDecorators();
+            if ($query->isResultsCastingEnabled()) {
+                $typeConverter = new FieldTypeConverter($query->getSelectTypeMap(), $this);
+                array_unshift($decorators, Closure::fromCallable($typeConverter));
+            }
         }
 
         /** @var \Cake\Database\StatementInterface */
-        return new (static::STATEMENT_CLASS)($statement, $this, $typeMap);
+        return new (static::STATEMENT_CLASS)($statement, $this, $decorators);
     }
 
     /**

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -392,17 +392,29 @@ abstract class Driver
             );
         }
 
-        $decorators = [];
+        /** @var \Cake\Database\StatementInterface */
+        return new (static::STATEMENT_CLASS)($statement, $this, $this->getResultSetDecorators($query));
+    }
+
+    /**
+     * Returns the decorators to be applied to the result set incase of a SelectQuery.
+     *
+     * @param \Cake\Database\Query|string $query The query to be decorated.
+     * @return array<\Closure>
+     */
+    protected function getResultSetDecorators(Query|string $query): array
+    {
         if ($query instanceof SelectQuery) {
             $decorators = $query->getResultDecorators();
             if ($query->isResultsCastingEnabled()) {
                 $typeConverter = new FieldTypeConverter($query->getSelectTypeMap(), $this);
                 array_unshift($decorators, Closure::fromCallable($typeConverter));
             }
+
+            return $decorators;
         }
 
-        /** @var \Cake\Database\StatementInterface */
-        return new (static::STATEMENT_CLASS)($statement, $this, $decorators);
+        return [];
     }
 
     /**

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -214,13 +214,8 @@ class Sqlserver extends Driver
             ]
         );
 
-        $typeMap = null;
-        if ($query instanceof SelectQuery && $query->isResultsCastingEnabled()) {
-            $typeMap = $query->getSelectTypeMap();
-        }
-
         /** @var \Cake\Database\StatementInterface */
-        return new (static::STATEMENT_CLASS)($statement, $this, $typeMap);
+        return new (static::STATEMENT_CLASS)($statement, $this, $this->getResultSetDecorators($query));
     }
 
     /**

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -86,6 +86,14 @@ class SelectQuery extends Query implements IteratorAggregate
     protected ?iterable $_results = null;
 
     /**
+     * Boolean for tracking whether buffered results
+     * are enabled.
+     *
+     * @var bool
+     */
+    protected bool $useBufferedResults = true;
+
+    /**
      * The Type map for fields in the select clause
      *
      * @var \Cake\Database\TypeMap|null
@@ -758,13 +766,17 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function getIterator(): Traversable
     {
-        /** @var \Traversable|array $results */
-        $results = $this->all();
-        if (is_array($results)) {
-            return new ArrayIterator($results);
+        if ($this->useBufferedResults) {
+            /** @var \Traversable|array $results */
+            $results = $this->all();
+            if (is_array($results)) {
+                return new ArrayIterator($results);
+            }
+
+            return $results;
         }
 
-        return $results;
+        return $this->execute();
     }
 
     /**
@@ -817,6 +829,59 @@ class SelectQuery extends Query implements IteratorAggregate
     public function getResultDecorators(): array
     {
         return $this->_resultDecorators;
+    }
+
+    /**
+     * Enables/Disables buffered results.
+     *
+     * When enabled the results returned by this query will be
+     * buffered. This enables you to iterate a result set multiple times, or
+     * both cache and iterate it.
+     *
+     * When disabled it will consume less memory as fetched results are not
+     * remembered for future iterations.
+     *
+     * @return $this
+     */
+    public function enableBufferedResults()
+    {
+        $this->_dirty();
+        $this->useBufferedResults = true;
+
+        return $this;
+    }
+
+    /**
+     * Disables buffered results.
+     *
+     * Disabling buffering will consume less memory as fetched results are not
+     * remembered for future iterations.
+     *
+     * @return $this
+     */
+    public function disableBufferedResults()
+    {
+        $this->_dirty();
+        $this->useBufferedResults = false;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether buffered results are enabled/disabled.
+     *
+     * When enabled the results returned by this query will be
+     * buffered. This enables you to iterate a result set multiple times, or
+     * both cache and iterate it.
+     *
+     * When disabled it will consume less memory as fetched results are not
+     * remembered for future iterations.
+     *
+     * @return bool
+     */
+    public function isBufferedResultsEnabled(): bool
+    {
+        return $this->useBufferedResults;
     }
 
     /**

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -91,7 +91,7 @@ class SelectQuery extends Query implements IteratorAggregate
      *
      * @var bool
      */
-    protected bool $useBufferedResults = true;
+    protected bool $bufferedResults = true;
 
     /**
      * The Type map for fields in the select clause
@@ -766,7 +766,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function getIterator(): Traversable
     {
-        if ($this->useBufferedResults) {
+        if ($this->bufferedResults) {
             /** @var \Traversable|array $results */
             $results = $this->all();
             if (is_array($results)) {
@@ -846,7 +846,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function enableBufferedResults()
     {
         $this->_dirty();
-        $this->useBufferedResults = true;
+        $this->bufferedResults = true;
 
         return $this;
     }
@@ -862,7 +862,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function disableBufferedResults()
     {
         $this->_dirty();
-        $this->useBufferedResults = false;
+        $this->bufferedResults = false;
 
         return $this;
     }
@@ -881,7 +881,7 @@ class SelectQuery extends Query implements IteratorAggregate
      */
     public function isBufferedResultsEnabled(): bool
     {
-        return $this->useBufferedResults;
+        return $this->bufferedResults;
     }
 
     /**

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -832,7 +832,7 @@ class SelectQuery extends Query implements IteratorAggregate
     }
 
     /**
-     * Enables/Disables buffered results.
+     * Enables buffered results.
      *
      * When enabled the results returned by this query will be
      * buffered. This enables you to iterate a result set multiple times, or

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -74,7 +74,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * statement upon retrieval. Each one of the callback function will receive
      * the row array as first argument.
      *
-     * @var array<\Closure>
+     * @var list<\Closure>
      */
     protected array $_resultDecorators = [];
 
@@ -111,13 +111,6 @@ class SelectQuery extends Query implements IteratorAggregate
     {
         if ($this->_results === null || $this->_dirty) {
             $this->_results = $this->execute()->fetchAll(StatementInterface::FETCH_TYPE_ASSOC);
-            if ($this->_resultDecorators) {
-                foreach ($this->_results as &$row) {
-                    foreach ($this->_resultDecorators as $decorator) {
-                        $row = $decorator($row);
-                    }
-                }
-            }
         }
 
         return $this->_results;
@@ -814,6 +807,16 @@ class SelectQuery extends Query implements IteratorAggregate
         }
 
         return $this;
+    }
+
+    /**
+     * Get result decorators.
+     *
+     * @return array
+     */
+    public function getResultDecorators(): array
+    {
+        return $this->_resultDecorators;
     }
 
     /**

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -22,11 +22,10 @@ use Cake\Database\TypeFactory;
 use Cake\Database\TypeInterface;
 use Generator;
 use InvalidArgumentException;
-use IteratorAggregate;
 use PDO;
 use PDOStatement;
 
-class Statement implements StatementInterface, IteratorAggregate
+class Statement implements StatementInterface
 {
     /**
      * @var array<string, int>

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -20,11 +20,13 @@ use Cake\Database\Driver;
 use Cake\Database\StatementInterface;
 use Cake\Database\TypeFactory;
 use Cake\Database\TypeInterface;
+use Generator;
 use InvalidArgumentException;
+use IteratorAggregate;
 use PDO;
 use PDOStatement;
 
-class Statement implements StatementInterface
+class Statement implements StatementInterface, IteratorAggregate
 {
     /**
      * @var array<string, int>
@@ -282,5 +284,25 @@ class Statement implements StatementInterface
     public function queryString(): string
     {
         return $this->statement->queryString;
+    }
+
+    /**
+     * Get the inner iterator
+     *
+     * @return \Generator
+     */
+    public function getIterator(): Generator
+    {
+        $this->statement->setFetchMode(PDO::FETCH_ASSOC);
+
+        foreach ($this->statement as $row) {
+            foreach ($this->resultDecorators as $decorator) {
+                $row = $decorator($row);
+            }
+
+            yield $row;
+        }
+
+        $this->closeCursor();
     }
 }

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -16,9 +16,13 @@ declare(strict_types=1);
  */
 namespace Cake\Database;
 
+use IteratorAggregate;
 use PDO;
 
-interface StatementInterface
+/**
+ * @template-extends \IteratorAggregate<array>
+ */
+interface StatementInterface extends IteratorAggregate
 {
     /**
      * Maps to PDO::FETCH_NUM.

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
+use Cake\Collection\Collection;
 use Cake\ORM\Query\SelectQuery;
 use Closure;
 use InvalidArgumentException;
@@ -664,6 +665,94 @@ class EagerLoader
             );
             $results = array_map($callback, $results);
         }
+
+        return $results;
+    }
+
+    /**
+     * Inject data from associations that cannot be joined directly for unbuffered queries.
+     *
+     * @param \Cake\ORM\Query\SelectQuery $query The query for which to eager load external.
+     * associations.
+     * @param iterable $results Results array.
+     * @return iterable
+     * @throws \RuntimeException
+     */
+    public function loadExternalUnbuffered(SelectQuery $query, iterable $results): iterable
+    {
+        $table = $query->getRepository();
+        $external = $this->externalAssociations($table);
+        if (!$external) {
+            return $results;
+        }
+
+        $assocData = [];
+
+        foreach ($external as $meta) {
+            // $contain = $meta->associations();
+            $instance = $meta->instance();
+            $config = $meta->getConfig();
+            $alias = $instance->getSource()->getAlias();
+            $path = $meta->aliasPath();
+
+            if ($instance->requiresKeys($config)) {
+                $source = $instance->getSource();
+                $keys = $instance->type() === Association::MANY_TO_ONE ?
+                    (array)$instance->getForeignKey() :
+                    (array)$instance->getBindingKey();
+
+                $alias = $source->getAlias();
+                $pkFields = [];
+                /** @var string $key */
+                foreach ($keys as $key) {
+                    $pkFields[] = key($query->aliasField($key, $alias));
+                }
+                $assocData[$path] = [
+                    'alias' => $alias,
+                    'pkFields' => $pkFields,
+                ];
+            }
+        }
+
+        $results = (new Collection($results))
+            ->map(function ($row) use ($query, $external, $assocData) {
+                foreach ($external as $meta) {
+                    $path = $meta->aliasPath();
+                    $keys = null;
+                    if (count($assocData[$path]['pkFields']) === 1) {
+                        // Missed joins will have null in the results.
+                        if (array_key_exists($assocData[$path]['pkFields'][0], $row)) {
+                            // Assign empty array to avoid not found association when optional.
+                            if (!isset($row[$assocData[$path]['pkFields'][0]])) {
+                                $keys = [];
+                            } else {
+                                $value = $row[$assocData[$path]['pkFields'][0]];
+                                $keys = [$value => $value];
+                            }
+                        }
+                    } else {
+                        // Handle composite keys.
+                        $collected = [];
+                        foreach ($assocData[$path]['pkFields'] as $key) {
+                            $collected[] = $row[$key];
+                        }
+                        $keys[implode(';', $collected)] = $collected;
+                    }
+
+                    $callback = $meta->instance()->eagerLoader(
+                        $meta->getConfig() + [
+                            'query' => $query,
+                            'contain' => $meta->associations(),
+                            'keys' => $keys,
+                            'nestKey' => $meta->aliasPath(),
+                        ]
+                    );
+
+                    $row = $callback($row);
+                }
+
+                return $row;
+            });
 
         return $results;
     }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -609,10 +609,10 @@ class EagerLoader
      * @param \Cake\ORM\Query\SelectQuery $query The query for which to eager load external.
      * associations.
      * @param iterable $results Results.
-     * @return array
+     * @return iterable
      * @throws \RuntimeException
      */
-    public function loadExternal(SelectQuery $query, iterable $results): array
+    public function loadExternal(SelectQuery $query, iterable $results): iterable
     {
         if (!$results) {
             return $results;

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1584,11 +1584,16 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             return $this->_results;
         }
 
-        $results = parent::all();
-        if (!is_array($results)) {
-            $results = iterator_to_array($results);
+        if ($this->useBufferedResults) {
+            $results = parent::all();
+            if (!is_array($results)) {
+                $results = iterator_to_array($results);
+            }
+            $results = $this->getEagerLoader()->loadExternal($this, $results);
+        } else {
+            $statement = $this->execute();
+            $results = $this->getEagerLoader()->loadExternalUnbuffered($this, $statement);
         }
-        $results = $this->getEagerLoader()->loadExternal($this, $results);
 
         return $this->resultSetFactory()->createResultSet($this, $results);
     }

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1586,14 +1586,10 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
 
         if ($this->useBufferedResults) {
             $results = parent::all();
-            if (!is_array($results)) {
-                $results = iterator_to_array($results);
-            }
-            $results = $this->getEagerLoader()->loadExternal($this, $results);
         } else {
-            $statement = $this->execute();
-            $results = $this->getEagerLoader()->loadExternalUnbuffered($this, $statement);
+            $results = $this->execute();
         }
+        $results = $this->getEagerLoader()->loadExternal($this, $results);
 
         return $this->resultSetFactory()->createResultSet($this, $results);
     }

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1584,7 +1584,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             return $this->_results;
         }
 
-        if ($this->useBufferedResults) {
+        if ($this->bufferedResults) {
             $results = parent::all();
         } else {
             $results = $this->execute();

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -16,10 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
-use Cake\Collection\CollectionTrait;
-use Cake\Datasource\EntityInterface;
+use Cake\Collection\Collection;
 use Cake\Datasource\ResultSetInterface;
-use SplFixedArray;
 
 /**
  * Represents the results obtained after executing a query for a specific table
@@ -30,184 +28,8 @@ use SplFixedArray;
  * @template T of \Cake\Datasource\EntityInterface|array
  * @implements \Cake\Datasource\ResultSetInterface<T>
  */
-class ResultSet implements ResultSetInterface
+class ResultSet extends Collection implements ResultSetInterface
 {
-    use CollectionTrait;
-
-    /**
-     * Points to the next record number that should be fetched
-     *
-     * @var int
-     */
-    protected int $_index = 0;
-
-    /**
-     * Last record fetched from the statement
-     *
-     * @var \Cake\Datasource\EntityInterface|array|null
-     * @psalm-var T|null
-     */
-    protected EntityInterface|array|null $_current;
-
-    /**
-     * Holds the count of records in this result set
-     *
-     * @var int
-     */
-    protected int $_count = 0;
-
-    /**
-     * Results that have been fetched or hydrated into the results.
-     *
-     * @var \SplFixedArray<T>
-     */
-    protected SplFixedArray $_results;
-
-    /**
-     * Constructor
-     *
-     * @param array $results Results array.
-     */
-    public function __construct(array $results)
-    {
-        $this->__unserialize($results);
-    }
-
-    /**
-     * Returns the current record in the result iterator.
-     *
-     * Part of Iterator interface.
-     *
-     * @return \Cake\Datasource\EntityInterface|array|null
-     * @psalm-return T|null
-     */
-    public function current(): EntityInterface|array|null
-    {
-        return $this->_current;
-    }
-
-    /**
-     * Returns the key of the current record in the iterator.
-     *
-     * Part of Iterator interface.
-     *
-     * @return int
-     */
-    public function key(): int
-    {
-        return $this->_index;
-    }
-
-    /**
-     * Advances the iterator pointer to the next record.
-     *
-     * Part of Iterator interface.
-     *
-     * @return void
-     */
-    public function next(): void
-    {
-        $this->_index++;
-    }
-
-    /**
-     * Rewinds a ResultSet.
-     *
-     * Part of Iterator interface.
-     *
-     * @return void
-     */
-    public function rewind(): void
-    {
-        $this->_index = 0;
-    }
-
-    /**
-     * Whether there are more results to be fetched from the iterator.
-     *
-     * Part of Iterator interface.
-     *
-     * @return bool
-     */
-    public function valid(): bool
-    {
-        if ($this->_index < $this->_count) {
-            $this->_current = $this->_results[$this->_index];
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the first record from a result set.
-     *
-     * This method will also close the underlying statement cursor.
-     *
-     * @return \Cake\Datasource\EntityInterface|array|null
-     * @psalm-return T|null
-     */
-    public function first(): EntityInterface|array|null
-    {
-        foreach ($this as $result) {
-            return $result;
-        }
-
-        return null;
-    }
-
-    /**
-     * Serializes a resultset.
-     *
-     * @return array
-     */
-    public function __serialize(): array
-    {
-        return $this->_results->toArray();
-    }
-
-    /**
-     * Unserializes a resultset.
-     *
-     * @param array $data Data array.
-     * @return void
-     */
-    public function __unserialize(array $data): void
-    {
-        $this->_results = SplFixedArray::fromArray($data);
-        $this->_count = $this->_results->count();
-    }
-
-    /**
-     * Gives the number of rows in the result set.
-     *
-     * Part of the Countable interface.
-     *
-     * @return int
-     */
-    public function count(): int
-    {
-        return $this->_count;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function countKeys(): int
-    {
-        // This is an optimization over the implementation provided by CollectionTrait::countKeys()
-        return $this->_count;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function isEmpty(): bool
-    {
-        return !$this->_count;
-    }
-
     /**
      * Returns an array that can be used to describe the internal state of this
      * object.
@@ -216,13 +38,8 @@ class ResultSet implements ResultSetInterface
      */
     public function __debugInfo(): array
     {
-        $currentIndex = $this->_index;
-        // toArray() adjusts the current index, so we have to reset it
-        $items = $this->toArray();
-        $this->_index = $currentIndex;
-
         return [
-            'items' => $items,
+            'items' => $this->toArray(),
         ];
     }
 }

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -37,12 +37,19 @@ class ResultSetFactory
      * @param array $results Results array.
      * @return \Cake\ORM\ResultSet<array|\Cake\Datasource\EntityInterface>
      */
-    public function createResultSet(SelectQuery $query, array $results): ResultSet
+    public function createResultSet(SelectQuery $query, iterable $results, bool $bufferedResults = true): ResultSet
     {
         $data = $this->collectData($query);
 
-        foreach ($results as $i => $row) {
-            $results[$i] = $this->groupResult($row, $data);
+        if (is_array($results)) {
+            foreach ($results as $i => $row) {
+                $results[$i] = $this->groupResult($row, $data);
+            }
+        } else {
+            $results = (new Collection($results))
+                ->map(function ($row) use ($data) {
+                    return $this->groupResult($row, $data);
+                });
         }
 
         return new ResultSet($results);

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -37,7 +37,7 @@ class ResultSetFactory
      * @param array $results Results array.
      * @return \Cake\ORM\ResultSet<array|\Cake\Datasource\EntityInterface>
      */
-    public function createResultSet(SelectQuery $query, iterable $results, bool $bufferedResults = true): ResultSet
+    public function createResultSet(SelectQuery $query, iterable $results): ResultSet
     {
         $data = $this->collectData($query);
 

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -34,7 +34,7 @@ class ResultSetFactory
      * Constructor
      *
      * @param \Cake\ORM\Query\SelectQuery<T> $query Query from where results came.
-     * @param array $results Results array.
+     * @param iterable $results Results.
      * @return \Cake\ORM\ResultSet<array|\Cake\Datasource\EntityInterface>
      */
     public function createResultSet(SelectQuery $query, iterable $results): ResultSet

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -19,6 +19,7 @@ namespace Cake\ORM;
 use Cake\Collection\Collection;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Query\SelectQuery;
+use SplFixedArray;
 
 /**
  * Factory class for generation ResulSet instances.
@@ -45,6 +46,8 @@ class ResultSetFactory
             foreach ($results as $i => $row) {
                 $results[$i] = $this->groupResult($row, $data);
             }
+
+            $results = SplFixedArray::fromArray($results);
         } else {
             $results = (new Collection($results))
                 ->map(function ($row) use ($data) {

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1139,7 +1139,7 @@ class ConnectionTest extends TestCase
 
         $statement = $this->connection->run($query);
         foreach ($statement as $row) {
-            $this->assertSame(['field' => 1], $row);
+            $this->assertEquals(['field' => 1], $row);
         }
     }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -1135,11 +1135,11 @@ class ConnectionTest extends TestCase
     public function testRunAndStatementIteration(): void
     {
         $query = new SelectQuery($this->connection);
-        $query->select($query->newExpr('1'));
+        $query->select(fields: ['field' => $query->newExpr('1')]);
 
         $statement = $this->connection->run($query);
         foreach ($statement as $row) {
-            $this->assertSame(['(1)' => 1], $row);
+            $this->assertSame(['field' => 1], $row);
         }
     }
 }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -26,6 +26,7 @@ use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\MissingDriverException;
 use Cake\Database\Exception\MissingExtensionException;
 use Cake\Database\Exception\NestedTransactionRollbackException;
+use Cake\Database\Query\SelectQuery;
 use Cake\Database\Schema\CachedCollection;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
@@ -1128,6 +1129,17 @@ class ConnectionTest extends TestCase
             $this->assertInstanceOf(Exception::class, $e);
             $prop->setValue($conn, $oldDriver);
             $conn->rollback();
+        }
+    }
+
+    public function testRunAndStatementIteration(): void
+    {
+        $query = new SelectQuery($this->connection);
+        $query->select($query->newExpr('1'));
+
+        $statement = $this->connection->run($query);
+        foreach ($statement as $row) {
+            $this->assertSame(['(1)' => 1], $row);
         }
     }
 }

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Query;
 
+use ArrayIterator;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Driver\Sqlite;
@@ -2816,12 +2817,13 @@ class SelectQueryTest extends TestCase
         }
         $this->assertSame(3, $count);
 
+        $iterable = $query->getIterator();
+        $this->assertInstanceOf(ArrayIterator::class, $iterable);
+
         $this->connection->execute('DELETE FROM articles WHERE author_id = 3')->closeCursor();
 
-        // Mark query as dirty
-        $query->select(['id'], true);
+        $query->disableBufferedResults();
 
-        // Verify all() is called again
         $count = 0;
         foreach ($query as $row) {
             ++$count;
@@ -2829,6 +2831,9 @@ class SelectQueryTest extends TestCase
             $this->assertSame('test', $row['generated']);
         }
         $this->assertSame(2, $count);
+
+        $iterable = $query->getIterator();
+        $this->assertInstanceOf(StatementInterface::class, $iterable);
     }
 
     /**

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -461,9 +461,7 @@ class HasManyTest extends TestCase
             ->with('all')
             ->willReturn($query);
 
-        $results = new ResultSet([]);
-
-        $results->__unserialize([
+        $results = new ResultSet([
             ['id' => 1, 'title' => 'article 1', 'author_id' => 2, 'site_id' => 10],
             ['id' => 2, 'title' => 'article 2', 'author_id' => 1, 'site_id' => 20],
         ]);

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -1952,6 +1952,7 @@ class SelectQueryTest extends TestCase
         $query = new SelectQuery($table);
         $query
             ->select()
+            ->disableBufferedResults()
             ->contain([
                 'articles' => function ($q) {
                     return $q->where(['articles.id' => 1]);


### PR DESCRIPTION
Refs #17517

I have been playing around to add back support for unbuffered queries and have come up with a POC. The implementation is a bit different than earlier since we got rid of statement decoration in 5.0.

Digging into the topic I learned that at PDO level postgres is always buffered, sqlite is always unbuffered, only mysql has the option to toggle buffered/unbuffered at connection level.

Here are a few noteworthy points about the implementation:
- At the ORM level for non joined association a separate query is made to fetch related records of each primary record. So for Posts hasMany Comments if a query returns 2 posts then there will be one query each to fetch related Comments unlike for buffered results where all related comments are fetched using a single query.
- In unbuffered mode the `Statement` instance is iterated which returns a generator. Since generators can't be rewind, trying to iterate the resultset again or using any collection method which internally iterates will throw an exception. Personally I think that's a reasonable limitation. An alternative would be to try and transparently re-execute the query.
- Trying to make `Statement::getIterator()` directly return the `PDOStatment` instance failed as the results are later wrapped in collection for decoration and `Collection::unwrap()` has return type `Iterator` instead of `Traversable`.
- For simplicity I have made `ResultSet` simply extend `Collection`.

TODO:

- [x] Fix the one failing test
- [ ] Lot of additional tests required

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
