### PR TITLE
Set the request instance to the Router after each middleware is run.

### DIFF
--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -116,7 +116,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
         } catch (RedirectException $exception) {
             return $this->handleRedirect($exception);
         } catch (Throwable $exception) {
-            return $this->handleException($exception, $request);
+            return $this->handleException($exception, Router::getRequest() ?? $request);
         }
     }
 

--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -57,13 +57,6 @@ class Runner implements RequestHandlerInterface
         $this->queue->rewind();
         $this->fallbackHandler = $fallbackHandler;
 
-        if (
-            $fallbackHandler instanceof RoutingApplicationInterface &&
-            $request instanceof ServerRequest
-        ) {
-            Router::setRequest($request);
-        }
-
         return $this->handle($request);
     }
 
@@ -75,6 +68,13 @@ class Runner implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        if (
+            $this->fallbackHandler instanceof RoutingApplicationInterface &&
+            $request instanceof ServerRequest
+        ) {
+            Router::setRequest($request);
+        }
+
         if ($this->queue->valid()) {
             $middleware = $this->queue->current();
             $this->queue->next();

--- a/tests/TestCase/Http/RunnerTest.php
+++ b/tests/TestCase/Http/RunnerTest.php
@@ -78,7 +78,7 @@ class RunnerTest extends TestCase
     public function testRunSingle(): void
     {
         $this->queue->add($this->ok);
-        $req = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $req = new ServerRequest();
 
         $runner = new Runner();
         $result = $runner->run($this->queue, $req);
@@ -109,7 +109,7 @@ class RunnerTest extends TestCase
         $this->queue->add($one)->add($two)->add($three);
         $runner = new Runner();
 
-        $req = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $req = new ServerRequest();
         $result = $runner->run($this->queue, $req);
         $this->assertInstanceof(Response::class, $result);
 
@@ -125,7 +125,7 @@ class RunnerTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('A bad thing');
         $this->queue->add($this->ok)->add($this->fail);
-        $req = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $req = new ServerRequest();
 
         $runner = new Runner();
         $runner->run($this->queue, $req);


### PR DESCRIPTION
This allows an error handleware middleware to pull the upto date request instance from the route for response generation. Closes #17731.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
