### PR TITLE
Remove phpstan as dev dependency from split packages.

### DIFF
--- a/contrib/validate-split-packages-phpstan.php
+++ b/contrib/validate-split-packages-phpstan.php
@@ -38,6 +38,10 @@ foreach ($iterator as $file) {
 }
 ksort($packages);
 
+$mainJsonContent = file_get_contents(dirname(__FILE__, 2) . DS . 'composer.json');
+$mainJson = json_decode($mainJsonContent, true);
+$composerCommand = 'composer require --dev phpstan/phpstan:' . $mainJson['require-dev']['phpstan/phpstan'];
+
 $issues = [];
 foreach ($packages as $path => $package) {
     if (!file_exists($path . 'phpstan.neon.dist')) {
@@ -45,7 +49,11 @@ foreach ($packages as $path => $package) {
     }
 
     $exitCode = null;
-    exec('cd ' . $path . ' && composer install && vendor/bin/phpstan analyze ./', $output, $exitCode);
+    exec(
+        'cd ' . $path . ' && ' . $composerCommand . ' && vendor/bin/phpstan analyze ./',
+        $output,
+        $exitCode
+    );
     if ($exitCode !== 0) {
         $code = $exitCode;
 

--- a/src/Database/composer.json
+++ b/src/Database/composer.json
@@ -41,7 +41,6 @@
     },
     "require-dev": {
         "cakephp/i18n": "^5.0",
-        "cakephp/log": "^5.0",
-        "phpstan/phpstan": "1.12.0"
+        "cakephp/log": "^5.0"
     }
 }

--- a/src/Datasource/composer.json
+++ b/src/Datasource/composer.json
@@ -41,7 +41,6 @@
     "require-dev": {
         "cakephp/cache": "^5.0",
         "cakephp/collection": "^5.0",
-        "cakephp/utility": "^5.0",
-        "phpstan/phpstan": "1.12.0"
+        "cakephp/utility": "^5.0"
     }
 }

--- a/src/Http/composer.json
+++ b/src/Http/composer.json
@@ -59,7 +59,6 @@
         "cakephp/console": "^5.0",
         "cakephp/orm": "^5.0",
         "cakephp/i18n": "^5.0",
-        "paragonie/csp-builder": "^2.3",
-        "phpstan/phpstan": "1.12.0"
+        "paragonie/csp-builder": "^2.3"
     }
 }

--- a/src/ORM/composer.json
+++ b/src/ORM/composer.json
@@ -46,7 +46,6 @@
     },
     "require-dev": {
         "cakephp/cache": "^5.0",
-        "cakephp/i18n": "^5.0",
-        "phpstan/phpstan": "1.12.0"
+        "cakephp/i18n": "^5.0"
     }
 }

--- a/src/Validation/composer.json
+++ b/src/Validation/composer.json
@@ -36,7 +36,6 @@
         }
     },
     "require-dev": {
-        "cakephp/i18n": "^5.0",
-        "phpstan/phpstan": "1.12.0"
+        "cakephp/i18n": "^5.0"
     }
 }


### PR DESCRIPTION
Use the phpstan version from the main composer.json for split package checks for consistency.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
