### PR TITLE
Allow keeping existing tab indentation for plugin load

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,4 +14,6 @@
         <severity>0</severity>
         <exclude-pattern>src/Collection/functions.php</exclude-pattern>
     </rule>
+
+    <exclude-pattern>/tests/test_app/config/plugins_tab_indentation.php</exclude-pattern>
 </ruleset>

--- a/src/Command/PluginLoadCommand.php
+++ b/src/Command/PluginLoadCommand.php
@@ -32,6 +32,8 @@ use Cake\Utility\Hash;
  */
 class PluginLoadCommand extends Command
 {
+    use PluginLoadTrait;
+
     /**
      * Config file
      *
@@ -127,6 +129,10 @@ class PluginLoadCommand extends Command
         } else {
             $array = var_export($config, true);
         }
+        if ($this->isTabIndentation($this->configFile)) {
+            $array = $this->indentWithTab($array);
+        }
+
         $contents = '<?php' . "\n\n" . 'return ' . $array . ';' . "\n";
 
         if (file_put_contents($this->configFile, $contents)) {

--- a/src/Command/PluginLoadTrait.php
+++ b/src/Command/PluginLoadTrait.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         5.1.2
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Command;
+
+/**
+ * Trait for plugin load/unload functionality.
+ *
+ * @internal
+ */
+trait PluginLoadTrait
+{
+    /**
+     * @param string $configFile Config file.
+     * @return bool
+     */
+    protected function isTabIndentation(string $configFile): bool
+    {
+        if (!file_exists($configFile)) {
+            return false;
+        }
+
+        $content = (string)file_get_contents($configFile);
+
+        return str_contains($content, "\t");
+    }
+
+    /**
+     * @param string $array Content
+     * @return string
+     */
+    protected function indentWithTab(string $array): string
+    {
+        return str_replace(['    ', '  '], "\t", $array);
+    }
+}

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -27,6 +27,8 @@ use Cake\Utility\Hash;
  */
 class PluginUnloadCommand extends Command
 {
+    use PluginLoadTrait;
+
     /**
      * Config file
      *
@@ -99,6 +101,10 @@ class PluginUnloadCommand extends Command
         } else {
             $array = var_export($config, true);
         }
+        if ($this->isTabIndentation($this->configFile)) {
+            $array = $this->indentWithTab($array);
+        }
+
         $contents = '<?php' . "\n" . 'return ' . $array . ';';
 
         if (file_put_contents($this->configFile, $contents)) {

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -126,4 +126,22 @@ class PluginLoadCommandTest extends TestCase
         $this->assertTrue(isset($config['NopeNotThere']));
         $this->assertSame(['optional' => true], $config['NopeNotThere']);
     }
+
+    /**
+     * Test writing file with existing content and tab indentation.
+     */
+    public function testLoadWithExistingFileAndTabIndentation(): void
+    {
+        copy(CONFIG . 'plugins_tab_indentation.php', CONFIG . 'plugins.php');
+        $this->exec('plugin load TestPlugin --optional');
+        Plugin::getCollection()->remove('TestPlugin');
+
+        $contentAfter = (string)file_get_contents($this->configFile);
+        $this->assertTrue(str_contains($contentAfter, "\t"));
+        $this->assertFalse(str_contains($contentAfter, '    '));
+
+        $config = include $this->configFile;
+        $this->assertTrue(isset($config['TestPlugin']));
+        $this->assertTrue(isset($config['TestPlugin']['optional']));
+    }
 }

--- a/tests/TestCase/Command/PluginUnloadCommandTest.php
+++ b/tests/TestCase/Command/PluginUnloadCommandTest.php
@@ -20,6 +20,7 @@ use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use TestPlugin\Plugin as TestPlugin;
 
 /**
  * PluginUnloadCommandTest class
@@ -111,5 +112,24 @@ class PluginUnloadCommandTest extends TestCase
         $this->exec('plugin unload NopeNotThere');
         $this->assertExitCode(CommandInterface::CODE_ERROR);
         $this->assertErrorContains('Plugin `NopeNotThere` could not be found');
+    }
+
+    /**
+     * Test writing file with existing content and tab indentation.
+     */
+    public function testUnloadWithExistingFileAndTabIndentation(): void
+    {
+        $plugin = new TestPlugin();
+        Plugin::getCollection()->add($plugin);
+
+        copy(CONFIG . 'plugins_tab_indentation.php', CONFIG . 'plugins.php');
+        $this->exec('plugin unload TestPlugin');
+
+        $contentAfter = (string)file_get_contents($this->configFile);
+        $this->assertTrue(str_contains($contentAfter, "\t"));
+        $this->assertFalse(str_contains($contentAfter, '    '));
+
+        $config = include $this->configFile;
+        $this->assertTrue(!isset($config['TestPlugin']));
     }
 }

--- a/tests/test_app/config/plugins.php
+++ b/tests/test_app/config/plugins.php
@@ -1,2 +1,3 @@
 <?php
+
 return [];

--- a/tests/test_app/config/plugins_tab_indentation.php
+++ b/tests/test_app/config/plugins_tab_indentation.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'Foo' => [
+		'optional' => true,
+	],
+	'TestPlugin' => [],
+];


### PR DESCRIPTION
When working with existing files that have tab indentation set up, this would rewrite the whole file.
This fixes it.