### PR TITLE
Throw exception when setting association with duplicate alias.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,11 @@ jobs:
           - 11211/tcp
 
     steps:
-    - name: Setup MySQL latest
+    - name: Setup MySQL
       if: matrix.db-type == 'mysql'
-      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql --default-authentication-plugin=mysql_native_password --disable-log-bin
+      run: |
+        sudo service mysql start
+        mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp;'
 
     - name: Setup PostgreSQL latest
       if: matrix.db-type == 'pgsql'
@@ -100,10 +102,6 @@ jobs:
     - name: Setup problem matchers for PHPUnit
       if: matrix.php-version == '8.1' && matrix.db-type == 'mysql'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-    - name: Wait for MySQL
-      if: matrix.db-type == 'mysql' || matrix.db-type == 'mariadb'
-      run: while ! `mysqladmin ping -h 127.0.0.1 --silent`; do printf 'Waiting for MySQL...\n'; sleep 2; done;
 
     - name: Run PHPUnit
       env:

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\ORM;
 
 use ArrayIterator;
+use Cake\Core\Exception\CakeException;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Locator\LocatorInterface;
@@ -70,6 +71,7 @@ class AssociationCollection implements IteratorAggregate
      * @param string $alias The association alias
      * @param \Cake\ORM\Association $association The association to add.
      * @return \Cake\ORM\Association The association object being added.
+     * @throws \Cake\Core\Exception\CakeException If the alias is already added.
      * @template T of \Cake\ORM\Association
      * @psalm-param T $association
      * @psalm-return T
@@ -77,6 +79,10 @@ class AssociationCollection implements IteratorAggregate
     public function add(string $alias, Association $association): Association
     {
         [, $alias] = pluginSplit($alias);
+
+        if (isset($this->_items[$alias])) {
+            throw new CakeException(sprintf('Association alias `%s` is already in use.', $alias));
+        }
 
         return $this->_items[$alias] = $association;
     }

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -81,7 +81,7 @@ class AssociationCollection implements IteratorAggregate
         [, $alias] = pluginSplit($alias);
 
         if (isset($this->_items[$alias])) {
-            throw new CakeException(sprintf('Association alias `%s` is already in use.', $alias));
+            throw new CakeException(sprintf('Association alias `%s` is already set.', $alias));
         }
 
         return $this->_items[$alias] = $association;

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -131,6 +131,10 @@ class EavStrategy implements TranslateStrategyInterface
                 $conditions[$name . '.content !='] = '';
             }
 
