### PR TITLE
Fix client side buffering disabling for SqlServer.

### DIFF
--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -192,6 +192,11 @@ class Sqlserver extends Driver
      */
     public function prepare(Query|string $query): StatementInterface
     {
+        $options = [
+            PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL,
+            PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => PDO::SQLSRV_CURSOR_BUFFERED,
+        ];
+
         $sql = $query;
         if ($query instanceof Query) {
             $sql = $query->sql();
@@ -203,15 +208,16 @@ class Sqlserver extends Driver
                     'If using an Association, try changing the `strategy` from select to subquery.'
                 );
             }
+
+            if ($query instanceof SelectQuery && !$query->isBufferedResultsEnabled()) {
+                $options = [];
+            }
         }
 
         /** @var string $sql */
         $statement = $this->getPdo()->prepare(
             $sql,
-            [
-                PDO::ATTR_CURSOR => PDO::CURSOR_SCROLL,
-                PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => PDO::SQLSRV_CURSOR_BUFFERED,
-            ]
+            $options
         );
 
         /** @var \Cake\Database\StatementInterface */


### PR DESCRIPTION
Don't set client side buffering flags when preparing PDO statement when it's disabled for the `SelectQuery`.

Fixes #16848.

This restores the behavior of 4.x.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
