### PR TITLE
Add BeforeMarshalEventInterface

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -49,6 +49,7 @@ use Cake\ORM\Query\QueryFactory;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Query\UpdateQuery;
 use Cake\ORM\Rule\IsUnique;
+use Cake\ORM\TableEvents\BeforeMarshalEventInterface;
 use Cake\Utility\Inflector;
 use Cake\Validation\ValidatorAwareInterface;
 use Cake\Validation\ValidatorAwareTrait;
@@ -3191,7 +3192,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function implementedEvents(): array
     {
         $eventMap = [
-            'Model.beforeMarshal' => 'beforeMarshal',
+            'Model.beforeMarshal' => BeforeMarshalEventInterface::class,
             'Model.afterMarshal' => 'afterMarshal',
             'Model.buildValidator' => 'buildValidator',
             'Model.beforeFind' => 'beforeFind',
@@ -3206,10 +3207,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         ];
         $events = [];
 
-        foreach ($eventMap as $event => $method) {
-            if (!method_exists($this, $method)) {
+        foreach ($eventMap as $event => $interface) {
+            if (!($this instanceof $interface)) {
                 continue;
             }
+            $method = explode('.', $event)[1];
             $events[$event] = $method;
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -3208,10 +3208,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         $events = [];
 
         foreach ($eventMap as $event => $interface) {
-            if (!($this instanceof $interface)) {
+            $method = explode('.', $event)[1];
+            if (!method_exists($this, $method)) {
                 continue;
             }
-            $method = explode('.', $event)[1];
+            if (!($this instanceof $interface)) {
+            	throw new CakeException(self::class . ' must implement ' . $interface . ' interface');
+            }
             $events[$event] = $method;
         }
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -3213,7 +3213,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 continue;
             }
             if (!($this instanceof $interface)) {
-            	throw new CakeException(self::class . ' must implement ' . $interface . ' interface');
+                throw new CakeException(self::class . ' must implement ' . $interface . ' interface');
             }
             $events[$event] = $method;
         }

--- a/src/ORM/TableEvents/BeforeMarshalEventInterface.php
+++ b/src/ORM/TableEvents/BeforeMarshalEventInterface.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\ORM\TableEvents;
+
+use ArrayObject;
+use Cake\Event\EventInterface;
+
+interface BeforeMarshalEventInterface {
+
+    /**
+     * The Model.beforeMarshal event is fired before request data is converted into entities.
+     *
+     * @param \Cake\Event\EventInterface<\Cake\ORM\Table> $event Model event.
+     * @param \ArrayObject<string, mixed> $data Data to be saved.
+     * @param \ArrayObject<string, mixed> $options Options.
+     * @return void
+     */
+    public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void;
+}

--- a/src/ORM/TableEvents/BeforeMarshalEventInterface.php
+++ b/src/ORM/TableEvents/BeforeMarshalEventInterface.php
@@ -20,7 +20,6 @@ use ArrayObject;
 use Cake\Event\EventInterface;
 
 interface BeforeMarshalEventInterface {
-
     /**
      * The Model.beforeMarshal event is fired before request data is converted into entities.
      *


### PR DESCRIPTION
The idea is to explicitly define model callback methods so that in order to use the callbacks table classes would need to implement callback interfaces like BeforeMarshalEventInterface. This way it would be possible to enforce the consistent methods signatures of model callbacks in table classes. For example, if the client code would have `public function beforeMarshal($event, $data, $options): void` method an error would be generated because it does not match the method defined in BeforeMarshalEventInterface.

Would this approach be okay? Only one callback interface is added here just to make it easier to explain. 
