### PR TITLE
Correcting RulesChecker add method description

### DIFF
--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -117,7 +117,7 @@ class RulesChecker
     }
 
     /**
-     * Adds a rule that will be applied to the entity both on create and update
+     * Adds a rule that will be applied to the entity on create, update and delete
      * operations.
      *
      * ### Options


### PR DESCRIPTION
The docblock for the `RulesChecker.add` method didn't state that rules added with this method where also checked during delete operation