### PR TITLE
restore passed down args assertions

### DIFF
--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -18,11 +18,11 @@ namespace Cake\Test\TestCase\Datasource\Paging;
 
 use ArrayIterator;
 use Cake\Collection\Collection;
-use Cake\Collection\CollectionInterface;
 use Cake\Datasource\Paging\PaginatedResultSet;
 use Cake\Datasource\ResultSetInterface;
 use Cake\ORM\ResultSet;
 use Cake\TestSuite\TestCase;
+use Mockery;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use function Cake\Collection\collection;
 
@@ -51,12 +51,11 @@ class PaginatedResultSetTest extends TestCase
     #[WithoutErrorHandler]
     public function testCall(): void
     {
-        $resultSet = new class ([]) extends ResultSet {
-            public function extract(callable|string $path): CollectionInterface
-            {
-                return collection(['bar']);
-            }
-        };
+        $resultSet = Mockery::mock(ResultSet::class);
+        $resultSet->shouldReceive('extract')
+            ->with('foo')
+            ->once()
+            ->andReturn(collection(['bar']));
 
         $paginatedResults = new PaginatedResultSet(
             $resultSet,

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -23,6 +23,7 @@ use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 use TestApp\TestCase\Event\CustomTestEventListenerInterface;
 use TestApp\TestCase\Event\EventTestListener;
 
@@ -221,7 +222,7 @@ class EventManagerTest extends TestCase
      */
     public function testDispatch(): void
     {
-        $manager = new EventManager();
+        $manager = Mockery::mock(EventManager::class)->makePartial();
         $listener = new class implements EventListenerInterface {
             public array $callList = [];
 

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -23,6 +23,7 @@ use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestApp\Routing\Route\ProtectedRoute;
 
@@ -1038,12 +1039,11 @@ class RouteTest extends TestCase
      */
     public function testParseRequestDelegates(): void
     {
-        $route = new class ('/forward', ['controller' => 'Articles', 'action' => 'index']) extends Route {
-            public function parse(string $url, string $method): ?array
-            {
-                return ['works!'];
-            }
-        };
+        $route = Mockery::mock(Route::class)->makePartial();
+        $route->shouldReceive('parse')
+            ->once()
+            ->with('/forward', 'GET')
+            ->andReturn(['works!']);
 
         $request = new ServerRequest([
             'environment' => [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -43,6 +43,7 @@ use Cake\View\Widget\LabelWidget;
 use Cake\View\Widget\WidgetInterface;
 use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
+use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
@@ -217,20 +218,14 @@ class FormHelperTest extends TestCase
      */
     public function testAddWidgetAndRenderWidget(): void
     {
-        $widget = new class implements WidgetInterface
-        {
-            public function render(array $data, ContextInterface $context): string
-            {
-                return 'HTML';
-            }
-
-            public function secureFields(array $data): array
-            {
-                return ['val'];
-            }
-        };
+        $data = ['val' => 1];
+        $widget = Mockery::mock(WidgetInterface::class);
+        $widget->shouldReceive('render')
+            ->withSomeOfArgs($data)
+            ->once()
+            ->andReturn('HTML');
         $this->Form->addWidget('test', $widget);
-        $result = $this->Form->widget('test', ['val' => 1]);
+        $result = $this->Form->widget('test', $data);
         $this->assertSame('HTML', $result);
     }
 
@@ -244,18 +239,16 @@ class FormHelperTest extends TestCase
             'unlockedFields' => [],
         ]));
 
-        $widget = new class implements WidgetInterface
-        {
-            public function render(array $data, ContextInterface $context): string
-            {
-                return 'HTML';
-            }
-
-            public function secureFields(array $data): array
-            {
-                return ['test'];
-            }
-        };
+        $data = ['val' => 1, 'name' => 'test'];
+        $widget = Mockery::mock(WidgetInterface::class);
+        $widget->shouldReceive('render')
+            ->withSomeOfArgs($data)
+            ->once()
+            ->andReturn('HTML');
+        $widget->shouldReceive('secureFields')
+            ->with($data)
+            ->once()
+            ->andReturn(['test']);
         $this->Form->addWidget('test', $widget);
         $this->Form->create();
         $result = $this->Form->widget('test', ['val' => 1, 'name' => 'test', 'secure' => true]);


### PR DESCRIPTION
I wasn't aware that passed down args need to be asserted (or that its that important)

So i restored what was lost in my recent "unmockify" ordeal and converted what was lost to mockery.