### PR TITLE
Pass the $config array to the component constructor.

### DIFF
--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -27,6 +27,8 @@ use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Countable;
 use Exception;
+use League\Container\ReflectionContainer;
+use TestApp\Controller\Component\ConfiguredComponent;
 use TestApp\Controller\Component\FlashAliasComponent;
 use TestPlugin\Controller\Component\OtherComponent;
 use Traversable;
@@ -102,6 +104,21 @@ class ComponentRegistryTest extends TestCase
 
         $this->assertInstanceOf(FlashComponent::class, $flash);
         $this->assertSame('customFlash', $flash->getConfig('key'));
+    }
+
+    public function testLoadWithContainerAutoWiring(): void
+    {
+        $controller = new Controller(new ServerRequest());
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+        $components = new ComponentRegistry($controller, $container);
+
+        $container->add(ComponentRegistry::class, $components);
+
+        $component = $components->load(ConfiguredComponent::class, ['key' => 'customFlash']);
+
+        $this->assertInstanceOf(ConfiguredComponent::class, $component);
+        $this->assertSame(['key' => 'customFlash'], $component->configCopy);
     }
 
     /**


### PR DESCRIPTION
This avoids having to call setConfig() and ensures initialize() is called with the initial config.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
