### PR TITLE
5.next: route action check in `bin/cake routes`

### DIFF
--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -44,15 +44,13 @@ class RoutesCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $header = [
-            'Route name', 'URI template', 'Plugin', 'Prefix',
-            'Controller', 'Action', 'Valid Action', 'Method(s)',
-        ];
+        $header = ['Route name', 'URI template', 'Plugin', 'Prefix', 'Controller', 'Action', 'Method(s)'];
         if ($args->getOption('with-middlewares') || $args->getOption('verbose')) {
             $header[] = 'Middlewares';
         }
         if ($args->getOption('verbose')) {
             $header[] = 'Defaults';
+            $header[] = 'Existing';
         }
 
         $availableRoutes = Router::routes();
@@ -69,7 +67,6 @@ class RoutesCommand extends Command
                 $route->defaults['prefix'] ?? '',
                 $route->defaults['controller'] ?? '',
                 $route->defaults['action'] ?? '',
-                $route->isActionPresent() ? '' : 'X',
                 implode(', ', $methods),
             ];
 
@@ -79,6 +76,7 @@ class RoutesCommand extends Command
             if ($args->getOption('verbose')) {
                 ksort($route->defaults);
                 $item[] = json_encode($route->defaults, JSON_THROW_ON_ERROR);
+                $item[] = $route->isActionPresent() ? '' : 'X';
             }
 
             $output[] = $item;
@@ -121,7 +119,6 @@ class RoutesCommand extends Command
                         $route->defaults['prefix'] ?? '',
                         $route->defaults['controller'] ?? '',
                         $route->defaults['action'] ?? '',
-                        $route->isActionPresent() ? '' : 'X',
                         implode(', ', $methods),
                     ];
 

--- a/src/Command/RoutesCommand.php
+++ b/src/Command/RoutesCommand.php
@@ -44,7 +44,10 @@ class RoutesCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io): ?int
     {
-        $header = ['Route name', 'URI template', 'Plugin', 'Prefix', 'Controller', 'Action', 'Method(s)'];
+        $header = [
+            'Route name', 'URI template', 'Plugin', 'Prefix',
+            'Controller', 'Action', 'Valid Action', 'Method(s)',
+        ];
         if ($args->getOption('with-middlewares') || $args->getOption('verbose')) {
             $header[] = 'Middlewares';
         }
@@ -66,6 +69,7 @@ class RoutesCommand extends Command
                 $route->defaults['prefix'] ?? '',
                 $route->defaults['controller'] ?? '',
                 $route->defaults['action'] ?? '',
+                $route->isActionPresent() ? '' : 'X',
                 implode(', ', $methods),
             ];
 
@@ -117,6 +121,7 @@ class RoutesCommand extends Command
                         $route->defaults['prefix'] ?? '',
                         $route->defaults['controller'] ?? '',
                         $route->defaults['action'] ?? '',
+                        $route->isActionPresent() ? '' : 'X',
                         implode(', ', $methods),
                     ];
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Routing\Route;
 
+use Cake\Core\App;
 use Cake\Core\Exception\CakeException;
 use Cake\Http\Exception\BadRequestException;
 use InvalidArgumentException;
