### PR TITLE
5.1 - Restore command helper tests and add BannerHelper

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,18 +2,21 @@ includes:
 	- phpstan-baseline.neon
 
 rules:
-    - Symplify\PHPStanRules\Rules\Explicit\NoMixedPropertyFetcherRule
-    - Symplify\PHPStanRules\Rules\Explicit\NoMixedMethodCallerRule
+	- Symplify\PHPStanRules\Rules\Explicit\NoMixedPropertyFetcherRule
+	- Symplify\PHPStanRules\Rules\Explicit\NoMixedMethodCallerRule
 
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- tests/bootstrap.php
 	paths:
 		- src/
+	ignoreErrors:
+		-
+		  identifier: missingType.iterableValue
+		-
+		  identifier: missingType.generics
 
 services:
 	-

--- a/src/Command/Helper/BannerHelper.php
+++ b/src/Command/Helper/BannerHelper.php
@@ -86,10 +86,10 @@ class BannerHelper extends Helper
         ];
         foreach ($args as $line) {
             $lineLength = mb_strlen($line);
-            $linePadding = (int)max($this->padding, ($bannerLength - $lineLength) / 2);
+            $linePadding = (int)max($this->padding, $bannerLength - $lineLength - $this->padding);
 
             $lines[] = $start .
-                str_repeat(' ', $linePadding) .
+                str_repeat(' ', $this->padding) .
                 $line .
                 str_repeat(' ', $linePadding) .
                 $end;

--- a/src/Command/Helper/BannerHelper.php
+++ b/src/Command/Helper/BannerHelper.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Command\Helper;
+
+use Cake\Console\Helper;
+use InvalidArgumentException;
+
+/**
+ * Banner command helper.
+ *
+ * Formats one or more lines of text into a large banner with
+ * padding and a blank line below.
+ */
+class BannerHelper extends Helper
+{
+    /**
+     * @var int $padding The horizontal padding that is added to the longest line.
+     */
+    private int $padding = 2;
+
+    /**
+     * @var string $style The console output style to use on the banner.
+     */
+    private string $style = 'success.bg';
+
+    /**
+     * Modify the padding of the helper
+     *
+     * @param int $padding The padding value to use.
+     * @return $this
+     */
+    public function withPadding(int $padding)
+    {
+        if ($padding < 0) {
+            throw new InvalidArgumentException('padding must be greater than 0');
+        }
+        $this->padding = $padding;
+
+        return $this;
+    }
+
+    /**
+     * Modify the padding of the helper
+     *
+     * @param string $style The style value to use.
+     * @return $this
+     */
+    public function withStyle(string $style)
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * Output a banner
+     *
+     * @param array $args The messages to output
+     * @return void
+     */
+    public function output(array $args): void
+    {
+        $lengths = array_map(fn ($i) => mb_strlen($i), $args);
+        $maxLength = max($lengths);
+        $bannerLength = $maxLength + $this->padding * 2;
+        $start = "<{$this->style}>";
+        $end = "</{$this->style}>";
+
+        $lines = [
+            '',
+            $start . str_repeat(' ', $bannerLength) . $end,
+        ];
+        foreach ($args as $line) {
+            $lineLength = mb_strlen($line);
+            $linePadding = (int)max($this->padding, ($bannerLength - $lineLength) / 2);
+
+            $lines[] = $start .
+                str_repeat(' ', $linePadding) .
+                $line .
+                str_repeat(' ', $linePadding) .
+                $end;
+        }
+
+        $lines[] = $start . str_repeat(' ', $bannerLength) . $end;
+        $lines[] = '';
+
+        $this->_io->out($lines);
+    }
+}

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -156,7 +156,7 @@ class ConsoleOutput
         'warning' => ['text' => 'yellow'],
         'warning.bg' => ['background' => 'yellow', 'text' => 'black'],
         'info' => ['text' => 'cyan'],
-        'info.bg' => ['background' => 'cyan', 'text' => 'black'],
+        'info.bg' => ['background' => 'white', 'text' => 'cyan'],
         'debug' => ['text' => 'yellow'],
         'success' => ['text' => 'green'],
         'success.bg' => ['background' => 'green', 'text' => 'black'],

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -32,6 +32,11 @@ use function Cake\Core\env;
  * - `info` Informational messages.
  * - `comment` Additional text.
  * - `question` Magenta text used for user prompts
+ * - `success` Green foreground text
+ * - `info.bg` Cyan background with black text
+ * - `warning.bg` Yellow background with black text
+ * - `error.bg` Red background with black text
+ * - `success.bg` Green background with black text
  *
  * By defining styles with addStyle() you can create custom console styles.
  *
@@ -147,13 +152,18 @@ class ConsoleOutput
         'alert' => ['text' => 'red'],
         'critical' => ['text' => 'red'],
         'error' => ['text' => 'red'],
+        'error.bg' => ['background' => 'red', 'text' => 'black'],
         'warning' => ['text' => 'yellow'],
+        'warning.bg' => ['background' => 'yellow', 'text' => 'black'],
         'info' => ['text' => 'cyan'],
+        'info.bg' => ['background' => 'cyan', 'text' => 'black'],
         'debug' => ['text' => 'yellow'],
         'success' => ['text' => 'green'],
+        'success.bg' => ['background' => 'green', 'text' => 'black'],
+        'notice' => ['text' => 'cyan'],
+        'notice.bg' => ['background' => 'cyan', 'text' => 'black'],
         'comment' => ['text' => 'blue'],
         'question' => ['text' => 'magenta'],
-        'notice' => ['text' => 'cyan'],
     ];
 
     /**
@@ -230,7 +240,7 @@ class ConsoleOutput
             $replaceTags = $this->_replaceTags(...);
 
             $output = preg_replace_callback(
-                '/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims',
+                '/<(?P<tag>[a-z0-9-_.]+)>(?P<text>.*?)<\/(\1)>/ims',
                 $replaceTags,
                 $text
             );

--- a/src/Database/phpstan.neon.dist
+++ b/src/Database/phpstan.neon.dist
@@ -1,7 +1,5 @@
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- tests/phpstan-bootstrap.php
@@ -10,4 +8,8 @@ parameters:
 	excludePaths:
 		- vendor/
 	ignoreErrors:
+		-
+			identifier: missingType.iterableValue
+		-
+			identifier: missingType.generics
 		- '#Unsafe usage of new static\(\).#'

--- a/src/Datasource/phpstan.neon.dist
+++ b/src/Datasource/phpstan.neon.dist
@@ -1,7 +1,5 @@
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- tests/phpstan-bootstrap.php
@@ -10,6 +8,10 @@ parameters:
 	excludePaths:
 		- vendor/
 	ignoreErrors:
+		-
+			identifier: missingType.iterableValue
+		-
+			identifier: missingType.generics
 		- "#^Template type T of method Cake\\\\Datasource\\\\QueryInterface\\:\\:all\\(\\) is not referenced in a parameter\\.$#"
 		- '#Class Cake\\Database\\Driver\\.+ not found.#'
 		- '#Class Cake\\Database\\Connection not found.#'

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -109,13 +109,13 @@ class EventManager implements EventManagerInterface
             return $this;
         }
 
-        if (!$callable && !is_callable($options)) {
+        if ($callable === null && !is_callable($options)) {
             throw new InvalidArgumentException(
                 'Second argument of `EventManager::on()` must be a callable if `$callable` is null.'
             );
         }
 
-        if (!$callable) {
+        if ($callable === null) {
             /** @var callable $options */
             $this->_listeners[$eventKey][static::$defaultPriority][] = [
                 'callable' => $options(...),
@@ -124,6 +124,7 @@ class EventManager implements EventManagerInterface
             return $this;
         }
 
