### PR TITLE
5.x: remove stickler ci config

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,8 +1,0 @@
----
-linters:
-  phpcs:
-    standard: CakePHP4
-    extensions: 'php'
-
-branches:
-    ignore: ['5.x']


### PR DESCRIPTION
Its been long dead so no need to keep it here