+            if ($this->table->associations()->has($name)) {
+                $this->table->associations()->remove($name);
+            }
+
             $this->table->hasOne($name, [
                 'targetTable' => $fieldTable,
                 'foreignKey' => 'foreign_key',
@@ -145,6 +149,9 @@ class EavStrategy implements TranslateStrategyInterface
             $conditions["$targetAlias.content !="] = '';
         }
 
+        if ($this->table->associations()->has($targetAlias)) {
+            $this->table->associations()->remove($targetAlias);
+        }
         $this->table->hasMany($targetAlias, [
             'className' => $table,
             'foreignKey' => 'foreign_key',

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -105,6 +105,11 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         $config = $this->getConfig();
 
         $targetAlias = $this->translationTable->getAlias();
+
+        if ($this->table->associations()->has($targetAlias)) {
+            $this->table->associations()->remove($targetAlias);
+        }
+
         $this->table->hasMany($targetAlias, [
             'className' => $config['translationTable'],
             'foreignKey' => 'id',
@@ -182,6 +187,10 @@ class ShadowTableStrategy implements TranslateStrategyInterface
             $joinType = $options['filterByCurrentLocale'] ? 'INNER' : 'LEFT';
         } else {
             $joinType = $config['onlyTranslated'] ? 'INNER' : 'LEFT';
+        }
+
+        if ($this->table->associations()->has($config['hasOneAlias'])) {
+            $this->table->associations()->remove($config['hasOneAlias']);
         }
 
         $this->table->hasOne($config['hasOneAlias'], [

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -163,11 +163,11 @@ trait PaginatorTestTrait
     public function testPaginateNestedEagerLoader(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->belongsToMany('Tags');
         $tags = $this->getTableLocator()->get('Tags');
+        $tags->associations()->remove('Authors');
         $tags->belongsToMany('Authors');
         $articles->getEventManager()->on('Model.beforeFind', function ($event, $query): void {
-            $query ->matching('Tags', function ($q) {
+            $query->matching('Tags', function ($q) {
                 return $q->matching('Authors', function ($q) {
                     return $q->where(['Authors.name' => 'larry']);
                 });

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -399,11 +399,7 @@ class BelongsToManyTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
 
-        $tags->belongsToMany('Articles', [
-            'sourceTable' => $tags,
-            'targetTable' => $articles,
-            'finder' => 'published',
-        ]);
+        $tags->associations()->get('Articles')->setFinder('published');
         $articles->updateAll(['published' => 'N'], ['id' => 1]);
         $entity = $tags->get(1, ...['contain' => 'Articles']);
         $this->assertCount(1, $entity->articles, 'only one article should load');
@@ -926,12 +922,9 @@ class BelongsToManyTest extends TestCase
 
         // Update an article to not match the association finder.
         $articles->updateAll(['published' => 'N'], ['id' => 1]);
-        $assoc = $tags->belongsToMany('Articles', [
-            'sourceTable' => $tags,
-            'targetTable' => $articles,
-            'through' => $joint,
-            'finder' => 'published',
-        ]);
+        $assoc = $tags->associations()->get('Articles')
+            ->setFinder('published')
+            ->setThrough($joint);
         $entity = $tags->get(1, ...['contain' => 'Articles']);
         $this->assertCount(1, $entity->articles);
 
@@ -984,15 +977,11 @@ class BelongsToManyTest extends TestCase
         $this->setAppNamespace('TestApp');
 
         $joint = $this->getTableLocator()->get('ArticlesTags');
-        $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
 
-        $assoc = $tags->belongsToMany('Articles', [
-            'sourceTable' => $tags,
-            'targetTable' => $articles,
-            'through' => $joint,
-            'finder' => ['published' => ['title' => 'First Article']],
-        ]);
+        $assoc = $tags->associations()->get('Articles')
+            ->setFinder(['published' => ['title' => 'First Article']])
+            ->setThrough($joint);
         $entity = $tags->get(1, ...['contain' => 'Articles']);
         $this->assertCount(1, $entity->articles);
 
@@ -1018,12 +1007,9 @@ class BelongsToManyTest extends TestCase
         $articles = $this->getTableLocator()->get('Articles');
         $tags = $this->getTableLocator()->get('Tags');
 
-        $assoc = $tags->belongsToMany('Articles', [
-            'sourceTable' => $tags,
-            'targetTable' => $articles,
-            'through' => $joint,
-            'finder' => 'withAuthors',
-        ]);
+        $assoc = $tags->associations()->get('Articles')
+            ->setFinder('withAuthors')
+            ->setThrough($joint);
         $tag = $tags->get(1);
         $article = $articles->get(1);
 

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -461,7 +461,7 @@ class BelongsToTest extends TestCase
     {
         $this->setAppNamespace('TestApp');
         $articles = $this->getTableLocator()->get('Articles');
-        $articles->belongsTo('Authors')
+        $articles->associations()->get('Authors')
             ->setFinder('formatted');
 
         $query = $articles->find()

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -181,7 +181,7 @@ class HasManyTest extends TestCase
     public function testSorting(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $assoc = $authors->hasMany('Articles');
+        $assoc = $authors->Articles;
 
         $field = 'Articles.id';
         $driver = $authors->getConnection()->getDriver();
@@ -502,7 +502,6 @@ class HasManyTest extends TestCase
     public function testEagerloaderNoForeignKeys(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to load `Articles` association. Ensure foreign key in `Authors`');
@@ -666,9 +665,7 @@ class HasManyTest extends TestCase
     public function testPropertyOptionMarshalAndValidation(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', [
-            'propertyName' => 'blogs',
-        ]);
+        $authors->Articles->setProperty('blogs');
         $authors->getValidator()
             ->requirePresence('blogs', true, 'blogs must be set');
 
@@ -703,9 +700,7 @@ class HasManyTest extends TestCase
     public function testValueBinderUpdateOnSubQueryStrategy(): void
     {
         $Authors = $this->getTableLocator()->get('Authors');
-        $Authors->hasMany('Articles', [
-            'strategy' => Association::STRATEGY_SUBQUERY,
-        ]);
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
 
         $query = $Authors->find();
         $authorsAndArticles = $query
@@ -730,9 +725,7 @@ class HasManyTest extends TestCase
     public function testSubqueryWithLimit()
     {
         $Authors = $this->getTableLocator()->get('Authors');
-        $Authors->hasMany('Articles', [
-            'strategy' => Association::STRATEGY_SUBQUERY,
-        ]);
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
 
         $query = $Authors->find();
         $result = $query
@@ -755,9 +748,7 @@ class HasManyTest extends TestCase
         $this->skipIf(ConnectionManager::get('test')->getDriver() instanceof Sqlserver, 'Sql Server does not support ORDER BY on field not in GROUP BY');
 
         $Authors = $this->getTableLocator()->get('Authors');
-        $Authors->hasMany('Articles', [
-            'strategy' => Association::STRATEGY_SUBQUERY,
-        ]);
+        $Authors->Articles->setStrategy(Association::STRATEGY_SUBQUERY);
 
         $query = $Authors->find();
         $result = $query
@@ -842,10 +833,7 @@ class HasManyTest extends TestCase
     public function testUnlinkSuccess(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $assoc = $this->author->hasMany('Articles', [
-            'sourceTable' => $this->author,
-            'targetTable' => $articles,
-        ]);
+        $assoc = $this->author->Articles;
 
         $entity = $this->author->get(1, ...['contain' => 'Articles']);
         $initial = $entity->articles;
@@ -866,10 +854,7 @@ class HasManyTest extends TestCase
     public function testUnlinkWithEmptyArray(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $assoc = $this->author->hasMany('Articles', [
-            'sourceTable' => $this->author,
-            'targetTable' => $articles,
-        ]);
+        $assoc = $this->author->Articles;
 
         $entity = $this->author->get(1, ...['contain' => 'Articles']);
         $initial = $entity->articles;
@@ -889,10 +874,7 @@ class HasManyTest extends TestCase
     public function testLinkUsesSingleTransaction(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
-        $assoc = $this->author->hasMany('Articles', [
-            'sourceTable' => $this->author,
-            'targetTable' => $articles,
-        ]);
+        $assoc = $this->author->Articles;
 
         // Ensure author in fixture has zero associated articles
         $entity = $this->author->get(2, ...['contain' => 'Articles']);
@@ -1129,7 +1111,7 @@ class HasManyTest extends TestCase
     public function testSaveReplaceSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_REPLACE]);
+        $authors->Articles->setSaveStrategy(HasMany::SAVE_REPLACE);
 
         $entity = $authors->newEntity([
             'name' => 'mylux',
@@ -1160,7 +1142,7 @@ class HasManyTest extends TestCase
     public function testSaveReplaceSaveStrategyClosureConditions(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles')
+        $authors->Articles
             ->setDependent(true)
             ->setSaveStrategy('replace')
             ->setConditions(function () {
@@ -1201,7 +1183,7 @@ class HasManyTest extends TestCase
     public function testSaveReplaceSaveStrategyNotAdding(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', ['saveStrategy' => 'replace']);
+        $authors->Articles->setSaveStrategy('replace');
 
         $entity = $authors->newEntity([
             'name' => 'mylux',
@@ -1229,7 +1211,7 @@ class HasManyTest extends TestCase
     public function testSaveAppendSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', ['saveStrategy' => 'append']);
+        $authors->Articles->setSaveStrategy('append');
 
         $entity = $authors->newEntity([
             'name' => 'mylux',
@@ -1261,8 +1243,8 @@ class HasManyTest extends TestCase
     public function testSaveDefaultSaveStrategy(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_APPEND]);
-        $this->assertSame(HasMany::SAVE_APPEND, $authors->getAssociation('articles')->getSaveStrategy());
+        $authors->Articles->setSaveStrategy(HasMany::SAVE_APPEND);
+        $this->assertSame(HasMany::SAVE_APPEND, $authors->getAssociation('Articles')->getSaveStrategy());
     }
 
     /**
@@ -1271,7 +1253,8 @@ class HasManyTest extends TestCase
     public function testSaveReplaceSaveStrategyDependent(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_REPLACE, 'dependent' => true]);
+        $authors->Articles->setSaveStrategy(HasMany::SAVE_REPLACE)
+            ->setDependent(true);
 
         $entity = $authors->newEntity([
             'name' => 'mylux',
@@ -1303,7 +1286,8 @@ class HasManyTest extends TestCase
     public function testSaveReplaceSaveStrategyDependentWithStringKeys(): void
     {
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', ['saveStrategy' => HasMany::SAVE_REPLACE, 'dependent' => true]);
+        $authors->Articles->setSaveStrategy(HasMany::SAVE_REPLACE)
+            ->setDependent(true);
 
         $entity = $authors->newEntity([
             'name' => 'mylux',
@@ -1341,11 +1325,9 @@ class HasManyTest extends TestCase
         $this->setAppNamespace('TestApp');
 
         $authors = $this->getTableLocator()->get('Authors');
-        $authors->hasMany('Articles', [
-            'finder' => 'published',
-            'saveStrategy' => HasMany::SAVE_REPLACE,
-            'dependent' => true,
-        ]);
+        $authors->Articles->setSaveStrategy(HasMany::SAVE_REPLACE)
+            ->setDependent(true)
+            ->setFinder('published');
         $articles = $authors->Articles->getTarget();
 
         // Remove an article from the association finder scope

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Core\Exception\CakeException;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\AssociationCollection;
@@ -435,5 +436,15 @@ class AssociationCollectionTest extends TestCase
         $expected = ['Users' => $belongsTo, 'Cart' => $belongsToMany];
         $result = iterator_to_array($this->associations, true);
         $this->assertSame($expected, $result);
+    }
+
+    public function testExceptionOnDuplicateAlias(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('Association alias `Users` is already in use.');
+
+        $belongsTo = new BelongsTo('');
+        $this->associations->add('Users', $belongsTo);
+        $this->associations->add('Users', $belongsTo);
     }
 }

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -441,7 +441,7 @@ class AssociationCollectionTest extends TestCase
     public function testExceptionOnDuplicateAlias(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Association alias `Users` is already in use.');
+        $this->expectExceptionMessage('Association alias `Users` is already set.');
 
         $belongsTo = new BelongsTo('');
         $this->associations->add('Users', $belongsTo);

--- a/tests/TestCase/ORM/AssociationProxyTest.php
+++ b/tests/TestCase/ORM/AssociationProxyTest.php
@@ -100,9 +100,7 @@ class AssociationProxyTest extends TestCase
         // Exclude a record from the published finder.
         $articles->updateAll(['published' => 'N'], ['id' => 1]);
 
-        $authors->hasMany('Articles', [
-            'finder' => 'published',
-        ]);
+        $authors->Articles->setFinder('published');
         $authors->Articles->updateAll(['published' => '?'], '1=1');
         $missed = $articles->find()->where(['published' => 'Y'])->count();
         $this->assertSame(0, $missed);
@@ -136,9 +134,7 @@ class AssociationProxyTest extends TestCase
         // Exclude a record from the published finder.
         $articles->updateAll(['published' => 'N'], ['id' => 1]);
 
-        $authors->hasMany('Articles', [
-            'finder' => 'published',
-        ]);
+        $authors->Articles->setFinder('published');
         $authors->Articles->deleteAll('1=1');
         $remaining = $articles->find()->all();
         $this->assertCount(1, $remaining);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -602,7 +602,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
-        $comments = $table->hasMany('Comments')->getTarget();
+        $comments = $table->associations()->get('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $table->setLocale('eng');
@@ -638,7 +638,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
-        $comments = $table->hasMany('Comments')->getTarget();
+        $comments = $table->associations()->get('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $results = $table->find('translations')->contain([
@@ -677,7 +677,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
         $table->hasMany('Comments');
-        $comments = $table->hasMany('Comments')->getTarget();
+        $comments = $table->associations()->get('Comments')->getTarget();
         $comments->addBehavior('Translate', ['fields' => ['comment']]);
 
         $table->setLocale('cze');

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -1799,7 +1799,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeBelongsToManyFromIdsWithConditions(): void
     {
-        $this->articles->belongsToMany('Tags', [
+        $this->articles->associations()->get('Tags')->setConditions([
             'conditions' => ['ArticleTags.article_id' => 1],
         ]);
 
@@ -1832,7 +1832,7 @@ class MarshallerTest extends TestCase
      */
     public function testMergeBelongsToManyFromArrayWithConditions(): void
     {
-        $this->articles->belongsToMany('Tags', [
+        $this->articles->associations()->get('Tags')->setConditions([
             'conditions' => ['ArticleTags.article_id' => 1],
         ]);
 
@@ -2325,7 +2325,6 @@ class MarshallerTest extends TestCase
      */
     public function testMergeBelongsToManyIdsRetainJoinData(): void
     {
-        $this->articles->belongsToMany('Tags');
         $entity = $this->articles->get(1, ...['contain' => ['Tags']]);
         $entity->setAccess('*', true);
         $original = $entity->tags[0]->_joinData;

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -325,6 +325,7 @@ class QueryRegressionTest extends TestCase
             'saveStrategy' => $strategy,
         ]);
         $articles->Highlights->junction()->belongsTo('Authors');
+        $articles->Highlights->associations()->remove('Authors');
         $articles->Highlights->hasOne('Authors', [
             'foreignKey' => 'id',
         ]);
@@ -608,10 +609,7 @@ class QueryRegressionTest extends TestCase
             ->contain('Tags.TagsTranslations')
             ->all();
 
-        $tags->hasMany('TagsTranslations', [
-            'foreignKey' => 'id',
-            'strategy' => 'subquery',
-        ]);
+        $tags->TagsTranslations->setStrategy('subquery');
         $findViaSubquery = $featuredTags
             ->find()
             ->where(['FeaturedTags.tag_id' => 2])

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -964,10 +964,6 @@ class LinkConstraintTest extends TestCase
     public function testImplicitBelongsToManyJunctionDeleteErrors(): void
     {
         $Articles = $this->getTableLocator()->get('Articles');
-        $Articles
-            ->getAssociation('Tags')
-            ->junction()
-            ->belongsTo('Articles');
 
         $rulesChecker = $Articles->getAssociation('Tags')->junction()->rulesChecker();
         $rulesChecker->addDelete(

--- a/tests/test_app/TestApp/Model/Table/AuthorsTable.php
+++ b/tests/test_app/TestApp/Model/Table/AuthorsTable.php
@@ -28,7 +28,7 @@ class AuthorsTable extends Table
      */
     public function initialize(array $config): void
     {
-        $this->hasMany('articles');
+        $this->hasMany('Articles');
     }
 
     /**


### PR DESCRIPTION
This is quite a common mistake done by new users (when creating multiple associations to the same table) and the exception should save them lot of debugging and support requests.
