### PR TITLE
Ensure we do not accidentally override validation rules.

### DIFF
--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -18,6 +18,7 @@ namespace Cake\Validation;
 
 use ArrayAccess;
 use ArrayIterator;
+use Cake\Core\Exception\CakeException;
 use Countable;
 use IteratorAggregate;
 use Traversable;
@@ -138,11 +139,15 @@ class ValidationSet implements ArrayAccess, IteratorAggregate, Countable
      * @param string $name The name under which the rule should be set
      * @param \Cake\Validation\ValidationRule|array $rule The validation rule to be set
      * @return $this
+     * @throws \Cake\Core\Exception\CakeException If a rule with the same name already exists
      */
     public function add(string $name, ValidationRule|array $rule)
     {
         if (!($rule instanceof ValidationRule)) {
             $rule = new ValidationRule($rule);
+        }
+        if (array_key_exists($name, $this->_rules)) {
+            throw new CakeException('A validation rule with the same name already exists');
         }
         $this->_rules[$name] = $rule;
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -5879,12 +5879,6 @@ class TableTest extends TestCase
 
         $data = ['username' => 'larry'];
         $this->assertNotEmpty($validator->validate($data, false));
-
-        $validator->add('username', 'unique', [
-            'rule' => 'validateUnique', 'provider' => 'table',
-        ]);
-        $data = ['username' => 'larry'];
-        $this->assertNotEmpty($validator->validate($data, false));
     }
 
     /**

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -16,8 +16,10 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Validation;
 
+use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\ValidationRule;
+use Cake\Validation\ValidationSet;
 use InvalidArgumentException;
 
 /**
@@ -177,5 +179,15 @@ class ValidationRuleTest extends TestCase
         $this->assertSame('willPass', $Rule->get('rule'));
         $this->assertSame('bar', $Rule->get('message'));
         $this->assertEquals(['param'], $Rule->get('pass'));
+    }
+
+    public function testAddDuplicateName(): void
+    {
+        $rules = new ValidationSet();
+        $rules->add('myUniqueName', ['rule' => fn () => false]);
+
+        $this->expectException(CakeException::class);
+        $rules->add('myUniqueName', ['rule' => fn () => true]);
+        $this->fail('Exception not thrown');
     }
 }

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -2934,6 +2934,7 @@ class ValidatorTest extends TestCase
      */
     protected function assertProxyMethod($validator, $method, $extra = null, $pass = [], $name = null): void
     {
+        $validator->remove('username', $method);
         $name = $name ?: $method;
         if ($extra !== null) {
             $this->assertSame($validator, $validator->{$method}('username', $extra));
@@ -2949,6 +2950,7 @@ class ValidatorTest extends TestCase
         $this->assertEquals($pass, $rule->get('pass'), 'Passed options are different');
         $this->assertSame('default', $rule->get('provider'), 'Provider does not match');
 
+        $validator->remove('username', $method);
         if ($extra !== null) {
             $validator->{$method}('username', $extra, 'the message', 'create');
         } else {


### PR DESCRIPTION
Avoid replacing validation rules by accident. Similar approach to the recent PR to protect rules from accidental replacement using the same name.
