### PR TITLE
Allow preserving keys when using Collection::groupBy().

### DIFF
--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -668,6 +668,30 @@ class CollectionTest extends TestCase
         $this->assertEquals($expected, iterator_to_array($grouped));
     }
 
+    public function testGroupByPreserveIndex(): void
+    {
+        $items = [
+            'first' => ['name' => 'foo', 'type' => 'a'],
+            'second' => ['name' => 'bar', 'type' => 'b'],
+            'third' => ['name' => 'baz', 'type' => 'b'],
+            'fourth' => ['name' => 'aah', 'type' => 'a'],
+        ];
+
+        $collection = new Collection($items);
+        $grouped = $collection->groupBy('type', true);
+        $expected = [
+            'a' => [
+                'first' => ['name' => 'foo', 'type' => 'a'],
+                'fourth' => ['name' => 'aah', 'type' => 'a'],
+            ],
+            'b' => [
+                'second' => ['name' => 'bar', 'type' => 'b'],
+                'third' => ['name' => 'baz', 'type' => 'b'],
+            ],
+        ];
+        $this->assertEquals($expected, iterator_to_array($grouped));
+    }
+
     /**
      * Tests grouping by a deep key
      */


### PR DESCRIPTION
Refs #17870

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
