### PR TITLE
5.next: partially unmockify the testsuite in cache, collection and console tests

### DIFF
--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -262,10 +262,14 @@ class CacheTest extends TestCase
      */
     public function testConfigFailedInit(): void
     {
-        $mock = $this->getMockBuilder(TestAppCacheEngine::class)->getMock();
-        $mock->method('init')->willReturn(false);
+        $engine = new class extends TestAppCacheEngine {
+            public function init(array $config = []): bool
+            {
+                return false;
+            }
+        };
         Cache::setConfig('tests', [
-            'engine' => $mock,
+            'engine' => $engine,
         ]);
 
         $engine = Cache::pool('tests');
@@ -402,14 +406,11 @@ class CacheTest extends TestCase
      */
     public function testConfigInvalidObject(): void
     {
-        $this->getMockBuilder(stdClass::class)
-            ->setMockClassName('RubbishEngine')
-            ->getMock();
-
+        $object = new stdClass();
         $this->expectException(BadMethodCallException::class);
 
         Cache::setConfig('test', [
-            'engine' => '\RubbishEngine',
+            'engine' => $object,
         ]);
     }
 

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -35,7 +35,6 @@ use InvalidArgumentException;
 use LogicException;
 use NoRewindIterator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use stdClass;
 use TestApp\Collection\CountableIterator;
 use TestApp\Collection\TestCollection;
 use TestApp\Model\Enum\ArticleStatus;
@@ -2728,17 +2727,14 @@ class CollectionTest extends TestCase
     {
         $items = ['a' => 1, 'b' => 2, 'c' => 3];
         $collection = (new Collection($items))->lazy();
-        $callable = $this->getMockBuilder(stdMock::class)
-            ->getMock();
+        $callable = new class {
+            public function __invoke()
+            {
+                throw new Exception('This should not be called');
+            }
+        };
 
-        $callable->expects($this->never())->method('__invoke');
         $collection->filter($callable)->filter($callable);
+        $this->assertTrue(true);
     }
 }
-
-// phpcs:disable
-class stdMock extends stdClass
-{
-    public function __invoke() {}
-}
-// phpcs:enable

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -25,7 +25,6 @@ use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\Core\Configure;
-use Cake\Core\ConsoleApplicationInterface;
 use Cake\Event\EventManager;
 use Cake\Http\BaseApplication;
 use Cake\Http\MiddlewareQueue;
@@ -62,7 +61,7 @@ class CommandRunnerTest extends TestCase
     {
         parent::setUp();
         Configure::write('App.namespace', 'TestApp');
-        $this->config = dirname(__DIR__, 2);
+        $this->config = CONFIG;
     }
 
     /**
@@ -87,9 +86,7 @@ class CommandRunnerTest extends TestCase
      */
     public function testGetEventManagerNonEventedApplication(): void
     {
-        $app = $this->createMock(ConsoleApplicationInterface::class);
-
-        $runner = new CommandRunner($app);
+        $runner = $this->getRunner();
         $this->assertSame(EventManager::instance(), $runner->getEventManager());
     }
 
@@ -98,13 +95,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunInvalidCommand(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app);
+        $runner = $this->getRunner();
         $runner->run(['cake', 'nope', 'nope', 'nope'], $this->getMockIo($output));
 
         $messages = implode("\n", $output->messages());
@@ -120,13 +112,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunInvalidCommandWithSpecialCharacters(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app);
+        $runner = $this->getRunner();
         $runner->run(['cake', 's/pec[ial'], $this->getMockIo($output));
 
         $messages = implode("\n", $output->messages());
@@ -141,13 +128,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunInvalidCommandSuggestion(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app);
+        $runner = $this->getRunner();
         $runner->run(['cake', 'cache'], $this->getMockIo($output));
 
         $messages = implode("\n", $output->messages());
