### PR TITLE
Get request data as specific type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ help:
 	@echo "  Publish the dist/cakephp-VERSION.zip to github."
 	@echo ""
 	@echo "components"
-	@echo "  Split each of the public namespaces into separate repos and push the to Github."
+	@echo "  Split each of the public namespaces into separate repos and push them to Github."
 	@echo ""
 	@echo "clean-components CURRENT_BRANCH=xx"
 	@echo "  Delete branch xx from each subsplit. Useful when cleaning up after a security release."

--- a/contrib/validate-split-packages-phpstan.php
+++ b/contrib/validate-split-packages-phpstan.php
@@ -45,11 +45,12 @@ foreach ($packages as $path => $package) {
     }
 
     $exitCode = null;
+    $output = [];
     exec('cd ' . $path . ' && composer install && vendor/bin/phpstan analyze ./', $output, $exitCode);
     if ($exitCode !== 0) {
         $code = $exitCode;
 
-        $issues[] = $package . ': ' . PHP_EOL . implode(PHP_EOL, $output);
+        $issues[] = 'Issue(s) detected with ' . $package . ' package: ' . PHP_EOL . implode(PHP_EOL, $output);
     }
     exec('cd ' . $path . ' && rm composer.lock && rm -rf vendor');
 }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use Cake\I18n\DateTime;
-use DateTimeImmutable;
 use DateTimeInterface;
+use Exception;
 use JsonException;
 use Stringable;
 
@@ -493,6 +493,17 @@ function toBool(mixed $value): ?bool
     return null;
 }
 
