### PR TITLE
Add EventAwareApplicationInterface in place of annotated definitions

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -22,6 +22,7 @@ use Cake\Console\Exception\MissingOptionException;
 use Cake\Console\Exception\StopException;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\ContainerApplicationInterface;
+use Cake\Core\EventAwareApplicationInterface;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Event\EventDispatcherInterface;
 use Cake\Event\EventDispatcherTrait;
@@ -317,10 +318,8 @@ class CommandRunner implements EventDispatcherInterface
     {
         try {
             $eventManager = $this->getEventManager();
-            if (method_exists($this->app, 'pluginEvents')) {
+            if ($this->app instanceof EventAwareApplicationInterface) {
                 $eventManager = $this->app->pluginEvents($eventManager);
-            }
-            if (method_exists($this->app, 'events')) {
                 $eventManager = $this->app->events($eventManager);
             }
             $this->setEventManager($eventManager);

--- a/src/Core/ConsoleApplicationInterface.php
+++ b/src/Core/ConsoleApplicationInterface.php
@@ -20,9 +20,6 @@ use Cake\Console\CommandCollection;
 /**
  * An interface defining the methods that the
  * console runner depend on.
- *
- * @method events(\Cake\Event\EventManagerInterface $eventManager)
- * @method pluginEvents(\Cake\Event\EventManagerInterface $eventManager)
  */
 interface ConsoleApplicationInterface
 {

--- a/src/Core/EventAwareApplicationInterface.php
+++ b/src/Core/EventAwareApplicationInterface.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use Cake\Event\EventManagerInterface;
+
+interface EventAwareApplicationInterface
+{
+    /**
+     * Register application events.
+     *
+     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function events(EventManagerInterface $eventManager): EventManagerInterface;
+
+    /**
+     * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
+     * @return \Cake\Event\EventManagerInterface
+     */
+    public function pluginEvents(EventManagerInterface $eventManager): EventManagerInterface;
+}

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -23,6 +23,7 @@ use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\Container;
 use Cake\Core\ContainerApplicationInterface;
 use Cake\Core\ContainerInterface;
+use Cake\Core\EventAwareApplicationInterface;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\HttpApplicationInterface;
 use Cake\Core\Plugin;
@@ -58,6 +59,7 @@ use Psr\Http\Message\ServerRequestInterface;
 abstract class BaseApplication implements
     ConsoleApplicationInterface,
     ContainerApplicationInterface,
+    EventAwareApplicationInterface,
     EventDispatcherInterface,
     HttpApplicationInterface,
     PluginApplicationInterface,


### PR DESCRIPTION
Cake 5.1 introduced some new methods to the application classes but without a formal definition which could break console only apps (including Cake upgrade tool). This proposal adds a new interface with `events()` and `pluginEvents()` methods definitions and updates the `CommandRunner` to check if a console app implements these methods.

Any comments and suggestions are welcome.