### PR TITLE
Add FormProtectionException

### DIFF
--- a/src/Controller/Component/FormProtectionComponent.php
+++ b/src/Controller/Component/FormProtectionComponent.php
@@ -17,10 +17,10 @@ declare(strict_types=1);
 namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Controller\Exception\FormProtectionException;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\Form\FormProtector;
-use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Response;
 use Cake\Routing\Router;
 use Closure;
@@ -148,14 +148,14 @@ class FormProtectionComponent extends Component
      *
      * @param \Cake\Form\FormProtector $formProtector Form Protector instance.
      * @return \Cake\Http\Response|null If specified, validationFailureCallback's response, or no return otherwise.
-     * @throws \Cake\Http\Exception\BadRequestException
+     * @throws \Cake\Controller\Exception\FormProtectionException
      */
     protected function validationFailure(FormProtector $formProtector): ?Response
     {
         if (Configure::read('debug')) {
-            $exception = new BadRequestException($formProtector->getError());
+            $exception = new FormProtectionException($formProtector->getError());
         } else {
-            $exception = new BadRequestException(static::DEFAULT_EXCEPTION_MESSAGE);
+            $exception = new FormProtectionException(static::DEFAULT_EXCEPTION_MESSAGE);
         }
 
         if ($this->_config['validationFailureCallback']) {
@@ -169,10 +169,10 @@ class FormProtectionComponent extends Component
      * Execute callback.
      *
      * @param \Closure $callback Callback
-     * @param \Cake\Http\Exception\BadRequestException $exception Exception instance.
+     * @param \Cake\Controller\Exception\FormProtectionException $exception Exception instance.
      * @return \Cake\Http\Response|null
      */
-    protected function executeCallback(Closure $callback, BadRequestException $exception): ?Response
+    protected function executeCallback(Closure $callback, FormProtectionException $exception): ?Response
     {
         return $callback($exception);
     }

--- a/src/Controller/Exception/AuthSecurityException.php
+++ b/src/Controller/Exception/AuthSecurityException.php
@@ -16,6 +16,8 @@ namespace Cake\Controller\Exception;
 
 /**
  * Auth Security exception - used when SecurityComponent detects any issue with the current request
+ *
+ * @deprecated 5.2.0 This exception is no longer used in the CakePHP core.
  */
 class AuthSecurityException extends SecurityException
 {

--- a/src/Controller/Exception/FormProtectionException.php
+++ b/src/Controller/Exception/FormProtectionException.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @since         5.2.0
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Controller\Exception;
+
+use Cake\Http\Exception\BadRequestException;
+
+/**
+ * Form Protection exception - used when FormProtection detects any issue with the current request
+ */
+class FormProtectionException extends BadRequestException
+{
+}

--- a/src/Controller/Exception/SecurityException.php
+++ b/src/Controller/Exception/SecurityException.php
@@ -15,9 +15,13 @@ declare(strict_types=1);
 namespace Cake\Controller\Exception;
 
 use Cake\Http\Exception\BadRequestException;
+use Throwable;
+use function Cake\Core\deprecationWarning;
 
 /**
  * Security exception - used when SecurityComponent detects any issue with the current request
+ *
+ * @deprecated 5.2.0 This exception is no longer used in the CakePHP core.
  */
 class SecurityException extends BadRequestException
 {
@@ -34,6 +38,23 @@ class SecurityException extends BadRequestException
      * @var string|null
      */
     protected ?string $_reason = null;
+
+    /**
+     * Constructor
+     *
+     * @param string|null $message If no message is given 'Bad Request' will be the message
+     * @param int|null $code Status code, defaults to 400
+     * @param \Throwable|null $previous The previous exception.
+     */
+    public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
+    {
+        deprecationWarning(
+            '5.2.0',
+            static::class . ' is deprecated. Use BadRequestException or a custom exception instead.'
+        );
+
+        parent::__construct($message, $code, $previous);
+    }
 
     /**
      * Getter for type

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -18,8 +18,8 @@ namespace Cake\Test\TestCase\Controller\Component;
 
 use Cake\Controller\Component\FormProtectionComponent;
 use Cake\Controller\Controller;
+use Cake\Controller\Exception\FormProtectionException;
 use Cake\Event\Event;
-use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -147,7 +147,7 @@ class FormProtectionComponentTest extends TestCase
 
         $event = new Event('Controller.startup', $this->Controller);
 
-        $this->expectException(BadRequestException::class);
+        $this->expectException(FormProtectionException::class);
         $this->FormProtection->startup($event);
     }
 
@@ -169,7 +169,7 @@ class FormProtectionComponentTest extends TestCase
 
         $event = new Event('Controller.startup', $this->Controller);
 
-        $this->expectException(BadRequestException::class);
+        $this->expectException(FormProtectionException::class);
         $this->expectExceptionMessage('Unexpected field `Model.password` in POST data, Unexpected field `Model.username` in POST data');
         $this->FormProtection->startup($event);
     }
@@ -182,7 +182,7 @@ class FormProtectionComponentTest extends TestCase
 
         $event = new Event('Controller.startup', $this->Controller);
 
-        $this->expectException(BadRequestException::class);
+        $this->expectException(FormProtectionException::class);
         $this->expectExceptionMessage('`_Token` was not found in request data.');
         $this->FormProtection->startup($event);
     }
@@ -207,7 +207,7 @@ class FormProtectionComponentTest extends TestCase
             '_Token' => compact('fields', 'unlocked', 'debug'),
         ]));
 
-        $this->expectException(BadRequestException::class);
+        $this->expectException(FormProtectionException::class);
         $this->expectExceptionMessage('Tampered field `Model.hidden` in POST data (expected value `value` but found `tampered`)');
 
         $event = new Event('Controller.startup', $this->Controller);
@@ -232,7 +232,7 @@ class FormProtectionComponentTest extends TestCase
             '_Token' => compact('fields', 'unlocked', 'debug'),
         ]));
 
-        $this->expectException(BadRequestException::class);
+        $this->expectException(FormProtectionException::class);
         $this->expectExceptionMessage('Missing unlocked field');
 
         $event = new Event('Controller.startup', $this->Controller);
@@ -265,7 +265,7 @@ class FormProtectionComponentTest extends TestCase
 
     public function testCallbackReturnResponse(): void
     {
-        $this->FormProtection->setConfig('validationFailureCallback', function (BadRequestException $exception) {
+        $this->FormProtection->setConfig('validationFailureCallback', function (FormProtectionException $exception) {
             return new Response(['body' => 'from callback']);
         });
 
@@ -297,7 +297,7 @@ class FormProtectionComponentTest extends TestCase
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage('error description');
 
-        $this->FormProtection->setConfig('validationFailureCallback', function (BadRequestException $exception): void {
+        $this->FormProtection->setConfig('validationFailureCallback', function (FormProtectionException $exception): void {
             throw new NotFoundException('error description');
         });
 

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -21,6 +21,8 @@ use Cake\TestSuite\TestCase;
 
 /**
  * AuthSecurityException Test class
+ *
+ * @deprecated
  */
 class AuthSecurityExceptionTest extends TestCase
 {

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -21,6 +21,8 @@ use Cake\TestSuite\TestCase;
 
 /**
  * SecurityException Test class
+ *
+ * @deprecated
  */
 class SecurityExceptionTest extends TestCase
 {

--- a/tests/TestCase/ExceptionsTest.php
+++ b/tests/TestCase/ExceptionsTest.php
@@ -21,10 +21,9 @@ namespace Cake\Test\TestCase;
 use Cake\Console\Exception\ConsoleException;
 use Cake\Console\Exception\MissingHelperException;
 use Cake\Console\Exception\StopException;
-use Cake\Controller\Exception\AuthSecurityException;
+use Cake\Controller\Exception\FormProtectionException;
 use Cake\Controller\Exception\MissingActionException;
 use Cake\Controller\Exception\MissingComponentException;
-use Cake\Controller\Exception\SecurityException;
 use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\MissingPluginException;
 use Cake\Database\Exception\DatabaseException;
@@ -182,10 +181,9 @@ class ExceptionsTest extends TestCase
             [ConsoleException::class, 1],
             [MissingHelperException::class, 1],
             [StopException::class, 1],
-            [AuthSecurityException::class, 400],
+            [FormProtectionException::class, 400],
             [MissingActionException::class, 0],
             [MissingComponentException::class, 0],
-            [SecurityException::class, 400],
             [CakeException::class, 0],
             [MissingPluginException::class, 0],
             [DatabaseException::class, 0],


### PR DESCRIPTION
This exception is now used by `FormProtectionComponent` when request validation fails. This allows to filter out the exception when logging errors.