### PR TITLE
Avoid exception in FormHelper::unlockField() when FormComponent is not loaded.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -658,13 +658,18 @@ class FormHelper extends Helper
      * Add to the list of fields that are currently unlocked.
      *
      * Unlocked fields are not included in the form protection field hash.
+     * It will be no-op if the FormProtectionComponent is not loaded in the controller.
      *
      * @param string $name The dot separated name for the field.
      * @return $this
      */
     public function unlockField(string $name)
     {
-        $this->getFormProtector()->unlockField($name);
+        try {
+            $this->getFormProtector()->unlockField($name);
+        } catch (CakeException) {
+            // Ignore exception when the FormProtector is not created (FormProtectionComponent is not loaded).
+        }
 
         return $this;
     }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2279,6 +2279,22 @@ class FormHelperTest extends TestCase
     }
 
     /**
+     * testUnlockFieldWithFormTokenData method
+     *
+     * Test that unlockField() becomes a no-op and does not throw an exception
+     * when called without `formTokenData` being present in the request.
+     *
+     * @return void
+     */
+    public function testUnlockFieldWithFormTokenData(): void
+    {
+        $this->Form->create();
+        $result = $this->Form->unlockField('foo');
+
+        $this->assertSame($this->Form, $result);
+    }
+
+    /**
      * testSecuredFormUrlIgnoresHost method
      *
      * Test that only the path + query elements of a form's URL show up in their hash.


### PR DESCRIPTION
Refs #17736

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
