### PR TITLE
Fix method not found error.

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -214,12 +214,9 @@ class CommandRunner implements EventDispatcherInterface
      */
     public function setEventManager(EventManagerInterface $eventManager)
     {
-        assert(
-            $this->app instanceof EventDispatcherInterface,
-            'Cannot set the event manager, the application does not support events.'
-        );
-
-        $this->app->setEventManager($eventManager);
+        if ($this->app instanceof EventDispatcherInterface) {
+            $this->app->setEventManager($eventManager);
+        }
 
         return $this;
     }

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -320,8 +320,12 @@ class CommandRunner implements EventDispatcherInterface
     {
         try {
             $eventManager = $this->getEventManager();
-            $eventManager = $this->app->pluginEvents($eventManager);
-            $eventManager = $this->app->events($eventManager);
+            if (method_exists($this->app, 'pluginEvents')) {
+                $eventManager = $this->app->pluginEvents($eventManager);
+            }
+            if (method_exists($this->app, 'events')) {
+                $eventManager = $this->app->events($eventManager);
+            }
             $this->setEventManager($eventManager);
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());


### PR DESCRIPTION
Existing console only applications which directly implement the ConsoleApplicationInterface would not have the events() and pluginEvents() method.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
