### PR TITLE
Add missing cast to StringCompareTrait

### DIFF
--- a/src/TestSuite/StringCompareTrait.php
+++ b/src/TestSuite/StringCompareTrait.php
@@ -57,7 +57,7 @@ trait StringCompareTrait
             $path = $this->_compareBasePath . $path;
         }
 
-        $this->_updateComparisons ??= env('UPDATE_TEST_COMPARISON_FILES') ?: false;
+        $this->_updateComparisons ??= (bool)env('UPDATE_TEST_COMPARISON_FILES') ?: false;
 
         if ($this->_updateComparisons) {
             file_put_contents($path, $result);


### PR DESCRIPTION
Without this using the environment variable would result in a typeerror. Adding a cast resolves this problem.
