### PR TITLE
5.next: unmockify the testsuite in database and datasource tests

### DIFF
--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -20,7 +20,6 @@ use Cake\Cache\Engine\NullEngine;
 use Cake\Core\App;
 use Cake\Database\Connection;
 use Cake\Database\Driver;
-use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlserver;
 use Cake\Database\Exception\MissingConnectionException;
 use Cake\Database\Exception\MissingDriverException;
@@ -32,6 +31,7 @@ use Cake\Database\Schema\Collection;
 use Cake\Database\StatementInterface;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
+use Cake\Test\TestCase\Database\Driver\BaseDriverTrait;
 use Cake\TestSuite\TestCase;
 use DateTime;
 use Error;
@@ -43,6 +43,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 use TestApp\Database\Driver\DisabledDriver;
 use TestApp\Database\Driver\RetryDriver;
+use TestApp\Database\Driver\StubDriver;
 use TestApp\Database\Driver\TestDriver;
 use TestPlugin\Database\Driver\TestDriver as PluginTestDriver;
 use function Cake\Core\namespaceSplit;
@@ -109,16 +110,13 @@ class ConnectionTest extends TestCase
      * Auxiliary method to build a mock for a driver so it can be injected into
      * the connection object
      *
-     * @return \Cake\Database\Driver|\PHPUnit\Framework\MockObject\MockObject
+     * @return \Cake\Database\Driver
      */
-    public function getMockFormDriver()
+    public function getDriver()
     {
-        $driver = $this->getMockBuilder(Driver::class)->getMock();
-        $driver->expects($this->once())
-            ->method('enabled')
-            ->willReturn(true);
-
-        return $driver;
+        return new class extends Driver {
+            use BaseDriverTrait;
+        };
     }
 
     /**
@@ -156,15 +154,17 @@ class ConnectionTest extends TestCase
     public function testDisabledDriver(): void
     {
         $this->expectException(MissingExtensionException::class);
-        $this->expectExceptionMessage(
-            'Database driver `DriverMock` cannot be used due to a missing PHP extension or unmet dependency. ' .
-            'Requested by connection `custom_connection_name`'
+        $this->expectExceptionMessageMatches(
+            '/Database driver `.+` cannot be used due to a missing PHP extension or unmet dependency\. ' .
+            'Requested by connection `custom_connection_name`/'
         );
-        $mock = $this->getMockBuilder(Mysql::class)
-            ->onlyMethods(['enabled'])
-            ->setMockClassName('DriverMock')
-            ->getMock();
-        new Connection(['driver' => $mock, 'name' => 'custom_connection_name']);
+        $driver = new class extends StubDriver {
+            public function enabled(): bool
+            {
+                return false;
+            }
+        };
+        new Connection(['driver' => $driver, 'name' => 'custom_connection_name']);
     }
 
     /**
@@ -653,7 +653,7 @@ class ConnectionTest extends TestCase
      */
     public function testDestructorWithUncommittedTransaction(): void
     {
-        $driver = $this->getMockFormDriver();
+        $driver = $this->getDriver();
         $connection = new Connection(['driver' => $driver]);
         $connection->begin();
         $this->assertTrue($connection->inTransaction());
@@ -871,19 +871,31 @@ class ConnectionTest extends TestCase
      */
     public function testTransactionalSuccess(): void
     {
-        $driver = $this->getMockFormDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['commit', 'begin'])
-            ->setConstructorArgs([['driver' => $driver]])
-            ->getMock();
-        $connection->expects($this->once())->method('begin');
-        $connection->expects($this->once())->method('commit');
+        $driver = $this->getDriver();
+        $connection = new class (['driver' => $driver]) extends Connection {
+            public bool $beginIsCalled = false;
+            public bool $commitIsCalled = false;
+
+            public function begin(): void
+            {
+                $this->beginIsCalled = true;
+            }
+
+            public function commit(): bool
+            {
+                $this->commitIsCalled = true;
+
+                return true;
+            }
+        };
         $result = $connection->transactional(function ($conn) use ($connection) {
             $this->assertSame($connection, $conn);
 
             return 'thing';
         });
         $this->assertSame('thing', $result);
+        $this->assertTrue($connection->beginIsCalled);
+        $this->assertTrue($connection->commitIsCalled);
     }
 
     /**
@@ -892,20 +904,36 @@ class ConnectionTest extends TestCase
      */
     public function testTransactionalFail(): void
     {
-        $driver = $this->getMockFormDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['commit', 'begin', 'rollback'])
-            ->setConstructorArgs([['driver' => $driver]])
-            ->getMock();
-        $connection->expects($this->once())->method('begin');
-        $connection->expects($this->once())->method('rollback');
-        $connection->expects($this->never())->method('commit');
+        $driver = $this->getDriver();
+        $connection = new class (['driver' => $driver]) extends Connection {
+            public bool $beginIsCalled = false;
+            public bool $rollbackIsCalled = false;
+
+            public function commit(): bool
+            {
+                throw new Exception('Should not be called');
+            }
+
+            public function begin(): void
+            {
+                $this->beginIsCalled = true;
+            }
+
+            public function rollback(?bool $toBeginning = null): bool
+            {
+                $this->rollbackIsCalled = true;
+
+                return true;
+            }
+        };
         $result = $connection->transactional(function ($conn) use ($connection) {
             $this->assertSame($connection, $conn);
 
             return false;
         });
         $this->assertFalse($result);
