### PR TITLE
Fix context array being passed for optional argument of validation method.

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -3132,7 +3132,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * @param array|null $context Either the validation context or null.
      * @return bool True if the value is unique, or false if a non-scalar, non-unique value was given.
      */
-    public function validateUnique(mixed $value, array $options, ?array $context = null): bool
+    public function validateUnique(mixed $value, array $options = [], ?array $context = null): bool
     {
         if ($context === null) {
             $context = $options;

--- a/src/Validation/RulesProvider.php
+++ b/src/Validation/RulesProvider.php
@@ -17,12 +17,15 @@ declare(strict_types=1);
 namespace Cake\Validation;
 
 use ReflectionClass;
+use function Cake\Core\deprecationWarning;
 
 /**
  * A Proxy class used to remove any extra arguments when the user intended to call
  * a method in another class that is not aware of validation providers signature
  *
  * @method bool extension(mixed $check, array $extensions, array $context = [])
+ * @deprecated 5.2.0 This class is no longer used. Cake\Validation\Validation
+ *  is now directly used as a provider in Cake\Validation\Validator.
  */
 class RulesProvider
 {
@@ -49,6 +52,15 @@ class RulesProvider
      */
     public function __construct(object|string $class = Validation::class)
     {
+        deprecationWarning(
+            '5.2.0',
+            sprintf(
+                'The class Cake\Validation\RulesProvider is deprecated. '
+                . 'Directly set %s as a validation provider.',
+                (is_string($class) ? $class : get_class($class))
+            )
+        );
+
         $this->_class = $class;
         $this->_reflection = new ReflectionClass($class);
     }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -20,7 +20,8 @@ declare(strict_types=1);
  */
 namespace Cake\Validation;
 
-use InvalidArgumentException;
+use Closure;
+use ReflectionFunction;
 
 /**
  * ValidationRule object. Represents a validation method, error message and
@@ -120,32 +121,28 @@ class ValidationRule
 
         if (is_string($this->_rule)) {
             $provider = $providers[$this->_provider];
-            /** @var callable $callable */
-            $callable = [$provider, $this->_rule];
-            $isCallable = is_callable($callable);
+            /** @phpstan-ignore-next-line */
+            $callable = [$provider, $this->_rule](...);
         } else {
             $callable = $this->_rule;
-            $isCallable = true;
+            if (!$callable instanceof Closure) {
+                $callable = $callable(...);
+            }
         }
 
-        if (!$isCallable) {
-            /** @var string $method */
-            $method = $this->_rule;
-            $message = sprintf(
-                'Unable to call method `%s` in `%s` provider for field `%s`',
-                $method,
-                $this->_provider,
-                $context['field']
-            );
-            throw new InvalidArgumentException($message);
-        }
+        $args = [$value];
 
         if ($this->_pass) {
-            $args = array_values(array_merge([$value], $this->_pass, [$context]));
-            $result = $callable(...$args);
-        } else {
-            $result = $callable($value, $context);
+            $args = array_merge([$value], array_values($this->_pass));
         }
+
+        $params = (new ReflectionFunction($callable))->getParameters();
+        $lastParm = array_pop($params);
+        if ($lastParm && $lastParm->getName() === 'context') {
+            $args['context'] = $context;
+        }
+
+        $result = $callable(...$args);
 
         if ($result === false) {
             return $this->_message ?: false;

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -330,7 +330,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             return null;
         }
 
-        $this->_providers[$name] = new RulesProvider();
+        $this->_providers[$name] = Validation::class;
 
         return $this->_providers[$name];
     }

--- a/tests/TestCase/Validation/ValidationRuleTest.php
+++ b/tests/TestCase/Validation/ValidationRuleTest.php
@@ -20,7 +20,7 @@ use Cake\Core\Exception\CakeException;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\ValidationRule;
 use Cake\Validation\ValidationSet;
-use InvalidArgumentException;
+use Error;
 
 /**
  * ValidationRuleTest
@@ -93,8 +93,8 @@ class ValidationRuleTest extends TestCase
      */
     public function testCustomMethodMissingError(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to call method `totallyMissing` in `default` provider for field `test`');
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Call to undefined method Cake\Test\TestCase\Validation\ValidationRuleTest::totallyMissing()');
         $def = ['rule' => ['totallyMissing']];
         $data = 'some data';
         $providers = ['default' => $this];


### PR DESCRIPTION
Prior to this patch validation providers had to be used through the `RulesProvider` class to handle properly passing the context array.
Fixes #17631

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
