### PR TITLE
Add PaginatedResultSet::toArray()

### DIFF
--- a/src/Datasource/Paging/PaginatedInterface.php
+++ b/src/Datasource/Paging/PaginatedInterface.php
@@ -69,6 +69,15 @@ interface PaginatedInterface extends Countable, Traversable
     public function hasNextPage(): bool;
 
     /**
+     * Get the paginated items as an array.
+     *
+     * This will exhaust the iterator `items`.
+     *
+     * @return array
+     */
+    public function toArray(): array;
+
+    /**
      * Get paginated items.
      *
      * @return iterable

--- a/src/Datasource/Paging/PaginatedInterface.php
+++ b/src/Datasource/Paging/PaginatedInterface.php
@@ -23,6 +23,7 @@ use Traversable;
  * This interface describes the methods for pagination instance.
  *
  * @template-extends \Traversable<mixed>
+ * @method array<mixed> toArray() Get the paginated items as an array
  */
 interface PaginatedInterface extends Countable, Traversable
 {
@@ -67,15 +68,6 @@ interface PaginatedInterface extends Countable, Traversable
      * @return bool
      */
     public function hasNextPage(): bool;
-
-    /**
-     * Get the paginated items as an array.
-     *
-     * This will exhaust the iterator `items`.
-     *
-     * @return array
-     */
-    public function toArray(): array;
 
     /**
      * Get paginated items.

--- a/src/Datasource/Paging/PaginatedResultSet.php
+++ b/src/Datasource/Paging/PaginatedResultSet.php
@@ -72,7 +72,7 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
      */
     public function toArray(): array
     {
-        return iterator_to_array($this->items());
+        return $this->jsonSerialize();
     }
 
     /**

--- a/src/Datasource/Paging/PaginatedResultSet.php
+++ b/src/Datasource/Paging/PaginatedResultSet.php
@@ -64,6 +64,18 @@ class PaginatedResultSet implements IteratorAggregate, JsonSerializable, Paginat
     }
 
     /**
+     * Get the paginated items as an array.
+     *
+     * This will exhaust the iterator `items`.
+     *
+     * @return array<array-key, T>
+     */
+    public function toArray(): array
+    {
+        return iterator_to_array($this->items());
+    }
+
+    /**
      * Get paginated items.
      *
      * @return \Traversable<T> The paginated items result set.

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource\Paging;
 
 use ArrayIterator;
+use Cake\Collection\Collection;
 use Cake\Datasource\Paging\PaginatedResultSet;
 use Cake\Datasource\ResultSetInterface;
 use Cake\TestSuite\TestCase;
@@ -33,6 +34,14 @@ class PaginatedResultSetTest extends TestCase
         );
 
         $this->assertInstanceOf(ResultSetInterface::class, $paginatedResults->items());
+    }
+
+    public function testToArray(): void
+    {
+        $paginatedResults = new PaginatedResultSet( new Collection([1, 2, 3]), []);
+
+        $out = $paginatedResults->toArray();
+        $this->assertSame([1, 2, 3], $out);
     }
 
     #[WithoutErrorHandler]

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -38,7 +38,7 @@ class PaginatedResultSetTest extends TestCase
 
     public function testToArray(): void
     {
-        $paginatedResults = new PaginatedResultSet( new Collection([1, 2, 3]), []);
+        $paginatedResults = new PaginatedResultSet(new Collection([1, 2, 3]), []);
 
         $out = $paginatedResults->toArray();
         $this->assertSame([1, 2, 3], $out);


### PR DESCRIPTION
This was giving me deprecation warnings that I felt were unnecessary toil for developers to fix. I couldn't easily find a rector method that would solve this and I think the ongoing maintenance cost of a one liner is low.
