### PR TITLE
5.1 Add support for geospatial types

### DIFF
--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -523,6 +523,9 @@ class MysqlSchemaDialect extends SchemaDialect
             $out .= ' NULL';
             unset($data['default']);
         }
+        if (isset($data['srid']) && in_array($data['type'], TableSchemaInterface::GEOSPATIAL_TYPES)) {
+            $out .= " SRID {$data['srid']}";
+        }
 
         $dateTimeTypes = [
             TableSchemaInterface::TYPE_DATETIME,
@@ -531,9 +534,6 @@ class MysqlSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_TIMESTAMP_FRACTIONAL,
             TableSchemaInterface::TYPE_TIMESTAMP_TIMEZONE,
         ];
-        if (isset($data['srid']) && in_array($data['type'], TableSchemaInterface::GEOSPATIAL_TYPES)) {
-            $out .= " SRID {$data['srid']}";
-        }
         if (
             isset($data['default']) &&
             in_array($data['type'], $dateTimeTypes) &&

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -196,6 +196,14 @@ class MysqlSchemaDialect extends SchemaDialect
         if (str_contains($col, 'json')) {
             return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
         }
+        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {
+            // TODO how can srid be preserved? It doesn't come back
+            // in the output of show full columns from ...
+            return [
+                'type' => $col,
+                'length' => null,
+            ];
+        }
 
         return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => null];
     }
@@ -374,6 +382,10 @@ class MysqlSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_CHAR => ' CHAR',
             TableSchemaInterface::TYPE_UUID => ' CHAR(36)',
             TableSchemaInterface::TYPE_JSON => $nativeJson ? ' JSON' : ' LONGTEXT',
+            TableSchemaInterface::TYPE_GEOMETRY => ' GEOMETRY',
+            TableSchemaInterface::TYPE_POINT => ' POINT',
+            TableSchemaInterface::TYPE_LINESTRING => ' LINESTRING',
+            TableSchemaInterface::TYPE_POLYGON => ' POLYGON',
         ];
         $specialMap = [
             'string' => true,
@@ -519,6 +531,9 @@ class MysqlSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_TIMESTAMP_FRACTIONAL,
             TableSchemaInterface::TYPE_TIMESTAMP_TIMEZONE,
         ];
+        if (isset($data['srid']) && in_array($data['type'], TableSchemaInterface::GEOSPATIAL_TYPES)) {
+            $out .= " SRID {$data['srid']}";
+        }
         if (
             isset($data['default']) &&
             in_array($data['type'], $dateTimeTypes) &&

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -489,10 +489,10 @@ class SqliteSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_TIMESTAMP_FRACTIONAL => ' TIMESTAMPFRACTIONAL',
             TableSchemaInterface::TYPE_TIMESTAMP_TIMEZONE => ' TIMESTAMPTIMEZONE',
             TableSchemaInterface::TYPE_JSON => ' TEXT',
-            TableSchemaInterface::TYPE_GEOMETRY => ' GEOMETRY',
-            TableSchemaInterface::TYPE_POINT => ' POINT',
-            TableSchemaInterface::TYPE_LINESTRING => ' LINESTRING',
-            TableSchemaInterface::TYPE_POLYGON => ' POLYGON',
+            TableSchemaInterface::TYPE_GEOMETRY => ' GEOMETRY_TEXT',
+            TableSchemaInterface::TYPE_POINT => ' POINT_TEXT',
+            TableSchemaInterface::TYPE_LINESTRING => ' LINESTRING_TEXT',
+            TableSchemaInterface::TYPE_POLYGON => ' POLYGON_TEXT',
         ];
 
         $out = $this->_driver->quoteIdentifier($name);

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -86,7 +86,7 @@ class SqliteSchemaDialect extends SchemaDialect
         if ($col === 'tinyint') {
             return ['type' => TableSchemaInterface::TYPE_TINYINTEGER, 'length' => $length, 'unsigned' => $unsigned];
         }
