### PR TITLE
Remove check for zend.assertions when debug is enabled.

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -97,13 +97,6 @@ class Configure
             if (static::$_hasIniSet) {
                 ini_set('display_errors', $config['debug'] ? '1' : '0');
             }
-
-            if ($config['debug'] && PHP_SAPI !== 'cli' && ini_get('zend.assertions') === '-1') {
-                trigger_error(
-                    'You should set `zend.assertions` to `1` in your php.ini for your development environment.',
-                    E_USER_WARNING
-                );
-            }
         }
     }
 


### PR DESCRIPTION
zend.assertions cannot be changed using per directory ini file and at times the developer does not have access to php.ini.

We can move this check and show a message somewhere in DebugKit instead.