### PR TITLE
Use hasDebugFlag name.

### DIFF
--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -1020,7 +1020,7 @@ trait IntegrationTestTrait
     public function assertResponseEquals(mixed $content, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $verboseMessage .= $this->responseBody();
         }
         $this->assertThat($content, new BodyEquals($this->_response), $verboseMessage);
@@ -1036,7 +1036,7 @@ trait IntegrationTestTrait
     public function assertResponseNotEquals(mixed $content, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $verboseMessage .= $this->responseBody();
         }
         $this->assertThat($content, new BodyNotEquals($this->_response), $verboseMessage);
@@ -1057,7 +1057,7 @@ trait IntegrationTestTrait
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $verboseMessage .= $this->responseBody();
         }
         $this->assertThat($content, new BodyContains($this->_response, $ignoreCase), $verboseMessage);
@@ -1078,7 +1078,7 @@ trait IntegrationTestTrait
         }
 
         $verboseMessage = $this->extractVerboseMessage($message);
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $verboseMessage .= $this->responseBody();
         }
         $this->assertThat($content, new BodyNotContains($this->_response, $ignoreCase), $verboseMessage);
@@ -1094,7 +1094,7 @@ trait IntegrationTestTrait
     public function assertResponseRegExp(string $pattern, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $verboseMessage .= $this->responseBody();
         }
         $this->assertThat($pattern, new BodyRegExp($this->_response), $verboseMessage);
@@ -1110,7 +1110,7 @@ trait IntegrationTestTrait
     public function assertResponseNotRegExp(string $pattern, string $message = ''): void
     {
         $verboseMessage = $this->extractVerboseMessage($message);
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $verboseMessage .= $this->responseBody();
         }
         $this->assertThat($pattern, new BodyNotRegExp($this->_response), $verboseMessage);
@@ -1124,7 +1124,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseNotEmpty(string $message = ''): void
     {
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $message .= $this->responseBody();
         }
         $this->assertThat(null, new BodyNotEmpty($this->_response), $message);
@@ -1138,7 +1138,7 @@ trait IntegrationTestTrait
      */
     public function assertResponseEmpty(string $message = ''): void
     {
-        if ($this->isDebug()) {
+        if ($this->hasDebugFlag()) {
             $message .= $this->responseBody();
         }
         $this->assertThat(null, new BodyEmpty($this->_response), $message);
@@ -1459,7 +1459,7 @@ trait IntegrationTestTrait
      *
      * @return bool Success
      */
-    protected function isDebug(): bool
+    protected function hasDebugFlag(): bool
     {
         return !empty($_SERVER['argv']) && in_array('--debug', $_SERVER['argv'], true);
     }


### PR DESCRIPTION
Follow https://github.com/cakephp/cakephp/pull/17651/

Should we name it something more clear and less colliding?
I had a trait that uses isDebug() and it would crash.
So maybe with this, there is 0 change of this happening.