### PR TITLE
Create unique read and write drivers if read or write config exists

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -154,18 +154,21 @@ class Connection implements ConnectionInterface
 
         $sharedConfig = array_diff_key($config, array_flip([
             'name',
+            'className',
             'driver',
             'cacheMetaData',
             'cacheKeyPrefix',
+            'read',
+            'write',
         ]));
 
         $writeConfig = $config['write'] ?? [] + $sharedConfig;
         $readConfig = $config['read'] ?? [] + $sharedConfig;
-        if ($readConfig == $writeConfig) {
-            $readDriver = $writeDriver = new $driverClass(['_role' => self::ROLE_WRITE] + $writeConfig);
-        } else {
+        if (array_key_exists('write', $config) || array_key_exists('read', $config)) {
             $readDriver = new $driverClass(['_role' => self::ROLE_READ] + $readConfig);
             $writeDriver = new $driverClass(['_role' => self::ROLE_WRITE] + $writeConfig);
+        } else {
+            $readDriver = $writeDriver = new $driverClass(['_role' => self::ROLE_WRITE] + $writeConfig);
         }
 
         if (!$writeDriver->enabled()) {


### PR DESCRIPTION
This creates unique read and write role drivers if the `read` or `write` config exists even if the configs are the same.