### PR TITLE
Changes to remove features deprecated in PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "phpstan/phpstan": "1.11.*",
         "phpstan/extension-installer": "^1.3",
         "symplify/phpstan-rules": "^12.4",
-        "phpunit/phpunit": "^10.5.5"
+        "phpunit/phpunit": "^10.5.5 || ^11.1.3"
     },
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",

--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -28,6 +28,7 @@ use Cake\Console\TestSuite\Constraint\ExitCode;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\TestSuite\ContainerStubTrait;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\After;
 
 /**
  * A bundle of methods that makes testing commands
@@ -112,10 +113,10 @@ trait ConsoleIntegrationTestTrait
     /**
      * Cleans state to get ready for the next test
      *
-     * @after
      * @return void
      * @psalm-suppress PossiblyNullPropertyAssignmentValue
      */
+    #[After]
     public function cleanupConsoleTrait(): void
     {
         $this->_exitCode = null;

--- a/src/Console/TestSuite/Constraint/ContentsContainRow.php
+++ b/src/Console/TestSuite/Constraint/ContentsContainRow.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Cake\Console\TestSuite\Constraint;
 
+use SebastianBergmann\Exporter\Exporter;
+
 /**
  * ContentsContainRow
  *
@@ -55,7 +57,7 @@ class ContentsContainRow extends ContentsRegExp
      */
     public function failureDescription(mixed $other): string
     {
-        return '`' . $this->exporter()->shortenedExport($other) . '` ' . $this->toString();
+        return '`' . (new Exporter())->shortenedExport($other) . '` ' . $this->toString();
     }
 }
 

--- a/src/Core/TestSuite/ContainerStubTrait.php
+++ b/src/Core/TestSuite/ContainerStubTrait.php
@@ -24,6 +24,7 @@ use Cake\Routing\Router;
 use Closure;
 use League\Container\Exception\NotFoundException;
 use LogicException;
+use PHPUnit\Framework\Attributes\After;
 
 /**
  * A set of methods used for defining container services
@@ -175,9 +176,9 @@ trait ContainerStubTrait
      * Clears any mocks that were defined and cleans
      * up application class configuration.
      *
-     * @after
      * @return void
      */
