### PR TITLE
Check all fields for new entities. 

### DIFF
--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -66,12 +66,12 @@ class IsUnique
      */
     public function __invoke(EntityInterface $entity, array $options): bool
     {
-        if (!$entity->extract($this->_fields, true)) {
-            return true;
+        $fields = $entity->extract($this->_fields, !$entity->isNew());
+        if ($this->_options['allowMultipleNulls']) {
+            $fields = array_filter($fields, 'is_null');
         }
 
-        $fields = $entity->extract($this->_fields);
-        if ($this->_options['allowMultipleNulls'] && array_filter($fields, 'is_null')) {
+        if ($fields === []) {
             return true;
         }
 


### PR DESCRIPTION
Not sure why but it restored behavior to 4.x. Without the change it skips the check for new entities.

For some reason: $entity->extract($this->_fields, true) returns [] for some new entities that it wasnt before. This was found during phpunit when testing our 5.x upgrade branch.
