### PR TITLE
Add countAll() query function

### DIFF
--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -103,6 +103,16 @@ class FunctionsBuilder
     }
 
     /**
+     * Returns a AggregateExpression representing a call to SQL COUNT(*) function.
+     *
+     * @return \Cake\Database\Expression\AggregateExpression
+     */
+    public function countAll(): AggregateExpression
+    {
+        return $this->count('*');
+    }
+
+    /**
      * Returns a FunctionExpression representing a string concatenation
      *
      * @param array $args List of strings or expressions to concatenate

--- a/tests/TestCase/Database/FunctionsBuilderTest.php
+++ b/tests/TestCase/Database/FunctionsBuilderTest.php
@@ -128,7 +128,18 @@ class FunctionsBuilderTest extends TestCase
      */
     public function testCount(): void
     {
-        $function = $this->functions->count('*');
+        $function = $this->functions->count('col_a');
+        $this->assertInstanceOf(AggregateExpression::class, $function);
+        $this->assertSame('COUNT(col_a)', $function->sql(new ValueBinder()));
+        $this->assertSame('integer', $function->getReturnType());
+    }
+
+    /**
+     * Tests generating a COUNT(*) function
+     */
+    public function testCountAll(): void
+    {
+        $function = $this->functions->countAll();
         $this->assertInstanceOf(AggregateExpression::class, $function);
         $this->assertSame('COUNT(*)', $function->sql(new ValueBinder()));
         $this->assertSame('integer', $function->getReturnType());


### PR DESCRIPTION
Thought this would be a clean helper to avoid having to type in the special sql value each time.

Would could also default `count()` to `'*'`.