+    #[After]
     public function cleanupContainer(): void
     {
         $this->_appArgs = null;

--- a/src/Http/TestSuite/HttpClientTrait.php
+++ b/src/Http/TestSuite/HttpClientTrait.php
@@ -18,6 +18,7 @@ namespace Cake\Http\TestSuite;
 
 use Cake\Http\Client;
 use Cake\Http\Client\Response;
+use PHPUnit\Framework\Attributes\After;
 
 /**
  * Define mock responses and have mocks automatically cleared.
@@ -27,9 +28,9 @@ trait HttpClientTrait
     /**
      * Resets mocked responses
      *
-     * @after
      * @return void
      */
+    #[After]
     public function cleanupMockResponses(): void
     {
         Client::clearMockResponses();

--- a/src/TestSuite/EmailTrait.php
+++ b/src/TestSuite/EmailTrait.php
@@ -26,6 +26,8 @@ use Cake\TestSuite\Constraint\Email\MailSentTo;
 use Cake\TestSuite\Constraint\Email\MailSentWith;
 use Cake\TestSuite\Constraint\Email\MailSubjectContains;
 use Cake\TestSuite\Constraint\Email\NoMailSent;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 
 /**
  * Make assertions on emails sent through the Cake\TestSuite\TestEmailTransport
@@ -39,9 +41,9 @@ trait EmailTrait
     /**
      * Replaces all transports with the test transport during test setup
      *
-     * @before
      * @return void
      */
+    #[Before]
     public function setupTransports(): void
     {
         TestEmailTransport::replaceAllTransports();
@@ -50,9 +52,9 @@ trait EmailTrait
     /**
      * Resets transport state
      *
-     * @after
      * @return void
      */
+    #[After]
     public function cleanupEmailTrait(): void
     {
         TestEmailTransport::clearMessages();

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -66,6 +66,7 @@ use Cake\Utility\Security;
 use Exception;
 use Laminas\Diactoros\Uri;
 use PHPUnit\Exception as PHPUnitException;
+use PHPUnit\Framework\Attributes\After;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
@@ -199,10 +200,10 @@ trait IntegrationTestTrait
     /**
      * Clears the state used for requests.
      *
-     * @after
      * @return void
      * @psalm-suppress PossiblyNullPropertyAssignmentValue
      */
+    #[After]
     public function cleanup(): void
     {
         $this->_request = [];

--- a/src/TestSuite/LogTestTrait.php
+++ b/src/TestSuite/LogTestTrait.php
@@ -18,6 +18,7 @@ namespace Cake\TestSuite;
 
 use Cake\Log\Engine\ArrayLog;
 use Cake\Log\Log;
+use PHPUnit\Framework\Attributes\After;
 
 /**
  * Make assertions on logs
@@ -27,9 +28,9 @@ trait LogTestTrait
     /**
      * Reset log configs
      *
-     * @after
      * @return void
      */
+    #[After]
     public function cleanupLog(): void
     {
         Log::reset();

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -956,8 +956,15 @@ abstract class TestCase extends BaseTestCase
         }
 
         if ($nonExistingMethods) {
-            trigger_error('Adding non existent methods to your model ' .
-                'via testing will not work in future PHPUnit versions.', E_USER_DEPRECATED);
+            trigger_error(
+                sprintf(
+                    'Adding non-existent methods (%s) to model `%s` ' .
+                    'when mocking will not work in future PHPUnit versions.',
+                    join(',', $nonExistingMethods),
+                    $alias
+                ),
+                E_USER_DEPRECATED
+            );
             $builder->addMethods($nonExistingMethods);
         }
 

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -26,6 +26,7 @@ use Cake\Cache\Engine\NullEngine;
 use Cake\Cache\Exception\CacheWriteException;
 use Cake\Cache\Exception\InvalidArgumentException;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use stdClass;
 use TestApp\Cache\Engine\TestAppCacheEngine;
@@ -369,9 +370,9 @@ class CacheTest extends TestCase
     /**
      * testConfig method
      *
-     * @dataProvider configProvider
      * @param \Cake\Cache\CacheEngine|array $config
      */
+    #[DataProvider('configProvider')]
     public function testConfigVariants($config): void
     {
         $this->assertNotContains('test', Cache::configured(), 'test config should not exist.');

--- a/tests/TestCase/Cache/Engine/CacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/CacheEngineTest.php
@@ -5,6 +5,7 @@ namespace Cake\Test\TestCase\Cache\Engine;
 
 use Cake\TestSuite\TestCase;
 use DateInterval;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Cache\Engine\TestAppCacheEngine;
 
 class CacheEngineTest extends TestCase
@@ -21,9 +22,8 @@ class CacheEngineTest extends TestCase
 
     /**
      * Test duration with null, int and DateInterval multiple format.
-     *
-     * @dataProvider durationProvider
      */
+    #[DataProvider('durationProvider')]
     public function testDuration($ttl, $expected): void
     {
         $engine = new TestAppCacheEngine();

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -31,6 +31,7 @@ use Generator;
 use InvalidArgumentException;
 use LogicException;
 use NoRewindIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TestApp\Collection\CountableIterator;
 use TestApp\Collection\TestCollection;
@@ -41,8 +42,6 @@ use function Cake\Collection\collection;
 
 /**
  * Collection Test
- *
- * @coversDefaultClass \Cake\Collection\Collection
  */
 class CollectionTest extends TestCase
 {
@@ -73,9 +72,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the avg method
-     *
-     * @dataProvider avgProvider
      */
+    #[DataProvider('avgProvider')]
     public function testAvg(iterable $items): void
     {
         $collection = new Collection($items);
@@ -115,9 +113,8 @@ class CollectionTest extends TestCase
 
     /**
      * ests the avg method
-     *
-     * @dataProvider avgWithMatcherProvider
      */
+    #[DataProvider('avgWithMatcherProvider')]
     public function testAvgWithMatcher(iterable $items): void
     {
         $collection = new Collection($items);
@@ -141,9 +138,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the median method
-     *
-     * @dataProvider medianProvider
      */
+    #[DataProvider('medianProvider')]
     public function testMedian(iterable $items): void
     {
         $collection = new Collection($items);
@@ -164,9 +160,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the median method
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testMedianEven(iterable $items): void
     {
         $collection = new Collection($items);
@@ -196,9 +191,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the median method
-     *
-     * @dataProvider medianWithMatcherProvider
      */
+    #[DataProvider('medianWithMatcherProvider')]
     public function testMedianWithMatcher(iterable $items): void
     {
         $this->assertSame(333, (new Collection($items))->median('invoice.total'));
@@ -241,9 +235,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test filter() with no callback.
-     *
-     * @dataProvider filterProvider
      */
+    #[DataProvider('filterProvider')]
     public function testFilterNoCallback(iterable $items): void
     {
         $collection = new Collection($items);
@@ -429,9 +422,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests map
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testMap(iterable $items): void
     {
         $collection = new Collection($items);
@@ -446,9 +438,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests reduce with initial value
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testReduceWithInitialValue(iterable $items): void
     {
         $collection = new Collection($items);
@@ -459,9 +450,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests reduce without initial value
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testReduceWithoutInitialValue(iterable $items): void
     {
         $collection = new Collection($items);
@@ -487,9 +477,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests extract
-     *
-     * @dataProvider extractProvider
      */
+    #[DataProvider('extractProvider')]
     public function testExtract(iterable $items): void
     {
         $collection = new Collection($items);
@@ -519,9 +508,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests sort
-     *
-     * @dataProvider sortProvider
      */
+    #[DataProvider('sortProvider')]
     public function testSortString(iterable $items): void
     {
         $collection = new Collection($items);
@@ -537,9 +525,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests max
-     *
-     * @dataProvider sortProvider
      */
+    #[DataProvider('sortProvider')]
     public function testMax(iterable $items): void
     {
         $collection = new Collection($items);
@@ -548,9 +535,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests max
-     *
-     * @dataProvider sortProvider
      */
+    #[DataProvider('sortProvider')]
     public function testMaxCallback(iterable $items): void
     {
         $collection = new Collection($items);
@@ -562,9 +548,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests max
-     *
-     * @dataProvider sortProvider
      */
+    #[DataProvider('sortProvider')]
     public function testMaxCallable(iterable $items): void
     {
         $collection = new Collection($items);
@@ -593,9 +578,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests min
-     *
-     * @dataProvider sortProvider
      */
+    #[DataProvider('sortProvider')]
     public function testMin(iterable $items): void
     {
         $collection = new Collection($items);
@@ -641,9 +625,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests groupBy
-     *
-     * @dataProvider groupByProvider
      */
+    #[DataProvider('groupByProvider')]
     public function testGroupBy(iterable $items): void
     {
         $collection = new Collection($items);
@@ -663,9 +646,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests groupBy
-     *
-     * @dataProvider groupByProvider
      */
+    #[DataProvider('groupByProvider')]
     public function testGroupByCallback(iterable $items): void
     {
         $collection = new Collection($items);
@@ -795,9 +777,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests indexBy
-     *
-     * @dataProvider indexByProvider
      */
+    #[DataProvider('indexByProvider')]
     public function testIndexBy(iterable $items): void
     {
         $collection = new Collection($items);
@@ -813,9 +794,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests indexBy
-     *
-     * @dataProvider indexByProvider
      */
+    #[DataProvider('indexByProvider')]
     public function testIndexByCallback(iterable $items): void
     {
         $collection = new Collection($items);
@@ -929,9 +909,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests countBy
-     *
-     * @dataProvider groupByProvider
      */
+    #[DataProvider('groupByProvider')]
     public function testCountBy(iterable $items): void
     {
         $collection = new Collection($items);
@@ -947,9 +926,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests countBy
-     *
-     * @dataProvider groupByProvider
      */
+    #[DataProvider('groupByProvider')]
     public function testCountByCallback(iterable $items): void
     {
         $expected = [
@@ -965,9 +943,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests shuffle
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testShuffle(iterable $data): void
     {
         $collection = (new Collection($data))->shuffle();
@@ -994,9 +971,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests sample
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testSample(iterable $data): void
     {
         $result = (new Collection($data))->sample(2)->toArray();
@@ -1039,9 +1015,8 @@ class CollectionTest extends TestCase
 
     /**
      * Test toList method
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testToList(iterable $data): void
     {
         $collection = new Collection($data);
@@ -1060,9 +1035,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that Count returns the number of elements
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testCollectionCount(iterable $list): void
     {
         $list = (new Collection($list))->buffered();
@@ -1072,9 +1046,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests that countKeys returns the number of unique keys
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testCollectionCountKeys(iterable $list): void
     {
         $list = (new Collection($list))->buffered();
@@ -1769,9 +1742,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the listNested method with the default 'children' nesting key
-     *
-     * @dataProvider nestedListProvider
      */
+    #[DataProvider('nestedListProvider')]
     public function testListNested(string $dir, array $expected): void
     {
         $items = [
@@ -1871,9 +1843,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the sumOf method
      *
-     * @dataProvider sumOfProvider
      * @param float|int $expected
      */
+    #[DataProvider('sumOfProvider')]
     public function testSumOf(iterable $items, $expected): void
     {
         $this->assertEquals($expected, (new Collection($items))->sumOf('invoice.total'));
@@ -1882,9 +1854,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the sumOf method
      *
-     * @dataProvider sumOfProvider
      * @param float|int $expected
      */
+    #[DataProvider('sumOfProvider')]
     public function testSumOfCallable(iterable $items, $expected): void
     {
         $sum = (new Collection($items))->sumOf(function ($v) {
@@ -1895,9 +1867,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the stopWhen method with a callable
-     *
-     * @dataProvider simpleProvider
      */
+    #[DataProvider('simpleProvider')]
     public function testStopWhenCallable(iterable $items): void
     {
         $collection = (new Collection($items))->stopWhen(function ($v) {
@@ -2250,10 +2221,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the takeLast() method
      *
-     * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @covers ::takeLast
      */
+    #[DataProvider('simpleProvider')]
     public function testLastN($data): void
     {
         $collection = new Collection($data);
@@ -2265,10 +2235,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the takeLast() method with overflow
      *
-     * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @covers ::takeLast
      */
+    #[DataProvider('simpleProvider')]
     public function testLastNtWithOverflow($data): void
     {
         $collection = new Collection($data);
@@ -2280,10 +2249,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the takeLast() with an odd numbers collection
      *
-     * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @covers ::takeLast
      */
+    #[DataProvider('simpleProvider')]
     public function testLastNtWithOddData($data): void
     {
         $collection = new Collection($data);
@@ -2294,8 +2262,6 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the takeLast() with countable collection
-     *
-     * @covers ::takeLast
      */
     public function testLastNtWithCountable(): void
     {
@@ -2313,10 +2279,9 @@ class CollectionTest extends TestCase
     /**
      * Tests the takeLast() with countable collection
      *
-     * @dataProvider simpleProvider
      * @param iterable $data The data to test with.
-     * @covers ::takeLast
      */
+    #[DataProvider('simpleProvider')]
     public function testLastNtWithNegative($data): void
     {
         $collection = new Collection($data);
@@ -2464,9 +2429,8 @@ class CollectionTest extends TestCase
 
     /**
      * Tests the chunk method with exact chunks
-     *
-     * @dataProvider chunkProvider
      */
+    #[DataProvider('chunkProvider')]
     public function testChunk(iterable $items): void
     {
         $collection = new Collection($items);

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -19,6 +19,7 @@ use Cake\Console\CommandInterface;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * PluginUnloadCommandTest class
@@ -75,9 +76,8 @@ class PluginUnloadCommandTest extends TestCase
 
     /**
      * testUnload
-     *
-     * @dataProvider pluginNameProvider
      */
+    #[DataProvider('pluginNameProvider')]
     public function testUnload($plugin): void
     {
         $this->exec('plugin unload ' . $plugin);

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -22,6 +22,7 @@ use Cake\Console\CommandCollection;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Command\DemoCommand;
 use TestApp\Command\SampleCommand;
 
@@ -119,9 +120,8 @@ class CommandCollectionTest extends TestCase
 
     /**
      * test adding a command instance.
-     *
-     * @dataProvider invalidNameProvider
      */
+    #[DataProvider('invalidNameProvider')]
     public function testAddCommandInvalidName(string $name): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -21,6 +21,7 @@ use Cake\Console\Exception\StopException;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Filesystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * ConsoleIo test.
@@ -98,9 +99,9 @@ class ConsoleIoTest extends TestCase
     /**
      * test ask choices method
      *
-     * @dataProvider choiceProvider
      * @param array|string $choices
      */
+    #[DataProvider('choiceProvider')]
     public function testAskChoices($choices): void
     {
         $this->in->expects($this->once())
@@ -114,9 +115,9 @@ class ConsoleIoTest extends TestCase
     /**
      * test ask choices method
      *
-     * @dataProvider choiceProvider
      * @param array|string $choices
      */
+    #[DataProvider('choiceProvider')]
     public function testAskChoicesInsensitive($choices): void
     {
         $this->in->expects($this->once())
@@ -585,9 +586,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * test out helper methods
-     *
-     * @dataProvider outHelperProvider
      */
+    #[DataProvider('outHelperProvider')]
     public function testOutHelpers(string $method): void
     {
         $this->out->expects($this->exactly(2))
@@ -605,9 +605,8 @@ class ConsoleIoTest extends TestCase
 
     /**
      * test err helper methods
-     *
-     * @dataProvider errHelperProvider
      */
+    #[DataProvider('errHelperProvider')]
     public function testErrHelpers(string $method): void
     {
         $this->err->expects($this->exactly(2))

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -20,6 +20,7 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Console\TestSuite\MissingConsoleInputException;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class ConsoleIntegrationTestTraitTest extends TestCase
@@ -223,8 +224,8 @@ class ConsoleIntegrationTestTraitTest extends TestCase
      * @param string $message Expected failure message
      * @param string $command Command to test
      * @param mixed ...$rest
-     * @dataProvider assertionFailureMessagesProvider
      */
+    #[DataProvider('assertionFailureMessagesProvider')]
     public function testAssertionFailureMessages($assertion, $message, $command, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -68,8 +68,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * testSet method
-     *
-     * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testSet(): void
     {
@@ -162,8 +160,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * test setting messages with using the clear option
-     *
-     * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testSetWithClear(): void
     {
@@ -196,8 +192,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * testSetWithException method
-     *
-     * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testSetWithException(): void
     {
@@ -239,8 +233,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * Test magic call method.
-     *
-     * @covers \Cake\Controller\Component\FlashComponent::__call
      */
     public function testCall(): void
     {
@@ -283,8 +275,6 @@ class FlashComponentTest extends TestCase
 
     /**
      * Test a magic call with the "clear" flag to true
-     *
-     * @covers \Cake\Controller\Component\FlashComponent::set
      */
     public function testCallWithClear(): void
     {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -32,6 +32,7 @@ use Cake\View\View;
 use Cake\View\XmlView;
 use InvalidArgumentException;
 use Laminas\Diactoros\Uri;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionFunction;
 use RuntimeException;
 use TestApp\Controller\Admin\PostsController as AdminPostsController;
@@ -478,9 +479,8 @@ class ControllerTest extends TestCase
 
     /**
      * testRedirect method
-     *
-     * @dataProvider statusCodeProvider
      */
+    #[DataProvider('statusCodeProvider')]
     public function testRedirectByCode(int $code, string $msg): void
     {
         $Controller = new Controller(new ServerRequest());

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use Cake\Database\Driver\Mysql;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Core\TestApp;
 
 /**
@@ -46,8 +47,8 @@ class AppTest extends TestCase
      * @param string $suffix Class suffix
      * @param bool $existsInBase Whether class exists in base.
      * @param mixed $expected Expected value.
-     * @dataProvider classNameProvider
      */
+    #[DataProvider('classNameProvider')]
     public function testClassName($class, $type, $suffix = '', $existsInBase = false, $expected = false): void
     {
         static::setAppNamespace();
@@ -91,8 +92,8 @@ class AppTest extends TestCase
      * @param string $type Class type
      * @param string $suffix Class suffix
      * @param mixed $expected Expected value.
-     * @dataProvider shortNameProvider
      */
+    #[DataProvider('shortNameProvider')]
     public function testShortName($class, $type, $suffix = '', $expected = false): void
     {
         static::setAppNamespace();

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -26,6 +26,7 @@ use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
 use Company\TestPluginThree\TestPluginThreePlugin;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use TestPlugin\Plugin as TestPlugin;
 
 /**
@@ -88,9 +89,7 @@ class BasePluginTest extends TestCase
         $this->assertSame($commands, $plugin->console($commands));
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testServices(): void
     {
         $plugin = new BasePlugin();

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Core;
 use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 require_once CAKE . 'Core/functions_global.php';
@@ -123,10 +124,10 @@ class FunctionsGlobalTest extends TestCase
     /**
      * Test cases for h()
      *
-     * @dataProvider hInputProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('hInputProvider')]
     public function testH($value, $expected): void
     {
         $result = h($value);

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Http\Response;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use function Cake\Core\deprecationWarning;
 use function Cake\Core\env;
@@ -181,10 +182,10 @@ class FunctionsTest extends TestCase
     /**
      * Test cases for h()
      *
-     * @dataProvider hInputProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('hInputProvider')]
     public function testH($value, $expected): void
     {
         $result = h($value);
@@ -393,9 +394,7 @@ class FunctionsTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider toStringProvider
-     */
+    #[DataProvider('toStringProvider')]
     public function testToString(mixed $rawValue, ?string $expected): void
     {
         $this->assertSame($expected, toString($rawValue));
@@ -450,9 +449,7 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider toIntProvider
-     */
+    #[DataProvider('toIntProvider')]
     public function testToInt(mixed $rawValue, null|int $expected): void
     {
         $this->assertSame($expected, toInt($rawValue));
@@ -545,9 +542,7 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider toBoolProvider
-     */
+    #[DataProvider('toBoolProvider')]
     public function testToBool(mixed $rawValue, ?bool $expected): void
     {
         $this->assertSame($expected, toBool($rawValue));

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -21,6 +21,7 @@ use Cake\Database\DriverFeatureEnum;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests MySQL driver
@@ -166,10 +167,10 @@ class MysqlTest extends TestCase
     }
 
     /**
-     * @dataProvider versionStringProvider
      * @param string $dbVersion
      * @param string $expectedVersion
      */
+    #[DataProvider('versionStringProvider')]
     public function testVersion($dbVersion, $expectedVersion): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject&\PDO $connection */

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -23,6 +23,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Mockery;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Sqlite driver
@@ -167,10 +168,10 @@ class SqliteTest extends TestCase
     /**
      * Test the schemaValue method on Driver.
      *
-     * @dataProvider schemaValueProvider
      * @param mixed $input
      * @param mixed $expected
      */
+    #[DataProvider('schemaValueProvider')]
     public function testSchemaValue($input, $expected): void
     {
         $mock = Mockery::mock(PDO::class)

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -27,6 +27,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Sqlserver driver
@@ -96,10 +97,10 @@ class SqlserverTest extends TestCase
     /**
      * Test if all options in dns string are set
      *
-     * @dataProvider dnsStringDataProvider
      * @param array $constructorArgs
      * @param string $dnsString
      */
+    #[DataProvider('dnsStringDataProvider')]
     public function testDnsString($constructorArgs, $dnsString): void
     {
         $driver = $this->getMockBuilder('Cake\Database\Driver\Sqlserver')

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -33,6 +33,7 @@ use Exception;
 use PDO;
 use PDOException;
 use PDOStatement;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Driver\RetryDriver;
 use TestApp\Database\Driver\StubDriver;
 
@@ -101,9 +102,9 @@ class DriverTest extends TestCase
      * Test schemaValue().
      * Uses a provider for all the different values we can pass to the method.
      *
-     * @dataProvider schemaValueProvider
      * @param mixed $input
      */
+    #[DataProvider('schemaValueProvider')]
     public function testSchemaValue($input, string $expected): void
     {
         $result = $this->driver->schemaValue($input);

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -36,6 +36,7 @@ use Cake\Test\test_app\TestApp\Stub\WhenThenExpressionStub;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TestApp\Database\Type\CustomExpressionType;
 use TestApp\View\Object\TestObjectWithToString;
@@ -230,10 +231,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider valueTypeInferenceDataProvider
      * @param mixed $value The value from which to infer the type.
      * @param string|null $type The expected type.
      */
+    #[DataProvider('valueTypeInferenceDataProvider')]
     public function testInferValueType($value, ?string $type): void
     {
         $expression = new CaseStatementExpressionStub();
@@ -272,10 +273,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider whenTypeInferenceDataProvider
      * @param mixed $value The value from which to infer the type.
      * @param string|null $type The expected type.
      */
+    #[DataProvider('whenTypeInferenceDataProvider')]
     public function testInferWhenType($value, ?string $type): void
     {
         $expression = (new CaseStatementExpressionStub())
@@ -310,10 +311,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider resultTypeInferenceDataProvider
      * @param mixed $value The value from which to infer the type.
      * @param string|null $type The expected type.
      */
+    #[DataProvider('resultTypeInferenceDataProvider')]
     public function testInferResultType($value, ?string $type): void
     {
         $expression = (new CaseStatementExpressionStub())
@@ -332,10 +333,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider resultTypeInferenceDataProvider
      * @param mixed $value The value from which to infer the type.
      * @param string|null $type The expected type.
      */
+    #[DataProvider('resultTypeInferenceDataProvider')]
     public function testInferElseType($value, ?string $type): void
     {
         $expression = new CaseStatementExpressionStub();
@@ -1348,11 +1349,11 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider validCaseValuesDataProvider
      * @param mixed $value The case value.
      * @param string|null $sqlValue The expected SQL string value.
      * @param string|null $type The expected bound type.
      */
+    #[DataProvider('validCaseValuesDataProvider')]
     public function testValidCaseValue($value, ?string $sqlValue, ?string $type): void
     {
         $expression = (new CaseStatementExpression($value))
@@ -1507,11 +1508,11 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider validWhenValuesSimpleCaseDataProvider
      * @param mixed $value The when value.
      * @param string|null $expectedSql The expected SQL string.
      * @param array|string|null $typeOrBindings The expected bound type(s).
      */
+    #[DataProvider('validWhenValuesSimpleCaseDataProvider')]
     public function testValidWhenValueSimpleCase($value, ?string $expectedSql, $typeOrBindings = null): void
     {
         $typeMap = new TypeMap([
@@ -1629,11 +1630,11 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider validWhenValuesSearchedCaseDataProvider
      * @param mixed $value The when value.
      * @param string|null $expectedSql The expected SQL string.
      * @param array|string|null $typeOrBindings The expected bound type(s).
      */
+    #[DataProvider('validWhenValuesSearchedCaseDataProvider')]
     public function testValidWhenValueSearchedCase($value, ?string $expectedSql, $typeOrBindings = null): void
     {
         $typeMap = new TypeMap([
@@ -1693,11 +1694,11 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider validThenValuesDataProvider
      * @param mixed $value The then value.
      * @param string|null $sqlValue The expected SQL string value.
      * @param string|null $type The expected bound type.
      */
+    #[DataProvider('validThenValuesDataProvider')]
     public function testValidThenValue($value, ?string $sqlValue, ?string $type): void
     {
         $expression = (new CaseStatementExpression())
@@ -1769,11 +1770,11 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider validElseValuesDataProvider
      * @param mixed $value The else value.
      * @param string|null $sqlValue The expected SQL string value.
      * @param string|null $type The expected bound type.
      */
+    #[DataProvider('validElseValuesDataProvider')]
     public function testValidElseValue($value, ?string $sqlValue, ?string $type): void
     {
         $expression = (new CaseStatementExpression())
@@ -1855,10 +1856,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidCaseValuesDataProvider
      * @param mixed $value The case value.
      * @param string $typeName The expected error type name.
      */
+    #[DataProvider('invalidCaseValuesDataProvider')]
     public function testInvalidCaseValue($value, string $typeName): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1899,10 +1900,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidThenValueDataProvider
      * @param mixed $value The then value.
      * @param string $typeName The expected error type name.
      */
+    #[DataProvider('invalidThenValueDataProvider')]
     public function testInvalidThenValue($value, string $typeName): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -1934,9 +1935,9 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidThenTypeDataProvider
      * @param mixed $type The then type.
      */
+    #[DataProvider('invalidThenTypeDataProvider')]
     public function testInvalidThenType($type): void
     {
         $this->expectException(TypeError::class);
@@ -1963,10 +1964,10 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidElseValueDataProvider
      * @param mixed $value The else value.
      * @param string $typeName The expected error type name.
      */
+    #[DataProvider('invalidElseValueDataProvider')]
     public function testInvalidElseValue($value, string $typeName): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -2000,9 +2001,9 @@ class CaseStatementExpressionTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidElseTypeDataProvider
      * @param mixed $type The else type.
      */
+    #[DataProvider('invalidElseTypeDataProvider')]
     public function testInvalidElseType($type): void
     {
         $this->expectException(TypeError::class);

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Database\Expression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ValueBinder;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests QueryExpression class
@@ -206,9 +207,8 @@ class QueryExpressionTest extends TestCase
     /**
      * Tests that the query expression uses the type map when the
      * specific comparison functions are used.
-     *
-     * @dataProvider methodsProvider
      */
+    #[DataProvider('methodsProvider')]
     public function testTypeMapUsage(string $method): void
     {
         $expr = new QueryExpression([], ['created' => 'date']);

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -2839,8 +2839,6 @@ class SelectQueryTest extends TestCase
 
     /**
      * Tests that functions are correctly transformed and their parameters are bound
-     *
-     * @group FunctionExpression
      */
     public function testSQLFunctions(): void
     {

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -28,6 +28,7 @@ use Cake\Test\Fixture\ArticlesFixture;
 use Cake\Test\Fixture\CommentsFixture;
 use Cake\Test\Fixture\ProductsFixture;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CaseExpressionQueryTest extends TestCase
 {
@@ -276,10 +277,10 @@ class CaseExpressionQueryTest extends TestCase
     }
 
     /**
-     * @dataProvider bindingValueDataProvider
      * @param string $when The `WHEN` value.
      * @param int $result The result value.
      */
+    #[DataProvider('bindingValueDataProvider')]
     public function testBindValues(string $when, int $result): void
     {
         $value = '1';

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -22,6 +22,7 @@ use Cake\Database\Exception\DatabaseException;
 use Cake\Database\Schema\Collection;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * Test case for Collection
@@ -94,9 +95,7 @@ class CollectionTest extends TestCase
         $this->assertEquals($table, $result);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
+    #[DoesNotPerformAssertions]
     public function testListTables()
     {
         $config = $this->connection->config();

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -26,6 +26,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Exception;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for MySQL Schema Dialect.
@@ -224,9 +225,8 @@ class MysqlSchemaTest extends TestCase
 
     /**
      * Test parsing MySQL column types from field description.
-     *
-     * @dataProvider convertColumnProvider
      */
+    #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $type, array $expected): void
     {
         $field = [
@@ -903,9 +903,8 @@ SQL;
 
     /**
      * Test generating column definitions
-     *
-     * @dataProvider columnSqlProvider
      */
+    #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
@@ -977,9 +976,8 @@ SQL;
 
     /**
      * Test the constraintSql method.
-     *
-     * @dataProvider constraintSqlProvider
      */
+    #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
@@ -1018,9 +1016,8 @@ SQL;
 
     /**
      * Test the indexSql method.
-     *
-     * @dataProvider indexSqlProvider
      */
+    #[DataProvider('indexSqlProvider')]
     public function testIndexSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -24,6 +24,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Postgres schema test case.
@@ -253,9 +254,8 @@ SQL;
 
     /**
      * Test parsing Postgres column types from field description.
-     *
-     * @dataProvider convertColumnProvider
      */
+    #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(array $field, array $expected): void
     {
         $field += [
@@ -954,9 +954,8 @@ SQL;
 
     /**
      * Test generating column definitions
-     *
-     * @dataProvider columnSqlProvider
      */
+    #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
@@ -1041,9 +1040,8 @@ SQL;
 
     /**
      * Test the constraintSql method.
-     *
-     * @dataProvider constraintSqlProvider
      */
+    #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -24,6 +24,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test case for Sqlite Schema Dialect.
@@ -179,9 +180,8 @@ class SqliteSchemaTest extends TestCase
 
     /**
      * Test parsing SQLite column types from field description.
-     *
-     * @dataProvider convertColumnProvider
      */
+    #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $type, array $expected): void
     {
         $field = [
@@ -910,9 +910,8 @@ SQL;
 
     /**
      * Test generating column definitions
-     *
-     * @dataProvider columnSqlProvider
      */
+    #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
@@ -1025,9 +1024,8 @@ SQL;
 
     /**
      * Test the constraintSql method.
-     *
-     * @dataProvider constraintSqlProvider
      */
+    #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
@@ -1061,9 +1059,8 @@ SQL;
 
     /**
      * Test the indexSql method.
-     *
-     * @dataProvider indexSqlProvider
      */
+    #[DataProvider('indexSqlProvider')]
     public function testIndexSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -25,6 +25,7 @@ use Cake\Datasource\ConnectionInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * SQL Server schema test case.
@@ -304,9 +305,8 @@ SQL;
 
     /**
      * Test parsing Sqlserver column types from field description.
-     *
-     * @dataProvider convertColumnProvider
      */
+    #[DataProvider('convertColumnProvider')]
     public function testConvertColumn(string $type, ?int $length, ?int $precision, ?int $scale, array $expected): void
     {
         $field = [
@@ -832,9 +832,8 @@ SQL;
 
     /**
      * Test generating column definitions
-     *
-     * @dataProvider columnSqlProvider
      */
+    #[DataProvider('columnSqlProvider')]
     public function testColumnSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();
@@ -897,9 +896,8 @@ SQL;
 
     /**
      * Test the constraintSql method.
-     *
-     * @dataProvider constraintSqlProvider
      */
+    #[DataProvider('constraintSqlProvider')]
     public function testConstraintSql(string $name, array $data, string $expected): void
     {
         $driver = $this->_getMockedDriver();

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -23,6 +23,7 @@ use Cake\Database\Schema\TableSchema;
 use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Type\IntType;
 
 /**
@@ -369,9 +370,8 @@ class TableSchemaTest extends TestCase
     /**
      * Test that an exception is raised when constraints
      * are added for fields that do not exist.
-     *
-     * @dataProvider addConstraintErrorProvider
      */
+    #[DataProvider('addConstraintErrorProvider')]
     public function testAddConstraintError(array $props): void
     {
         $this->expectException(DatabaseException::class);
@@ -417,9 +417,8 @@ class TableSchemaTest extends TestCase
     /**
      * Test that an exception is raised when indexes
      * are added for fields that do not exist.
-     *
-     * @dataProvider addIndexErrorProvider
      */
+    #[DataProvider('addIndexErrorProvider')]
     public function testAddIndexError(array $props): void
     {
         $this->expectException(DatabaseException::class);
@@ -607,9 +606,8 @@ class TableSchemaTest extends TestCase
 
     /**
      * Add a foreign key constraint with bad data
-     *
-     * @dataProvider badForeignKeyProvider
      */
+    #[DataProvider('badForeignKeyProvider')]
     public function testAddConstraintForeignKeyBadData(array $data): void
     {
         $this->expectException(DatabaseException::class);

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Type\DateTimeFractionalType;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use DateTimeZone;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test for the DateTime type.
@@ -278,10 +279,10 @@ class DateTimeFractionalTypeTest extends TestCase
     /**
      * test marshalling data.
      *
-     * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProvider')]
     public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
@@ -384,10 +385,10 @@ class DateTimeFractionalTypeTest extends TestCase
     /**
      * test marshalling data.
      *
-     * @dataProvider marshalProviderWithoutMicroseconds
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProvider')]
     public function testMarshalWithoutMicroseconds($value, $expected): void
     {
         $result = $this->type->marshal($value);

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Database\Type\DateTimeTimezoneType;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use DateTimeZone;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test for the DateTimeTimezone type.
@@ -316,10 +317,10 @@ class DateTimeTimezoneTypeTest extends TestCase
     /**
      * test marshalling data.
      *
-     * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProvider')]
     public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);
@@ -422,10 +423,10 @@ class DateTimeTimezoneTypeTest extends TestCase
     /**
      * test marshalling data.
      *
-     * @dataProvider marshalProviderWithoutMicroseconds
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProviderWithoutMicroseconds')]
     public function testMarshalWithoutMicroseconds($value, $expected): void
     {
         $result = $this->type->marshal($value);

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -24,6 +24,7 @@ use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
 use DateTimeZone;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test for the DateTime type.
@@ -307,10 +308,10 @@ class DateTimeTypeTest extends TestCase
     /**
      * test marshalling data.
      *
-     * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProvider')]
     public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -23,6 +23,7 @@ use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test for the Date type.
@@ -216,10 +217,10 @@ class DateTypeTest extends TestCase
     /**
      * test marshaling data.
      *
-     * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProvider')]
     public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test for the Integer type.
@@ -150,9 +151,9 @@ class IntegerTypeTest extends TestCase
     /**
      * Tests that passing an invalid value will throw an exception
      *
-     * @dataProvider invalidIntegerProvider
      * @param  mixed $value Invalid value to test against the database type.
      */
+    #[DataProvider('invalidIntegerProvider')]
     public function testToDatabaseInvalid($value): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -25,6 +25,7 @@ use Cake\I18n\Time;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test for the Time type.
@@ -211,10 +212,10 @@ class TimeTypeTest extends TestCase
     /**
      * test marshalling data.
      *
-     * @dataProvider marshalProvider
      * @param mixed $value
      * @param mixed $expected
      */
+    #[DataProvider('marshalProvider')]
     public function testMarshal($value, $expected): void
     {
         $result = $this->type->marshal($value);

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -21,6 +21,7 @@ use Cake\Database\TypeInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Database\Type\BarType;
 use TestApp\Database\Type\FooType;
 
@@ -57,9 +58,8 @@ class TypeFactoryTest extends TestCase
 
     /**
      * Tests Type class is able to instantiate basic types
-     *
-     * @dataProvider basicTypesProvider
      */
+    #[DataProvider('basicTypesProvider')]
     public function testBuildBasicTypes(string $name): void
     {
         $type = TypeFactory::build($name);

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -19,6 +19,7 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\Exception\MissingDatasourceException;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Datasource\FakeConnection;
 
 /**
@@ -58,9 +59,9 @@ class ConnectionManagerTest extends TestCase
     /**
      * Test the various valid config() calls.
      *
-     * @dataProvider configProvider
      * @param \Cake\Datasource\ConnectionInterface|array $settings
      */
+    #[DataProvider('configProvider')]
     public function testConfigVariants($settings): void
     {
         $this->assertNotContains('test_variant', ConnectionManager::configured(), 'test_variant config should not exist.');
@@ -380,9 +381,8 @@ class ConnectionManagerTest extends TestCase
 
     /**
      * Test parseDsn method.
-     *
-     * @dataProvider dsnProvider
      */
+    #[DataProvider('dsnProvider')]
     public function testParseDsn(string $dsn, array $expected): void
     {
         $result = ConnectionManager::parseDsn($dsn);

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -23,6 +23,7 @@ use Cake\Datasource\Paging\Exception\PageOutOfBoundsException;
 use Cake\Datasource\Paging\NumericPaginator;
 use Cake\Datasource\RepositoryInterface;
 use Cake\ORM\Query\SelectQuery;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 trait PaginatorTestTrait
 {
@@ -1113,9 +1114,8 @@ trait PaginatorTestTrait
 
     /**
      * test that maxLimit is respected
-     *
-     * @dataProvider checkLimitProvider
      */
+    #[DataProvider('checkLimitProvider')]
     public function testCheckLimit(array $input, int $expected): void
     {
         $result = $this->Paginator->checkLimit($input);

--- a/tests/TestCase/Error/ErrorTrapTest.php
+++ b/tests/TestCase/Error/ErrorTrapTest.php
@@ -28,6 +28,7 @@ use Cake\Error\Renderer\TextErrorRenderer;
 use Cake\Log\Log;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ErrorTrapTest extends TestCase
 {
@@ -109,9 +110,7 @@ class ErrorTrapTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider logLevelProvider
-     */
+    #[DataProvider('logLevelProvider')]
     public function testHandleErrorLoggingLevel($level, $logLevel)
     {
         Log::setConfig('test_error', [

--- a/tests/TestCase/Error/ExceptionTrapTest.php
+++ b/tests/TestCase/Error/ExceptionTrapTest.php
@@ -29,6 +29,9 @@ use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use RuntimeException;
 use Throwable;
 
@@ -189,10 +192,9 @@ class ExceptionTrapTest extends TestCase
      * Test integration with HTML exception rendering
      *
      * Run in a separate process because HTML output writes headers.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testHandleExceptionHtmlRendering()
     {
         $trap = new ExceptionTrap([
@@ -237,10 +239,8 @@ class ExceptionTrapTest extends TestCase
         $this->assertEmpty($logs);
     }
 
-    /**
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
-     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testSkipLogException(): void
     {
         Log::setConfig('test_error', [
@@ -370,10 +370,9 @@ class ExceptionTrapTest extends TestCase
      * Test integration with HTML rendering for fatal errors
      *
      * Run in a separate process because HTML output writes headers.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testHandleFatalErrorHtmlRendering()
     {
         $trap = new ExceptionTrap([
@@ -401,9 +400,7 @@ class ExceptionTrapTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider initialMemoryProvider
-     */
+    #[DataProvider('initialMemoryProvider')]
     public function testIncreaseMemoryLimit($initial)
     {
         ini_set('memory_limit', $initial);

--- a/tests/TestCase/Error/PhpErrorTest.php
+++ b/tests/TestCase/Error/PhpErrorTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Error;
 
 use Cake\Error\PhpError;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PhpErrorTest extends TestCase
 {
@@ -45,9 +46,7 @@ class PhpErrorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider errorCodeProvider
-     */
+    #[DataProvider('errorCodeProvider')]
     public function testMappings($phpCode, $label, $logLevel)
     {
         $error = new PhpError($phpCode, 'something bad');

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -47,6 +47,7 @@ use Cake\View\Exception\MissingTemplateException;
 use Exception;
 use OutOfBoundsException;
 use PDOException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use TestApp\Controller\Admin\ErrorController as PrefixErrorController;
 use TestApp\Error\Exception\MissingWidgetThing;
@@ -656,9 +657,8 @@ class WebExceptionRendererTest extends TestCase
 
     /**
      * Test the various Cake Exception sub classes
-     *
-     * @dataProvider exceptionProvider
      */
+    #[DataProvider('exceptionProvider')]
     public function testCakeExceptionHandling(Exception $exception, array $patterns, int $code): void
     {
         $exceptionRenderer = new WebExceptionRenderer($exception);

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -27,16 +27,17 @@ use Cake\View\Exception\MissingElementException;
 use Cake\View\Exception\MissingLayoutException;
 use Cake\View\Exception\MissingTemplateException;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ExceptionsTest extends TestCase
 {
     /**
      * Tests simple exceptions work.
      *
-     * @dataProvider exceptionProvider
      * @param string $class The exception class name
      * @param int $defaultCode The default exception code
      */
+    #[DataProvider('exceptionProvider')]
     public function testSimpleException($class, $defaultCode): void
     {
         $previous = new Exception();

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -33,8 +33,6 @@ use TestPlugin\Plugin as TestPlugin;
 
 /**
  * Base application test.
- *
- * @coversDefaultClass \Cake\Http\BaseApplication
  */
 class BaseApplicationTest extends TestCase
 {
@@ -215,8 +213,6 @@ class BaseApplicationTest extends TestCase
 
     /**
      * Tests that loading a nonexistent plugin through addOptionalPlugin() does not throw an exception
-     *
-     * @covers ::addOptionalPlugin
      */
     public function testAddOptionalPluginLoadingNonExistentPlugin(): void
     {
@@ -230,8 +226,6 @@ class BaseApplicationTest extends TestCase
 
     /**
      * Tests that loading an existing plugin through addOptionalPlugin() works
-     *
-     * @covers ::addOptionalPlugin
      */
     public function testAddOptionalPluginLoadingNonExistentPluginValid(): void
     {

--- a/tests/TestCase/Http/Client/Auth/DigestTest.php
+++ b/tests/TestCase/Http/Client/Auth/DigestTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Client\Request;
 use Cake\Http\Client\Response;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Digest authentication test
@@ -331,9 +332,9 @@ class DigestTest extends TestCase
     /**
      * testAlgorithms method
      *
-     * @dataProvider algorithmsProvider
      * @return void
      */
+    #[DataProvider('algorithmsProvider')]
     public function testAlgorithms($message, $headers, $method, $data, $expected)
     {
         $response = new Response($headers, '');

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Http\Client;
 
 use Cake\Http\Client\Request;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * HTTP request test.
@@ -45,8 +46,8 @@ class RequestTest extends TestCase
      * @param array $headers The HTTP headers to set.
      * @param array|string|null $data The request body to use.
      * @param string $method The HTTP method to use.
-     * @dataProvider additionProvider
      */
+    #[DataProvider('additionProvider')]
     public function testMethods(array $headers, $data, $method): void
     {
         $request = new Request('http://example.com', $method, $headers, json_encode($data));
@@ -57,9 +58,7 @@ class RequestTest extends TestCase
         $this->assertSame(json_encode($data), $request->getBody()->__toString());
     }
 
-    /**
-     * @dataProvider additionProvider
-     */
+    #[DataProvider('additionProvider')]
     public static function additionProvider(): array
     {
         $headers = [

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Http\Client;
 use Cake\Http\Client\Response;
 use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * HTTP response test.
@@ -280,9 +281,8 @@ XML;
 
     /**
      * Test isSuccess()
-     *
-     * @dataProvider isSuccessProvider
      */
+    #[DataProvider('isSuccessProvider')]
     public function testIsSuccess(bool $expected, Response $response): void
     {
         $this->assertEquals($expected, $response->isSuccess());

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -27,6 +27,7 @@ use Cake\Http\Cookie\CookieCollection;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\Request as LaminasRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * HTTP client test.
@@ -203,9 +204,7 @@ class ClientTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider urlProvider
-     */
+    #[DataProvider('urlProvider')]
     public function testBuildUrl(string $expected, string $url, array $query, ?array $opts): void
     {
         $http = new Client();
@@ -466,9 +465,8 @@ class ClientTest extends TestCase
 
     /**
      * test simple POST request.
-     *
-     * @dataProvider methodProvider
      */
+    #[DataProvider('methodProvider')]
     public function testMethodsSimple(string $method): void
     {
         $response = new Response();
@@ -512,9 +510,8 @@ class ClientTest extends TestCase
 
     /**
      * Test that using the 'type' option sets the correct headers
-     *
-     * @dataProvider typeProvider
      */
+    #[DataProvider('typeProvider')]
     public function testPostWithTypeKey(string $type, string $mime): void
     {
         $response = new Response();

--- a/tests/TestCase/Http/Cookie/CookieTest.php
+++ b/tests/TestCase/Http/Cookie/CookieTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Cookie\SameSiteEnum;
 use Cake\TestSuite\TestCase;
 use DateTimeInterface;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ValueError;
 
 /**
@@ -47,9 +48,8 @@ class CookieTest extends TestCase
 
     /**
      * Test invalid cookie name
-     *
-     * @dataProvider invalidNameProvider
      */
+    #[DataProvider('invalidNameProvider')]
     public function testValidateNameInvalidChars(string $name): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -20,6 +20,7 @@ use Cake\Http\FlashMessage;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * FlashMessageTest class
@@ -282,9 +283,7 @@ class FlashMessageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @dataProvider convenienceMethods
-     */
+    #[DataProvider('convenienceMethods')]
     public function testConvenienceMethods(string $type): void
     {
         $this->assertNull($this->Session->read('Flash.flash'));

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Middleware\BodyParserMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -160,9 +161,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test skipping parsing on unknown type
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvokeMismatchedType(string $method): void
     {
         $parser = new BodyParserMiddleware();
@@ -184,9 +184,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test parsing on valid http method
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvokeCaseInsensitiveContentType(string $method): void
     {
         $parser = new BodyParserMiddleware();
@@ -208,9 +207,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test parsing on valid http method
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvokeParse(string $method): void
     {
         $parser = new BodyParserMiddleware();
@@ -254,9 +252,8 @@ class BodyParserMiddlewareTest extends TestCase
 
     /**
      * test parsing on ignored http method
-     *
-     * @dataProvider safeHttpMethodProvider
      */
+    #[DataProvider('safeHttpMethodProvider')]
     public function testInvokeNoParseOnSafe(string $method): void
     {
         $parser = new BodyParserMiddleware();
@@ -382,9 +379,9 @@ XML;
     /**
      * test parsing non array/object values on JSON
      *
-     * @dataProvider jsonScalarValues
      * @param mixed $expected
      */
+    #[DataProvider('jsonScalarValues')]
     public function testInvokeParseNoArray(string $body, $expected): void
     {
         $parser = new BodyParserMiddleware();

--- a/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/CsrfProtectionMiddlewareTest.php
@@ -27,6 +27,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
 use Laminas\Diactoros\Response as DiactorosResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TestApp\Http\TestRequestHandler;
@@ -175,9 +176,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the CSRF tokens are not required for idempotent operations
-     *
-     * @dataProvider safeHttpMethodProvider
      */
+    #[DataProvider('safeHttpMethodProvider')]
     public function testSafeMethodNoCsrfRequired(string $method): void
     {
         $request = new ServerRequest([
@@ -269,9 +269,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenInHeaderCompat(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
@@ -293,9 +292,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenInHeader(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
@@ -318,9 +316,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvalidTokenInHeader(string $method): void
     {
         $request = new ServerRequest([
@@ -351,9 +348,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that request data works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenRequestDataCompat(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
@@ -379,9 +375,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that request data works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenRequestDataSalted(string $method): void
     {
         $middleware = new CsrfProtectionMiddleware();
@@ -464,9 +459,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that request data works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvalidTokenRequestData(string $method): void
     {
         $request = new ServerRequest([
@@ -532,9 +526,8 @@ class CsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that missing header and cookie fails
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvalidTokenMissingCookie(string $method): void
     {
         $request = new ServerRequest([

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -23,6 +23,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\CookieCryptTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -85,9 +86,9 @@ class EncryptedCookieMiddlewareTest extends TestCase
     /**
      * Test decoding malformed cookies
      *
-     * @dataProvider malformedCookies
      * @param string $cookie
      */
+    #[DataProvider('malformedCookies')]
     public function testDecodeMalformedCookies($cookie): void
     {
         $request = new ServerRequest(['url' => '/cookies/nom']);

--- a/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/SessionCsrfProtectionMiddlewareTest.php
@@ -21,6 +21,7 @@ use Cake\Http\Middleware\SessionCsrfProtectionMiddleware;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TestApp\Http\TestRequestHandler;
@@ -100,9 +101,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the CSRF tokens are not required for idempotent operations
-     *
-     * @dataProvider safeHttpMethodProvider
      */
+    #[DataProvider('safeHttpMethodProvider')]
     public function testSafeMethodNoCsrfRequired(string $method): void
     {
         $request = new ServerRequest([
@@ -123,9 +123,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that the X-CSRF-Token works with the various http methods.
      *
      * Ensure unsalted tokens work.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenInHeaderBackwardsCompat(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
@@ -147,9 +146,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenInHeader(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
@@ -172,9 +170,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that the X-CSRF-Token works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvalidTokenInHeader(string $method): void
     {
         $request = new ServerRequest([
@@ -202,9 +199,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that request data works with the various http methods.
      *
      * Ensure unsalted tokens are still accepted.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenInRequestDataBackwardsCompat(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
@@ -232,9 +228,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
      * Test that request data works with the various http methods.
      *
      * Ensure salted tokens are accepted.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testValidTokenInRequestData(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
@@ -261,9 +256,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that request data works with the various http methods.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvalidTokenRequestData(string $method): void
     {
         $middleware = new SessionCsrfProtectionMiddleware();
@@ -302,9 +296,8 @@ class SessionCsrfProtectionMiddlewareTest extends TestCase
 
     /**
      * Test that missing session key fails
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testInvalidTokenMissingSession(string $method): void
     {
         $request = new ServerRequest([

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -32,6 +32,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use Laminas\Diactoros\Stream;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * ResponseTest
@@ -1017,9 +1018,8 @@ class ResponseTest extends TestCase
 
     /**
      * test withFile and invalid paths
-     *
-     * @dataProvider invalidFileProvider
      */
+    #[DataProvider('invalidFileProvider')]
     public function testWithFileInvalidPath(string $path, string $expectedMessage): void
     {
         $this->expectException(NotFoundException::class);
@@ -1173,9 +1173,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test withFile() & the various range offset types.
-     *
-     * @dataProvider rangeProvider
      */
+    #[DataProvider('rangeProvider')]
     public function testWithFileRangeOffsets(string $range, int $length, string $offsetResponse): void
     {
         $_SERVER['HTTP_RANGE'] = $range;
@@ -1239,9 +1238,8 @@ class ResponseTest extends TestCase
 
     /**
      * Test withFile() and invalid ranges
-     *
-     * @dataProvider invalidFileRangeProvider
      */
+    #[DataProvider('invalidFileRangeProvider')]
     public function testWithFileInvalidRange(string $range): void
     {
         $_SERVER['HTTP_RANGE'] = $range;

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -23,6 +23,9 @@ use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Exception\InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Psr\Http\Message\UploadedFileInterface;
 
 /**
@@ -86,10 +89,9 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * Test fromGlobals includes the session
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testFromGlobalsUrlSession(): void
     {
         Configure::write('App.base', '/basedir');
@@ -900,11 +902,11 @@ class ServerRequestFactoryTest extends TestCase
     /**
      * Test environment detection
      *
-     * @dataProvider environmentGenerator
      * @param string $name
      * @param array $data
      * @param array $expected
      */
+    #[DataProvider('environmentGenerator')]
     public function testEnvironmentDetection($name, $data, $expected): void
     {
         if (isset($data['App'])) {

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -28,6 +28,7 @@ use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * ServerRequest Test
@@ -1199,9 +1200,9 @@ class ServerRequestTest extends TestCase
     /**
      * Test reading params
      *
-     * @dataProvider paramReadingDataProvider
      * @param mixed $expected
      */
+    #[DataProvider('paramReadingDataProvider')]
     public function testGetParam(string $toRead, $expected): void
     {
         $request = new ServerRequest([
@@ -1824,9 +1825,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * Test that withoutAttribute() cannot remove emulatedAttributes properties.
-     *
-     * @dataProvider emulatedPropertyProvider
      */
+    #[DataProvider('emulatedPropertyProvider')]
     public function testWithoutAttributesDenyEmulatedProperties(string $prop): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -20,6 +20,8 @@ use Cake\Core\Exception\CakeException;
 use Cake\Http\Session;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use TestApp\Http\Session\TestAppLibSession;
 use TestApp\Http\Session\TestWebSession;
 
@@ -40,10 +42,9 @@ class SessionTest extends TestCase
 
     /**
      * test setting ini properties with Session configuration.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testSessionConfigIniSetting(): void
     {
         $_SESSION = null;
@@ -66,10 +67,9 @@ class SessionTest extends TestCase
 
     /**
      * test setting ini properties with Session configuration.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testSessionConfigTimeoutZero(): void
     {
         $_SESSION = null;
@@ -86,10 +86,9 @@ class SessionTest extends TestCase
 
     /**
      * test setting ini properties with Session configuration.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testSessionConfigTimeout(): void
     {
         $_SESSION = null;
@@ -106,10 +105,9 @@ class SessionTest extends TestCase
 
     /**
      * test session cookie path setting
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testCookiePath(): void
     {
         ini_set('session.cookie_path', '/foo');
@@ -286,10 +284,9 @@ class SessionTest extends TestCase
 
     /**
      * testId method
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testId(): void
     {
         $session = new Session();
@@ -468,10 +465,9 @@ class SessionTest extends TestCase
 
     /**
      * test using a handler from app/Http/Session.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testUsingAppLibsHandler(): void
     {
         static::setAppNamespace();
@@ -492,10 +488,9 @@ class SessionTest extends TestCase
 
     /**
      * test using a handler from a plugin.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testUsingPluginHandler(): void
     {
         static::setAppNamespace();
@@ -515,10 +510,9 @@ class SessionTest extends TestCase
 
     /**
      * Tests that it is possible to pass an already made instance as the session engine
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testEngineWithPreMadeInstance(): void
     {
         static::setAppNamespace();
@@ -550,10 +544,9 @@ class SessionTest extends TestCase
 
     /**
      * Test that cookieTimeout matches timeout when unspecified.
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testCookieTimeoutFallback(): void
     {
         $config = [
@@ -568,10 +561,9 @@ class SessionTest extends TestCase
 
     /**
      * Tests that the cookie name can be changed with configuration
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testSessionName(): void
     {
         new Session(['cookie' => 'made_up_name']);
@@ -580,10 +572,9 @@ class SessionTest extends TestCase
 
     /**
      * Test that a call of check() starts the session when cookies are disabled in php.ini
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testCheckStartsSessionWithCookiesDisabled(): void
     {
         $_COOKIE = [];
@@ -623,10 +614,9 @@ class SessionTest extends TestCase
 
     /**
      * Test that a call of check() starts the session when the session ID is passed via URL and session.use_trans_sid is enabled
-     *
-     * @preserveGlobalState disabled
-     * @runInSeparateProcess
      */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
     public function testCheckStartsSessionWithSIDinURL(): void
     {
         $_COOKIE = [];

--- a/tests/TestCase/Http/TestSuite/HttpClientTraitTest.php
+++ b/tests/TestCase/Http/TestSuite/HttpClientTraitTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Http\TestSuite;
 use Cake\Http\Client;
 use Cake\Http\TestSuite\HttpClientTrait;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HttpClientTraitTest extends TestCase
 {
@@ -40,9 +41,7 @@ class HttpClientTraitTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider methodProvider
-     */
+    #[DataProvider('methodProvider')]
     public function testRequestMethods(string $httpMethod)
     {
         $traitMethod = "mockClient{$httpMethod}";

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -23,6 +23,7 @@ use Cake\I18n\I18n;
 use Cake\I18n\Package;
 use Cake\TestSuite\TestCase;
 use IntlDateFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * DateTest class
@@ -207,9 +208,8 @@ class DateTest extends TestCase
 
     /**
      * testTimeAgoInWords method
-     *
-     * @dataProvider timeAgoProvider
      */
+    #[DataProvider('timeAgoProvider')]
     public function testTimeAgoInWords(string $input, string $expected): void
     {
         $date = new Date($input);
@@ -281,9 +281,8 @@ class DateTest extends TestCase
 
     /**
      * test the end option for timeAgoInWords
-     *
-     * @dataProvider timeAgoEndProvider
      */
+    #[DataProvider('timeAgoEndProvider')]
     public function testTimeAgoInWordsEnd(string $input, string $expected, string $end): void
     {
         $time = new Date($input);

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -23,6 +23,7 @@ use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use DateTimeZone;
 use IntlDateFormatter;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * DateTimeTest class
@@ -104,9 +105,8 @@ class DateTimeTest extends TestCase
 
     /**
      * testTimeAgoInWords method
-     *
-     * @dataProvider timeAgoProvider
      */
+    #[DataProvider('timeAgoProvider')]
     public function testTimeAgoInWords(string $input, string $expected): void
     {
         $time = new DateTime($input);
@@ -178,9 +178,8 @@ class DateTimeTest extends TestCase
 
     /**
      * test the end option for timeAgoInWords
-     *
-     * @dataProvider timeAgoEndProvider
      */
+    #[DataProvider('timeAgoEndProvider')]
     public function testTimeAgoInWordsEnd(string $input, string $expected, string $end): void
     {
         $time = new DateTime($input);
@@ -537,9 +536,9 @@ class DateTimeTest extends TestCase
     /**
      * Test that invalid datetime values do not trigger errors.
      *
-     * @dataProvider invalidDataProvider
      * @param mixed $value
      */
+    #[DataProvider('invalidDataProvider')]
     public function testToStringInvalid($value): void
     {
         $time = new DateTime($value);
@@ -550,9 +549,9 @@ class DateTimeTest extends TestCase
     /**
      * Test that invalid datetime values do not trigger errors.
      *
-     * @dataProvider invalidDataProvider
      * @param mixed $value
      */
+    #[DataProvider('invalidDataProvider')]
     public function testToStringInvalidFrozen($value): void
     {
         $time = new DateTime($value);

--- a/tests/TestCase/I18n/PluralRulesTest.php
+++ b/tests/TestCase/I18n/PluralRulesTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\I18n;
 
 use Cake\I18n\PluralRules;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * PluralRules tests
@@ -126,9 +127,8 @@ class PluralRulesTest extends TestCase
 
     /**
      * Tests that the correct plural form is selected for the locale, number combination
-     *
-     * @dataProvider localesProvider
      */
+    #[DataProvider('localesProvider')]
     public function testCalculate(string $locale, int $number, int $expected): void
     {
         $this->assertEquals($expected, PluralRules::calculate($locale, $number));

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Log\Engine;
 
 use Cake\Log\Engine\SyslogLog;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * SyslogLogTest class
@@ -51,9 +52,8 @@ class SyslogLogTest extends TestCase
 
     /**
      * Tests that single lines are written to syslog
-     *
-     * @dataProvider typesProvider
      */
+    #[DataProvider('typesProvider')]
     public function testWriteOneLine(string $type, int $expected): void
     {
         /** @var \Cake\Log\Engine\SyslogLog|\PHPUnit\Framework\MockObject\MockObject $log */

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -21,6 +21,7 @@ use Cake\Log\Engine\FileLog;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**
@@ -155,9 +156,9 @@ class LogTest extends TestCase
     /**
      * Test the various config call signatures.
      *
-     * @dataProvider configProvider
      * @param mixed $settings
      */
+    #[DataProvider('configProvider')]
     public function testConfigVariants($settings): void
     {
         Log::setConfig('test', $settings);
@@ -169,9 +170,9 @@ class LogTest extends TestCase
     /**
      * Test the various setConfig call signatures.
      *
-     * @dataProvider configProvider
      * @param mixed $settings
      */
+    #[DataProvider('configProvider')]
     public function testSetConfigVariants($settings): void
     {
         Log::setConfig('test', $settings);

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -22,6 +22,7 @@ use Cake\Mailer\Transport\DebugTransport;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use TestApp\Mailer\TestMessage;
 use function Cake\Core\env;
@@ -484,9 +485,9 @@ HTML;
     /**
      * testBuildInvalidData
      *
-     * @dataProvider invalidEmails
      * @param array|string $value
      */
+    #[DataProvider('invalidEmails')]
     public function testInvalidEmail($value): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -496,9 +497,9 @@ HTML;
     /**
      * testBuildInvalidData
      *
-     * @dataProvider invalidEmails
      * @param array|string $value
      */
+    #[DataProvider('invalidEmails')]
     public function testInvalidEmailAdd($value): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -20,6 +20,7 @@ use Cake\Network\Exception\SocketException;
 use Cake\Network\Socket;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * SocketTest class
@@ -139,9 +140,8 @@ class SocketTest extends TestCase
 
     /**
      * testInvalidConnection method
-     *
-     * @dataProvider invalidConnections
      */
+    #[DataProvider('invalidConnections')]
     public function testInvalidConnection(array $data): void
     {
         $this->expectException(SocketException::class);

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -38,6 +38,7 @@ use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\ArticlesTag;
 use function Cake\Collection\collection;
 
@@ -1187,9 +1188,9 @@ class BelongsToManyTest extends TestCase
     /**
      * Test that saving an empty set on create works.
      *
-     * @dataProvider emptyProvider
      * @param mixed $value
      */
+    #[DataProvider('emptyProvider')]
     public function testSaveAssociatedEmptySetSuccess($value): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */
@@ -1217,9 +1218,9 @@ class BelongsToManyTest extends TestCase
     /**
      * Test that saving an empty set on update works.
      *
-     * @dataProvider emptyProvider
      * @param mixed $value
      */
+    #[DataProvider('emptyProvider')]
     public function testSaveAssociatedEmptySetUpdateSuccess($value): void
     {
         /** @var \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockBuilder $table */

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -33,6 +33,7 @@ use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use function Cake\I18n\__;
 
 /**
@@ -943,9 +944,9 @@ class HasManyTest extends TestCase
      * Test that saving empty sets with the `append` strategy does not
      * affect the associated records for not yet persisted parent entities.
      *
-     * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
      */
+    #[DataProvider('emptySetDataProvider')]
     public function testSaveAssociatedEmptySetWithAppendStrategyDoesNotAffectAssociatedRecordsOnCreate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
@@ -968,9 +969,9 @@ class HasManyTest extends TestCase
      * Test that saving empty sets with the `append` strategy does not
      * affect the associated records for already persisted parent entities.
      *
-     * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
      */
+    #[DataProvider('emptySetDataProvider')]
     public function testSaveAssociatedEmptySetWithAppendStrategyDoesNotAffectAssociatedRecordsOnUpdate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
@@ -998,9 +999,9 @@ class HasManyTest extends TestCase
      * Test that saving empty sets with the `replace` strategy does not
      * affect the associated records for not yet persisted parent entities.
      *
-     * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
      */
+    #[DataProvider('emptySetDataProvider')]
     public function testSaveAssociatedEmptySetWithReplaceStrategyDoesNotAffectAssociatedRecordsOnCreate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');
@@ -1023,9 +1024,9 @@ class HasManyTest extends TestCase
      * Test that saving empty sets with the `replace` strategy does remove
      * the associated records for already persisted parent entities.
      *
-     * @dataProvider emptySetDataProvider
      * @param mixed $value Empty value.
      */
+    #[DataProvider('emptySetDataProvider')]
     public function testSaveAssociatedEmptySetWithReplaceStrategyRemovesAssociatedRecordsOnUpdate($value): void
     {
         $articles = $this->getTableLocator()->get('Articles');

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -24,6 +24,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Locator\LocatorInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * AssociationCollection test case.
@@ -184,8 +185,8 @@ class AssociationCollectionTest extends TestCase
      *
      * @param string $belongsToStr
      * @param string $belongsToManyStr
-     * @dataProvider associationCollectionType
      */
+    #[DataProvider('associationCollectionType')]
     public function testGetByType($belongsToStr, $belongsToManyStr): void
     {
         $belongsTo = new BelongsTo('');

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Integration tests for using the bindingKey in associations
@@ -56,9 +57,8 @@ class BindingKeyTest extends TestCase
 
     /**
      * Tests that bindingKey can be used in belongsTo associations
-     *
-     * @dataProvider strategiesProviderJoinable
      */
+    #[DataProvider('strategiesProviderJoinable')]
     public function testBelongsto(string $strategy): void
     {
         $users = $this->getTableLocator()->get('Users');
@@ -87,9 +87,8 @@ class BindingKeyTest extends TestCase
 
     /**
      * Tests that bindingKey can be used in hasOne associations
-     *
-     * @dataProvider strategiesProviderJoinable
      */
+    #[DataProvider('strategiesProviderJoinable')]
     public function testHasOne(string $strategy): void
     {
         $users = $this->getTableLocator()->get('Users');
@@ -110,9 +109,8 @@ class BindingKeyTest extends TestCase
 
     /**
      * Tests that bindingKey can be used in hasOne associations
-     *
-     * @dataProvider strategiesProviderExternal
      */
+    #[DataProvider('strategiesProviderExternal')]
     public function testHasMany(string $strategy): void
     {
         $users = $this->getTableLocator()->get('Users');

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -24,6 +24,7 @@ use Cake\ORM\Marshaller;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\OpenArticleEntity;
 use TestApp\Model\Entity\OpenTag;
 use TestApp\Model\Entity\ProtectedArticle;
@@ -1322,9 +1323,9 @@ class MarshallerTest extends TestCase
     /**
      * Test merging empty values into an entity.
      *
-     * @dataProvider emptyProvider
      * @param mixed $value
      */
+    #[DataProvider('emptyProvider')]
     public function testMergeFalseyValues($value): void
     {
         $marshall = new Marshaller($this->articles);

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -26,6 +26,7 @@ use Cake\ORM\Marshaller;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Model\Entity\OpenArticleEntity;
 
 /**
@@ -102,8 +103,6 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Test that you cannot save rows with composite keys if some columns are missing.
-     *
-     * @group save
      */
     public function testSaveNewErrorCompositeKeyNoIncrement(): void
     {
@@ -118,8 +117,6 @@ class CompositeKeysTest extends TestCase
      * Test that saving into composite primary keys where one column is missing & autoIncrement works.
      *
      * SQLite is skipped because it doesn't support autoincrement composite keys.
-     *
-     * @group save
      */
     public function testSaveNewCompositeKeyIncrement(): void
     {
@@ -134,9 +131,8 @@ class CompositeKeysTest extends TestCase
     /**
      * Tests that HasMany associations are correctly eager loaded and results
      * correctly nested when multiple foreignKeys are used
-     *
-     * @dataProvider strategiesProviderHasMany
      */
+    #[DataProvider('strategiesProviderHasMany')]
     public function testHasManyEager(string $strategy): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
@@ -209,9 +205,8 @@ class CompositeKeysTest extends TestCase
     /**
      * Tests that BelongsToMany associations are correctly eager loaded when multiple
      * foreignKeys are used
-     *
-     * @dataProvider strategiesProviderBelongsToMany
      */
+    #[DataProvider('strategiesProviderBelongsToMany')]
     public function testBelongsToManyEager(string $strategy): void
     {
         $articles = $this->getTableLocator()->get('SiteArticles');
@@ -295,9 +290,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Tests loading belongsTo with composite keys
-     *
-     * @dataProvider strategiesProviderBelongsTo
      */
+    #[DataProvider('strategiesProviderBelongsTo')]
     public function testBelongsToEager(string $strategy): void
     {
         $table = $this->getTableLocator()->get('SiteArticles');
@@ -343,9 +337,8 @@ class CompositeKeysTest extends TestCase
 
     /**
      * Tests loading hasOne with composite keys
-     *
-     * @dataProvider strategiesProviderHasOne
      */
+    #[DataProvider('strategiesProviderHasOne')]
     public function testHasOneEager(string $strategy): void
     {
         $table = $this->getTableLocator()->get('SiteAuthors');
@@ -393,8 +386,6 @@ class CompositeKeysTest extends TestCase
     /**
      * Tests that it is possible to insert a new row using the save method
      * if the entity has composite primary key
-     *
-     * @group save
      */
     public function testSaveNewEntity(): void
     {
@@ -416,8 +407,6 @@ class CompositeKeysTest extends TestCase
     /**
      * Tests that it is possible to insert a new row using the save method
      * if the entity has composite primary key
-     *
-     * @group save
      */
     public function testSaveNewEntityMissingKey(): void
     {

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -28,6 +28,7 @@ use Cake\ORM\Query\SelectQuery;
 use Cake\TestSuite\TestCase;
 use DateTime as NativeDateTime;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use function Cake\Collection\collection;
 
 /**
@@ -312,9 +313,9 @@ class QueryRegressionTest extends TestCase
      * Checks that only relevant associations are passed when saving _joinData
      * Tests that _joinData can also save deeper associations
      *
-     * @dataProvider strategyProvider
      * @param string $strategy
      */
+    #[DataProvider('strategyProvider')]
     public function testBelongsToManyDeepSave($strategy): void
     {
         $articles = $this->getTableLocator()->get('Articles');

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -41,6 +41,7 @@ use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
 /**
@@ -208,9 +209,8 @@ class SelectQueryTest extends TestCase
     /**
      * Tests that results are grouped correctly when using contain()
      * and results are not hydrated
-     *
-     * @dataProvider strategiesProviderBelongsTo
      */
+    #[DataProvider('strategiesProviderBelongsTo')]
     public function testContainResultFetchingOneLevel(string $strategy): void
     {
         $table = $this->getTableLocator()->get('articles', ['table' => 'articles']);
@@ -265,9 +265,8 @@ class SelectQueryTest extends TestCase
      * correctly nested when no hydration is used
      * Also that the query object passes the correct parent model keys to the
      * association objects in order to perform eager loading with select strategy
-     *
-     * @dataProvider strategiesProviderHasMany
      */
+    #[DataProvider('strategiesProviderHasMany')]
     public function testHasManyEagerLoadingNoHydration(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
@@ -343,9 +342,8 @@ class SelectQueryTest extends TestCase
     /**
      * Tests that it is possible to count results containing hasMany associations
      * both hydrating and not hydrating the results.
-     *
-     * @dataProvider strategiesProviderHasMany
      */
+    #[DataProvider('strategiesProviderHasMany')]
     public function testHasManyEagerLoadingCount(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
@@ -373,9 +371,8 @@ class SelectQueryTest extends TestCase
 
     /**
      * Tests that it is possible to set fields & order in a hasMany result set
-     *
-     * @dataProvider strategiesProviderHasMany
      */
+    #[DataProvider('strategiesProviderHasMany')]
     public function testHasManyEagerLoadingFieldsAndOrderNoHydration(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
@@ -424,9 +421,8 @@ class SelectQueryTest extends TestCase
 
     /**
      * Tests that deep associations can be eagerly loaded
-     *
-     * @dataProvider strategiesProviderHasMany
      */
+    #[DataProvider('strategiesProviderHasMany')]
     public function testHasManyEagerLoadingDeep(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
@@ -497,9 +493,8 @@ class SelectQueryTest extends TestCase
     /**
      * Tests that hasMany associations can be loaded even when related to a secondary
      * model in the query
-     *
-     * @dataProvider strategiesProviderHasMany
      */
+    #[DataProvider('strategiesProviderHasMany')]
     public function testHasManyEagerLoadingFromSecondaryTable(string $strategy): void
     {
         $author = $this->getTableLocator()->get('authors');
@@ -602,9 +597,8 @@ class SelectQueryTest extends TestCase
      * Tests that BelongsToMany associations are correctly eager loaded.
      * Also that the query object passes the correct parent model keys to the
      * association objects in order to perform eager loading with select strategy
-     *
-     * @dataProvider strategiesProviderBelongsToMany
      */
+    #[DataProvider('strategiesProviderBelongsToMany')]
     public function testBelongsToManyEagerLoadingNoHydration(string $strategy): void
     {
         $table = $this->getTableLocator()->get('Articles');
@@ -1436,9 +1430,8 @@ class SelectQueryTest extends TestCase
 
     /**
      * Tests that belongsTo relations are correctly hydrated
-     *
-     * @dataProvider strategiesProviderBelongsTo
      */
+    #[DataProvider('strategiesProviderBelongsTo')]
     public function testHydrateBelongsTo(string $strategy): void
     {
         $table = $this->getTableLocator()->get('articles');
@@ -1460,9 +1453,8 @@ class SelectQueryTest extends TestCase
 
     /**
      * Tests that deeply nested associations are also hydrated correctly
-     *
-     * @dataProvider strategiesProviderBelongsTo
      */
+    #[DataProvider('strategiesProviderBelongsTo')]
     public function testHydrateDeep(string $strategy): void
     {
         $table = $this->getTableLocator()->get('authors');
@@ -2731,9 +2723,8 @@ class SelectQueryTest extends TestCase
     /**
      * Tests that it is possible to use the same association aliases in the association
      * chain for contain
-     *
-     * @dataProvider strategiesProviderBelongsTo
      */
+    #[DataProvider('strategiesProviderBelongsTo')]
     public function testRepeatedAssociationAliases(string $strategy): void
     {
         $table = $this->getTableLocator()->get('ArticlesTags');

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -1550,7 +1550,8 @@ class SelectQueryTest extends TestCase
      */
     public function testHydrateBelongsToCustomEntity(): void
     {
-        $authorEntity = get_class($this->createMock('Cake\ORM\Entity'));
+        // phpcs:ignore
+        $authorEntity = get_class(new class extends Entity {});
         $table = $this->getTableLocator()->get('articles');
         $this->getTableLocator()->get('authors', [
             'entityClass' => '\\' . $authorEntity,

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -27,6 +27,7 @@ use Cake\ORM\Rule\LinkConstraint;
 use Cake\ORM\RulesChecker;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 /**
@@ -181,9 +182,9 @@ class LinkConstraintTest extends TestCase
     /**
      * Tests that an exception is thrown when the `repository` option holds an invalid value.
      *
-     * @dataProvider invalidRepositoryOptionsDataProvider
      * @param mixed $options
      */
+    #[DataProvider('invalidRepositoryOptionsDataProvider')]
     public function testInvalidRepository($options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -48,8 +48,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests saving belongsTo association and get a validation error
-     *
-     * @group save
      */
     public function testSaveBelongsToWithValidationError(): void
     {
@@ -86,8 +84,6 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests saving hasOne association and returning a validation error will
      * abort the saving process
-     *
-     * @group save
      */
     public function testSaveHasOneWithValidationError(): void
     {
@@ -213,8 +209,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests saving belongsToMany records with a validation error in a joint entity
-     *
-     * @group save
      */
     public function testSaveBelongsToManyWithValidationErrorInJointEntity(): void
     {
@@ -252,8 +246,6 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests saving belongsToMany records with a validation error in a joint entity
      * and atomic set to false
-     *
-     * @group save
      */
     public function testSaveBelongsToManyWithValidationErrorInJointEntityNonAtomic(): void
     {
@@ -291,8 +283,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Test adding rule with name
-     *
-     * @group save
      */
     public function testAddingRuleWithName(): void
     {
@@ -338,8 +328,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the isUnique domain rule
-     *
-     * @group save
      */
     public function testIsUniqueDomainRule(): void
     {
@@ -364,8 +352,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests isUnique with multiple fields
-     *
-     * @group save
      */
     public function testIsUniqueMultipleFields(): void
     {
@@ -408,8 +394,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests isUnique with allowMultipleNulls
-     *
-     * @group save
      */
     public function testIsUniqueAllowMultipleNulls(): void
     {
@@ -440,8 +424,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the existsIn domain rule
-     *
-     * @group save
      */
     public function testExistsInDomainRule(): void
     {
@@ -485,8 +467,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the existsIn domain rule when passing an object
-     *
-     * @group save
      */
     public function testExistsInDomainRuleWithObject(): void
     {
@@ -571,8 +551,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests existsIn with invalid associations
-     *
-     * @group save
      */
     public function testExistsInInvalidAssociation(): void
     {
@@ -649,8 +627,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the checkRules save option
-     *
-     * @group save
      */
     public function testSkipRulesChecking(): void
     {
@@ -668,8 +644,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the beforeRules event
-     *
-     * @group save
      */
     public function testUseBeforeRules(): void
     {
@@ -708,8 +682,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the afterRules event
-     *
-     * @group save
      */
     public function testUseAfterRules(): void
     {
@@ -749,8 +721,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests that rules can be changed using the buildRules event
-     *
-     * @group save
      */
     public function testUseBuildRulesEvent(): void
     {
@@ -769,8 +739,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests isUnique with untouched fields
-     *
-     * @group save
      */
     public function testIsUniqueWithCleanFields(): void
     {
@@ -788,8 +756,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests isUnique rule with conflicting columns
-     *
-     * @group save
      */
     public function testIsUniqueAliasPrefix(): void
     {
@@ -813,8 +779,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the existsIn rule when passing non dirty fields
-     *
-     * @group save
      */
     public function testExistsInWithCleanFields(): void
     {
@@ -832,8 +796,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the existsIn with conflicting columns
-     *
-     * @group save
      */
     public function testExistsInAliasPrefix(): void
     {
@@ -1123,8 +1085,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests using rules to prevent delete operations
-     *
-     * @group delete
      */
     public function testDeleteRules(): void
     {
@@ -1140,8 +1100,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Checks that it is possible to pass custom options to rules when saving
-     *
-     * @group save
      */
     public function testCustomOptionsPassingSave(): void
     {
@@ -1163,8 +1121,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests passing custom options to rules from delete
-     *
-     * @group delete
      */
     public function testCustomOptionsPassingDelete(): void
     {
@@ -1183,8 +1139,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Test adding rules that return error string
-     *
-     * @group save
      */
     public function testCustomErrorMessageFromRule(): void
     {
@@ -1204,8 +1158,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Test adding rules with no errorField do not accept strings
-     *
-     * @group save
      */
     public function testCustomErrorMessageFromRuleNoErrorField(): void
     {
@@ -1226,8 +1178,6 @@ class RulesCheckerIntegrationTest extends TestCase
     /**
      * Tests that using existsIn for a hasMany association will not be called
      * as the foreign key for the association was automatically validated already.
-     *
-     * @group save
      */
     public function testAvoidExistsInOnAutomaticSaving(): void
     {
@@ -1265,8 +1215,6 @@ class RulesCheckerIntegrationTest extends TestCase
 
     /**
      * Tests the existsIn domain rule respects the conditions set for the associations
-     *
-     * @group save
      */
     public function testExistsInDomainRuleWithAssociationConditions(): void
     {

--- a/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
+++ b/tests/TestCase/ORM/TableGetWithCustomFinderTest.php
@@ -20,6 +20,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TableGetWithCustomFinderTest extends TestCase
 {
@@ -42,9 +43,9 @@ class TableGetWithCustomFinderTest extends TestCase
     /**
      * Test that get() will call a custom finder.
      *
-     * @dataProvider providerForTestGetWithCustomFinder
      * @param array $options
      */
+    #[DataProvider('providerForTestGetWithCustomFinder')]
     public function testGetWithCustomFinder($options): void
     {
         $table = $this->getMockBuilder(GetWithCustomFinderTable::class)

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -57,6 +57,7 @@ use Cake\Validation\Validator;
 use Exception;
 use InvalidArgumentException;
 use PDOException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use RuntimeException;
 use TestApp\Model\Entity\ProtectedEntity;
@@ -2108,8 +2109,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to insert a new row using the save method
-     *
-     * @group save
      */
     public function testSaveNewEntity(): void
     {
@@ -2129,8 +2128,6 @@ class TableTest extends TestCase
 
     /**
      * Test that saving a new empty entity does nothing.
-     *
-     * @group save
      */
     public function testSaveNewEmptyEntity(): void
     {
@@ -2141,8 +2138,6 @@ class TableTest extends TestCase
 
     /**
      * Test that saving a new empty entity does not call exists.
-     *
-     * @group save
      */
     public function testSaveNewEntityNoExists(): void
     {
@@ -2165,8 +2160,6 @@ class TableTest extends TestCase
 
     /**
      * Test that saving a new entity with a Primary Key set does call exists.
-     *
-     * @group save
      */
     public function testSavePrimaryKeyEntityExists(): void
     {
@@ -2189,8 +2182,6 @@ class TableTest extends TestCase
 
     /**
      * Test that saving a new entity with a Primary Key set does not call exists when checkExisting is false.
-     *
-     * @group save
      */
     public function testSavePrimaryKeyEntityNoExists(): void
     {
@@ -2214,8 +2205,6 @@ class TableTest extends TestCase
     /**
      * Tests that saving an entity will filter out properties that
      * are not present in the table schema when saving
-     *
-     * @group save
      */
     public function testSaveEntityOnlySchemaFields(): void
     {
@@ -2237,8 +2226,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to modify data from the beforeSave callback
-     *
-     * @group save
      */
     public function testBeforeSaveModifyData(): void
     {
@@ -2261,8 +2248,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that it is possible to modify the options array in beforeSave
-     *
-     * @group save
      */
     public function testBeforeSaveModifyOptions(): void
     {
@@ -2291,8 +2276,6 @@ class TableTest extends TestCase
     /**
      * Tests that it is possible to stop the saving altogether, without implying
      * the save operation failed
-     *
-     * @group save
      */
     public function testBeforeSaveStopEvent(): void
     {
@@ -2317,8 +2300,6 @@ class TableTest extends TestCase
     /**
      * Tests that if beforeSave event is stopped and callback doesn't return any
      * value then save() returns false.
-     *
-     * @group save
      */
     public function testBeforeSaveStopEventWithNoResult(): void
     {
@@ -2335,9 +2316,6 @@ class TableTest extends TestCase
         $this->assertFalse($table->save($data));
     }
 
-    /**
-     * @group save
-     */
     public function testBeforeSaveException(): void
     {
         $this->expectException(AssertionError::class);
@@ -2360,8 +2338,6 @@ class TableTest extends TestCase
 
     /**
      * Asserts that afterSave callback is called on successful save
-     *
-     * @group save
      */
     public function testAfterSave(): void
     {
@@ -2473,8 +2449,6 @@ class TableTest extends TestCase
 
     /**
      * Asserts that afterSave callback not is called on unsuccessful save
-     *
-     * @group save
      */
     public function testAfterSaveNotCalled(): void
     {
@@ -2522,8 +2496,6 @@ class TableTest extends TestCase
 
     /**
      * Asserts that afterSaveCommit callback is triggered only for primary table
-     *
-     * @group save
      */
     public function testAfterSaveCommitTriggeredOnlyForPrimaryTable(): void
     {
@@ -2559,8 +2531,6 @@ class TableTest extends TestCase
 
     /**
      * Test that you cannot save rows without a primary key.
-     *
-     * @group save
      */
     public function testSaveNewErrorOnNoPrimaryKey(): void
     {
@@ -2578,8 +2548,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that save is wrapped around a transaction
-     *
-     * @group save
      */
     public function testAtomicSave(): void
     {
@@ -2605,8 +2573,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that save will rollback the transaction in the case of an exception
-     *
-     * @group save
      */
     public function testAtomicSaveRollback(): void
     {
@@ -2647,8 +2613,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that save will rollback the transaction in the case of an exception
-     *
-     * @group save
      */
     public function testAtomicSaveRollbackOnFailure(): void
     {
@@ -2695,8 +2659,6 @@ class TableTest extends TestCase
     /**
      * Tests that only the properties marked as dirty are actually saved
      * to the database
-     *
-     * @group save
      */
     public function testSaveOnlyDirtyProperties(): void
     {
@@ -2722,8 +2684,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that a recently saved entity is marked as clean
-     *
-     * @group save
      */
     public function testASavedEntityIsClean(): void
     {
@@ -2743,8 +2703,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that a recently saved entity is marked as not new
-     *
-     * @group save
      */
     public function testASavedEntityIsNotNew(): void
     {
@@ -2762,8 +2720,6 @@ class TableTest extends TestCase
     /**
      * Tests that save can detect automatically if it needs to insert
      * or update a row
-     *
-     * @group save
      */
     public function testSaveUpdateAuto(): void
     {
@@ -2808,8 +2764,6 @@ class TableTest extends TestCase
     /**
      * Tests that marking an entity as already persisted will prevent the save
      * method from trying to infer the entity's actual status.
-     *
-     * @group save
      */
     public function testSaveUpdateWithHint(): void
     {
@@ -2830,8 +2784,6 @@ class TableTest extends TestCase
     /**
      * Tests that when updating the primary key is not passed to the list of
      * attributes to change
-     *
-     * @group save
      */
     public function testSaveUpdatePrimaryKeyNotModified(): void
     {
@@ -2861,8 +2813,6 @@ class TableTest extends TestCase
     /**
      * Tests that passing only the primary key to save will not execute any queries
      * but still return success
-     *
-     * @group save
      */
     public function testUpdateNoChange(): void
     {
@@ -2881,9 +2831,6 @@ class TableTest extends TestCase
     /**
      * Tests that passing only the primary key to save will not execute any queries
      * but still return success
-     *
-     * @group save
-     * @group integration
      */
     public function testUpdateDirtyNoActualChanges(): void
     {
@@ -2897,8 +2844,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that failing to pass a primary key to save will result in exception
-     *
-     * @group save
      */
     public function testUpdateNoPrimaryButOtherKeys(): void
     {
@@ -3754,8 +3699,6 @@ class TableTest extends TestCase
 
     /**
      * Tests saving belongsTo association
-     *
-     * @group save
      */
     public function testSaveBelongsTo(): void
     {
@@ -3778,8 +3721,6 @@ class TableTest extends TestCase
 
     /**
      * Tests saving hasOne association
-     *
-     * @group save
      */
     public function testSaveHasOne(): void
     {
@@ -3805,8 +3746,6 @@ class TableTest extends TestCase
     /**
      * Tests saving associations only saves associations
      * if they are entities.
-     *
-     * @group save
      */
     public function testSaveOnlySaveAssociatedEntities(): void
     {
@@ -3885,8 +3824,6 @@ class TableTest extends TestCase
 
     /**
      * Tests saving belongsToMany records
-     *
-     * @group save
      */
     public function testSaveBelongsToMany(): void
     {
@@ -3917,8 +3854,6 @@ class TableTest extends TestCase
 
     /**
      * Tests saving belongsToMany records when record exists.
-     *
-     * @group save
      */
     public function testSaveBelongsToManyJoinDataOnExistingRecord(): void
     {
@@ -4028,8 +3963,6 @@ class TableTest extends TestCase
 
     /**
      * Tests saving belongsToMany records can delete all links.
-     *
-     * @group save
      */
     public function testSaveBelongsToManyDeleteAllLinks(): void
     {
@@ -4050,8 +3983,6 @@ class TableTest extends TestCase
 
     /**
      * Tests saving belongsToMany records can delete some links.
-     *
-     * @group save
      */
     public function testSaveBelongsToManyDeleteSomeLinks(): void
     {
@@ -4091,8 +4022,6 @@ class TableTest extends TestCase
 
     /**
      * Tests that saving a persisted and clean entity will is a no-op
-     *
-     * @group save
      */
     public function testSaveCleanEntity(): void
     {
@@ -4109,8 +4038,6 @@ class TableTest extends TestCase
 
     /**
      * Integration test to show how to append a new tag to an article
-     *
-     * @group save
      */
     public function testBelongsToManyIntegration(): void
     {
@@ -4132,8 +4059,6 @@ class TableTest extends TestCase
     /**
      * Tests that it is possible to do a deep save and control what associations get saved,
      * while having control of the options passed to each level of the save
-     *
-     * @group save
      */
     public function testSaveDeepAssociationOptions(): void
     {
@@ -5349,9 +5274,9 @@ class TableTest extends TestCase
      * Test that get() will use the primary key for searching and return the first
      * entity found
      *
-     * @dataProvider providerForTestGet
      * @param array $options
      */
+    #[DataProvider('providerForTestGet')]
     public function testGet($options): void
     {
         $table = $this->getMockBuilder(Table::class)
@@ -5413,12 +5338,12 @@ class TableTest extends TestCase
     /**
      * Test that get() will use the cache.
      *
-     * @dataProvider providerForTestGetWithCache
      * @param array $options
      * @param string $cacheKey
      * @param string $cacheConfig
      * @param mixed $primaryKey
      */
+    #[DataProvider('providerForTestGetWithCache')]
     public function testGetWithCache($options, $cacheKey, $cacheConfig, $primaryKey): void
     {
         $table = $this->getMockBuilder(Table::class)
@@ -6133,8 +6058,6 @@ class TableTest extends TestCase
     /**
      * Tests that passing a coned entity that was marked as new to save() will
      * actually save it as a new entity
-     *
-     * @group save
      */
     public function testSaveWithClonedEntity(): void
     {
@@ -6245,8 +6168,6 @@ class TableTest extends TestCase
     /**
      * Tests that after saving then entity contains the right primary
      * key casted to the right type
-     *
-     * @group save
      */
     public function testSaveCorrectPrimaryKeyType(): void
     {

--- a/tests/TestCase/ORM/TableUuidTest.php
+++ b/tests/TestCase/ORM/TableUuidTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Integration tests for Table class with uuid primary keys.
@@ -56,9 +57,8 @@ class TableUuidTest extends TestCase
 
     /**
      * Test saving new records sets uuids
-     *
-     * @dataProvider uuidTableProvider
      */
+    #[DataProvider('uuidTableProvider')]
     public function testSaveNew(string $tableName): void
     {
         $entity = new Entity([
@@ -76,9 +76,8 @@ class TableUuidTest extends TestCase
 
     /**
      * Test saving new records allows manual uuids
-     *
-     * @dataProvider uuidTableProvider
      */
+    #[DataProvider('uuidTableProvider')]
     public function testSaveNewSpecificId(string $tableName): void
     {
         $id = Text::uuid();
@@ -99,9 +98,8 @@ class TableUuidTest extends TestCase
 
     /**
      * Test saving existing records works
-     *
-     * @dataProvider uuidTableProvider
      */
+    #[DataProvider('uuidTableProvider')]
     public function testSaveUpdate(string $tableName): void
     {
         $id = '481fc6d0-b920-43e0-a40d-6d1740cf8569';
@@ -122,9 +120,8 @@ class TableUuidTest extends TestCase
 
     /**
      * Test delete with string pk.
-     *
-     * @dataProvider uuidTableProvider
      */
+    #[DataProvider('uuidTableProvider')]
     public function testGetById(string $tableName): void
     {
         $table = $this->getTableLocator()->get($tableName);
@@ -136,9 +133,8 @@ class TableUuidTest extends TestCase
 
     /**
      * Test delete with string pk.
-     *
-     * @dataProvider uuidTableProvider
      */
+    #[DataProvider('uuidTableProvider')]
     public function testDelete(string $tableName): void
     {
         $table = $this->getTableLocator()->get($tableName);
@@ -151,9 +147,8 @@ class TableUuidTest extends TestCase
 
     /**
      * Tests that sql server does not error when an empty uuid is bound
-     *
-     * @dataProvider uuidTableProvider
      */
+    #[DataProvider('uuidTableProvider')]
     public function testEmptyUuid(string $tableName): void
     {
         $id = '';

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\Routing\Middleware;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Middleware\AssetMiddleware;
 use Cake\TestSuite\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Http\TestRequestHandler;
 
 /**
@@ -112,9 +113,8 @@ class AssetMiddlewareTest extends TestCase
 
     /**
      * Test assets in a plugin.
-     *
-     * @dataProvider assetProvider
      */
+    #[DataProvider('assetProvider')]
     public function testPluginAsset(string $url, string $expectedFile): void
     {
         $request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => $url]);

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -27,6 +27,7 @@ use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Cake\TestSuite\TestCase;
 use Laminas\Diactoros\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Application;
 use TestApp\Http\TestRequestHandler;
 use TestApp\Middleware\DumbMiddleware;
@@ -388,9 +389,8 @@ class RoutingMiddlewareTest extends TestCase
      *
      * Re-opening a scope should not inherit middleware declared
      * in the first context.
-     *
-     * @dataProvider scopedMiddlewareUrlProvider
      */
+    #[DataProvider('scopedMiddlewareUrlProvider')]
     public function testInvokeScopedMiddlewareIsolatedScopes(string $url, array $expected): void
     {
         $this->builder->registerMiddleware('first', function ($request, $handler) {

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -23,6 +23,7 @@ use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Routing\Route\ProtectedRoute;
 
 /**
@@ -292,8 +293,8 @@ class RouteTest extends TestCase
      * @param string $url
      * @param array $expected
      * @param array $ext
-     * @dataProvider provideMatchParseExtension
      */
+    #[DataProvider('provideMatchParseExtension')]
     public function testMatchParseExtension($url, array $expected, array $ext): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', [], ['_ext' => $ext]);
@@ -321,8 +322,8 @@ class RouteTest extends TestCase
      *
      * @param string $url
      * @param array $ext
-     * @dataProvider provideNoMatchParseExtension
      */
+    #[DataProvider('provideNoMatchParseExtension')]
     public function testNoMatchParseExtension($url, array $ext): void
     {
         $route = new ProtectedRoute('/{controller}/{action}/*', [], ['_ext' => $ext]);

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -28,6 +28,7 @@ use Cake\Routing\RouteCollection;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * RouteBuilder test case
@@ -1110,9 +1111,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that the HTTP method helpers create the right kind of routes.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testHttpMethods(string $method): void
     {
         $routes = new RouteBuilder($this->collection, '/', [], ['namePrefix' => 'app:']);
@@ -1133,9 +1133,8 @@ class RouteBuilderTest extends TestCase
 
     /**
      * Test that the HTTP method helpers create the right kind of routes.
-     *
-     * @dataProvider httpMethodProvider
      */
+    #[DataProvider('httpMethodProvider')]
     public function testHttpMethodsStringTarget(string $method): void
     {
         $routes = new RouteBuilder($this->collection, '/', [], ['namePrefix' => 'app:']);

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -24,6 +24,7 @@ use Cake\Routing\RouteBuilder;
 use Cake\Routing\RouteCollection;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RouteCollectionTest extends TestCase
 {
@@ -412,9 +413,8 @@ class RouteCollectionTest extends TestCase
 
     /**
      * Test parseRequest() checks host conditions
-     *
-     * @dataProvider hostProvider
      */
+    #[DataProvider('hostProvider')]
     public function testParseRequestCheckHostConditionFail(string $host): void
     {
         $this->expectException(MissingRouteException::class);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -29,6 +29,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use function Cake\Routing\url;
 use function Cake\Routing\urlArray;
@@ -1678,9 +1679,8 @@ class RouterTest extends TestCase
 
     /**
      * Test parse and reverse symmetry
-     *
-     * @dataProvider parseReverseSymmetryData
      */
+    #[DataProvider('parseReverseSymmetryData')]
     public function testParseReverseSymmetry(string $url): void
     {
         Router::createRouteBuilder('/')->fallbacks();
@@ -2385,9 +2385,8 @@ class RouterTest extends TestCase
 
     /**
      * Test parseRoutePath() with valid strings
-     *
-     * @dataProvider routePathProvider
      */
+    #[DataProvider('routePathProvider')]
     public function testParseRoutePath($path, $expected): void
     {
         $this->assertSame($expected, Router::parseRoutePath($path));
@@ -2427,9 +2426,8 @@ class RouterTest extends TestCase
 
     /**
      * Test parseRoutePath() with invalid strings
-     *
-     * @dataProvider invalidRoutePathProvider
      */
+    #[DataProvider('invalidRoutePathProvider')]
     public function testParseInvalidRoutePath(string $value): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -3468,8 +3466,8 @@ class RouterTest extends TestCase
      * Test url() doesn't let override parts of string route path
      *
      * @param array $params
-     * @dataProvider invalidRoutePathParametersArrayProvider
      */
+    #[DataProvider('invalidRoutePathParametersArrayProvider')]
     public function testUrlGenerationOverridingShortString(array $params): void
     {
         $routes = Router::createRouteBuilder('/');
@@ -3485,8 +3483,8 @@ class RouterTest extends TestCase
      * Test url() doesn't let override parts of string route path from `_path` key
      *
      * @param array $params
-     * @dataProvider invalidRoutePathParametersArrayProvider
      */
+    #[DataProvider('invalidRoutePathParametersArrayProvider')]
     public function testUrlGenerationOverridingPathKey(array $params): void
     {
         $routes = Router::createRouteBuilder('/');

--- a/tests/TestCase/TestSuite/EmailTraitTest.php
+++ b/tests/TestCase/TestSuite/EmailTraitTest.php
@@ -25,6 +25,7 @@ use Cake\TestSuite\EmailTrait;
 use Cake\TestSuite\TestCase;
 use Cake\TestSuite\TestEmailTransport;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\LogicalNot;
 
 /**
@@ -196,8 +197,8 @@ class EmailTraitTest extends TestCase
      * @param string $assertion Assertion method
      * @param string $expectedMessage Expected failure message
      * @param array $params Assertion params
-     * @dataProvider failureMessageDataProvider
      */
+    #[DataProvider('failureMessageDataProvider')]
     public function testFailureMessages($assertion, $expectedMessage, $params): void
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -36,6 +36,8 @@ use Laminas\Diactoros\UploadedFile;
 use LogicException;
 use OutOfBoundsException;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use stdClass;
 use TestApp\ReflectionDependency;
 
@@ -1405,9 +1407,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * Test if the EventManager is reset between tests.
-     *
-     * @depends testEventManagerReset1
      */
+    #[Depends('testEventManagerReset1')]
     public function testEventManagerReset2(EventManager $prevEventManager): void
     {
         $this->assertInstanceOf('Cake\Event\EventManager', $prevEventManager);
@@ -1484,9 +1485,8 @@ class IntegrationTestTraitTest extends TestCase
 
     /**
      * tests getting a secure action while passing a query string
-     *
-     * @dataProvider methodsProvider
      */
+    #[DataProvider('methodsProvider')]
     public function testSecureWithQueryString(string $method): void
     {
         $this->enableSecurityToken();
@@ -1543,8 +1543,8 @@ class IntegrationTestTraitTest extends TestCase
      * @param string $message Expected failure message
      * @param string $url URL to test
      * @param mixed ...$rest
-     * @dataProvider assertionFailureMessagesProvider
      */
+    #[DataProvider('assertionFailureMessagesProvider')]
     public function testAssertionFailureMessages($assertion, $message, $url, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
@@ -1714,9 +1714,9 @@ class IntegrationTestTraitTest extends TestCase
     /**
      * Test the assertion generates a verbose message for session related checks.
      *
-     * @dataProvider assertionFailureSessionVerboseProvider
      * @param mixed ...$rest
      */
+    #[DataProvider('assertionFailureSessionVerboseProvider')]
     public function testAssertSessionRelatedVerboseMessages(string $assertMethod, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -388,19 +388,21 @@ class TestCaseTest extends TestCase
         $Tags = $this->getMockForModel('Tags', ['save']);
         $this->assertSame('TestApp\Model\Entity\Tag', $Tags->getEntityClass());
 
-        $SluggedPosts = $this->getMockForModel('SluggedPosts', ['slugify']);
-        $SluggedPosts->expects($this->once())
-            ->method('slugify')
-            ->with('some value')
-            ->willReturn('mocked');
-        $this->assertSame('mocked', $SluggedPosts->slugify('some value'));
+        $this->deprecated(function () {
+            $SluggedPosts = $this->getMockForModel('SluggedPosts', ['slugify']);
+            $SluggedPosts->expects($this->once())
+                ->method('slugify')
+                ->with('some value')
+                ->willReturn('mocked');
+            $this->assertSame('mocked', $SluggedPosts->slugify('some value'));
 
-        $SluggedPosts = $this->getMockForModel('SluggedPosts', ['save', 'slugify']);
-        $SluggedPosts->expects($this->once())
-            ->method('slugify')
-            ->with('some value two')
-            ->willReturn('mocked');
-        $this->assertSame('mocked', $SluggedPosts->slugify('some value two'));
+            $SluggedPosts = $this->getMockForModel('SluggedPosts', ['save', 'slugify']);
+            $SluggedPosts->expects($this->once())
+                ->method('slugify')
+                ->with('some value two')
+                ->willReturn('mocked');
+            $this->assertSame('mocked', $SluggedPosts->slugify('some value two'));
+        });
     }
 
     /**

--- a/tests/TestCase/Utility/FilesystemTest.php
+++ b/tests/TestCase/Utility/FilesystemTest.php
@@ -22,8 +22,6 @@ use org\bovigo\vfs\vfsStream;
 
 /**
  * Filesystem class
- *
- * @coversDefaultClass \Cake\Utility\Filesystem
  */
 class FilesystemTest extends TestCase
 {
@@ -45,9 +43,6 @@ class FilesystemTest extends TestCase
         clearstatcache();
     }
 
-    /**
-     * @covers ::mkdir
-     */
     public function testMkdir(): void
     {
         $path = $this->vfsPath . DS . 'tests' . DS . 'first' . DS . 'second' . DS . 'third';
@@ -55,9 +50,6 @@ class FilesystemTest extends TestCase
         $this->assertTrue(is_dir($path));
     }
 
-    /**
-     * @covers ::dumpFile
-     */
     public function testDumpFile(): void
     {
         $path = $this->vfsPath . DS . 'foo.txt';
@@ -70,9 +62,6 @@ class FilesystemTest extends TestCase
         $this->assertSame(file_get_contents($path), '');
     }
 
-    /**
-     * @covers ::copyDir
-     */
     public function testCopyDir(): void
     {
         $return = $this->fs->copyDir(WWW_ROOT, $this->vfsPath . DS . 'dest');
@@ -80,9 +69,6 @@ class FilesystemTest extends TestCase
         $this->assertTrue($return);
     }
 
-    /**
-     * @covers ::deleteDir
-     */
     public function testDeleteDir(): void
     {
         $structure = [

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 /**
@@ -904,9 +905,9 @@ class HashTest extends TestCase
     /**
      * Test the extraction of a single value filtered by another field.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractSingleValueWithFilteringByAnotherField($data): void
     {
         $result = Hash::extract($data, '{*}.Article[id=1].title');
@@ -919,9 +920,9 @@ class HashTest extends TestCase
     /**
      * Test simple paths.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractBasic($data): void
     {
         $result = Hash::extract($data, '');
@@ -940,9 +941,9 @@ class HashTest extends TestCase
     /**
      * Test the {n} selector
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractNumericKey($data): void
     {
         $result = Hash::extract($data, '{n}.Article.title');
@@ -1073,9 +1074,9 @@ class HashTest extends TestCase
     /**
      * Test the {s} selector.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractStringKey($data): void
     {
         $result = Hash::extract($data, '{n}.{s}.user');
@@ -1139,9 +1140,9 @@ class HashTest extends TestCase
     /**
      * Test the attribute presence selector.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractAttributePresence($data): void
     {
         $result = Hash::extract($data, '{n}.Article[published]');
@@ -1156,9 +1157,9 @@ class HashTest extends TestCase
     /**
      * Test = and != operators.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractAttributeEquality($data): void
     {
         $result = Hash::extract($data, '{n}.Article[id=3]');
@@ -1269,9 +1270,9 @@ class HashTest extends TestCase
     /**
      * Test comparison operators.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractAttributeComparison($data): void
     {
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id > 2]');
@@ -1298,9 +1299,9 @@ class HashTest extends TestCase
     /**
      * Test multiple attributes with conditions.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractAttributeMultiple($data): void
     {
         $result = Hash::extract($data, '{n}.Comment.{n}[user_id > 2][id=1]');
@@ -1315,9 +1316,9 @@ class HashTest extends TestCase
     /**
      * Test attribute pattern matching.
      *
-     * @dataProvider articleDataSets
      * @param \ArrayAccess|array $data
      */
+    #[DataProvider('articleDataSets')]
     public function testExtractAttributePattern($data): void
     {
         $result = Hash::extract($data, '{n}.Article[title=/^First/]');

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Utility;
 
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Inflector;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Short description for class.
@@ -86,9 +87,8 @@ class InflectorTest extends TestCase
 
     /**
      * testInflectingSingulars method
-     *
-     * @dataProvider singularizeProvider
      */
+    #[DataProvider('singularizeProvider')]
     public function testInflectingSingulars(string $singular, string $plural): void
     {
         $this->assertSame($singular, Inflector::singularize($plural));
@@ -221,9 +221,8 @@ class InflectorTest extends TestCase
 
     /**
      * testInflectingPlurals method
-     *
-     * @dataProvider pluralizeProvider
      */
+    #[DataProvider('pluralizeProvider')]
     public function testInflectingPlurals(string $plural, string $singular): void
     {
         $this->assertSame($plural, Inflector::pluralize($singular));

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -19,6 +19,7 @@ use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Text;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use Transliterator;
 
@@ -339,9 +340,8 @@ class TextTest extends TestCase
 
     /**
      * test that wordWrap() works the same as built-in wordwrap function
-     *
-     * @dataProvider wordWrapProvider
      */
+    #[DataProvider('wordWrapProvider')]
     public function testWordWrap(string $text, int $width, string $break = "\n", bool $cut = false): void
     {
         $result = Text::wordWrap($text, $width, $break, $cut);
@@ -1534,9 +1534,9 @@ HTML;
     /**
      * testparseFileSize
      *
-     * @dataProvider filesizes
      * @param mixed $expected
      */
+    #[DataProvider('filesizes')]
     public function testParseFileSize(array $params, $expected): void
     {
         $result = Text::parseFileSize($params['size'], $params['default']);
@@ -1683,8 +1683,8 @@ HTML;
      * @param string $string String
      * @param \Transliterator|string|null $transliterator Transliterator
      * @param String $expected Expected string
-     * @dataProvider transliterateInputProvider
      */
+    #[DataProvider('transliterateInputProvider')]
     public function testTransliterate($string, $transliterator, $expected): void
     {
         $result = Text::transliterate($string, $transliterator);
@@ -1802,8 +1802,8 @@ HTML;
      * @param string $string String
      * @param array $options Options
      * @param String $expected Expected string
-     * @dataProvider slugInputProvider
      */
+    #[DataProvider('slugInputProvider')]
     public function testSlug($string, $options, $expected): void
     {
         $result = Text::slug($string, $options);

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -26,6 +26,7 @@ use Cake\Utility\Xml;
 use DateTime;
 use DOMDocument;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleXMLElement;
 use TypeError;
 
@@ -180,9 +181,9 @@ class XmlTest extends TestCase
     /**
      * testBuildInvalidData
      *
-     * @dataProvider invalidDataProvider
      * @param mixed $value
      */
+    #[DataProvider('invalidDataProvider')]
     public function testBuildInvalidData($value): void
     {
         $this->expectException(CakeException::class);
@@ -602,9 +603,9 @@ XML;
     /**
      * testFromArrayFail method
      *
-     * @dataProvider invalidArrayDataProvider
      * @param mixed $value
      */
+    #[DataProvider('invalidArrayDataProvider')]
     public function testFromArrayFail($value): void
     {
         $this->expectException(Exception::class);

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -30,6 +30,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Locale;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TestApp\Model\Enum\ArticleStatus;
 use TestApp\Model\Enum\NonBacked;
@@ -2721,9 +2722,8 @@ class ValidationTest extends TestCase
 
     /**
      * Test uploadedFile with a PSR7 object.
-     *
-     * @dataProvider uploadedFileProvider
      */
+    #[DataProvider('uploadedFileProvider')]
     public function testUploadedFile(bool $expected, array $options): void
     {
         $image = TEST_APP . 'webroot/img/cake.power.gif';

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -24,6 +24,7 @@ use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\ArticlesTag;
@@ -126,9 +127,9 @@ class EntityContextTest extends TestCase
     /**
      * Test isCreate on a collection.
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testIsCreateCollection($collection): void
     {
         $context = new EntityContext([
@@ -222,9 +223,9 @@ class EntityContextTest extends TestCase
     /**
      * Test collection operations that lack a table argument.
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testCollectionOperationsNoTableArg($collection): void
     {
         $context = new EntityContext([
@@ -272,9 +273,9 @@ class EntityContextTest extends TestCase
     /**
      * Test operations on a collection of entities.
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testValOnCollections($collection): void
     {
         $context = new EntityContext([
@@ -302,9 +303,9 @@ class EntityContextTest extends TestCase
      * Test operations on a collection of entities when prefixing with the
      * table name
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testValOnCollectionsWithRootName($collection): void
     {
         $context = new EntityContext([
@@ -330,9 +331,9 @@ class EntityContextTest extends TestCase
     /**
      * Test error operations on a collection of entities.
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testErrorsOnCollections($collection): void
     {
         $context = new EntityContext([
@@ -355,9 +356,9 @@ class EntityContextTest extends TestCase
     /**
      * Test schema operations on a collection of entities.
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testSchemaOnCollections($collection): void
     {
         $this->_setupTables();
@@ -383,9 +384,9 @@ class EntityContextTest extends TestCase
     /**
      * Test validation operations on a collection of entities.
      *
-     * @dataProvider collectionProvider
      * @param mixed $collection
      */
+    #[DataProvider('collectionProvider')]
     public function testValidatorsOnCollections($collection): void
     {
         $this->_setupTables();

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -37,6 +37,7 @@ use Cake\View\Helper\FormHelper;
 use Cake\View\View;
 use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
@@ -357,9 +358,9 @@ class FormHelperTest extends TestCase
     /**
      * Test default context selection in create()
      *
-     * @dataProvider contextSelectionProvider
      * @param mixed $data
      */
+    #[DataProvider('contextSelectionProvider')]
     public function testCreateContextSelectionBuiltIn($data, string $class): void
     {
         $this->Form->create($data);
@@ -596,9 +597,8 @@ class FormHelperTest extends TestCase
 
     /**
      * test the create() method
-     *
-     * @dataProvider requestTypeProvider
      */
+    #[DataProvider('requestTypeProvider')]
     public function testCreateTypeOptions(string $type, string $method, string $override): void
     {
         $encoding = strtolower(Configure::read('App.encoding'));
@@ -7446,9 +7446,8 @@ class FormHelperTest extends TestCase
      * testDateTimeWithFractional method
      *
      * Test that datetime() works with datetimefractional.
-     *
-     * @dataProvider fractionalTypeProvider
      */
+    #[DataProvider('fractionalTypeProvider')]
     public function testDateTimeWithFractional(string $type): void
     {
         $this->Form->create([
@@ -7475,9 +7474,8 @@ class FormHelperTest extends TestCase
      * testControlWithFractional method
      *
      * Test that control() works with datetimefractional.
-     *
-     * @dataProvider fractionalTypeProvider
      */
+    #[DataProvider('fractionalTypeProvider')]
     public function testControlWithFractional(string $type): void
     {
         $this->Form->create([

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -26,6 +26,7 @@ use Cake\TestSuite\TestCase;
 use Cake\Utility\Filesystem;
 use Cake\View\Helper\HtmlHelper;
 use Cake\View\View;
+use PHPUnit\Framework\Attributes\DataProvider;
 use function Cake\Core\h;
 
 /**
@@ -1597,8 +1598,8 @@ class HtmlHelperTest extends TestCase
      * @param string $type
      * @param array $url
      * @param string $expectedUrl
-     * @dataProvider dataMetaLinksProvider
      */
+    #[DataProvider('dataMetaLinksProvider')]
     public function testMetaLinks($type, array $url, $expectedUrl): void
     {
         $result = $this->Html->meta($type, $url);

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -21,6 +21,7 @@ namespace Cake\Test\TestCase\View\Helper;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\NumberHelper;
 use Cake\View\View;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * NumberHelperTest class
@@ -69,9 +70,8 @@ class NumberHelperTest extends TestCase
 
     /**
      * Tests calls are proxied to Number class.
-     *
-     * @dataProvider methodProvider
      */
+    #[DataProvider('methodProvider')]
     public function testMethodProxying(string $method, mixed $arg): void
     {
         $helper = new NumberHelper($this->View);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -25,6 +25,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\PaginatorHelper;
 use Cake\View\View;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * PaginatorHelperTest class
@@ -687,8 +688,8 @@ class PaginatorHelperTest extends TestCase
      * @param string $field
      * @param array $options
      * @param string $expected
-     * @dataProvider urlGenerationResetsToPage1Provider
      */
+    #[DataProvider('urlGenerationResetsToPage1Provider')]
     public function testUrlGenerationResetsToPage1($field, $options, $expected): void
     {
         $this->setPaginatedResult([
@@ -2679,8 +2680,8 @@ class PaginatorHelperTest extends TestCase
      * @param int $pageCount
      * @param array $options
      * @param string $expected
-     * @dataProvider dataMetaProvider
      */
+    #[DataProvider('dataMetaProvider')]
     public function testMeta($page, $prevPage, $nextPage, $pageCount, $options, $expected): void
     {
         $this->setPaginatedResult([

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\View\Helper;
 use Cake\TestSuite\TestCase;
 use Cake\View\Helper\TextHelper;
 use Cake\View\View;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * TextHelperTest class
@@ -71,9 +72,8 @@ class TextHelperTest extends TestCase
 
     /**
      * Tests calls are proxied to Number class.
-     *
-     * @dataProvider methodProvider
      */
+    #[DataProvider('methodProvider')]
     public function testMethodProxying(string $method, mixed $arg): void
     {
         $helper = new TextHelper($this->View);
@@ -317,9 +317,8 @@ class TextHelperTest extends TestCase
 
     /**
      * testAutoLinkUrls method
-     *
-     * @dataProvider autoLinkProvider
      */
+    #[DataProvider('autoLinkProvider')]
     public function testAutoLinkUrls(string $text, string $expected): void
     {
         $result = $this->Text->autoLinkUrls($text);
@@ -497,8 +496,8 @@ class TextHelperTest extends TestCase
      *
      * @param string $text The text to link
      * @param string $expected The expected results.
-     * @dataProvider autoLinkEmailProvider
      */
+    #[DataProvider('autoLinkEmailProvider')]
     public function testAutoLinkEmails(string $text, string $expected, array $attrs = []): void
     {
         $result = $this->Text->autoLinkEmails($text, $attrs);

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -25,6 +25,7 @@ use Cake\Datasource\Paging\PaginatedResultSet;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Cake\View\Exception\SerializationFailureException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * JsonViewTest
@@ -224,8 +225,8 @@ class JsonViewTest extends TestCase
      * @param string|null $serialize
      * @param int|false|null $jsonOptions
      * @param string $expected
-     * @dataProvider renderWithoutViewProvider
      */
+    #[DataProvider('renderWithoutViewProvider')]
     public function testRenderWithoutView($data, $serialize, $jsonOptions, $expected): void
     {
         $Request = new ServerRequest();

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -23,6 +23,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingViewException;
 use Cake\View\View;
 use Cake\View\ViewBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * View builder test case.
@@ -119,9 +120,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * Test string property accessor/mutator methods.
-     *
-     * @dataProvider stringPropertyProvider
      */
+    #[DataProvider('stringPropertyProvider')]
     public function testStringProperties(string $property, string $value): void
     {
         $get = 'get' . ucfirst($property);
@@ -135,9 +135,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * Test string property accessor/mutator methods.
-     *
-     * @dataProvider boolPropertyProvider
      */
+    #[DataProvider('boolPropertyProvider')]
     public function testBoolProperties(string $property, bool $default, bool $value): void
     {
         $set = 'enable' . ucfirst($property);
@@ -151,9 +150,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * Test array property accessor/mutator methods.
-     *
-     * @dataProvider arrayPropertyProvider
      */
+    #[DataProvider('arrayPropertyProvider')]
     public function testArrayProperties(string $property, array $value): void
     {
         $get = 'get' . ucfirst($property);
@@ -167,9 +165,8 @@ class ViewBuilderTest extends TestCase
 
     /**
      * Test array property accessor/mutator methods.
-     *
-     * @dataProvider arrayPropertyProvider
      */
+    #[DataProvider('arrayPropertyProvider')]
     public function testArrayPropertyMerge(string $property, array $value): void
     {
         $get = 'get' . ucfirst($property);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -36,6 +36,7 @@ use Exception;
 use InvalidArgumentException;
 use LogicException;
 use PDOException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use TestApp\Controller\ThemePostsController;
 use TestApp\Controller\ViewPostsController;
@@ -1362,8 +1363,8 @@ class ViewTest extends TestCase
      * Test appending to a block with append.
      *
      * @param mixed $value Value
-     * @dataProvider blockValueProvider
      */
+    #[DataProvider('blockValueProvider')]
     public function testBlockAppend($value): void
     {
         $this->View->assign('testBlock', 'Block');
@@ -1391,8 +1392,8 @@ class ViewTest extends TestCase
      * Test prepending to a block with prepend.
      *
      * @param mixed $value Value
-     * @dataProvider blockValueProvider
      */
+    #[DataProvider('blockValueProvider')]
     public function testBlockPrepend($value): void
     {
         $this->View->assign('test', 'Block');

--- a/tests/TestCase/View/Widget/CheckboxWidgetTest.php
+++ b/tests/TestCase/View/Widget/CheckboxWidgetTest.php
@@ -20,6 +20,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\CheckboxWidget;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Checkbox test case
@@ -173,9 +174,9 @@ class CheckboxWidgetTest extends TestCase
     /**
      * Test rendering checked checkboxes with value.
      *
-     * @dataProvider checkedProvider
      * @param mixed $checked
      */
+    #[DataProvider('checkedProvider')]
     public function testRenderCheckedValue($checked): void
     {
         $checkbox = new CheckboxWidget($this->templates);
@@ -215,9 +216,9 @@ class CheckboxWidgetTest extends TestCase
     /**
      * Test rendering unchecked checkboxes
      *
-     * @dataProvider uncheckedProvider
      * @param mixed $checked
      */
+    #[DataProvider('uncheckedProvider')]
     public function testRenderUnCheckedValue($checked): void
     {
         $checkbox = new CheckboxWidget($this->templates);

--- a/tests/TestCase/View/Widget/DateTimeWidgetTest.php
+++ b/tests/TestCase/View/Widget/DateTimeWidgetTest.php
@@ -21,6 +21,7 @@ use Cake\View\Form\NullContext;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\DateTimeWidget;
 use DateTime;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * DateTimeWidget test case
@@ -73,9 +74,9 @@ class DateTimeWidgetTest extends TestCase
     /**
      * test rendering selected values.
      *
-     * @dataProvider selectedValuesProvider
      * @param mixed $selected
      */
+    #[DataProvider('selectedValuesProvider')]
     public function testRenderValid($selected): void
     {
         $result = $this->DateTime->render(['val' => $selected], $this->context);


### PR DESCRIPTION
- [x] Convert test annotations to attributes
- [x] Replaced removed Constraint::exporter()
- [ ] Clean up added error handlers in tests
- [x] Fix mock error

