### PR TITLE
Allow input param to be a normal array list instead of strict phpstan…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,7 +141,7 @@ parameters:
 			path: src/Routing/RouteBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$methods of method PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\<Cake\\\\ORM\\\\Table\\>\\:\\:addMethods\\(\\) expects array\\<int, non\\-empty\\-string\\>, non\\-empty\\-array\\<int, string\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$methods of method PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\<Cake\\\\ORM\\\\Table\\>\\:\\:addMethods\\(\\) expects array\\<int, non\\-empty\\-string\\>, non\\-empty\\-array\\<string\\> given\\.$#"
 			count: 1
 			path: src/TestSuite/TestCase.php
 

--- a/src/Collection/ExtractTrait.php
+++ b/src/Collection/ExtractTrait.php
@@ -61,7 +61,7 @@ trait ExtractTrait
      * It will return arrays for elements in represented with `{*}`
      *
      * @param \ArrayAccess<string|int, mixed>|array $data Data.
-     * @param list<string> $parts Path to extract from.
+     * @param array<string> $parts Path to extract from.
      * @return mixed
      */
     protected function _extract(ArrayAccess|array $data, array $parts): mixed
@@ -104,7 +104,7 @@ trait ExtractTrait
      * by iterating over the column names contained in $path
      *
      * @param \ArrayAccess<string|int, mixed>|array $data Data.
-     * @param list<string> $parts Path to extract from.
+     * @param array<string> $parts Path to extract from.
      * @return mixed
      */
     protected function _simpleExtract(ArrayAccess|array $data, array $parts): mixed

--- a/src/Command/RoutesGenerateCommand.php
+++ b/src/Command/RoutesGenerateCommand.php
@@ -70,7 +70,7 @@ class RoutesGenerateCommand extends Command
     /**
      * Split the CLI arguments into a hash.
      *
-     * @param list<string> $args The arguments to split.
+     * @param array<string> $args The arguments to split.
      * @return array<string|bool>
      */
     protected function _splitArgs(array $args): array

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -180,7 +180,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
     }
 
     /**
-     * @param list<string> $names Names
+     * @param array<string> $names Names
      * @return string
      * @psalm-param non-empty-list<string> $names
      */

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -88,7 +88,7 @@ class CommandScanner
      * @param string $path The directory to read.
      * @param string $namespace The namespace the shells live in.
      * @param string $prefix The prefix to apply to commands for their full name.
-     * @param list<string> $hide A list of command names to hide as they are internal commands.
+     * @param array<string> $hide A list of command names to hide as they are internal commands.
      * @return array The list of shell info arrays based on scanning the filesystem and inflection.
      */
     protected function scanDir(string $path, string $namespace, string $prefix, array $hide): array

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -68,7 +68,7 @@ class ConsoleInputArgument
      * @param array<string, mixed>|string $name The long name of the option, or an array with all the properties.
      * @param string $help The help text for this option
      * @param bool $required Whether this argument is required. Missing required args will trigger exceptions
