### PR TITLE
5.next: restore exception handler when unregistering exception trap

### DIFF
--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -190,6 +190,7 @@ class ExceptionTrap
         if (static::$registeredTrap == $this) {
             $this->disabled = true;
             static::$registeredTrap = null;
+            restore_exception_handler();
         }
     }
 


### PR DESCRIPTION
no idea why this was not already the case but PHPUnit yelled about that