-        if (str_contains($col, 'int')) {
+        if (str_contains($col, 'int') && $col !== 'point') {
             return ['type' => TableSchemaInterface::TYPE_INTEGER, 'length' => $length, 'unsigned' => $unsigned];
         }
         if (str_contains($col, 'decimal')) {
@@ -138,6 +138,14 @@ class SqliteSchemaDialect extends SchemaDialect
         ];
         if (in_array($col, $datetimeTypes)) {
             return ['type' => $col, 'length' => null];
+        }
+        if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {
+            // TODO how can srid be preserved? It doesn't come back
+            // in the output of show full columns from ...
+            return [
+                'type' => $col,
+                'length' => null,
+            ];
         }
 
         return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
@@ -481,6 +489,10 @@ class SqliteSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_TIMESTAMP_FRACTIONAL => ' TIMESTAMPFRACTIONAL',
             TableSchemaInterface::TYPE_TIMESTAMP_TIMEZONE => ' TIMESTAMPTIMEZONE',
             TableSchemaInterface::TYPE_JSON => ' TEXT',
+            TableSchemaInterface::TYPE_GEOMETRY => ' GEOMETRY',
+            TableSchemaInterface::TYPE_POINT => ' POINT',
+            TableSchemaInterface::TYPE_LINESTRING => ' LINESTRING',
+            TableSchemaInterface::TYPE_POLYGON => ' POLYGON',
         ];
 
         $out = $this->_driver->quoteIdentifier($name);

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -203,6 +203,14 @@ class SqlserverSchemaDialect extends SchemaDialect
         if ($col === 'uniqueidentifier') {
             return ['type' => TableSchemaInterface::TYPE_UUID];
         }
+        if ($col === 'geometry') {
+            return ['type' => TableSchemaInterface::TYPE_GEOMETRY];
+        }
+        if ($col === 'geography') {
+            // SQLserver only has one generic geometry type that
+            // we map to point.
+            return ['type' => TableSchemaInterface::TYPE_POINT];
+        }
 
         return ['type' => TableSchemaInterface::TYPE_STRING, 'length' => null];
     }
@@ -430,6 +438,10 @@ class SqlserverSchemaDialect extends SchemaDialect
             TableSchemaInterface::TYPE_TIMESTAMP_TIMEZONE => ' DATETIME2',
             TableSchemaInterface::TYPE_UUID => ' UNIQUEIDENTIFIER',
             TableSchemaInterface::TYPE_JSON => ' NVARCHAR(MAX)',
