### PR TITLE
Make Arguments::hasArgument() safe

### DIFF
--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -104,8 +104,6 @@ class Arguments
      */
     public function hasArgument(string $name): bool
     {
-        $this->assertArgumentExists($name);
-
         $offset = array_search($name, $this->argNames, true);
         if ($offset === false) {
             return false;

--- a/tests/TestCase/Console/ArgumentsTest.php
+++ b/tests/TestCase/Console/ArgumentsTest.php
@@ -71,6 +71,7 @@ class ArgumentsTest extends TestCase
         $this->assertTrue($args->hasArgument('size'));
         $this->assertTrue($args->hasArgument('color'));
         $this->assertFalse($args->hasArgument('odd'));
+        $this->assertFalse($args->hasArgument('undefined'));
     }
 
     /**


### PR DESCRIPTION
If getArgument() is going to raise errors, then hasArgument() needs to be safe to call. If hasArgument() also raises then writing dynamic code that interacts with a variety of optional parameters is hard.
