### PR TITLE
5.next: add new events hook to BaseApplication and BasePlugin

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,6 +71,11 @@ parameters:
 			path: src/Event/EventManager.php
 
 		-
+			message: "#^Call to an undefined method Cake\\\\Core\\\\PluginInterface\\:\\:events\\(\\)\\.$#"
+			count: 1
+			path: src/Http/BaseApplication.php
+
+		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Http/Client.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,6 +71,11 @@ parameters:
 			path: src/Event/EventManager.php
 
 		-
+			message: "#^Call to an undefined method Cake\\\\Core\\\\PluginInterface\\:\\:consoleEvents\\(\\)\\.$#"
+			count: 1
+			path: src/Http/BaseApplication.php
+
+		-
 			message: "#^Call to an undefined method Cake\\\\Core\\\\PluginInterface\\:\\:events\\(\\)\\.$#"
 			count: 1
 			path: src/Http/BaseApplication.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,11 +71,6 @@ parameters:
 			path: src/Event/EventManager.php
 
 		-
-			message: "#^Call to an undefined method Cake\\\\Core\\\\PluginInterface\\:\\:consoleEvents\\(\\)\\.$#"
-			count: 1
-			path: src/Http/BaseApplication.php
-
-		-
 			message: "#^Call to an undefined method Cake\\\\Core\\\\PluginInterface\\:\\:events\\(\\)\\.$#"
 			count: 1
 			path: src/Http/BaseApplication.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -53,6 +53,11 @@
       <code><![CDATA[EventInterface]]></code>
     </InvalidReturnType>
   </file>