+        $this->assertTrue($connection->beginIsCalled);
+        $this->assertTrue($connection->rollbackIsCalled);
     }
 
     /**
@@ -917,18 +945,34 @@ class ConnectionTest extends TestCase
     public function testTransactionalWithException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $driver = $this->getMockFormDriver();
-        $connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['commit', 'begin', 'rollback'])
-            ->setConstructorArgs([['driver' => $driver]])
-            ->getMock();
-        $connection->expects($this->once())->method('begin');
-        $connection->expects($this->once())->method('rollback');
-        $connection->expects($this->never())->method('commit');
+        $driver = $this->getDriver();
+        $connection = new class (['driver' => $driver]) extends Connection {
+            public bool $beginIsCalled = false;
+            public bool $rollbackIsCalled = false;
+
+            public function commit(): bool
+            {
+                throw new Exception('Should not be called');
+            }
+
+            public function begin(): void
+            {
+                $this->beginIsCalled = true;
+            }
+
+            public function rollback(?bool $toBeginning = null): bool
+            {
+                $this->rollbackIsCalled = true;
+
+                return true;
+            }
+        };
         $connection->transactional(function ($conn) use ($connection): void {
             $this->assertSame($connection, $conn);
             throw new InvalidArgumentException();
         });
+        $this->assertTrue($connection->beginIsCalled);
+        $this->assertTrue($connection->rollbackIsCalled);
     }
 
     /**
@@ -936,15 +980,14 @@ class ConnectionTest extends TestCase
      */
     public function testSetSchemaCollection(): void
     {
-        $driver = $this->getMockFormDriver();
+        $driver = $this->getDriver();
         $connection = new Connection(['driver' => $driver]);
 
         $schema = $connection->getSchemaCollection();
         $this->assertInstanceOf(Collection::class, $schema);
 
-        $schema = $this->getMockBuilder(Collection::class)
-            ->setConstructorArgs([$connection])
-            ->getMock();
+        $schema = new class ($connection) extends Collection {
+        };
         $connection->setSchemaCollection($schema);
         $this->assertSame($schema, $connection->getSchemaCollection());
     }
