### PR TITLE
Shorten paths in error logs

### DIFF
--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -324,7 +324,7 @@ class Debugger
      *
      * - `depth` - The number of stack frames to return. Defaults to 999
      * - `format` - The format you want the return. Defaults to the currently selected format. If
-     *    format is 'array' or 'points' the return will be an array.
+     *    format is 'array', 'points', or 'shortPoints' the return will be an array.
      * - `args` - Should arguments for functions be shown? If true, the arguments for each method call
      *   will be displayed.
      * - `start` - The stack frame to start generating a trace from. Defaults to 0
@@ -349,7 +349,7 @@ class Debugger
      *
      * - `depth` - The number of stack frames to return. Defaults to 999
      * - `format` - The format you want the return. Defaults to 'text'. If
-     *    format is 'array' or 'points' the return will be an array.
+     *    format is 'array', 'points', or 'shortPoints' the return will be an array.
      * - `args` - Should arguments for functions be shown? If true, the arguments for each method call
      *   will be displayed.
      * - `start` - The stack frame to start generating a trace from. Defaults to 0
@@ -372,6 +372,7 @@ class Debugger
             'start' => 0,
             'scope' => null,
             'exclude' => ['call_user_func_array', 'trigger_error'],
+            'shortPath' => false,
         ];
         $options = Hash::merge($defaults, $options);
 
@@ -400,7 +401,13 @@ class Debugger
             if (in_array($signature, $options['exclude'], true)) {
                 continue;
             }
-            if ($options['format'] === 'points') {
+            if ($options['format'] === 'shortPoints') {
+                $back[] = [
+                    'file' => self::trimPath($frame['file']),
+                    'line' => $frame['line'],
+                    'reference' => $reference,
+                ];
+            } elseif ($options['format'] === 'points') {
                 $back[] = ['file' => $frame['file'], 'line' => $frame['line'], 'reference' => $reference];
             } elseif ($options['format'] === 'array') {
                 if (!$options['args']) {
@@ -417,7 +424,7 @@ class Debugger
                 );
             }
         }
-        if ($options['format'] === 'array' || $options['format'] === 'points') {
+        if (in_array($options['format'], ['array', 'points', 'shortPoints'])) {
             return $back;
         }
 

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -129,7 +129,7 @@ class ErrorLogger implements ErrorLoggerInterface
         }
 
         if ($includeTrace) {
-            $trace = Debugger::formatTrace($exception, ['format' => 'points']);
+            $trace = Debugger::formatTrace($exception, ['format' => 'shortPoints']);
             assert(is_array($trace));
             $message .= "\nStack Trace:\n";
             foreach ($trace as $line) {

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -605,7 +605,11 @@ TEXT;
     {
         $result = Debugger::trace(['format' => 'shortPoints']);
         $this->assertIsArray($result);
-        $this->assertEquals('CORE/vendor/phpunit/phpunit/src/Framework/TestCase.php', $result[0]['file']);
+        $this->assertEquals(
+            'CORE' . DS . 'vendor' . DS . 'phpunit' . DS . 'phpunit' . DS . 'src' . DS .
+                'Framework' . DS . 'TestCase.php',
+            $result[0]['file']
+        );
     }
 
     protected function _makeException(): RuntimeException

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -601,6 +601,13 @@ TEXT;
         $this->assertDoesNotMatchRegularExpression('/^Cake\\\Test\\\TestCase\\\Error\\\DebuggerTest..testTraceExclude/m', $result);
     }
 
+    public function testTraceShortPoints(): void
+    {
+        $result = Debugger::trace(['format' => 'shortPoints']);
+        $this->assertIsArray($result);
+        $this->assertEquals('CORE/vendor/phpunit/phpunit/src/Framework/TestCase.php', $result[0]['file']);
+    }
+
     protected function _makeException(): RuntimeException
     {
         return new RuntimeException('testing');


### PR DESCRIPTION
Switch to using application relative paths in log messages.  There are a few other places we generate stacktraces but those are currently using `Exception::getTraceAsString()`. If this doesn't address the problem with logging, I can revise those call sites as well.

Fixes #17671