### PR TITLE
Update MemcachedEngine to allow empty prefix

### DIFF
--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -437,7 +437,7 @@ class MemcachedEngine extends CacheEngine
         }
 
         foreach ($keys as $key) {
-            if (strpos($key, $this->_config['prefix']) === 0) {
+            if ($this->_config['prefix'] === '' || strpos($key, $this->_config['prefix']) === 0) {
                 $this->_Memcached->delete($key);
             }
         }

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -819,6 +819,26 @@ class MemcachedEngineTest extends TestCase
     }
 
     /**
+     * test clearing memcached with empty prefix.
+     */
+    public function testClearWithEmptyPrefix(): void
+    {
+        Cache::setConfig('memcached2', [
+            'engine' => 'Memcached',
+            'prefix' => '',
+            'duration' => 3600,
+            'servers' => ['127.0.0.1:' . $this->port],
+        ]);
+
+        Cache::write('some_value', 'cache1', 'memcached2');
+        sleep(1);
+        $this->assertTrue(Cache::clear('memcached2'));
+        $this->assertNull(Cache::read('some_value', 'memcached2'));
+
+        Cache::clear('memcached2');
+    }
+
+    /**
      * test that a 0 duration can successfully write.
      */
     public function testZeroDuration(): void


### PR DESCRIPTION
While using empty prefixes for Memcached configs, there is a warning because of the usage of `strpos` with an empty needle: `strpos(): Empty needle`