### PR TITLE
Replace md5 usage with xxh128.

### DIFF
--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -341,7 +341,7 @@ abstract class CacheEngine implements CacheInterface, CacheEngineInterface
 
         $prefix = '';
         if ($this->_groupPrefix) {
-            $prefix = md5(implode('_', $this->groups()));
+            $prefix = hash('xxh128', implode('_', $this->groups()));
         }
         $key = preg_replace('/[\s]+/', '_', $key);
 

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -372,7 +372,7 @@ if (!function_exists('Cake\Core\deprecationWarning')) {
         }
 
         static $errors = [];
-        $checksum = md5($message);
+        $checksum = hash('xxh128', $message);
         $duplicate = (bool)Configure::read('Error.allowDuplicateDeprecations', false);
         if (isset($errors[$checksum]) && !$duplicate) {
             return;

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -67,7 +67,7 @@ class FormData implements Countable, Stringable
         if ($this->_boundary) {
             return $this->_boundary;
         }
-        $this->_boundary = md5(uniqid((string)time()));
+        $this->_boundary = hash('xxh128', uniqid((string)time()));
 
         return $this->_boundary;
     }

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -1292,7 +1292,7 @@ class Message implements JsonSerializable
                 $this->emailFormat === static::MESSAGE_BOTH
             )
         ) {
-            $this->boundary = md5(Security::randomBytes(16));
+            $this->boundary = hash('xxh128', Security::randomBytes(16));
         }
     }
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -212,7 +212,10 @@ class Text
         );
 
         $dataKeys = array_keys($data);
-        $hashKeys = array_map('md5', $dataKeys);
+        $hashKeys = array_map(
+            fn ($str) => hash('xxh128', $str),
+            $dataKeys
+        );
         /** @var array<string, string> $tempData */
         $tempData = array_combine($dataKeys, $hashKeys);
         krsort($tempData);


### PR DESCRIPTION
The latter is much faster than md5. xxh128 is not cryptographically secure but that's not required in the context it is used.

https://xxhash.com/

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
