### PR TITLE
Fix typo in Database README

### DIFF
--- a/src/Database/README.md
+++ b/src/Database/README.md
@@ -218,7 +218,7 @@ Generating conditions:
 // WHERE id = 1
 $query->where(['id' => 1]);
 
-// WHERE id > 2
+// WHERE id > 1
 $query->where(['id >' => 1]);
 ```
 


### PR DESCRIPTION
Simple typo in a comment describing WHERE usage with greater operation.