### PR TITLE
5.next - Add DI support for Components

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,6 +26,11 @@ parameters:
 			path: src/Console/ConsoleOutput.php
 
 		-
+			message: "#^Unknown parameter \\$container in call to method ReflectionClass\\<Cake\\\\Controller\\\\Controller\\>\\:\\:newInstance\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/ControllerFactory.php
+
+		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 8
 			path: src/Database/Expression/QueryExpression.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,7 +26,17 @@ parameters:
 			path: src/Console/ConsoleOutput.php
 
 		-
-			message: "#^Unknown parameter \\$container in call to method ReflectionClass\\<Cake\\\\Controller\\\\Controller\\>\\:\\:newInstance\\(\\)\\.$#"
+			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/ControllerFactory.php
+
+		-
+			message: "#^Unknown parameter \\$components in call to method ReflectionClass\\<Cake\\\\Controller\\\\Controller\\>\\:\\:newInstance\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/ControllerFactory.php
+
+		-
+			message: "#^Unknown parameter \\$request in call to method ReflectionClass\\<Cake\\\\Controller\\\\Controller\\>\\:\\:newInstance\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/ControllerFactory.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
+<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
   <file src="src/Cache/Engine/FileEngine.php">
     <TooManyTemplateParams>
       <code><![CDATA[$iterator]]></code>
@@ -23,6 +23,11 @@
       <code><![CDATA[int|false]]></code>
       <code><![CDATA[int|false]]></code>
     </InvalidReturnType>
+  </file>
+  <file src="src/Controller/ControllerFactory.php">
+    <UndefinedMethod>
+      <code><![CDATA[getName]]></code>
+    </UndefinedMethod>
   </file>
   <file src="src/Core/PluginConfig.php">
     <RedundantCondition>

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -145,6 +145,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             return $class;
         }
         if ($this->container && $this->container->has($class)) {
+            /** @var \Cake\Controller\Component $instance */
             $instance = $this->container->get($class);
             $instance->setConfig($config);
         } else {

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -56,7 +56,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      * Constructor.
      *
      * @param \Cake\Controller\Controller|null $controller Controller instance.
-     * @param \Cake\Core\ContainerInterface|null $containter Container instance.
+     * @param \Cake\Core\ContainerInterface|null $container Container instance.
      */
     public function __construct(?Controller $controller = null, ?ContainerInterface $container = null)
     {
@@ -65,15 +65,12 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             $this->setController($controller);
         }
         $this->container = $container;
-        if ($this->container) {
-            $this->container->add(self::class, $this);
-        }
     }
 
     /**
      * Set the controller associated with the collection.
      *
-     * @param \Cake\Controller\Controller Controller instance.
+     * @param \Cake\Controller\Controller $controller Controller instance.
      * @return $this
      */
     public function setController(Controller $controller)
@@ -148,7 +145,8 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             return $class;
         }
         if ($this->container && $this->container->has($class)) {
-            $instance = $this->container->get($class)->setConfig($config);
+            $instance = $this->container->get($class);
+            $instance->setConfig($config);
         } else {
             $instance = new $class($this, $config);
         }

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -65,6 +65,9 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
             $this->setController($controller);
         }
         $this->container = $container;
+        if ($this->container) {
+            $this->container->add(self::class, $this);
+        }
     }
 
     /**

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -45,12 +45,12 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      *
      * @var \Cake\Controller\Controller|null
      */
-    protected ?Controller $_Controller;
+    protected ?Controller $_Controller = null;
 
     /**
-     * @var \Cake\Core\ContainerInterface
+     * @var \Cake\Core\ContainerInterface|null
      */
