### PR TITLE
Improve ResultSetFactory.

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\ORM;
 
-use Cake\Collection\Collection;
 use Cake\Collection\CollectionInterface;
 use Cake\Core\App;
 use Cake\Core\ConventionsTrait;
@@ -25,7 +24,6 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\ExpressionInterface;
 use Cake\Datasource\EntityInterface;
-use Cake\Datasource\ResultSetDecorator;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\ORM\Query\SelectQuery;
@@ -996,11 +994,12 @@ abstract class Association
                     }
                     $extracted[] = $result;
                 }
-                $extracted = new Collection($extracted);
+                $extracted = $query->resultSetFactory()->createResultSet($extracted);
+                $decoratorClass = $query->resultSetFactory()->decoratorClass();
                 foreach ($formatters as $callable) {
                     $extracted = $callable($extracted, $query);
                     if (!$extracted instanceof ResultSetInterface) {
-                        $extracted = new ResultSetDecorator($extracted);
+                        $extracted = new $decoratorClass($extracted);
                     }
                 }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -27,7 +27,6 @@ use Cake\Database\ValueBinder;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Datasource\QueryCacher;
 use Cake\Datasource\QueryInterface;
-use Cake\Datasource\ResultSetDecorator;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\Association;
 use Cake\ORM\EagerLoader;
@@ -734,7 +733,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     protected function _decorateResults(iterable $result): ResultSetInterface
     {
-        $decorator = $this->_decoratorClass();
+        $decorator = $this->resultSetFactory()->decoratorClass();
 
         if ($this->_mapReduce) {
             foreach ($this->_mapReduce as $functions) {
@@ -758,16 +757,6 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         }
 
         return $result;
-    }
-
-    /**
-     * Returns the name of the class to be used for decorating results
-     *
-     * @return class-string<\Cake\Datasource\ResultSetInterface>
-     */
-    protected function _decoratorClass(): string
-    {
-        return ResultSetDecorator::class;
     }
 
     /**
@@ -1591,7 +1580,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         }
         $results = $this->getEagerLoader()->loadExternal($this, $results);
 
-        return $this->resultSetFactory()->createResultSet($this, $results);
+        return $this->resultSetFactory()->createResultSet($results, $this);
     }
 
     /**
@@ -1599,7 +1588,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      *
      * @return \Cake\ORM\ResultSetFactory
      */
-    protected function resultSetFactory(): ResultSetFactory
+    public function resultSetFactory(): ResultSetFactory
     {
         return $this->resultSetFactory ??= new ResultSetFactory();
     }

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -18,11 +18,12 @@ namespace Cake\ORM;
 
 use Cake\Collection\Collection;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\ResultSetDecorator;
 use Cake\ORM\Query\SelectQuery;
 use SplFixedArray;
 
 /**
- * Factory class for generation ResulSet instances.
+ * Factory class for generating ResulSet instances.
  *
  * It is responsible for correctly nesting result keys reported from the query
  * and hydrating entities.
@@ -32,27 +33,29 @@ use SplFixedArray;
 class ResultSetFactory
 {
     /**
-     * Constructor
+     * Create a resultset instance.
      *
-     * @param \Cake\ORM\Query\SelectQuery<T> $query Query from where results came.
      * @param iterable $results Results.
+     * @param \Cake\ORM\Query\SelectQuery<T>|null $query Query from where results came.
      * @return \Cake\ORM\ResultSet<array|\Cake\Datasource\EntityInterface>
      */
-    public function createResultSet(SelectQuery $query, iterable $results): ResultSet
+    public function createResultSet(iterable $results, ?SelectQuery $query = null): ResultSet
     {
-        $data = $this->collectData($query);
+        if ($query) {
+            $data = $this->collectData($query);
 
-        if (is_array($results)) {
-            foreach ($results as $i => $row) {
-                $results[$i] = $this->groupResult($row, $data);
+            if (is_array($results)) {
+                foreach ($results as $i => $row) {
+                    $results[$i] = $this->groupResult($row, $data);
+                }
+
+                $results = SplFixedArray::fromArray($results);
+            } else {
+                $results = (new Collection($results))
+                    ->map(function ($row) use ($data) {
+                        return $this->groupResult($row, $data);
+                    });
             }
-
-            $results = SplFixedArray::fromArray($results);
-        } else {
-            $results = (new Collection($results))
-                ->map(function ($row) use ($data) {
-                    return $this->groupResult($row, $data);
-                });
         }
 
         return new ResultSet($results);
@@ -229,5 +232,15 @@ class ResultSetFactory
         }
 
         return $results;
+    }
+
+    /**
+     * Returns the name of the class to be used for decorating results
+     *
+     * @return class-string<\Cake\Datasource\ResultSetInterface>
+     */
+    public function decoratorClass(): string
+    {
+        return ResultSetDecorator::class;
     }
 }

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -183,7 +183,7 @@ class ResultSetFactoryTest extends TestCase
         $statement->method('fetchAll')
             ->willReturn([$row]);
 
-        $results = $this->factory->createResultSet($query, $statement->fetchAll());
+        $results = $this->factory->createResultSet($statement->fetchAll(), $query);
         $this->assertNotEmpty($results);
     }
 


### PR DESCRIPTION
The result decorator class is now fetched from the ResetSetFactory instead of being hardcoded in Association.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
