### PR TITLE
5.next revert mixin docblocs

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -86,7 +86,48 @@ use InvalidArgumentException;
  * Our mailer could either be registered in the application bootstrap, or
  * in the Table class' initialize() hook.
  *
- * @mixin \Cake\Mailer\Message
+ * @method $this setTo($email, $name = null) Sets "to" address. {@see \Cake\Mailer\Message::setTo()}
+ * @method array getTo() Gets "to" address. {@see \Cake\Mailer\Message::getTo()}
+ * @method $this setFrom($email, $name = null) Sets "from" address. {@see \Cake\Mailer\Message::setFrom()}
+ * @method array getFrom() Gets "from" address. {@see \Cake\Mailer\Message::getFrom()}
+ * @method $this setSender($email, $name = null) Sets "sender" address. {@see \Cake\Mailer\Message::setSender()}
+ * @method array getSender() Gets "sender" address. {@see \Cake\Mailer\Message::getSender()}
+ * @method $this setReplyTo($email, $name = null) Sets "Reply-To" address. {@see \Cake\Mailer\Message::setReplyTo()}
+ * @method array getReplyTo() Gets "Reply-To" address. {@see \Cake\Mailer\Message::getReplyTo()}
+ * @method $this addReplyTo($email, $name = null) Add "Reply-To" address. {@see \Cake\Mailer\Message::addReplyTo()}
+ * @method $this setReadReceipt($email, $name = null) Sets Read Receipt (Disposition-Notification-To header).
+ *   {@see \Cake\Mailer\Message::setReadReceipt()}
+ * @method array getReadReceipt() Gets Read Receipt (Disposition-Notification-To header).
+ *   {@see \Cake\Mailer\Message::getReadReceipt()}
+ * @method $this setReturnPath($email, $name = null) Sets return path. {@see \Cake\Mailer\Message::setReturnPath()}
+ * @method array getReturnPath() Gets return path. {@see \Cake\Mailer\Message::getReturnPath()}
+ * @method $this addTo($email, $name = null) Add "To" address. {@see \Cake\Mailer\Message::addTo()}
+ * @method $this setCc($email, $name = null) Sets "cc" address. {@see \Cake\Mailer\Message::setCc()}
+ * @method array getCc() Gets "cc" address. {@see \Cake\Mailer\Message::getCc()}
+ * @method $this addCc($email, $name = null) Add "cc" address. {@see \Cake\Mailer\Message::addCc()}
+ * @method $this setBcc($email, $name = null) Sets "bcc" address. {@see \Cake\Mailer\Message::setBcc()}
+ * @method array getBcc() Gets "bcc" address. {@see \Cake\Mailer\Message::getBcc()}
+ * @method $this addBcc($email, $name = null) Add "bcc" address. {@see \Cake\Mailer\Message::addBcc()}
+ * @method $this setCharset($charset) Charset setter. {@see \Cake\Mailer\Message::setCharset()}
+ * @method string getCharset() Charset getter. {@see \Cake\Mailer\Message::getCharset()}
+ * @method $this setHeaderCharset($charset) HeaderCharset setter. {@see \Cake\Mailer\Message::setHeaderCharset()}
+ * @method string getHeaderCharset() HeaderCharset getter. {@see \Cake\Mailer\Message::getHeaderCharset()}
+ * @method $this setSubject($subject) Sets subject. {@see \Cake\Mailer\Message::setSubject()}
+ * @method string getSubject() Gets subject. {@see \Cake\Mailer\Message::getSubject()}
+ * @method $this setHeaders(array $headers) Sets headers for the message. {@see \Cake\Mailer\Message::setHeaders()}
+ * @method $this addHeaders(array $headers) Add header for the message. {@see \Cake\Mailer\Message::addHeaders()}
+ * @method $this getHeaders(array $include = []) Get list of headers. {@see \Cake\Mailer\Message::getHeaders()}
+ * @method $this setEmailFormat($format) Sets email format. {@see \Cake\Mailer\Message::getHeaders()}
+ * @method string getEmailFormat() Gets email format. {@see \Cake\Mailer\Message::getEmailFormat()}
+ * @method $this setMessageId($message) Sets message ID. {@see \Cake\Mailer\Message::setMessageId()}
+ * @method string|bool getMessageId() Gets message ID. {@see \Cake\Mailer\Message::getMessageId()}
+ * @method $this setDomain($domain) Sets domain. {@see \Cake\Mailer\Message::setDomain()}
+ * @method string getDomain() Gets domain. {@see \Cake\Mailer\Message::getDomain()}
+ * @method $this setAttachments($attachments) Add attachments to the email message. {@see \Cake\Mailer\Message::setAttachments()}
+ * @method array getAttachments() Gets attachments to the email message. {@see \Cake\Mailer\Message::getAttachments()}
+ * @method $this addAttachments($attachments) Add attachments. {@see \Cake\Mailer\Message::addAttachments()}
+ * @method array|string getBody(?string $type = null) Get generated message body as array.
+ *   {@see \Cake\Mailer\Message::getBody()}
  */
 class Mailer implements EventListenerInterface
 {

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -41,8 +41,6 @@ use function Cake\Core\namespaceSplit;
  *
  * If you want to bring all or certain languages for each of the fetched records,
  * you can use the custom `translations` finders that is exposed to the table.
- *
- * @mixin \Cake\ORM\Behavior\Translate\TranslateStrategyInterface
  */
 class TranslateBehavior extends Behavior implements PropertyMarshalInterface
 {

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -25,9 +25,12 @@ use function Cake\Core\h;
  *
  * Methods to make numbers more readable.
  *
+ * @method string ordinal(float|int $value, array $options = []) See Number::ordinal()
+ * @method string precision(string|float|int $number, int $precision = 3, array $options = []) See Number::precision()
+ * @method string toPercentage(string|float|int $value, int $precision = 3, array $options = []) See Number::toPercentage()
+ * @method string toReadableSize(string|float|int $size) See Number::toReadableSize()
  * @link https://book.cakephp.org/5/en/views/helpers/number.html
  * @see \Cake\I18n\Number
- * @mixin \Cake\I18n\Number
  */
 class NumberHelper extends Helper
 {

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -27,9 +27,14 @@ use function Cake\Core\h;
  * Text manipulations: Highlight, excerpt, truncate, strip of links, convert email addresses to mailto: links...
  *
  * @property \Cake\View\Helper\HtmlHelper $Html
+ * @method string excerpt(string $text, string $phrase, int $radius = 100, string $ending = '…') See Text::excerpt()
+ * @method string highlight(string $text, array|string $phrase, array $options = []) See Text::highlight()
+ * @method string slug(string $string, array|string $options = []) See Text::slug()
+ * @method string tail(string $text, int $length = 100, array $options = []) See Text::tail()
+ * @method string toList(array $list, ?string $and = null, string $separator = ', ') See Text::toList()
+ * @method string truncate(string $text, int $length = 100, array $options = []) See Text::truncate()
  * @link https://book.cakephp.org/5/en/views/helpers/text.html
  * @see \Cake\Utility\Text
- * @mixin \Cake\Utility\Text
  */
 class TextHelper extends Helper
 {


### PR DESCRIPTION
Reverts https://github.com/cakephp/cakephp/pull/17892 due to the fact, that PHPStan doesn't understand `@mixin` correctly as it seems on the example of

```
    public function test(): self
    {
        $this->setTransport('gmail')
            ->setTo('test@text.com')
            ->setSubject('Debug Email')
            ->setEmailFormat('html')
            ->setViewVars([
                'slTitle' => 'Debug Email',
                'slSubtitle' => 'Random subtitle',
                'slContent' => 'Here is some content',
            ])
            ->viewBuilder()
            ->setTemplate('default'); // By default template with same name as method name is used.

        return $this;
    }
```

I get
```
 ------ ----------------------------------------------------------------- 
  Line   src/Mailer/DebugMailer.php                                       
 ------ ----------------------------------------------------------------- 
  22     Call to an undefined method Cake\Mailer\Message::setViewVars().  
 ------ ----------------------------------------------------------------- 
```

since `setEmailFormat()` returns a message object