### PR TITLE
Try stricter API for Command args existence.

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -126,8 +126,6 @@ class Arguments
      */
     public function getArgument(string $name): ?string
     {
-        debug($this->argNames);
-        debug($this->args);
         $this->assertArgumentExists($name);
 
         $offset = array_search($name, $this->argNames, true);

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -78,6 +78,8 @@ class Arguments
      */
     public function getArgumentAt(int $index): ?string
     {
+        $this->assertArgumentExistsAtPosition($index);
+
         if (!$this->hasArgumentAt($index)) {
             return null;
         }
@@ -93,6 +95,8 @@ class Arguments
      */
     public function hasArgumentAt(int $index): bool
     {
+        $this->assertArgumentExistsAtPosition($index);
+
         return isset($this->args[$index]);
     }
 
@@ -104,6 +108,8 @@ class Arguments
      */
     public function hasArgument(string $name): bool
     {
+        $this->assertArgumentExists($name);
+
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false) {
             return false;
@@ -120,6 +126,10 @@ class Arguments
      */
     public function getArgument(string $name): ?string
     {
+        debug($this->argNames);
+        debug($this->args);
+        $this->assertArgumentExists($name);
+
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false || !isset($this->args[$offset])) {
             return null;
@@ -204,5 +214,40 @@ class Arguments
     public function hasOption(string $name): bool
     {
         return isset($this->options[$name]);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return void
+     */
+    protected function assertArgumentExists(string $name): void
+    {
+        if (in_array($name, $this->argNames, true)) {
+            return;
+        }
+
+        throw new ConsoleException(sprintf(
+            'Argument `%s` is not defined on this Command. Could this be an option maybe?',
+            $name
+        ));
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return void
+     */
+    protected function assertArgumentExistsAtPosition(int $index): void
+    {
+        $count = count($this->args);
+        if ($index >= 0 && $index < $count) {
+            return;
+        }
+
+        throw new ConsoleException(sprintf(
+            'Argument at index `%s` is not defined on this Command. Could this be an option maybe?',
+            $index
+        ));
     }
 }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -206,7 +206,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
     protected function displayHelp(ConsoleOptionParser $parser, Arguments $args, ConsoleIo $io): void
     {
         $format = 'text';
-        if ($args->getArgumentAt(0) === 'xml') {
+        if ($args->getArguments() && $args->getArgumentAt(0) === 'xml') {
             $format = 'xml';
             $io->setOutputAs(ConsoleOutput::RAW);
         }

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -44,7 +44,10 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], []);
         $this->assertSame($values[0], $args->getArgumentAt(0));
         $this->assertSame($values[1], $args->getArgumentAt(1));
-        $this->assertNull($args->getArgumentAt(3));
+
+        $this->expectException(ConsoleException::class);
+
+        $args->getArgumentAt(3);
     }
 
     /**
@@ -56,7 +59,9 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], []);
         $this->assertTrue($args->hasArgumentAt(0));
         $this->assertTrue($args->hasArgumentAt(1));
-        $this->assertFalse($args->hasArgumentAt(3));
+
+        $this->expectException(ConsoleException::class);
+
         $this->assertFalse($args->hasArgumentAt(-1));
     }
 
@@ -70,8 +75,6 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], $names);
         $this->assertTrue($args->hasArgument('size'));
         $this->assertTrue($args->hasArgument('color'));
-        $this->assertFalse($args->hasArgument('hair'));
-        $this->assertFalse($args->hasArgument('Hair'), 'casing matters');
         $this->assertFalse($args->hasArgument('odd'));
     }
 
@@ -85,8 +88,7 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], $names);
         $this->assertSame($values[0], $args->getArgument('size'));
         $this->assertSame($values[1], $args->getArgument('color'));
-        $this->assertNull($args->getArgument('Color'));
-        $this->assertNull($args->getArgument('hair'));
+        $this->assertNull($args->getArgument('odd'));
     }
 
     /**
@@ -99,6 +101,20 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], $names);
         $this->assertNull($args->getArgument('size'));
         $this->assertNull($args->getArgument('color'));
+    }
+
+    /**
+     * get arguments by name
+     */
+    public function testGetArgumentInvalid(): void
+    {
+        $values = [];
+        $names = ['size'];
+        $args = new Arguments($values, [], $names);
+
+        $this->expectException(ConsoleException::class);
+
+        $args->getArgument('color');
     }
 
     /**

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -146,7 +146,7 @@ class CommandTest extends TestCase
 
         $this->assertSame(
             CommandInterface::CODE_SUCCESS,
-            $command->run(['--help'], $this->getMockIo($output))
+            $command->run(['test-me', '--help'], $this->getMockIo($output))
         );
         $messages = implode("\n", $output->messages());
         $this->assertStringNotContainsString('Demo', $messages);
@@ -162,7 +162,7 @@ class CommandTest extends TestCase
         $command->setName('cake demo');
         $output = new StubConsoleOutput();
 
-        $this->assertNull($command->run(['--verbose'], $this->getMockIo($output)));
+        $this->assertNull($command->run(['test-me', '--verbose'], $this->getMockIo($output)));
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString('Verbose!', $messages);
         $this->assertStringContainsString('Demo Command!', $messages);
@@ -179,7 +179,7 @@ class CommandTest extends TestCase
         $command->setName('cake demo');
         $output = new StubConsoleOutput();
 
-        $this->assertNull($command->run(['--quiet'], $this->getMockIo($output)));
+        $this->assertNull($command->run(['test-me', '--quiet'], $this->getMockIo($output)));
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString('Quiet!', $messages);
         $this->assertStringNotContainsString('Verbose!', $messages);
@@ -242,9 +242,9 @@ class CommandTest extends TestCase
     {
         $output = new StubConsoleOutput();
         $command = new Command();
-        $result = $command->executeCommand(DemoCommand::class, [], $this->getMockIo($output));
+        $result = $command->executeCommand(DemoCommand::class, ['test-me'], $this->getMockIo($output));
         $this->assertNull($result);
-        $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
+        $this->assertEquals(['Quiet!', 'Demo Command!', 'test-me'], $output->messages());
     }
 
     /**
@@ -276,9 +276,9 @@ class CommandTest extends TestCase
     {
         $output = new StubConsoleOutput();
         $command = new Command();
-        $result = $command->executeCommand(new DemoCommand(), [], $this->getMockIo($output));
+        $result = $command->executeCommand(new DemoCommand(), ['test-me'], $this->getMockIo($output));
         $this->assertNull($result);
-        $this->assertEquals(['Quiet!', 'Demo Command!'], $output->messages());
+        $this->assertEquals(['Quiet!', 'Demo Command!', 'test-me'], $output->messages());
     }
 
     /**

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -6,6 +6,7 @@ namespace TestApp\Command;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
 
 class DemoCommand extends Command
 {

--- a/tests/test_app/TestApp/Command/DemoCommand.php
+++ b/tests/test_app/TestApp/Command/DemoCommand.php
@@ -6,7 +6,6 @@ namespace TestApp\Command;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
-use Cake\Console\ConsoleOptionParser;
 
 class DemoCommand extends Command
 {


### PR DESCRIPTION
Showcasing some of the topic discussed in https://github.com/cakephp/cakephp/issues/17647
Would only resolve the args part, as options are not known to the Arguments class here (not passed in based on defined ones).

Also there are 4 remaining issues here.