@@ -918,6 +919,32 @@ class Route
     public function getMiddleware(): array
     {
         return $this->middleware;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isActionPresent(): bool
+    {
+        $action = $this->defaults['action'] ?? null;
+        $controller = $this->defaults['controller'] ?? null;
+        if (!$action || !$controller) {
+            // generic actions and controllers can't be checked
+            return true;
+        }
+
+        $pluginPath = '';
+        if ($this->defaults['plugin']) {
+            $pluginPath = $this->defaults['plugin'] . '.';
+        }
+        $controllerClass = App::className($pluginPath . $controller, 'Controller', 'Controller');
+
+        if (!$controllerClass) {
+            // Controller class couldn't be found for some reason
+            return true;
+        }
+
+        return method_exists($controllerClass, $action);
     }
 
     /**

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -73,6 +73,7 @@ class RoutesCommandTest extends TestCase
             '<info>Prefix</info>',
             '<info>Controller</info>',
             '<info>Action</info>',
+            '<info>Valid Action</info>',
             '<info>Method(s)</info>',
         ]);
         $this->assertOutputContainsRow([
@@ -82,6 +83,7 @@ class RoutesCommandTest extends TestCase
             '',
             'Articles',
             'index',
+            'X',
             '',
         ]);
         $this->assertOutputContainsRow([
@@ -92,6 +94,7 @@ class RoutesCommandTest extends TestCase
             '',
             'index',
             '',
+            '',
         ]);
         $this->assertOutputContainsRow([
             'testName',
@@ -100,6 +103,7 @@ class RoutesCommandTest extends TestCase
             '',
             'Tests',
             'index',
+            '',
             '',
         ]);
     }
@@ -118,6 +122,7 @@ class RoutesCommandTest extends TestCase
             '<info>Prefix</info>',
             '<info>Controller</info>',
             '<info>Action</info>',
+            '<info>Valid Action</info>',
             '<info>Method(s)</info>',
             '<info>Middlewares</info>',
             '<info>Defaults</info>',
@@ -129,6 +134,7 @@ class RoutesCommandTest extends TestCase
             '',
             'Articles',
             'index',
+            'X',
             '',
             'dumb, sample',
             '{"action":"index","controller":"Articles","plugin":null}',
@@ -165,6 +171,7 @@ class RoutesCommandTest extends TestCase
             '',
             'Articles',
             'index',
+            'X',
             '',
             'dumb, sample',
         ]);
@@ -346,6 +353,7 @@ class RoutesCommandTest extends TestCase
             '<info>Prefix</info>',
             '<info>Controller</info>',
             '<info>Action</info>',
+            '<info>Valid Action</info>',
             '<info>Method(s)</info>',
         ]);
         $this->assertOutputContainsRow([

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -73,7 +73,6 @@ class RoutesCommandTest extends TestCase
             '<info>Prefix</info>',
             '<info>Controller</info>',
             '<info>Action</info>',
-            '<info>Valid Action</info>',
             '<info>Method(s)</info>',
         ]);
         $this->assertOutputContainsRow([
@@ -83,7 +82,6 @@ class RoutesCommandTest extends TestCase
             '',
             'Articles',
             'index',
-            'X',
             '',
         ]);
         $this->assertOutputContainsRow([
@@ -94,7 +92,6 @@ class RoutesCommandTest extends TestCase
             '',
             'index',
             '',
-            '',
         ]);
         $this->assertOutputContainsRow([
             'testName',
@@ -103,7 +100,6 @@ class RoutesCommandTest extends TestCase
             '',
             'Tests',
             'index',
-            '',
             '',
         ]);
     }
@@ -122,10 +118,10 @@ class RoutesCommandTest extends TestCase
             '<info>Prefix</info>',
             '<info>Controller</info>',
             '<info>Action</info>',
-            '<info>Valid Action</info>',
             '<info>Method(s)</info>',
             '<info>Middlewares</info>',
             '<info>Defaults</info>',
+            '<info>Existing</info>',
         ]);
         $this->assertOutputContainsRow([
             'articles:_action',
@@ -134,10 +130,10 @@ class RoutesCommandTest extends TestCase
             '',
             'Articles',
             'index',
-            'X',
             '',
             'dumb, sample',
             '{"action":"index","controller":"Articles","plugin":null}',
+            'X',
         ]);
     }
 
@@ -171,7 +167,6 @@ class RoutesCommandTest extends TestCase
             '',
             'Articles',
             'index',
-            'X',
             '',
             'dumb, sample',
         ]);
@@ -353,7 +348,6 @@ class RoutesCommandTest extends TestCase
             '<info>Prefix</info>',
             '<info>Controller</info>',
             '<info>Action</info>',
-            '<info>Valid Action</info>',
             '<info>Method(s)</info>',
         ]);
         $this->assertOutputContainsRow([


### PR DESCRIPTION
<img width="1515" alt="image" src="https://github.com/user-attachments/assets/e6a5a433-b5c5-423c-be43-accd60989d9b">

This adds another column to the `bin/cake routes` command to indicate, if the configured controller+action combination is actually present or not.

e.g.
```
$builder->connect('/check-timesheet', ['controller' => 'Tools', 'action' => 'checkTimesheet']);
```

would required, that the `ToolsController` has a `checkTimesheet` action (which in my case it didn't)

This command should help people get rid of unnecessary routes

As always - my naming schema may be not up2standard so please feel free to provide better names 😉 