### PR TITLE
Allow 4.x callable to continue working in 5.x.

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Cake\Event;
 
 use Cake\Core\Exception\CakeException;
-use Closure;
 use InvalidArgumentException;
 
 /**
@@ -226,17 +225,19 @@ class EventManager implements EventManagerInterface
     /**
      * Builds an array of normalized handlers.
      *
-     * A normalized handler is an aray with these keys:
+     * A normalized handler is an array with these keys:
      *
      *  - `callable` - The event handler closure
      *  - `settings` - The event handler settings
      *
      * @param \Cake\Event\EventListenerInterface $subscriber Event subscriber
-     * @param \Closure|array|string $handlers Event handlers
+     * @param callable|array|string $handlers Event handlers
      * @return array
      */
-    protected function normalizeHandlers(EventListenerInterface $subscriber, Closure|array|string $handlers): array
-    {
+    protected function normalizeHandlers(
+        EventListenerInterface $subscriber,
+        callable|array|string $handlers
+    ): array {
         // Check if an array of handlers not single handler config array
         if (is_array($handlers) && !isset($handlers['callable'])) {
             foreach ($handlers as &$handler) {
@@ -258,11 +259,13 @@ class EventManager implements EventManagerInterface
      *  - `settings` - The event handler settings
      *
      * @param \Cake\Event\EventListenerInterface $subscriber Event subscriber
-     * @param \Closure|array|string $handler Event handler
+     * @param callable|array|string $handler Event handler
      * @return array
      */
-    protected function normalizeHandler(EventListenerInterface $subscriber, Closure|array|string $handler): array
-    {
+    protected function normalizeHandler(
+        EventListenerInterface $subscriber,
+        callable|array|string $handler
+    ): array {
         $callable = $handler;
         $settings = [];
 

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -432,6 +432,35 @@ class EventManagerTest extends TestCase
     }
 
     /**
+     * Tests subscribing an invokable listener class
+     */
+    public function testOnListenerClass(): void
+    {
+        $manager = new EventManager();
+        $listener = new class implements EventListenerInterface {
+            public array $callList = [];
+
+            final public function __invoke(EventInterface $event): void
+            {
+                $this->callList[] = __FUNCTION__;
+            }
+
+            public function implementedEvents(): array
+            {
+                return [
+                    'some.event' => $this,
+                ];
+            }
+        };
+        $manager->on($listener);
+
+        $event = new Event('some.event');
+        $manager->dispatch($event);
+
+        $this->assertEquals(['__invoke'], $listener->callList);
+    }
+
+    /**
      * Tests subscribing a listener object and firing the events it subscribed to
      */
     public function testDetachSubscriber(): void


### PR DESCRIPTION
When coming from a 4.x app with events and event system, the classes that implement __invoke are not working anymore.

Given that on()/off() accept callable, the Closure should be replaced with callable for normalizeHandlers() or at least callable be added, too.

I marked it as regression coming from 4.x as this is also not documented in the migration guide and makes apps trip over this when upgrading.