+            TableSchemaInterface::TYPE_GEOMETRY => ' GEOMETRY',
+            TableSchemaInterface::TYPE_POINT => ' GEOGRAPHY',
+            TableSchemaInterface::TYPE_LINESTRING => ' GEOGRAPHY',
+            TableSchemaInterface::TYPE_POLYGON => ' GEOGRAPHY',
         ];
 
         if (isset($typeMap[$data['type']])) {

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -167,6 +167,18 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         'float' => [
             'unsigned' => null,
         ],
+        'geometry' => [
+            'srid' => null,
+        ],
+        'point' => [
+            'srid' => null,
+        ],
+        'linestring' => [
+            'srid' => null,
+        ],
+        'polygon' => [
+            'srid' => null,
+        ],
     ];
 
     /**

--- a/src/Database/Schema/TableSchemaInterface.php
+++ b/src/Database/Schema/TableSchemaInterface.php
@@ -171,6 +171,46 @@ interface TableSchemaInterface extends SchemaInterface
     public const TYPE_UUID = 'uuid';
 
     /**
+     * Geometry column type
+     *
+     * @var string
+     */
+    public const TYPE_GEOMETRY = 'geometry';
+
+    /**
+     * Point column type
+     *
+     * @var string
+     */
+    public const TYPE_POINT = 'point';
+
+    /**
+     * Linestring column type
+     *
+     * @var string
+     */
+    public const TYPE_LINESTRING = 'linestring';
+
+    /**
+     * Polgon column type
+     *
+     * @var string
+     */
+    public const TYPE_POLYGON = 'polygon';
+
+    /**
+     * Geospatial column types
+     *
+     * @var array
+     */
+    public const GEOSPATIAL_TYPES = [
+        self::TYPE_GEOMETRY,
+        self::TYPE_POINT,
+        self::TYPE_LINESTRING,
+        self::TYPE_POLYGON,
+    ];
+
+    /**
      * Check whether a table has an autoIncrement column defined.
      *
      * @return bool

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -220,6 +220,22 @@ class MysqlSchemaTest extends TestCase
                 'JSON',
                 ['type' => 'json', 'length' => null],
             ],
+            [
+                'GEOMETRY',
+                ['type' => 'geometry', 'length' => null],
+            ],
+            [
+                'POINT',
+                ['type' => 'point', 'length' => null],
+            ],
+            [
+                'LINESTRING',
+                ['type' => 'linestring', 'length' => null],
+            ],
+            [
+                'POLYGON',
+                ['type' => 'polygon', 'length' => null],
+            ],
         ];
     }
 
@@ -897,6 +913,47 @@ SQL;
                 'created_with_precision',
                 ['type' => 'timestampfractional', 'precision' => 3, 'null' => false, 'default' => 'current_timestamp'],
                 '`created_with_precision` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)',
+            ],
+            // Geospatial types
+            [
+                'g',
+                ['type' => 'geometry'],
+                '`g` GEOMETRY',
+            ],
+            [
+                'g',
+                ['type' => 'geometry', 'null' => false, 'srid' => 4326],
+                '`g` GEOMETRY NOT NULL SRID 4326',
+            ],
+            [
+                'p',
+                ['type' => 'point'],
+                '`p` POINT',
+            ],
+            [
+                'p',
+                ['type' => 'point', 'null' => false, 'srid' => 4326],
+                '`p` POINT NOT NULL SRID 4326',
+            ],
+            [
+                'l',
+                ['type' => 'linestring'],
+                '`l` LINESTRING',
+            ],
+            [
+                'l',
+                ['type' => 'linestring', 'null' => false, 'srid' => 4326],
+                '`l` LINESTRING NOT NULL SRID 4326',
+            ],
+            [
+                'p',
+                ['type' => 'polygon'],
+                '`p` POLYGON',
+            ],
+            [
+                'p',
+                ['type' => 'polygon', 'null' => false, 'srid' => 4326],
+                '`p` POLYGON NOT NULL SRID 4326',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -302,6 +302,7 @@ SQL;
                 unique_id INT NOT NULL,
                 published BOOLEAN DEFAULT 0,
                 allow_comments TINYINT(1) DEFAULT 0,
+                location POINT,
                 created DATETIME,
                 created_with_precision DATETIME(3) DEFAULT CURRENT_TIMESTAMP(3),
                 KEY `author_idx` (`author_id`),
@@ -415,6 +416,15 @@ SQL;
                 'length' => null,
                 'precision' => null,
                 'comment' => null,
+            ],
+            'location' => [
+                'type' => 'point',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => null,
+                'comment' => null,
+                'srid' => null,
             ],
             'created' => [
                 'type' => 'datetime',

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -249,6 +249,23 @@ SQL;
                 ['type' => 'JSONB'],
                 ['type' => 'json', 'length' => null],
             ],
+            // Geospatial
+            [
+                ['type' => 'GEOGRAPHY(GEOMETRY, 4326)'],
+                ['type' => 'geometry', 'length' => null, 'srid' => 4326],
+            ],
+            [
+                ['type' => 'GEOGRAPHY(POINT, 4326)'],
+                ['type' => 'point', 'length' => null, 'srid' => 4326],
+            ],
+            [
+                ['type' => 'GEOGRAPHY(LINESTRING, 4326)'],
+                ['type' => 'linestring', 'length' => null, 'srid' => 4326],
+            ],
+            [
+                ['type' => 'GEOGRAPHY(POLYGON, 4326)'],
+                ['type' => 'polygon', 'length' => null, 'srid' => 4326],
+            ],
         ];
     }
 
@@ -948,6 +965,47 @@ SQL;
                 'current_timestamp_fractional',
                 ['type' => 'timestampfractional', 'null' => false, 'default' => 'CURRENT_TIMESTAMP'],
                 '"current_timestamp_fractional" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+            ],
+            // Geospatial
+            [
+                'g',
+                ['type' => 'geometry'],
+                '"g" GEOGRAPHY(GEOMETRY, 4326)',
+            ],
+            [
+                'g',
+                ['type' => 'geometry', 'null' => false, 'srid' => 4326],
+                '"g" GEOGRAPHY(GEOMETRY, 4326) NOT NULL',
+            ],
+            [
+                'p',
+                ['type' => 'point'],
+                '"p" GEOGRAPHY(POINT, 4326)',
+            ],
+            [
+                'p',
+                ['type' => 'point', 'null' => false, 'srid' => 4326],
+                '"p" GEOGRAPHY(POINT, 4326) NOT NULL',
+            ],
+            [
+                'l',
+                ['type' => 'linestring'],
+                '"l" GEOGRAPHY(LINESTRING, 4326)',
+            ],
+            [
+                'l',
+                ['type' => 'linestring', 'null' => false, 'srid' => 4326],
+                '"l" GEOGRAPHY(LINESTRING, 4326) NOT NULL',
+            ],
+            [
+                'p',
+                ['type' => 'polygon'],
+                '"p" GEOGRAPHY(POLYGON, 4326)',
+            ],
+            [
+                'p',
+                ['type' => 'polygon', 'null' => false, 'srid' => 4326],
+                '"p" GEOGRAPHY(POLYGON, 4326) NOT NULL',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -294,6 +294,7 @@ published BOOLEAN DEFAULT 0,
 created DATETIME,
 field1 VARCHAR(10) DEFAULT NULL,
 field2 VARCHAR(10) DEFAULT 'NULL',
+location POINT,
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
 CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
 );
@@ -470,6 +471,15 @@ SQL;
                 'precision' => null,
                 'comment' => null,
                 'collate' => null,
+            ],
+            'location' => [
+                'type' => 'point',
+                'null' => true,
+                'default' => null,
+                'length' => null,
+                'precision' => null,
+                'comment' => null,
+                'srid' => null,
             ],
         ];
         $this->assertInstanceOf('Cake\Database\Schema\TableSchema', $result);

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -175,6 +175,22 @@ class SqliteSchemaTest extends TestCase
                 'UUID_BLOB',
                 ['type' => 'binaryuuid', 'length' => null],
             ],
+            [
+                'GEOMETRY',
+                ['type' => 'geometry', 'length' => null],
+            ],
+            [
+                'POINT',
+                ['type' => 'point', 'length' => null],
+            ],
+            [
+                'LINESTRING',
+                ['type' => 'linestring', 'length' => null],
+            ],
+            [
+                'POLYGON',
+                ['type' => 'polygon', 'length' => null],
+            ],
         ];
     }
 
@@ -869,6 +885,47 @@ SQL;
                 'created',
                 ['type' => 'timestamp', 'null' => true],
                 '"created" TIMESTAMP DEFAULT NULL',
+            ],
+            // Geospatial types
+            [
+                'g',
+                ['type' => 'geometry'],
+                '"g" GEOMETRY',
+            ],
+            [
+                'g',
+                ['type' => 'geometry', 'null' => false, 'srid' => 4326],
+                '"g" GEOMETRY NOT NULL',
+            ],
+            [
+                'p',
+                ['type' => 'point'],
+                '"p" POINT',
+            ],
+            [
+                'p',
+                ['type' => 'point', 'null' => false, 'srid' => 4326],
+                '"p" POINT NOT NULL',
+            ],
+            [
+                'l',
+                ['type' => 'linestring'],
+                '"l" LINESTRING',
+            ],
+            [
+                'l',
+                ['type' => 'linestring', 'null' => false, 'srid' => 4326],
+                '"l" LINESTRING NOT NULL',
+            ],
+            [
+                'p',
+                ['type' => 'polygon'],
+                '"p" POLYGON',
+            ],
+            [
+                'p',
+                ['type' => 'polygon', 'null' => false, 'srid' => 4326],
+                '"p" POLYGON NOT NULL',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -176,19 +176,19 @@ class SqliteSchemaTest extends TestCase
                 ['type' => 'binaryuuid', 'length' => null],
             ],
             [
-                'GEOMETRY',
+                'GEOMETRY_TEXT',
                 ['type' => 'geometry', 'length' => null],
             ],
             [
-                'POINT',
+                'POINT_TEXT',
                 ['type' => 'point', 'length' => null],
             ],
             [
-                'LINESTRING',
+                'LINESTRING_TEXT',
                 ['type' => 'linestring', 'length' => null],
             ],
             [
-                'POLYGON',
+                'POLYGON_TEXT',
                 ['type' => 'polygon', 'length' => null],
             ],
         ];
@@ -294,7 +294,7 @@ published BOOLEAN DEFAULT 0,
 created DATETIME,
 field1 VARCHAR(10) DEFAULT NULL,
 field2 VARCHAR(10) DEFAULT 'NULL',
-location POINT,
+location POINT_TEXT,
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
 CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
 );
@@ -900,42 +900,42 @@ SQL;
             [
                 'g',
                 ['type' => 'geometry'],
-                '"g" GEOMETRY',
+                '"g" GEOMETRY_TEXT',
             ],
             [
                 'g',
                 ['type' => 'geometry', 'null' => false, 'srid' => 4326],
-                '"g" GEOMETRY NOT NULL',
+                '"g" GEOMETRY_TEXT NOT NULL',
             ],
             [
                 'p',
                 ['type' => 'point'],
-                '"p" POINT',
+                '"p" POINT_TEXT',
             ],
             [
                 'p',
                 ['type' => 'point', 'null' => false, 'srid' => 4326],
-                '"p" POINT NOT NULL',
+                '"p" POINT_TEXT NOT NULL',
             ],
             [
                 'l',
                 ['type' => 'linestring'],
-                '"l" LINESTRING',
+                '"l" LINESTRING_TEXT',
             ],
             [
                 'l',
                 ['type' => 'linestring', 'null' => false, 'srid' => 4326],
-                '"l" LINESTRING NOT NULL',
+                '"l" LINESTRING_TEXT NOT NULL',
             ],
             [
                 'p',
                 ['type' => 'polygon'],
-                '"p" POLYGON',
+                '"p" POLYGON_TEXT',
             ],
             [
                 'p',
                 ['type' => 'polygon', 'null' => false, 'srid' => 4326],
-                '"p" POLYGON NOT NULL',
+                '"p" POLYGON_TEXT NOT NULL',
             ],
         ];
     }

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -300,6 +300,21 @@ SQL;
                 null,
                 ['type' => 'binary', 'length' => TableSchema::LENGTH_LONG],
             ],
+            // Geospatial types
+            [
+                'GEOMETRY',
+                null,
+                null,
+                null,
+                ['type' => 'geometry', 'null' => true],
+            ],
+            [
+                'GEOGRAPHY',
+                null,
+                null,
+                null,
+                ['type' => 'point', 'null' => true],
+            ],
         ];
     }
 
@@ -826,6 +841,47 @@ SQL;
                 'created',
                 ['type' => 'timestamp', 'null' => true],
                 '[created] DATETIME2 DEFAULT NULL',
+            ],
+            // Geospatial
+            [
+                'g',
+                ['type' => 'geometry'],
+                '[g] GEOMETRY',
+            ],
+            [
+                'g',
+                ['type' => 'geometry', 'null' => false, 'srid' => 4326],
+                '[g] GEOMETRY NOT NULL',
+            ],
+            [
+                'p',
+                ['type' => 'point'],
+                '[p] GEOGRAPHY',
+            ],
+            [
+                'p',
+                ['type' => 'point', 'null' => false, 'srid' => 4326],
+                '[p] GEOGRAPHY NOT NULL',
+            ],
+            [
+                'l',
+                ['type' => 'linestring'],
+                '[l] GEOGRAPHY',
+            ],
+            [
+                'l',
+                ['type' => 'linestring', 'null' => false, 'srid' => 4326],
+                '[l] GEOGRAPHY NOT NULL',
+            ],
+            [
+                'p',
+                ['type' => 'polygon'],
+                '[p] GEOGRAPHY',
+            ],
+            [
+                'p',
+                ['type' => 'polygon', 'null' => false, 'srid' => 4326],
+                '[p] GEOGRAPHY NOT NULL',
             ],
         ];
     }


### PR DESCRIPTION
Add support for schema reflection and generation for geospatial types. They are supported across several database platforms and can help support more kinds of applications in the future. I don't have experience working with geospatial data to suggest an ORM model for these values so they are strings.

### TODO

- [x] Sqlserver support
- [x] Integration test for creating table and reflecting schema from it.
- [x] Find a way to read srid values from mysql schema.