### PR TITLE
Don't accumulate file handles in StubConsoleOutput

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,6 +29,11 @@
       <code><![CDATA[$callback($value, $key, $items)]]></code>
     </TooManyArguments>
   </file>
+  <file src="src/Console/TestSuite/StubConsoleOutput.php">
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->_output]]></code>
+    </InvalidPropertyAssignmentValue>
+  </file>
   <file src="src/Controller/ControllerFactory.php">
     <UndefinedMethod>
       <code><![CDATA[getName]]></code>

--- a/src/Console/TestSuite/StubConsoleOutput.php
+++ b/src/Console/TestSuite/StubConsoleOutput.php
@@ -41,6 +41,19 @@ class StubConsoleOutput extends ConsoleOutput
     protected array $_out = [];
 
     /**
+     * Constructor
+     *
+     * Closes and unsets the file handle created in the parent constructor to
+     * prevent 'too many open files' errors.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        fclose($this->_output);
+        unset($this->_output);
+    }
+
+    /**
      * Write output to the buffer.
      *
      * @param list<string>|string $message A string or an array of strings to output

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -248,20 +248,6 @@ class ConsoleOutputTest extends TestCase
         $this->output->write('<error>Bad</error> Regular <b>Left</b> <i>behind</i> <name>', 0);
     }
 
-    public function testWithInvalidStreamNum(): void
-    {
-        $this->expectException(ConsoleException::class);
-        $this->expectExceptionMessage('Invalid stream in constructor. It is not a valid resource.');
-        new StubConsoleOutput(1);
-    }
-
-    public function testWithInvalidStreamArray(): void
-    {
-        $this->expectException(ConsoleException::class);
-        $this->expectExceptionMessage('Invalid stream in constructor. It is not a valid resource.');
-        new StubConsoleOutput([]);
-    }
-
     public function testWorkingWithStub(): void
     {
         $output = new StubConsoleOutput();

--- a/tests/TestCase/Console/ConsoleOutputTest.php
+++ b/tests/TestCase/Console/ConsoleOutputTest.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 namespace Cake\Test\TestCase\Console;
 
 use Cake\Console\ConsoleOutput;
-use Cake\Console\Exception\ConsoleException;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
 


### PR DESCRIPTION
I occasionally run into problems of 'too many open files' when running tests for migrations. I think having many open handles to `php://stdout` is causing open file handles to accumulate. Closing those handles and freeing the memory should release those resources.