+        /** @var array $options */
         $priority = $options['priority'] ?? static::$defaultPriority;
         $this->_listeners[$eventKey][$priority][] = [
             'callable' => $callable(...),

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -157,8 +157,9 @@ class FormData implements Countable, Stringable
             if (stream_is_local($value)) {
                 $finfo = new finfo(FILEINFO_MIME);
                 $metadata = stream_get_meta_data($value);
-                $contentType = (string)$finfo->file($metadata['uri']);
-                $filename = basename($metadata['uri']);
+                $uri = $metadata['uri'] ?? '';
+                $contentType = (string)$finfo->file($uri);
+                $filename = basename($uri);
             }
         } else {
             $finfo = new finfo(FILEINFO_MIME);

--- a/src/Http/phpstan.neon.dist
+++ b/src/Http/phpstan.neon.dist
@@ -1,7 +1,5 @@
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- tests/phpstan-bootstrap.php
@@ -13,6 +11,10 @@ parameters:
 	    - Session.php
 	    - vendor/
 	ignoreErrors:
+		-
+			identifier: missingType.iterableValue
+		-
+			identifier: missingType.generics
 		- '#Unsafe usage of new static\(\).#'
 		- "#^Constructor of class Cake\\\\Http\\\\Client\\\\Auth\\\\Digest has an unused parameter \\$options\\.$#"
 		- '#Call to static method getRequest\(\) on an unknown class Cake\\Routing\\Router.#'

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -1580,7 +1580,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
     protected function _execute(): iterable
     {
         $this->triggerBeforeFind();
-        if ($this->_results) {
+        if ($this->_results !== null) {
             return $this->_results;
         }
 

--- a/src/ORM/phpstan.neon.dist
+++ b/src/ORM/phpstan.neon.dist
@@ -1,7 +1,5 @@
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- tests/phpstan-bootstrap.php
@@ -10,7 +8,14 @@ parameters:
 	excludePaths:
 		- vendor/
 	ignoreErrors:
+		-
+			identifier: missingType.iterableValue
+		-
+			identifier: missingType.generics
+
 		- '#Unsafe usage of new static\(\).#'
 		- "#^Method Cake\\\\ORM\\\\Behavior\\\\TreeBehavior\\:\\:_scope\\(\\) should return T of Cake\\\\ORM\\\\Query\\\\DeleteQuery\\|Cake\\\\ORM\\\\Query\\\\SelectQuery\\|Cake\\\\ORM\\\\Query\\\\UpdateQuery but returns Cake\\\\ORM\\\\Query\\\\DeleteQuery\\|Cake\\\\ORM\\\\Query\\\\SelectQuery\\|Cake\\\\ORM\\\\Query\\\\UpdateQuery\\.$#"
 		- "#^PHPDoc tag @return with type Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\> is not subtype of native type static\\(Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\)\\.$#"
 		- "#^Method Cake\\\\ORM\\\\Query\\\\SelectQuery\\:\\:find\\(\\) should return static\\(Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\) but returns Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\.$#"
+		- "#^Access to an undefined property Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\:\\:\\$bufferedResults\\.$#"
+		- "#^Parameter \\#2 \\$results of method Cake\\\\ORM\\\\EagerLoader\\:\\:loadExternal\\(\\) expects iterable, Cake\\\\Database\\\\StatementInterface\\|iterable given\\.$#"

--- a/src/Validation/phpstan.neon.dist
+++ b/src/Validation/phpstan.neon.dist
@@ -1,7 +1,5 @@
 parameters:
 	level: 8
-	checkMissingIterableValueType: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 	bootstrapFiles:
 		- tests/phpstan-bootstrap.php
@@ -9,3 +7,6 @@ parameters:
 		- ./
 	excludePaths:
 	    - vendor/
+	ignoreErrors:
+		-
+			identifier: missingType.iterableValue

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -253,6 +253,7 @@ class SelectBoxWidget extends BasicWidget
         foreach ($options as $key => $val) {
             // Option groups
             $isIterable = is_iterable($val);
+            /** @var \ArrayAccess|array $val */
             if (
                 (
                     !is_int($key) &&

--- a/tests/TestCase/Command/Helper/BannerHelperTest.php
+++ b/tests/TestCase/Command/Helper/BannerHelperTest.php
@@ -55,6 +55,15 @@ class BannerHelperTest extends TestCase
     }
 
     /**
+     * Test that the callback is invoked until 100 is reached.
+     */
+    public function testOutputInvalidPadding(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->helper->withPadding(-1);
+    }
+
+    /**
      * Test output with all options
      */
     public function testOutputSuccess(): void
@@ -93,11 +102,23 @@ class BannerHelperTest extends TestCase
     }
 
     /**
-     * Test that the callback is invoked until 100 is reached.
+     * Test that width is respected
      */
-    public function testOutputInvalidPadding(): void
+    public function testOutputLongestLine(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->helper->withPadding(-1);
+        $this->helper
+            ->withPadding(1)
+            ->withStyle('info.bg')
+            ->output(['All done', 'This line is longer', 'tiny']);
+        $expected = [
+            '',
+            '<info.bg>                     </info.bg>',
+            '<info.bg> All done            </info.bg>',
+            '<info.bg> This line is longer </info.bg>',
+            '<info.bg> tiny                </info.bg>',
+            '<info.bg>                     </info.bg>',
+            '',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
     }
 }

--- a/tests/TestCase/Command/Helper/BannerHelperTest.php
+++ b/tests/TestCase/Command/Helper/BannerHelperTest.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Command\Helper;
+
+use Cake\Command\Helper\BannerHelper;
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+
+/**
+ * BannerHelper test.
+ */
+class BannerHelperTest extends TestCase
+{
+    /**
+     * @var \Cake\Command\Helper\BannerHelper
+     */
+    protected BannerHelper $helper;
+
+    /**
+     * @var \Cake\Console\TestSuite\StubConsoleOutput
+     */
+    protected StubConsoleOutput $stub;
+
+    /**
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected ConsoleIo $io;
+
+    /**
+     * setUp method
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stub = new StubConsoleOutput();
+        $this->io = new ConsoleIo($this->stub);
+        $this->helper = new BannerHelper($this->io);
+    }
+
+    /**
+     * Test output with all options
+     */
+    public function testOutputSuccess(): void
+    {
+        $this->helper
+            ->withPadding(5)
+            ->withStyle('info.bg')
+            ->output(['All done']);
+        $expected = [
+            '',
+            '<info.bg>                  </info.bg>',
+            '<info.bg>     All done     </info.bg>',
+            '<info.bg>                  </info.bg>',
+            '',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test that width is respected
+     */
+    public function testOutputPadding(): void
+    {
+        $this->helper
+            ->withPadding(1)
+            ->withStyle('info.bg')
+            ->output(['All done']);
+        $expected = [
+            '',
+            '<info.bg>          </info.bg>',
+            '<info.bg> All done </info.bg>',
+            '<info.bg>          </info.bg>',
+            '',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test that the callback is invoked until 100 is reached.
+     */
+    public function testOutputInvalidPadding(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->helper->withPadding(-1);
+    }
+}

--- a/tests/TestCase/Command/Helper/ProgressHelperTest.php
+++ b/tests/TestCase/Command/Helper/ProgressHelperTest.php
@@ -1,0 +1,294 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         3.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Command\Helper;
+
+use Cake\Command\Helper\ProgressHelper;
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+
+/**
+ * ProgressHelper test.
+ */
+class ProgressHelperTest extends TestCase
+{
+    /**
+     * @var \Cake\Command\Helper\ProgressHelper
+     */
+    protected ProgressHelper $helper;
+
+    /**
+     * @var \Cake\Console\TestSuite\StubConsoleOutput
+     */
+    protected StubConsoleOutput $stub;
+
+    /**
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected ConsoleIo $io;
+
+    /**
+     * setUp method
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stub = new StubConsoleOutput();
+        $this->io = new ConsoleIo($this->stub);
+        $this->helper = new ProgressHelper($this->io);
+    }
+
+    /**
+     * Test using the helper manually.
+     */
+    public function testInit(): void
+    {
+        $helper = $this->helper->init([
+            'total' => 200,
+            'width' => 50,
+        ]);
+        $this->assertSame($helper, $this->helper, 'Should be chainable');
+    }
+
+    public function testIncrementWithoutInit(): void
+    {
+        $this->helper->increment(10);
+        $this->helper->draw();
+        $expected = [
+            '',
+            '======>                                                                      10%',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test that a callback is required.
+     */
+    public function testOutputFailure(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->helper->output(['not a callback']);
+    }
+
+    /**
+     * Test that the callback is invoked until 100 is reached.
+     */
+    public function testOutputSuccess(): void
+    {
+        $this->helper->output([function (ProgressHelper $progress): void {
+            $progress->increment(20);
+        }]);
+        $expected = [
+            '',
+            '',
+            '==============>                                                              20%',
+            '',
+            '=============================>                                               40%',
+            '',
+            '============================================>                                60%',
+            '',
+            '===========================================================>                 80%',
+            '',
+            '==========================================================================> 100%',
+            '',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with options
+     */
+    public function testOutputSuccessOptions(): void
+    {
+        $this->helper->output([
+            'total' => 10,
+            'width' => 20,
+            'callback' => function (ProgressHelper $progress): void {
+                $progress->increment(2);
+            },
+        ]);
+        $expected = [
+            '',
+            '',
+            '==>              20%',
+            '',
+            '=====>           40%',
+            '',
+            '========>        60%',
+            '',
+            '===========>     80%',
+            '',
+            '==============> 100%',
+            '',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test using the helper manually.
+     */
+    public function testIncrementAndRender(): void
+    {
+        $this->helper->init();
+
+        $this->helper->increment(20);
+        $this->helper->draw();
+
+        $this->helper->increment(40.0);
+        $this->helper->draw();
+
+        $this->helper->increment(40);
+        $this->helper->draw();
+
+        $expected = [
+            '',
+            '==============>                                                              20%',
+            '',
+            '============================================>                                60%',
+            '',
+            '==========================================================================> 100%',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test using the helper chained.
+     */
+    public function testIncrementAndRenderChained(): void
+    {
+        $this->helper->init()
+            ->increment(20)
+            ->draw()
+            ->increment(40)
+            ->draw()
+            ->increment(40)
+            ->draw();
+
+        $expected = [
+            '',
+            '==============>                                                              20%',
+            '',
+            '============================================>                                60%',
+            '',
+            '==========================================================================> 100%',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test negative numbers
+     */
+    public function testIncrementWithNegatives(): void
+    {
+        $this->helper->init();
+
+        $this->helper->increment(40);
+        $this->helper->draw();
+
+        $this->helper->increment(-60);
+        $this->helper->draw();
+
+        $this->helper->increment(80);
+        $this->helper->draw();
+
+        $expected = [
+            '',
+            '=============================>                                               40%',
+            '',
+            '                                                                              0%',
+            '',
+            '===========================================================>                 80%',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test increment and draw with options
+     */
+    public function testIncrementWithOptions(): void
+    {
+        $this->helper->init([
+            'total' => 10,
+            'width' => 20,
+        ]);
+        $expected = [
+            '',
+            '=====>           40%',
+            '',
+            '===========>     80%',
+            '',
+            '==============> 100%',
+        ];
+        $this->helper->increment(4);
+        $this->helper->draw();
+        $this->helper->increment(4);
+        $this->helper->draw();
+        $this->helper->increment(4);
+        $this->helper->draw();
+
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test increment and draw with value that makes the pad
+     * be a float
+     */
+    public function testIncrementFloatPad(): void
+    {
+        $this->helper->init([
+            'total' => 50,
+        ]);
+        $expected = [
+            '',
+            '=========>                                                                   14%',
+            '',
+            '====================>                                                        28%',
+            '',
+            '==============================>                                              42%',
+            '',
+            '=========================================>                                   56%',
+            '',
+            '===================================================>                         70%',
+            '',
+            '========================================================>                    76%',
+            '',
+            '==============================================================>              84%',
+            '',
+            '==========================================================================> 100%',
+        ];
+        $this->helper->increment(7);
+        $this->helper->draw();
+        $this->helper->increment(7);
+        $this->helper->draw();
+        $this->helper->increment(7);
+        $this->helper->draw();
+        $this->helper->increment(7);
+        $this->helper->draw();
+        $this->helper->increment(7);
+        $this->helper->draw();
+        $this->helper->increment(3);
+        $this->helper->draw();
+        $this->helper->increment(4);
+        $this->helper->draw();
+        $this->helper->increment(8);
+        $this->helper->draw();
+
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+}

--- a/tests/TestCase/Command/Helper/TableHelperTest.php
+++ b/tests/TestCase/Command/Helper/TableHelperTest.php
@@ -1,0 +1,451 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP :  Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP Project
+ * @since         3.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Command\Helper;
+
+use Cake\Command\Helper\TableHelper;
+use Cake\Console\ConsoleIo;
+use Cake\Console\TestSuite\StubConsoleOutput;
+use Cake\TestSuite\TestCase;
+
+/**
+ * TableHelper test.
+ */
+class TableHelperTest extends TestCase
+{
+    /**
+     * @var \Cake\Console\TestSuite\StubConsoleOutput
+     */
+    protected StubConsoleOutput $stub;
+
+    /**
+     * @var \Cake\Console\ConsoleIo
+     */
+    protected ConsoleIo $io;
+
+    /**
+     * @var \Cake\Shell\Helper\TableHelper
+     */
+    protected TableHelper $helper;
+
+    /**
+     * setUp method
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stub = new StubConsoleOutput();
+        $this->io = new ConsoleIo($this->stub);
+        $this->helper = new TableHelper($this->io);
+    }
+
+    /**
+     * Test output
+     */
+    public function testOutputDefaultOutput(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+            ['short', 'Longish thing', 'short'],
+            ['Longer thing', 'short', 'Longest Value'],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Long Header</info>   |',
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with inconsistent keys.
+     *
+     * When outputting entities or other structured data,
+     * headers shouldn't need to have the same keys as it is
+     * annoying to use.
+     */
+    public function testOutputInconsistentKeys(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+            ['a' => 'short', 'b' => 'Longish thing', 'c' => 'short'],
+            ['c' => 'Longer thing', 'a' => 'short', 'b' => 'Longest Value'],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Long Header</info>   |',
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test that output works when data contains just empty strings.
+     */
+    public function testOutputEmptyStrings(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Empty'],
+            ['short', 'Longish thing', ''],
+            ['Longer thing', 'short', ''],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+-------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Empty</info> |',
+            '+--------------+---------------+-------+',
+            '| short        | Longish thing |       |',
+            '| Longer thing | short         |       |',
+            '+--------------+---------------+-------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test that output works when data contains nulls.
+     */
+    public function testNullValues(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Empty'],
+            ['short', 'Longish thing', null],
+            ['Longer thing', 'short', null],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+-------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Empty</info> |',
+            '+--------------+---------------+-------+',
+            '| short        | Longish thing |       |',
+            '| Longer thing | short         |       |',
+            '+--------------+---------------+-------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with multi-byte characters
+     */
+    public function testOutputUtf8(): void
+    {
+        $data = [
+            ['Header 1', 'Head', 'Long Header'],
+            ['short', 'ÄÄÄÜÜÜ', 'short'],
+            ['Longer thing', 'longerish', 'Longest Value'],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+-----------+---------------+',
+            '| <info>Header 1</info>     | <info>Head</info>      | <info>Long Header</info>   |',
+            '+--------------+-----------+---------------+',
+            '| short        | ÄÄÄÜÜÜ    | short         |',
+            '| Longer thing | longerish | Longest Value |',
+            '+--------------+-----------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with multi-byte characters
+     */
+    public function testOutputFullwidth(): void
+    {
+        $data = [
+            ['Header 1', 'Head', 'Long Header'],
+            ['short', '竜頭蛇尾', 'short'],
+            ['Longer thing', 'longerish', 'Longest Value'],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+-----------+---------------+',
+            '| <info>Header 1</info>     | <info>Head</info>      | <info>Long Header</info>   |',
+            '+--------------+-----------+---------------+',
+            '| short        | 竜頭蛇尾  | short         |',
+            '| Longer thing | longerish | Longest Value |',
+            '+--------------+-----------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output without headers
+     */
+    public function testOutputWithoutHeaderStyle(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+            ['short', 'Longish thing', 'short'],
+            ['Longer thing', 'short', 'Longest Value'],
+        ];
+        $this->helper->setConfig(['headerStyle' => false]);
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| Header 1     | Header        | Long Header   |',
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with different header style
+     */
+    public function testOutputWithDifferentHeaderStyle(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+            ['short', 'Longish thing', 'short'],
+            ['Longer thing', 'short', 'Longest Value'],
+        ];
+        $this->helper->setConfig(['headerStyle' => 'error']);
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| <error>Header 1</error>     | <error>Header</error>        | <error>Long Header</error>   |',
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output without table headers
+     */
+    public function testOutputWithoutHeaders(): void
+    {
+        $data = [
+            ['short', 'Longish thing', 'short'],
+            ['Longer thing', 'short', 'Longest Value'],
+        ];
+        $this->helper->setConfig(['headers' => false]);
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with formatted cells
+     */
+    public function testOutputWithFormattedCells(): void
+    {
+        $data = [
+            ['short', 'Longish thing', '<info>short</info>'],
+            ['Longer thing', 'short', '<warning>Longest</warning> <error>Value</error>'],
+        ];
+        $this->helper->setConfig(['headers' => false]);
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | <info>short</info>         |',
+            '| Longer thing | short         | <warning>Longest</warning> <error>Value</error> |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with row separator
+     */
+    public function testOutputWithRowSeparator(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+            ['short', 'Longish thing', 'short'],
+            ['Longer thing', 'short', 'Longest Value'],
+        ];
+        $this->helper->setConfig(['rowSeparator' => true]);
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Long Header</info>   |',
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '+--------------+---------------+---------------+',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output with row separator and no headers
+     */
+    public function testOutputWithRowSeparatorAndHeaders(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+            ['short', 'Longish thing', 'short'],
+            ['Longer thing', 'short', 'Longest Value'],
+        ];
+        $this->helper->setConfig(['rowSeparator' => true]);
+        $this->helper->output($data);
+        $expected = [
+            '+--------------+---------------+---------------+',
+            '| <info>Header 1</info>     | <info>Header</info>        | <info>Long Header</info>   |',
+            '+--------------+---------------+---------------+',
+            '| short        | Longish thing | short         |',
+            '+--------------+---------------+---------------+',
+            '| Longer thing | short         | Longest Value |',
+            '+--------------+---------------+---------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test output when there is no data.
+     */
+    public function testOutputWithNoData(): void
+    {
+        $this->helper->output([]);
+        $this->assertEquals([], $this->stub->messages());
+    }
+
+    /**
+     * Test output with a header but no data.
+     */
+    public function testOutputWithHeaderAndNoData(): void
+    {
+        $data = [
+            ['Header 1', 'Header', 'Long Header'],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+----------+--------+-------------+',
+            '| <info>Header 1</info> | <info>Header</info> | <info>Long Header</info> |',
+            '+----------+--------+-------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Test no data when headers are disabled.
+     */
+    public function testOutputHeaderDisabledNoData(): void
+    {
+        $this->helper->setConfig(['header' => false]);
+        $this->helper->output([]);
+        $this->assertEquals([], $this->stub->messages());
+    }
+
+    /**
+     * Right-aligned text style test.
+     */
+    public function testTextRightStyle(): void
+    {
+        $data = [
+            ['Item', 'Price per piece (yen)'],
+            ['Apple', '<text-right><info>¥</info> 200</text-right>'],
+            ['Orange', '100'],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+--------+-----------------------+',
+            '| <info>Item</info>   | <info>Price per piece (yen)</info> |',
+            '+--------+-----------------------+',
+            '| Apple  |                 <info>¥</info> 200 |',
+            '| Orange | 100                   |',
+            '+--------+-----------------------+',
+        ];
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Right-aligned text style test.(If there is text rightside the text-right tag)
+     */
+    public function testTextRightsideTheTextRightTag(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $data = [
+            ['Item', 'Price per piece (yen)'],
+            ['Apple', '<text-right>some</text-right>text'],
+        ];
+        $this->helper->output($data);
+    }
+
+    /**
+     * Right-aligned text style test.(If there is text leftside the text-right tag)
+     */
+    public function testTextLeftsideTheTextRightTag(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $data = [
+            ['Item', 'Price per piece (yen)'],
+            ['Apple', 'text<text-right>some</text-right>'],
+        ];
+        $this->helper->output($data);
+    }
+
+    /**
+     * Table row column of type integer should be cast to string
+     */
+    public function testRowValueInteger(): void
+    {
+        $data = [
+            ['Item', 'Quantity'],
+            ['Cakes', 2],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+-------+----------+',
+            '| <info>Item</info>  | <info>Quantity</info> |',
+            '+-------+----------+',
+            '| Cakes | 2        |',
+            '+-------+----------+',
+        ];
+
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+
+    /**
+     * Table row column of type null should be cast to empty string
+     */
+    public function testRowValueNull(): void
+    {
+        $data = [
+            ['Item', 'Quantity'],
+            ['Cakes', null],
+        ];
+        $this->helper->output($data);
+        $expected = [
+            '+-------+----------+',
+            '| <info>Item</info>  | <info>Quantity</info> |',
+            '+-------+----------+',
+            '| Cakes |          |',
+            '+-------+----------+',
+        ];
+
+        $this->assertEquals($expected, $this->stub->messages());
+    }
+}

--- a/tests/TestCase/Command/Helper/TableHelperTest.php
+++ b/tests/TestCase/Command/Helper/TableHelperTest.php
@@ -20,6 +20,7 @@ use Cake\Command\Helper\TableHelper;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
+use UnexpectedValueException;
 
 /**
  * TableHelper test.
@@ -386,7 +387,7 @@ class TableHelperTest extends TestCase
      */
     public function testTextRightsideTheTextRightTag(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $data = [
             ['Item', 'Price per piece (yen)'],
             ['Apple', '<text-right>some</text-right>text'],
@@ -399,7 +400,7 @@ class TableHelperTest extends TestCase
      */
     public function testTextLeftsideTheTextRightTag(): void
     {
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $data = [
             ['Item', 'Price per piece (yen)'],
             ['Apple', 'text<text-right>some</text-right>'],

--- a/tests/TestCase/Console/HelperRegistryTest.php
+++ b/tests/TestCase/Console/HelperRegistryTest.php
@@ -15,8 +15,11 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Console;
 
+use Cake\Console\ConsoleIo;
 use Cake\Console\Exception\MissingHelperException;
 use Cake\Console\HelperRegistry;
+use Cake\Console\TestSuite\StubConsoleInput;
+use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
 use TestApp\Command\Helper\CommandHelper;
 use TestApp\Command\Helper\SimpleHelper;
@@ -30,7 +33,7 @@ class HelperRegistryTest extends TestCase
     /**
      * @var \Cake\Console\HelperRegistry
      */
-    protected $helpers;
+    protected HelperRegistry $helpers;
 
     /**
      * setUp
@@ -39,9 +42,11 @@ class HelperRegistryTest extends TestCase
     {
         parent::setUp();
         static::setAppNamespace();
-        $io = $this->getMockBuilder('Cake\Console\ConsoleIo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $io = new ConsoleIo(
+            new StubConsoleOutput(),
+            new StubConsoleOutput(),
+            new StubConsoleInput([]),
+        );
         $this->helpers = new HelperRegistry();
         $this->helpers->setIo($io);
     }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1295,11 +1295,9 @@ class TableTest extends TestCase
         $this->assertNotEmpty($article);
 
         // Options arrays are deprecated but should work
-        $this->deprecated(function () use ($articles) {
-            $article = $articles->find('titled', ['title' => 'Second Article'])->first();
-            $this->assertNotEmpty($article);
-            $this->assertEquals('Second Article', $article->title);
-        });
+        $article = $articles->find('titled', ['title' => 'Second Article'])->first();
+        $this->assertNotEmpty($article);
+        $this->assertEquals('Second Article', $article->title);
 
         // Named parameters should be compatible with options finders
         $article = $articles->find('titled', title: 'Second Article')->first();


### PR DESCRIPTION
When adding `BannerHelper` I noticed that we were missing test cases for the other helpers. It seems like the files were removed during 5.x, I have to assume during one of the many very large merge conflicts. I've restored those tests now.

These changes also contain a new console helper for emitting banners. With my terminal theme the following code

```php
$styles = ['info.bg', 'warning.bg', 'error.bg', 'success.bg'];
$helper = new BannerHelper(new ConsoleIo());
$helper->withPadding(5);
foreach ($styles as $style) {
    $helper
        ->withStyle($style)
        ->output(['All done!']);

}
```

Emits the following.

![Screenshot from 2024-05-16 23-38-43](https://github.com/cakephp/cakephp/assets/24086/59a1d403-d3d1-4d10-9ae6-23ac60a1aa85)

I would appreciate any other results, as I'm not sure I have the colors right.