### PR TITLE
Fix for inconsistency for JSON type field between mysql and sqlite

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
+use Cake\Core\Configure;
 use Cake\Database\Exception\DatabaseException;
 
 /**
@@ -139,8 +140,10 @@ class SqliteSchemaDialect extends SchemaDialect
         if (in_array($col, $datetimeTypes)) {
             return ['type' => $col, 'length' => null];
         }
-        if (str_contains($col, 'json') && !str_contains($col, 'jsonb')) {
-            return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
+        if (Configure::read('ORM.mapJsonTypeForSqlite') === true) {
+            if (str_contains($col, 'json') && !str_contains($col, 'jsonb')) {
+                return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
+            }
         }
 
         return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -139,6 +139,9 @@ class SqliteSchemaDialect extends SchemaDialect
         if (in_array($col, $datetimeTypes)) {
             return ['type' => $col, 'length' => null];
         }
+        if (str_contains($col, 'json') && !str_contains($col, 'jsonb')) {
+            return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
+        }
 
         return ['type' => TableSchemaInterface::TYPE_TEXT, 'length' => null];
     }

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -218,6 +218,22 @@ class SqliteTest extends TestCase
         $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
     }
 
+    public function testJSON(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $this->skipIf(!($connection->getDriver() instanceof Sqlite));
+        assert($connection instanceof Connection);
+
+        $connection->execute('CREATE TABLE json_test (id INTEGER PRIMARY KEY, data JSON_TEXT);');
+        $table = $this->getTableLocator()->get('json_test');
+
+        $data = ['foo' => 'bar', 'baz' => 1, 'qux' => ['a', 'b', 'c' => true]];
+        $entity = $table->newEntity(['data' => $data]);
+        $table->save($entity);
+        $result = $table->find()->first();
+        $this->assertEquals($data, $result->data);
+    }
+
     /**
      * Tests identifier quoting
      */

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -218,6 +218,12 @@ class SqliteTest extends TestCase
         $this->assertFalse($driver->supports(DriverFeatureEnum::JSON));
     }
 
+    /**
+     * Test of Inconsistency for JSON type field between mysql and sqlite
+     *
+     * @return void
+     */
+
     public function testJSON(): void
     {
         $connection = ConnectionManager::get('test');

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
+use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\DriverFeatureEnum;
@@ -226,6 +227,7 @@ class SqliteTest extends TestCase
 
     public function testJSON(): void
     {
+        Configure::write('ORM.mapJsonTypeForSqlite', true);
         $connection = ConnectionManager::get('test');
         $this->skipIf(!($connection->getDriver() instanceof Sqlite));
         assert($connection instanceof Connection);
@@ -238,6 +240,7 @@ class SqliteTest extends TestCase
         $table->save($entity);
         $result = $table->find()->first();
         $this->assertEquals($data, $result->data);
+        Configure::write('ORM.mapJsonTypeForSqlite', false);
     }
 
     /**


### PR DESCRIPTION
Issue described in #17713 - there is an inconsistency in json handling between mysql and sqlite