### PR TITLE
Defer support

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -188,6 +188,15 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
     protected array $viewClasses = [];
 
     /**
+     * Holds an array of deferred tasks (callables) to be executed after the response is sent to the client.
+     *
+     * Tasks are added to this array via the defer() method, and they are executed in the shutdown function.
+     *
+     * @var array<callable> $deferredTasks Array of callables to execute deferred tasks
+     */
+    protected array $deferredTasks = [];
+
+    /**
      * Constructor.
      *
      * Sets a number of properties based on conventions if they are empty. To override the
@@ -974,5 +983,78 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function afterFilter(EventInterface $event)
     {
+        // Only register deferred execution if there are deferred tasks
+        if (!empty($this->deferredTasks)) {
+            register_shutdown_function(function (): void {
+                $this->executeDeferredTasks();
+
+                echo $this->response->getBody();
+
+                foreach ($this->response->getHeaders() as $header => $values) {
+                    foreach ($values as $value) {
+                        header("{$header}: {$value}");
+                    }
+                }
+
+                if (function_exists('fastcgi_finish_request')) {
+                    fastcgi_finish_request();
+                } else {
+                    ob_end_flush();
+                    flush();
+                }
+            });
+        }
+    }
+
+    /**
+     * Adds a task (closure or callable) to the deferred queue for execution after the client receives the response.
+     *
+     * This method allows you to queue tasks that do not need to run immediately, such as sending emails or logging,
+     * to improve response time for the user. Deferred tasks will execute in the shutdown phase after the main
+     * response has been sent.
+     *
+     * Example usage:
+     *
+     * ```php
+     * // Using an anonymous function (closure)
+     * $this->defer(function () {
+     *     // Example task: send an email
+     *     $mailer = new UserMailer();
+     *     $mailer->sendWelcomeEmail($user)->send();
+     * });
+     *
+     * // Using an instance method as a callable
+     * $logger = new CustomLogger();
+     * $this->defer([$logger, 'logDeferredInfo']);
+     *
+     * // Using a static method as a callable
+     * $this->defer(['CustomLogger', 'logStaticDeferredInfo']);
+     *
+     * // Using a named function as a callable
+     * function logDeferredMessage() {
+     *     Log::info('This is a deferred log message');
+     * }
+     * $this->defer('logDeferredMessage');
+     * ```
+     *
+     * @param callable $task A callable (e.g., closure, function, method) that defines the deferred task to be executed.
+     *                        This task will run after the response is sent to the client.
+     */
+    public function defer(callable $task): void
+    {
+        $this->deferredTasks[] = $task;
+    }
+
+    /**
+     * Execute all deferred tasks after the response is sent.
+     */
+    protected function executeDeferredTasks(): void
+    {
+        foreach ($this->deferredTasks as $task) {
+            $task();
+        }
+
+        // Clear tasks to prevent re-running
+        $this->deferredTasks = [];
     }
 }


### PR DESCRIPTION
This pull request introduces **deferred task execution** support to optimize response times by offloading non-essential tasks to run in the background after the main response has been sent to the client. The `defer()` method allows you to add tasks that don’t need immediate execution, improving performance and user experience by reducing perceived wait times.

The new `defer()` functionality enables controllers to queue tasks that will execute after the response has been finalized and sent to the client. This approach is ideal for background processing tasks, such as sending emails, refreshing cache data, logging, or performing database updates that aren’t critical to the immediate response.

The deferred tasks are registered using the `defer()` method, which queues a callable or closure for execution. Upon request completion, these tasks are automatically executed in the shutdown phase, ensuring the client isn’t kept waiting.

While CakePHP offers a Queue plugin for handling background jobs, it introduces additional overhead, such as setting up a queue system (e.g., Redis, Beanstalkd) and managing queue workers. For lightweight background tasks that don’t require persistent queues or complex workflows, `defer()` provides a simpler, faster alternative that avoids the setup and maintenance requirements of a full queue system. This approach is especially useful for tasks that can run immediately after the main response, without requiring a long-running worker process.

### Use Cases for `defer()`

1. **Sending Emails**
   - **Example**: After a user registers or requests a password reset, an email can be sent in the background.
   - **Usage**:
     ```php
     $this->defer(function () use ($userEmail) {
         $mailer = new UserMailer();
         $mailer->sendWelcomeEmail($userEmail)->send();
     });
     ```

2. **Caching Frequently Accessed Data**
   - **Example**: For frequently accessed data (e.g., an active users list), we can defer a cache check and refresh task to keep the cache up-to-date without delaying the main response.
   - **Usage**:
     ```php
     $this->defer(function () use ($cacheKey) {
         $this->checkAndRefreshCache($cacheKey);
     });
     ```

3. **Logging and Analytics**
   - **Example**: Tracking user actions, page visits, or other metrics that are valuable but don’t require immediate processing.
   - **Usage**:
     ```php
     $this->defer(function () use ($userId, $action) {
         Log::info("User {$userId} performed action: {$action}");
     });
     ```

### Example Code for Implementation

Here’s an example of how the `defer()` method is integrated within the `UsersController` to send a welcome email and refresh the active users cache:

```php
// In UsersController.php

public function registerUser()
{
    // Registration logic here...

    // Send welcome email in the background
    $this->defer(function () use ($userEmail) {
        $mailer = new UserMailer();
        $mailer->sendWelcomeEmail($userEmail)->send();
    });

    // Return response to user
    $this->Flash->success('Welcome.');
}
```

### Limitations and Best Practices
While `defer()` is a powerful tool for background processing, it comes with some limitations:

- **PHP-FPM Process Locking**: When using defer(), the PHP-FPM process remains occupied until all deferred tasks are completed. This can impact server performance if too many requests have deferred tasks running, as it reduces the availability of PHP-FPM workers.
- **Avoid Long-Running Tasks**: `defer()` should not be used for long-running tasks such as large database updates, extensive API calls, or complex data processing. These tasks should be handled by a job queue system to avoid overloading PHP-FPM and to keep the server responsive.
- **Recommended Use**: `defer()` is best suited for lightweight tasks like sending emails, refreshing cache entries, logging, and simple cleanup operations.