### PR TITLE
Make select queries use read role by default

### DIFF
--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -33,6 +33,8 @@ use Traversable;
 /**
  * This class is used to generate SELECT queries for the relational database.
  *
+ * Uses the `read` connection role by default.
+ *
  * @template T of mixed
  * @implements \IteratorAggregate<T>
  */
@@ -98,6 +100,18 @@ class SelectQuery extends Query implements IteratorAggregate
      * @var bool
      */
     protected bool $typeCastEnabled = true;
+
+    /**
+     * Constructor.
+     *
+     * @param \Cake\Database\Connection $connection The connection
+     * object to be used for transforming and executing this query
+     */
+    public function __construct(Connection $connection)
+    {
+        parent::__construct($connection);
+        $this->useReadRole();
+    }
 
     /**
      * Executes query and returns set of decorated results.

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -71,17 +71,16 @@ class QueryTest extends TestCase
         // Defaults to write role
         $this->assertSame(Connection::ROLE_WRITE, $this->connection->insertQuery()->getConnectionRole());
 
+        // Defaults to read role
         $selectQuery = $this->connection->selectQuery();
-        $this->assertSame(Connection::ROLE_WRITE, $selectQuery->getConnectionRole());
+        $this->assertSame(Connection::ROLE_READ, $this->connection->selectQuery()->getConnectionRole());
 
-        // Can set read role for select queries
+        // Select queries can use both read and write roles
+        $this->assertSame(Connection::ROLE_WRITE, $selectQuery->setConnectionRole(Connection::ROLE_WRITE)->getConnectionRole());
         $this->assertSame(Connection::ROLE_READ, $selectQuery->setConnectionRole(Connection::ROLE_READ)->getConnectionRole());
 
-        // Can set read role for select queries
-        $this->assertSame(Connection::ROLE_READ, $selectQuery->useReadRole()->getConnectionRole());
-
-        // Can set write role for select queries
         $this->assertSame(Connection::ROLE_WRITE, $selectQuery->useWriteRole()->getConnectionRole());
+        $this->assertSame(Connection::ROLE_READ, $selectQuery->useReadRole()->getConnectionRole());
     }
 
     protected function newQuery()


### PR DESCRIPTION
I think the read connection is the most expected default and users would override to write for special cases.
