### PR TITLE
Fix superglobal usage in Connection

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -37,7 +37,6 @@ use Cake\Log\Log;
 use Closure;
 use Psr\SimpleCache\CacheInterface;
 use Throwable;
-
 use function Cake\Core\env;
 
 /**
@@ -192,12 +191,12 @@ class Connection implements ConnectionInterface
             $message = 'The connection is going to be closed but there is an active transaction.';
 
             $requestUrl = env('REQUEST_URI');
-            if ($requestUrl !== null) {
+            if ($requestUrl) {
                 $message .= "\nRequest URL: " . $requestUrl;
             }
 
             $clientIp = env('REMOTE_ADDR');
-            if ($clientIp !== null) {
+            if ($clientIp) {
                 $message .= "\nClient IP: " . $clientIp;
             }
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -38,6 +38,8 @@ use Closure;
 use Psr\SimpleCache\CacheInterface;
 use Throwable;
 
+use function Cake\Core\env;
+
 /**
  * Represents a connection with a database server.
  */
@@ -189,13 +191,13 @@ class Connection implements ConnectionInterface
         if ($this->_transactionStarted && class_exists(Log::class)) {
             $message = 'The connection is going to be closed but there is an active transaction.';
 
-            $requestUrl = $_SERVER['REQUEST_URI'] ?? '';
-            if ($requestUrl) {
+            $requestUrl = env('REQUEST_URI');
+            if ($requestUrl !== null) {
                 $message .= "\nRequest URL: " . $requestUrl;
             }
 
-            $clientIp = $_SERVER['REMOTE_ADDR'] ?? '';
-            if ($clientIp) {
+            $clientIp = env('REMOTE_ADDR');
+            if ($clientIp !== null) {
                 $message .= "\nClient IP: " . $clientIp;
             }
 


### PR DESCRIPTION
Don't directly reference the superglobals when generating log context for active transaction warnings. Instead use env(). I didn't want to introduce cross package dependencies that would read from the active request.
