### PR TITLE
Add gettext compatible paths to the list of translation folders

### DIFF
--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -156,9 +156,13 @@ class MessagesFileLoader
     {
         $locale = Locale::parseLocale($this->_locale) + ['region' => null];
 
+        $languageRegion = implode('_', [$locale['language'], $locale['region']]);
         $folders = [
-            implode('_', [$locale['language'], $locale['region']]),
+            $languageRegion,
             $locale['language'],
+            // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
+            $languageRegion . DIRECTORY_SEPARATOR . 'LC_MESSAGES',
+            $locale['language'] . DIRECTORY_SEPARATOR . 'LC_MESSAGES',
         ];
 
         $searchPaths = [];
@@ -167,20 +171,12 @@ class MessagesFileLoader
         if (!$localePaths && defined('APP')) {
             $localePaths[] = ROOT . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
         }
+        if ($this->_plugin && Plugin::isLoaded($this->_plugin)) {
+            $localePaths[] = App::path('locales', $this->_plugin)[0];
+        }
         foreach ($localePaths as $path) {
             foreach ($folders as $folder) {
                 $searchPaths[] = $path . $folder . DIRECTORY_SEPARATOR;
-                // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
-                $searchPaths[] = $path . $folder . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR;
-            }
-        }
-
-        if ($this->_plugin && Plugin::isLoaded($this->_plugin)) {
-            $basePath = App::path('locales', $this->_plugin)[0];
-            foreach ($folders as $folder) {
-                $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR;
-                // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
-                $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR;
             }
         }
 

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -156,19 +156,22 @@ class MessagesFileLoader
     {
         $locale = Locale::parseLocale($this->_locale) + ['region' => null];
 
-        $languageRegion = implode('_', [$locale['language'], $locale['region']]);
         $folders = [
-            $languageRegion,
             $locale['language'],
             // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
-            $languageRegion . DIRECTORY_SEPARATOR . 'LC_MESSAGES',
             $locale['language'] . DIRECTORY_SEPARATOR . 'LC_MESSAGES',
         ];
+        if (!empty($locale['region'])) {
+            $languageRegion = implode('_', [$locale['language'], $locale['region']]);
+            $folders[] = $languageRegion;
+            // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
+            $folders[] = $languageRegion . DIRECTORY_SEPARATOR . 'LC_MESSAGES';
+        }
 
         $searchPaths = [];
 
         $localePaths = App::path('locales');
-        if (!$localePaths && defined('APP')) {
+        if (!$localePaths && defined('ROOT')) {
             $localePaths[] = ROOT . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR;
         }
         if ($this->_plugin && Plugin::isLoaded($this->_plugin)) {

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -170,6 +170,8 @@ class MessagesFileLoader
         foreach ($localePaths as $path) {
             foreach ($folders as $folder) {
                 $searchPaths[] = $path . $folder . DIRECTORY_SEPARATOR;
+                // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
+                $searchPaths[] = $path . $folder . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR;
             }
         }
 
@@ -177,6 +179,8 @@ class MessagesFileLoader
             $basePath = App::path('locales', $this->_plugin)[0];
             foreach ($folders as $folder) {
                 $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR;
+                // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
+                $searchPaths[] = $basePath . $folder . DIRECTORY_SEPARATOR . 'LC_MESSAGES' . DIRECTORY_SEPARATOR;
             }
         }
 

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -161,7 +161,7 @@ class MessagesFileLoader
             // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php
             $locale['language'] . DIRECTORY_SEPARATOR . 'LC_MESSAGES',
         ];
-        if (!empty($locale['region'])) {
+        if ($locale['region']) {
             $languageRegion = implode('_', [$locale['language'], $locale['region']]);
             $folders[] = $languageRegion;
             // gettext compatible paths, see https://www.php.net/manual/en/function.gettext.php

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -73,7 +73,7 @@ class MessagesFileLoaderTest extends TestCase
         $loader = new MessagesFileLoader('company/test_plugin_three', 'es', 'mo');
 
         $result = $loader->translationsFolders();
-        $this->assertCount(8, $result);
+        $this->assertCount(4, $result);
     }
 
     /**
@@ -87,13 +87,9 @@ class MessagesFileLoaderTest extends TestCase
         $loader = new MessagesFileLoader('test_plugin_two', 'en');
 
         $expected = [
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
         ];
         $result = $loader->translationsFolders();
@@ -108,14 +104,14 @@ class MessagesFileLoaderTest extends TestCase
         $loader = new MessagesFileLoader('company/test_plugin_three', $locale);
 
         $expected = [
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
         ];
         $result = $loader->translationsFolders();
         $this->assertEquals($expected, $result);

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -73,7 +73,7 @@ class MessagesFileLoaderTest extends TestCase
         $loader = new MessagesFileLoader('company/test_plugin_three', 'es', 'mo');
 
         $result = $loader->translationsFolders();
-        $this->assertCount(4, $result);
+        $this->assertCount(8, $result);
     }
 
     /**
@@ -88,11 +88,36 @@ class MessagesFileLoaderTest extends TestCase
 
         $expected = [
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
         ];
         $result = $loader->translationsFolders();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testTranslationsFoldersGettextCompatible(): void
+    {
+        $this->loadPlugins(['Company/TestPluginThree']);
+
+        $locale = 'en_US';
+        $loader = new MessagesFileLoader('company/test_plugin_three', $locale);
+
+        $expected = [
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
+        ];
+        $result = $loader->translationsFolders();debug($result);
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -117,7 +117,7 @@ class MessagesFileLoaderTest extends TestCase
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
         ];
-        $result = $loader->translationsFolders();debug($result);
+        $result = $loader->translationsFolders();
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/TestCase/I18n/MessagesFileLoaderTest.php
+++ b/tests/TestCase/I18n/MessagesFileLoaderTest.php
@@ -88,12 +88,12 @@ class MessagesFileLoaderTest extends TestCase
 
         $expected = [
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en_' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
         ];
         $result = $loader->translationsFolders();
@@ -109,12 +109,12 @@ class MessagesFileLoaderTest extends TestCase
 
         $expected = [
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS,
-            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS,
+            ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . $locale . DS . 'LC_MESSAGES' . DS,
             ROOT . DS . 'tests' . DS . 'test_app' . DS . 'Plugin' . DS . 'Company' . DS . 'TestPluginThree' . DS . 'resources' . DS . 'locales' . DS . 'en' . DS . 'LC_MESSAGES' . DS,
         ];
         $result = $loader->translationsFolders();


### PR DESCRIPTION
This is probably the simplest solution to the problem described in #17887. 

If this is okay I could further optimize the code in translationsFolders().
