### PR TITLE
Fix up deprecations on interface

### DIFF
--- a/src/Datasource/QueryInterface.php
+++ b/src/Datasource/QueryInterface.php
@@ -279,6 +279,7 @@ interface QueryInterface
      *
      * @param \Cake\Datasource\RepositoryInterface $repository The default repository object to use
      * @return $this
+     * @deprecated
      */
     public function repository(RepositoryInterface $repository);
 


### PR DESCRIPTION
Following the deprecation changes on https://github.com/cakephp/cakephp/blame/4.x/src/Datasource/QueryTrait.php
shouldnt also the corresponding interface at least show the deprecation (e.g. in IDE)?
As those would also be moved away from there in 5.x no?

At least right now you often jump into the interface and dont see the deprecation.
Would be good if those were synced with the trait methods for clarification.