### PR TITLE
fix stan

### DIFF
--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -157,7 +157,7 @@ class FormData implements Countable, Stringable
             if (stream_is_local($value)) {
                 $finfo = new finfo(FILEINFO_MIME);
                 $metadata = stream_get_meta_data($value);
-                $uri = $metadata['uri'] ?? '';
+                $uri = $metadata['uri'];
                 $contentType = (string)$finfo->file($uri);
                 $filename = basename($uri);
             }


### PR DESCRIPTION
This nullable check was previously added, [because stan didn't know](https://github.com/cakephp/cakephp/commit/f72707c266f57bc5579ab62c6ea7bec49924ac9d#diff-f4b9ed467107957ebecc2830a969bc45d5d6d16e0d43819b2c483677826371e8), that the `uri` from `stream_get_meta_data` is not nullable