### PR TITLE
Fix finder compatibilty with 4.x

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2685,6 +2685,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             // with signature `findFoo(SelectQuery $query, array $options)`
             // called as `find('foo')` or `find('foo', [..])`
             if (isset($args[0])) {
+                deprecationWarning(
+                    '5.0.0',
+                    'Calling finders with options arrays is deprecated.'
+                    . ' Update your finder methods to used named arguments instead.'
+                );
                 $args = $args[0];
             }
             $query->applyOptions($args);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2669,45 +2669,49 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $reflected = new ReflectionFunction($callable);
         $params = $reflected->getParameters();
         $secondParam = $params[1] ?? null;
-        $secondParamType = null;
 
-        if ($args === [] || isset($args[0])) {
-            $secondParamType = $secondParam?->getType();
-            $secondParamTypeName = $secondParamType instanceof ReflectionNamedType ? $secondParamType->getName() : null;
-            // Backwards compatibility of 4.x style finders with signature `findFoo(SelectQuery $query, array $options)`
+        $secondParamType = $secondParam?->getType();
+        $secondParamTypeName = $secondParamType instanceof ReflectionNamedType ? $secondParamType->getName() : null;
+
+        $secondParamIsOptions = (
+            count($params) === 2 &&
+            $secondParam?->name === 'options' &&
+            !$secondParam->isVariadic() &&
+            ($secondParamType === null || $secondParamTypeName === 'array')
+        );
+
+        if (($args === [] || isset($args[0])) && $secondParamIsOptions) {
+            // Backwards compatibility of 4.x style finders
+            // with signature `findFoo(SelectQuery $query, array $options)`
             // called as `find('foo')` or `find('foo', [..])`
-            if (
-                count($params) === 2 &&
-                $secondParam?->name === 'options' &&
-                !$secondParam->isVariadic() &&
-                ($secondParamType === null || $secondParamTypeName === 'array')
-            ) {
-                if (isset($args[0])) {
-                    deprecationWarning(
-                        '5.0.0',
-                        'Using options array for the `find()` call is deprecated.'
-                        . ' Use named arguments instead.'
-                    );
-
-                    $args = $args[0];
-                }
-
-                $query->applyOptions($args);
-
-                return $callable($query, $query->getOptions());
-            }
-
-            // Backwards compatibility for core finders like `findList()` called in 4.x style
-            // with an array `find('list', ['valueField' => 'foo'])` instead of `find('list', valueField: 'foo')`
-            if (isset($args[0]) && is_array($args[0]) && $secondParamTypeName !== 'array') {
-                deprecationWarning(
-                    '5.0.0',
-                    "Calling `{$reflected->getName()}` finder with options array is deprecated."
-                     . ' Use named arguments instead.'
-                );
-
+            if (isset($args[0])) {
                 $args = $args[0];
             }
+            $query->applyOptions($args);
+
+            return $callable($query, $query->getOptions());
+        }
+
+        // Backwards compatibility for 4.x style finders with signatures like
+        // `findFoo(SelectQuery $query, array $options)` called as
+        // `find('foo', key: $value)`.
+        if (!isset($args[0]) && $secondParamIsOptions) {
+            $query->applyOptions($args);
+
+            return $callable($query, $query->getOptions());
+        }
+
+        // Backwards compatibility for core finders like `findList()` called in 4.x
+        // style with an array `find('list', ['valueField' => 'foo'])` instead of
+        // `find('list', valueField: 'foo')`
+        if (isset($args[0]) && is_array($args[0]) && $secondParamTypeName !== 'array') {
+            deprecationWarning(
+                '5.0.0',
+                "Calling `{$reflected->getName()}` finder with options array is deprecated."
+                 . ' Use named arguments instead.'
+            );
+
+            $args = $args[0];
         }
 
         if ($args) {

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -496,17 +496,15 @@ class AssociationTest extends TestCase
     {
         $this->association->setFinder('withOptions');
 
-        $this->deprecated(function () {
-            $this->assertEquals(
-                ['this' => 'worked'],
-                $this->association->find(null)->getOptions()
-            );
+        $this->assertEquals(
+            ['this' => 'worked'],
+            $this->association->find(null)->getOptions()
+        );
 
-            $this->assertEquals(
-                ['that' => 'custom', 'this' => 'worked'],
-                $this->association->find(null, ['that' => 'custom'])->getOptions()
-            );
-        });
+        $this->assertEquals(
+            ['that' => 'custom', 'this' => 'worked'],
+            $this->association->find(null, ['that' => 'custom'])->getOptions()
+        );
     }
 
     /**

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -496,15 +496,17 @@ class AssociationTest extends TestCase
     {
         $this->association->setFinder('withOptions');
 
-        $this->assertEquals(
-            ['this' => 'worked'],
-            $this->association->find(null)->getOptions()
-        );
+        $this->deprecated(function () {
+            $this->assertEquals(
+                ['this' => 'worked'],
+                $this->association->find(null)->getOptions()
+            );
 
-        $this->assertEquals(
-            ['that' => 'custom', 'this' => 'worked'],
-            $this->association->find(null, ['that' => 'custom'])->getOptions()
-        );
+            $this->assertEquals(
+                ['that' => 'custom', 'this' => 'worked'],
+                $this->association->find(null, ['that' => 'custom'])->getOptions()
+            );
+        });
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1286,6 +1286,23 @@ class TableTest extends TestCase
         $this->assertSame(2, $author->id);
     }
 
+    public function testFindTypedParameterCompatibility(): void
+    {
+        $articles = $this->fetchTable('Articles');
+        $article = $articles->find('titled')->first();
+        $this->assertNotEmpty($article);
+
+        // Options arrays should work
+        $article = $articles->find('titled', ['title' => 'Second Article'])->first();
+        $this->assertNotEmpty($article);
+        $this->assertEquals('Second Article', $article->title);
+
+        // Named parameters should be compatible with options finders
+        $article = $articles->find('titled', title: 'Second Article')->first();
+        $this->assertNotEmpty($article);
+        $this->assertEquals('Second Article', $article->title);
+    }
+
     public function testFindForFinderVariadic(): void
     {
         $testTable = $this->fetchTable('Test');

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1292,10 +1292,12 @@ class TableTest extends TestCase
         $article = $articles->find('titled')->first();
         $this->assertNotEmpty($article);
 
-        // Options arrays should work
-        $article = $articles->find('titled', ['title' => 'Second Article'])->first();
-        $this->assertNotEmpty($article);
-        $this->assertEquals('Second Article', $article->title);
+        // Options arrays are deprecated but should work
+        $this->deprecated(function () use ($articles) {
+            $article = $articles->find('titled', ['title' => 'Second Article'])->first();
+            $this->assertNotEmpty($article);
+            $this->assertEquals('Second Article', $article->title);
+        });
 
         // Named parameters should be compatible with options finders
         $article = $articles->find('titled', title: 'Second Article')->first();

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -58,6 +58,18 @@ class ArticlesTable extends Table
     }
 
     /**
+     * Finder for testing named parameter compatibility
+     */
+    public function findTitled(SelectQuery $query, array $options): SelectQuery
+    {
+        if (!empty($options['title'])) {
+            $query->where(['Articles.title' => $options['title']]);
+        }
+
+        return $query;
+    }
+
+    /**
      * Example public method
      */
     public function doSomething(): void


### PR DESCRIPTION
We have rector rules to update the callsites of finders to use named parameters. What we lack is rector operations to upgrade finder declarations to use named parameters. Because this is an impossible task, we should have better compatibility for new style finder calls with old style options arrays. This helps improve finder ergonomics (less typing) for more folks.

This would have saved me a bunch of work when upgraded an application recently and making the upgrade smoother is important to me.