-     * @param list<string> $choices Valid choices for this option.
+     * @param array<string> $choices Valid choices for this option.
      * @param string|null $default The default value for this argument.
      */
     public function __construct(

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -98,7 +98,7 @@ class ConsoleInputOption
      * @param string $help The help text for this option
      * @param bool $isBoolean Whether this option is a boolean option. Boolean options don't consume extra tokens
      * @param string|bool|null $default The default value for this option.
-     * @param list<string> $choices Valid choices for this option.
+     * @param array<string> $choices Valid choices for this option.
      * @param bool $multiple Whether this option can accept multiple value definition.
      * @param bool $required Whether this option is required or not.
      * @param string|null $prompt The prompt string.

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -155,7 +155,7 @@ class ConsoleIo
     /**
      * Output at the verbose level.
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if current level is less than ConsoleIo::VERBOSE
@@ -168,7 +168,7 @@ class ConsoleIo
     /**
      * Output at all levels.
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int|null The number of bytes returned from writing to stdout
      *   or null if current level is less than ConsoleIo::QUIET
@@ -189,7 +189,7 @@ class ConsoleIo
      * present in most shells. Using ConsoleIo::QUIET for a message means it will always display.
      * While using ConsoleIo::VERBOSE means it will only display when verbose output is toggled.
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -209,7 +209,7 @@ class ConsoleIo
     /**
      * Convenience method for out() that wraps message between <info> tag
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -227,7 +227,7 @@ class ConsoleIo
     /**
      * Convenience method for out() that wraps message between <comment> tag
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -245,7 +245,7 @@ class ConsoleIo
     /**
      * Convenience method for err() that wraps message between <warning> tag
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
@@ -261,7 +261,7 @@ class ConsoleIo
     /**
      * Convenience method for err() that wraps message between <error> tag
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      * @see https://book.cakephp.org/5/en/console-and-shells.html#ConsoleIo::err
@@ -277,7 +277,7 @@ class ConsoleIo
     /**
      * Convenience method for out() that wraps message between <success> tag
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @param int $level The message's output level, see above.
      * @return int|null The number of bytes returned from writing to stdout
@@ -311,7 +311,7 @@ class ConsoleIo
      * Wraps a message with a given message type, e.g. <warning>
      *
      * @param string $messageType The message type, e.g. "warning".
-     * @param list<string>|string $message The message to wrap.
+     * @param array<string>|string $message The message to wrap.
      * @return list<string>|string The message wrapped with the given message type.
      */
     protected function wrapMessageWithType(string $messageType, array|string $message): array|string
@@ -335,7 +335,7 @@ class ConsoleIo
      *
      * **Warning** You cannot overwrite text that contains newlines.
      *
-     * @param list<string>|string $message The message to output.
+     * @param array<string>|string $message The message to output.
      * @param int $newlines Number of newlines to append.
      * @param int|null $size The number of bytes to overwrite. Defaults to the
      *    length of the last message output.
@@ -371,7 +371,7 @@ class ConsoleIo
      * Outputs a single or multiple error messages to stderr. If no parameters
      * are passed outputs just a newline.
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to stderr.
      */
@@ -469,7 +469,7 @@ class ConsoleIo
      * Prompts the user for input based on a list of options, and returns it.
      *
      * @param string $prompt Prompt text.
-     * @param list<string>|string $options Array or string of options.
+     * @param array<string>|string $options Array or string of options.
      * @param string|null $default Default input value.
      * @return string Either the default value, or the user-provided input.
      */

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -286,7 +286,7 @@ class ConsoleOptionParser
     /**
      * Sets the description text for shell/task.
      *
-     * @param list<string>|string $text The text to set. If an array the
+     * @param array<string>|string $text The text to set. If an array the
      *   text will be imploded with "\n".
      * @return $this
      */
@@ -314,7 +314,7 @@ class ConsoleOptionParser
      * Sets an epilog to the parser. The epilog is added to the end of
      * the options and arguments listing when help is generated.
      *
-     * @param list<string>|string $text The text to set. If an array the text will
+     * @param array<string>|string $text The text to set. If an array the text will
      *   be imploded with "\n".
      * @return $this
      */

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -211,7 +211,7 @@ class ConsoleOutput
      * Outputs a single or multiple messages to stdout or stderr. If no parameters
      * are passed, outputs just a newline.
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int The number of bytes returned from writing to output.
      */

--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -41,7 +41,7 @@ class MissingOptionException extends ConsoleException
      *
      * @param string $message The string message.
      * @param string $requested The requested value.
-     * @param list<string> $suggestions The list of potential values that were valid.
+     * @param array<string> $suggestions The list of potential values that were valid.
      * @param int|null $code The exception code if relevant.
      * @param \Throwable|null $previous the previous exception.
      */
@@ -87,7 +87,7 @@ class MissingOptionException extends ConsoleException
      * Find the best match for requested in suggestions
      *
      * @param string $needle Unknown option name trying to be used.
-     * @param list<string> $haystack Suggestions to look through.
+     * @param array<string> $haystack Suggestions to look through.
      * @return string|null The best match
      */
     protected function findClosestItem(string $needle, array $haystack): ?string

--- a/src/Console/TestSuite/Constraint/ContentsBase.php
+++ b/src/Console/TestSuite/Constraint/ContentsBase.php
@@ -37,7 +37,7 @@ abstract class ContentsBase extends Constraint
     /**
      * Constructor
      *
-     * @param list<string> $contents Contents
+     * @param array<string> $contents Contents
      * @param string $output Output type
      */
     public function __construct(array $contents, string $output)

--- a/src/Console/TestSuite/StubConsoleInput.php
+++ b/src/Console/TestSuite/StubConsoleInput.php
@@ -43,7 +43,7 @@ class StubConsoleInput extends ConsoleInput
     /**
      * Constructor
      *
-     * @param list<string> $replies A list of replies for read()
+     * @param array<string> $replies A list of replies for read()
      */
     public function __construct(array $replies)
     {

--- a/src/Console/TestSuite/StubConsoleOutput.php
+++ b/src/Console/TestSuite/StubConsoleOutput.php
@@ -56,7 +56,7 @@ class StubConsoleOutput extends ConsoleOutput
     /**
      * Write output to the buffer.
      *
-     * @param list<string>|string $message A string or an array of strings to output
+     * @param array<string>|string $message A string or an array of strings to output
      * @param int $newlines Number of newlines to append
      * @return int
      */

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -733,7 +733,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      * Each view class must implement the `getContentType()` hook method
      * to participate in negotiation.
      *
-     * @param list<string> $viewClasses View classes list.
+     * @param array<string> $viewClasses View classes list.
      * @return $this
      * @see \Cake\Http\ContentTypeNegotiation
      * @since 4.5.0

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -371,7 +371,7 @@ class Configure
      * @param string $key The identifier to create in the config adapter.
      *   This could be a filename or a cache key depending on the adapter being used.
      * @param string $config The name of the configured adapter to dump data with.
-     * @param list<string> $keys The name of the top-level keys you want to dump.
+     * @param array<string> $keys The name of the top-level keys you want to dump.
      *   This allows you save only some data stored in Configure.
      * @return bool Success
      * @throws \Cake\Core\Exception\CakeException if the adapter does not implement a `dump` method.

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -32,7 +32,7 @@ if (!function_exists('Cake\Core\pathCombine')) {
      *
      * Skips adding a forward-slash if either `/` or `\` already exists.
      *
-     * @param list<string> $parts
+     * @param array<string> $parts
      * @param bool|null $trailing Determines how trailing slashes are handled
      *  - If true, ensures a trailing forward-slash is added if one doesn't exist
      *  - If false, ensures any trailing slash is removed

--- a/src/Core/functions_global.php
+++ b/src/Core/functions_global.php
@@ -36,7 +36,7 @@ if (!function_exists('pathCombine')) {
      *
      * Skips adding a forward-slash if either `/` or `\` already exists.
      *
-     * @param list<string> $parts
+     * @param array<string> $parts
      * @param bool|null $trailing Determines how trailing slashes are handled
      *  - If true, ensures a trailing forward-slash is added if one doesn't exist
      *  - If false, ensures any trailing slash is removed

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -333,7 +333,7 @@ abstract class Query implements ExpressionInterface, Stringable
      * ```
      *
      * @param \Closure $visitor Callback executed for each part
-     * @param list<string> $parts The list of query parts to traverse
+     * @param array<string> $parts The list of query parts to traverse
      * @return $this
      */
     public function traverseParts(Closure $visitor, array $parts)

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -101,7 +101,7 @@ abstract class SchemaDialect
      * Convert foreign key constraints references to a valid
      * stringified list
      *
-     * @param list<string>|string $references The referenced columns of a foreign key constraint statement
+     * @param array<string>|string $references The referenced columns of a foreign key constraint statement
      * @return string
      */
     protected function _convertConstraintColumns(array|string $references): string
@@ -274,9 +274,9 @@ abstract class SchemaDialect
      * Generate the SQL to create a table.
      *
      * @param \Cake\Database\Schema\TableSchema $schema Table instance.
-     * @param list<string> $columns The columns to go inside the table.
-     * @param list<string> $constraints The constraints for the table.
-     * @param list<string> $indexes The indexes for the table.
+     * @param array<string> $columns The columns to go inside the table.
+     * @param array<string> $constraints The constraints for the table.
+     * @param array<string> $indexes The indexes for the table.
      * @return list<string> SQL statements to create a table.
      */
     abstract public function createTableSql(

--- a/src/Database/Statement/Statement.php
+++ b/src/Database/Statement/Statement.php
@@ -51,7 +51,7 @@ class Statement implements StatementInterface
     /**
      * @param \PDOStatement $statement PDO statement
      * @param \Cake\Database\Driver $driver Database driver
-     * @param list<\Closure> $resultDecorators Results decorators
+     * @param array<\Closure> $resultDecorators Results decorators
      */
     public function __construct(
         protected PDOStatement $statement,

--- a/src/Database/Type/BatchCastingInterface.php
+++ b/src/Database/Type/BatchCastingInterface.php
@@ -29,7 +29,7 @@ interface BatchCastingInterface
      * this type.
      *
      * @param array $values The original array of values containing the fields to be casted
-     * @param list<string> $fields The field keys to cast
+     * @param array<string> $fields The field keys to cast
      * @param \Cake\Database\Driver $driver Object from which database preferences and configuration will be extracted.
      * @return array<string, mixed>
      */

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -33,7 +33,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     /**
      * Sets hidden fields.
      *
-     * @param list<string> $fields An array of fields to hide from array exports.
+     * @param array<string> $fields An array of fields to hide from array exports.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -49,7 +49,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     /**
      * Sets the virtual fields on this entity.
      *
-     * @param list<string> $fields An array of fields to treat as virtual.
+     * @param array<string> $fields An array of fields to treat as virtual.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -148,7 +148,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     /**
      * Stores whether a field value can be changed or set in this entity.
      *
-     * @param list<string>|string $field single or list of fields to change its accessibility
+     * @param array<string>|string $field single or list of fields to change its accessibility
      * @param bool $set true marks the field as accessible, false will
      * mark it as protected.
      * @return $this
@@ -189,7 +189,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      * Returns an array with the requested original fields
      * stored in this entity, indexed by field name.
      *
-     * @param list<string> $fields List of fields to be returned
+     * @param array<string> $fields List of fields to be returned
      * @return array<string, mixed>
      */
     public function extractOriginal(array $fields): array;
@@ -198,7 +198,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      * Returns an array with only the original fields
      * stored in this entity, indexed by field name.
      *
-     * @param list<string> $fields List of fields to be returned
+     * @param array<string> $fields List of fields to be returned
      * @return array<string, mixed>
      */
     public function extractOriginalChanged(array $fields): array;
@@ -262,7 +262,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      *
      * The method will return `true` even when the field is set to `null`.
      *
-     * @param list<string>|string $field The field to check.
+     * @param array<string>|string $field The field to check.
      * @return bool
      */
     public function has(array|string $field): bool;
@@ -270,7 +270,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
     /**
      * Removes a field or list of fields from this entity
      *
-     * @param list<string>|string $field The field to unset.
+     * @param array<string>|string $field The field to unset.
      * @return $this
      */
     public function unset(array|string $field);
@@ -296,7 +296,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      * Returns an array with the requested fields
      * stored in this entity, indexed by field name
      *
-     * @param list<string> $fields list of fields to be returned
+     * @param array<string> $fields list of fields to be returned
      * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array<string, mixed>
      */

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -433,7 +433,7 @@ trait EntityTrait
      * When checking multiple fields all fields must have a value (even `null`)
      * present for the method to return `true`.
      *
-     * @param list<string>|string $field The field or fields to check.
+     * @param array<string>|string $field The field or fields to check.
      * @return bool
      */
     public function has(array|string $field): bool
@@ -509,7 +509,7 @@ trait EntityTrait
      * $entity->unset(['name', 'last_name']);
      * ```
      *
-     * @param list<string>|string $field The field to unset.
+     * @param array<string>|string $field The field to unset.
      * @return $this
      */
     public function unset(array|string $field)
@@ -525,7 +525,7 @@ trait EntityTrait
     /**
      * Sets hidden fields.
      *
-     * @param list<string> $fields An array of fields to hide from array exports.
+     * @param array<string> $fields An array of fields to hide from array exports.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -556,7 +556,7 @@ trait EntityTrait
     /**
      * Sets the virtual fields on this entity.
      *
-     * @param list<string> $fields An array of fields to treat as virtual.
+     * @param array<string> $fields An array of fields to treat as virtual.
      * @param bool $merge Merge the new fields with the existing. By default false.
      * @return $this
      */
@@ -737,7 +737,7 @@ trait EntityTrait
      * Returns an array with the requested fields
      * stored in this entity, indexed by field name
      *
-     * @param list<string> $fields list of fields to be returned
+     * @param array<string> $fields list of fields to be returned
      * @param bool $onlyDirty Return the requested field only if it is dirty
      * @return array<string, mixed>
      */
@@ -760,7 +760,7 @@ trait EntityTrait
      * Fields that are unchanged from their original value will be included in the
      * return of this method.
      *
-     * @param list<string> $fields List of fields to be returned
+     * @param array<string> $fields List of fields to be returned
      * @return array<string, mixed>
      */
     public function extractOriginal(array $fields): array
@@ -784,7 +784,7 @@ trait EntityTrait
      * This method will only return fields that have been modified since
      * the entity was built. Unchanged fields will be omitted.
      *
-     * @param list<string> $fields List of fields to be returned
+     * @param array<string> $fields List of fields to be returned
      * @return array<string, mixed>
      */
     public function extractOriginalChanged(array $fields): array
@@ -829,7 +829,7 @@ trait EntityTrait
      * Sets the given field or a list of fields to as original.
      * Normally there is no need to call this method manually.
      *
-     * @param list<string>|string $field the name of a field or a list of fields to set as original
+     * @param array<string>|string $field the name of a field or a list of fields to set as original
      * @param bool $merge
      * @return $this
      */
@@ -1275,7 +1275,7 @@ trait EntityTrait
      * $entity->setAccess('*', false); // Mark all fields as protected
      * ```
      *
-     * @param list<string>|string $field Single or list of fields to change its accessibility
+     * @param array<string>|string $field Single or list of fields to change its accessibility
      * @param bool $set True marks the field as accessible, false will
      * mark it as protected.
      * @return $this

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -107,7 +107,7 @@ class FormProtector
     /**
      * Determine which fields of a form should be used for hash.
      *
-     * @param list<string>|string $field Reference to field to be secured. Can be dot
+     * @param array<string>|string $field Reference to field to be secured. Can be dot
      *   separated string to indicate nesting or array of fieldname parts.
      * @param bool $lock Whether this field should be part of the validation
      *   or excluded as part of the unlockedFields. Default `true`.
@@ -422,7 +422,7 @@ class FormProtector
      * Generate validation hash.
      *
      * @param array $fields Fields list.
-     * @param list<string> $unlockedFields Unlocked fields.
+     * @param array<string> $unlockedFields Unlocked fields.
      * @param string $url Form URL.
      * @param string $sessionId Session Id.
      * @return string

--- a/src/Http/Client/Response.php
+++ b/src/Http/Client/Response.php
@@ -122,7 +122,7 @@ class Response extends Message implements ResponseInterface
     /**
      * Constructor
      *
-     * @param list<string> $headers Unparsed headers.
+     * @param array<string> $headers Unparsed headers.
      * @param string $body The response body.
      */
     public function __construct(array $headers = [], string $body = '')
@@ -171,7 +171,7 @@ class Response extends Message implements ResponseInterface
      * - Decodes the status code and reasonphrase.
      * - Parses and normalizes header names + values.
      *
-     * @param list<string> $headers Headers to parse.
+     * @param array<string> $headers Headers to parse.
      * @return void
      */
     protected function _parseHeaders(array $headers): void

--- a/src/Http/ContentTypeNegotiation.php
+++ b/src/Http/ContentTypeNegotiation.php
@@ -64,7 +64,7 @@ class ContentTypeNegotiation
      * You can expect null when the request has no Accept header.
      *
      * @param \Psr\Http\Message\RequestInterface $request The request to use.
-     * @param list<string> $choices The supported content type choices.
+     * @param array<string> $choices The supported content type choices.
      * @return string|null The preferred type or null if there is no match with choices or if the
      *   request had no Accept header.
      */

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -62,7 +62,7 @@ class CookieCollection implements IteratorAggregate, Countable
     /**
      * Create a Cookie Collection from an array of Set-Cookie Headers
      *
-     * @param list<string> $header The array of set-cookie header values.
+     * @param array<string> $header The array of set-cookie header values.
      * @param array<string, mixed> $defaults The defaults attributes.
      * @return static
      */

--- a/src/Http/CorsBuilder.php
+++ b/src/Http/CorsBuilder.php
@@ -104,7 +104,7 @@ class CorsBuilder
      * Accepts a string or an array of domains that have CORS enabled.
      * You can use `*.example.com` wildcards to accept subdomains, or `*` to allow all domains
      *
-     * @param list<string>|string $domains The allowed domains
+     * @param array<string>|string $domains The allowed domains
      * @return $this
      */
     public function allowOrigin(array|string $domains)
@@ -125,7 +125,7 @@ class CorsBuilder
     /**
      * Normalize the origin to regular expressions and put in an array format
      *
-     * @param list<string> $domains Domain names to normalize.
+     * @param array<string> $domains Domain names to normalize.
      * @return array<array<string, string>>
      */
     protected function _normalizeDomains(array $domains): array
@@ -151,7 +151,7 @@ class CorsBuilder
     /**
      * Set the list of allowed HTTP Methods.
      *
-     * @param list<string> $methods The allowed HTTP methods
+     * @param array<string> $methods The allowed HTTP methods
      * @return $this
      */
     public function allowMethods(array $methods)
@@ -176,7 +176,7 @@ class CorsBuilder
     /**
      * Allowed headers that can be sent in CORS requests.
      *
-     * @param list<string> $headers The list of headers to accept in CORS requests.
+     * @param array<string> $headers The list of headers to accept in CORS requests.
      * @return $this
      */
     public function allowHeaders(array $headers)
@@ -189,7 +189,7 @@ class CorsBuilder
     /**
      * Define the headers a client library/browser can expose to scripting
      *
-     * @param list<string> $headers The list of headers to expose CORS responses
+     * @param array<string> $headers The list of headers to expose CORS responses
      * @return $this
      */
     public function exposeHeaders(array $headers)

--- a/src/Http/Exception/HttpException.php
+++ b/src/Http/Exception/HttpException.php
@@ -40,7 +40,7 @@ class HttpException extends CakeException
      * Set a single HTTP response header.
      *
      * @param string $header Header name
-     * @param list<string>|string|null $value Header value
+     * @param array<string>|string|null $value Header value
      * @return void
      */
     public function setHeader(string $header, array|string|null $value = null): void

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -82,7 +82,7 @@ class BodyParserMiddleware implements MiddlewareInterface
     /**
      * Set the HTTP methods to parse request bodies on.
      *
-     * @param list<string> $methods The methods to parse data on.
+     * @param array<string> $methods The methods to parse data on.
      * @return $this
      */
     public function setMethods(array $methods)
@@ -117,7 +117,7 @@ class BodyParserMiddleware implements MiddlewareInterface
      * });
      * ```
      *
-     * @param list<string> $types An array of content-type header values to match. eg. application/json
+     * @param array<string> $types An array of content-type header values to match. eg. application/json
      * @param \Closure $parser The parser function. Must return an array of data to be inserted
      *   into the request.
      * @return $this

--- a/src/Http/Middleware/EncryptedCookieMiddleware.php
+++ b/src/Http/Middleware/EncryptedCookieMiddleware.php
@@ -66,7 +66,7 @@ class EncryptedCookieMiddleware implements MiddlewareInterface
     /**
      * Constructor
      *
-     * @param list<string> $cookieNames The list of cookie names that should have their values encrypted.
+     * @param array<string> $cookieNames The list of cookie names that should have their values encrypted.
      * @param string $key The encryption key to use.
      * @param string $cipherType The cipher type to use. Defaults to 'aes'.
      */

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -247,7 +247,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
      *
      * @throws \InvalidArgumentException Thrown when a value is invalid.
      * @param string $value Value to check
-     * @param list<string> $allowed List of allowed values
+     * @param array<string> $allowed List of allowed values
      * @return void
      */
     protected function checkValues(string $value, array $allowed): void

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -681,7 +681,7 @@ class Response implements ResponseInterface, Stringable
      * This is needed for RequestHandlerComponent and recognition of types.
      *
      * @param string $type Content type.
-     * @param list<string>|string $mimeType Definition of the mime type.
+     * @param array<string>|string $mimeType Definition of the mime type.
      * @return void
      */
     public function setTypeMap(string $type, array|string $mimeType): void
@@ -1023,7 +1023,7 @@ class Response implements ResponseInterface, Stringable
      * separated string. If no parameters are passed, then an
      * array with the current Vary header value is returned
      *
-     * @param list<string>|string $cacheVariances A single Vary string or an array
+     * @param array<string>|string $cacheVariances A single Vary string or an array
      *   containing the list for variances.
      * @return static
      */

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -406,7 +406,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * register trusted proxies
      *
-     * @param list<string> $proxies ips list of trusted proxies
+     * @param array<string> $proxies ips list of trusted proxies
      * @return void
      */
     public function setTrustedProxies(array $proxies): void
@@ -488,7 +488,7 @@ class ServerRequest implements ServerRequestInterface
      * defined with {@link \Cake\Http\ServerRequest::addDetector()}. Any detector can be called
      * as `is($type)` or `is$Type()`.
      *
-     * @param list<string>|string $type The type of request you want to check. If an array
+     * @param array<string>|string $type The type of request you want to check. If an array
      *   this method will return true if the request matches any type.
      * @param mixed ...$args List of arguments
      * @return bool Whether the request is the type you are checking.
@@ -663,7 +663,7 @@ class ServerRequest implements ServerRequestInterface
      * See Request::is() for how to add additional types and the
      * built-in types.
      *
-     * @param list<string> $types The types to check.
+     * @param array<string> $types The types to check.
      * @return bool Success.
      * @see \Cake\Http\ServerRequest::is()
      */
@@ -1426,7 +1426,7 @@ class ServerRequest implements ServerRequestInterface
      * If the request would be GET, response header "Allow: POST, DELETE" will be set
      * and a 405 error will be returned.
      *
-     * @param list<string>|string $methods Allowed HTTP request methods.
+     * @param array<string>|string $methods Allowed HTTP request methods.
      * @return true
      * @throws \Cake\Http\Exception\MethodNotAllowedException
      */

--- a/src/Http/TestSuite/HttpClientTrait.php
+++ b/src/Http/TestSuite/HttpClientTrait.php
@@ -40,7 +40,7 @@ trait HttpClientTrait
      * Create a new response.
      *
      * @param int $code The response code to use. Defaults to 200
-     * @param list<string> $headers A list of headers for the response. Example `Content-Type: application/json`
+     * @param array<string> $headers A list of headers for the response. Example `Content-Type: application/json`
      * @param string $body The body for the response.
      * @return \Cake\Http\Client\Response
      */

--- a/src/I18n/MessagesFileLoader.php
+++ b/src/I18n/MessagesFileLoader.php
@@ -187,7 +187,7 @@ class MessagesFileLoader
     }
 
     /**
-     * @param list<string> $folders Folders
+     * @param array<string> $folders Folders
      * @param string $name File name
      * @param string $ext File extension
      * @return string|null File if found

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -593,7 +593,7 @@ class Mailer implements EventListenerInterface
     /**
      * Converts given value to string
      *
-     * @param list<string>|string $value The value to convert
+     * @param array<string>|string $value The value to convert
      * @return string
      */
     protected function flatten(array|string $value): string

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -962,7 +962,7 @@ class Message implements JsonSerializable
     /**
      * Get headers as string.
      *
-     * @param list<string> $include List of headers.
+     * @param array<string> $include List of headers.
      * @param string $eol End of line string for concatenating headers.
      * @param \Closure|null $callback Callback to run each header value through before stringifying.
      * @return string

--- a/src/Mailer/Renderer.php
+++ b/src/Mailer/Renderer.php
@@ -49,7 +49,7 @@ class Renderer
      * of the specified content types for the email.
      *
      * @param string $content The content.
-     * @param list<string> $types Content types to render. Valid array values are {@link Message::MESSAGE_HTML}, {@link Message::MESSAGE_TEXT}.
+     * @param array<string> $types Content types to render. Valid array values are {@link Message::MESSAGE_HTML}, {@link Message::MESSAGE_TEXT}.
      * @return array<string, string> The rendered content with "html" and/or "text" keys.
      * @psalm-param array<\Cake\Mailer\Message::MESSAGE_HTML|\Cake\Mailer\Message::MESSAGE_TEXT> $types
      * @psalm-return array{html?: string, text?: string}

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -216,7 +216,7 @@ class SmtpTransport extends AbstractTransport
     /**
      * Parses and stores the response lines in `'code' => 'message'` format.
      *
-     * @param list<string> $responseLines Response lines to parse.
+     * @param array<string> $responseLines Response lines to parse.
      * @return void
      */
     protected function _bufferResponseLines(array $responseLines): void

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -428,7 +428,7 @@ abstract class Association
      * Sets the name of the field representing the binding field with the target table.
      * When not manually specified the primary key of the owning side table is used.
      *
-     * @param list<string>|string $key the table field or fields to be used to link both tables together
+     * @param array<string>|string $key the table field or fields to be used to link both tables together
      * @return $this
      */
     public function setBindingKey(array|string $key)
@@ -468,7 +468,7 @@ abstract class Association
     /**
      * Sets the name of the field representing the foreign key to the target table.
      *
-     * @param list<string>|string $key the key or keys to be used to link both tables together
+     * @param array<string>|string $key the key or keys to be used to link both tables together
      * @return $this
      */
     public function setForeignKey(array|string $key)

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -62,7 +62,7 @@ class BelongsTo extends Association
     /**
      * Sets the name of the field representing the foreign key to the target table.
      *
-     * @param list<string>|string|false $key the key or keys to be used to link both tables together, if set to `false`
+     * @param array<string>|string|false $key the key or keys to be used to link both tables together, if set to `false`
      *  no join conditions will be generated automatically.
      * @return $this
      */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -166,7 +166,7 @@ class BelongsToMany extends Association
     /**
      * Sets the name of the field representing the foreign key to the target table.
      *
-     * @param list<string>|string $key the key to be used to link both tables together
+     * @param array<string>|string $key the key to be used to link both tables together
      * @return $this
      */
     public function setTargetForeignKey(array|string $key)

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -60,7 +60,7 @@ class HasOne extends Association
     /**
      * Sets the name of the field representing the foreign key to the target table.
      *
-     * @param list<string>|string|false $key the key or keys to be used to link both tables together, if set to `false`
+     * @param array<string>|string|false $key the key or keys to be used to link both tables together, if set to `false`
      *  no join conditions will be generated automatically.
      * @return $this
      */

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -243,7 +243,7 @@ class SelectLoader
      * If the required fields are missing, throws an exception.
      *
      * @param \Cake\ORM\Query\SelectQuery $fetchQuery The association fetching query
-     * @param list<string> $key The foreign key fields to check
+     * @param array<string> $key The foreign key fields to check
      * @return void
      * @throws \InvalidArgumentException
      */
@@ -290,7 +290,7 @@ class SelectLoader
      * filtering needs to be done using a subquery.
      *
      * @param \Cake\ORM\Query\SelectQuery $query Target table's query
-     * @param list<string>|string $key the fields that should be used for filtering
+     * @param array<string>|string $key the fields that should be used for filtering
      * @param \Cake\ORM\Query\SelectQuery $subquery The Subquery to use for filtering
      * @return \Cake\ORM\Query\SelectQuery
      */
@@ -326,7 +326,7 @@ class SelectLoader
      * target table query given a filter key and some filtering values.
      *
      * @param \Cake\ORM\Query\SelectQuery $query Target table's query
-     * @param list<string>|string $key The fields that should be used for filtering
+     * @param array<string>|string $key The fields that should be used for filtering
      * @param mixed $filter The value that should be used to match for $key
      * @return \Cake\ORM\Query\SelectQuery
      */
@@ -346,7 +346,7 @@ class SelectLoader
      * from $keys with the tuple values in $filter using the provided operator.
      *
      * @param \Cake\ORM\Query\SelectQuery $query Target table's query
-     * @param list<string> $keys the fields that should be used for filtering
+     * @param array<string> $keys the fields that should be used for filtering
      * @param mixed $filter the value that should be used to match for $key
      * @param string $operator The operator for comparing the tuples
      * @return \Cake\Database\Expression\TupleComparison
@@ -553,7 +553,7 @@ class SelectLoader
      * be done with multiple foreign keys
      *
      * @param array<string, mixed> $resultMap A keyed arrays containing the target table
-     * @param list<string> $sourceKeys An array with aliased keys to match
+     * @param array<string> $sourceKeys An array with aliased keys to match
      * @param string $nestKey The key under which results should be nested
      * @return \Closure
      */

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -162,7 +162,7 @@ class AssociationCollection implements IteratorAggregate
     /**
      * Get an array of associations matching a specific type.
      *
-     * @param list<string>|string $class The type of associations you want.
+     * @param array<string>|string $class The type of associations you want.
      *   For example 'BelongsTo' or array like ['BelongsTo', 'HasOne']
      * @return array<\Cake\ORM\Association> An array of Association objects.
      * @since 3.5.3

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -342,7 +342,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
      * for each record.
      *
      * @param \Cake\ORM\Query\SelectQuery $query The original query to modify
-     * @param list<string> $locales A list of locales or options with the `locales` key defined
+     * @param array<string> $locales A list of locales or options with the `locales` key defined
      * @return \Cake\ORM\Query\SelectQuery
      */
     public function findTranslations(SelectQuery $query, array $locales = []): SelectQuery

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -40,7 +40,7 @@ class PersistenceFailedException extends CakeException
      * Constructor.
      *
      * @param \Cake\Datasource\EntityInterface $entity The entity on which the persistence operation failed
-     * @param list<string>|string $message Either the string of the error message, or an array of attributes
+     * @param array<string>|string $message Either the string of the error message, or an array of attributes
      *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
      * @param int|null $code The code of the error, is also the HTTP status code for the error.
      * @param \Throwable|null $previous the previous exception.

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -111,7 +111,7 @@ class LazyEagerLoader
      * in the top level entities.
      *
      * @param \Cake\ORM\Table $source The table having the top level associations
-     * @param list<string> $associations The name of the top level associations
+     * @param array<string> $associations The name of the top level associations
      * @return array<string, string>
      */
     protected function _getPropertyMap(Table $source, array $associations): array
@@ -133,7 +133,7 @@ class LazyEagerLoader
      *
      * @param array<\Cake\Datasource\EntityInterface> $entities The original list of entities
      * @param \Cake\ORM\Query\SelectQuery $query The query to load results
-     * @param list<string> $associations The top level associations that were loaded
+     * @param array<string> $associations The top level associations that were loaded
      * @param \Cake\ORM\Table $source The table where the entities came from
      * @return array<\Cake\Datasource\EntityInterface>
      */

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -83,7 +83,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
     /**
      * Constructor.
      *
-     * @param list<string>|null $locations Locations where tables should be looked for.
+     * @param array<string>|null $locations Locations where tables should be looked for.
      *   If none provided, the default `Model\Table` under your app's namespace is used.
      */
     public function __construct(?array $locations = null, ?QueryFactory $queryFactory = null)

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -845,7 +845,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * pass overwrite boolean true which will reset the select clause removing all previous additions.
      *
      * @param \Cake\ORM\Table|\Cake\ORM\Association $table The table to use to get an array of columns
-     * @param list<string> $excludedFields The un-aliased column names you do not want selected from $table
+     * @param array<string> $excludedFields The un-aliased column names you do not want selected from $table
      * @param bool $overwrite Whether to reset/remove previous selected fields
      * @return $this
      */

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -54,7 +54,7 @@ class ExistsIn
      * Available option for $options is 'allowNullableNulls' flag.
      * Set to true to accept composite foreign keys where one or more nullable columns are null.
      *
-     * @param list<string>|string $fields The field or fields to check existence as primary key.
+     * @param array<string>|string $fields The field or fields to check existence as primary key.
      * @param \Cake\ORM\Table|\Cake\ORM\Association|string $repository The repository where the
      * field will be looked for, or the association name for the repository.
      * @param array<string, mixed> $options The options that modify the rule's behavior.

--- a/src/ORM/Rule/IsUnique.php
+++ b/src/ORM/Rule/IsUnique.php
@@ -47,7 +47,7 @@ class IsUnique
      *
      * - `allowMultipleNulls` Allows any field to have multiple null values. Defaults to true.
      *
-     * @param list<string> $fields The list of fields to check uniqueness for
+     * @param array<string> $fields The list of fields to check uniqueness for
      * @param array<string, mixed> $options The options for unique checks.
      */
     public function __construct(array $fields, array $options = [])

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -118,7 +118,7 @@ class LinkConstraint
     /**
      * Alias fields.
      *
-     * @param list<string> $fields The fields that should be aliased.
+     * @param array<string> $fields The fields that should be aliased.
      * @param \Cake\ORM\Table $source The object to use for aliasing.
      * @return list<string> The aliased fields
      */
@@ -134,7 +134,7 @@ class LinkConstraint
     /**
      * Build conditions.
      *
-     * @param list<string> $fields The condition fields.
+     * @param array<string> $fields The condition fields.
      * @param array $values The condition values.
      * @return array<string, string> A conditions array combined from the passed fields and values.
      */

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -48,7 +48,7 @@ class RulesChecker extends BaseRulesChecker
      *
      * - `allowMultipleNulls` Allows any field to have multiple null values. Defaults to false.
      *
-     * @param list<string> $fields The list of fields to check for uniqueness.
+     * @param array<string> $fields The list of fields to check for uniqueness.
      * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can
      *   also be an array of options. When an array, the 'message' key can be used to provide a message.
      * @return \Cake\Datasource\RuleInvoker
@@ -90,7 +90,7 @@ class RulesChecker extends BaseRulesChecker
      * 'message' sets a custom error message.
      * Set 'allowNullableNulls' to true to accept composite foreign keys where one or more nullable columns are null.
      *
-     * @param list<string>|string $field The field or list of fields to check for existence by
+     * @param array<string>|string $field The field or list of fields to check for existence by
      * primary key lookup in the other table.
      * @param \Cake\ORM\Table|\Cake\ORM\Association|string $table The table name where the fields existence will be checked.
      * @param array<string, mixed>|string|null $message The error message to show in case the rule does not pass. Can

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -639,7 +639,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the primary key field name.
      *
-     * @param list<string>|string $key Sets a new name to be used as primary key
+     * @param array<string>|string $key Sets a new name to be used as primary key
      * @return $this
      */
     public function setPrimaryKey(array|string $key)
@@ -670,7 +670,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     /**
      * Sets the display field.
      *
-     * @param list<string>|string $field Name to be used as display field.
+     * @param array<string>|string $field Name to be used as display field.
      * @return $this
      */
     public function setDisplayField(array|string $field)
@@ -1464,7 +1464,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * composite keys when comparing values.
      *
      * @param array<string, mixed> $options the original options passed to a finder
-     * @param list<string> $keys the keys to check in $options to build matchers from
+     * @param array<string> $keys the keys to check in $options to build matchers from
      * the associated value
      * @return array<string, mixed>
      */
@@ -2214,7 +2214,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * Note: The ORM will not generate primary key values for composite primary keys.
      * You can overwrite _newId() in your table class.
      *
-     * @param list<string> $primary The primary key columns to get a new ID for.
+     * @param array<string> $primary The primary key columns to get a new ID for.
      * @return string|null Either null or the primary key value or a list of primary key values.
      */
     protected function _newId(array $primary): ?string

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -162,7 +162,7 @@ class Route
     /**
      * Set the supported extensions for this route.
      *
-     * @param list<string> $extensions The extensions to set.
+     * @param array<string> $extensions The extensions to set.
      * @return $this
      */
     public function setExtensions(array $extensions)
@@ -185,7 +185,7 @@ class Route
     /**
      * Set the accepted HTTP methods for this route.
      *
-     * @param list<string> $methods The HTTP methods to accept.
+     * @param array<string> $methods The HTTP methods to accept.
      * @return $this
      * @throws \InvalidArgumentException When methods are not in `VALID_METHODS` list.
      */
@@ -199,7 +199,7 @@ class Route
     /**
      * Normalize method names to upper case and validate that they are valid HTTP methods.
      *
-     * @param list<string>|string $methods Methods.
+     * @param array<string>|string $methods Methods.
      * @return list<string>|string
      * @throws \InvalidArgumentException When methods are not in `VALID_METHODS` list.
      */
@@ -255,7 +255,7 @@ class Route
     /**
      * Set the names of parameters that will be converted into passed parameters
      *
-     * @param list<string> $names The names of the parameters that should be passed.
+     * @param array<string> $names The names of the parameters that should be passed.
      * @return $this
      */
     public function setPass(array $names)

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -172,7 +172,7 @@ class RouteBuilder
      * Future routes connected in through this builder will have the connected
      * extensions applied. However, setting extensions does not modify existing routes.
      *
-     * @param list<string>|string $extensions The extensions to set.
+     * @param array<string>|string $extensions The extensions to set.
      * @return $this
      */
     public function setExtensions(array|string $extensions)
@@ -195,7 +195,7 @@ class RouteBuilder
     /**
      * Add additional extensions to what is already in current scope
      *
-     * @param list<string>|string $extensions One or more extensions to add
+     * @param array<string>|string $extensions One or more extensions to add
      * @return $this
      */
     public function addExtensions(array|string $extensions)
@@ -1018,7 +1018,7 @@ class RouteBuilder
      * Apply a set of middleware to a group
      *
      * @param string $name Name of the middleware group
-     * @param list<string> $middlewareNames Names of the middleware
+     * @param array<string> $middlewareNames Names of the middleware
      * @return $this
      */
     public function middlewareGroup(string $name, array $middlewareNames)

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -350,7 +350,7 @@ class RouteCollection
     /**
      * Set the extensions that the route collection can handle.
      *
-     * @param list<string> $extensions The list of extensions to set.
+     * @param array<string> $extensions The list of extensions to set.
      * @param bool $merge Whether to merge with or override existing extensions.
      *   Defaults to `true`.
      * @return $this
@@ -390,7 +390,7 @@ class RouteCollection
      * Add middleware to a middleware group
      *
      * @param string $name Name of the middleware group
-     * @param list<string> $middlewareNames Names of the middleware
+     * @param array<string> $middlewareNames Names of the middleware
      * @return $this
      * @throws \InvalidArgumentException
      */
@@ -449,7 +449,7 @@ class RouteCollection
     /**
      * Get an array of middleware given a list of names
      *
-     * @param list<string> $names The names of the middleware or groups to fetch
+     * @param array<string> $names The names of the middleware or groups to fetch
      * @return array An array of middleware. If any of the passed names are groups,
      *   the groups middleware will be flattened into the returned list.
      * @throws \InvalidArgumentException when a requested middleware does not exist.

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -709,7 +709,7 @@ class Router
      * A string or an array of valid extensions can be passed to this method.
      * If called without any parameters it will return current list of set extensions.
      *
-     * @param list<string>|string|null $extensions List of extensions to be added.
+     * @param array<string>|string|null $extensions List of extensions to be added.
      * @param bool $merge Whether to merge with or override existing extensions.
      *   Defaults to `true`.
      * @return list<string> Array of extensions Router is configured to parse.

--- a/src/TestSuite/ConnectionHelper.php
+++ b/src/TestSuite/ConnectionHelper.php
@@ -83,7 +83,7 @@ class ConnectionHelper
      * Drops all tables.
      *
      * @param string $connectionName Connection name
-     * @param list<string>|null $tables List of tables names or null for all.
+     * @param array<string>|null $tables List of tables names or null for all.
      * @return void
      */
     public static function dropTables(string $connectionName, ?array $tables = null): void
@@ -119,7 +119,7 @@ class ConnectionHelper
      * Truncates all tables.
      *
      * @param string $connectionName Connection name
-     * @param list<string>|null $tables List of tables names or null for all.
+     * @param array<string>|null $tables List of tables names or null for all.
      * @return void
      */
     public static function truncateTables(string $connectionName, ?array $tables = null): void

--- a/src/TestSuite/EmailTrait.php
+++ b/src/TestSuite/EmailTrait.php
@@ -177,7 +177,7 @@ trait EmailTrait
     /**
      * Asserts an email was sent from an address
      *
-     * @param list<string>|string $address Email address
+     * @param array<string>|string $address Email address
      * @param string $message Message
      * @return void
      */

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -37,7 +37,7 @@ class FixtureHelper
     /**
      * Finds fixtures from their TestCase names such as 'core.Articles'.
      *
-     * @param list<string> $fixtureNames Fixture names from test case
+     * @param array<string> $fixtureNames Fixture names from test case
      * @return array<\Cake\Datasource\FixtureInterface>
      */
     public function loadFixtures(array $fixtureNames): array

--- a/src/TestSuite/Fixture/FixtureStrategyInterface.php
+++ b/src/TestSuite/Fixture/FixtureStrategyInterface.php
@@ -24,7 +24,7 @@ interface FixtureStrategyInterface
     /**
      * Called before each test run in each TestCase.
      *
-     * @param list<string> $fixtureNames Name of fixtures used by test.
+     * @param array<string> $fixtureNames Name of fixtures used by test.
      * @return void
      */
     public function setupTest(array $fixtureNames): void;

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -38,7 +38,7 @@ class SchemaLoader
     /**
      * Load and apply schema sql file, or an array of files.
      *
-     * @param list<string>|string $paths Schema files to load
+     * @param array<string>|string $paths Schema files to load
      * @param string $connectionName Connection name
      * @param bool $dropTables Drop all tables prior to loading schema files
      * @param bool $truncateTables Truncate all tables after loading schema files

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -236,7 +236,7 @@ trait IntegrationTestTrait
     /**
      * Set list of fields that are excluded from field validation.
      *
-     * @param list<string> $unlockedFields List of fields that are excluded from field validation.
+     * @param array<string> $unlockedFields List of fields that are excluded from field validation.
      * @return void
      */
     public function setUnlockedFields(array $unlockedFields = []): void

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -352,7 +352,7 @@ abstract class TestCase extends BaseTestCase
      *
      * Useful in test case teardown methods.
      *
-     * @param list<string> $names A list of plugins you want to remove.
+     * @param array<string> $names A list of plugins you want to remove.
      * @return void
      */
     public function removePlugins(array $names = []): void
@@ -924,7 +924,7 @@ abstract class TestCase extends BaseTestCase
      * Mock a model, maintain fixtures and table association
      *
      * @param string $alias The model to get a mock for.
-     * @param list<string> $methods The list of methods to mock
+     * @param array<string> $methods The list of methods to mock
      * @param array<string, mixed> $options The config data for the mock's constructor.
      * @throws \Cake\ORM\Exception\MissingTableClassException
      * @return \Cake\ORM\Table|\PHPUnit\Framework\MockObject\MockObject

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -90,7 +90,7 @@ trait CookieCryptTrait
     /**
      * Decrypts $value using public $type method in Security class
      *
-     * @param list<string>|string $values Values to decrypt
+     * @param array<string>|string $values Values to decrypt
      * @param string|false $mode Encryption mode
      * @param string|null $key Used as the security salt if specified.
      * @return array|string Decrypted values

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -46,7 +46,7 @@ class Hash
      *
      * @param \ArrayAccess|array $data Array of data or object implementing
      *   \ArrayAccess interface to operate on.
-     * @param list<string>|string|int|null $path The path being searched for. Either a dot
+     * @param array<string>|string|int|null $path The path being searched for. Either a dot
      *   separated string, or an array of path segments.
      * @param mixed $default The return value when the path does not exist
      * @throws \InvalidArgumentException
@@ -345,7 +345,7 @@ class Hash
      *
      * @param string $op The operation to do.
      * @param \ArrayAccess|array $data The data to operate on.
-     * @param list<string> $path The path to work on.
+     * @param array<string> $path The path to work on.
      * @param mixed $values The values to insert when doing inserts.
      * @return \ArrayAccess|array
      */
@@ -460,8 +460,8 @@ class Hash
      * following the path specified in `$groupPath`.
      *
      * @param array $data Array from where to extract keys and values
-     * @param list<string>|string|null $keyPath A dot-separated string.
-     * @param list<string>|string|null $valuePath A dot-separated string.
+     * @param array<string>|string|null $keyPath A dot-separated string.
+     * @param array<string>|string|null $valuePath A dot-separated string.
      * @param string|null $groupPath A dot-separated string.
      * @return array Combined array
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::combine
@@ -549,7 +549,7 @@ class Hash
      * The `$format` string can use any format options that `vsprintf()` and `sprintf()` do.
      *
      * @param array $data Source array from which to extract the data
-     * @param list<string> $paths An array containing one or more Hash::extract()-style key paths
+     * @param array<string> $paths An array containing one or more Hash::extract()-style key paths
      * @param string $format Format string into which values will be inserted, see sprintf()
      * @return list<string>|null An array of strings extracted from `$path` and formatted with `$format`
      * @link https://book.cakephp.org/5/en/core-libraries/hash.html#Cake\Utility\Hash::format

--- a/src/Utility/MergeVariablesTrait.php
+++ b/src/Utility/MergeVariablesTrait.php
@@ -29,7 +29,7 @@ trait MergeVariablesTrait
      * - `associative` - A list of properties that should be treated as associative arrays.
      *   Properties in this list will be passed through Hash::normalize() before merging.
      *
-     * @param list<string> $properties An array of properties and the merge strategy for them.
+     * @param array<string> $properties An array of properties and the merge strategy for them.
      * @param array<string, mixed> $options The options to use when merging properties.
      * @return void
      */
@@ -61,7 +61,7 @@ trait MergeVariablesTrait
      * Merge a single property with the values declared in all parent classes.
      *
      * @param string $property The name of the property being merged.
-     * @param list<string> $parentClasses An array of classes you want to merge with.
+     * @param array<string> $parentClasses An array of classes you want to merge with.
      * @param array<string, mixed> $options Options for merging the property, see _mergeVars()
      * @return void
      */

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -473,7 +473,7 @@ class Text
      * - `limit` A limit, optional, defaults to -1 (none)
      *
      * @param string $text Text to search the phrase in.
-     * @param list<string>|string $phrase The phrase or phrases that will be searched.
+     * @param array<string>|string $phrase The phrase or phrases that will be searched.
      * @param array<string, mixed> $options An array of HTML attributes and options.
      * @return string The highlighted text
      * @link https://book.cakephp.org/5/en/core-libraries/text.html#highlighting-substrings
@@ -890,7 +890,7 @@ class Text
     /**
      * Creates a comma separated list where the last two items are joined with 'and', forming natural language.
      *
-     * @param list<string> $list The list to be joined.
+     * @param array<string> $list The list to be joined.
      * @param string|null $and The word used to join the last and second last items together with. Defaults to 'and'.
      * @param string $separator The separator used to join all the other items together. Defaults to ', '.
      * @return string The glued together string.

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -465,7 +465,7 @@ class Xml
      * @param \SimpleXMLElement $xml SimpleXMLElement object
      * @param array<string, mixed> $parentData Parent array with data
      * @param string $ns Namespace of current child
-     * @param list<string> $namespaces List of namespaces in XML
+     * @param array<string> $namespaces List of namespaces in XML
      * @return void
      */
     protected static function _toArray(SimpleXMLElement $xml, array &$parentData, string $ns, array $namespaces): void

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -238,7 +238,7 @@ class Validation
      * Returns true if $check is in the proper credit card format.
      *
      * @param mixed $check credit card number to validate
-     * @param list<string>|string $type 'all' may be passed as a string, defaults to fast which checks format of
+     * @param array<string>|string $type 'all' may be passed as a string, defaults to fast which checks format of
      *     most major credit cards if an array is used only the values of the array are checked.
      *    Example: ['amex', 'bankcard', 'maestro']
      * @param bool $deep set to true this will check the Luhn algorithm of the credit card.
@@ -444,7 +444,7 @@ class Validation
      * - `y` 2006 just the year without any separators
      *
      * @param mixed $check a valid date string/object
-     * @param list<string>|string $format Use a string or an array of the keys above.
+     * @param array<string>|string $format Use a string or an array of the keys above.
      *    Arrays should be passed as ['dmy', 'mdy', ...]
      * @param string|null $regex If a custom regular expression is used this is the only validation that will occur.
      * @return bool Success
@@ -805,7 +805,7 @@ class Validation
      * Checks that the value is a valid backed enum instance or value.
      *
      * @param mixed $check Value to check
-     * @param list<\BackedEnum> $cases Array of enum cases that are valid.
+     * @param array<\BackedEnum> $cases Array of enum cases that are valid.
      * @return bool Success
      * @since 5.1.0
      */
@@ -828,7 +828,7 @@ class Validation
      * Checks that the value is a valid backed enum instance or value.
      *
      * @param mixed $check Value to check
-     * @param list<\BackedEnum> $cases Array of enum cases that are not valid.
+     * @param array<\BackedEnum> $cases Array of enum cases that are not valid.
      * @return bool Success
      * @since 5.1.0
      */
@@ -965,7 +965,7 @@ class Validation
      * and arrays with a `name` key.
      *
      * @param mixed $check Value to check
-     * @param list<string> $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
+     * @param array<string> $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
      * @return bool Success
      */
     public static function extension(mixed $check, array $extensions = ['gif', 'jpeg', 'png', 'jpg']): bool
@@ -1249,7 +1249,7 @@ class Validation
      * Checks if a value is in a given list. Comparison is case-sensitive by default.
      *
      * @param mixed $check Value to check.
-     * @param list<string> $list List to check against.
+     * @param array<string> $list List to check against.
      * @param bool $caseInsensitive Set to true for case-insensitive comparison.
      * @return bool Success.
      */

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1789,7 +1789,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a date format validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param list<string> $formats A list of accepted date formats.
+     * @param array<string> $formats A list of accepted date formats.
      * @param string|null $message The error message when the rule fails.
      * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
      *   true when the validation rule should be applied.
@@ -1830,7 +1830,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
      * Add a date time format validation rule to a field.
      *
      * @param string $field The field you want to apply the rule to.
-     * @param list<string> $formats A list of accepted date formats.
+     * @param array<string> $formats A list of accepted date formats.
      * @param string|null $message The error message when the rule fails.
      * @param \Closure|string|null $when Either 'create' or 'update' or a Closure that returns
      *   true when the validation rule should be applied.

--- a/src/View/Exception/MissingCellTemplateException.php
+++ b/src/View/Exception/MissingCellTemplateException.php
@@ -36,7 +36,7 @@ class MissingCellTemplateException extends MissingTemplateException
      *
      * @param string $name The Cell name that is missing a view.
      * @param string $file The view filename.
-     * @param list<string> $paths The path list that template could not be found in.
+     * @param array<string> $paths The path list that template could not be found in.
      * @param int|null $code The code of the error.
      * @param \Throwable|null $previous the previous exception.
      */

--- a/src/View/Exception/MissingTemplateException.php
+++ b/src/View/Exception/MissingTemplateException.php
@@ -45,8 +45,8 @@ class MissingTemplateException extends CakeException
     /**
      * Constructor
      *
-     * @param list<string>|string $file Either the file name as a string, or in an array for backwards compatibility.
-     * @param list<string> $paths The path list that template could not be found in.
+     * @param array<string>|string $file Either the file name as a string, or in an array for backwards compatibility.
+     * @param array<string> $paths The path list that template could not be found in.
      * @param int|null $code The code of the error.
      * @param \Throwable|null $previous the previous exception.
      */

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -279,7 +279,7 @@ class EntityContext implements ContextInterface
     /**
      * Get default value from table schema for given entity field.
      *
-     * @param list<string> $parts Each one of the parts in a path for a field name
+     * @param array<string> $parts Each one of the parts in a path for a field name
      * @return mixed
      */
     protected function _schemaDefault(array $parts): mixed
@@ -302,7 +302,7 @@ class EntityContext implements ContextInterface
      * primary key column is guessed out of the provided $path array
      *
      * @param mixed $values The list from which to extract primary keys from
-     * @param list<string> $path Each one of the parts in a path for a field name
+     * @param array<string> $path Each one of the parts in a path for a field name
      * @return array|null
      */
     protected function _extractMultiple(mixed $values, array $path): ?array
@@ -324,7 +324,7 @@ class EntityContext implements ContextInterface
      *
      * If you only want the terminal Entity for a path use `leafEntity` instead.
      *
-     * @param list<string>|null $path Each one of the parts in a path for a field name
+     * @param array<string>|null $path Each one of the parts in a path for a field name
      *  or null to get the entity passed in constructor context.
      * @return \Cake\Datasource\EntityInterface|iterable|null
      * @throws \Cake\Core\Exception\CakeException When properties cannot be read.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2583,7 +2583,7 @@ class FormHelper extends Helper
     /**
      * Validate value sources.
      *
-     * @param list<string> $sources A list of strings identifying a source.
+     * @param array<string> $sources A list of strings identifying a source.
      * @return void
      * @throws \InvalidArgumentException If sources list contains invalid value.
      */
@@ -2609,7 +2609,7 @@ class FormHelper extends Helper
      * Order sets priority.
      *
      * @see FormHelper::$supportedValueSources for valid values.
-     * @param list<string>|string $sources A string or a list of strings identifying a source.
+     * @param array<string>|string $sources A string or a list of strings identifying a source.
      * @return $this
      * @throws \InvalidArgumentException If sources list contains invalid value.
      */

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -373,7 +373,7 @@ class HtmlHelper extends Helper
      * `cspStyleNonce` attribute, that value will be applied as the `nonce` attribute on the
      * generated HTML.
      *
-     * @param list<string>|string $path The name of a CSS style sheet or an array containing names of
+     * @param array<string>|string $path The name of a CSS style sheet or an array containing names of
      *   CSS stylesheets. If `$path` is prefixed with '/', the path will be relative to the webroot
      *   of your application. Otherwise, the path will be relative to your CSS path, usually webroot/css.
      * @param array<string, mixed> $options Array of options and HTML arguments.
@@ -474,7 +474,7 @@ class HtmlHelper extends Helper
      * If the current request has a `cspScriptNonce` attribute, that value will
      * be inserted as a `nonce` attribute on the script tag.
      *
-     * @param list<string>|string $url String or array of javascript files to include
+     * @param array<string>|string $url String or array of javascript files to include
      * @param array<string, mixed> $options Array of options, and html attributes see above.
      * @return string|null String of `<script>` tags or null if block is specified in options
      *   or if $once is true and the file has been included before.

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -169,7 +169,7 @@ class StringTemplate
     /**
      * Compile templates into a more efficient printf() compatible format.
      *
-     * @param list<string> $templates The template names to compile. If empty all templates will be compiled.
+     * @param array<string> $templates The template names to compile. If empty all templates will be compiled.
      * @return void
      */
     protected function _compileTemplates(array $templates = []): void
@@ -284,7 +284,7 @@ class StringTemplate
      * templates to change how attributes are formatted.
      *
      * @param array<string, mixed>|null $options Array of options.
-     * @param list<string>|null $exclude Array of options to be excluded, the options here will not be part of the return.
+     * @param array<string>|null $exclude Array of options to be excluded, the options here will not be part of the return.
      * @return string Composed attributes.
      */
     public function formatAttributes(?array $options, ?array $exclude = null): string
@@ -347,7 +347,7 @@ class StringTemplate
      * Adds a class and returns a unique list either in array or space separated
      *
      * @param mixed $input The array or string to add the class to
-     * @param list<string>|string|false|null $newClass the new class or classes to add
+     * @param array<string>|string|false|null $newClass the new class or classes to add
      * @param string $useIndex if you are inputting an array with an element other than default of 'class'.
      * @return list<string>|string|null
      */

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -236,7 +236,7 @@ class MultiCheckboxWidget extends BasicWidget
      * Helper method for deciding what options are selected.
      *
      * @param string $key The key to test.
-     * @param list<string>|string|int|false|null $selected The selected values.
+     * @param array<string>|string|int|false|null $selected The selected values.
      * @return bool
      */
     protected function _isSelected(string $key, array|string|int|false|null $selected): bool

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -236,7 +236,7 @@ class SelectBoxWidget extends BasicWidget
      * Will recursively call itself when option groups are in use.
      *
      * @param iterable $options The options to render.
-     * @param list<string>|null $disabled The options to disable.
+     * @param array<string>|null $disabled The options to disable.
      * @param mixed $selected The options to select.
      * @param array $templateVars Additional template variables.
      * @param bool $escape Toggle HTML escaping.
@@ -333,7 +333,7 @@ class SelectBoxWidget extends BasicWidget
      * Helper method for deciding what options are disabled.
      *
      * @param string $key The key to test.
-     * @param list<string>|null $disabled The disabled values.
+     * @param array<string>|null $disabled The disabled values.
      * @return bool
      */
     protected function _isDisabled(string $key, ?array $disabled): bool


### PR DESCRIPTION
This makes it easier to upgrade existing apps and plugins to PHPStan 2.
Return values are fine to be strict, as `list<type>` is acceptable for other `array<type>` expectations.
But the other way around does not work.
And even simple array merging or alike will screw things up here for it.
The PHPStan implementation here unfortunately does not provide a normal "value" based list annotation yet, until then we need to stick to the generic one for `@param`.

I didnt update properties' `@var` yet, as here we might want to see which ones are based on input and which ones are purely read and returned. The latter can probably stay then in 5.2+.

See for example https://github.com/dereuromark/cakephp-ide-helper/pull/363 which would be green with this fix.
This affects the whole user land and plugin code base. So quite important to get done with the next patch IMO.