### PR TITLE
TypedMap with CookieMap + trait

### DIFF
--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -18,9 +18,9 @@ namespace Cake\Core;
 
 use Cake\I18n\Date;
 use Cake\I18n\DateTime;
-use Cake\I18n\FrozenDate;
 use DateTimeInterface;
 use Exception;
+use IntlDateFormatter;
 use JsonException;
 use Stringable;
 
@@ -552,13 +552,13 @@ function toDateTime(mixed $value): ?DateTime
     } else if (is_int($value)) {
         try {
             return DateTime::createFromTimestamp($value);
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     } else if (is_string($value)) {
         try {
             return DateTime::createFromFormat(DateTimeInterface::ATOM, $value);
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -574,7 +574,7 @@ function toDateTime(mixed $value): ?DateTime
  *  Other values returns as null.
  *
  * @param mixed $value The value to convert to DateInterface.
- * @return FrozenDate|null Returns a FrozenDate if parsing is successful, or NULL otherwise.
+ * @return \Cake\I18n\FrozenDate|null Returns a FrozenDate if parsing is successful, or NULL otherwise.
  * @since 5.1.0
  */
 function toDate(mixed $value): ?Date
@@ -596,7 +596,7 @@ function toDate(mixed $value): ?Date
         }
     } else if (is_string($value)) {
         try {
-            return Date::parseDate($value, \IntlDateFormatter::SHORT);
+            return Date::parseDate($value, IntlDateFormatter::SHORT);
         } catch (Exception) {
             return null;
         }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -540,14 +540,14 @@ function toBool(mixed $value): ?bool
  *  Other values returns as null.
  *
  * @param mixed $value The value to convert to DateTimeInterface.
- * @return \DateTime|null Returns a DateTimeInterface if parsing is successful, or NULL otherwise.
+ * @return \Cake\I18n\DateTime|null Returns a DateTime object if parsing is successful, or NULL otherwise.
  * @since 5.1.0
  */
 function toDateTime(mixed $value): ?DateTime
 {
     if ($value instanceof DateTime) {
         return $value;
-    } else if ($value instanceof DateTimeInterface) {
+    } elseif ($value instanceof DateTimeInterface) {
         return DateTime::parse($value);
     } else if (is_int($value)) {
         try {
@@ -574,14 +574,14 @@ function toDateTime(mixed $value): ?DateTime
  *  Other values returns as null.
  *
  * @param mixed $value The value to convert to DateInterface.
- * @return \Cake\I18n\FrozenDate|null Returns a FrozenDate if parsing is successful, or NULL otherwise.
+ * @return Date|null Returns a Date object if parsing is successful, or NULL otherwise.
  * @since 5.1.0
  */
 function toDate(mixed $value): ?Date
 {
     if ($value instanceof Date) {
         return $value;
-    } else if ($value instanceof DateTimeInterface) {
+    } elseif ($value instanceof DateTimeInterface) {
         return Date::parse($value);
     } else if (is_int($value)) {
         try {

--- a/src/Map/CookieMap.php
+++ b/src/Map/CookieMap.php
@@ -44,6 +44,18 @@ class CookieMap extends TypedMap
     ];
 
     /**
+     * Class constructor.
+     *
+     * @param array<string, mixed> $cookies
+     */
+    public function __construct(array $cookies)
+    {
+        foreach ($cookies as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    /**
      * Sets a value in the map with the given key and type.
      *
      * @param string $key

--- a/src/Map/CookieMap.php
+++ b/src/Map/CookieMap.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Map;
+
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use InvalidArgumentException;
+use OutOfBoundsException;
+
+/**
+ * Map that stores keys, values, and value types for Cookies.
+ */
+class CookieMap extends TypedMap
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $map = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $types = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $supportedTypes = [
+        'string',
+    ];
+
+    /**
+     * Sets a value in the map with the given key and type.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @throws \InvalidArgumentException
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $type = $this->detectType($value);
+        if (!$this->isValidType($type)) {
+            throw new InvalidArgumentException("Cannot store unsupported type `${type}` in Map object. " .
+                'Supported types are: ' . implode(', ', $this->supportedTypes));
+        }
+
+        $this->map[$key] = $value;
+        $this->types[$key] = $type;
+    }
+
+    /**
+     * Gets a value from the map by the given key.
+     *
+     * @param string $key
+     * @return mixed
+     * @throws \OutOfBoundsException
+     */
+    public function get(string $key): mixed
+    {
+        if (!array_key_exists($key, $this->map)) {
+            throw new OutOfBoundsException("No value found for key {$key}");
+        }
+
+        return $this->map[$key];
+    }
+
+    /**
+     * Gets the type of a value stored in the map by the given key.
+     *
+     * @param string $key
+     * @return string
+     * @throws \OutOfBoundsException
+     */
+    public function getType(string $key): string
+    {
+        if (!array_key_exists($key, $this->types)) {
+            throw new OutOfBoundsException("No type found for key {$key}");
+        }
+
+        return $this->types[$key];
+    }
+}

--- a/src/Map/CookieMap.php
+++ b/src/Map/CookieMap.php
@@ -24,7 +24,7 @@ use OutOfBoundsException;
  */
 class CookieMap extends TypedMap
 {
-    use TypeAwareMapTrait;
+    use TypedMapTrait;
 
     /**
      * @var array<string, mixed>

--- a/src/Map/CookieMap.php
+++ b/src/Map/CookieMap.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Map;
 
-use Cake\I18n\Date;
-use Cake\I18n\DateTime;
 use InvalidArgumentException;
 use OutOfBoundsException;
 
@@ -26,6 +24,8 @@ use OutOfBoundsException;
  */
 class CookieMap extends TypedMap
 {
+    use TypeAwareMapTrait;
+
     /**
      * @var array<string, mixed>
      */

--- a/src/Map/MapInterface.php
+++ b/src/Map/MapInterface.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         2.0.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Map;
+
+/**
+ * Describe the interface for a map of keys, values, and other metadata.
+ */
+interface MapInterface
+{
+    /**
+     * Sets a value in the map with the given key and type.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @throws \InvalidArgumentException
+     */
+    public function set(string $key, mixed $value): void;
+
+    /**
+     * Gets a value from the map by the given key.
+     *
+     * @param string $key
+     * @return mixed
+     * @throws \OutOfBoundsException
+     */
+    public function get(string $key): mixed;
+}

--- a/src/Map/TypeAwareMapTrait.php
+++ b/src/Map/TypeAwareMapTrait.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Map;
+
+use Cake\I18n\FrozenDate;
+use Cake\I18n\FrozenTime;
+use function Cake\Core\toBool;
+use function Cake\Core\toDate;
+use function Cake\Core\toDateTime;
+use function Cake\Core\toFloat;
+use function Cake\Core\toInt;
+
+/**
+ * Trait for fetching values from a Map with type casting.
+ *
+ * This trait expects that the implementing class define a get() method for
+ * obtaining raw values.
+ */
+trait TypeAwareMapTrait
+{
+    /**
+     * Returns the string value of the key.
+     *
+     * @param string $key
+     * @return string
+     */
+    public function getString(string $key): string
+    {
+        return (string) $this->get($key);
+    }
+
+    /**
+     * Returns the integer value of the key.
+     *
+     * @param string $key
+     * @return int|null
+     */
+    public function getInteger(string $key): ?int
+    {
+        return toInt($this->get($key));
+    }
+
+    /**
+     * Returns the float value of the key.
+     *
+     * @param string $key
+     * @return float|null
+     */
+    public function getFloat(string $key): ?float
+    {
+        return toFloat($this->get($key));
+    }
+
+    /**
+     * Returns the boolean value of the key.
+     *
+     * @param string $key
+     * @return bool|null
+     */
+    public function getBool(string $key): ?bool
+    {
+        return toBool($this->get($key));
+    }
+
+    /**
+     * Returns the value of the key as a Date object.
+     *
+     * @param string $key
+     * @return FrozenDate|null
+     */
+    public function getDate(string $key): ?bool
+    {
+        return toDate($this->get($key));
+    }
+
+    /**
+     * Returns the value of the key as a DateTime object.
+     *
+     * @param string $key
+     * @return FrozenTime|null
+     */
+    public function getDateTime(string $key): ?bool
+    {
+        return toDateTime($this->get($key));
+    }
+}

--- a/src/Map/TypeAwareMapTrait.php
+++ b/src/Map/TypeAwareMapTrait.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Map;
 
-use Cake\I18n\FrozenDate;
-use Cake\I18n\FrozenTime;
 use function Cake\Core\toBool;
 use function Cake\Core\toDate;
 use function Cake\Core\toDateTime;
@@ -40,7 +38,7 @@ trait TypeAwareMapTrait
      */
     public function getString(string $key): string
     {
-        return (string) $this->get($key);
+        return (string)$this->get($key);
     }
 
     /**
@@ -80,7 +78,7 @@ trait TypeAwareMapTrait
      * Returns the value of the key as a Date object.
      *
      * @param string $key
-     * @return FrozenDate|null
+     * @return \Cake\I18n\FrozenDate|null
      */
     public function getDate(string $key): ?bool
     {
@@ -91,7 +89,7 @@ trait TypeAwareMapTrait
      * Returns the value of the key as a DateTime object.
      *
      * @param string $key
-     * @return FrozenTime|null
+     * @return \Cake\I18n\FrozenTime|null
      */
     public function getDateTime(string $key): ?bool
     {

--- a/src/Map/TypedMap.php
+++ b/src/Map/TypedMap.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Map;
+
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
+use InvalidArgumentException;
+use OutOfBoundsException;
+
+/**
+ * Map that stores keys, values, and the types of those values. Ensures type
+ * safety by validating the types of values before storing them.
+ */
+class TypedMap implements MapInterface
+{
+    /**
+     * @var array
+     */
+    protected array $map = [];
+
+    /**
+     * @var array
+     */
+    protected array $types = [];
+
+    /**
+     * TODO: Consider expanding this list and having children override it to narrow acceptable types
+     *
+     * @var array|string[]
+     */
+    protected array $supportedTypes = [
+        'string',
+        'int',
+        'float',
+        'bool',
+        'DateTime',
+        'Date',
+    ];
+
+    /**
+     * Sets a value in the map with the given key and type.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @throws \InvalidArgumentException
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $type = $this->detectType($value);
+        if (!$this->isValidType($type)) {
+            throw new InvalidArgumentException("Cannot store unsupported type `${type}` in Map object. " .
+                "Supported types are: " . implode(', ', $this->supportedTypes));
+        }
+
+        $this->map[$key] = $value;
+        $this->types[$key] = $type;
+    }
+
+    /**
+     * Gets a value from the map by the given key.
+     *
+     * @param string $key
+     * @return mixed
+     * @throws \OutOfBoundsException
+     */
+    public function get(string $key): mixed
+    {
+        if (!array_key_exists($key, $this->map)) {
+            throw new OutOfBoundsException("No value found for key {$key}");
+        }
+
+        return $this->map[$key];
+    }
+
+    /**
+     * Gets the type of a value stored in the map by the given key.
+     *
+     * @param string $key
+     * @return string
+     * @throws \OutOfBoundsException
+     */
+    public function getType(string $key): string
+    {
+        if (!array_key_exists($key, $this->types)) {
+            throw new OutOfBoundsException("No type found for key {$key}");
+        }
+
+        return $this->types[$key];
+    }
+
+    /**
+     * Detects the type of a value.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    protected function detectType(mixed $value): string
+    {
+        return match (true) {
+            is_int($value) => 'int',
+            is_float($value) => 'float',
+            is_string($value) => 'string',
+            is_bool($value) => 'bool',
+            is_array($value) => 'array',
+            is_object($value) => 'object',
+            is_callable($value) => 'callable',
+            is_iterable($value) => 'iterable',
+            get_class($value) === DateTime::class => 'DateTime',
+            get_class($value) === Date::class => 'Date',
+            default => 'mixed',
+        };
+    }
+
+    /**
+     * Checks if the given type is one of the supported types.
+     *
+     * @param string $type
+     * @return bool
+     */
+    protected function isValidType(string $type): bool
+    {
+        return in_array($type, $this->supportedTypes);
+    }
+}

--- a/src/Map/TypedMapTrait.php
+++ b/src/Map/TypedMapTrait.php
@@ -28,7 +28,7 @@ use function Cake\Core\toInt;
  * This trait expects that the implementing class define a get() method for
  * obtaining raw values.
  */
-trait TypeAwareMapTrait
+trait TypedMapTrait
 {
     /**
      * Returns the string value of the key.

--- a/src/Map/TypedMapTrait.php
+++ b/src/Map/TypedMapTrait.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  */
 namespace Cake\Map;
 
+use Cake\I18n\Date;
+use Cake\I18n\DateTime;
 use function Cake\Core\toBool;
 use function Cake\Core\toDate;
 use function Cake\Core\toDateTime;
@@ -78,9 +80,9 @@ trait TypedMapTrait
      * Returns the value of the key as a Date object.
      *
      * @param string $key
-     * @return \Cake\I18n\FrozenDate|null
+     * @return \Cake\I18n\Date|null
      */
-    public function getDate(string $key): ?bool
+    public function getDate(string $key): ?Date
     {
         return toDate($this->get($key));
     }
@@ -89,9 +91,9 @@ trait TypedMapTrait
      * Returns the value of the key as a DateTime object.
      *
      * @param string $key
-     * @return \Cake\I18n\FrozenTime|null
+     * @return \Cake\I18n\DateTime|null
      */
-    public function getDateTime(string $key): ?bool
+    public function getDateTime(string $key): ?DateTime
     {
         return toDateTime($this->get($key));
     }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\Configure;
 use Cake\Http\Response;
+use Cake\I18n\Date;
 use Cake\I18n\DateTime;
 use Cake\I18n\FrozenDate;
 use Cake\I18n\FrozenTime;
@@ -33,6 +34,8 @@ use function Cake\Core\namespaceSplit;
 use function Cake\Core\pathCombine;
 use function Cake\Core\pluginSplit;
 use function Cake\Core\toBool;
+use function Cake\Core\toDate;
+use function Cake\Core\toDateTime;
 use function Cake\Core\toFloat;
 use function Cake\Core\toInt;
 use function Cake\Core\toString;

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -683,4 +683,100 @@ class FunctionsTest extends TestCase
             '(other) simple object' => [new stdClass(), null],
         ];
     }
+
+    /**
+     * @dataProvider toDateTimeProvider
+     */
+    public function testToDateTime(mixed $rawValue, ?DateTime $expected): void
+    {
+        $this->assertEquals($expected, toDateTime($rawValue));
+    }
+
+    /**
+     * @return array The array of test cases.
+     */
+    public static function toDateTimeProvider(): array
+    {
+        $date = new DateTime('2024-07-01T14:30:00Z');
+        $now = $date->toAtomString();
+
+        return [
+            // datetime input types
+            '(datetime) datetime interface' => [new \DateTime($now), $date],
+            '(datetime) frozentime interface' => [new FrozenTime($now), $date],
+            // string input types
+            '(string) datetime string' => [$now, $date],
+            '(string) empty string' => ['', null],
+            '(string) space' => [' ', null],
+            '(string) some word' => ['abc', null],
+            '(string) double 0' => ['00', null],
+            '(string) single 0' => ['0', null],
+            '(string) false' => ['false', null],
+            '(string) double 1' => ['11', null],
+            '(string) true-string' => ['true', null],
+            // int input types
+            '(int) timestamp' => [1719844200, $date],
+            '(int) negative number' => [-1000, DateTime::createFromTimestamp(-1000)],
+            // float input types
+            '(float) positive' => [5.5, null],
+            '(float) round' => [5.0, null],
+            '(float) NaN' => [acos(8), null],
+            '(float) INF' => [INF, null],
+            '(float) -INF' => [-INF, null],
+            // other input types
+            '(other) null' => [null, null],
+            '(other) empty-array' => [[], null],
+            '(other) int-array' => [[5], null],
+            '(other) string-array' => [['5'], null],
+            '(other) simple object' => [new stdClass(), null],
+        ];
+    }
+
+    /**
+     * @dataProvider toDateProvider
+     */
+    public function testToDate(mixed $rawValue, ?Date $expected): void
+    {
+        $this->assertEquals($expected, toDate($rawValue));
+    }
+
+    /**
+     * @return array The array of test cases.
+     */
+    public static function toDateProvider(): array
+    {
+        $epoch = Date::createFromArray(['year' => 1970, 'month' => 01, 'day' => 01]);
+        $date = Date::createFromArray(['year' => 2024, 'month' => 07, 'day' => 01]);
+        $now = $date->toAtomString();
+
+        return [
+            // datetime input types
+            '(datetime) datetime interface' => [new \DateTime($now), $date],
+            '(datetime frozendate object' => [new FrozenDate($now), $date],
+            // string input types
+            '(string) date string' => [$date->i18nFormat(\IntlDateFormatter::SHORT), $date],
+            '(string) empty string' => ['', null],
+            '(string) space' => [' ', null],
+            '(string) some word' => ['abc', null],
+            '(string) double 0' => ['00', null],
+            '(string) false' => ['false', null],
+            '(string) double 1' => ['11', null],
+            '(string) true-string' => ['true', null],
+            // int input types
+            '(int) timestamp' => [1_719_844_200, $date],
+            '(int) negative number' => [-2_592_000, $epoch->subDays(30)],
+            // float input types
+            '(float) positive' => [5.5, null],
+            '(float) round' => [5.0, null],
+            '(float) NaN' => [acos(8), null],
+            '(float) INF' => [INF, null],
+            '(float) -INF' => [-INF, null],
+            // other input types
+            '(other) null' => [null, null],
+            '(other) empty-array' => [[], null],
+            '(other) int-array' => [[5], null],
+            '(other) string-array' => [['5'], null],
+            '(other) simple object' => [new stdClass(), null],
+        ];
+    }
 }

--- a/tests/TestCase/Core/FunctionsTest.php
+++ b/tests/TestCase/Core/FunctionsTest.php
@@ -18,8 +18,12 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\Configure;
 use Cake\Http\Response;
+use Cake\I18n\DateTime;
+use Cake\I18n\FrozenDate;
+use Cake\I18n\FrozenTime;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
+use IntlDateFormatter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use function Cake\Core\deprecationWarning;
@@ -702,7 +706,7 @@ class FunctionsTest extends TestCase
 
         return [
             // datetime input types
-            '(datetime) datetime interface' => [new \DateTime($now), $date],
+            '(datetime) datetime interface' => [new DateTime($now), $date],
             '(datetime) frozentime interface' => [new FrozenTime($now), $date],
             // string input types
             '(string) datetime string' => [$now, $date],
@@ -751,10 +755,10 @@ class FunctionsTest extends TestCase
 
         return [
             // datetime input types
-            '(datetime) datetime interface' => [new \DateTime($now), $date],
+            '(datetime) datetime interface' => [new DateTime($now), $date],
             '(datetime frozendate object' => [new FrozenDate($now), $date],
             // string input types
-            '(string) date string' => [$date->i18nFormat(\IntlDateFormatter::SHORT), $date],
+            '(string) date string' => [$date->i18nFormat(IntlDateFormatter::SHORT), $date],
             '(string) empty string' => ['', null],
             '(string) space' => [' ', null],
             '(string) some word' => ['abc', null],


### PR DESCRIPTION
Created a `TypedMap` class which other Map classes will inherit from. I added a `CookieMap` as a demonstration, but other maps can be added eventually (e.g. `QueryStringMap`). The interface that the maps inherit only require `get()` and `set()` which is why I created the `TypedMapTrait` which contains methods such as `getString()` / `getInt()` / `getBool()`.