### PR TITLE
Avoid lock file being created for vendor lib root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "psr/simple-cache-implementation": "^3.0"
     },
     "config": {
+        "lock": false,
         "process-timeout": 900,
         "sort-packages": true,
         "allow-plugins": {


### PR DESCRIPTION
This creates less issues when switching branches and developing actively.
Since we don't need it it was noise anyway.