@@ -166,13 +148,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunHelpLongOption(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $result = $runner->run(['cake', '--help'], $this->getMockIo($output));
         $this->assertSame(0, $result);
         $messages = implode("\n", $output->messages());
@@ -186,13 +163,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunHelpShortOption(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $result = $runner->run(['cake', '-h'], $this->getMockIo($output));
         $this->assertSame(0, $result);
         $messages = implode("\n", $output->messages());
@@ -205,13 +177,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunNoCommand(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app);
+        $runner = $this->getRunner();
         $result = $runner->run(['cake'], $this->getMockIo($output));
 
         $this->assertSame(0, $result, 'help output is success.');
@@ -226,13 +193,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunVersionAlias(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $runner->run(['cake', '--version'], $this->getMockIo($output));
         $this->assertStringContainsString(Configure::version(), $output->messages()[0]);
     }
@@ -242,14 +204,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunValidCommand(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $result = $runner->run(['cake', 'routes'], $this->getMockIo($output));
         $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
 
@@ -263,14 +219,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunValidCommandInflection(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $result = $runner->run(['cake', 'schema_cache', 'build'], $this->getMockIo($output));
         $this->assertSame(CommandInterface::CODE_SUCCESS, $result);
 
@@ -426,13 +376,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunTriggersBuildCommandsEvent(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $runner->getEventManager()->on('Console.buildCommands', function ($event, $commands): void {
             $this->assertInstanceOf(CommandCollection::class, $commands);
             $this->eventTriggered = true;
@@ -446,13 +391,8 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunTriggersCommandEvents(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap', 'routes'])
-            ->setConstructorArgs([$this->config])
-            ->getMock();
-
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $startedEventTriggered = false;
         $finishedEventTriggered = false;
         $runner->getEventManager()->on('Command.beforeExecute', function ($event, $args) use (&$startedEventTriggered): void {
@@ -507,13 +447,9 @@ class CommandRunnerTest extends TestCase
      */
     public function testRunLoadsRoutes(): void
     {
-        $app = $this->getMockBuilder(BaseApplication::class)
-            ->onlyMethods(['middleware', 'bootstrap'])
-            ->setConstructorArgs([TEST_APP . 'config' . DS])
-            ->getMock();
-
+        $this->config = TEST_APP . 'config' . DS;
         $output = new StubConsoleOutput();
-        $runner = new CommandRunner($app, 'cake');
+        $runner = $this->getRunner();
         $runner->run(['cake', '--version'], $this->getMockIo($output));
         $this->assertGreaterThan(2, count(Router::getRouteCollection()->routes()));
     }
@@ -535,5 +471,29 @@ class CommandRunnerTest extends TestCase
         return Mockery::mock(ConsoleIo::class, [$output, $output, null, null])
             ->shouldAllowMockingMethod('in')
             ->makePartial();
+    }
+
+    protected function getRunner(): CommandRunner
+    {
+        $app = new class ($this->config) extends BaseApplication {
+            public function bootstrap(): void
+            {
+                parent::bootstrap();
+            }
+
+            public function console(CommandCollection $commands): CommandCollection
+            {
+                parent::console($commands);
+
+                return $commands;
+            }
+
+            public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+            {
+                return $middlewareQueue;
+            }
+        };
+
+        return new CommandRunner($app);
     }
 }

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -108,13 +108,17 @@ class CommandTest extends TestCase
      */
     public function testRunCallsInitialize(): void
     {
-        /** @var \Cake\Command\Command|\PHPUnit\Framework\MockObject\MockObject $command */
-        $command = $this->getMockBuilder(Command::class)
-            ->onlyMethods(['initialize'])
-            ->getMock();
+        $command = new class extends Command {
+            public bool $initializeCalled = false;
+
+            public function initialize(): void
+            {
+                $this->initializeCalled = true;
+            }
+        };
         $command->setName('cake example');
-        $command->expects($this->once())->method('initialize');
         $command->run([], $this->getMockIo(new StubConsoleOutput()));
+        $this->assertTrue($command->initializeCalled);
     }
 
     /**
@@ -191,14 +195,15 @@ class CommandTest extends TestCase
      */
     public function testRunOptionParserFailure(): void
     {
-        /** @var \Cake\Command\Command|\PHPUnit\Framework\MockObject\MockObject $command */
-        $command = $this->getMockBuilder(Command::class)
-            ->onlyMethods(['getOptionParser'])
-            ->getMock();
-        $parser = new ConsoleOptionParser('cake example');
-        $parser->addArgument('name', ['required' => true]);
+        $command = new class extends Command {
+            public function getOptionParser(): ConsoleOptionParser
+            {
+                $parser = new ConsoleOptionParser('cake example');
+                $parser->addArgument('name', ['required' => true]);
 
-        $command->method('getOptionParser')->willReturn($parser);
+                return $parser;
+            }
+        };
 
         $output = new StubConsoleOutput();
         $result = $command->run([], $this->getMockIo($output));


### PR DESCRIPTION
This will be one of many PR's where I will try to unmockify our testsuite (where its reasonably possible)

Also I am going to try and keep these PR's smaller so that its easier to review (and less chance for bigger discussion if I do something horrendous 😛)