+  <file src="src/Http/BaseApplication.php">
+    <UndefinedInterfaceMethod>
+      <code><![CDATA[events]]></code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="src/I18n/Date.php">
     <ImpureFunctionCall>
       <code><![CDATA[call_user_func(static::$_jsonEncodeFormat, $this)]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -55,7 +55,6 @@
   </file>
   <file src="src/Http/BaseApplication.php">
     <UndefinedInterfaceMethod>
-      <code><![CDATA[consoleEvents]]></code>
       <code><![CDATA[events]]></code>
     </UndefinedInterfaceMethod>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -55,6 +55,7 @@
   </file>
   <file src="src/Http/BaseApplication.php">
     <UndefinedInterfaceMethod>
+      <code><![CDATA[consoleEvents]]></code>
       <code><![CDATA[events]]></code>
     </UndefinedInterfaceMethod>
   </file>

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -320,8 +320,8 @@ class CommandRunner implements EventDispatcherInterface
     {
         try {
             $eventManager = $this->getEventManager();
-            $eventManager = $this->app->events($eventManager);
             $eventManager = $this->app->pluginEvents($eventManager);
+            $eventManager = $this->app->events($eventManager);
             $this->setEventManager($eventManager);
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -320,9 +320,9 @@ class CommandRunner implements EventDispatcherInterface
     {
         try {
             $eventManager = $this->getEventManager();
-            $eventManager = $this->app->consoleEvents($eventManager);
-            $eventManager = $this->app->pluginConsoleEvents($eventManager);
-            EventManager::instance($eventManager);
+            $eventManager = $this->app->events($eventManager);
+            $eventManager = $this->app->pluginEvents($eventManager);
+            $this->setEventManager($eventManager);
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());
             }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -319,6 +319,10 @@ class CommandRunner implements EventDispatcherInterface
     protected function runCommand(CommandInterface $command, array $argv, ConsoleIo $io): ?int
     {
         try {
+            $eventManager = $this->getEventManager();
+            $eventManager = $this->app->consoleEvents($eventManager);
+            $eventManager = $this->app->pluginConsoleEvents($eventManager);
+            EventManager::instance($eventManager);
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());
             }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -74,13 +74,6 @@ class BasePlugin implements PluginInterface
     protected bool $eventsEnabled = true;
 
     /**
-     * Load console events or not
-     *
-     * @var bool
-     */
-    protected bool $consoleEventsEnabled = true;
-
-    /**
      * The path to this plugin.
      *
      * @var string|null
@@ -325,15 +318,6 @@ class BasePlugin implements PluginInterface
      * @return \Cake\Event\EventManagerInterface
      */
     public function events(EventManagerInterface $eventsManager): EventManagerInterface
-    {
-        return $eventsManager;
-    }
-
-    /**
-     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
-     * @return \Cake\Event\EventManagerInterface
-     */
-    public function consoleEvents(EventManagerInterface $eventsManager): EventManagerInterface
     {
         return $eventsManager;
     }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Core;
 
 use Cake\Console\CommandCollection;
+use Cake\Event\EventManagerInterface;
 use Cake\Http\MiddlewareQueue;
 use Cake\Routing\RouteBuilder;
 use Closure;
@@ -64,6 +65,13 @@ class BasePlugin implements PluginInterface
      * @var bool
      */
     protected bool $routesEnabled = true;
+
+    /**
+     * Load events or not
+     *
+     * @var bool
+     */
+    protected bool $eventsEnabled = true;
 
     /**
      * The path to this plugin.
@@ -301,5 +309,16 @@ class BasePlugin implements PluginInterface
      */
     public function services(ContainerInterface $container): void
     {
+    }
+
+    /**
+     * Register application events.
+     *
+     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    {
+        return $eventsManager;
     }
 }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -314,11 +314,11 @@ class BasePlugin implements PluginInterface
     /**
      * Register application events.
      *
-     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
+     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
      * @return \Cake\Event\EventManagerInterface
      */
-    public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
-        return $eventsManager;
+        return $eventManager;
     }
 }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -74,6 +74,13 @@ class BasePlugin implements PluginInterface
     protected bool $eventsEnabled = true;
 
     /**
+     * Load console events or not
+     *
+     * @var bool
+     */
+    protected bool $consoleEventsEnabled = true;
+
+    /**
      * The path to this plugin.
      *
      * @var string|null
@@ -318,6 +325,15 @@ class BasePlugin implements PluginInterface
      * @return \Cake\Event\EventManagerInterface
      */
     public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    {
+        return $eventsManager;
+    }
+
+    /**
+     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function consoleEvents(EventManagerInterface $eventsManager): EventManagerInterface
     {
         return $eventsManager;
     }

--- a/src/Core/ConsoleApplicationInterface.php
+++ b/src/Core/ConsoleApplicationInterface.php
@@ -21,8 +21,8 @@ use Cake\Console\CommandCollection;
  * An interface defining the methods that the
  * console runner depend on.
  *
- * @method consoleEvents(\Cake\Event\EventManagerInterface $eventManager)
- * @method pluginConsoleEvents(\Cake\Event\EventManagerInterface $eventManager)
+ * @method events(\Cake\Event\EventManagerInterface $eventManager)
+ * @method pluginEvents(\Cake\Event\EventManagerInterface $eventManager)
  */
 interface ConsoleApplicationInterface
 {

--- a/src/Core/ConsoleApplicationInterface.php
+++ b/src/Core/ConsoleApplicationInterface.php
@@ -20,6 +20,9 @@ use Cake\Console\CommandCollection;
 /**
  * An interface defining the methods that the
  * console runner depend on.
+ *
+ * @method consoleEvents(\Cake\Event\EventManagerInterface $eventManager)
+ * @method pluginConsoleEvents(\Cake\Event\EventManagerInterface $eventManager)
  */
 interface ConsoleApplicationInterface
 {

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -28,7 +28,7 @@ interface PluginInterface
      *
      * @var list<string>
      */
-    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services', 'events', 'consoleEvents'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services', 'events'];
 
     /**
      * Get the name of this plugin.

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -28,7 +28,7 @@ interface PluginInterface
      *
      * @var list<string>
      */
-    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services', 'events'];
 
     /**
      * Get the name of this plugin.

--- a/src/Core/PluginInterface.php
+++ b/src/Core/PluginInterface.php
@@ -28,7 +28,7 @@ interface PluginInterface
      *
      * @var list<string>
      */
-    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services', 'events'];
+    public const VALID_HOOKS = ['bootstrap', 'console', 'middleware', 'routes', 'services', 'events', 'consoleEvents'];
 
     /**
      * Get the name of this plugin.

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -345,9 +345,10 @@ abstract class BaseApplication implements
         $container->add(ServerRequest::class, $request);
         $container->add(ContainerInterface::class, $container);
 
+        $eventsManager = EventManager::instance();
+        $eventsManager = $this->pluginEvents($eventsManager);
         /** @var \Cake\Event\EventManager $eventsManager */
-        $eventsManager = $this->events(EventManager::instance());
-        $this->pluginEvents($eventsManager);
+        $eventsManager = $this->events($eventsManager);
         EventManager::instance($eventsManager);
 
         $this->controllerFactory ??= new ControllerFactory($container);

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -320,12 +320,12 @@ abstract class BaseApplication implements
     /**
      * Register application events.
      *
-     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
+     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
      * @return \Cake\Event\EventManagerInterface
      */
-    public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
-        return $eventsManager;
+        return $eventManager;
     }
 
     /**
@@ -345,11 +345,8 @@ abstract class BaseApplication implements
         $container->add(ServerRequest::class, $request);
         $container->add(ContainerInterface::class, $container);
 
-        $eventsManager = EventManager::instance();
-        $eventsManager = $this->pluginEvents($eventsManager);
-        /** @var \Cake\Event\EventManager $eventsManager */
-        $eventsManager = $this->events($eventsManager);
-        EventManager::instance($eventsManager);
+        $eventManager = $this->pluginEvents($this->getEventManager());
+        $this->setEventManager($this->events($eventManager));
 
         $this->controllerFactory ??= new ControllerFactory($container);
 

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -258,6 +258,19 @@ abstract class BaseApplication implements
     }
 
     /**
+     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function pluginEvents(EventManagerInterface $eventManager): EventManagerInterface
+    {
+        foreach ($this->plugins->with('events') as $plugin) {
+            $eventManager = $plugin->events($eventManager);
+        }
+
+        return $eventManager;
+    }
+
+    /**
      * Get the dependency injection container for the application.
      *
      * The first time the container is fetched it will be constructed
@@ -305,6 +318,17 @@ abstract class BaseApplication implements
     }
 
     /**
+     * Register application events.
+     *
+     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    {
+        return $eventsManager;
+    }
+
+    /**
      * Invoke the application.
      *
      * - Add the request to the container, enabling its injection into other services.
@@ -320,6 +344,11 @@ abstract class BaseApplication implements
         $container = $this->getContainer();
         $container->add(ServerRequest::class, $request);
         $container->add(ContainerInterface::class, $container);
+
+        /** @var \Cake\Event\EventManager $eventsManager */
+        $eventsManager = $this->events(EventManager::instance());
+        $this->pluginEvents($eventsManager);
+        EventManager::instance($eventsManager);
 
         $this->controllerFactory ??= new ControllerFactory($container);
 

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -271,19 +271,6 @@ abstract class BaseApplication implements
     }
 
     /**
-     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
-     * @return \Cake\Event\EventManagerInterface
-     */
-    public function pluginConsoleEvents(EventManagerInterface $eventManager): EventManagerInterface
-    {
-        foreach ($this->plugins->with('consoleEvents') as $plugin) {
-            $eventManager = $plugin->consoleEvents($eventManager);
-        }
-
-        return $eventManager;
-    }
-
-    /**
      * Get the dependency injection container for the application.
      *
      * The first time the container is fetched it will be constructed
@@ -337,15 +324,6 @@ abstract class BaseApplication implements
      * @return \Cake\Event\EventManagerInterface
      */
     public function events(EventManagerInterface $eventsManager): EventManagerInterface
