### PR TITLE
Fix BehaviorRegistry::unload() for camelcase methods

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -216,12 +216,12 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         $instance = $this->get($name);
         $result = parent::unload($name);
 
-        $methods = $instance->implementedMethods();
-        foreach ($methods as $method) {
+        $methods = array_change_key_case($instance->implementedMethods());
+        foreach (array_keys($methods) as $method) {
             unset($this->_methodMap[$method]);
         }
-        $finders = $instance->implementedFinders();
-        foreach ($finders as $finder) {
+        $finders = array_change_key_case($instance->implementedFinders());
+        foreach (array_keys($finders) as $finder) {
             unset($this->_finderMap[$finder]);
         }
 

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -282,20 +282,12 @@ class BehaviorRegistryTest extends TestCase
     public function testCallFinder(): void
     {
         $this->Behaviors->load('Sluggable');
-        $mockedBehavior = $this->getMockBuilder('Cake\ORM\Behavior')
-            ->addMethods(['findNoSlug'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->Behaviors->set('Sluggable', $mockedBehavior);
 
         $query = new Query($this->Table->getConnection(), $this->Table);
-        $mockedBehavior
-            ->expects($this->once())
-            ->method('findNoSlug')
-            ->with($query, [])
-            ->will($this->returnValue($query));
         $return = $this->Behaviors->callFinder('noSlug', [$query, []]);
         $this->assertSame($query, $return);
+        $sql = $query->sql();
+        $this->assertMatchesRegularExpression('/slug[^ ]+ IS NULL/', $sql);
     }
 
     /**
@@ -319,9 +311,11 @@ class BehaviorRegistryTest extends TestCase
         $this->Behaviors->load('Sluggable');
 
         $this->assertTrue($this->Behaviors->hasMethod('slugify'));
+        $this->assertTrue($this->Behaviors->hasMethod('camelCase'));
         $this->Behaviors->unload('Sluggable');
 
         $this->assertFalse($this->Behaviors->hasMethod('slugify'), 'should not have method anymore');
+        $this->assertFalse($this->Behaviors->hasMethod('camelCase'), 'should not have method anymore');
         $this->Behaviors->call('slugify');
     }
 
@@ -336,8 +330,8 @@ class BehaviorRegistryTest extends TestCase
         $this->assertTrue($this->Behaviors->hasFinder('noSlug'));
         $this->Behaviors->unload('Sluggable');
 
-        $this->Behaviors->callFinder('noSlug');
         $this->assertFalse($this->Behaviors->hasFinder('noSlug'));
+        $this->Behaviors->callFinder('noSlug');
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Behavior/SluggableBehavior.php
+++ b/tests/test_app/TestApp/Model/Behavior/SluggableBehavior.php
@@ -27,7 +27,7 @@ use Cake\Utility\Text;
 
 class SluggableBehavior extends Behavior
 {
-    public function beforeFind(EventInterface $event, Query $query, array $options = []): Query
+    public function beforeFind(EventInterface $event, Query $query, $options = []): Query
     {
         $query->where(['slug' => 'test']);
 
@@ -44,5 +44,10 @@ class SluggableBehavior extends Behavior
     public function slugify(string $value): string
     {
         return Text::slug($value);
+    }
+
+    public function camelCase(): string
+    {
+        return 'camelCase';
     }
 }


### PR DESCRIPTION
I missed a case in the previous fix/backport. I'll port these changes to 5.x after this merges.

Refs #17697
