### PR TITLE
Update FormHelper::getFormProtector().

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -665,11 +665,7 @@ class FormHelper extends Helper
      */
     public function unlockField(string $name)
     {
-        try {
-            $this->getFormProtector()->unlockField($name);
-        } catch (CakeException) {
-            // Ignore exception when the FormProtector is not created (FormProtectionComponent is not loaded).
-        }
+        $this->getFormProtector()?->unlockField($name);
 
         return $this;
     }
@@ -693,18 +689,10 @@ class FormHelper extends Helper
     /**
      * Get form protector instance.
      *
-     * @return \Cake\Form\FormProtector
-     * @throws \Cake\Core\Exception\CakeException
+     * @return \Cake\Form\FormProtector|null
      */
-    public function getFormProtector(): FormProtector
+    public function getFormProtector(): ?FormProtector
     {
-        if ($this->formProtector === null) {
-            throw new CakeException(
-                '`FormProtector` instance has not been created. Ensure you have loaded the `FormProtectionComponent`'
-                . ' in your controller and called `FormHelper::create()` before calling `FormHelper::unlockField()`.'
-            );
-        }
-
         return $this->formProtector;
     }
 


### PR DESCRIPTION
It now returns null instead of throwing an exception if the form proctector instance is not set. Refs #17736

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
