### PR TITLE
Avoid falsey values being assigned for plugin param.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -438,7 +438,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     public function setRequest(ServerRequest $request)
     {
         $this->request = $request;
-        $this->plugin = $request->getParam('plugin');
+        $this->plugin = $request->getParam('plugin') ?: null;
 
         return $this;
     }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -438,7 +438,7 @@ class View implements EventDispatcherInterface
     public function setRequest(ServerRequest $request)
     {
         $this->request = $request;
-        $this->plugin = $request->getParam('plugin');
+        $this->plugin = $request->getParam('plugin') ?: null;
 
         return $this;
     }


### PR DESCRIPTION
When upgrading an app to 5.x I got this on a non existing URL (404):
```
[Cake\Error\FatalErrorException] Fatal Error: Uncaught Cake\Error\FatalErrorException: 
[TypeError] Cannot assign false to property Cake\Controller\Controller::$plugin of type ?string (/var/www/testing/vendor/cakephp/cakephp/src/Controller/Controller.php:441) in /var/www/testing/vendor/cakephp/cakephp/src/Error/ExceptionTrap.php:378
Stack trace:
#0 [internal function]: Cake\Error\ErrorTrap->handleError()
#1 /var/www/testing/vendor/cakephp/cakephp/src/Error/ExceptionTrap.php(378): trigger_error()
#2 /var/www/testing/vendor/cakephp/cakephp/src/Error/ExceptionTrap.php(242): Cake\Error\ExceptionTrap->logInternalError()
#3 [internal function]: Cake\Error\ExceptionTrap->handleException()
#4 {main}
```

So instead of going 5xx here, would it seem sensable to use this assignment here to make sure it is either a non empty plugin string or null?