### PR TITLE
add DI container to plugin events hook

### DIFF
--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -109,6 +109,11 @@ class BasePlugin implements PluginInterface
     protected ?string $name = null;
 
     /**
+     * @var \Cake\Core\ContainerInterface|null
+     */
+    protected ?ContainerInterface $container;
+
+    /**
      * Constructor
      *
      * @param array<string, mixed> $options Options
@@ -315,11 +320,26 @@ class BasePlugin implements PluginInterface
      * Register application events.
      *
      * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
-     * @param \Cake\Core\ContainerInterface $container The DI container instance
      * @return \Cake\Event\EventManagerInterface
      */
-    public function events(EventManagerInterface $eventManager, ContainerInterface $container): EventManagerInterface
+    public function events(EventManagerInterface $eventManager): EventManagerInterface
     {
         return $eventManager;
+    }
+
+    /**
+     * @return \Cake\Core\ContainerInterface|null
+     */
+    public function getContainer(): ?ContainerInterface
+    {
+        return $this->container;
+    }
+
+    /**
+     * @param \Cake\Core\ContainerInterface|null $container
+     */
+    public function setContainer(?ContainerInterface $container): void
+    {
+        $this->container = $container;
     }
 }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -315,9 +315,10 @@ class BasePlugin implements PluginInterface
      * Register application events.
      *
      * @param \Cake\Event\EventManagerInterface $eventManager The global event manager to register listeners on
+     * @param \Cake\Core\ContainerInterface $container The DI container instance
      * @return \Cake\Event\EventManagerInterface
      */
-    public function events(EventManagerInterface $eventManager): EventManagerInterface
+    public function events(EventManagerInterface $eventManager, ContainerInterface $container): EventManagerInterface
     {
         return $eventManager;
     }

--- a/src/Core/PluginCollection.php
+++ b/src/Core/PluginCollection.php
@@ -70,6 +70,13 @@ class PluginCollection implements Iterator, Countable
     protected int $loopDepth = -1;
 
     /**
+     * Container instance
+     *
+     * @var \Cake\Core\ContainerInterface
+     */
+    protected ContainerInterface $container;
+
+    /**
      * Constructor
      *
      * @param array<\Cake\Core\PluginInterface> $plugins The map of plugins to add to the collection.
@@ -272,6 +279,7 @@ class PluginCollection implements Iterator, Countable
         $config += ['name' => $name];
         $namespace = str_replace('/', '\\', $name);
 
+        /** @var class-string<\Cake\Core\PluginInterface> $className */
         $className = $namespace . '\\' . 'Plugin';
         // Check for [Vendor/]Foo/Plugin class
         if (!class_exists($className)) {
@@ -291,8 +299,11 @@ class PluginCollection implements Iterator, Countable
             }
         }
 
