### PR TITLE
Allow easy generation of meta tag with CSRF token

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -137,6 +137,7 @@ class HtmlHelper extends Helper
     {
         if (!is_array($type)) {
             $types = [
+                'csrfToken' => ['name' => 'csrf-token'],
                 'rss' => ['type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $content],
                 'atom' => ['type' => 'application/atom+xml', 'title' => $type, 'link' => $content],
                 'icon' => ['type' => 'image/x-icon', 'rel' => 'icon', 'link' => $content],
@@ -153,6 +154,10 @@ class HtmlHelper extends Helper
 
             if ($type === 'icon' && $content === null) {
                 $types['icon']['link'] = 'favicon.ico';
+            }
+
+            if ($type === 'csrfToken') {
+                $types['csrfToken']['content'] = $this->_View->getRequest()->getAttribute('csrfToken');
             }
 
             if (isset($types[$type])) {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -130,12 +130,12 @@ class HtmlHelper extends Helper
      * @param array|string|null $content The address of the external resource or string for content attribute
      * @param array<string, mixed> $options Other attributes for the generated tag. If the type attribute is html,
      *    rss, atom, or icon, the mime-type is returned.
-     * @return string|null A completed `<link>` element, or null if the element was sent to a block.
+     * @return string|null A completed `<link>` or `<meta>` element, or null if the element was sent to a block.
      * @link https://book.cakephp.org/5/en/views/helpers/html.html#creating-meta-tags
      */
     public function meta(array|string $type, array|string|null $content = null, array $options = []): ?string
     {
-        if (!is_array($type)) {
+        if (is_string($type)) {
             $types = [
                 'csrfToken' => ['name' => 'csrf-token'],
                 'rss' => ['type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $content],

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -72,6 +72,7 @@ class HtmlHelperTest extends TestCase
         $request = new ServerRequest([
             'webroot' => '',
         ]);
+        $request = $request->withAttribute('csrfToken', 'test');
         Router::reload();
         Router::setRequest($request);
 
@@ -1574,6 +1575,12 @@ class HtmlHelperTest extends TestCase
         $result = $this->Html->meta(['link' => 'http://example.com/manifest', 'rel' => 'manifest']);
         $expected = [
             'link' => ['href' => 'http://example.com/manifest', 'rel' => 'manifest'],
+        ];
+        $this->assertHtml($expected, $result);
+
+        $result = $this->Html->meta('csrfToken');
+        $expected = [
+            'meta' => ['name' => 'csrf-token', 'content' => 'test'],
         ];
         $this->assertHtml($expected, $result);
     }


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