-    protected ?ContainerInterface $container;
+    protected ?ContainerInterface $container = null;
 
     /**
      * Constructor.
@@ -60,7 +60,6 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      */
     public function __construct(?Controller $controller = null, ?ContainerInterface $container = null)
     {
-        $this->_Controller = null;
         if ($controller !== null) {
             $this->setController($controller);
         }
@@ -89,7 +88,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     public function getController(): Controller
     {
         if ($this->_Controller === null) {
-            throw new RuntimeException('Cannot getController() it has not been set yet.');
+            throw new RuntimeException('Controller must be set first.');
         }
 
         return $this->_Controller;
@@ -144,7 +143,7 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
         if (is_object($class)) {
             return $class;
         }
-        if ($this->container && $this->container->has($class)) {
+        if ($this->container?->has($class)) {
             /** @var \Cake\Controller\Component $instance */
             $instance = $this->container->get($class);
             $instance->setConfig($config);

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -18,9 +18,11 @@ namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingComponentException;
 use Cake\Core\App;
+use Cake\Core\ContainerInterface;
 use Cake\Core\ObjectRegistry;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
+use RuntimeException;
 
 /**
  * ComponentRegistry is a registry for loaded components
@@ -41,19 +43,42 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
     /**
      * The controller that this collection is associated with.
      *
-     * @var \Cake\Controller\Controller
+     * @var \Cake\Controller\Controller|null
      */
-    protected Controller $_Controller;
+    protected ?Controller $_Controller;
+
+    /**
+     * @var \Cake\Core\ContainerInterface
+     */
+    protected ?ContainerInterface $container;
 
     /**
      * Constructor.
      *
-     * @param \Cake\Controller\Controller $controller Controller instance.
+     * @param \Cake\Controller\Controller|null $controller Controller instance.
+     * @param \Cake\Core\ContainerInterface|null $containter Container instance.
      */
-    public function __construct(Controller $controller)
+    public function __construct(?Controller $controller = null, ?ContainerInterface $container = null)
+    {
+        $this->_Controller = null;
+        if ($controller !== null) {
+            $this->setController($controller);
+        }
+        $this->container = $container;
+    }
+
+    /**
+     * Set the controller associated with the collection.
+     *
+     * @param \Cake\Controller\Controller Controller instance.
+     * @return $this
+     */
+    public function setController(Controller $controller)
     {
         $this->_Controller = $controller;
         $this->setEventManager($controller->getEventManager());
+
+        return $this;
     }
 
     /**
@@ -63,6 +88,10 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
      */
     public function getController(): Controller
     {
+        if ($this->_Controller === null) {
+            throw new RuntimeException('Cannot getController() it has not been set yet.');
+        }
+
         return $this->_Controller;
     }
 
@@ -115,8 +144,12 @@ class ComponentRegistry extends ObjectRegistry implements EventDispatcherInterfa
         if (is_object($class)) {
             return $class;
         }
+        if ($this->container && $this->container->has($class)) {
+            $instance = $this->container->get($class)->setConfig($config);
+        } else {
+            $instance = new $class($this, $config);
+        }
 
-        $instance = new $class($this, $config);
         if ($config['enabled'] ?? true) {
             $this->getEventManager()->on($instance);
         }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -18,7 +18,6 @@ namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\App;
-use Cake\Core\ContainerInterface;
 use Cake\Datasource\Paging\Exception\PageOutOfBoundsException;
 use Cake\Datasource\Paging\NumericPaginator;
 use Cake\Datasource\Paging\PaginatedInterface;
@@ -198,12 +197,13 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      *   but expect that features that use the request parameters will not work.
      * @param string|null $name Override the name useful in testing when using mocks.
      * @param \Cake\Event\EventManagerInterface|null $eventManager The event manager. Defaults to a new instance.
+     * @param \Cake\Controller\ComponentRegistry|null $components ComponentRegistry to use. Defaults to a new instance.
      */
     public function __construct(
         ServerRequest $request,
         ?string $name = null,
         ?EventManagerInterface $eventManager = null,
-        ?ContainerInterface $container = null,
+        ?ComponentRegistry $components = null,
     ) {
         if ($name !== null) {
             $this->name = $name;
@@ -225,11 +225,10 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);
         }
-        if ($container !== null) {
-            $this->_components = new ComponentRegistry($this, $container);
-            $container->addShared(ComponentRegistry::class, $this->_components);
+        if ($components !== null) {
+            $this->_components = $components;
+            $components->setController($this);
         }
-
         if ($this->defaultTable === null) {
             $plugin = $this->request->getParam('plugin');
             $tableAlias = ($plugin ? $plugin . '.' : '') . $this->name;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -227,6 +227,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         }
         if ($container !== null) {
             $this->_components = new ComponentRegistry($this, $container);
+            $container->addShared(ComponentRegistry::class, $this->_components);
         }
 
         if ($this->defaultTable === null) {

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -18,6 +18,7 @@ namespace Cake\Controller;
 
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\App;
+use Cake\Core\ContainerInterface;
 use Cake\Datasource\Paging\Exception\PageOutOfBoundsException;
 use Cake\Datasource\Paging\NumericPaginator;
 use Cake\Datasource\Paging\PaginatedInterface;
@@ -202,6 +203,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         ServerRequest $request,
         ?string $name = null,
         ?EventManagerInterface $eventManager = null,
+        ?ContainerInterface $container = null,
     ) {
         if ($name !== null) {
             $this->name = $name;
@@ -222,6 +224,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
 
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);
+        }
+        if ($container !== null) {
+            $this->_components = new ComponentRegistry($this, $container);
         }
 
         if ($this->defaultTable === null) {

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -80,7 +80,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         }
         $this->container->addShared(
             ComponentRegistry::class,
-            new ComponentRegistry(null, $this->container)
+            new ComponentRegistry(container: $this->container)
         );
 
         // Get the controller from the container if defined.

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -85,6 +85,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             $controller = $this->container->get($className);
         } else {
             $constructor = $reflection->getConstructor();
+            assert($constructor !== null);
             $hasContainer = false;
             foreach ($constructor->getParameters() as $parameter) {
                 if ($parameter->getName() === 'container') {

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -84,7 +84,18 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         if ($this->container->has($className)) {
             $controller = $this->container->get($className);
         } else {
-            $controller = $reflection->newInstance($request);
+            $constructor = $reflection->getConstructor();
+            $hasContainer = false;
+            foreach ($constructor->getParameters() as $parameter) {
+                if ($parameter->getName() === 'container') {
+                    $hasContainer = true;
+                }
+            }
+            if ($hasContainer) {
+                $controller = $reflection->newInstance($request, container: $this->container);
+            } else {
+                $controller = $reflection->newInstance($request);
+            }
         }
 
         return $controller;

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -95,7 +95,11 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
             foreach ($constructor->getParameters() as $parameter) {
                 $paramType = $parameter->getType();
                 // TODO: In a future minor release it would be good to start requiring the components parameter
-                if ($parameter->getName() === 'components' && $paramType !== null && $paramType->getName() == ComponentRegistry::class) {
+                if (
+                    $parameter->getName() === 'components' &&
+                    $paramType !== null &&
+                    $paramType->getName() == ComponentRegistry::class
+                ) {
                     $hasComponents = true;
                     break;
                 }

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -83,6 +83,7 @@ class ComponentRegistryTest extends TestCase
         $components = new ComponentRegistry($controller, $container);
         $this->assertEquals([], $components->loaded());
 
+        $container->add(ComponentRegistry::class, $components);
         $container->add(FlashComponent::class, function (ComponentRegistry $registry, array $config) {
             $this->created = true;
 

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Controller;
 
+use Cake\Controller\Component\FlashComponent;
+use Cake\Controller\ComponentRegistry;
 use Cake\Controller\ControllerFactory;
 use Cake\Controller\Exception\InvalidParameterException;
 use Cake\Core\Container;
@@ -897,6 +899,34 @@ class ControllerFactoryTest extends TestCase
         $data = json_decode((string)$result->getBody(), true);
 
         $this->assertSame(['one' => '1'], $data);
+    }
+
+    /**
+     * Test that default values work for typed parameters
+     */
+    public function testInvokeComponentFromContainer(): void
+    {
+        $this->container->add(FlashComponent::class, function (ComponentRegistry $registry, array $config) {
+            return new FlashComponent($registry, $config);
+        })
+        ->addArgument(ComponentRegistry::class)
+        ->addArgument(['key' => 'customFlash']);
+
+        $request = new ServerRequest([
+            'url' => 'test_plugin_three/component-test/flash',
+            'params' => [
+                'plugin' => null,
+                'controller' => 'ComponentTest',
+                'action' => 'flash',
+                'pass' => [],
+            ],
+        ]);
+        $controller = $this->factory->create($request);
+
+        $result = $this->factory->invoke($controller);
+        $data = json_decode((string)$result->getBody(), true);
+
+        $this->assertSame(['flashKey' => 'customFlash'], $data);
     }
 
     public function testMiddleware(): void

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -17,9 +17,12 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Controller;
 
 use AssertionError;
+use Cake\Controller\Component\FlashComponent;
+use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Core\Configure;
+use Cake\Core\Container;
 use Cake\Datasource\Paging\PaginatedInterface;
 use Cake\Event\Event;
 use Cake\Event\EventInterface;
@@ -978,6 +981,29 @@ class ControllerTest extends TestCase
         } catch (RuntimeException $e) {
             $this->assertStringContainsString('The `FormProtection` alias has already been loaded', $e->getMessage());
         }
+    }
+
+    /**
+     * Test adding a component with container passed to controller
+     */
+    public function testLoadComponentWithContainer(): void
+    {
+        $container = new Container();
+        $container->add(FlashComponent::class, function (ComponentRegistry $registry, array $config) {
+            return new FlashComponent($registry, $config);
+        })
+        ->addArgument(ComponentRegistry::class)
+        ->addArgument(['key' => 'customFlash']);
+
+        $request = new ServerRequest(['url' => '/']);
+
+        $controller = new TestController($request);
+        $result = $controller->loadComponent('Flash');
+        $this->assertInstanceOf(FlashComponent::class, $result);
+        $this->assertSame($result, $controller->Flash);
+
+        $registry = $controller->components();
+        $this->assertTrue(isset($registry->Flash));
     }
 
     /**

--- a/tests/test_app/TestApp/Application.php
+++ b/tests/test_app/TestApp/Application.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace TestApp;
 
 use Cake\Console\CommandCollection;
-use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
 use Cake\Core\ContainerInterface;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
@@ -109,7 +108,6 @@ class Application extends BaseApplication
         $container->add(stdClass::class, json_decode('{"key":"value"}'));
         $container->add(DependencyCommand::class)
             ->addArgument(stdClass::class);
-        $container->add(ComponentRegistry::class);
         $container->delegate(new ReflectionContainer());
     }
 }

--- a/tests/test_app/TestApp/Controller/ComponentTestController.php
+++ b/tests/test_app/TestApp/Controller/ComponentTestController.php
@@ -22,10 +22,17 @@ use Cake\Controller\Controller;
  */
 class ComponentTestController extends Controller
 {
-    /**
-     * uses property
-     *
-     * @var array
-     */
-    public $uses = [];
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->loadComponent('Flash');
+    }
+
+    public function flash()
+    {
+        return $this->response->withStringBody(json_encode([
+            'flashKey' => $this->Flash->getConfig('key'),
+        ]));
+    }
 }


### PR DESCRIPTION
This implements the somewhat frequently requested feature of having DI support for components. I've included tests at a few different layers as some critical path methods have changed.

This *should* be backwards compatible with custom constructors. Right now I'm only matching parameters based on name, I did this because it was fast and simple to write. We probably want type based checking instead and I'd like to hear folks thoughts on how we should approach this.

Refs #17231