### PR TITLE
fix commandrunner breaking console only apps + fix new core functions not being wrapped in if function_exists

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -27,6 +27,7 @@ use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventManager;
 use Cake\Event\EventManagerInterface;
+use Cake\Http\BaseApplication;
 use Cake\Routing\Router;
 use Cake\Routing\RoutingApplicationInterface;
 use Cake\Utility\Inflector;
@@ -320,9 +321,11 @@ class CommandRunner implements EventDispatcherInterface
     {
         try {
             $eventManager = $this->getEventManager();
-            $eventManager = $this->app->pluginEvents($eventManager);
-            $eventManager = $this->app->events($eventManager);
-            $this->setEventManager($eventManager);
+            if ($this->app instanceof BaseApplication) {
+                $eventManager = $this->app->pluginEvents($eventManager);
+                $eventManager = $this->app->events($eventManager);
+                $this->setEventManager($eventManager);
+            }
             if ($command instanceof EventDispatcherInterface) {
                 $command->setEventManager($this->getEventManager());
             }

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -385,144 +385,152 @@ if (!function_exists('Cake\Core\deprecationWarning')) {
     }
 }
 
-/**
- * Converts the given value to a string.
- *
- * This method attempts to convert the given value to a string.
- * If the value is already a string, it returns the value as it is.
- * ``null`` is returned if the conversion is not possible.
- *
- * @param mixed $value The value to be converted.
- * @return ?string Returns the string representation of the value, or null if the value is not a string.
- * @since 5.1.0
- */
-function toString(mixed $value): ?string
-{
-    if (is_string($value)) {
-        return $value;
-    }
-    if (is_int($value)) {
-        return (string)$value;
-    }
-    if (is_bool($value)) {
-        return $value ? '1' : '0';
-    }
-    if (is_float($value)) {
-        if (is_nan($value) || is_infinite($value)) {
-            return null;
+if (!function_exists('Cake\Core\toString')) {
+    /**
+     * Converts the given value to a string.
+     *
+     * This method attempts to convert the given value to a string.
+     * If the value is already a string, it returns the value as it is.
+     * ``null`` is returned if the conversion is not possible.
+     *
+     * @param mixed $value The value to be converted.
+     * @return ?string Returns the string representation of the value, or null if the value is not a string.
+     * @since 5.1.0
+     */
+    function toString(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            return $value;
         }
-        try {
-            $return = json_encode($value, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            $return = null;
+        if (is_int($value)) {
+            return (string)$value;
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+        if (is_float($value)) {
+            if (is_nan($value) || is_infinite($value)) {
+                return null;
+            }
+            try {
+                $return = json_encode($value, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                $return = null;
+            }
+
+            if ($return === null || str_contains($return, 'e')) {
+                return rtrim(sprintf('%.' . (PHP_FLOAT_DIG + 3) . 'F', $value), '.0');
+            }
+
+            return $return;
+        }
+        if ($value instanceof Stringable) {
+            return (string)$value;
         }
 
-        if ($return === null || str_contains($return, 'e')) {
-            return rtrim(sprintf('%.' . (PHP_FLOAT_DIG + 3) . 'F', $value), '.0');
-        }
-
-        return $return;
+        return null;
     }
-    if ($value instanceof Stringable) {
-        return (string)$value;
-    }
-
-    return null;
 }
 
-/**
- * Converts a value to an integer.
- *
- * This method attempts to convert the given value to an integer.
- * If the conversion is successful, it returns the value as an integer.
- * If the conversion fails, it returns NULL.
- *
- * String values are trimmed using trim().
- *
- * @param mixed $value The value to be converted to an integer.
- * @return int|null Returns the converted integer value or null if the conversion fails.
- * @since 5.1.0
- */
-function toInt(mixed $value): ?int
-{
-    if (is_int($value)) {
-        return $value;
-    }
-    if (is_string($value)) {
-        $value = filter_var($value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+if (!function_exists('Cake\Core\toInt')) {
+    /**
+     * Converts a value to an integer.
+     *
+     * This method attempts to convert the given value to an integer.
+     * If the conversion is successful, it returns the value as an integer.
+     * If the conversion fails, it returns NULL.
+     *
+     * String values are trimmed using trim().
+     *
+     * @param mixed $value The value to be converted to an integer.
+     * @return int|null Returns the converted integer value or null if the conversion fails.
+     * @since 5.1.0
+     */
+    function toInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value)) {
+            $value = filter_var($value, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
 
-        return $value === PHP_INT_MIN ? null : $value;
-    }
-    if (is_float($value)) {
-        if (is_nan($value) || is_infinite($value)) {
-            return null;
+            return $value === PHP_INT_MIN ? null : $value;
+        }
+        if (is_float($value)) {
+            if (is_nan($value) || is_infinite($value)) {
+                return null;
+            }
+
+            return (int)$value;
+        }
+        if (is_bool($value)) {
+            return (int)$value;
         }
 
-        return (int)$value;
+        return null;
     }
-    if (is_bool($value)) {
-        return (int)$value;
-    }
-
-    return null;
 }
 
-/**
- * Converts a value to a float.
- *
- * This method attempts to convert the given value to a float.
- * If the conversion is successful, it returns the value as an float.
- * If the conversion fails, it returns NULL.
- *
- * String values are trimmed using trim().
- *
- * @param mixed $value The value to be converted to a float.
- * @return float|null Returns the converted float value or null if the conversion fails.
- * @since 5.1.0
- */
-function toFloat(mixed $value): ?float
-{
-    if (is_string($value)) {
-        $value = filter_var($value, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
+if (!function_exists('Cake\Core\toFloat')) {
+    /**
+     * Converts a value to a float.
+     *
+     * This method attempts to convert the given value to a float.
+     * If the conversion is successful, it returns the value as an float.
+     * If the conversion fails, it returns NULL.
+     *
+     * String values are trimmed using trim().
+     *
+     * @param mixed $value The value to be converted to a float.
+     * @return float|null Returns the converted float value or null if the conversion fails.
+     * @since 5.1.0
+     */
+    function toFloat(mixed $value): ?float
+    {
+        if (is_string($value)) {
+            $value = filter_var($value, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE);
 
-        return $value === PHP_FLOAT_MIN ? null : $value;
-    }
-    if (is_float($value)) {
-        if (is_nan($value) || is_infinite($value)) {
-            return null;
+            return $value === PHP_FLOAT_MIN ? null : $value;
+        }
+        if (is_float($value)) {
+            if (is_nan($value) || is_infinite($value)) {
+                return null;
+            }
+
+            return $value;
+        }
+        if (is_int($value)) {
+            return (float)$value;
+        }
+        if (is_bool($value)) {
+            return (float)$value;
         }
 
-        return $value;
+        return null;
     }
-    if (is_int($value)) {
-        return (float)$value;
-    }
-    if (is_bool($value)) {
-        return (float)$value;
-    }
-
-    return null;
 }
 
-/**
- * Converts a value to boolean.
- *
- *  1 | '1' | 1.0 | true  - values returns as true
- *  0 | '0' | 0.0 | false - values returns as false
- *  Other values returns as null.
- *
- * @param mixed $value The value to convert to boolean.
- * @return bool|null Returns true if the value is truthy, false if it's falsy, or NULL otherwise.
- * @since 5.1.0
- */
-function toBool(mixed $value): ?bool
-{
-    if ($value === '1' || $value === 1 || $value === 1.0 || $value === true) {
-        return true;
-    }
-    if ($value === '0' || $value === 0 || $value === 0.0 || $value === false) {
-        return false;
-    }
+if (!function_exists('Cake\Core\toBool')) {
+    /**
+     * Converts a value to boolean.
+     *
+     *  1 | '1' | 1.0 | true  - values returns as true
+     *  0 | '0' | 0.0 | false - values returns as false
+     *  Other values returns as null.
+     *
+     * @param mixed $value The value to convert to boolean.
+     * @return bool|null Returns true if the value is truthy, false if it's falsy, or NULL otherwise.
+     * @since 5.1.0
+     */
+    function toBool(mixed $value): ?bool
+    {
+        if ($value === '1' || $value === 1 || $value === 1.0 || $value === true) {
+            return true;
+        }
+        if ($value === '0' || $value === 0 || $value === 0.0 || $value === false) {
+            return false;
+        }
 
-    return null;
+        return null;
+    }
 }


### PR DESCRIPTION
1. Console only apps like cakephp/upgrade don't have these methods present by default, therefore calling these methods should be restricted to full BaseApplications which actually have these methods present
2. the newly added core functions to transform request data into specific types were not wrapped in `if(!function_exists())`, therefore causing the already known `Fatal error: Cannot redeclare Cake\Core\toString()` since the upgrade tool bootstraps 2 different cake apps at the same time