### PR TITLE
fix styling for debugger dumped variables

### DIFF
--- a/src/Error/Debug/dumpHeader.html
+++ b/src/Error/Debug/dumpHeader.html
@@ -80,9 +80,7 @@
 
     /* Copy button */
     .cake-debug-copy {
-        position: absolute;
-        top: 0;
-        right: 0;
+        margin-left: 10px;
         padding: 6px;
         background: var(--color-control-bg);
         color: var(--color-blue);


### PR DESCRIPTION
The copy button was previously overlapping the content of the variable in e.g. the environment panel of the Debug Kit.

![image](https://github.com/user-attachments/assets/55455ccd-b05b-487a-840f-423bb498c796)

Now (in combination with https://github.com/cakephp/debug_kit/pull/1026) this will change to

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/c5ee5753-9648-40c5-a713-e7e94fb71c9e">

BUT this of course will also move the copy button for e.g. the Variables panel to the bottom left

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a0d1ff9f-ebb1-4772-88af-120fa1547b91">