+/**
+ * Converts a value to a DateTimeInterface.
+ *
+ *  integer  - value is treated as a Unix timestamp
+ *  string - value is treated as a ISO-8601 (Atom) formatted timestamp
+ *  Other values returns as null.
+ *
+ * @param mixed $value The value to convert to DateTimeInterface.
+ * @return \DateTimeInterface|null Returns a DateTimeInterface if parsing is successful, or NULL otherwise.
+ * @since 5.1.0
+ */
 function toDateTime(mixed $value): ?DateTimeInterface
 {
     if ($value instanceof DateTimeInterface) {
@@ -502,7 +513,7 @@ function toDateTime(mixed $value): ?DateTimeInterface
     if (is_int($value)) {
         try {
             return DateTime::createFromTimestamp($value);
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -510,7 +521,7 @@ function toDateTime(mixed $value): ?DateTimeInterface
     if (is_string($value)) {
         try {
             return DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -510,17 +510,15 @@ function toDateTime(mixed $value): ?DateTime
 {
     if ($value instanceof DateTime) {
         return $value;
-    }
-
-    if (is_int($value)) {
+    } else if ($value instanceof DateTimeInterface) {
+        return DateTime::parse($value);
+    } else if (is_int($value)) {
         try {
             return DateTime::createFromTimestamp($value);
         } catch (Exception) {
             return null;
         }
-    }
-
-    if (is_string($value)) {
+    } else if (is_string($value)) {
         try {
             return DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
         } catch (Exception) {

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
+use Cake\I18n\Date;
 use Cake\I18n\DateTime;
+use Cake\I18n\FrozenDate;
 use DateTimeInterface;
 use Exception;
 use JsonException;
@@ -501,12 +503,12 @@ function toBool(mixed $value): ?bool
  *  Other values returns as null.
  *
  * @param mixed $value The value to convert to DateTimeInterface.
- * @return \DateTimeInterface|null Returns a DateTimeInterface if parsing is successful, or NULL otherwise.
+ * @return \DateTime|null Returns a DateTimeInterface if parsing is successful, or NULL otherwise.
  * @since 5.1.0
  */
-function toDateTime(mixed $value): ?DateTimeInterface
+function toDateTime(mixed $value): ?DateTime
 {
-    if ($value instanceof DateTimeInterface) {
+    if ($value instanceof DateTime) {
         return $value;
     }
 
@@ -521,6 +523,47 @@ function toDateTime(mixed $value): ?DateTimeInterface
     if (is_string($value)) {
         try {
             return DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Converts a value to a DateInterface.
+ *
+ *  integer  - value is treated as a Unix timestamp
+ *  string - value is treated as a ISO-8601 (Atom) formatted timestamp
+ *  Other values returns as null.
+ *
+ * @param mixed $value The value to convert to DateInterface.
+ * @return FrozenDate|null Returns a FrozenDate if parsing is successful, or NULL otherwise.
+ * @since 5.1.0
+ */
+function toDate(mixed $value): ?Date
+{
+    if ($value instanceof Date) {
+        return $value;
+    }
+
+    if (is_int($value)) {
+        try {
+            $ts = DateTime::createFromTimestamp($value);
+            return Date::createFromArray([
+                'year' => $ts->format('Y'),
+                'month' => $ts->format('m'),
+                'day' => $ts->format('d'),
+            ]);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    if (is_string($value)) {
+        try {
+            return Date::createFromFormat(DateTimeInterface::ATOM, $value);
         } catch (Exception) {
             return null;
         }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
  */
 namespace Cake\Core;
 
+use Cake\I18n\DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use JsonException;
 use Stringable;
 
@@ -485,6 +488,31 @@ function toBool(mixed $value): ?bool
     }
     if ($value === '0' || $value === 0 || $value === 0.0 || $value === false) {
         return false;
+    }
+
+    return null;
+}
+
+function toDateTime(mixed $value): ?DateTimeInterface
+{
+    if ($value instanceof DateTimeInterface) {
+        return $value;
+    }
+
+    if (is_int($value)) {
+        try {
+            return DateTime::createFromTimestamp($value);
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    if (is_string($value)) {
+        try {
+            return DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     return null;

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -21,6 +21,7 @@ use Cake\I18n\DateTime;
 use Cake\I18n\FrozenDate;
 use DateTimeInterface;
 use Exception;
+use IntlDateFormatter;
 use JsonException;
 use Stringable;
 
@@ -530,10 +531,10 @@ function toDateTime(mixed $value): ?DateTime
 }
 
 /**
- * Converts a value to a DateInterface.
+ * Converts a value to a native Date object.
  *
  *  integer  - value is treated as a Unix timestamp
- *  string - value is treated as a ISO-8601 (Atom) formatted timestamp
+ *  string - value is treated as a I18N short formatted date
  *  Other values returns as null.
  *
  * @param mixed $value The value to convert to DateInterface.
@@ -544,9 +545,9 @@ function toDate(mixed $value): ?Date
 {
     if ($value instanceof Date) {
         return $value;
-    }
-
-    if (is_int($value)) {
+    } else if ($value instanceof DateTimeInterface) {
+        return Date::parse($value);
+    } else if (is_int($value)) {
         try {
             $ts = DateTime::createFromTimestamp($value);
             return Date::createFromArray([
@@ -557,11 +558,9 @@ function toDate(mixed $value): ?Date
         } catch (Exception) {
             return null;
         }
-    }
-
-    if (is_string($value)) {
+    } else if (is_string($value)) {
         try {
-            return Date::createFromFormat(DateTimeInterface::ATOM, $value);
+            return Date::parseDate($value, \IntlDateFormatter::SHORT);
         } catch (Exception) {
             return null;
         }

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -24,13 +24,10 @@ use function Cake\Core\pathCombine as cakePathCombine;
 use function Cake\Core\pj as cakePj;
 use function Cake\Core\pluginSplit as cakePluginSplit;
 use function Cake\Core\pr as cakePr;
-use function Cake\Core\toBool as cakeToBool;
-use function Cake\Core\toInt as cakeToInt;
-use function Cake\Core\toString as cakeToString;
 use function Cake\Core\triggerWarning as cakeTriggerWarning;
 
 if (!function_exists('pathCombine')) {
-    /**G
+    /**
      * Combines parts with a forward-slash `/`.
      *
      * Skips adding a forward-slash if either `/` or `\` already exists.
@@ -190,62 +187,5 @@ if (!function_exists('deprecationWarning')) {
     function deprecationWarning(string $version, string $message, int $stackFrame = 1): void
     {
         cakeDeprecationWarning($version, $message, $stackFrame + 1);
-    }
-}
-
-// FIXME: Well, this is going to be a problem...
-if (!function_exists('toString')) {
-    /**
-     * Converts the given value to a string.
-     *
-     * This method attempts to convert the given value to a string.
-     * If the value is already a string, it returns the value as it is.
-     * ``null`` is returned if the conversion is not possible.
-     *
-     * @param mixed $value The value to be converted.
-     * @return ?string Returns the string representation of the value, or null if the value is not a string.
-     * @since 5.1.0
-     */
-    function toString(mixed $value): ?string
-    {
-        return cakeToString($value);
-    }
-}
-
-if (!function_exists('toInt')) {
-    /**
-     * Converts a value to an integer.
-     *
-     * This method attempts to convert the given value to an integer.
-     * If the conversion is successful, it returns the value as an integer.
-     * If the conversion fails, it returns NULL.
-     *
-     * String values are trimmed using trim().
-     *
-     * @param mixed $value The value to be converted to an integer.
-     * @return int|null Returns the converted integer value or null if the conversion fails.
-     * @since 5.1.0
-     */
-    function toInt(mixed $value): ?int
-    {
-        return cakeToInt($value);
-    }
-}
-
-if (!function_exists('toBool')) {
-    /**
-     * Converts a value to boolean.
-     *
-     *  1 | '1' | 1.0 | true  - values returns as true
-     *  0 | '0' | 0.0 | false - values returns as false
-     *  Other values returns as null.
-     *
-     * @param mixed $value The value to convert to boolean.
-     * @return bool|null Returns true if the value is truthy, false if it's falsy, or NULL otherwise.
-     * @since 5.1.0
-     */
-    function toBool(mixed $value): ?bool
-    {
-        return cakeToBool($value);
     }
 }

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -24,10 +24,10 @@ use function Cake\Core\pathCombine as cakePathCombine;
 use function Cake\Core\pj as cakePj;
 use function Cake\Core\pluginSplit as cakePluginSplit;
 use function Cake\Core\pr as cakePr;
-use function Cake\Core\triggerWarning as cakeTriggerWarning;
-use function Cake\Core\toString as cakeToString;
-use function Cake\Core\toInt as cakeToInt;
 use function Cake\Core\toBool as cakeToBool;
+use function Cake\Core\toInt as cakeToInt;
+use function Cake\Core\toString as cakeToString;
+use function Cake\Core\triggerWarning as cakeTriggerWarning;
 
 if (!function_exists('pathCombine')) {
     /**G

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -25,9 +25,12 @@ use function Cake\Core\pj as cakePj;
 use function Cake\Core\pluginSplit as cakePluginSplit;
 use function Cake\Core\pr as cakePr;
 use function Cake\Core\triggerWarning as cakeTriggerWarning;
+use function Cake\Core\toString as cakeToString;
+use function Cake\Core\toInt as cakeToInt;
+use function Cake\Core\toBool as cakeToBool;
 
 if (!function_exists('pathCombine')) {
-    /**
+    /**G
      * Combines parts with a forward-slash `/`.
      *
      * Skips adding a forward-slash if either `/` or `\` already exists.
@@ -187,5 +190,62 @@ if (!function_exists('deprecationWarning')) {
     function deprecationWarning(string $version, string $message, int $stackFrame = 1): void
     {
         cakeDeprecationWarning($version, $message, $stackFrame + 1);
+    }
+}
+
+// FIXME: Well, this is going to be a problem...
+if (!function_exists('toString')) {
+    /**
+     * Converts the given value to a string.
+     *
+     * This method attempts to convert the given value to a string.
+     * If the value is already a string, it returns the value as it is.
+     * ``null`` is returned if the conversion is not possible.
+     *
+     * @param mixed $value The value to be converted.
+     * @return ?string Returns the string representation of the value, or null if the value is not a string.
+     * @since 5.1.0
+     */
+    function toString(mixed $value): ?string
+    {
+        return cakeToString($value);
+    }
+}
+
+if (!function_exists('toInt')) {
+    /**
+     * Converts a value to an integer.
+     *
+     * This method attempts to convert the given value to an integer.
+     * If the conversion is successful, it returns the value as an integer.
+     * If the conversion fails, it returns NULL.
+     *
+     * String values are trimmed using trim().
+     *
+     * @param mixed $value The value to be converted to an integer.
+     * @return int|null Returns the converted integer value or null if the conversion fails.
+     * @since 5.1.0
+     */
+    function toInt(mixed $value): ?int
+    {
+        return cakeToInt($value);
+    }
+}
+
+if (!function_exists('toBool')) {
+    /**
+     * Converts a value to boolean.
+     *
+     *  1 | '1' | 1.0 | true  - values returns as true
+     *  0 | '0' | 0.0 | false - values returns as false
+     *  Other values returns as null.
+     *
+     * @param mixed $value The value to convert to boolean.
+     * @return bool|null Returns true if the value is truthy, false if it's falsy, or NULL otherwise.
+     * @since 5.1.0
+     */
+    function toBool(mixed $value): ?bool
+    {
+        return cakeToBool($value);
     }
 }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -33,7 +33,6 @@ use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use function Cake\Core\env;
 use function Cake\Core\toBool;
-use function Cake\Core\toDateTime;
 use function Cake\Core\toInt;
 use function Cake\Core\toString;
 
@@ -569,8 +568,6 @@ class ServerRequest implements ServerRequestInterface
             'string' => toString($rawValue),
             'int', 'integer' => toInt($rawValue),
             'bool', 'boolean' => toBool($rawValue),
-            // TODO: Add just date? Add just time?
-            'datetime' => toDateTime($rawValue),
             default => throw new InvalidArgumentException(sprintf('Unable to convert request data to %s.', $type)),
         };
     }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  * @since         2.0.0
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Http;
 
 use ArrayAccess;
@@ -32,6 +33,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use function Cake\Core\env;
+
 // TODO: Unsure if I still need these? PHPStan fails with or without them.
 //use function Cake\Core\toBool;
 //use function Cake\Core\toInt;
@@ -49,11 +51,11 @@ class ServerRequest implements ServerRequestInterface
      * @var array
      */
     protected array $params = [
-        'plugin' => null,
+        'plugin'     => null,
         'controller' => null,
-        'action' => null,
-        '_ext' => null,
-        'pass' => [],
+        'action'     => null,
+        '_ext'       => null,
+        'pass'       => [],
     ];
 
     /**
@@ -125,21 +127,21 @@ class ServerRequest implements ServerRequestInterface
      * @var array<\Closure|array>
      */
     protected static array $_detectors = [
-        'get' => ['env' => 'REQUEST_METHOD', 'value' => 'GET'],
-        'post' => ['env' => 'REQUEST_METHOD', 'value' => 'POST'],
-        'put' => ['env' => 'REQUEST_METHOD', 'value' => 'PUT'],
-        'patch' => ['env' => 'REQUEST_METHOD', 'value' => 'PATCH'],
-        'delete' => ['env' => 'REQUEST_METHOD', 'value' => 'DELETE'],
-        'head' => ['env' => 'REQUEST_METHOD', 'value' => 'HEAD'],
+        'get'     => ['env' => 'REQUEST_METHOD', 'value' => 'GET'],
+        'post'    => ['env' => 'REQUEST_METHOD', 'value' => 'POST'],
+        'put'     => ['env' => 'REQUEST_METHOD', 'value' => 'PUT'],
+        'patch'   => ['env' => 'REQUEST_METHOD', 'value' => 'PATCH'],
+        'delete'  => ['env' => 'REQUEST_METHOD', 'value' => 'DELETE'],
+        'head'    => ['env' => 'REQUEST_METHOD', 'value' => 'HEAD'],
         'options' => ['env' => 'REQUEST_METHOD', 'value' => 'OPTIONS'],
-        'https' => ['env' => 'HTTPS', 'options' => [1, 'on']],
-        'ajax' => ['env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'],
-        'json' => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
-        'xml' => [
-            'accept' => ['application/xml', 'text/xml'],
+        'https'   => ['env' => 'HTTPS', 'options' => [1, 'on']],
+        'ajax'    => ['env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'],
+        'json'    => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
+        'xml'     => [
+            'accept'  => ['application/xml', 'text/xml'],
             'exclude' => ['text/html'],
-            'param' => '_ext',
-            'value' => 'xml',
+            'param'   => '_ext',
+            'value'   => 'xml',
         ],
     ];
 
@@ -238,17 +240,17 @@ class ServerRequest implements ServerRequestInterface
     public function __construct(array $config = [])
     {
         $config += [
-            'params' => $this->params,
-            'query' => [],
-            'post' => [],
-            'files' => [],
-            'cookies' => [],
+            'params'      => $this->params,
+            'query'       => [],
+            'post'        => [],
+            'files'       => [],
+            'cookies'     => [],
             'environment' => [],
-            'url' => '',
-            'uri' => null,
-            'base' => '',
-            'webroot' => '',
-            'input' => null,
+            'url'         => '',
+            'uri'         => null,
+            'base'        => '',
+            'webroot'     => '',
+            'input'       => null,
         ];
 
         $this->_setConfig($config);
@@ -498,7 +500,9 @@ class ServerRequest implements ServerRequestInterface
                 'getParam' => $source = $this->params,
                 'getData' => $source = $this->data ?? [],
                 'getHeader', 'getHeaderLine' =>
-                throw new BadMethodCallException('Type conversion is not supported for request headers.'),
+                    throw new BadMethodCallException('Type conversion is not supported for request headers.'),
+                default =>
+                    throw new BadMethodCallException('Type conversion is not supported for given datasource.'),
             };
 
             if ($source !== null) {
@@ -1646,10 +1650,10 @@ class ServerRequest implements ServerRequestInterface
     public function getAttributes(): array
     {
         $emulated = [
-            'params' => $this->params,
+            'params'  => $this->params,
             'webroot' => $this->webroot,
-            'base' => $this->base,
-            'here' => $this->base . $this->uri->getPath(),
+            'base'    => $this->base,
+            'here'    => $this->base . $this->uri->getPath(),
         ];
 
         return $this->attributes + $emulated;

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -51,11 +51,11 @@ class ServerRequest implements ServerRequestInterface
      * @var array
      */
     protected array $params = [
-        'plugin'     => null,
+        'plugin' => null,
         'controller' => null,
-        'action'     => null,
-        '_ext'       => null,
-        'pass'       => [],
+        'action' => null,
+        '_ext' => null,
+        'pass' => [],
     ];
 
     /**
@@ -127,21 +127,21 @@ class ServerRequest implements ServerRequestInterface
      * @var array<\Closure|array>
      */
     protected static array $_detectors = [
-        'get'     => ['env' => 'REQUEST_METHOD', 'value' => 'GET'],
-        'post'    => ['env' => 'REQUEST_METHOD', 'value' => 'POST'],
-        'put'     => ['env' => 'REQUEST_METHOD', 'value' => 'PUT'],
-        'patch'   => ['env' => 'REQUEST_METHOD', 'value' => 'PATCH'],
-        'delete'  => ['env' => 'REQUEST_METHOD', 'value' => 'DELETE'],
-        'head'    => ['env' => 'REQUEST_METHOD', 'value' => 'HEAD'],
+        'get' => ['env' => 'REQUEST_METHOD', 'value' => 'GET'],
+        'post' => ['env' => 'REQUEST_METHOD', 'value' => 'POST'],
+        'put' => ['env' => 'REQUEST_METHOD', 'value' => 'PUT'],
+        'patch' => ['env' => 'REQUEST_METHOD', 'value' => 'PATCH'],
+        'delete' => ['env' => 'REQUEST_METHOD', 'value' => 'DELETE'],
+        'head' => ['env' => 'REQUEST_METHOD', 'value' => 'HEAD'],
         'options' => ['env' => 'REQUEST_METHOD', 'value' => 'OPTIONS'],
-        'https'   => ['env' => 'HTTPS', 'options' => [1, 'on']],
-        'ajax'    => ['env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'],
-        'json'    => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
-        'xml'     => [
-            'accept'  => ['application/xml', 'text/xml'],
+        'https' => ['env' => 'HTTPS', 'options' => [1, 'on']],
+        'ajax' => ['env' => 'HTTP_X_REQUESTED_WITH', 'value' => 'XMLHttpRequest'],
+        'json' => ['accept' => ['application/json'], 'param' => '_ext', 'value' => 'json'],
+        'xml' => [
+            'accept' => ['application/xml', 'text/xml'],
             'exclude' => ['text/html'],
-            'param'   => '_ext',
-            'value'   => 'xml',
+            'param' => '_ext',
+            'value' => 'xml',
         ],
     ];
 
@@ -240,17 +240,17 @@ class ServerRequest implements ServerRequestInterface
     public function __construct(array $config = [])
     {
         $config += [
-            'params'      => $this->params,
-            'query'       => [],
-            'post'        => [],
-            'files'       => [],
-            'cookies'     => [],
+            'params' => $this->params,
+            'query' => [],
+            'post' => [],
+            'files' => [],
+            'cookies' => [],
             'environment' => [],
-            'url'         => '',
-            'uri'         => null,
-            'base'        => '',
-            'webroot'     => '',
-            'input'       => null,
+            'url' => '',
+            'uri' => null,
+            'base' => '',
+            'webroot' => '',
+            'input' => null,
         ];
 
         $this->_setConfig($config);
@@ -485,29 +485,21 @@ class ServerRequest implements ServerRequestInterface
 
             return $this->is(...$params);
         } elseif (str_starts_with($name, 'get')) {
-            // e.g. getCookieAsInt(), getQueryAsDateTime()
+            // e.g. getCookieAsInt(), getQueryAsBool()
             $parts = explode('As', $name);
             if (count($parts) !== 2) {
                 return $this->$name(...$params);
             }
 
-            [$methodName, $userType] = $parts;
+            [$methodName, $type] = $parts;
 
-            $source = null;
-            match ($methodName) {
-                'getCookie' => $source = $this->cookies,
-                'getQuery' => $source = $this->query,
-                'getParam' => $source = $this->params,
-                'getData' => $source = $this->data ?? [],
-                'getHeader', 'getHeaderLine' =>
-                    throw new BadMethodCallException('Type conversion is not supported for request headers.'),
-                default =>
-                    throw new BadMethodCallException('Type conversion is not supported for given datasource.'),
+            return match ($methodName) {
+                'getCookie' => $this->asType($type, $this->cookies, ...$params),
+                'getQuery' => $this->asType($type, $this->query, ...$params),
+                'getParam' => $this->asType($type, $this->params, ...$params),
+                'getData' => $this->asType($type, $this->data ?? [], ...$params),
+                default => throw new BadMethodCallException(sprintf('Unable to convert request data to %s.', $type)),
             };
-
-            if ($source !== null) {
-                return $this->asType($userType, $source, ...$params);
-            }
         }
 
         throw new BadMethodCallException(sprintf('Method `%s()` does not exist.', $name));
@@ -1650,10 +1642,10 @@ class ServerRequest implements ServerRequestInterface
     public function getAttributes(): array
     {
         $emulated = [
-            'params'  => $this->params,
+            'params' => $this->params,
             'webroot' => $this->webroot,
-            'base'    => $this->base,
-            'here'    => $this->base . $this->uri->getPath(),
+            'base' => $this->base,
+            'here' => $this->base . $this->uri->getPath(),
         ];
 
         return $this->attributes + $emulated;

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http;
 
+use ArrayAccess;
 use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
@@ -556,8 +557,12 @@ class ServerRequest implements ServerRequestInterface
      * @return mixed The requested data converted to the specified type.
      * @throws \InvalidArgumentException If no detector has been set for the provided type.
      */
-    protected function asType(string $type, array|object $source, mixed ...$args): mixed
+    public function asType(string $type, array|object $source, mixed ...$args): mixed
     {
+        if (is_object($source)) {
+            assert($source instanceof ArrayAccess);
+        }
+
         $rawValue = Hash::get($source, $args[0], $args[1]);
 
         return match (strtolower($type)) {

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -33,11 +33,9 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use function Cake\Core\env;
-
-// TODO: Unsure if I still need these? PHPStan fails with or without them.
-//use function Cake\Core\toBool;
-//use function Cake\Core\toInt;
-//use function Cake\Core\toString;
+use function Cake\Core\toBool;
+use function Cake\Core\toInt;
+use function Cake\Core\toString;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.
@@ -473,10 +471,10 @@ class ServerRequest implements ServerRequestInterface
      *
      * @param string $name The method called
      * @param array $params Array of parameters for the method call
-     * @return bool
+     * @return mixed
      * @throws \BadMethodCallException when an invalid method is called.
      */
-    public function __call(string $name, array $params): bool
+    public function __call(string $name, array $params): mixed
     {
         if (str_starts_with($name, 'is')) {
             $type = strtolower(substr($name, 2));

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -32,9 +32,10 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use function Cake\Core\env;
-use function Cake\Core\toBool;
-use function Cake\Core\toInt;
-use function Cake\Core\toString;
+// TODO: Unsure if I still need these? PHPStan fails with or without them.
+//use function Cake\Core\toBool;
+//use function Cake\Core\toInt;
+//use function Cake\Core\toString;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -31,10 +31,10 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use function Cake\Core\env;
-use function Cake\Core\toDateTime;
-use function Cake\Core\toString;
 use function Cake\Core\toBool;
+use function Cake\Core\toDateTime;
 use function Cake\Core\toInt;
+use function Cake\Core\toString;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -545,13 +545,18 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
+     * Returns a piece of data from the Request converted to a given data type.
+     *
+     * Example: `asType('Int', $this->params, 'id', 0)` will return
+     * the 'id' parameter from the request converted to an integer.
+     *
      * @param string $type The desired type to convert the data to. Example: 'Int', 'Bool', 'String'.
      * @param object|array $source Source from which data should be extracted.
      * @param mixed ...$args List of arguments
      * @return mixed The requested data converted to the specified type.
      * @throws \InvalidArgumentException If no detector has been set for the provided type.
      */
-    private function asType(string $type, array|object $source, mixed ...$args): mixed
+    protected function asType(string $type, array|object $source, mixed ...$args): mixed
     {
         $rawValue = Hash::get($source, $args[0], $args[1]);
 

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -485,19 +485,17 @@ class ServerRequest implements ServerRequestInterface
         } elseif (str_starts_with($name, 'get')) {
             // e.g. getCookieAsInt(), getQueryAsBool()
             $parts = explode('As', $name);
-            if (count($parts) !== 2) {
-                return $this->$name(...$params);
+
+            if (count($parts) === 2) {
+                [$methodName, $type] = $parts;
+                return match ($methodName) {
+                    'getCookie' => $this->asType($type, $this->cookies, ...$params),
+                    'getQuery' => $this->asType($type, $this->query, ...$params),
+                    'getParam' => $this->asType($type, $this->params, ...$params),
+                    'getData' => $this->asType($type, $this->data ?? [], ...$params),
+                    default => throw new BadMethodCallException(sprintf('Unable to convert request data to %s.', $type)),
+                };
             }
-
-            [$methodName, $type] = $parts;
-
-            return match ($methodName) {
-                'getCookie' => $this->asType($type, $this->cookies, ...$params),
-                'getQuery' => $this->asType($type, $this->query, ...$params),
-                'getParam' => $this->asType($type, $this->params, ...$params),
-                'getData' => $this->asType($type, $this->data ?? [], ...$params),
-                default => throw new BadMethodCallException(sprintf('Unable to convert request data to %s.', $type)),
-            };
         }
 
         throw new BadMethodCallException(sprintf('Method `%s()` does not exist.', $name));

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -18,6 +18,9 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\Configure;
 use Cake\Http\Response;
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use stdClass;
@@ -28,6 +31,8 @@ use function Cake\Core\namespaceSplit;
 use function Cake\Core\pathCombine;
 use function Cake\Core\pluginSplit;
 use function Cake\Core\toBool;
+use function Cake\Core\toDate;
+use function Cake\Core\toDateTime;
 use function Cake\Core\toInt;
 use function Cake\Core\toString;
 use function Cake\Core\triggerWarning;
@@ -559,6 +564,111 @@ class FunctionsTest extends TestCase
     public static function toBoolProvider(): array
     {
         return [
+            // string input types
+            '(string) empty string' => ['', null],
+            '(string) space' => [' ', null],
+            '(string) some word' => ['abc', null],
+            '(string) double 0' => ['00', null],
+            '(string) single 0' => ['0', false],
+            '(string) false' => ['false', null],
+            '(string) double 1' => ['11', null],
+            '(string) single 1' => ['1', true],
+            '(string) true-string' => ['true', null],
+            // int input types
+            '(int) 0' => [0, false],
+            '(int) 1' => [1, true],
+            '(int) -1' => [-1, null],
+            '(int) 55' => [55, null],
+            '(int) negative number' => [-5, null],
+            // float input types
+            '(float) positive' => [5.5, null],
+            '(float) round' => [5.0, null],
+            '(float) 0.0' => [0.0, false],
+            '(float) 1.0' => [1.0, true],
+            '(float) NaN' => [acos(8), null],
+            '(float) INF' => [INF, null],
+            '(float) -INF' => [-INF, null],
+            // boolean input types
+            '(bool) true' => [true, true],
+            '(bool) false' => [false, false],
+            // other input types
+            '(other) null' => [null, null],
+            '(other) empty-array' => [[], null],
+            '(other) int-array' => [[5], null],
+            '(other) string-array' => [['5'], null],
+            '(other) simple object' => [new stdClass(), null],
+        ];
+    }
+
+    /**
+     * @dataProvider toDateTimeProvider
+     */
+    public function testToDateTime(mixed $rawValue, ?DateTime $expected): void
+    {
+        $this->assertEquals($expected, toDateTime($rawValue));
+    }
+
+    /**
+     * @return array The array of test cases.
+     */
+    public static function toDateTimeProvider(): array
+    {
+        $now = '2024-07-01T14:30:00Z';
+        // TODO: Not sure if necessary
+        DateTime::setTestNow(new DateTime($now));
+
+        return [
+            // datetime input types
+            '(datetime) datetime interface' => [new \DateTime($now), new DateTime($now)],
+            '(datetime) frozentime interface' => [new FrozenTime($now), new DateTime($now)],
+            // string input types
+            '(string) datetime string' => [$now, new DateTime($now)],
+            '(string) empty string' => ['', null],
+            '(string) space' => [' ', null],
+            '(string) some word' => ['abc', null],
+            '(string) double 0' => ['00', null],
+            '(string) single 0' => ['0', null],
+            '(string) false' => ['false', null],
+            '(string) double 1' => ['11', null],
+            '(string) true-string' => ['true', null],
+            // int input types
+            '(int) timestamp' => [1719844200, new DateTime($now)],
+            '(int) negative number' => [-1000, DateTime::createFromTimestamp(-1000)],
+            // float input types
+            '(float) positive' => [5.5, null],
+            '(float) round' => [5.0, null],
+            '(float) NaN' => [acos(8), null],
+            '(float) INF' => [INF, null],
+            '(float) -INF' => [-INF, null],
+            // other input types
+            '(other) null' => [null, null],
+            '(other) empty-array' => [[], null],
+            '(other) int-array' => [[5], null],
+            '(other) string-array' => [['5'], null],
+            '(other) simple object' => [new stdClass(), null],
+        ];
+    }
+
+    /**
+     * @dataProvider toDateProvider
+     */
+    public function testToDate(mixed $rawValue, ?Date $expected): void
+    {
+        $this->assertSame($expected, toDate($rawValue));
+    }
+
+    /**
+     * @return array The array of test cases.
+     */
+    public static function toDateProvider(): array
+    {
+        return [
+            // ai-generated
+            'timestamp' => [1622548800, new Date('2021-06-01')],
+            'datetime_interface' => [new \DateTime('2021-06-01'), new Date('2021-06-01')],
+            'valid_date_string' => ['2021-06-01', new Date('2021-06-01')],
+            'invalid_date_string' => ['invalid-date', null],
+            'null_value' => [null, null],
             // string input types
             '(string) empty string' => ['', null],
             '(string) space' => [' ', null],

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\I18n\Date;
 use Cake\I18n\DateTime;
+use Cake\I18n\FrozenDate;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
@@ -613,16 +614,16 @@ class FunctionsTest extends TestCase
      */
     public static function toDateTimeProvider(): array
     {
-        $now = '2024-07-01T14:30:00Z';
-        // TODO: Not sure if necessary
-        DateTime::setTestNow(new DateTime($now));
+        $date = new DateTime('2024-07-01T14:30:00Z');
+        $now = $date->toAtomString();
+        DateTime::setTestNow($now);
 
         return [
             // datetime input types
-            '(datetime) datetime interface' => [new \DateTime($now), new DateTime($now)],
-            '(datetime) frozentime interface' => [new FrozenTime($now), new DateTime($now)],
+            '(datetime) datetime interface' => [new \DateTime($now), $date],
+            '(datetime) frozentime interface' => [new FrozenTime($now), $date],
             // string input types
-            '(string) datetime string' => [$now, new DateTime($now)],
+            '(string) datetime string' => [$now, $date],
             '(string) empty string' => ['', null],
             '(string) space' => [' ', null],
             '(string) some word' => ['abc', null],
@@ -632,7 +633,7 @@ class FunctionsTest extends TestCase
             '(string) double 1' => ['11', null],
             '(string) true-string' => ['true', null],
             // int input types
-            '(int) timestamp' => [1719844200, new DateTime($now)],
+            '(int) timestamp' => [1719844200, $date],
             '(int) negative number' => [-1000, DateTime::createFromTimestamp(-1000)],
             // float input types
             '(float) positive' => [5.5, null],
@@ -654,7 +655,7 @@ class FunctionsTest extends TestCase
      */
     public function testToDate(mixed $rawValue, ?Date $expected): void
     {
-        $this->assertSame($expected, toDate($rawValue));
+        $this->assertEquals($expected, toDate($rawValue));
     }
 
     /**
@@ -662,40 +663,33 @@ class FunctionsTest extends TestCase
      */
     public static function toDateProvider(): array
     {
+        $epoch = Date::createFromArray(['year' => 1970, 'month' => 01, 'day' => 01]);
+        $date = Date::createFromArray(['year' => 2024, 'month' => 07, 'day' => 01]);
+        $now = $date->toAtomString();
+        DateTime::setTestNow($now);
+
         return [
-            // ai-generated
-            'timestamp' => [1622548800, new Date('2021-06-01')],
-            'datetime_interface' => [new \DateTime('2021-06-01'), new Date('2021-06-01')],
-            'valid_date_string' => ['2021-06-01', new Date('2021-06-01')],
-            'invalid_date_string' => ['invalid-date', null],
-            'null_value' => [null, null],
+            // datetime input types
+            '(datetime) datetime interface' => [new \DateTime($now), $date],
+            '(datetime frozendate object' => [new FrozenDate($now), $date],
             // string input types
+            '(string) date string' => [$date->i18nFormat(\IntlDateFormatter::SHORT), $date],
             '(string) empty string' => ['', null],
             '(string) space' => [' ', null],
             '(string) some word' => ['abc', null],
             '(string) double 0' => ['00', null],
-            '(string) single 0' => ['0', false],
             '(string) false' => ['false', null],
             '(string) double 1' => ['11', null],
-            '(string) single 1' => ['1', true],
             '(string) true-string' => ['true', null],
             // int input types
-            '(int) 0' => [0, false],
-            '(int) 1' => [1, true],
-            '(int) -1' => [-1, null],
-            '(int) 55' => [55, null],
-            '(int) negative number' => [-5, null],
+            '(int) timestamp' => [1_719_844_200, $date],
+            '(int) negative number' => [-2_592_000, $epoch->subDays(30)],
             // float input types
             '(float) positive' => [5.5, null],
             '(float) round' => [5.0, null],
-            '(float) 0.0' => [0.0, false],
-            '(float) 1.0' => [1.0, true],
             '(float) NaN' => [acos(8), null],
             '(float) INF' => [INF, null],
             '(float) -INF' => [-INF, null],
-            // boolean input types
-            '(bool) true' => [true, true],
-            '(bool) false' => [false, false],
             // other input types
             '(other) null' => [null, null],
             '(other) empty-array' => [[], null],

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -616,7 +616,6 @@ class FunctionsTest extends TestCase
     {
         $date = new DateTime('2024-07-01T14:30:00Z');
         $now = $date->toAtomString();
-        DateTime::setTestNow($now);
 
         return [
             // datetime input types
@@ -666,7 +665,6 @@ class FunctionsTest extends TestCase
         $epoch = Date::createFromArray(['year' => 1970, 'month' => 01, 'day' => 01]);
         $date = Date::createFromArray(['year' => 2024, 'month' => 07, 'day' => 01]);
         $now = $date->toAtomString();
-        DateTime::setTestNow($now);
 
         return [
             // datetime input types

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -449,7 +449,7 @@ class ServerRequestTest extends TestCase
     }
 
     /**
-     * test the simple uses of is()
+     * Test the simple uses of is()
      */
     public function testIsHttpMethods(): void
     {
@@ -473,7 +473,7 @@ class ServerRequestTest extends TestCase
         $this->assertFalse($request->is('delete'));
     }
 
-    public function testExceptionForInvalidType()
+    public function testIsThrowsExceptionForInvalidType()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No detector set for type `nonexistent`');
@@ -531,6 +531,135 @@ class ServerRequestTest extends TestCase
         $this->assertTrue($request->isAll(['ajax', 'get']));
         $this->assertFalse($request->isAll(['post', 'get']));
         $this->assertFalse($request->isAll(['ajax', 'post']));
+    }
+
+    /**
+     * Test the simple uses of asType()
+     */
+    public function testAsTypeThrowsExceptionForInvalidType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to convert request data to Elephants.');
+
+        $request = new ServerRequest();
+
+        $this->assertFalse($request->asType('Elephants', []));
+    }
+
+    /**
+     * Test the magic methods on cookie data
+     */
+    public function testGetCookieAsDifferentTypes(): void
+    {
+        $request = new ServerRequest();
+        $request = $request->withCookieParams([
+           'myint' => '123',
+           'mystring' => 'mushroom',
+           'mybool' => '1',
+        ]);
+
+        $this->assertSame(123, $request->getCookieAsInt('myint'));
+        $this->assertSame('mushroom', $request->getCookieAsString('mystring'));
+        $this->assertSame(true, $request->getCookieAsBool('mybool'));
+    }
+
+    /**
+     * Test the magic methods on query parameters
+     */
+    public function testGetQueryAsDifferentTypes(): void
+    {
+        $request = new ServerRequest();
+        $request = $request->withQueryParams([
+            'myint' => '123',
+            'mystring' => 'mushroom',
+            'mybool' => '1',
+        ]);
+
+        $this->assertSame(123, $request->getQueryAsInt('myint'));
+        $this->assertSame('mushroom', $request->getQueryAsString('mystring'));
+        $this->assertSame(true, $request->getQueryAsBool('mybool'));
+    }
+
+    /**
+     * Test the magic methods on query parameters
+     */
+    public function testGetParamAsDifferentTypes(): void
+    {
+        $request = new ServerRequest();
+        $request = $request->withParam('myint', '123');
+        $request = $request->withParam('mystring', 'mushroom');
+        $request = $request->withParam('mybool', '1');
+
+        $this->assertSame(123, $request->getParamAsInt('myint'));
+        $this->assertSame('mushroom', $request->getParamAsString('mystring'));
+        $this->assertSame(true, $request->getParamAsBool('mybool'));
+    }
+
+    /**
+     * Test the magic methods on query parameters
+     */
+    public function testGetDataAsDifferentTypes(): void
+    {
+        $request = new ServerRequest();
+        $request = $request->withData('myint', '123');
+        $request = $request->withData('mystring', 'mushroom');
+        $request = $request->withData('mybool', '1');
+
+
+        $this->assertSame(123, $request->getDataAsInt('myint'));
+        $this->assertSame('mushroom', $request->getDataAsString('mystring'));
+        $this->assertSame(true, $request->getDataAsBool('mybool'));
+    }
+
+    public function testGetRequestDataAsTypeString(): void
+    {
+        $request = new ServerRequest();
+
+        $request = $request->withCookieParams(['mycookie' => 'correct']);
+        $request = $request->withQueryParams(['myquery' => 'horse']);
+        $request = $request->withParam('myparam', 'battery');
+        $request = $request->withData('mydata', 'staple');
+
+        $this->assertSame('correct', $request->asType('string', $request->getCookieParams(), 'mycookie'));
+        $this->assertSame('horse', $request->asType('string', $request->getQueryParams(), 'myquery'));
+        $this->assertSame('battery', $request->asType('string', $request->getAttribute('params'), 'myparam'));
+        $this->assertSame('staple', $request->asType('string', $request->getData(), 'mydata'));
+    }
+
+    /**
+     * Test asType() for integer datapoints
+     */
+    public function testGetRequestDataAsTypeInt(): void
+    {
+        $request = new ServerRequest();
+
+        $request = $request->withCookieParams(['mycookie' => '123']);
+        $request = $request->withQueryParams(['myquery' => 456]);
+        $request = $request->withParam('myparam', '789');
+        $request = $request->withData('mydata', 30 / 3);
+
+        $this->assertSame(123, $request->asType('int', $request->getCookieParams(), 'mycookie'));
+        $this->assertSame(456, $request->asType('int', $request->getQueryParams(), 'myquery'));
+        $this->assertSame(789, $request->asType('int', $request->getAttribute('params'), 'myparam'));
+        $this->assertSame(10, $request->asType('integer', $request->getData(), 'mydata'));
+    }
+
+    /**
+     * Test asType() for boolean datapoints
+     */
+    public function testGetRequestDataAsTypeBool(): void
+    {
+        $request = new ServerRequest();
+
+        $request = $request->withCookieParams(['mycookie' => true]);
+        $request = $request->withQueryParams(['myquery' => false]);
+        $request = $request->withParam('myparam', 1);
+        $request = $request->withData('mydata', '0');
+
+        $this->assertSame(true, $request->asType('bool', $request->getCookieParams(), 'mycookie'));
+        $this->assertSame(false, $request->asType('bool', $request->getQueryParams(), 'myquery'));
+        $this->assertSame(true, $request->asType('bool', $request->getAttribute('params'), 'myparam'));
+        $this->assertSame(false, $request->asType('boolean', $request->getData(), 'mydata'));
     }
 
     /**


### PR DESCRIPTION
Continuing on the work of a community member in #17295 to add support for calling methods like `getCookieAsString()` on a ServerRequest object. This increases the convenience of accessing data on the request and encourages type safety in userland code.

This is a work-in-progress.