### PR TITLE
5.2 - Add debugOutput to ConsoleIntegrationTestTrait

### DIFF
--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -18,6 +18,7 @@ namespace Cake\Console\TestSuite;
 use Cake\Command\Command;
 use Cake\Console\CommandRunner;
 use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOutput;
 use Cake\Console\Exception\StopException;
 use Cake\Console\TestSuite\Constraint\ContentsContain;
 use Cake\Console\TestSuite\Constraint\ContentsContainRow;
@@ -27,6 +28,7 @@ use Cake\Console\TestSuite\Constraint\ContentsRegExp;
 use Cake\Console\TestSuite\Constraint\ExitCode;
 use Cake\Core\ConsoleApplicationInterface;
 use Cake\Core\TestSuite\ContainerStubTrait;
+use Cake\Error\Debugger;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\After;
 
@@ -251,6 +253,35 @@ trait ConsoleIntegrationTestTrait
     public function assertErrorEmpty(string $message = ''): void
     {
         $this->assertThat(null, new ContentsEmpty($this->_err->messages(), 'error output'), $message);
+    }
+
+    /**
+     * Dump the exit code, stdout and stderr from the most recently run command
+     *
+     * @param resource|null $stream The stream to write to. Defaults to STDOUT
+     * @return void
+     */
+    public function debugOutput($stream = null): void
+    {
+        $output = new ConsoleOutput($stream ?? STDOUT);
+        if (class_exists(Debugger::class)) {
+            $trace = Debugger::trace(['start' => 0, 'depth' => 1, 'format' => 'array']);
+            $file = $trace[0]['file'];
+            $line = $trace[0]['line'];
+            $output->write("{$file} on {$line}");
+        }
+        $output->write('########## debugOutput() ##########');
+
+        if ($this->_exitCode !== null) {
+            $output->write('<info>Exit Code</info>');
+            $output->write((string)$this->_exitCode, 2);
+        }
+        $output->write('<info>STDOUT</info>');
+        $output->write($this->_out->messages(), 2);
+
+        $output->write('<info>STDERR</info>');
+        $output->write($this->_err->messages());
+        $output->write('###################################');
     }
 
     /**

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -254,4 +254,38 @@ class ConsoleIntegrationTestTraitTest extends TestCase
             'assertErrorRegExp' => ['assertErrorRegExp', 'Failed asserting that `/test/` PCRE pattern found in error output', 'routes', '/test/'],
         ];
     }
+
+    /**
+     * Test the debugOutput helper
+     *
+     * @return void
+     */
+    public function testDebugOutput(): void
+    {
+        $this->exec('sample');
+        $temp = tempnam(TMP, 'debug-output');
+        $f = fopen($temp, 'w');
+        $this->debugOutput($f);
+
+        $f = fopen($temp, 'r');
+        $result = fread($f, 1024);
+        $file = __FILE__;
+        $line = __LINE__ - 5;
+
+        $expected = <<<TEXT
+$file on $line
+########## debugOutput() ##########
+Exit Code
+0
+
+STDOUT
+This is the main method called from SampleCommand
+
+STDERR
+
+###################################
+
+TEXT;
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -286,6 +286,6 @@ STDERR
 ###################################
 
 TEXT;
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, str_replace("\r\n", "\n", $result));
     }
 }


### PR DESCRIPTION
I frequently find myself needing to dump the output of commands when writing tests for them. This is pretty tedious right now and I think having a helper like this will make writing tests simpler.

I'd also like to add similar methods for HTTP integration tests as well.