-        /** @var class-string<\Cake\Core\PluginInterface> $className */
-        return new $className($config);
+        /** @var \Cake\Core\BasePlugin $plugin */
+        $plugin = new $className($config);
+        $plugin->setContainer($this->container);
+
+        return $plugin;
     }
 
     /**
@@ -384,5 +395,21 @@ class PluginCollection implements Iterator, Countable
                 yield $plugin;
             }
         }
+    }
+
+    /**
+     * @return \Cake\Core\ContainerInterface
+     */
+    public function getContainer(): ContainerInterface
+    {
+        return $this->container;
+    }
+
+    /**
+     * @param \Cake\Core\ContainerInterface $container
+     */
+    public function setContainer(ContainerInterface $container): void
+    {
+        $this->container = $container;
     }
 }

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -266,7 +266,7 @@ abstract class BaseApplication implements
     public function pluginEvents(EventManagerInterface $eventManager): EventManagerInterface
     {
         foreach ($this->plugins->with('events') as $plugin) {
-            $eventManager = $plugin->events($eventManager);
+            $eventManager = $plugin->events($eventManager, $this->container);
         }
 
         return $eventManager;

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -138,6 +138,7 @@ abstract class BaseApplication implements
      */
     public function addPlugin($name, array $config = [])
     {
+        $this->plugins->setContainer($this->getContainer());
         if (is_string($name)) {
             $plugin = $this->plugins->create($name, $config);
         } else {
@@ -188,6 +189,7 @@ abstract class BaseApplication implements
         // phpcs:ignore
         $plugins = @include $this->configDir . 'plugins.php';
         if (is_array($plugins)) {
+            $this->plugins->setContainer($this->getContainer());
             $this->plugins->addFromConfig($plugins);
         }
     }
@@ -266,7 +268,7 @@ abstract class BaseApplication implements
     public function pluginEvents(EventManagerInterface $eventManager): EventManagerInterface
     {
         foreach ($this->plugins->with('events') as $plugin) {
-            $eventManager = $plugin->events($eventManager, $this->container);
+            $eventManager = $plugin->events($eventManager);
         }
 
         return $eventManager;

--- a/tests/TestCase/Core/BasePluginTest.php
+++ b/tests/TestCase/Core/BasePluginTest.php
@@ -217,7 +217,7 @@ class BasePluginTest extends TestCase
 
         $basePlugin = new class extends BasePlugin
         {
-            public function events(EventManagerInterface $eventManager, ContainerInterface $container): EventManagerInterface
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
                 $eventManager->on('testTrue', function ($event) {
                     return true;
@@ -244,8 +244,9 @@ class BasePluginTest extends TestCase
         static::setAppNamespace();
         $basePlugin = new class extends BasePlugin
         {
-            public function events(EventManagerInterface $eventManager, ContainerInterface $container): EventManagerInterface
+            public function events(EventManagerInterface $eventManager): EventManagerInterface
             {
+                $container = $this->getContainer();
                 $eventManager->on('testTrue', function ($event) use ($container) {
                     return $container->get(stdClass::class);
                 });
@@ -270,6 +271,7 @@ class BasePluginTest extends TestCase
                 $container->add(stdClass::class, json_decode('{"key":"value"}', true));
             }
         };
+        $basePlugin->setContainer($app->getContainer());
         $app = $app->addPlugin($basePlugin);
         $output = new StubConsoleOutput();
         $consoleIo = Mockery::mock(ConsoleIo::class, [$output, $output, null, null])

--- a/tests/TestCase/Core/PluginCollectionTest.php
+++ b/tests/TestCase/Core/PluginCollectionTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Core;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
+use Cake\Core\Container;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Core\PluginCollection;
@@ -72,6 +73,7 @@ class PluginCollectionTest extends TestCase
         ];
 
         $plugins = new PluginCollection();
+        $plugins->setContainer(new Container());
         $plugins->addFromConfig($config);
 
         $this->assertCount(2, $plugins);
@@ -127,6 +129,7 @@ class PluginCollectionTest extends TestCase
     public function testGetAutoload(): void
     {
         $plugins = new PluginCollection();
+        $plugins->setContainer(new Container());
         $plugin = $plugins->get('Named');
         $this->assertInstanceOf(NamedPlugin::class, $plugin);
     }
@@ -142,6 +145,7 @@ class PluginCollectionTest extends TestCase
     public function testCreate(): void
     {
         $plugins = new PluginCollection();
+        $plugins->setContainer(new Container());
 
         $plugin = $plugins->create('Named');
         $this->assertInstanceOf(NamedPlugin::class, $plugin);

--- a/tests/test_app/Plugin/TestPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Plugin.php
@@ -16,13 +16,12 @@ declare(strict_types=1);
 namespace TestPlugin;
 
 use Cake\Core\BasePlugin;
-use Cake\Core\ContainerInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\MiddlewareQueue;
 
 class Plugin extends BasePlugin
 {
-    public function events(EventManagerInterface $event, ContainerInterface $container): EventManagerInterface
+    public function events(EventManagerInterface $event): EventManagerInterface
     {
         $event->on('TestPlugin.load', function (): void {
         });

--- a/tests/test_app/Plugin/TestPlugin/src/Plugin.php
+++ b/tests/test_app/Plugin/TestPlugin/src/Plugin.php
@@ -16,12 +16,13 @@ declare(strict_types=1);
 namespace TestPlugin;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\ContainerInterface;
 use Cake\Event\EventManagerInterface;
 use Cake\Http\MiddlewareQueue;
 
 class Plugin extends BasePlugin
 {
-    public function events(EventManagerInterface $event): EventManagerInterface
+    public function events(EventManagerInterface $event, ContainerInterface $container): EventManagerInterface
     {
         $event->on('TestPlugin.load', function (): void {
         });


### PR DESCRIPTION
This was missed when introducing the `events` hook in 5.1

The DI Container was not accessible from within a plugin class, only from the application class.