-    {
-        return $eventsManager;
-    }
-
-    /**
-     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
-     * @return \Cake\Event\EventManagerInterface
-     */
-    public function consoleEvents(EventManagerInterface $eventsManager): EventManagerInterface
     {
         return $eventsManager;
     }

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -271,6 +271,19 @@ abstract class BaseApplication implements
     }
 
     /**
+     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function pluginConsoleEvents(EventManagerInterface $eventManager): EventManagerInterface
+    {
+        foreach ($this->plugins->with('consoleEvents') as $plugin) {
+            $eventManager = $plugin->consoleEvents($eventManager);
+        }
+
+        return $eventManager;
+    }
+
+    /**
      * Get the dependency injection container for the application.
      *
      * The first time the container is fetched it will be constructed
@@ -324,6 +337,15 @@ abstract class BaseApplication implements
      * @return \Cake\Event\EventManagerInterface
      */
     public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    {
+        return $eventsManager;
+    }
+
+    /**
+     * @param \Cake\Event\EventManagerInterface $eventsManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function consoleEvents(EventManagerInterface $eventsManager): EventManagerInterface
     {
         return $eventsManager;
     }

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -215,13 +215,13 @@ class BasePluginTest extends TestCase
 
         $basePlugin = new class extends BasePlugin
         {
-            public function events(EventManagerInterface $eventsManager): EventManagerInterface
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventsManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', function ($event) {
                     return true;
                 });
 
-                return $eventsManager;
+                return $eventManager;
             }
         };
 
@@ -242,13 +242,13 @@ class BasePluginTest extends TestCase
         static::setAppNamespace();
         $basePlugin = new class extends BasePlugin
         {
-            public function events(EventManagerInterface $eventsManager): EventManagerInterface
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventsManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', function ($event) {
                     return true;
                 });
 
-                return $eventsManager;
+                return $eventManager;
             }
         };
 

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -242,7 +242,7 @@ class BasePluginTest extends TestCase
         static::setAppNamespace();
         $basePlugin = new class extends BasePlugin
         {
-            public function consoleEvents(EventManagerInterface $eventsManager): EventManagerInterface
+            public function events(EventManagerInterface $eventsManager): EventManagerInterface
             {
                 $eventsManager->on('testTrue', function ($event) {
                     return true;

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -93,7 +93,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
             ],
             'OtherPlugin' => [
                 'isLoaded' => true,
@@ -106,7 +105,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
             ],
         ];
         $this->assertSame($result, PluginConfig::getAppConfig());
@@ -145,7 +143,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
             ],
             'OtherPlugin' => [
                 'isLoaded' => false,
@@ -171,7 +168,7 @@ PHP;
 <?php
 return [
     'OtherPlugin' => ['onlyDebug' => true, 'onlyCli' => false, 'optional' => true],
-    'AnotherPlugin' => ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false, 'events' => false, 'consoleEvents' => false],
+    'AnotherPlugin' => ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false, 'events' => false],
 ];
 PHP;
         file_put_contents($this->pluginsConfigPath, $config);
@@ -188,7 +185,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
             ],
             'AnotherPlugin' => [
                 'isLoaded' => true,
@@ -201,7 +197,6 @@ PHP;
                 'routes' => false,
                 'services' => false,
                 'events' => false,
-                'consoleEvents' => false,
             ],
         ];
         $this->assertSame($result, PluginConfig::getAppConfig());
@@ -319,7 +314,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
                 'packagePath' => $pathToRootVendor . 'cakephp' . DS . 'chronos',
                 'package' => 'cakephp/chronos',
                 'version' => '3.0.4',
@@ -336,7 +330,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
                 'packagePath' => $pathToRootVendor . 'cakephp' . DS . 'cakephp-codesniffer',
                 'package' => 'cakephp/cakephp-codesniffer',
                 'version' => '5.1.1',
@@ -391,7 +384,6 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
-                'consoleEvents' => true,
             ],
         ], PluginConfig::getAppConfig());
         unlink($pathToTestPlugin . 'composer.json');

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -92,6 +92,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
             ],
             'OtherPlugin' => [
                 'isLoaded' => true,
@@ -103,6 +104,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
             ],
         ];
         $this->assertSame($result, PluginConfig::getAppConfig());
@@ -140,6 +142,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
             ],
             'OtherPlugin' => [
                 'isLoaded' => false,
@@ -165,7 +168,7 @@ PHP;
 <?php
 return [
     'OtherPlugin' => ['onlyDebug' => true, 'onlyCli' => false, 'optional' => true],
-    'AnotherPlugin' => ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false]
+    'AnotherPlugin' => ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false, 'events' => false],
 ];
 PHP;
         file_put_contents($this->pluginsConfigPath, $config);
@@ -181,6 +184,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
             ],
             'AnotherPlugin' => [
                 'isLoaded' => true,
@@ -192,6 +196,7 @@ PHP;
                 'middleware' => false,
                 'routes' => false,
                 'services' => false,
+                'events' => false,
             ],
         ];
         $this->assertSame($result, PluginConfig::getAppConfig());
@@ -308,6 +313,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
                 'packagePath' => $pathToRootVendor . 'cakephp' . DS . 'chronos',
                 'package' => 'cakephp/chronos',
                 'version' => '3.0.4',
@@ -323,6 +329,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
                 'packagePath' => $pathToRootVendor . 'cakephp' . DS . 'cakephp-codesniffer',
                 'package' => 'cakephp/cakephp-codesniffer',
                 'version' => '5.1.1',
@@ -376,6 +383,7 @@ PHP;
                 'middleware' => true,
                 'routes' => true,
                 'services' => true,
+                'events' => true,
             ],
         ], PluginConfig::getAppConfig());
         unlink($pathToTestPlugin . 'composer.json');

--- a/tests/TestCase/Core/PluginConfigTest.php
+++ b/tests/TestCase/Core/PluginConfigTest.php
@@ -93,6 +93,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
             ],
             'OtherPlugin' => [
                 'isLoaded' => true,
@@ -105,6 +106,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
             ],
         ];
         $this->assertSame($result, PluginConfig::getAppConfig());
@@ -143,6 +145,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
             ],
             'OtherPlugin' => [
                 'isLoaded' => false,
@@ -168,7 +171,7 @@ PHP;
 <?php
 return [
     'OtherPlugin' => ['onlyDebug' => true, 'onlyCli' => false, 'optional' => true],
-    'AnotherPlugin' => ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false, 'events' => false],
+    'AnotherPlugin' => ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false, 'events' => false, 'consoleEvents' => false],
 ];
 PHP;
         file_put_contents($this->pluginsConfigPath, $config);
@@ -185,6 +188,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
             ],
             'AnotherPlugin' => [
                 'isLoaded' => true,
@@ -197,6 +201,7 @@ PHP;
                 'routes' => false,
                 'services' => false,
                 'events' => false,
+                'consoleEvents' => false,
             ],
         ];
         $this->assertSame($result, PluginConfig::getAppConfig());
@@ -314,6 +319,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
                 'packagePath' => $pathToRootVendor . 'cakephp' . DS . 'chronos',
                 'package' => 'cakephp/chronos',
                 'version' => '3.0.4',
@@ -330,6 +336,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
                 'packagePath' => $pathToRootVendor . 'cakephp' . DS . 'cakephp-codesniffer',
                 'package' => 'cakephp/cakephp-codesniffer',
                 'version' => '5.1.1',
@@ -384,6 +391,7 @@ PHP;
                 'routes' => true,
                 'services' => true,
                 'events' => true,
+                'consoleEvents' => true,
             ],
         ], PluginConfig::getAppConfig());
         unlink($pathToTestPlugin . 'composer.json');

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -318,7 +318,7 @@ class BaseApplicationTest extends TestCase
                 return $middlewareQueue;
             }
 
-            public function consoleEvents(EventManagerInterface $eventsManager): EventManagerInterface
+            public function events(EventManagerInterface $eventsManager): EventManagerInterface
             {
                 $eventsManager->on('testTrue', function ($event) {
                     return true;

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -60,13 +60,13 @@ class BaseApplicationTest extends TestCase
                 return $middlewareQueue;
             }
 
-            public function events(EventManagerInterface $eventsManager): EventManagerInterface
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventsManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', function ($event) {
                     return true;
                 });
 
-                return $eventsManager;
+                return $eventManager;
             }
         };
     }
@@ -318,13 +318,13 @@ class BaseApplicationTest extends TestCase
                 return $middlewareQueue;
             }
 
-            public function events(EventManagerInterface $eventsManager): EventManagerInterface
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
-                $eventsManager->on('testTrue', function ($event) {
+                $eventManager->on('testTrue', function ($event) {
                     return true;
                 });
 
-                return $eventsManager;
+                return $eventManager;
             }
         };
         $output = new StubConsoleOutput();

--- a/tests/test_app/Plugin/TestPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Plugin.php
@@ -21,12 +21,12 @@ use Cake\Http\MiddlewareQueue;
 
 class Plugin extends BasePlugin
 {
-    public function events(EventManagerInterface $events): EventManagerInterface
+    public function events(EventManagerInterface $event): EventManagerInterface
     {
-        $events->on('TestPlugin.load', function (): void {
+        $event->on('TestPlugin.load', function (): void {
         });
 
-        return $events;
+        return $event;
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue

--- a/tests/test_app/TestApp/Http/EventApplication.php
+++ b/tests/test_app/TestApp/Http/EventApplication.php
@@ -22,12 +22,12 @@ use TestApp\Command\DemoCommand;
 
 class EventApplication extends BaseApplication
 {
-    public function events(EventManagerInterface $eventManager): EventManagerInterface
+    public function events(EventManagerInterface $eventsManager): EventManagerInterface
     {
-        $eventManager->on('My.event', function (): void {
+        $eventsManager->on('My.event', function (): void {
         });
 
-        return $eventManager;
+        return $eventsManager;
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue

--- a/tests/test_app/TestApp/Http/EventApplication.php
+++ b/tests/test_app/TestApp/Http/EventApplication.php
@@ -22,12 +22,12 @@ use TestApp\Command\DemoCommand;
 
 class EventApplication extends BaseApplication
 {
-    public function events(EventManagerInterface $eventsManager): EventManagerInterface
+    public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
-        $eventsManager->on('My.event', function (): void {
+        $eventManager->on('My.event', function (): void {
         });
 
-        return $eventsManager;
+        return $eventManager;
     }
 
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/17694

This is my crude first implementation of what was discussed in the issue above.

---

One question I would like to ask here is: How much do we want to intergrate the DIC into this events setup system as well?

Technically each app/plugin can currently also just call 
```
$container = $this->getContainer();
$listener = $container->get(MyCustomListener::class);
$eventsManager->on($listener);
```
to leverage the DIC for event listener constructors but this seems a bit clunky.

---

Also this only set's up events for web requests, not commands. I guess events should also be setup for console operations. Or should we seperate those 2 setup calls for users?