### PR TITLE
Don't ignore platform requirements for PHP 8.4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,6 @@ jobs:
       run: |
         if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
           composer update --prefer-lowest --prefer-stable
-        elif ${{ matrix.php-version == '8.4' }}; then
-          composer update --ignore-platform-req=php
         else
           composer update
         fi

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -359,7 +359,7 @@ class ExceptionTrap
     /**
      * Trigger an error that occurred during rendering an exception.
      *
-     * By triggering an E_USER_ERROR we can end up in the default
+     * By triggering an E_USER_WARNING we can end up in the default
      * exception handling which will log the rendering failure,
      * and hopefully render an error page.
      *
@@ -375,6 +375,6 @@ class ExceptionTrap
             $exception->getFile(),
             $exception->getLine(),
         );
-        trigger_error($message, E_USER_ERROR);
+        trigger_error($message, E_USER_WARNING);
     }
 }

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -63,7 +63,6 @@ class PhpError
         E_RECOVERABLE_ERROR => 'warning',
         E_NOTICE => 'notice',
         E_USER_NOTICE => 'notice',
-        E_STRICT => 'strict',
         E_DEPRECATED => 'deprecated',
         E_USER_DEPRECATED => 'deprecated',
     ];
@@ -95,6 +94,10 @@ class PhpError
         ?int $line = null,
         array $trace = []
     ) {
+        if (version_compare(PHP_VERSION, '8.4.0-dev', '<')) {
+            $this->levelMap[E_STRICT] = 'strict';
+        }
+
         $this->code = $code;
         $this->message = $message;
         $this->file = $file;

--- a/tests/TestCase/Error/PhpErrorTest.php
+++ b/tests/TestCase/Error/PhpErrorTest.php
@@ -36,14 +36,18 @@ class PhpErrorTest extends TestCase
     public static function errorCodeProvider(): array
     {
         // [php error code, label, log-level]
-        return [
+        $return = [
             [E_ERROR, 'error', LOG_ERR],
             [E_WARNING, 'warning', LOG_WARNING],
             [E_NOTICE, 'notice', LOG_NOTICE],
-            [E_STRICT, 'strict', LOG_NOTICE],
-            [E_STRICT, 'strict', LOG_NOTICE],
             [E_USER_DEPRECATED, 'deprecated', LOG_NOTICE],
         ];
+
+        if (version_compare(PHP_VERSION, '8.4.0-dev', '<')) {
+            $return[] = [E_STRICT, 'strict', LOG_NOTICE];
+        }
+
+        return $return;
     }
 
     #[DataProvider('errorCodeProvider')]


### PR DESCRIPTION
All our dependencies should be PHP 8.4 compatible now.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
