### PR TITLE
Add cjs/mjs extensions.

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -179,6 +179,8 @@ class Response implements ResponseInterface, Stringable
         'ips' => 'application/x-ipscript',
         'ipx' => 'application/x-ipix',
         'js' => 'application/javascript',
+        'cjs' => 'application/javascript',
+        'mjs' => 'application/javascript',
         'jsonapi' => 'application/vnd.api+json',
         'latex' => 'application/x-latex',
         'jsonld' => 'application/ld+json',


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/18004 for 5.1 until 5.2 can be released, which is probably still a bit away.
Since the array is moved anyway into its own class in 5.2, the perfect order doesn't matter at this point I assume.