### PR TITLE
Optimize count updation in CounterCache behavior.

### DIFF
--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -338,6 +338,28 @@ class CounterCacheBehaviorTest extends TestCase
         $this->assertSame(2, $after->get('posts_published'));
     }
 
+    public function testCustomFindWithoutSubquery(): void
+    {
+        $this->post->belongsTo('Users');
+
+        $this->post->addBehavior('CounterCache', [
+            'Users' => [
+                'posts_published' => [
+                    'finder' => 'published',
+                    'useSubQuery' => false,
+                ],
+            ],
+        ]);
+
+        $before = $this->_getUser();
+        $entity = $this->_getEntity()->set('published', true);
+        $this->post->save($entity);
+        $after = $this->_getUser();
+
+        $this->assertSame(1, $before->get('posts_published'));
+        $this->assertSame(2, $after->get('posts_published'));
+    }
+
     /**
      * Testing counter cache with lambda returning number
      */


### PR DESCRIPTION
Use sub query to update the count instead of separate queries to fetch and update the count.

There have been times when I have had the counter cache values go out of sync. Updating the count using a single query should hopefully avoid this.
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
