### PR TITLE
Allow specifying key when emitting intermediate value for MapReduce

### DIFF
--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -144,11 +144,18 @@ class MapReduce implements IteratorAggregate
      *
      * @param mixed $val The record itself to store in the bucket
      * @param mixed $bucket the name of the bucket where to put the record
+     * @param mixed $key An optional key to assign to the value
      * @return void
      */
-    public function emitIntermediate(mixed $val, mixed $bucket): void
+    public function emitIntermediate(mixed $val, mixed $bucket, mixed $key = null): void
     {
-        $this->_intermediate[$bucket][] = $val;
+        if ($key === null) {
+            $this->_intermediate[$bucket][] = $val;
+
+            return;
+        }
+
+        $this->_intermediate[$bucket][$key] = $val;
     }
 
     /**


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
