### PR TITLE
Fix object naming issue in ObjectRegistry.

### DIFF
--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -82,14 +82,17 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
     {
         $plugin = null;
         if (isset($config['className'])) {
-            $objName = $name;
+            if ($name === $config['className']) {
+                [$plugin, $objName] = pluginSplit($name);
+            } else {
+                $objName = $name;
+            }
             $name = $config['className'];
         } else {
             [$plugin, $objName] = pluginSplit($name);
-        }
-
-        if ($plugin) {
-            $config['className'] = $name;
+            if ($plugin) {
+                $config['className'] = $name;
+            }
         }
 
         $loaded = isset($this->_loaded[$objName]);

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -103,6 +103,13 @@ class BehaviorRegistryTest extends TestCase
 
         $result = $this->Behaviors->load('TestPlugin.PersisterOne');
         $this->assertInstanceOf(PersisterOneBehavior::class, $result);
+
+        $config = ['className' => 'TestPlugin.PersisterOne'];
+        $this->assertSame($config, $result->getConfig());
+
+        $this->Behaviors->unload('PersisterOne');
+        $this->Behaviors->load('TestPlugin.PersisterOne', $config);
+        $this->assertInstanceOf(PersisterOneBehavior::class, $this->Behaviors->PersisterOne);
     }
 
     /**


### PR DESCRIPTION
For plugin prefixed names when `$name` is the same as `$config['className']`, the object name deduced should be without the plugin prefix. Refs #17620

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
