### PR TITLE
Fix XML to not break with enums.

### DIFF
--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Utility;
 
+use BackedEnum;
 use Cake\Core\Exception\CakeException;
 use Cake\Utility\Exception\XmlException;
 use Closure;
@@ -25,6 +26,7 @@ use DOMNode;
 use DOMText;
 use Exception;
 use SimpleXMLElement;
+use UnitEnum;
 
 /**
  * XML handling for CakePHP.
@@ -341,7 +343,14 @@ class Xml
                             // https://www.w3.org/TR/REC-xml/#syntax
                             // https://bugs.php.net/bug.php?id=36795
                             $child = $dom->createElement($key, '');
-                            $child->appendChild(new DOMText((string)$value));
+                            if ($value instanceof BackedEnum) {
+                                $value = (string)$value->value;
+                            } elseif ($value instanceof UnitEnum) {
+                                $value = $value->name;
+                            } else {
+                                $value = (string)$value;
+                            }
+                            $child->appendChild(new DOMText($value));
                         } else {
                             $child = $dom->createElement($key, (string)$value);
                         }

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -28,6 +28,9 @@ use DOMDocument;
 use Exception;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SimpleXMLElement;
+use TestApp\Model\Enum\ArticleStatus;
+use TestApp\Model\Enum\NonBacked;
+use TestApp\Model\Enum\Priority;
 use TypeError;
 
 /**
@@ -1134,6 +1137,35 @@ XML;
             ],
         ];
         $expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root xmlns:ns="http://cakephp.org"/>';
+        $xmlResponse = Xml::fromArray($xml);
+        $this->assertXmlStringEqualsXmlString($expected, $xmlResponse->asXML());
+    }
+
+    /**
+     * Tests that Enums don't blow up SimpleXml.
+     */
+    public function testEnum(): void
+    {
+        $xml = [
+            'root' => [
+                'tag' => [
+                    'xmlns:pref' => 'http://cakephp.org',
+                    'backed-int' => Priority::Medium,
+                    'backend-string' => ArticleStatus::Published,
+                    'non-backed' => NonBacked::Basic,
+                ],
+            ],
+        ];
+        $expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <tag xmlns:pref="http://cakephp.org">
+     <backed-int>2</backed-int>
+     <backend-string>Y</backend-string>
+     <non-backed>Basic</non-backed>
+  </tag>
+</root>
+XML;
         $xmlResponse = Xml::fromArray($xml);
         $this->assertXmlStringEqualsXmlString($expected, $xmlResponse->asXML());
     }


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18016

The reporter is right that it is not consistent that serialization and handling in general of enum is now supported throughout the framework, but the XML would blow up here.
There is an easy fix and it shouldnt make it too much slower.

With this instead of the exception it now renders out
```php
$user = $this->Users->get($id); // containing backed enum Status
$xmlResponse = Xml::fromArray(['user' => $user]);
```
just fine:

![xml](https://github.com/user-attachments/assets/ffe4270b-cfc5-45ee-a8aa-23f4c8a3c2db)
