### PR TITLE
Update documentation for SelectQuery::select()

### DIFF
--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -146,7 +146,7 @@ class SelectQuery extends Query implements IteratorAggregate
      * $query->select('id', true); // Resets the list: SELECT id
      * $query->select(['total' => $countQuery]); // SELECT id, (SELECT ...) AS total
      * $query->select(function ($query) {
-     *     return ['article_id', 'total' => $query->count('*')];
+     *     return ['article_id', 'total' => $query->func()->count('*')];
      * })
      * ```
      *


### PR DESCRIPTION
When using a Closure as first parameter of SelectQuery::select(), it will receive the SelectQuery instance as parameter. However, SelectQuery::count() is not an existing method and FunctionsBuilder returned by SelectQuery::func() must be used instead.

---

After playing with SelectQuery() and trying to add a COUNT(*) field in my SQL query, I assumed there was a typo in the documentation. Let me know if I am right.
