### PR TITLE
Drop use of resultset decorator class in the ORM.

### DIFF
--- a/src/Datasource/ResultSetDecorator.php
+++ b/src/Datasource/ResultSetDecorator.php
@@ -23,7 +23,7 @@ use Cake\Core\Configure;
  * Generic ResultSet decorator. This will make any traversable object appear to
  * be a database result
  *
- * @template T of \Cake\Datasource\EntityInterface|array
+ * @template T
  * @implements \Cake\Datasource\ResultSetInterface<T>
  */
 class ResultSetDecorator extends Collection implements ResultSetInterface

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -995,11 +995,11 @@ abstract class Association
                     $extracted[] = $result;
                 }
                 $extracted = $query->resultSetFactory()->createResultSet($extracted);
-                $decoratorClass = $query->resultSetFactory()->decoratorClass();
+                $resultSetClass = $query->resultSetFactory()->getResultSetClass();
                 foreach ($formatters as $callable) {
                     $extracted = $callable($extracted, $query);
                     if (!$extracted instanceof ResultSetInterface) {
-                        $extracted = new $decoratorClass($extracted);
+                        $extracted = new $resultSetClass($extracted);
                     }
                 }
 

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -733,17 +733,17 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     protected function _decorateResults(iterable $result): ResultSetInterface
     {
-        $decorator = $this->resultSetFactory()->decoratorClass();
+        $resultSetClass = $this->resultSetFactory()->getResultSetClass();
 
         if ($this->_mapReduce) {
             foreach ($this->_mapReduce as $functions) {
                 $result = new MapReduce($result, $functions['mapper'], $functions['reducer']);
             }
-            $result = new $decorator($result);
+            $result = new $resultSetClass($result);
         }
 
         if (!($result instanceof ResultSetInterface)) {
-            $result = new $decorator($result);
+            $result = new $resultSetClass($result);
         }
 
         if ($this->_formatters) {
@@ -752,7 +752,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             }
 
             if (!($result instanceof ResultSetInterface)) {
-                $result = new $decorator($result);
+                $result = new $resultSetClass($result);
             }
         }
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -25,7 +25,7 @@ use Cake\Datasource\ResultSetInterface;
  * the query, casting each field to the correct type and executing the extra
  * queries required for eager loading external associations.
  *
- * @template T of \Cake\Datasource\EntityInterface|array
+ * @template T
  * @implements \Cake\Datasource\ResultSetInterface<T>
  */
 class ResultSet extends Collection implements ResultSetInterface

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -32,7 +32,6 @@ use Cake\Database\StatementInterface;
 use Cake\Database\TypeMap;
 use Cake\Database\ValueBinder;
 use Cake\Datasource\ConnectionManager;
-use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
 use Cake\ORM\Association\BelongsTo;
@@ -899,7 +898,7 @@ class SelectQueryTest extends TestCase
         $this->assertSame($results, $query->all());
 
         $query->setResult([]);
-        $this->assertInstanceOf(ResultSetDecorator::class, $query->all());
+        $this->assertInstanceOf(ResultSet::class, $query->all());
     }
 
     /**

--- a/tests/TestCase/ORM/ResultSetFactoryTest.php
+++ b/tests/TestCase/ORM/ResultSetFactoryTest.php
@@ -19,10 +19,12 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Database\Log\QueryLogger;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
+use Cake\Datasource\ResultSetInterface;
 use Cake\Log\Log;
 use Cake\ORM\ResultSetFactory;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
+use Mockery;
 
 /**
  * ResultSetFactory test case.
@@ -72,6 +74,14 @@ class ResultSetFactoryTest extends TestCase
             ['id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
             ['id' => 3, 'author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y'],
         ];
+    }
+
+    public function testSetResultSetClass(): void
+    {
+        $mock = Mockery::mock(ResultSetInterface::class);
+
+        $this->factory->setResultSetClass($mock::class);
+        $this->assertSame($mock::class, $this->factory->getResultSetClass());
     }
 
     /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -32,7 +32,6 @@ use Cake\Datasource\ConnectionManager;
 use Cake\Datasource\EntityInterface;
 use Cake\Datasource\Exception\InvalidPrimaryKeyException;
 use Cake\Datasource\Exception\RecordNotFoundException;
-use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
 use Cake\I18n\DateTime;
@@ -49,6 +48,7 @@ use Cake\ORM\Query\DeleteQuery;
 use Cake\ORM\Query\InsertQuery;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Query\UpdateQuery;
+use Cake\ORM\ResultSet;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
@@ -778,7 +778,7 @@ class TableTest extends TestCase
         );
 
         $query = $table->find('all')
-            ->formatResults(function (ResultSetDecorator $results) {
+            ->formatResults(function (ResultSet $results) {
                 return $results;
             });
         $query->limit(1);


### PR DESCRIPTION
It serves no purpose anymore since ResultSetInterface simply extends CollectionInterface and ResultSet extends Collection.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