@@ -954,7 +997,7 @@ class ConnectionTest extends TestCase
      */
     public function testGetCachedCollection(): void
     {
-        $driver = $this->getMockFormDriver();
+        $driver = $this->getDriver();
 
         $connection = new Connection([
             'driver' => $driver,
@@ -966,7 +1009,7 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf(CachedCollection::class, $schema);
         $this->assertSame('default_key', $schema->cacheKey('key'));
 
-        $driver = $this->getMockFormDriver();
+        $driver = $this->getDriver();
         $connection = new Connection([
             'driver' => $driver,
             'name' => 'default',

--- a/tests/TestCase/Database/Driver/BaseDriverTrait.php
+++ b/tests/TestCase/Database/Driver/BaseDriverTrait.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Database\Driver;
+
+use Cake\Database\DriverFeatureEnum;
+use Cake\Database\Schema\SchemaDialect;
+use Cake\Database\Schema\SqliteSchemaDialect;
+use Mockery;
+
+trait BaseDriverTrait
+{
+    public function connect(): void
+    {
+        $this->pdo = Mockery::mock('PDO')
+            ->shouldReceive('inTransaction', 'beginTransaction')
+            ->getMock();
+    }
+
+    public function enabled(): bool
+    {
+        return true;
+    }
+
+    public function disableForeignKeySQL(): string
+    {
+        return '';
+    }
+
+    public function enableForeignKeySQL(): string
+    {
+        return '';
+    }
+
+    public function schemaDialect(): SchemaDialect
+    {
+        return new SqliteSchemaDialect($this);
+    }
+
+    public function supports(DriverFeatureEnum $feature): bool
+    {
+        return true;
+    }
+}

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\Database\Driver;
 use Cake\Database\Type\DecimalType;
 use Cake\I18n\I18n;
+use Cake\Test\TestCase\Database\Driver\BaseDriverTrait;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
@@ -51,7 +52,9 @@ class DecimalTypeTest extends TestCase
     {
         parent::setUp();
         $this->type = new DecimalType();
-        $this->driver = $this->getMockBuilder(Driver::class)->getMock();
+        $this->driver = new class extends Driver {
+            use BaseDriverTrait;
+        };
         $this->numberClass = DecimalType::$numberClass;
     }
 

--- a/tests/TestCase/Datasource/FactoryLocatorTest.php
+++ b/tests/TestCase/Datasource/FactoryLocatorTest.php
@@ -19,6 +19,7 @@ use Cake\Datasource\FactoryLocator;
 use Cake\Datasource\Locator\LocatorInterface;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use TestApp\Datasource\StubFactory;
 
 /**
  * FactoryLocatorTest test case
@@ -49,8 +50,7 @@ class FactoryLocatorTest extends TestCase
      */
     public function testAdd(): void
     {
-        $locator = $this->getMockBuilder(LocatorInterface::class)->getMock();
-        FactoryLocator::add('MyType', $locator);
+        FactoryLocator::add('MyType', new StubFactory());
         $this->assertInstanceOf(LocatorInterface::class, FactoryLocator::get('MyType'));
     }
 

--- a/tests/TestCase/Datasource/ModelAwareTraitTest.php
+++ b/tests/TestCase/Datasource/ModelAwareTraitTest.php
@@ -122,13 +122,15 @@ class ModelAwareTraitTest extends TestCase
         $stub = new Stub();
         $stub->setProps('Articles');
 
-        $mock = $this->getMockBuilder(RepositoryInterface::class)->getMock();
-        $mock->expects($this->any())
-            ->method('getAlias')
-            ->willReturn('Magic');
+        $table = new class extends Table {
+            public function getAlias(): string
+            {
+                return 'Magic';
+            }
+        };
 
         $locator = new StubFactory();
-        $locator->set('Magic', $mock);
+        $locator->set('Magic', $table);
         $stub->modelFactory('Table', $locator);
 
         $result = $stub->fetchModel('Magic', 'Table');
@@ -136,11 +138,13 @@ class ModelAwareTraitTest extends TestCase
         $this->assertSame('Magic', $result->getAlias());
 
         $locator = new StubFactory();
-        $mock2 = $this->getMockBuilder(RepositoryInterface::class)->getMock();
-        $mock2->expects($this->any())
-            ->method('getAlias')
-            ->willReturn('Foo');
-        $locator->set('Foo', $mock2);
+        $table2 = new class extends Table {
+            public function getAlias(): string
+            {
+                return 'Foo';
+            }
+        };
+        $locator->set('Foo', $table2);
 
         $stub->modelFactory('MyType', $locator);
         $result = $stub->fetchModel('Foo', 'MyType');

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource\Paging;
 
 use ArrayIterator;
-use Cake\Collection\CollectionInterface;
 use Cake\Collection\Collection;
+use Cake\Collection\CollectionInterface;
 use Cake\Datasource\Paging\PaginatedResultSet;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\ResultSet;

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -17,8 +17,10 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Datasource\Paging;
 
 use ArrayIterator;
+use Cake\Collection\CollectionInterface;
 use Cake\Datasource\Paging\PaginatedResultSet;
 use Cake\Datasource\ResultSetInterface;
+use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use function Cake\Collection\collection;
@@ -27,8 +29,10 @@ class PaginatedResultSetTest extends TestCase
 {
     public function testItems(): void
     {
+        $resultSet = new class ([]) extends ResultSet {
+        };
         $paginatedResults = new PaginatedResultSet(
-            $this->getMockBuilder(ResultSetInterface::class)->getMock(),
+            $resultSet,
             []
         );
 
@@ -38,12 +42,12 @@ class PaginatedResultSetTest extends TestCase
     #[WithoutErrorHandler]
     public function testCall(): void
     {
-        $resultSet = $this->getMockBuilder(ResultSetInterface::class)->getMock();
-        $resultSet
-            ->expects($this->once())
-            ->method('extract')
-            ->with('foo')
-            ->willReturn(collection(['bar']));
+        $resultSet = new class ([]) extends ResultSet {
+            public function extract(callable|string $path): CollectionInterface
+            {
+                return collection(['bar']);
+            }
+        };
 
         $paginatedResults = new PaginatedResultSet(
             $resultSet,


### PR DESCRIPTION
Certain stub classes where already present, so I tried to reuse them