### PR TITLE
Fix form's request type inference.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -386,6 +386,10 @@ class FormHelper extends Helper
             unset($options['context']);
         }
 
+        if (isset($options['method'])) {
+            $options['type'] = $options['method'];
+        }
+
         $isCreate = $context->isCreate();
 
         $options += [
@@ -448,9 +452,6 @@ class FormHelper extends Helper
             // Default to post method
             default:
                 $htmlAttributes['method'] = 'post';
-        }
-        if (isset($options['method'])) {
-            $htmlAttributes['method'] = strtolower($options['method']);
         }
         if (isset($options['enctype'])) {
             $htmlAttributes['enctype'] = strtolower($options['enctype']);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -413,6 +413,12 @@ class FormHelperTest extends TestCase
             'accept-charset' => $encoding,
         ]];
         $this->assertHtml($expected, $result);
+
+        $request = $this->View->getRequest()->withAttribute('csrfToken', 'this-is-a-csrf-token');
+        $this->View->setRequest($request);
+
+        $result = $this->Form->create(null, ['method' => 'get']);
+        $this->assertStringNotContainsString('this-is-a-csrf-token', $result);
     }
 
     /**
@@ -429,7 +435,7 @@ class FormHelperTest extends TestCase
             'enctype' => 'multipart/form-data',
         ]);
         $expected = ['form' => [
-            'method' => 'put',
+            'method' => 'post',
             'action' => '/articles/add',
             'enctype' => 'multipart/form-data',
             'accept-charset' => $encoding,


### PR DESCRIPTION
If "method" option is specified for `FormHelper::create()` it should take precedence over the value of "type" option. Before this fix `FormHelper::$requestType` was incorrectly set to "post" for a call like `create(null, ['method' => 'get'])` causing the input with CSRF token to be incorrectly added to the form.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
