### PR TITLE
Backport #17703 to 4.x

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -204,6 +204,31 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
     }
 
     /**
+     * Remove an object from the registry.
+     *
+     * If this registry has an event manager, the object will be detached from any events as well.
+     *
+     * @param string $name The name of the object to remove from the registry.
+     * @return $this
+     */
+    public function unload(string $name)
+    {
+        $instance = $this->get($name);
+        $result = parent::unload($name);
+
+        $methods = $instance->implementedMethods();
+        foreach ($methods as $method) {
+            unset($this->_methodMap[$method]);
+        }
+        $finders = $instance->implementedFinders();
+        foreach ($finders as $finder) {
+            unset($this->_finderMap[$finder]);
+        }
+
+        return $result;
+    }
+
+    /**
      * Check if any loaded behavior implements a method.
      *
      * Will return true if any behavior provides a public non-finder method

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\ORM;
 
 use BadMethodCallException;
-use Cake\Core\Exception\CakeException;
 use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Exception\MissingBehaviorException;
 use Cake\ORM\Query;

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1790,6 +1790,20 @@ class TableTest extends TestCase
     }
 
     /**
+     * Test removing a behavior from a table clears the method map for the behavior
+     */
+    public function testRemoveBehaviorMethodMapCleared(): void
+    {
+        $table = new Table(['table' => 'articles']);
+        $table->addBehavior('Sluggable');
+        $this->assertTrue($table->behaviors()->hasMethod('slugify'), 'slugify should be mapped');
+        $this->assertSame('foo-bar', $table->slugify('foo bar'));
+
+        $table->removeBehavior('Sluggable');
+        $this->assertFalse($table->behaviors()->hasMethod('slugify'), 'slugify should not be callable');
+    }
+
+    /**
      * Test adding multiple behaviors to a table.
      */
     public function testAddBehaviors(): void


### PR DESCRIPTION
When behaviors are unloaded we should clear up the additional method mappings that BehaviorRegistry collects.

Fixes #17697