### PR TITLE
Make order of events hooks consistent with other hooks

### DIFF
--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -319,8 +319,8 @@ class CommandRunner implements EventDispatcherInterface
         try {
             $eventManager = $this->getEventManager();
             if ($this->app instanceof EventAwareApplicationInterface) {
-                $eventManager = $this->app->pluginEvents($eventManager);
                 $eventManager = $this->app->events($eventManager);
+                $eventManager = $this->app->pluginEvents($eventManager);
             }
             $this->setEventManager($eventManager);
             if ($command instanceof EventDispatcherInterface) {

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -347,8 +347,8 @@ abstract class BaseApplication implements
         $container->add(ServerRequest::class, $request);
         $container->add(ContainerInterface::class, $container);
 
-        $eventManager = $this->pluginEvents($this->getEventManager());
-        $this->setEventManager($this->events($eventManager));
+        $eventManager = $this->events($this->getEventManager());
+        $this->setEventManager($this->pluginEvents($eventManager));
 
         $this->controllerFactory ??= new ControllerFactory($container);
 


### PR DESCRIPTION
Other hooks like services, and routes call the Application first, and then plugins. This aligns the behavior of the `events` hook that call order.
