### PR TITLE
Fix phpcs and micro optimization for EventManager

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -83,11 +83,14 @@ class EventManager implements EventManagerInterface
      */
     public static function instance(?EventManager $manager = null): EventManager
     {
+        if ($manager === null && static::$_generalManager) {
+            return static::$_generalManager;
+        }
+
         if ($manager instanceof EventManager) {
             static::$_generalManager = $manager;
         }
         static::$_generalManager ??= new static();
-
         static::$_generalManager->_isGlobal = true;
 
         return static::$_generalManager;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1448,7 +1448,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $options = $this->_setFieldMatchers(compact('keyField', 'parentField'), ['keyField', 'parentField']);
 
-        return $query->formatResults(fn (CollectionInterface $results) => $results->nest($options['keyField'], $options['parentField'], $nestingKey));
+        return $query->formatResults(fn (CollectionInterface $results) => $results->nest(
+            $options['keyField'],
+            $options['parentField'],
+            $nestingKey
+        ));
     }
 
     /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1409,12 +1409,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ['keyField', 'valueField', 'groupField']
         );
 
-        return $query->formatResults(fn (CollectionInterface $results) =>
-            $results->combine(
-                $options['keyField'],
-                $options['valueField'],
-                $options['groupField']
-            ));
+        return $query->formatResults(fn (CollectionInterface $results) => $results->combine(
+            $options['keyField'],
+            $options['valueField'],
+            $options['groupField']
+        ));
     }
 
     /**
@@ -1449,8 +1448,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $options = $this->_setFieldMatchers(compact('keyField', 'parentField'), ['keyField', 'parentField']);
 
-        return $query->formatResults(fn (CollectionInterface $results) =>
-            $results->nest($options['keyField'], $options['parentField'], $nestingKey));
+        return $query->formatResults(fn (CollectionInterface $results) => $results->nest($options['keyField'], $options['parentField'], $nestingKey));
     }
 
     /**


### PR DESCRIPTION
- Fix arrow function formatting to resolve phpcs build failure.
- Add an early return to avoid setting `_isGlobal` each time an event manager is read.