### PR TITLE
deprecate `Mailer::setMessage`

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -22,6 +22,7 @@ use Cake\Mailer\Exception\MissingActionException;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Cake\View\ViewBuilder;
 use InvalidArgumentException;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Mailer base class.
@@ -259,9 +260,14 @@ class Mailer implements EventListenerInterface
      *
      * @param \Cake\Mailer\Message $message Message instance.
      * @return $this
+     * @deprecated 5.1.0 Configure the mailer according to the documentation instead of manually setting the Message instance.
      */
     public function setMessage(Message $message)
     {
+        deprecationWarning(
+            '5.1.0',
+            'Setting the message instance is deprecated. Configure the mailer according to the documentation instead.'
+        );
         $this->message = $message;
 
         return $this;

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -27,6 +27,7 @@ use Cake\TestSuite\TestCase;
 use Cake\View\Exception\MissingTemplateException;
 use DateTime;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use TestApp\Mailer\TestMailer;
 use function Cake\Core\env;
 
@@ -107,13 +108,16 @@ class MailerTest extends TestCase
     /**
      * testMessage function
      */
-    public function testMessage(): void
+    #[WithoutErrorHandler]
+    public function testSetMessage(): void
     {
         $message = $this->mailer->getMessage();
         $this->assertInstanceOf(Message::class, $message);
 
         $newMessage = new Message();
-        $this->mailer->setMessage($newMessage);
+        $this->deprecated(function () use ($newMessage): void {
+            $this->mailer->setMessage($newMessage);
+        });
         $this->assertSame($newMessage, $this->mailer->getMessage());
         $this->assertNotSame($message, $newMessage);
     }

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -107,6 +107,8 @@ class MailerTest extends TestCase
 
     /**
      * testMessage function
+     *
+     * @deprecated
      */
     #[WithoutErrorHandler]
     public function testSetMessage(): void


### PR DESCRIPTION
As reported by Slavo Basko in the community chat the `Mailer::setMessage` method doesn't behave as expected in combination with `deliver`:

Manually setting a ready made Message object doesn't result in the already set Message body being sent since it gets overwritten by `Mailer::deliver` or more specifically `Mailer::render()`.

---

Since this method is not used anywhere else in the framework, it will be deprecated in 5.1.0 and removed in 6.0

The alternative to setting a message instance yourself is to properly configure a mailer method to set all the necessary data like it is [described in the docs](https://book.cakephp.org/5/en/core-libraries/email.html#creating-reusable-emails)

With that, the mailer instance will create the Message object itself when trying to send a mail via the mailer.
