### PR TITLE
Try stricter API for Command args existence.

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -104,6 +104,8 @@ class Arguments
      */
     public function hasArgument(string $name): bool
     {
+        $this->assertArgumentExists($name);
+
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false) {
             return false;
@@ -120,6 +122,8 @@ class Arguments
      */
     public function getArgument(string $name): ?string
     {
+        $this->assertArgumentExists($name);
+
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false || !isset($this->args[$offset])) {
             return null;
@@ -204,5 +208,21 @@ class Arguments
     public function hasOption(string $name): bool
     {
         return isset($this->options[$name]);
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    protected function assertArgumentExists(string $name): void
+    {
+        if (in_array($name, $this->argNames, true)) {
+            return;
+        }
+
+        throw new ConsoleException(sprintf(
+            'Argument `%s` is not defined on this Command. Could this be an option maybe?',
+            $name
+        ));
     }
 }

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -70,8 +70,6 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], $names);
         $this->assertTrue($args->hasArgument('size'));
         $this->assertTrue($args->hasArgument('color'));
-        $this->assertFalse($args->hasArgument('hair'));
-        $this->assertFalse($args->hasArgument('Hair'), 'casing matters');
         $this->assertFalse($args->hasArgument('odd'));
     }
 
@@ -85,8 +83,7 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], $names);
         $this->assertSame($values[0], $args->getArgument('size'));
         $this->assertSame($values[1], $args->getArgument('color'));
-        $this->assertNull($args->getArgument('Color'));
-        $this->assertNull($args->getArgument('hair'));
+        $this->assertNull($args->getArgument('odd'));
     }
 
     /**
@@ -99,6 +96,20 @@ class ArgumentsTest extends TestCase
         $args = new Arguments($values, [], $names);
         $this->assertNull($args->getArgument('size'));
         $this->assertNull($args->getArgument('color'));
+    }
+
+    /**
+     * get arguments by name
+     */
+    public function testGetArgumentInvalid(): void
+    {
+        $values = [];
+        $names = ['size'];
+        $args = new Arguments($values, [], $names);
+
+        $this->expectException(ConsoleException::class);
+
+        $args->getArgument('color');
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/17647

We can only control the named and defined arguments.
Everything else is not clearly known to the class, and we probably cannot easily change that at this point.
