### PR TITLE
Allow setting session lifetime from middleware before starting session

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -59,7 +59,7 @@ class Session
      *
      * @var int
      */
-    protected int $_lifetime;
+    protected int $_lifetime = 0;
 
     /**
      * Whether this session is running under a CLI environment
@@ -221,12 +221,8 @@ class Session
             'handler' => [],
         ];
 
-        $lifetime = 0;
-        if (isset($config['timeout'])) {
-            $lifetime = (int)$config['timeout'] * 60;
-        }
-        if ($lifetime !== 0) {
-            $config['ini']['session.gc_maxlifetime'] = $lifetime;
+        if (!is_null($config['timeout'])) {
+            $this->configureSessionLifetime((int)$config['timeout'] * 60);
         }
 
         if ($config['cookie']) {
@@ -246,7 +242,6 @@ class Session
             $this->engine($class, $config['handler']);
         }
 
-        $this->_lifetime = $lifetime;
         $this->_isCLI = (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg');
         session_register_shutdown();
     }
@@ -687,5 +682,40 @@ class Session
         $this->write('Config.time', time());
 
         return $result;
+    }
+
+    /**
+     * Allow to set session timeout before session is started in Middleware.
+     * Setting it in bootstrap when fetching the value from database result in query not showing DebugKit
+     * and other issues due to using ORM before bootstrapping of other plugins.
+     *
+     * @param int $lifetime in seconds
+     * @return void
+     * @throws \Cake\Core\Exception\CakeException
+     */
+    public function setSessionLifetime(int $lifetime): void
+    {
+        if ($this->started()) {
+            throw new CakeException("Can't modify session lifetime after session has already been started.");
+        }
+
+        $this->configureSessionLifetime($lifetime);
+    }
+
+    /**
+     * Configure session lifetime
+     *
+     * @param int $lifetime
+     * @return void
+     */
+    private function configureSessionLifetime(int $lifetime): void
+    {
+        if ($lifetime !== 0) {
+            $this->options([
+                'session.gc_maxlifetime' => $lifetime,
+            ]);
+        }
+
+        $this->_lifetime = $lifetime;
     }
 }

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -708,7 +708,7 @@ class Session
      * @param int $lifetime
      * @return void
      */
-    private function configureSessionLifetime(int $lifetime): void
+    protected function configureSessionLifetime(int $lifetime): void
     {
         if ($lifetime !== 0) {
             $this->options([

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -685,9 +685,9 @@ class Session
     }
 
     /**
-     * Allow to set session timeout before session is started in Middleware.
-     * Setting it in bootstrap when fetching the value from database result in query not showing DebugKit
-     * and other issues due to using ORM before bootstrapping of other plugins.
+     * Set the session timeout period.
+     *
+     * If set to `0`, no server side timeout will be applied.
      *
      * @param int $lifetime in seconds
      * @return void

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -221,7 +221,7 @@ class Session
             'handler' => [],
         ];
 
-        if (!is_null($config['timeout'])) {
+        if ($config['timeout'] !== null) {
             $this->configureSessionLifetime((int)$config['timeout'] * 60);
         }
 

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -672,5 +672,9 @@ class SessionTest extends TestCase
         $session = Session::create($config);
         $session->setSessionLifetime(3540); // 59*60
         $this->assertEquals(59 * 60, ini_get('session.gc_maxlifetime'), 'timeout should set gc maxlifetime');
+
+        $session->start();
+        $this->expectException(CakeException::class);
+        $session->setSessionLifetime(3600); // 60*60
     }
 }

--- a/tests/TestCase/Http/SessionTest.php
+++ b/tests/TestCase/Http/SessionTest.php
@@ -654,4 +654,23 @@ class SessionTest extends TestCase
         $session->check('something');
         $this->assertFalse($session->started());
     }
+
+    /**
+     * test setting ini properties with Session configuration after session is created before started.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testSessionConfigTimeoutUpdate(): void
+    {
+        $_SESSION = null;
+
+        ini_set('session.gc_maxlifetime', 86400);
+        $config = [
+            'defaults' => 'php',
+        ];
+
+        $session = Session::create($config);
+        $session->setSessionLifetime(3540); // 59*60
+        $this->assertEquals(59 * 60, ini_get('session.gc_maxlifetime'), 'timeout should set gc maxlifetime');
+    }
 }


### PR DESCRIPTION
Ability to change session lifetime in Middleware (so after already having created Session instance) but before session started (as this is used when starting a session).

The purpose is to have the session lifetime setting set in database, but fetching data from database in bootstrap have side-effects (like not showing the query in DebugKit, or having wrong db connection if it's configured by another bootstrap file (like a plugin). It is up to developer to correctly order the middlewares.

While currently the only way to change that would be to create new Session instance in middleware and replace it.

Other simpler implementation could be just putting a setter for that private value:
```
    public function setSessionLifetime(int $lifetime): void
    {
        if ($this->started()) {
            throw new CakeException("Can't modify session lifetime after session has already been started.");
        }

        $this->_lifetime = $lifetime;
    }
```
I can make different PR with only the setter if that would be preferred.