### PR TITLE
cleanup

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -186,7 +186,7 @@ trait CollectionTrait
         if (is_string($path) && str_contains($path, '{*}')) {
             return $extractor
                 ->filter(function ($data) {
-                    return $data !== null && (is_iterable($data));
+                    return is_iterable($data);
                 })
                 ->unfold();
         }

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -197,7 +197,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
 
                 // Use passedParams as a source of typed dependencies.
                 // The accepted types for passedParams was never defined and userland code relies on that.
-                if ($passedParams && is_object($passedParams[0]) && $passedParams[0] instanceof $typeName) {
+                if ($passedParams && $passedParams[0] instanceof $typeName) {
                     $resolved[] = array_shift($passedParams);
                     continue;
                 }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1827,8 +1827,6 @@ abstract class Query implements ExpressionInterface, Stringable
      */
     public function __debugInfo(): array
     {
-        $sql = 'SQL could not be generated for this query as it is incomplete.';
-        $params = [];
         try {
             set_error_handler(
                 /** @return no-return */

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -113,7 +113,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
      */
     public function marshal(mixed $value): ?int
     {
-        if ($value === null || $value === '' || !is_numeric($value)) {
+        if ($value === '' || !is_numeric($value)) {
             return null;
         }
 

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -261,7 +261,7 @@ class Cookie implements CookieInterface
             return new DateTimeImmutable('@' . $expires);
         }
 
-        return $expires;
+        return null;
     }
 
     /**

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -111,7 +111,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
         }
 
         $session = $request->getAttribute('session');
-        if (!$session || !($session instanceof Session)) {
+        if (!($session instanceof Session)) {
             throw new CakeException('You must have a `session` attribute to use session based CSRF tokens');
         }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -805,7 +805,7 @@ class BelongsToMany extends Association
 
         foreach ($targetEntities as $e) {
             $joint = $e->get($jointProperty);
-            if (!$joint || !($joint instanceof EntityInterface)) {
+            if (!($joint instanceof EntityInterface)) {
                 $joint = new $entityClass([], ['markNew' => true, 'source' => $junctionRegistryAlias]);
             }
             $sourceKeys = array_combine($foreignKey, $sourceEntity->extract($bindingKey));
@@ -1405,7 +1405,7 @@ class BelongsToMany extends Association
             }
             $joint = $entity->get($jointProperty);
 
-            if (!$joint || !($joint instanceof EntityInterface)) {
+            if (!($joint instanceof EntityInterface)) {
                 $missing[] = $entity->extract($primary);
                 continue;
             }

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -203,7 +203,7 @@ class Behavior implements EventListenerInterface
         if (!isset($defaults[$key], $config[$key])) {
             return $config;
         }
-        if (isset($config[$key]) && $config[$key] === []) {
+        if ($config[$key] === []) {
             $this->setConfig($key, [], false);
             unset($config[$key]);
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -847,7 +847,7 @@ class Marshaller
             $entity->setAccess('_joinData', true);
 
             $joinData = $entity->get('_joinData');
-            if ($joinData && $joinData instanceof EntityInterface) {
+            if ($joinData instanceof EntityInterface) {
                 $extra[spl_object_hash($entity)] = $joinData;
             }
         }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -2551,7 +2551,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new PersistenceFailedException($entity, ['delete']);
         }
 
-        return $deleted;
+        return true;
     }
 
     /**

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -834,7 +834,7 @@ abstract class TestCase extends BaseTestCase
                     debug($string);
                     debug($regex);
                 }
-                $this->assertTrue(false, 'Attribute did not match. Was expecting ' . $explains[$j]);
+                $this->assertTrue(false,'Attribute did not match. Was expecting ' . $explains[$j]);
             }
             $len = count($asserts);
         } while ($len > 0);

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -834,7 +834,7 @@ abstract class TestCase extends BaseTestCase
                     debug($string);
                     debug($regex);
                 }
-                $this->assertTrue(false,'Attribute did not match. Was expecting ' . $explains[$j]);
+                $this->assertTrue(false, 'Attribute did not match. Was expecting ' . $explains[$j]);
             }
             $len = count($asserts);
         } while ($len > 0);


### PR DESCRIPTION
Most of them are reported by PHPStorm which make sense imho.

Either conditions are not needed since its not possible to trigger them, or certain conditions are already checked by other parts of the if statement.

Also if a variable is returned, but it can only be 1 specific state, the state directly should be retruned instead of the variable.