### PR TITLE
Add type assertions for values in $defaults when connecting routes

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Route;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Http\Exception\BadRequestException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -131,6 +132,21 @@ class Route
      */
     public function __construct(string $template, array $defaults = [], array $options = [])
     {
+        $checker = function () use ($defaults): bool {
+            foreach (['plugin', 'prefix', 'controller', 'action'] as $key) {
+                if (isset($defaults[$key]) && !is_string($defaults[$key])) {
+                    throw new CakeException(
+                        'Value for `' . $key . '` in $defaults when connecting routes'
+                        . ' must be of type `string` or `null`'
+                    );
+                }
+            }
+
+            return true;
+        };
+
+        assert($checker());
+
         $this->template = $template;
         $this->defaults = $defaults;
         $this->options = $options + ['_ext' => [], '_middleware' => []];

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2070,9 +2070,9 @@ class RouterTest extends TestCase
     public function testRouteParamDefaults(): void
     {
         $routes = Router::createRouteBuilder('/');
-        $routes->connect('/cache/*', ['prefix' => false, 'plugin' => true, 'controller' => 0, 'action' => 1]);
+        $routes->connect('/cache/*', ['prefix' => null, 'plugin' => '1', 'controller' => '0', 'action' => '1']);
 
-        $url = Router::url(['prefix' => '0', 'plugin' => '1', 'controller' => '0', 'action' => '1', 'test']);
+        $url = Router::url(['prefix' => null, 'plugin' => '1', 'controller' => '0', 'action' => '1', 'test']);
         $expected = '/cache/test';
         $this->assertSame($expected, $url);
 
@@ -2089,6 +2089,17 @@ class RouterTest extends TestCase
         } catch (Exception) {
             $this->assertTrue(true, 'Exception was raised');
         }
+    }
+
+    public function testRouteInvalidDefaults(): void
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage(
+            'Value for `plugin` in $defaults when connecting routes must be of type `string` or `null`'
+        );
+
+        $routes = Router::createRouteBuilder('/');
+        $routes->connect('/foo', ['plugin' => false, 'controller' => 'Foo', 'action' => 'index']);
     }
 
     /**


### PR DESCRIPTION
Closes #17931

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
