### PR TITLE
Allow preserving keys when using select loaders.

### DIFF
--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -485,16 +485,25 @@ class SelectLoader
             $this->bindingKey;
         $key = (array)$keys;
 
-        foreach ($fetchQuery->all() as $result) {
+        $preserveKeys = $fetchQuery->getOptions()['preserveKeys'] ?? false;
+
+        foreach ($fetchQuery->all() as $i => $result) {
             $values = [];
             foreach ($key as $k) {
                 $values[] = $result[$k];
             }
+
             if ($singleResult) {
                 $resultMap[implode(';', $values)] = $result;
-            } else {
-                $resultMap[implode(';', $values)][] = $result;
+                continue;
             }
+
+            if ($preserveKeys) {
+                $resultMap[implode(';', $values)][$i] = $result;
+                continue;
+            }
+
+            $resultMap[implode(';', $values)][] = $result;
         }
 
         return $resultMap;

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -178,8 +178,9 @@ class SelectWithPivotLoader extends SelectLoader
     {
         $resultMap = [];
         $key = (array)$options['foreignKey'];
+        $preserveKeys = $fetchQuery->getOptions()['preserveKeys'] ?? false;
 
-        foreach ($fetchQuery->all() as $result) {
+        foreach ($fetchQuery->all() as $i => $result) {
             if (!isset($result[$this->junctionProperty])) {
                 throw new DatabaseException(sprintf(
                     '`%s` is missing from the belongsToMany results. Results cannot be created.',
@@ -191,6 +192,12 @@ class SelectWithPivotLoader extends SelectLoader
             foreach ($key as $k) {
                 $values[] = $result[$this->junctionProperty][$k];
             }
+
+            if ($preserveKeys) {
+                $resultMap[implode(';', $values)][$i] = $result;
+                continue;
+            }
+
             $resultMap[implode(';', $values)][] = $result;
         }
 

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -16,6 +16,7 @@ namespace TestApp\Model\Table;
 
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
+use Cake\Utility\Text;
 
 /**
  * Article table class
@@ -67,6 +68,15 @@ class ArticlesTable extends Table
         }
 
         return $query;
+    }
+
+    public function findSlugged(SelectQuery $query): SelectQuery
+    {
+        return $query->formatResults(function ($results) {
+            return $results->indexBy(function ($row) {
+                return Text::slug($row['title']);
+            });
+        });
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
  */
 namespace TestApp\Model\Table;
 
+use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
+use Cake\Utility\Text;
 
 /**
  * Tag table class
@@ -26,5 +28,15 @@ class TagsTable extends Table
         $this->belongsTo('Authors');
         $this->belongsToMany('Articles');
         $this->hasMany('ArticlesTags', ['propertyName' => 'extraInfo']);
+    }
+
+    public function findSlugged(SelectQuery $query): SelectQuery
+    {
+        return $query->applyOptions(['preserveKeys' => true])
+            ->formatResults(function ($results) {
+                return $results->indexBy(function ($record) {
+                    return Text::slug($record->name);
+                });
+            });
     }
 }


### PR DESCRIPTION
Setting the `preserveKeys` option for the association's finder query now preserves the record keys when populating the associated records array for the parent records.

Refs #10118

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
