### PR TITLE
CS: Trailing comma on function calls

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -127,34 +127,34 @@
   <file src="src/TestSuite/Constraint/EventFired.php">
     <InternalClass>
       <code><![CDATA[new AssertionFailedError(
-                'The event manager you are asserting against is not configured to track events.'
+                'The event manager you are asserting against is not configured to track events.',
             )]]></code>
     </InternalClass>
     <InternalMethod>
       <code><![CDATA[new AssertionFailedError(
-                'The event manager you are asserting against is not configured to track events.'
+                'The event manager you are asserting against is not configured to track events.',
             )]]></code>
     </InternalMethod>
   </file>
   <file src="src/TestSuite/Constraint/EventFiredWith.php">
     <InternalClass>
       <code><![CDATA[new AssertionFailedError(
-                'The event manager you are asserting against is not configured to track events.'
+                'The event manager you are asserting against is not configured to track events.',
             )]]></code>
       <code><![CDATA[new AssertionFailedError(sprintf(
                 'Event `%s` was fired %d times, cannot make data assertion',
                 $other,
-                count($events)
+                count($events),
             ))]]></code>
     </InternalClass>
     <InternalMethod>
       <code><![CDATA[new AssertionFailedError(
-                'The event manager you are asserting against is not configured to track events.'
+                'The event manager you are asserting against is not configured to track events.',
             )]]></code>
       <code><![CDATA[new AssertionFailedError(sprintf(
                 'Event `%s` was fired %d times, cannot make data assertion',
                 $other,
-                count($events)
+                count($events),
             ))]]></code>
     </InternalMethod>
   </file>

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -143,7 +143,7 @@ class Cache
 
         if (empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
-                sprintf('The `%s` cache configuration does not exist.', $name)
+                sprintf('The `%s` cache configuration does not exist.', $name),
             );
         }
 
@@ -166,7 +166,7 @@ class Cache
             if ($config['fallback'] === $name) {
                 throw new InvalidArgumentException(sprintf(
                     '`%s` cache configuration cannot fallback to itself.',
-                    $name
+                    $name,
                 ), 0, $e);
             }
 
@@ -253,7 +253,7 @@ class Cache
                 "%s cache was unable to write '%s' to %s cache",
                 $config,
                 $key,
-                $backend::class
+                $backend::class,
             ));
         }
 

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -85,8 +85,8 @@ class CacheRegistry extends ObjectRegistry
             throw new CakeException(
                 sprintf(
                     'Cache engine `%s` is not properly configured. Check error log for additional information.',
-                    $instance::class
-                )
+                    $instance::class,
+                ),
             );
         }
 

--- a/src/Cache/Engine/ApcuEngine.php
+++ b/src/Cache/Engine/ApcuEngine.php
@@ -145,7 +145,7 @@ class ApcuEngine extends CacheEngine
         if (class_exists(APCUIterator::class, false)) {
             $iterator = new APCUIterator(
                 '/^' . preg_quote($this->_config['prefix'], '/') . '/',
-                APC_ITER_NONE
+                APC_ITER_NONE,
             );
             apcu_delete($iterator);
 
@@ -204,7 +204,7 @@ class ApcuEngine extends CacheEngine
                     $value = 1;
                     if (apcu_store($group, $value) === false) {
                         $this->warning(
-                            sprintf('Failed to store key `%s` with value `%s` into APCu cache.', $group, $value)
+                            sprintf('Failed to store key `%s` with value `%s` into APCu cache.', $group, $value),
                         );
                     }
                     $groups[$group] = $value;

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -243,12 +243,12 @@ class FileEngine extends CacheEngine
 
         $directory = new RecursiveDirectoryIterator(
             $this->_config['path'],
-            FilesystemIterator::SKIP_DOTS
+            FilesystemIterator::SKIP_DOTS,
         );
         /** @var \RecursiveDirectoryIterator<\SplFileInfo> $iterator Coerce for phpstan/psalm */
         $iterator = new RecursiveIteratorIterator(
             $directory,
-            RecursiveIteratorIterator::SELF_FIRST
+            RecursiveIteratorIterator::SELF_FIRST,
         );
         $cleared = [];
         foreach ($iterator as $fileInfo) {
@@ -394,7 +394,7 @@ class FileEngine extends CacheEngine
                 trigger_error(sprintf(
                     'Could not apply permission mask `%s` on cache file `%s`',
                     $this->_File->getPathname(),
-                    $this->_config['mask']
+                    $this->_config['mask'],
                 ), E_USER_WARNING);
             }
         }
@@ -423,7 +423,7 @@ class FileEngine extends CacheEngine
             $this->_init = false;
             trigger_error(sprintf(
                 '%s is not writable',
-                $this->_config['path']
+                $this->_config['path'],
             ), E_USER_WARNING);
         }
 
@@ -455,7 +455,7 @@ class FileEngine extends CacheEngine
         $directoryIterator = new RecursiveDirectoryIterator($this->_config['path']);
         $contents = new RecursiveIteratorIterator(
             $directoryIterator,
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
         /** @var array<\SplFileInfo> $filtered */
         $filtered = new CallbackFilterIterator(
@@ -472,9 +472,9 @@ class FileEngine extends CacheEngine
 
                 return str_contains(
                     $current->getPathname(),
-                    DIRECTORY_SEPARATOR . $group . DIRECTORY_SEPARATOR
+                    DIRECTORY_SEPARATOR . $group . DIRECTORY_SEPARATOR,
                 );
-            }
+            },
         );
         foreach ($filtered as $object) {
             $path = $object->getPathname();

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -154,7 +154,7 @@ class MemcachedEngine extends CacheEngine
                         throw new InvalidArgumentException(
                             'Invalid cache configuration. Multiple persistent cache configurations are detected' .
                             ' with different `servers` values. `servers` values for persistent cache configurations' .
-                            ' must be the same when using the same persistence id.'
+                            ' must be the same when using the same persistence id.',
                         );
                     }
                 }
@@ -180,20 +180,20 @@ class MemcachedEngine extends CacheEngine
 
         if (empty($this->_config['username']) && !empty($this->_config['login'])) {
             throw new InvalidArgumentException(
-                'Please pass "username" instead of "login" for connecting to Memcached'
+                'Please pass "username" instead of "login" for connecting to Memcached',
             );
         }
 
         if ($this->_config['username'] !== null && $this->_config['password'] !== null) {
             if (!method_exists($this->_Memcached, 'setSaslAuthData')) {
                 throw new InvalidArgumentException(
-                    'Memcached extension is not built with SASL support'
+                    'Memcached extension is not built with SASL support',
                 );
             }
             $this->_Memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
             $this->_Memcached->setSaslAuthData(
                 $this->_config['username'],
-                $this->_config['password']
+                $this->_config['password'],
             );
         }
 
@@ -214,7 +214,7 @@ class MemcachedEngine extends CacheEngine
         $serializer = strtolower($this->_config['serialize']);
         if (!isset($this->_serializers[$serializer])) {
             throw new InvalidArgumentException(
-                sprintf('`%s` is not a valid serializer engine for Memcached.', $serializer)
+                sprintf('`%s` is not a valid serializer engine for Memcached.', $serializer),
             );
         }
 
@@ -223,13 +223,13 @@ class MemcachedEngine extends CacheEngine
             !constant('Memcached::HAVE_' . strtoupper($serializer))
         ) {
             throw new InvalidArgumentException(
-                sprintf('Memcached extension is not compiled with `%s` support.', $serializer)
+                sprintf('Memcached extension is not compiled with `%s` support.', $serializer),
             );
         }
 
         $this->_Memcached->setOption(
             Memcached::OPT_SERIALIZER,
-            $this->_serializers[$serializer]
+            $this->_serializers[$serializer],
         );
 
         // Check for Amazon ElastiCache instance
@@ -242,7 +242,7 @@ class MemcachedEngine extends CacheEngine
 
         $this->_Memcached->setOption(
             Memcached::OPT_COMPRESSION,
-            (bool)$this->_config['compress']
+            (bool)$this->_config['compress'],
         );
     }
 

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -157,7 +157,7 @@ class RedisEngine extends CacheEngine
             return $this->_Redis->connect(
                 $server,
                 (int)$this->_config['port'],
-                (int)$this->_config['timeout']
+                (int)$this->_config['timeout'],
             );
         }
 
@@ -168,7 +168,7 @@ class RedisEngine extends CacheEngine
             null,
             0,
             0.0,
-            ['ssl' => $ssl]
+            ['ssl' => $ssl],
         );
     }
 
@@ -189,7 +189,7 @@ class RedisEngine extends CacheEngine
                 $server,
                 (int)$this->_config['port'],
                 (int)$this->_config['timeout'],
-                $persistentId
+                $persistentId,
             );
         }
 
@@ -200,7 +200,7 @@ class RedisEngine extends CacheEngine
             $persistentId,
             0,
             0.0,
-            ['ssl' => $ssl]
+            ['ssl' => $ssl],
         );
     }
 

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -319,7 +319,7 @@ trait CollectionTrait
             if ($pathValue === null) {
                 throw new InvalidArgumentException(
                     'Cannot group by path that does not exist or contains a null value. ' .
-                    'Use a callback to return a default value for that path.'
+                    'Use a callback to return a default value for that path.',
                 );
             }
             if ($pathValue instanceof BackedEnum) {
@@ -351,7 +351,7 @@ trait CollectionTrait
             if ($pathValue === null) {
                 throw new InvalidArgumentException(
                     'Cannot index by path that does not exist or contains a null value. ' .
-                    'Use a callback to return a default value for that path.'
+                    'Use a callback to return a default value for that path.',
                 );
             }
             if ($pathValue instanceof BackedEnum) {
@@ -657,7 +657,7 @@ trait CollectionTrait
                 if ($mapKey === null) {
                     throw new InvalidArgumentException(
                         'Cannot index by path that does not exist or contains a null value. ' .
-                        'Use a callback to return a default value for that path.'
+                        'Use a callback to return a default value for that path.',
                     );
                 }
 
@@ -676,7 +676,7 @@ trait CollectionTrait
             if ($key === null) {
                 throw new InvalidArgumentException(
                     'Cannot group by path that does not exist or contains a null value. ' .
-                    'Use a callback to return a default value for that path.'
+                    'Use a callback to return a default value for that path.',
                 );
             }
 
@@ -684,13 +684,13 @@ trait CollectionTrait
             if ($mapKey === null) {
                 throw new InvalidArgumentException(
                     'Cannot index by path that does not exist or contains a null value. ' .
-                    'Use a callback to return a default value for that path.'
+                    'Use a callback to return a default value for that path.',
                 );
             }
 
             $mapReduce->emitIntermediate(
                 [$mapKey => $rowVal($value, $key)],
-                $key
+                $key,
             );
         };
 
@@ -848,7 +848,7 @@ trait CollectionTrait
             if (!isset($modes[$order])) {
                 throw new InvalidArgumentException(sprintf(
                     "Invalid direction `%s` provided. Must be one of: 'desc', 'asc', 'leaves'.",
-                    $order
+                    $order,
                 ));
             }
             $order = $modes[$order];
@@ -856,7 +856,7 @@ trait CollectionTrait
 
         return new TreeIterator(
             new NestIterator($this, $nestingKey),
-            $order
+            $order,
         );
     }
 
@@ -882,8 +882,8 @@ trait CollectionTrait
         return $this->newCollection(
             new RecursiveIteratorIterator(
                 new UnfoldIterator($this->unwrap(), $callback),
-                RecursiveIteratorIterator::LEAVES_ONLY
-            )
+                RecursiveIteratorIterator::LEAVES_ONLY,
+            ),
         );
     }
 

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -112,7 +112,7 @@ class TreeIterator extends RecursiveIteratorIterator implements CollectionInterf
             $valuePath,
             $keyPath,
             $spacer,
-            $this->_mode
+            $this->_mode,
         );
     }
 }

--- a/src/Collection/Iterator/ZipIterator.php
+++ b/src/Collection/Iterator/ZipIterator.php
@@ -76,7 +76,7 @@ class ZipIterator implements CollectionInterface
     public function __construct(array $sets, ?callable $callable = null)
     {
         $this->multipleIterator = new MultipleIterator(
-            MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC
+            MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC,
         );
 
         $this->_callback = $callable;
@@ -163,7 +163,7 @@ class ZipIterator implements CollectionInterface
     public function __unserialize(array $data): void
     {
         $this->multipleIterator = new MultipleIterator(
-            MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC
+            MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC,
         );
 
         $this->_iterators = $data;

--- a/src/Command/CacheClearGroupCommand.php
+++ b/src/Command/CacheClearGroupCommand.php
@@ -102,7 +102,7 @@ class CacheClearGroupCommand extends Command
                 $io->error(sprintf(
                     'Error encountered clearing group "%s". Was unable to clear entries for "%s".',
                     $group,
-                    $groupConfig
+                    $groupConfig,
                 ));
                 $this->abort();
             } else {

--- a/src/Command/CompletionCommand.php
+++ b/src/Command/CompletionCommand.php
@@ -72,7 +72,7 @@ class CompletionCommand extends Command implements CommandCollectionAwareInterfa
         }
 
         $parser->setDescription(
-            static::getDescription()
+            static::getDescription(),
         )->addArgument('mode', [
             'help' => 'The type of thing to get completion on.',
             'required' => true,

--- a/src/Command/I18nCommand.php
+++ b/src/Command/I18nCommand.php
@@ -68,7 +68,7 @@ class I18nCommand extends Command
                 default:
                     $io->err(
                         'You have made an invalid selection. ' .
-                        'Please choose a command to execute by entering E, I, H, or Q.'
+                        'Please choose a command to execute by entering E, I, H, or Q.',
                     );
             }
             if ($code === static::CODE_ERROR) {

--- a/src/Command/I18nExtractCommand.php
+++ b/src/Command/I18nExtractCommand.php
@@ -144,14 +144,14 @@ class I18nExtractCommand extends Command
         $defaultPaths = array_merge(
             [APP],
             array_values(App::path('templates')),
-            ['D'] // This is required to break the loop below
+            ['D'], // This is required to break the loop below
         );
         $defaultPathIndex = 0;
         while (true) {
             $currentPaths = $this->_paths !== [] ? $this->_paths : ['None'];
             $message = sprintf(
                 "Current paths: %s\nWhat is the path you would like to extract?\n[Q]uit [D]one",
-                implode(', ', $currentPaths)
+                implode(', ', $currentPaths),
             );
             $response = $io->ask($message, $defaultPaths[$defaultPathIndex] ?? 'D');
             if (strtoupper($response) === 'Q') {
@@ -209,7 +209,7 @@ class I18nExtractCommand extends Command
             $response = $io->askChoice(
                 'Would you like to extract the messages from the CakePHP core?',
                 ['y', 'n'],
-                'n'
+                'n',
             );
             $this->_extractCore = strtolower($response) === 'y';
         }
@@ -237,7 +237,7 @@ class I18nExtractCommand extends Command
             while (true) {
                 $response = $io->ask(
                     $message,
-                    $localePaths[0]
+                    $localePaths[0],
                 );
                 if (strtoupper($response) === 'Q') {
                     $io->err('Extract Aborted');
@@ -252,7 +252,7 @@ class I18nExtractCommand extends Command
                 $io->err('');
                 $io->err(
                     '<error>The directory path you supplied was ' .
-                    'not found. Please try again.</error>'
+                    'not found. Please try again.</error>',
                 );
                 $io->err('');
             }
@@ -265,7 +265,7 @@ class I18nExtractCommand extends Command
             $response = $io->askChoice(
                 'Would you like to merge all domain strings into the default.pot file?',
                 ['y', 'n'],
-                'n'
+                'n',
             );
             $this->_merge = strtolower($response) === 'y';
         }
@@ -645,7 +645,7 @@ class I18nExtractCommand extends Command
                 $response = $io->askChoice(
                     sprintf('Error: %s already exists in this location. Overwrite? [Y]es, [N]o, [A]ll', $filename),
                     ['y', 'n', 'a'],
-                    'y'
+                    'y',
                 );
                 if (strtoupper($response) === 'N') {
                     $response = '';

--- a/src/Command/PluginAssetsCopyCommand.php
+++ b/src/Command/PluginAssetsCopyCommand.php
@@ -76,7 +76,7 @@ class PluginAssetsCopyCommand extends Command
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(
-            static::getDescription()
+            static::getDescription(),
         )->addArgument('name', [
             'help' => 'A specific plugin you want to copy assets for.',
             'required' => false,

--- a/src/Command/PluginAssetsRemoveCommand.php
+++ b/src/Command/PluginAssetsRemoveCommand.php
@@ -85,7 +85,7 @@ class PluginAssetsRemoveCommand extends Command
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(
-            static::getDescription()
+            static::getDescription(),
         )->addArgument('name', [
             'help' => 'A specific plugin you want to remove.',
             'required' => false,

--- a/src/Command/PluginAssetsSymlinkCommand.php
+++ b/src/Command/PluginAssetsSymlinkCommand.php
@@ -77,7 +77,7 @@ class PluginAssetsSymlinkCommand extends Command
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(
-            static::getDescription()
+            static::getDescription(),
         )->addArgument('name', [
             'help' => 'A specific plugin you want to symlink assets for.',
             'required' => false,

--- a/src/Command/PluginAssetsTrait.php
+++ b/src/Command/PluginAssetsTrait.php
@@ -67,7 +67,7 @@ trait PluginAssetsTrait
                 $this->io->verbose('', 1);
                 $this->io->verbose(
                     sprintf('Skipping plugin %s. It does not have webroot folder.', $plugin),
-                    2
+                    2,
                 );
                 continue;
             }
@@ -126,7 +126,7 @@ trait PluginAssetsTrait
                 if (!$overwrite) {
                     $this->io->verbose(
                         $dest . ' already exists',
-                        1
+                        1,
                     );
                     continue;
                 }
@@ -135,7 +135,7 @@ trait PluginAssetsTrait
             if (!$copy) {
                 $result = $this->_createSymlink(
                     $config['srcPath'],
-                    $dest
+                    $dest,
                 );
                 if ($result) {
                     continue;
@@ -144,7 +144,7 @@ trait PluginAssetsTrait
 
             $this->_copyDirectory(
                 $config['srcPath'],
-                $dest
+                $dest,
             );
         }
 
@@ -163,7 +163,7 @@ trait PluginAssetsTrait
         if ($config['namespaced'] && !is_dir($config['destDir'])) {
             $this->io->verbose(
                 $config['destDir'] . $config['link'] . ' does not exist',
-                1
+                1,
             );
 
             return false;
@@ -174,7 +174,7 @@ trait PluginAssetsTrait
         if (!file_exists($dest)) {
             $this->io->verbose(
                 $dest . ' does not exist',
-                1
+                1,
             );
 
             return false;

--- a/src/Command/PluginUnloadCommand.php
+++ b/src/Command/PluginUnloadCommand.php
@@ -117,7 +117,7 @@ class PluginUnloadCommand extends Command
     public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(
-            static::getDescription()
+            static::getDescription(),
         )
         ->addArgument('plugin', [
             'help' => 'Name of the plugin to unload.',

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -141,7 +141,7 @@ class ServerCommand extends Command
             $phpBinary,
             $this->_host,
             $this->_port,
-            escapeshellarg($this->_documentRoot)
+            escapeshellarg($this->_documentRoot),
         );
 
         if ($this->_iniPath) {

--- a/src/Console/Arguments.php
+++ b/src/Console/Arguments.php
@@ -152,7 +152,7 @@ class Arguments
         if (is_array($value)) {
             throw new ConsoleException(sprintf(
                 'Cannot get multiple values for option `%s`, use `getMultipleOption()` instead.',
-                $name
+                $name,
             ));
         }
 
@@ -172,7 +172,7 @@ class Arguments
         if ($value !== null && !is_bool($value)) {
             throw new ConsoleException(sprintf(
                 'Option `%s` is not of type `bool`, use `getOption()` instead.',
-                $name
+                $name,
             ));
         }
 
@@ -190,7 +190,7 @@ class Arguments
         if ($value !== null && !is_array($value)) {
             throw new ConsoleException(sprintf(
                 'Option `%s` is not of type `array`, use `getOption()` instead.',
-                $name
+                $name,
             ));
         }
 
@@ -220,7 +220,7 @@ class Arguments
 
         throw new ConsoleException(sprintf(
             'Argument `%s` is not defined on this Command. Could this be an option maybe?',
-            $name
+            $name,
         ));
     }
 }

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -66,7 +66,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
     {
         assert(
             str_contains($name, ' ') && !str_starts_with($name, ' '),
-            "The name '{$name}' is missing a space. Names should look like `cake routes`"
+            "The name '{$name}' is missing a space. Names should look like `cake routes`",
         );
         $this->name = $name;
 
@@ -180,7 +180,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
             $args = new Arguments(
                 $arguments,
                 $options,
-                $parser->argumentNames()
+                $parser->argumentNames(),
             );
         } catch (ConsoleException $e) {
             $io->err('Error: ' . $e->getMessage());
@@ -285,7 +285,7 @@ abstract class BaseCommand implements CommandInterface, EventDispatcherInterface
         if (is_string($command)) {
             assert(
                 is_subclass_of($command, CommandInterface::class),
-                sprintf('Command `%s` is not a subclass of `%s`.', $command, CommandInterface::class)
+                sprintf('Command `%s` is not a subclass of `%s`.', $command, CommandInterface::class),
             );
 
             $command = $this->factory?->create($command) ?? new $command();

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -226,7 +226,7 @@ class HelpCommand extends BaseCommand implements CommandCollectionAwareInterface
     protected function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser
     {
         $parser->setDescription(
-            'Get the list of available commands for this application.'
+            'Get the list of available commands for this application.',
         )->addOption('xml', [
             'help' => 'Get the listing as XML.',
             'boolean' => true,

--- a/src/Console/CommandCollection.php
+++ b/src/Console/CommandCollection.php
@@ -71,13 +71,13 @@ class CommandCollection implements IteratorAggregate, Countable
                     'It is not a subclass of `%s`.',
                     $command,
                     $name,
-                    CommandInterface::class
-                )
+                    CommandInterface::class,
+                ),
             );
         }
         if (!preg_match('/^[^\s]+(?:(?: [^\s]+){1,2})?$/ui', $name)) {
             throw new InvalidArgumentException(
-                "The command name `{$name}` is invalid. Names can only be a maximum of three words."
+                "The command name `{$name}` is invalid. Names can only be a maximum of three words.",
             );
         }
 

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -299,7 +299,7 @@ class CommandRunner implements EventDispatcherInterface
                 "Unknown command `{$this->root} {$name}`. " .
                 "Run `{$this->root} --help` to get the list of commands.",
                 $name,
-                $commands->keys()
+                $commands->keys(),
             );
         }
 

--- a/src/Console/CommandScanner.php
+++ b/src/Console/CommandScanner.php
@@ -42,7 +42,7 @@ class CommandScanner
             dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Command' . DIRECTORY_SEPARATOR,
             'Cake\Command\\',
             '',
-            ['command_list']
+            ['command_list'],
         );
     }
 
@@ -59,7 +59,7 @@ class CommandScanner
             App::classPath('Command')[0],
             $appNamespace . '\Command\\',
             '',
-            []
+            [],
         );
     }
 

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -197,8 +197,8 @@ class ConsoleInputArgument
                     '`%s` is not a valid value for `%s`. Please use one of `%s`',
                     $value,
                     $this->_name,
-                    implode(', ', $this->_choices)
-                )
+                    implode(', ', $this->_choices),
+                ),
             );
         }
 

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -132,13 +132,13 @@ class ConsoleInputOption
 
         if (strlen($this->_short) > 1) {
             throw new ConsoleException(
-                sprintf('Short option `%s` is invalid, short options must be one letter.', $this->_short)
+                sprintf('Short option `%s` is invalid, short options must be one letter.', $this->_short),
             );
         }
         if ($this->_default !== null && $this->prompt) {
             throw new ConsoleException(
                 'You cannot set both `prompt` and `default` options. ' .
-                'Use either a static `default` or interactive `prompt`'
+                'Use either a static `default` or interactive `prompt`',
             );
         }
     }
@@ -275,8 +275,8 @@ class ConsoleInputOption
                     '`%s` is not a valid value for `--%s`. Please use one of `%s`',
                     (string)$value,
                     $this->_name,
-                    implode(', ', $this->_choices)
-                )
+                    implode(', ', $this->_choices),
+                ),
             );
         }
 

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -489,7 +489,7 @@ class ConsoleIo
         $options = array_merge(
             array_map('strtolower', $options),
             array_map('strtoupper', $options),
-            $options
+            $options,
         );
         $in = '';
         while ($in === '' || !in_array($in, $options, true)) {

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -388,7 +388,7 @@ class ConsoleOptionParser
                 $options['choices'],
                 $options['multiple'],
                 $options['required'],
-                $options['prompt']
+                $options['prompt'],
             );
         }
         $this->_options[$name] = $option;
@@ -585,7 +585,7 @@ class ConsoleOptionParser
             if (!isset($args[$i])) {
                 if ($arg->isRequired()) {
                     throw new ConsoleException(
-                        sprintf('Missing required argument. The `%s` argument is required.', $arg->name())
+                        sprintf('Missing required argument. The `%s` argument is required.', $arg->name()),
                     );
                 }
                 if ($arg->defaultValue() !== null) {
@@ -610,7 +610,7 @@ class ConsoleOptionParser
                 if (!$io) {
                     throw new ConsoleException(
                         'Cannot use interactive option prompts without a ConsoleIo instance. ' .
-                        'Please provide a `$io` parameter to `parse()`.'
+                        'Please provide a `$io` parameter to `parse()`.',
                     );
                 }
                 $choices = $option->choices();
@@ -623,7 +623,7 @@ class ConsoleOptionParser
             }
             if ($option->isRequired() && !isset($params[$name])) {
                 throw new ConsoleException(
-                    sprintf('Missing required option. The `%s` option is required and has no default value.', $name)
+                    sprintf('Missing required option. The `%s` option is required and has no default value.', $name),
                 );
             }
         }
@@ -716,7 +716,7 @@ class ConsoleOptionParser
             throw new MissingOptionException(
                 sprintf('Unknown short option `%s`.', $key),
                 $key,
-                $options
+                $options,
             );
         }
         $name = $this->_shortOptions[$key];
@@ -738,7 +738,7 @@ class ConsoleOptionParser
             throw new MissingOptionException(
                 sprintf('Unknown option `%s`.', $name),
                 $name,
-                array_keys($this->_options)
+                array_keys($this->_options),
             );
         }
         $option = $this->_options[$name];
@@ -804,7 +804,7 @@ class ConsoleOptionParser
             throw new ConsoleException(sprintf(
                 'Received too many arguments. Got `%s` but only `%s` arguments are defined.',
                 $next,
-                $expected
+                $expected,
             ));
         }
 

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -242,7 +242,7 @@ class ConsoleOutput
             $output = preg_replace_callback(
                 '/<(?P<tag>[a-z0-9-_.]+)>(?P<text>.*?)<\/(\1)>/ims',
                 $replaceTags,
-                $text
+                $text,
             );
             if ($output !== null) {
                 return $output;

--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -88,7 +88,7 @@ trait ConsoleIntegrationTestTrait
             $this->_in = new StubConsoleInput($input);
         } elseif ($input) {
             throw new InvalidArgumentException(
-                'You can use `$input` only if `$_in` property is null and will be reset.'
+                'You can use `$input` only if `$_in` property is null and will be reset.',
             );
         }
         $this->_out->clear();

--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -152,7 +152,7 @@ class Component implements EventListenerInterface
 
             return $this->componentInstances[$name] = $this->_registry->load(
                 $name,
-                $config
+                $config,
             );
         }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -319,9 +319,9 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
                 array_pop($parts),
                 $name,
                 $trace[0]['file'],
-                $trace[0]['line']
+                $trace[0]['line'],
             ),
-            E_USER_NOTICE
+            E_USER_NOTICE,
         );
 
         return null;
@@ -507,8 +507,8 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
                 sprintf(
                     'Controller actions can only return Response instance or null. '
                     . 'Got %s instead.',
-                    get_debug_type($result)
-                )
+                    get_debug_type($result),
+                ),
             );
         } elseif ($this->isAutoRenderEnabled()) {
             $result = $this->render();
@@ -646,7 +646,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($status < 300 || $status > 399) {
             throw new InvalidArgumentException(
                 sprintf('Invalid status code `%s`. It should be within the range ' .
-                    '`300` - `399` for redirect responses.', $status)
+                    '`300` - `399` for redirect responses.', $status),
             );
         }
 
@@ -808,7 +808,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         if ($this->request->getParam('prefix')) {
             $prefixes = array_map(
                 'Cake\Utility\Inflector::camelize',
-                explode('/', $this->request->getParam('prefix'))
+                explode('/', $this->request->getParam('prefix')),
             );
             $templatePath = implode(DIRECTORY_SEPARATOR, $prefixes) . DIRECTORY_SEPARATOR . $templatePath;
         }
@@ -874,7 +874,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
         $paginator = App::className(
             $settings['className'] ?? NumericPaginator::class,
             'Datasource/Paging',
-            'Paginator'
+            'Paginator',
         );
         $paginator = new $paginator();
         unset($settings['className']);
@@ -883,7 +883,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
             $results = $paginator->paginate(
                 $object,
                 $this->request->getQueryParams(),
-                $settings
+                $settings,
             );
         } catch (PageOutOfBoundsException $exception) {
             throw new NotFoundException(null, null, $exception);

--- a/src/Controller/ControllerFactory.php
+++ b/src/Controller/ControllerFactory.php
@@ -83,7 +83,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         }
         $this->container->addShared(
             ComponentRegistry::class,
-            new ComponentRegistry(container: $this->container)
+            new ComponentRegistry(container: $this->container),
         );
 
         // Get the controller from the container if defined.
@@ -161,7 +161,7 @@ class ControllerFactory implements ControllerFactoryInterface, RequestHandlerInt
         $action = $controller->getAction();
         $args = $this->getActionArgs(
             $action,
-            array_values((array)$controller->getRequest()->getParam('pass'))
+            array_values((array)$controller->getRequest()->getParam('pass')),
         );
         $controller->invokeAction($action, $args);
 

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -198,7 +198,7 @@ class App
             'locales' => [Plugin::path($plugin) . 'resources' . DIRECTORY_SEPARATOR . 'locales' . DIRECTORY_SEPARATOR],
             default => throw new CakeException(sprintf(
                 'Invalid type `%s`. Only path types `templates` and `locales` are supported for plugins.',
-                $type
+                $type,
             ))
         };
     }

--- a/src/Core/BasePlugin.php
+++ b/src/Core/BasePlugin.php
@@ -255,7 +255,7 @@ class BasePlugin implements PluginInterface
             throw new InvalidArgumentException(sprintf(
                 '`%s` is not a valid hook name. Must be one of `%s.`',
                 $hook,
-                implode(', ', static::VALID_HOOKS)
+                implode(', ', static::VALID_HOOKS),
             ));
         }
     }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -331,8 +331,8 @@ class Configure
                 sprintf(
                     'Config %s engine not found when attempting to load %s.',
                     $config,
-                    $key
-                )
+                    $key,
+                ),
             );
         }
 

--- a/src/Core/Configure/Engine/JsonConfig.php
+++ b/src/Core/Configure/Engine/JsonConfig.php
@@ -85,13 +85,13 @@ class JsonConfig implements ConfigEngineInterface
             throw new CakeException(sprintf(
                 'Error parsing JSON string fetched from config file `%s.json`: %s',
                 $key,
-                json_last_error_msg()
+                json_last_error_msg(),
             ));
         }
         if (!is_array($values)) {
             throw new CakeException(sprintf(
                 'Decoding JSON config file `%s.json` did not return an array',
-                $key
+                $key,
             ));
         }
 

--- a/src/Core/ObjectRegistry.php
+++ b/src/Core/ObjectRegistry.php
@@ -159,7 +159,7 @@ abstract class ObjectRegistry implements Countable, IteratorAggregate
                     ' The `%s` key has a value of `%s` but previously had a value of `%s`',
                     $key,
                     json_encode($value, JSON_THROW_ON_ERROR),
-                    json_encode($existingConfig[$key], JSON_THROW_ON_ERROR)
+                    json_encode($existingConfig[$key], JSON_THROW_ON_ERROR),
                 );
                 break;
             }

--- a/src/Core/PluginConfig.php
+++ b/src/Core/PluginConfig.php
@@ -146,7 +146,7 @@ class PluginConfig
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new CakeException(sprintf(
                 'Error parsing composer.lock: %s',
-                json_last_error_msg()
+                json_last_error_msg(),
             ));
         }
 
@@ -178,7 +178,7 @@ class PluginConfig
             throw new CakeException(sprintf(
                 'Error parsing %ss: %s',
                 $jsonPath,
-                json_last_error_msg()
+                json_last_error_msg(),
             ));
         }
 

--- a/src/Core/ServiceProvider.php
+++ b/src/Core/ServiceProvider.php
@@ -53,8 +53,8 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
             sprintf(
                 'Unexpected container type. Expected `%s` got `%s` instead.',
                 ContainerInterface::class,
-                get_debug_type($container)
-            )
+                get_debug_type($container),
+            ),
         );
 
         return $container;
@@ -115,7 +115,7 @@ abstract class ServiceProvider extends AbstractServiceProvider implements Bootab
     {
         if (!$this->provides) {
             throw new LogicException(
-                'The property `$provides` should contain a list with service ids for this service provider'
+                'The property `$provides` should contain a list with service ids for this service provider',
             );
         }
 

--- a/src/Core/functions.php
+++ b/src/Core/functions.php
@@ -316,7 +316,7 @@ if (!function_exists('Cake\Core\triggerWarning')) {
                 '%s - %s, line: %s',
                 $message,
                 $frame['file'],
-                $frame['line']
+                $frame['line'],
             );
         }
         trigger_error($message, E_USER_WARNING);
@@ -367,7 +367,7 @@ if (!function_exists('Cake\Core\deprecationWarning')) {
                 $message,
                 $frame['file'],
                 $frame['line'],
-                $relative
+                $relative,
             );
         }
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -378,7 +378,7 @@ class Connection implements ConnectionInterface
             return $this->_schemaCollection = new CachedCollection(
                 new SchemaCollection($this),
                 empty($this->_config['cacheKeyPrefix']) ? $this->configName() : $this->_config['cacheKeyPrefix'],
-                $this->getCacher()
+                $this->getCacher(),
             );
         }
 
@@ -766,7 +766,7 @@ class Connection implements ConnectionInterface
         if (!class_exists(Cache::class)) {
             throw new CakeException(
                 'To use caching you must either set a cacher using Connection::setCacher()' .
-                ' or require the cakephp/cache package in your composer config.'
+                ' or require the cakephp/cache package in your composer config.',
             );
         }
 

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -155,7 +155,7 @@ abstract class Driver
     {
         if (empty($config['username']) && !empty($config['login'])) {
             throw new InvalidArgumentException(
-                'Please pass "username" instead of "login" for connecting to the database'
+                'Please pass "username" instead of "login" for connecting to the database',
             );
         }
         $config += $this->_baseConfig + ['log' => false];
@@ -192,7 +192,7 @@ abstract class Driver
             $dsn,
             $config['username'] ?: null,
             $config['password'] ?: null,
-            $config['flags']
+            $config['flags'],
         );
 
         $retry = new CommandRetry(new ErrorCodeWaitStrategy(static::RETRY_ERROR_CODES, 5), 4);
@@ -205,7 +205,7 @@ abstract class Driver
                     'reason' => $e->getMessage(),
                 ],
                 null,
-                $e
+                $e,
             );
         } finally {
             $this->connectRetries = $retry->getRetries();
@@ -396,7 +396,7 @@ abstract class Driver
         } catch (PDOException $e) {
             throw new QueryException(
                 $query instanceof Query ? $query->sql() : $query,
-                $e
+                $e,
             );
         }
 
@@ -551,7 +551,7 @@ abstract class Driver
             $query instanceof DeleteQuery => $this->_deleteQueryTranslator($query),
             default => throw new InvalidArgumentException(sprintf(
                 'Instance of SelectQuery, UpdateQuery, InsertQuery, DeleteQuery expected. Found `%s` instead.',
-                get_debug_type($query)
+                get_debug_type($query),
             )),
         };
 
@@ -676,7 +676,7 @@ abstract class Driver
         if ($query->clause('join')) {
             throw new DatabaseException(
                 'Aliases are being removed from conditions for UPDATE/DELETE queries, ' .
-                'this can break references to joined tables.'
+                'this can break references to joined tables.',
             );
         }
 
@@ -963,7 +963,7 @@ abstract class Driver
         if ($className === null) {
             throw new CakeException(
                 'For logging you must either set the `log` config to a FQCN which implemnts Psr\Log\LoggerInterface' .
-                ' or require the cakephp/log package in your composer config.'
+                ' or require the cakephp/log package in your composer config.',
             );
         }
 

--- a/src/Database/Driver/Mysql.php
+++ b/src/Database/Driver/Mysql.php
@@ -239,7 +239,7 @@ class Mysql extends Driver
             return version_compare(
                 $this->version(),
                 $this->featureVersions[$this->serverType][$feature->value],
-                '>='
+                '>=',
             );
         };
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -121,7 +121,7 @@ class Sqlite extends Driver
         if (!is_string($config['database']) || $config['database'] === '') {
             $name = $config['name'] ?? 'unknown';
             throw new InvalidArgumentException(
-                "The `database` key for the `{$name}` SQLite connection needs to be a non-empty string."
+                "The `database` key for the `{$name}` SQLite connection needs to be a non-empty string.",
             );
         }
 
@@ -202,7 +202,7 @@ class Sqlite extends Driver
             DriverFeatureEnum::WINDOW => version_compare(
                 $this->version(),
                 $this->featureVersions[$feature->value],
-                '>='
+                '>=',
             ),
             DriverFeatureEnum::INTERSECT => true,
             DriverFeatureEnum::INTERSECT_ALL => false,

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -120,7 +120,7 @@ class Sqlserver extends Driver
         if (isset($config['persistent']) && $config['persistent']) {
             throw new InvalidArgumentException(
                 'Config setting "persistent" cannot be set to true, '
-                . 'as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT'
+                . 'as the Sqlserver PDO driver does not support PDO::ATTR_PERSISTENT',
             );
         }
 
@@ -205,7 +205,7 @@ class Sqlserver extends Driver
                     'Exceeded maximum number of parameters (2100) for prepared statements in Sql Server. ' .
                     'This is probably due to a very large WHERE IN () clause which generates a parameter ' .
                     'for each value in the array. ' .
-                    'If using an Association, try changing the `strategy` from select to subquery.'
+                    'If using an Association, try changing the `strategy` from select to subquery.',
                 );
             }
 
@@ -217,7 +217,7 @@ class Sqlserver extends Driver
         /** @var string $sql */
         $statement = $this->getPdo()->prepare(
             $sql,
-            $options
+            $options,
         );
 
         /** @var \Cake\Database\StatementInterface */

--- a/src/Database/Driver/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Driver/TupleComparisonTranslatorTrait.php
@@ -62,8 +62,8 @@ trait TupleComparisonTranslatorTrait
             throw new InvalidArgumentException(
                 sprintf(
                     'Tuple comparison transform only supports the `IN` and `=` operators, `%s` given.',
-                    $operator
-                )
+                    $operator,
+                ),
             );
         }
 

--- a/src/Database/Expression/CaseStatementExpression.php
+++ b/src/Database/Expression/CaseStatementExpression.php
@@ -134,7 +134,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
                     'The `$value` argument must be either `null`, a scalar value, an object, ' .
                     'or an instance of `\%s`, `%s` given.',
                     ExpressionInterface::class,
-                    get_debug_type($value)
+                    get_debug_type($value),
                 ));
             }
 
@@ -303,7 +303,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
                 throw new LogicException(sprintf(
                     '`when()` callables must return an instance of `\%s`, `%s` given.',
                     WhenThenExpression::class,
-                    get_debug_type($when)
+                    get_debug_type($when),
                 ));
             }
         }
@@ -416,7 +416,7 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
                 'The `$result` argument must be either `null`, a scalar value, an object, ' .
                 'or an instance of `\%s`, `%s` given.',
                 ExpressionInterface::class,
-                get_debug_type($result)
+                get_debug_type($result),
             ));
         }
 
@@ -504,8 +504,8 @@ class CaseStatementExpression implements ExpressionInterface, TypedResultInterfa
                 sprintf(
                     'The `$clause` argument must be one of `%s`, the given value `%s` is invalid.',
                     implode('`, `', $this->validClauseNames),
-                    $clause
-                )
+                    $clause,
+                ),
             );
         }
 

--- a/src/Database/Expression/CommonTableExpression.php
+++ b/src/Database/Expression/CommonTableExpression.php
@@ -103,7 +103,7 @@ class CommonTableExpression implements ExpressionInterface
             $query = $query();
             if (!($query instanceof ExpressionInterface)) {
                 throw new DatabaseException(
-                    'You must return an `ExpressionInterface` from a Closure passed to `query()`.'
+                    'You must return an `ExpressionInterface` from a Closure passed to `query()`.',
                 );
             }
         }
@@ -198,7 +198,7 @@ class CommonTableExpression implements ExpressionInterface
             $this->name->sql($binder),
             $fields,
             $suffix,
-            $this->query ? $this->query->sql($binder) : ''
+            $this->query ? $this->query->sql($binder) : '',
         );
     }
 

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -231,7 +231,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
                 $field = $this->_field instanceof ExpressionInterface ? $this->_field->sql($binder) : $this->_field;
                 /** @var string $field */
                 throw new DatabaseException(
-                    "Impossible to generate condition with empty list of values for field ({$field})"
+                    "Impossible to generate condition with empty list of values for field ({$field})",
                 );
             }
         } else {

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -162,7 +162,7 @@ class FunctionExpression extends QueryExpression implements TypedResultInterface
 
         return $this->_name . sprintf('(%s)', implode(
             $this->_conjunction . ' ',
-            $parts
+            $parts,
         ));
     }
 

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -81,8 +81,8 @@ class OrderByExpression extends QueryExpression
                         'is not allowed to avoid potential SQL injection. ' .
                         'Use QueryExpression or numeric array instead.',
                         $key,
-                        $val
-                    )
+                        $val,
+                    ),
                 );
             }
         }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -724,7 +724,7 @@ class QueryExpression implements ExpressionInterface, Countable
             return new UnaryExpression(
                 'IS NULL',
                 new IdentifierExpression($expression),
-                UnaryExpression::POSTFIX
+                UnaryExpression::POSTFIX,
             );
         }
 
@@ -732,7 +732,7 @@ class QueryExpression implements ExpressionInterface, Countable
             return new UnaryExpression(
                 'IS NOT NULL',
                 new IdentifierExpression($expression),
-                UnaryExpression::POSTFIX
+                UnaryExpression::POSTFIX,
             );
         }
 
@@ -746,7 +746,7 @@ class QueryExpression implements ExpressionInterface, Countable
 
         if ($value === null && $this->_conjunction !== ',') {
             throw new InvalidArgumentException(
-                sprintf('Expression `%s` is missing operator (IS, IS NOT) with `null` value.', $expression)
+                sprintf('Expression `%s` is missing operator (IS, IS NOT) with `null` value.', $expression),
             );
         }
 

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -77,12 +77,12 @@ class TupleComparison extends ComparisonExpression
         if ($this->isMulti()) {
             if (is_array($value) && !is_array(current($value))) {
                 throw new InvalidArgumentException(
-                    'Multi-tuple comparisons require a multi-tuple value, single-tuple given.'
+                    'Multi-tuple comparisons require a multi-tuple value, single-tuple given.',
                 );
             }
         } elseif (is_array($value) && is_array(current($value))) {
             throw new InvalidArgumentException(
-                'Single-tuple comparisons require a single-tuple value, multi-tuple given.'
+                'Single-tuple comparisons require a single-tuple value, multi-tuple given.',
             );
         }
 

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -98,7 +98,7 @@ class ValuesExpression implements ExpressionInterface
             )
         ) {
             throw new DatabaseException(
-                'You cannot mix subqueries and array values in inserts.'
+                'You cannot mix subqueries and array values in inserts.',
             );
         }
         if ($values instanceof Query) {

--- a/src/Database/Expression/WhenThenExpression.php
+++ b/src/Database/Expression/WhenThenExpression.php
@@ -132,7 +132,7 @@ class WhenThenExpression implements ExpressionInterface
                 throw new InvalidArgumentException(sprintf(
                     'When using an array for the `$when` argument, the `$type` argument must be an ' .
                     'array too, `%s` given.',
-                    get_debug_type($type)
+                    get_debug_type($type),
                 ));
             }
 
@@ -154,7 +154,7 @@ class WhenThenExpression implements ExpressionInterface
                 throw new InvalidArgumentException(sprintf(
                     'When using a non-array value for the `$when` argument, the `$type` argument must ' .
                     'be a string, `%s` given.',
-                    get_debug_type($type)
+                    get_debug_type($type),
                 ));
             }
 
@@ -192,7 +192,7 @@ class WhenThenExpression implements ExpressionInterface
                 'The `$result` argument must be either `null`, a scalar value, an object, ' .
                 'or an instance of `\%s`, `%s` given.',
                 ExpressionInterface::class,
-                get_debug_type($result)
+                get_debug_type($result),
             ));
         }
 
@@ -237,8 +237,8 @@ class WhenThenExpression implements ExpressionInterface
                 sprintf(
                     'The `$clause` argument must be one of `%s`, the given value `%s` is invalid.',
                     implode('`, `', $this->validClauseNames),
-                    $clause
-                )
+                    $clause,
+                ),
             );
         }
 

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -246,12 +246,12 @@ class WindowExpression implements ExpressionInterface, WindowInterface
             $start = $this->buildOffsetSql(
                 $binder,
                 $this->frame['start']['offset'],
-                $this->frame['start']['direction']
+                $this->frame['start']['direction'],
             );
             $end = $this->buildOffsetSql(
                 $binder,
                 $this->frame['end']['offset'],
-                $this->frame['end']['direction']
+                $this->frame['end']['direction'],
             );
 
             $frameSql = sprintf('%s BETWEEN %s AND %s', $this->frame['type'], $start, $end);
@@ -322,7 +322,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
         return sprintf(
             '%s %s',
             $offset ?? 'UNBOUNDED',
-            $direction
+            $direction,
         );
     }
 

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -121,7 +121,7 @@ class IdentifierQuoter
             default =>
                 throw new DatabaseException(sprintf(
                     'Instance of SelectQuery, UpdateQuery, InsertQuery, DeleteQuery expected. Found `%s` instead.',
-                    get_debug_type($query)
+                    get_debug_type($query),
                 ))
         };
 
@@ -341,7 +341,7 @@ class IdentifierQuoter
     protected function _quoteIdentifierExpression(IdentifierExpression $expression): void
     {
         $expression->setIdentifier(
-            $this->quoteIdentifier($expression->getIdentifier())
+            $this->quoteIdentifier($expression->getIdentifier()),
         );
     }
 }

--- a/src/Database/PostgresCompiler.php
+++ b/src/Database/PostgresCompiler.php
@@ -76,7 +76,7 @@ class PostgresCompiler extends QueryCompiler
                 preg_match_all(
                     '/\b' . trim($selectKey, '"') . '\b/i',
                     $p,
-                    $matches
+                    $matches,
                 );
 
                 if (empty($matches[0])) {
@@ -86,7 +86,7 @@ class PostgresCompiler extends QueryCompiler
                 $parts[$k] = preg_replace(
                     ['/"/', '/\b' . trim($selectKey, '"') . '\b/i'],
                     ['', $selectPart->sql($binder)],
-                    $p
+                    $p,
                 );
             }
         }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -398,7 +398,7 @@ abstract class Query implements ExpressionInterface, Stringable
             $cte = $cte(new CommonTableExpression(), $query);
             if (!($cte instanceof CommonTableExpression)) {
                 throw new CakeException(
-                    'You must return a `CommonTableExpression` from a Closure passed to `with()`.'
+                    'You must return a `CommonTableExpression` from a Closure passed to `with()`.',
                 );
             }
         }
@@ -1035,7 +1035,7 @@ abstract class Query implements ExpressionInterface, Stringable
             [
                 'OR' => [$field . ' NOT IN' => $values, $field . ' IS' => null],
             ],
-            $options['types']
+            $options['types'],
         );
     }
 
@@ -1611,7 +1611,7 @@ abstract class Query implements ExpressionInterface, Stringable
             throw new InvalidArgumentException(sprintf(
                 'The `%s` clause is not defined. Valid clauses are: %s.',
                 $name,
-                $clauses
+                $clauses,
             ));
         }
 
@@ -1833,7 +1833,7 @@ abstract class Query implements ExpressionInterface, Stringable
                 function ($errno, $errstr): void {
                     throw new CakeException($errstr, $errno);
                 },
-                E_ALL
+                E_ALL,
             );
             $sql = $this->sql();
             $params = $this->getValueBinder()->bindings();

--- a/src/Database/Query/InsertQuery.php
+++ b/src/Database/Query/InsertQuery.php
@@ -106,7 +106,7 @@ class InsertQuery extends Query
     {
         if (empty($this->_parts['insert'])) {
             throw new DatabaseException(
-                'You cannot add values before defining columns to use.'
+                'You cannot add values before defining columns to use.',
             );
         }
 

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -98,7 +98,7 @@ class QueryCompiler
         $type = $query->type();
         $query->traverseParts(
             $this->_sqlCompiler($sql, $query, $binder),
-            $this->{"_{$type}Parts"}
+            $this->{"_{$type}Parts"},
         );
 
         // Propagate bound parameters from sub-queries if the
@@ -267,7 +267,7 @@ class QueryCompiler
                 throw new DatabaseException(sprintf(
                     'Could not compile join clause for alias `%s`. No table was specified. ' .
                     'Use the `table` key to define a table.',
-                    $join['alias']
+                    $join['alias'],
                 ));
             }
             if ($join['table'] instanceof ExpressionInterface) {
@@ -421,7 +421,7 @@ class QueryCompiler
         if (!isset($parts[0])) {
             throw new DatabaseException(
                 'Could not compile insert query. No table was specified. ' .
-                'Use `into()` to define a table.'
+                'Use `into()` to define a table.',
             );
         }
         $table = $parts[0];

--- a/src/Database/Retry/ReconnectStrategy.php
+++ b/src/Database/Retry/ReconnectStrategy.php
@@ -112,7 +112,7 @@ class ReconnectStrategy implements RetryStrategyInterface
             $this->connection->getDriver()->connect();
             $this->connection->getDriver()->log(
                 'connection={connection} [RECONNECT]',
-                ['connection' => $this->connection->configName()]
+                ['connection' => $this->connection->configName()],
             );
 
             return true;

--- a/src/Database/Schema/MysqlSchemaDialect.php
+++ b/src/Database/Schema/MysqlSchemaDialect.php
@@ -119,7 +119,7 @@ class MysqlSchemaDialect extends SchemaDialect
 
         $type = $this->_applyTypeSpecificColumnConversion(
             $col,
-            compact('length', 'precision', 'scale')
+            compact('length', 'precision', 'scale'),
         );
         if ($type !== null) {
             return $type;
@@ -570,7 +570,7 @@ class MysqlSchemaDialect extends SchemaDialect
         if ($data['type'] === TableSchema::CONSTRAINT_PRIMARY) {
             $columns = array_map(
                 $this->_driver->quoteIdentifier(...),
-                $data['columns']
+                $data['columns'],
             );
 
             return sprintf('PRIMARY KEY (%s)', implode(', ', $columns));
@@ -659,7 +659,7 @@ class MysqlSchemaDialect extends SchemaDialect
     {
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
         foreach ($data['columns'] as $i => $column) {
             if (isset($data['length'][$column])) {
@@ -673,7 +673,7 @@ class MysqlSchemaDialect extends SchemaDialect
                 $this->_driver->quoteIdentifier($data['references'][0]),
                 $this->_convertConstraintColumns($data['references'][1]),
                 $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete'])
+                $this->_foreignOnClause($data['delete']),
             );
         }
 

--- a/src/Database/Schema/PostgresSchemaDialect.php
+++ b/src/Database/Schema/PostgresSchemaDialect.php
@@ -120,7 +120,7 @@ class PostgresSchemaDialect extends SchemaDialect
 
         $type = $this->_applyTypeSpecificColumnConversion(
             $col,
-            compact('length', 'precision', 'scale')
+            compact('length', 'precision', 'scale'),
         );
         if ($type !== null) {
             return $type;
@@ -264,7 +264,7 @@ class PostgresSchemaDialect extends SchemaDialect
         return preg_replace(
             "/^'(.*)'(?:::.*)$/",
             '$1',
-            $default
+            $default,
         );
     }
 
@@ -608,14 +608,14 @@ class PostgresSchemaDialect extends SchemaDialect
         assert($data !== null);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
 
         return sprintf(
             'CREATE INDEX %s ON %s (%s)',
             $this->_driver->quoteIdentifier($name),
             $this->_driver->quoteIdentifier($schema->name()),
-            implode(', ', $columns)
+            implode(', ', $columns),
         );
     }
 
@@ -648,7 +648,7 @@ class PostgresSchemaDialect extends SchemaDialect
     {
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
         if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             return $prefix . sprintf(
@@ -657,7 +657,7 @@ class PostgresSchemaDialect extends SchemaDialect
                 $this->_driver->quoteIdentifier($data['references'][0]),
                 $this->_convertConstraintColumns($data['references'][1]),
                 $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete'])
+                $this->_foreignOnClause($data['delete']),
             );
         }
 
@@ -689,7 +689,7 @@ class PostgresSchemaDialect extends SchemaDialect
                     'COMMENT ON COLUMN %s.%s IS %s',
                     $tableName,
                     $this->_driver->quoteIdentifier($column),
-                    $this->_driver->schemaValue($columnData['comment'])
+                    $this->_driver->schemaValue($columnData['comment']),
                 );
             }
         }
@@ -719,7 +719,7 @@ class PostgresSchemaDialect extends SchemaDialect
     {
         $sql = sprintf(
             'DROP TABLE %s CASCADE',
-            $this->_driver->quoteIdentifier($schema->name())
+            $this->_driver->quoteIdentifier($schema->name()),
         );
 
         return [$sql];

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -112,7 +112,7 @@ abstract class SchemaDialect
 
         return implode(', ', array_map(
             $this->_driver->quoteIdentifier(...),
-            $references
+            $references,
         ));
     }
 
@@ -176,7 +176,7 @@ abstract class SchemaDialect
     {
         $sql = sprintf(
             'DROP TABLE %s',
-            $this->_driver->quoteIdentifier($schema->name())
+            $this->_driver->quoteIdentifier($schema->name()),
         );
 
         return [$sql];

--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -74,7 +74,7 @@ class SqliteSchemaDialect extends SchemaDialect
 
         $type = $this->_applyTypeSpecificColumnConversion(
             $col,
-            compact('length', 'precision', 'scale')
+            compact('length', 'precision', 'scale'),
         );
         if ($type !== null) {
             return $type;
@@ -207,7 +207,7 @@ class SqliteSchemaDialect extends SchemaDialect
         $sql = sprintf(
             'PRAGMA %s(%s)',
             $pragma,
-            $this->_driver->quoteIdentifier($tableName)
+            $this->_driver->quoteIdentifier($tableName),
         );
 
         return [$sql, []];
@@ -278,7 +278,7 @@ class SqliteSchemaDialect extends SchemaDialect
     {
         $sql = sprintf(
             'PRAGMA index_list(%s)',
-            $this->_driver->quoteIdentifier($tableName)
+            $this->_driver->quoteIdentifier($tableName),
         );
 
         return [$sql, []];
@@ -360,7 +360,7 @@ class SqliteSchemaDialect extends SchemaDialect
 
         $sql = sprintf(
             'PRAGMA index_info(%s)',
-            $this->_driver->quoteIdentifier($row['name'])
+            $this->_driver->quoteIdentifier($row['name']),
         );
         $statement = $this->_driver->prepare($sql);
         $statement->execute();
@@ -375,7 +375,7 @@ class SqliteSchemaDialect extends SchemaDialect
 
                 $sql = sprintf(
                     'SELECT sql FROM sqlite_master WHERE type = "table" AND tbl_name = %s',
-                    $this->_driver->quoteIdentifier($schema->name())
+                    $this->_driver->quoteIdentifier($schema->name()),
                 );
                 $statement = $this->_driver->prepare($sql);
                 $statement->execute();
@@ -388,8 +388,8 @@ class SqliteSchemaDialect extends SchemaDialect
                         '\s*,\s*',
                         array_map(
                             fn ($column) => '(?:' . $this->possiblyQuotedIdentifierRegex($column) . ')',
-                            $columns
-                        )
+                            $columns,
+                        ),
                     );
 
                     $regex = "/CONSTRAINT\s*(['\"`\[ ].+?['\"`\] ])\s*UNIQUE\s*\(\s*(?:{$columnsPattern})\s*\)/i";
@@ -418,7 +418,7 @@ class SqliteSchemaDialect extends SchemaDialect
     {
         $sql = sprintf(
             'SELECT id FROM pragma_foreign_key_list(%s) GROUP BY id',
-            $this->_driver->quoteIdentifier($tableName)
+            $this->_driver->quoteIdentifier($tableName),
         );
 
         return [$sql, []];
@@ -432,7 +432,7 @@ class SqliteSchemaDialect extends SchemaDialect
         $sql = sprintf(
             'SELECT * FROM pragma_foreign_key_list(%s) WHERE id = %d ORDER BY seq',
             $this->_driver->quoteIdentifier($schema->name()),
-            $row['id']
+            $row['id'],
         );
         $statement = $this->_driver->prepare($sql);
         $statement->execute();
@@ -652,12 +652,12 @@ class SqliteSchemaDialect extends SchemaDialect
                 $this->_driver->quoteIdentifier($data['references'][0]),
                 $this->_convertConstraintColumns($data['references'][1]),
                 $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete'])
+                $this->_foreignOnClause($data['delete']),
             );
         }
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
 
         return sprintf(
@@ -665,7 +665,7 @@ class SqliteSchemaDialect extends SchemaDialect
             $this->_driver->quoteIdentifier($name),
             $type,
             implode(', ', $columns),
-            $clause
+            $clause,
         );
     }
 
@@ -706,14 +706,14 @@ class SqliteSchemaDialect extends SchemaDialect
         assert($data !== null);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
 
         return sprintf(
             'CREATE INDEX %s ON %s (%s)',
             $this->_driver->quoteIdentifier($name),
             $this->_driver->quoteIdentifier($schema->name()),
-            implode(', ', $columns)
+            implode(', ', $columns),
         );
     }
 
@@ -759,7 +759,7 @@ class SqliteSchemaDialect extends SchemaDialect
     public function hasSequences(): bool
     {
         $result = $this->_driver->prepare(
-            'SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"'
+            'SELECT 1 FROM sqlite_master WHERE name = "sqlite_sequence"',
         );
         $result->execute();
         $this->_hasSequences = (bool)$result->fetch();

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -117,7 +117,7 @@ class SqlserverSchemaDialect extends SchemaDialect
 
         $type = $this->_applyTypeSpecificColumnConversion(
             $col,
-            compact('length', 'precision', 'scale')
+            compact('length', 'precision', 'scale'),
         );
         if ($type !== null) {
             return $type;
@@ -224,7 +224,7 @@ class SqlserverSchemaDialect extends SchemaDialect
             $row['type'],
             $row['char_length'] !== null ? (int)$row['char_length'] : null,
             $row['precision'] !== null ? (int)$row['precision'] : null,
-            $row['scale'] !== null ? (int)$row['scale'] : null
+            $row['scale'] !== null ? (int)$row['scale'] : null,
         );
 
         if (!empty($row['autoincrement'])) {
@@ -618,14 +618,14 @@ class SqlserverSchemaDialect extends SchemaDialect
         assert($data !== null);
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
 
         return sprintf(
             'CREATE INDEX %s ON %s (%s)',
             $this->_driver->quoteIdentifier($name),
             $this->_driver->quoteIdentifier($schema->name()),
-            implode(', ', $columns)
+            implode(', ', $columns),
         );
     }
 
@@ -658,7 +658,7 @@ class SqlserverSchemaDialect extends SchemaDialect
     {
         $columns = array_map(
             $this->_driver->quoteIdentifier(...),
-            $data['columns']
+            $data['columns'],
         );
         if ($data['type'] === TableSchema::CONSTRAINT_FOREIGN) {
             return $prefix . sprintf(
@@ -667,7 +667,7 @@ class SqlserverSchemaDialect extends SchemaDialect
                 $this->_driver->quoteIdentifier($data['references'][0]),
                 $this->_convertConstraintColumns($data['references'][1]),
                 $this->_foreignOnClause($data['update']),
-                $this->_foreignOnClause($data['delete'])
+                $this->_foreignOnClause($data['delete']),
             );
         }
 
@@ -711,7 +711,7 @@ class SqlserverSchemaDialect extends SchemaDialect
                     "IF EXISTS (SELECT * FROM sys.identity_columns WHERE OBJECT_NAME(OBJECT_ID) = '%s' AND " .
                     "last_value IS NOT NULL) DBCC CHECKIDENT('%s', RESEED, 0)",
                     $schema->name(),
-                    $schema->name()
+                    $schema->name(),
                 );
             }
         }

--- a/src/Database/Schema/TableSchema.php
+++ b/src/Database/Schema/TableSchema.php
@@ -496,7 +496,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                 'Invalid index type `%s` in index `%s` in table `%s`.',
                 $attrs['type'],
                 $name,
-                $this->_table
+                $this->_table,
             ));
         }
         $attrs['columns'] = (array)$attrs['columns'];
@@ -507,7 +507,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                     'The column `%s` was not found.',
                     $name,
                     $this->_table,
-                    $field
+                    $field,
                 );
                 throw new DatabaseException($msg);
             }
@@ -565,13 +565,13 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             throw new DatabaseException(sprintf(
                 'Invalid constraint type `%s` in table `%s`.',
                 $attrs['type'],
-                $this->_table
+                $this->_table,
             ));
         }
         if (empty($attrs['columns'])) {
             throw new DatabaseException(sprintf(
                 'Constraints in table `%s` must have at least one column.',
-                $this->_table
+                $this->_table,
             ));
         }
         $attrs['columns'] = (array)$attrs['columns'];
@@ -581,7 +581,7 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
                     'Columns used in constraints must be added to the Table schema first. ' .
                     'The column `%s` was not found in table `%s`.',
                     $field,
-                    $this->_table
+                    $this->_table,
                 );
                 throw new DatabaseException($msg);
             }
@@ -593,13 +593,13 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
             if (isset($this->_constraints[$name])) {
                 $this->_constraints[$name]['columns'] = array_unique(array_merge(
                     $this->_constraints[$name]['columns'],
-                    $attrs['columns']
+                    $attrs['columns'],
                 ));
 
                 if (isset($this->_constraints[$name]['references'])) {
                     $this->_constraints[$name]['references'][1] = array_unique(array_merge(
                         (array)$this->_constraints[$name]['references'][1],
-                        [$attrs['references'][1]]
+                        [$attrs['references'][1]],
                     ));
                 }
 
@@ -657,13 +657,13 @@ class TableSchema implements TableSchemaInterface, SqlGeneratorInterface
         if (!in_array($attrs['update'], static::$_validForeignKeyActions)) {
             throw new DatabaseException(sprintf(
                 'Update action is invalid. Must be one of %s',
-                implode(',', static::$_validForeignKeyActions)
+                implode(',', static::$_validForeignKeyActions),
             ));
         }
         if (!in_array($attrs['delete'], static::$_validForeignKeyActions)) {
             throw new DatabaseException(sprintf(
                 'Delete action is invalid. Must be one of %s',
-                implode(',', static::$_validForeignKeyActions)
+                implode(',', static::$_validForeignKeyActions),
             ));
         }
 

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -89,7 +89,7 @@ class SqlserverCompiler extends QueryCompiler
         if (!isset($parts[0])) {
             throw new DatabaseException(
                 'Could not compile insert query. No table was specified. ' .
-                'Use `into()` to define a table.'
+                'Use `into()` to define a table.',
             );
         }
         $table = $parts[0];
@@ -100,7 +100,7 @@ class SqlserverCompiler extends QueryCompiler
             'INSERT%s INTO %s (%s) OUTPUT INSERTED.*',
             $modifiers,
             $table,
-            implode(', ', $columns)
+            implode(', ', $columns),
         );
     }
 
@@ -145,7 +145,7 @@ class SqlserverCompiler extends QueryCompiler
                 preg_match_all(
                     '/\b' . trim($selectKey, '[]') . '\b/i',
                     $p,
-                    $matches
+                    $matches,
                 );
 
                 if (empty($matches[0])) {
@@ -155,7 +155,7 @@ class SqlserverCompiler extends QueryCompiler
                 $parts[$k] = preg_replace(
                     ['/\[|\]/', '/\b' . trim($selectKey, '[]') . '\b/i'],
                     ['', $selectPart->sql($binder)],
-                    $p
+                    $p,
                 );
             }
         }

--- a/src/Database/Type/BinaryUuidType.php
+++ b/src/Database/Type/BinaryUuidType.php
@@ -122,7 +122,7 @@ class BinaryUuidType extends BaseType
         $string = preg_replace(
             '/([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})/',
             '$1-$2-$3-$4-$5',
-            $string
+            $string,
         );
 
         return $string[1];

--- a/src/Database/Type/BoolType.php
+++ b/src/Database/Type/BoolType.php
@@ -47,7 +47,7 @@ class BoolType extends BaseType implements BatchCastingInterface
         throw new InvalidArgumentException(sprintf(
             'Cannot convert value `%s` of type `%s` to bool',
             print_r($value, true),
-            get_debug_type($value)
+            get_debug_type($value),
         ));
     }
 

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -363,7 +363,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             $value['hour'],
             $value['minute'],
             $value['second'],
-            $value['microsecond']
+            $value['microsecond'],
         );
 
         $dateTime = new $class($format, $value['timezone'] ?? $this->userTimezone);
@@ -391,7 +391,7 @@ class DateTimeType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new DatabaseException(
-            sprintf('Cannot use locale parsing with the %s class', $this->_className)
+            sprintf('Cannot use locale parsing with the %s class', $this->_className),
         );
     }
 

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -216,7 +216,7 @@ class DateType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new DatabaseException(
-            sprintf('Cannot use locale parsing with %s', $this->_className)
+            sprintf('Cannot use locale parsing with %s', $this->_className),
         );
     }
 

--- a/src/Database/Type/DecimalType.php
+++ b/src/Database/Type/DecimalType.php
@@ -74,7 +74,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
         throw new InvalidArgumentException(sprintf(
             'Cannot convert value `%s` of type `%s` to a decimal',
             print_r($value, true),
-            get_debug_type($value)
+            get_debug_type($value),
         ));
     }
 
@@ -166,7 +166,7 @@ class DecimalType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new DatabaseException(
-            sprintf('Cannot use locale parsing with the %s class', static::$numberClass)
+            sprintf('Cannot use locale parsing with the %s class', static::$numberClass),
         );
     }
 

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -65,14 +65,14 @@ class EnumType extends BaseType
                 'Unable to use `%s` for type `%s`. %s.',
                 $enumClassName,
                 $name,
-                $e->getMessage()
+                $e->getMessage(),
             ));
         }
 
         $namedType = $reflectionEnum->getBackingType();
         if ($namedType == null) {
             throw new DatabaseException(
-                sprintf('Unable to use enum `%s` for type `%s`, must be a backed enum.', $enumClassName, $name)
+                sprintf('Unable to use enum `%s` for type `%s`, must be a backed enum.', $enumClassName, $name),
             );
         }
 
@@ -98,7 +98,7 @@ class EnumType extends BaseType
                     'Given value type `%s` does not match associated `%s` backed enum in `%s`',
                     get_debug_type($value),
                     $this->backingType,
-                    $this->enumClassName
+                    $this->enumClassName,
                 ));
             }
 
@@ -109,7 +109,7 @@ class EnumType extends BaseType
             throw new InvalidArgumentException(sprintf(
                 'Cannot convert value `%s` of type `%s` to string or int',
                 print_r($value, true),
-                get_debug_type($value)
+                get_debug_type($value),
             ));
         }
 
@@ -117,7 +117,7 @@ class EnumType extends BaseType
             throw new InvalidArgumentException(sprintf(
                 '`%s` is not a valid value for `%s`',
                 $value,
-                $this->enumClassName
+                $this->enumClassName,
             ));
         }
 
@@ -199,7 +199,7 @@ class EnumType extends BaseType
                 'Given value type `%s` does not match associated `%s` backed enum in `%s`',
                 get_debug_type($value),
                 $this->backingType,
-                $this->enumClassName
+                $this->enumClassName,
             ));
         }
 

--- a/src/Database/Type/FloatType.php
+++ b/src/Database/Type/FloatType.php
@@ -147,7 +147,7 @@ class FloatType extends BaseType implements BatchCastingInterface
             return $this;
         }
         throw new DatabaseException(
-            sprintf('Cannot use locale parsing with the %s class', static::$numberClass)
+            sprintf('Cannot use locale parsing with the %s class', static::$numberClass),
         );
     }
 

--- a/src/Database/Type/IntegerType.php
+++ b/src/Database/Type/IntegerType.php
@@ -40,7 +40,7 @@ class IntegerType extends BaseType implements BatchCastingInterface
             throw new InvalidArgumentException(sprintf(
                 'Cannot convert value `%s` of type `%s` to int',
                 print_r($value, true),
-                get_debug_type($value)
+                get_debug_type($value),
             ));
         }
     }

--- a/src/Database/Type/StringType.php
+++ b/src/Database/Type/StringType.php
@@ -52,7 +52,7 @@ class StringType extends BaseType implements OptionalConvertInterface
         throw new InvalidArgumentException(sprintf(
             'Cannot convert value `%s` of type `%s` to string',
             print_r($value, true),
-            get_debug_type($value)
+            get_debug_type($value),
         ));
     }
 

--- a/src/Database/Type/TimeType.php
+++ b/src/Database/Type/TimeType.php
@@ -125,7 +125,7 @@ class TimeType extends BaseType implements BatchCastingInterface
             $value['hour'],
             $value['minute'],
             $value['second'],
-            $value['microsecond']
+            $value['microsecond'],
         );
 
         return new $this->_className($format);

--- a/src/Datasource/FactoryLocator.php
+++ b/src/Datasource/FactoryLocator.php
@@ -69,7 +69,7 @@ class FactoryLocator
 
         throw new InvalidArgumentException(sprintf(
             'Unknown repository type `%s`. Make sure you register a type before trying to use it.',
-            $type
+            $type,
         ));
     }
 }

--- a/src/Datasource/Locator/AbstractLocator.php
+++ b/src/Datasource/Locator/AbstractLocator.php
@@ -56,7 +56,7 @@ abstract class AbstractLocator implements LocatorInterface
             if ($storeOptions && isset($this->options[$alias]) && $this->options[$alias] !== $storeOptions) {
                 throw new CakeException(sprintf(
                     'You cannot configure `%s`, it already exists in the registry.',
-                    $alias
+                    $alias,
                 ));
             }
 
@@ -100,7 +100,7 @@ abstract class AbstractLocator implements LocatorInterface
     {
         unset(
             $this->instances[$alias],
-            $this->options[$alias]
+            $this->options[$alias],
         );
     }
 

--- a/src/Datasource/ModelAwareTrait.php
+++ b/src/Datasource/ModelAwareTrait.php
@@ -108,7 +108,7 @@ trait ModelAwareTrait
             $alias = substr(
                 $modelClass,
                 strrpos($modelClass, '\\') + 1,
-                -strlen($modelType)
+                -strlen($modelType),
             );
             $modelClass = $alias;
         }

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -216,7 +216,7 @@ class NumericPaginator implements PaginatorInterface
         assert(
             $target instanceof RepositoryInterface,
             'Pagination target must be an instance of `' . QueryInterface::class
-                . '` or `' . RepositoryInterface::class . '`.'
+                . '` or `' . RepositoryInterface::class . '`.',
         );
 
         $data = $this->extractData($target, $params, $settings);
@@ -325,7 +325,7 @@ class NumericPaginator implements PaginatorInterface
             triggerWarning(
                 'Passing query options as paginator settings is no longer supported.'
                 . ' Use a custom finder through the `finder` config or pass a SelectQuery instance to paginate().'
-                . ' Extra keys found are: `' . implode('`, `', array_keys($extraSettings)) . '`.'
+                . ' Extra keys found are: `' . implode('`, `', array_keys($extraSettings)) . '`.',
             );
         }
 
@@ -602,7 +602,7 @@ class NumericPaginator implements PaginatorInterface
             if (is_int($field)) {
                 throw new CakeException(sprintf(
                     'The `order` config must be an associative array. Found invalid value with numeric key: `%s`',
-                    $sort
+                    $sort,
                 ));
             }
 

--- a/src/Datasource/RulesAwareTrait.php
+++ b/src/Datasource/RulesAwareTrait.php
@@ -60,7 +60,7 @@ trait RulesAwareTrait
         if ($hasEvents) {
             $event = $this->dispatchEvent(
                 'Model.beforeRules',
-                compact('entity', 'options', 'operation')
+                compact('entity', 'options', 'operation'),
             );
             if ($event->isStopped()) {
                 return $event->getResult();
@@ -72,7 +72,7 @@ trait RulesAwareTrait
         if ($hasEvents) {
             $event = $this->dispatchEvent(
                 'Model.afterRules',
-                compact('entity', 'options', 'result', 'operation')
+                compact('entity', 'options', 'result', 'operation'),
             );
 
             if ($event->isStopped()) {

--- a/src/Datasource/RulesChecker.php
+++ b/src/Datasource/RulesChecker.php
@@ -331,7 +331,7 @@ class RulesChecker
         return $this->_checkRules(
             $entity,
             $options,
-            array_merge(array_values($this->_rules), array_values($this->_createRules))
+            array_merge(array_values($this->_rules), array_values($this->_createRules)),
         );
     }
 
@@ -348,7 +348,7 @@ class RulesChecker
         return $this->_checkRules(
             $entity,
             $options,
-            array_merge(array_values($this->_rules), array_values($this->_updateRules))
+            array_merge(array_values($this->_rules), array_values($this->_updateRules)),
         );
     }
 
@@ -365,7 +365,7 @@ class RulesChecker
         return $this->_checkRules(
             $entity,
             $options,
-            array_merge(array_values($this->_rules), array_values($this->_deleteRules))
+            array_merge(array_values($this->_rules), array_values($this->_deleteRules)),
         );
     }
 

--- a/src/Error/Debug/HtmlFormatter.php
+++ b/src/Error/Debug/HtmlFormatter.php
@@ -70,7 +70,7 @@ class HtmlFormatter implements FormatterInterface
             $lineInfo = sprintf(
                 '<span><strong>%s</strong> (line <strong>%s</strong>)</span>',
                 $location['file'],
-                $location['line']
+                $location['line'],
             );
         }
         $parts = [
@@ -193,7 +193,7 @@ class HtmlFormatter implements FormatterInterface
         $objectId = "cake-db-object-{$this->id}-{$var->getId()}";
         $out = sprintf(
             '<span class="cake-debug-object" id="%s">',
-            $objectId
+            $objectId,
         );
         $break = "\n" . str_repeat('  ', $indent);
         $endBreak = "\n" . str_repeat('  ', $indent - 1);
@@ -202,7 +202,7 @@ class HtmlFormatter implements FormatterInterface
             $link = sprintf(
                 '<a class="cake-debug-ref" href="#%s">id: %s</a>',
                 $objectId,
-                $var->getId()
+                $var->getId(),
             );
 
             return '<span class="cake-debug-ref">' .
@@ -269,7 +269,7 @@ class HtmlFormatter implements FormatterInterface
         return sprintf(
             '<span class="cake-debug-%s">%s</span>',
             $style,
-            h($text)
+            h($text),
         );
     }
 }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -420,7 +420,6 @@ class Debugger
                 $path = static::trimPath($frame['file']);
                 $back[] = sprintf('%s - %s, line %d', $reference, $path, $frame['line']);
             } else {
-                debug($options);
                 throw new InvalidArgumentException(
                     "Invalid trace format of `$format` chosen. Must be one of `array`, `points` or `text`.",
                 );

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -206,7 +206,7 @@ class Debugger
             throw new InvalidArgumentException(sprintf(
                 'Unknown editor `%s`. Known editors are `%s`.',
                 $name,
-                $known
+                $known,
             ));
         }
         $instance->setConfig('editor', $name);
@@ -226,7 +226,7 @@ class Debugger
         if (!isset($instance->editors[$editor])) {
             throw new InvalidArgumentException(sprintf(
                 'Cannot format editor URL `%s` is not a known editor.',
-                $editor
+                $editor,
             ));
         }
 
@@ -269,7 +269,7 @@ class Debugger
 
         Log::write(
             $level,
-            "\n" . $source . static::exportVarAsPlainText($var, $maxDepth)
+            "\n" . $source . static::exportVarAsPlainText($var, $maxDepth),
         );
     }
 
@@ -420,7 +420,7 @@ class Debugger
             } else {
                 debug($options);
                 throw new InvalidArgumentException(
-                    "Invalid trace format of `{$options['format']}` chosen. Must be one of `array`, `points` or `text`."
+                    "Invalid trace format of `{$options['format']}` chosen. Must be one of `array`, `points` or `text`.",
                 );
             }
         }
@@ -529,7 +529,7 @@ class Debugger
             return str_replace(
                 ['&lt;?php&nbsp;<br/>', '&lt;?php&nbsp;<br />', '&lt;?php '],
                 '',
-                $highlight
+                $highlight,
             );
         }
 
@@ -561,7 +561,7 @@ class Debugger
             throw new CakeException(sprintf(
                 'The `%s` formatter does not implement `%s`.',
                 $class,
-                FormatterInterface::class
+                FormatterInterface::class,
             ));
         }
 
@@ -607,7 +607,7 @@ class Debugger
     public static function exportVarAsPlainText(mixed $var, int $maxDepth = 3): string
     {
         return (new TextFormatter())->dump(
-            static::export($var, new DebugContext($maxDepth))
+            static::export($var, new DebugContext($maxDepth)),
         );
     }
 
@@ -690,7 +690,7 @@ class Debugger
         } else {
             $items[] = new ArrayItemNode(
                 new ScalarNode('string', ''),
-                new SpecialNode('[maximum depth reached]')
+                new SpecialNode('[maximum depth reached]'),
             );
         }
 
@@ -737,7 +737,7 @@ class Debugger
                     $value = $outputMask[$key];
                 }
                 $node->addProperty(
-                    new PropertyNode((string)$key, 'public', static::export($value, $context->withAddedDepth()))
+                    new PropertyNode((string)$key, 'public', static::export($value, $context->withAddedDepth())),
                 );
             }
 
@@ -764,8 +764,8 @@ class Debugger
                         new PropertyNode(
                             $reflectionProperty->getName(),
                             $visibility,
-                            $value
-                        )
+                            $value,
+                        ),
                     );
                 }
             }
@@ -862,7 +862,7 @@ class Debugger
             trigger_error(
                 'Please change the value of `Security.salt` in `ROOT/config/app_local.php` ' .
                 'to a random value of at least 32 characters.',
-                E_USER_NOTICE
+                E_USER_NOTICE,
             );
         }
     }

--- a/src/Error/Debugger.php
+++ b/src/Error/Debugger.php
@@ -401,26 +401,28 @@ class Debugger
             if (in_array($signature, $options['exclude'], true)) {
                 continue;
             }
-            if ($options['format'] === 'shortPoints') {
+
+            $format = $options['format'];
+            if ($format === 'shortPoints') {
                 $back[] = [
                     'file' => self::trimPath($frame['file']),
                     'line' => $frame['line'],
                     'reference' => $reference,
                 ];
-            } elseif ($options['format'] === 'points') {
+            } elseif ($format === 'points') {
                 $back[] = ['file' => $frame['file'], 'line' => $frame['line'], 'reference' => $reference];
-            } elseif ($options['format'] === 'array') {
+            } elseif ($format === 'array') {
                 if (!$options['args']) {
                     unset($frame['args']);
                 }
                 $back[] = $frame;
-            } elseif ($options['format'] === 'text') {
+            } elseif ($format === 'text') {
                 $path = static::trimPath($frame['file']);
                 $back[] = sprintf('%s - %s, line %d', $reference, $path, $frame['line']);
             } else {
                 debug($options);
                 throw new InvalidArgumentException(
-                    "Invalid trace format of `{$options['format']}` chosen. Must be one of `array`, `points` or `text`.",
+                    "Invalid trace format of `$format` chosen. Must be one of `array`, `points` or `text`.",
                 );
             }
         }

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -117,7 +117,7 @@ class ErrorLogger implements ErrorLoggerInterface
             $exception::class,
             $exception->getMessage(),
             $exception->getFile(),
-            $exception->getLine()
+            $exception->getLine(),
         );
         $debug = Configure::read('debug');
 

--- a/src/Error/ExceptionTrap.php
+++ b/src/Error/ExceptionTrap.php
@@ -125,7 +125,7 @@ class ExceptionTrap
             if (!is_subclass_of($class, ExceptionRendererInterface::class)) {
                 throw new InvalidArgumentException(
                     "Cannot use `{$class}` as an `exceptionRenderer`. " .
-                    'It must be an instance of `Cake\Error\ExceptionRendererInterface`.'
+                    'It must be an instance of `Cake\Error\ExceptionRendererInterface`.',
                 );
             }
 
@@ -279,7 +279,7 @@ class ExceptionTrap
             $error['type'],
             $error['message'],
             $error['file'],
-            $error['line']
+            $error['line'],
         );
     }
 

--- a/src/Error/Middleware/ErrorHandlerMiddleware.php
+++ b/src/Error/Middleware/ErrorHandlerMiddleware.php
@@ -137,7 +137,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
         $event = $this->dispatchEvent(
             'Exception.beforeRender',
             ['exception' => $exception, 'request' => $request],
-            $trap
+            $trap,
         );
 
         $exception = $event->getData('exception');
@@ -172,7 +172,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
         return new RedirectResponse(
             $exception->getMessage(),
             $exception->getCode(),
-            $exception->getHeaders()
+            $exception->getHeaders(),
         );
     }
 
@@ -230,7 +230,7 @@ class ErrorHandlerMiddleware implements MiddlewareInterface
             triggerWarning(sprintf(
                 "Exception loading routes when rendering an error page: \n %s - %s",
                 $e::class,
-                $e->getMessage()
+                $e->getMessage(),
             ));
         }
     }

--- a/src/Error/Renderer/ConsoleErrorRenderer.php
+++ b/src/Error/Renderer/ConsoleErrorRenderer.php
@@ -78,7 +78,7 @@ class ConsoleErrorRenderer implements ErrorRendererInterface
             $error->getMessage(),
             $error->getLine() ?? '',
             $error->getFile() ?? '',
-            $trace
+            $trace,
         );
     }
 }

--- a/src/Error/Renderer/ConsoleExceptionRenderer.php
+++ b/src/Error/Renderer/ConsoleExceptionRenderer.php
@@ -99,7 +99,7 @@ class ConsoleExceptionRenderer implements ExceptionRendererInterface
                 $exception::class,
                 $exception->getMessage(),
                 $exception->getFile(),
-                $exception->getLine()
+                $exception->getLine(),
             ),
         ];
 

--- a/src/Error/Renderer/HtmlErrorRenderer.php
+++ b/src/Error/Renderer/HtmlErrorRenderer.php
@@ -57,7 +57,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         $errorMessage = sprintf(
             '<b>%s</b> (%s)',
             h(ucfirst($error->getLabel())),
-            h($error->getCode())
+            h($error->getCode()),
         );
         $toggle = $this->renderToggle($errorMessage, $id, 'trace');
         $codeToggle = $this->renderToggle('Code', $id, 'code');

--- a/src/Error/Renderer/WebExceptionRenderer.php
+++ b/src/Error/Renderer/WebExceptionRenderer.php
@@ -191,7 +191,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
                 "Failed to construct or call startup() on the resolved controller class of `{$class}`. " .
                     "Using Fallback Controller instead. Error {$e->getMessage()}" .
                     "\nStack Trace\n: {$e->getTraceAsString()}",
-                'cake.error'
+                'cake.error',
             );
             $controller = null;
         }
@@ -423,7 +423,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             Log::warning(
                 "MissingTemplateException - Failed to render error template `{$template}` . Error: {$e->getMessage()}" .
                     "\nStack Trace\n: {$e->getTraceAsString()}",
-                'cake.error'
+                'cake.error',
             );
             $attributes = $e->getAttributes();
             if (
@@ -438,7 +438,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             Log::warning(
                 "MissingPluginException - Failed to render error template `{$template}`. Error: {$e->getMessage()}" .
                     "\nStack Trace\n: {$e->getTraceAsString()}",
-                'cake.error'
+                'cake.error',
             );
             $attributes = $e->getAttributes();
             if (isset($attributes['plugin']) && $attributes['plugin'] === $this->controller->getPlugin()) {
@@ -450,7 +450,7 @@ class WebExceptionRenderer implements ExceptionRendererInterface
             Log::warning(
                 "Throwable - Failed to render error template `{$template}`. Error: {$outer->getMessage()}" .
                     "\nStack Trace\n: {$outer->getTraceAsString()}",
-                'cake.error'
+                'cake.error',
             );
             try {
                 return $this->_outputMessageSafe('error500');

--- a/src/Error/functions_global.php
+++ b/src/Error/functions_global.php
@@ -134,7 +134,7 @@ if (!function_exists('breakpoint')) {
         }
         trigger_error(
             'psy/psysh must be installed and you must be in a CLI environment to use the breakpoint function',
-            E_USER_WARNING
+            E_USER_WARNING,
         );
 
         return null;

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -111,7 +111,7 @@ class EventManager implements EventManagerInterface
 
         if ($callable === null && !is_callable($options)) {
             throw new InvalidArgumentException(
-                'Second argument of `EventManager::on()` must be a callable if `$callable` is null.'
+                'Second argument of `EventManager::on()` must be a callable if `$callable` is null.',
             );
         }
 
@@ -390,8 +390,8 @@ class EventManager implements EventManagerInterface
         return array_intersect_key(
             $this->_listeners,
             array_flip(
-                preg_grep($matchPattern, array_keys($this->_listeners), 0) ?: []
-            )
+                preg_grep($matchPattern, array_keys($this->_listeners), 0) ?: [],
+            ),
         );
     }
 

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -75,7 +75,7 @@ class FormProtector
             $hashParts['fields'],
             $hashParts['unlockedFields'],
             $url,
-            $sessionId
+            $sessionId,
         );
 
         if (hash_equals($generatedToken, $extractedToken)) {
@@ -325,8 +325,8 @@ class FormProtector
         $unlockedFields = array_unique(
             array_merge(
                 $this->unlockedFields,
-                $unlocked
-            )
+                $unlocked,
+            ),
         );
 
         /** @var string $key */
@@ -469,7 +469,7 @@ class FormProtector
             $expectedFields,
             'Unexpected field `%s` in POST data',
             'Tampered field `%s` in POST data (expected value `%s` but found `%s`)',
-            'Missing field `%s` in POST data'
+            'Missing field `%s` in POST data',
         );
         $expectedUnlockedFields = Hash::get($expectedParts, 2);
         $dataUnlockedFields = Hash::get($hashParts, 'unlockedFields') ?: [];
@@ -478,7 +478,7 @@ class FormProtector
             $expectedUnlockedFields,
             'Unexpected unlocked field `%s` in POST data',
             '',
-            'Missing unlocked field: `%s`'
+            'Missing unlocked field: `%s`',
         );
 
         $messages = array_merge($messages, $fieldsMessages, $unlockFieldsMessages);

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -238,7 +238,7 @@ class Client implements EventDispatcherInterface, ClientInterface
         if ($parts === false) {
             throw new InvalidArgumentException(sprintf(
                 'String `%s` did not parse.',
-                $url
+                $url,
             ));
         }
 
@@ -310,7 +310,7 @@ class Client implements EventDispatcherInterface, ClientInterface
             Request::METHOD_GET,
             $url,
             $body,
-            $options
+            $options,
         );
     }
 
@@ -441,7 +441,7 @@ class Client implements EventDispatcherInterface, ClientInterface
             $method,
             $url,
             $data,
-            $options
+            $options,
         );
 
         return $this->send($request, $options);
@@ -492,7 +492,7 @@ class Client implements EventDispatcherInterface, ClientInterface
             /** @var \Cake\Http\Client\ClientEvent $event */
             $event = $this->dispatchEvent(
                 'HttpClient.beforeSend',
-                ['request' => $request, 'adapterOptions' => $options, 'redirects' => $redirects]
+                ['request' => $request, 'adapterOptions' => $options, 'redirects' => $redirects],
             );
 
             $request = $event->getRequest();
@@ -512,7 +512,7 @@ class Client implements EventDispatcherInterface, ClientInterface
                     'redirects' => $redirects,
                     'requestSent' => $requestSent,
                     'response' => $response,
-                ]
+                ],
             );
             $response = $event->getResult();
             assert($response instanceof Response);
@@ -710,7 +710,7 @@ class Client implements EventDispatcherInterface, ClientInterface
         if (!isset($typeMap[$type])) {
             throw new CakeException(sprintf(
                 'Unknown type alias `%s`.',
-                $type
+                $type,
             ));
         }
 
@@ -778,7 +778,7 @@ class Client implements EventDispatcherInterface, ClientInterface
         $class = App::className($name, 'Http/Client/Auth');
         if (!$class) {
             throw new CakeException(
-                sprintf('Invalid authentication type `%s`.', $name)
+                sprintf('Invalid authentication type `%s`.', $name),
             );
         }
 

--- a/src/Http/Client/Adapter/Mock.php
+++ b/src/Http/Client/Adapter/Mock.php
@@ -57,7 +57,7 @@ class Mock implements AdapterInterface
             $type = get_debug_type($options['match']);
             throw new InvalidArgumentException(sprintf(
                 'The `match` option must be a `Closure`. Got `%s`.',
-                $type
+                $type,
             ));
         }
         $this->responses[] = [

--- a/src/Http/Client/Auth/Digest.php
+++ b/src/Http/Client/Auth/Digest.php
@@ -155,7 +155,7 @@ class Digest
         $response = $this->_client->get(
             (string)$request->getUri(),
             [],
-            ['auth' => ['type' => null]]
+            ['auth' => ['type' => null]],
         );
 
         $header = $response->getHeader('WWW-Authenticate');
@@ -221,7 +221,7 @@ class Digest
             $response = hash(
                 $this->hashType,
                 $ha1 . ':' . $credentials['nonce'] . ':' . $nc . ':' .
-                $credentials['cnonce'] . ':' . $credentials['qop'] . ':' . $ha2
+                $credentials['cnonce'] . ':' . $credentials['qop'] . ':' . $ha2,
             );
         }
 

--- a/src/Http/Client/Auth/Oauth.php
+++ b/src/Http/Client/Auth/Oauth.php
@@ -56,7 +56,7 @@ class Oauth
                 $hasKeys = isset(
                     $credentials['consumerSecret'],
                     $credentials['token'],
-                    $credentials['tokenSecret']
+                    $credentials['tokenSecret'],
                 );
                 if (!$hasKeys) {
                     return $request;
@@ -75,7 +75,7 @@ class Oauth
                 $hasKeys = isset(
                     $credentials['consumerSecret'],
                     $credentials['token'],
-                    $credentials['tokenSecret']
+                    $credentials['tokenSecret'],
                 );
                 if (!$hasKeys) {
                     return $request;
@@ -156,7 +156,7 @@ class Oauth
         $key = implode('&', $key);
 
         $values['oauth_signature'] = base64_encode(
-            hash_hmac('sha1', $baseString, $key, true)
+            hash_hmac('sha1', $baseString, $key, true),
         );
 
         return $this->_buildAuth($values);

--- a/src/Http/Client/ClientEvent.php
+++ b/src/Http/Client/ClientEvent.php
@@ -66,7 +66,7 @@ class ClientEvent extends Event
     {
         if ($value !== null && !$value instanceof Response) {
             throw new InvalidArgumentException(
-                'The result for Http Client events must be a `Cake\Http\Client\Response` instance.'
+                'The result for Http Client events must be a `Cake\Http\Client\Response` instance.',
             );
         }
 

--- a/src/Http/Client/FormData.php
+++ b/src/Http/Client/FormData.php
@@ -167,8 +167,8 @@ class FormData implements Countable, Stringable
                 sprintf(
                     '`$value` must be a string, a resource or an instance of `Psr\Http\Message\UploadedFileInterface`.'
                     . ' `%s` given.',
-                    get_debug_type($value)
-                )
+                    get_debug_type($value),
+                ),
             );
 
             $finfo = new finfo(FILEINFO_MIME);

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -229,7 +229,7 @@ class Cookie implements CookieInterface
             $options['domain'],
             $options['secure'],
             $options['httponly'],
-            $options['samesite']
+            $options['samesite'],
         );
     }
 
@@ -326,7 +326,7 @@ class Cookie implements CookieInterface
         return Cookie::create(
             $name,
             $value,
-            $data
+            $data,
         );
     }
 
@@ -410,7 +410,7 @@ class Cookie implements CookieInterface
     {
         if (preg_match("/[=,;\t\r\n\013\014]/", $name)) {
             throw new InvalidArgumentException(
-                sprintf('The cookie name `%s` contains invalid characters.', $name)
+                sprintf('The cookie name `%s` contains invalid characters.', $name),
             );
         }
 

--- a/src/Http/Cookie/CookieCollection.php
+++ b/src/Http/Cookie/CookieCollection.php
@@ -140,8 +140,8 @@ class CookieCollection implements IteratorAggregate, Countable
             throw new InvalidArgumentException(
                 sprintf(
                     'Cookie `%s` not found. Use `has()` to check first for existence.',
-                    $name
-                )
+                    $name,
+                ),
             );
         }
 
@@ -225,8 +225,8 @@ class CookieCollection implements IteratorAggregate, Countable
                         'Expected `%s[]` as $cookies but instead got `%s` at index %d',
                         static::class,
                         get_debug_type($cookie),
-                        $index
-                    )
+                        $index,
+                    ),
                 );
             }
         }
@@ -260,7 +260,7 @@ class CookieCollection implements IteratorAggregate, Countable
         $cookies = $this->findMatchingCookies(
             $uri->getScheme(),
             $uri->getHost(),
-            $uri->getPath() ?: '/'
+            $uri->getPath() ?: '/',
         );
         $cookies = $extraCookies + $cookies;
         $cookiePairs = [];
@@ -270,7 +270,7 @@ class CookieCollection implements IteratorAggregate, Countable
             if ($size > 4096) {
                 triggerWarning(sprintf(
                     'The cookie `%s` exceeds the recommended maximum cookie length of 4096 bytes.',
-                    $key
+                    $key,
                 ));
             }
             $cookiePairs[] = $cookie;
@@ -338,7 +338,7 @@ class CookieCollection implements IteratorAggregate, Countable
 
         $cookies = static::createFromHeader(
             $response->getHeader('Set-Cookie'),
-            ['domain' => $host, 'path' => $path]
+            ['domain' => $host, 'path' => $path],
         );
         $new = clone $this;
         foreach ($cookies as $cookie) {

--- a/src/Http/HeaderUtility.php
+++ b/src/Http/HeaderUtility.php
@@ -119,7 +119,7 @@ class HeaderUtility
             '@(\w+)=(?:(?:")([^"]+)"|([^\s,$]+))@',
             $value,
             $matches,
-            PREG_SET_ORDER
+            PREG_SET_ORDER,
         );
 
         $return = [];

--- a/src/Http/Middleware/BodyParserMiddleware.php
+++ b/src/Http/Middleware/BodyParserMiddleware.php
@@ -65,13 +65,13 @@ class BodyParserMiddleware implements MiddlewareInterface
         if ($options['json']) {
             $this->addParser(
                 ['application/json', 'text/json'],
-                $this->decodeJson(...)
+                $this->decodeJson(...),
             );
         }
         if ($options['xml']) {
             $this->addParser(
                 ['application/xml', 'text/xml'],
-                $this->decodeXml(...)
+                $this->decodeXml(...),
             );
         }
         if ($options['methods']) {

--- a/src/Http/Middleware/ClosureDecoratorMiddleware.php
+++ b/src/Http/Middleware/ClosureDecoratorMiddleware.php
@@ -66,7 +66,7 @@ class ClosureDecoratorMiddleware implements MiddlewareInterface
     {
         return ($this->callable)(
             $request,
-            $handler
+            $handler,
         );
     }
 

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -138,7 +138,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
                 'A CSRF token is already set in the request.' .
                 "\n" .
                 'Ensure you do not have the CSRF middleware applied more than once. ' .
-                'Check both your `Application::middleware()` method and `config/routes.php`.'
+                'Check both your `Application::middleware()` method and `config/routes.php`.',
             );
         }
 
@@ -380,7 +380,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
 
         throw new InvalidCsrfTokenException(__d(
             'cake',
-            'CSRF token from either the request body or request headers did not match or is missing.'
+            'CSRF token from either the request body or request headers did not match or is missing.',
         ));
     }
 
@@ -402,7 +402,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
                 'secure' => $this->_config['secure'],
                 'httponly' => $this->_config['httponly'],
                 'samesite' => $this->_config['samesite'],
-            ]
+            ],
         );
     }
 }

--- a/src/Http/Middleware/HttpsEnforcerMiddleware.php
+++ b/src/Http/Middleware/HttpsEnforcerMiddleware.php
@@ -110,12 +110,12 @@ class HttpsEnforcerMiddleware implements MiddlewareInterface
             return new RedirectResponse(
                 $uri,
                 $this->config['statusCode'],
-                $this->config['headers']
+                $this->config['headers'],
             );
         }
 
         throw new BadRequestException(
-            'Requests to this URL must be made with HTTPS.'
+            'Requests to this URL must be made with HTTPS.',
         );
     }
 

--- a/src/Http/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Http/Middleware/SecurityHeadersMiddleware.php
@@ -257,7 +257,7 @@ class SecurityHeadersMiddleware implements MiddlewareInterface
             throw new InvalidArgumentException(sprintf(
                 'Invalid arg `%s`, use one of these: %s.',
                 $value,
-                implode(', ', $allowed)
+                implode(', ', $allowed),
             ));
         }
     }

--- a/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/SessionCsrfProtectionMiddleware.php
@@ -266,7 +266,7 @@ class SessionCsrfProtectionMiddleware implements MiddlewareInterface
 
         throw new InvalidCsrfTokenException(__d(
             'cake',
-            'CSRF token from either the request body or request headers did not match or is missing.'
+            'CSRF token from either the request body or request headers did not match or is missing.',
         ));
     }
 

--- a/src/Http/MiddlewareQueue.php
+++ b/src/Http/MiddlewareQueue.php
@@ -84,7 +84,7 @@ class MiddlewareQueue implements Countable, SeekableIterator
                 if ($className === null) {
                     throw new InvalidArgumentException(sprintf(
                         'Middleware `%s` was not found.',
-                        $middleware
+                        $middleware,
                     ));
                 }
                 $middleware = new $className();

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -639,7 +639,7 @@ class Response implements ResponseInterface, Stringable
         if ($code < static::STATUS_CODE_MIN || $code > static::STATUS_CODE_MAX) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid status code: %s. Use a valid HTTP status code in range 1xx - 5xx.',
-                $code
+                $code,
             ));
         }
 
@@ -828,7 +828,7 @@ class Response implements ResponseInterface, Stringable
             $time = strtotime($time);
             if ($time === false) {
                 throw new InvalidArgumentException(
-                    'Invalid time parameter. Ensure your time value can be parsed by strtotime'
+                    'Invalid time parameter. Ensure your time value can be parsed by strtotime',
                 );
             }
         }

--- a/src/Http/ResponseEmitter.php
+++ b/src/Http/ResponseEmitter.php
@@ -160,7 +160,7 @@ class ResponseEmitter
             'HTTP/%s %d%s',
             $response->getProtocolVersion(),
             $response->getStatusCode(),
-            ($reasonPhrase ? ' ' . $reasonPhrase : '')
+            ($reasonPhrase ? ' ' . $reasonPhrase : ''),
         ));
     }
 
@@ -192,7 +192,7 @@ class ResponseEmitter
                 header(sprintf(
                     '%s: %s',
                     $name,
-                    $value
+                    $value,
                 ), $first);
                 $first = false;
             }

--- a/src/Http/ServerRequest.php
+++ b/src/Http/ServerRequest.php
@@ -301,7 +301,7 @@ class ServerRequest implements ServerRequestInterface
             throw new InvalidArgumentException(sprintf(
                 '`post` key must be an array, object or null.'
                 . ' Got `%s` instead.',
-                get_debug_type($post)
+                get_debug_type($post),
             ));
         }
         $this->data = $post;
@@ -962,7 +962,7 @@ class ServerRequest implements ServerRequestInterface
         if (!preg_match('/^[!#$%&\'*+.^_`\|~0-9a-z-]+$/i', $method)) {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported HTTP method `%s` provided.',
-                $method
+                $method,
             ));
         }
         $new->_environment['REQUEST_METHOD'] = $method;
@@ -1548,7 +1548,7 @@ class ServerRequest implements ServerRequestInterface
         $new = clone $this;
         if (in_array($name, $this->emulatedAttributes, true)) {
             throw new InvalidArgumentException(
-                "You cannot unset '{$name}'. It is a required CakePHP attribute."
+                "You cannot unset '{$name}'. It is a required CakePHP attribute.",
             );
         }
         unset($new->attributes[$name]);

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -283,7 +283,7 @@ class Session
         $className = App::className($class, 'Http/Session');
         if ($className === null) {
             throw new InvalidArgumentException(
-                sprintf('The class `%s` does not exist and cannot be used as a session engine', $class)
+                sprintf('The class `%s` does not exist and cannot be used as a session engine', $class),
             );
         }
 
@@ -328,7 +328,7 @@ class Session
         foreach ($options as $setting => $value) {
             if (ini_set($setting, (string)$value) === false) {
                 throw new CakeException(
-                    sprintf('Unable to configure the session, setting %s failed.', $setting)
+                    sprintf('Unable to configure the session, setting %s failed.', $setting),
                 );
             }
         }
@@ -516,7 +516,7 @@ class Session
                 $message .= sprintf(
                     ', headers already sent in file `%s` on line `%s`',
                     Debugger::trimPath($this->headerSentInfo['filename']),
-                    $this->headerSentInfo['line']
+                    $this->headerSentInfo['line'],
                 );
             }
 
@@ -660,7 +660,7 @@ class Session
             $params['path'],
             $params['domain'],
             $params['secure'],
-            $params['httponly']
+            $params['httponly'],
         );
 
         if (session_id() !== '') {

--- a/src/I18n/ChainMessagesLoader.php
+++ b/src/I18n/ChainMessagesLoader.php
@@ -55,7 +55,7 @@ class ChainMessagesLoader
             if (!is_callable($loader)) {
                 throw new CakeException(sprintf(
                     'Loader `%s` in the chain is not a valid callable.',
-                    $k
+                    $k,
                 ));
             }
 
@@ -67,7 +67,7 @@ class ChainMessagesLoader
             if (!($package instanceof Package)) {
                 throw new CakeException(sprintf(
                     'Loader `%s` in the chain did not return a valid Package object.',
-                    $k
+                    $k,
                 ));
             }
 

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -65,7 +65,7 @@ trait DateFormatTrait
         if (
             preg_match(
                 '/@calendar=(japanese|buddhist|chinese|persian|indian|islamic|hebrew|coptic|ethiopic)/',
-                $locale
+                $locale,
             )
         ) {
             $calendar = IntlDateFormatter::TRADITIONAL;
@@ -89,13 +89,13 @@ trait DateFormatTrait
                 $timeFormat,
                 $timezone,
                 $calendar,
-                $pattern
+                $pattern,
             );
 
             if (!$formatter) {
                 throw new CakeException(
                     'Your version of icu does not support creating a date formatter for ' .
-                    "`{$key}`. You should try to upgrade libicu and the intl extension."
+                    "`{$key}`. You should try to upgrade libicu and the intl extension.",
                 );
             }
 
@@ -152,7 +152,7 @@ trait DateFormatTrait
             $timeFormat,
             $tz,
             null,
-            $pattern
+            $pattern,
         );
         if (!$formatter) {
             throw new CakeException('Unable to create IntlDateFormatter instance');

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -69,7 +69,7 @@ class I18n
                 'default' => IcuFormatter::class,
                 'sprintf' => SprintfFormatter::class,
             ]),
-            static::getLocale()
+            static::getLocale(),
         );
 
         if (class_exists(Cache::class)) {
@@ -79,7 +79,7 @@ class I18n
                 $pool = Cache::pool('_cake_core_');
                 deprecationWarning(
                     '5.1.0',
-                    'Cache config `_cake_core_` is deprecated. Use `_cake_translations_` instead'
+                    'Cache config `_cake_core_` is deprecated. Use `_cake_translations_` instead',
                 );
             }
             static::$_collection->setCacher($pool);
@@ -161,7 +161,7 @@ class I18n
         if ($translator === null) {
             throw new I18nException(sprintf(
                 'Translator for domain `%s` could not be found.',
-                $name
+                $name,
             ));
         }
 

--- a/src/I18n/Number.php
+++ b/src/I18n/Number.php
@@ -370,7 +370,7 @@ class Number
     {
         static::$_formatters[$locale][$type] = static::_setAttributes(
             new NumberFormatter($locale, $type),
-            $options
+            $options,
         );
     }
 

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -51,7 +51,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
         }
         assert(
             ($first instanceof ChronosDate && $second instanceof ChronosDate) ||
-            ($first instanceof DateTimeInterface && $second instanceof DateTimeInterface)
+            ($first instanceof DateTimeInterface && $second instanceof DateTimeInterface),
         );
 
         $diffInterval = $first->diff($second);
@@ -312,7 +312,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
         $fNum = str_replace(
             ['year', 'month', 'week', 'day', 'hour', 'minute', 'second'],
             ['1', '2', '3', '4', '5', '6', '7'],
-            $fWord
+            $fWord,
         );
 
         return [

--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -62,7 +62,7 @@ function __n(string $singular, string $plural, int $count, mixed ...$args): stri
 
     return I18n::getTranslator()->translate(
         $plural,
-        ['_count' => $count, '_singular' => $singular] + $args
+        ['_count' => $count, '_singular' => $singular] + $args,
     );
 }
 
@@ -111,7 +111,7 @@ function __dn(string $domain, string $singular, string $plural, int $count, mixe
 
     return I18n::getTranslator($domain)->translate(
         $plural,
-        ['_count' => $count, '_singular' => $singular] + $args
+        ['_count' => $count, '_singular' => $singular] + $args,
     );
 }
 
@@ -163,7 +163,7 @@ function __xn(string $context, string $singular, string $plural, int $count, mix
 
     return I18n::getTranslator()->translate(
         $plural,
-        ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args
+        ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args,
     );
 }
 
@@ -190,7 +190,7 @@ function __dx(string $domain, string $context, string $msg, mixed ...$args): str
 
     return I18n::getTranslator($domain)->translate(
         $msg,
-        ['_context' => $context] + $args
+        ['_context' => $context] + $args,
     );
 }
 
@@ -226,7 +226,7 @@ function __dxn(
 
     return I18n::getTranslator($domain)->translate(
         $plural,
-        ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args
+        ['_count' => $count, '_singular' => $singular, '_context' => $context] + $args,
     );
 }
 

--- a/src/Log/Engine/BaseLog.php
+++ b/src/Log/Engine/BaseLog.php
@@ -128,7 +128,7 @@ abstract class BaseLog extends AbstractLogger
         $found = preg_match_all(
             '/(?<!\\\\)\{([a-z0-9-_]+)\}/i',
             $message,
-            $matches
+            $matches,
         );
         if ($found === false) {
             return $message;

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -147,7 +147,7 @@ class FileLog extends BaseLog
             $selfError = true;
             trigger_error(vsprintf(
                 'Could not apply permission mask `%s` on log file `%s`',
-                [$mask, $pathname]
+                [$mask, $pathname],
             ), E_USER_WARNING);
             $selfError = false;
         }

--- a/src/Mailer/AbstractTransport.php
+++ b/src/Mailer/AbstractTransport.php
@@ -68,7 +68,7 @@ abstract class AbstractTransport
         ) {
             throw new CakeException(
                 'You must specify at least one recipient.'
-                . ' Use one of `setTo`, `setCc` or `setBcc` to define a recipient.'
+                . ' Use one of `setTo`, `setCc` or `setBcc` to define a recipient.',
             );
         }
     }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -266,7 +266,7 @@ class Mailer implements EventListenerInterface
     {
         deprecationWarning(
             '5.1.0',
-            'Setting the message instance is deprecated. Configure the mailer according to the documentation instead.'
+            'Setting the message instance is deprecated. Configure the mailer according to the documentation instead.',
         );
         $this->message = $message;
 
@@ -360,7 +360,7 @@ class Mailer implements EventListenerInterface
     {
         $content = $this->getRenderer()->render(
             $content,
-            $this->message->getBodyTypes()
+            $this->message->getBodyTypes(),
         );
 
         $this->message->setBody($content);
@@ -483,7 +483,7 @@ class Mailer implements EventListenerInterface
         if ($this->transport === null) {
             throw new BadMethodCallException(
                 'Transport was not defined. '
-                . 'You must set on using setTransport() or set `transport` option in your mailer profile.'
+                . 'You must set on using setTransport() or set `transport` option in your mailer profile.',
             );
         }
 
@@ -564,7 +564,7 @@ class Mailer implements EventListenerInterface
         Log::write(
             $this->logConfig['level'],
             PHP_EOL . $this->flatten($contents['headers']) . PHP_EOL . PHP_EOL . $this->flatten($contents['message']),
-            $this->logConfig['scope']
+            $this->logConfig['scope'],
         );
     }
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -435,7 +435,7 @@ class Message implements JsonSerializable
             'readReceipt',
             $email,
             $name,
-            'Disposition-Notification-To requires only 1 email address.'
+            'Disposition-Notification-To requires only 1 email address.',
         );
     }
 
@@ -642,8 +642,8 @@ class Message implements JsonSerializable
                 throw new InvalidArgumentException(
                     sprintf(
                         'Transfer encoding not available. Can be : %s.',
-                        implode(', ', $this->transferEncodingAvailable)
-                    )
+                        implode(', ', $this->transferEncodingAvailable),
+                    ),
                 );
             }
         }
@@ -892,7 +892,7 @@ class Message implements JsonSerializable
                 'from', 'sender', 'replyTo', 'readReceipt', 'returnPath',
                 'to', 'cc', 'bcc', 'subject',
             ],
-            false
+            false,
         );
         $include += $defaults;
 
@@ -1076,7 +1076,7 @@ class Message implements JsonSerializable
         } else {
             if (!preg_match('/^\<.+@.+\>$/', $message)) {
                 throw new InvalidArgumentException(
-                    'Invalid format to Message-ID. The text should be something like "<uuid@server.com>"'
+                    'Invalid format to Message-ID. The text should be something like "<uuid@server.com>"',
                 );
             }
             $this->messageId = $message;
@@ -1202,7 +1202,7 @@ class Message implements JsonSerializable
             } else {
                 throw new InvalidArgumentException(sprintf(
                     'File must be a filepath or UploadedFileInterface instance. Found `%s` instead.',
-                    gettype($fileInfo['file'])
+                    gettype($fileInfo['file']),
                 ));
             }
             if (
@@ -1518,7 +1518,7 @@ class Message implements JsonSerializable
             if (!in_array($type, $this->emailFormatAvailable, true)) {
                 throw new InvalidArgumentException(sprintf(
                     'Invalid message type: `%s`. Valid types are: `text`, `html`.',
-                    $type
+                    $type,
                 ));
             }
 
@@ -1634,7 +1634,7 @@ class Message implements JsonSerializable
             if (!preg_match('/<[a-z]+.*>/i', $line)) {
                 $formatted = array_merge(
                     $formatted,
-                    explode("\n", Text::wordWrap($line, $wrapLength, "\n", $cut))
+                    explode("\n", Text::wordWrap($line, $wrapLength, "\n", $cut)),
                 );
                 continue;
             }
@@ -1656,7 +1656,7 @@ class Message implements JsonSerializable
                             if ($tmpLineLength > 0) {
                                 $formatted = array_merge(
                                     $formatted,
-                                    explode("\n", Text::wordWrap(trim($tmpLine), $wrapLength, "\n", $cut))
+                                    explode("\n", Text::wordWrap(trim($tmpLine), $wrapLength, "\n", $cut)),
                                 );
                                 $tmpLine = '';
                                 $tmpLineLength = 0;

--- a/src/Mailer/Transport/DebugTransport.php
+++ b/src/Mailer/Transport/DebugTransport.php
@@ -33,7 +33,7 @@ class DebugTransport extends AbstractTransport
     public function send(Message $message): array
     {
         $headers = $message->getHeadersString(
-            ['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'subject']
+            ['from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'subject'],
         );
         $message = implode("\r\n", $message->getBody());
 

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -55,7 +55,7 @@ class MailTransport extends AbstractTransport
             $eol,
             function ($val) {
                 return str_replace("\r\n", '', $val);
-            }
+            },
         );
 
         $message = $message->getBodyString($eol);

--- a/src/Mailer/Transport/SmtpTransport.php
+++ b/src/Mailer/Transport/SmtpTransport.php
@@ -244,7 +244,7 @@ class SmtpTransport extends AbstractTransport
         if ($authType !== null) {
             if (!in_array($authType, self::SUPPORTED_AUTH_TYPES)) {
                 throw new CakeException(
-                    'Unsupported auth type. Available types are: ' . implode(', ', self::SUPPORTED_AUTH_TYPES)
+                    'Unsupported auth type. Available types are: ' . implode(', ', self::SUPPORTED_AUTH_TYPES),
                 );
             }
 
@@ -321,7 +321,7 @@ class SmtpTransport extends AbstractTransport
                 throw new SocketException(
                     'SMTP server did not accept the connection or trying to connect to non TLS SMTP server using TLS.',
                     null,
-                    $e
+                    $e,
                 );
             }
             try {
@@ -384,9 +384,9 @@ class SmtpTransport extends AbstractTransport
         return $this->_smtpSend(
             sprintf(
                 'AUTH PLAIN %s',
-                base64_encode(chr(0) . $username . chr(0) . $password)
+                base64_encode(chr(0) . $username . chr(0) . $password),
             ),
-            '235|504|534|535'
+            '235|504|534|535',
         );
     }
 
@@ -415,7 +415,7 @@ class SmtpTransport extends AbstractTransport
             throw new SocketException('SMTP authentication method not allowed, check if SMTP server requires TLS.');
         } else {
             throw new SocketException(
-                'AUTH command not recognized or not implemented, SMTP server may not require authentication.'
+                'AUTH command not recognized or not implemented, SMTP server may not require authentication.',
             );
         }
     }
@@ -434,7 +434,7 @@ class SmtpTransport extends AbstractTransport
         $authString = base64_encode(sprintf(
             "user=%s\1auth=Bearer %s\1\1",
             $username,
-            $token
+            $token,
         ));
 
         $this->_smtpSend('AUTH XOAUTH2 ' . $authString, '235');

--- a/src/Mailer/TransportFactory.php
+++ b/src/Mailer/TransportFactory.php
@@ -79,13 +79,13 @@ class TransportFactory
     {
         if (!isset(static::$_config[$name])) {
             throw new InvalidArgumentException(
-                sprintf('The `%s` transport configuration does not exist', $name)
+                sprintf('The `%s` transport configuration does not exist', $name),
             );
         }
 
         if (is_array(static::$_config[$name]) && empty(static::$_config[$name]['className'])) {
             throw new InvalidArgumentException(
-                sprintf('Transport config `%s` is invalid, the required `className` option is missing', $name)
+                sprintf('Transport config `%s` is invalid, the required `className` option is missing', $name),
             );
         }
 

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -162,7 +162,7 @@ class Socket
             $errStr,
             (int)$this->_config['timeout'],
             $connectAs,
-            $context
+            $context,
         );
         restore_error_handler();
 
@@ -221,7 +221,7 @@ class Socket
             $errStr,
             $timeout,
             $connectAs,
-            $context
+            $context,
         );
 
         if (!$resource) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -295,7 +295,7 @@ abstract class Association
             throw new InvalidArgumentException(sprintf(
                 "The class name `%s` doesn't match the target table class name of `%s`.",
                 $className,
-                $this->_targetTable::class
+                $this->_targetTable::class,
             ));
         }
 
@@ -388,7 +388,7 @@ abstract class Association
                         $this->getName(),
                         $this->type(),
                         $this->_targetTable::class,
-                        $className
+                        $className,
                     ));
                 }
             }
@@ -574,7 +574,7 @@ abstract class Association
                     ' You should explicitly specify the `propertyName` option.';
                 trigger_error(
                     sprintf($msg, $this->_propertyName, $this->_sourceTable->getTable()),
-                    E_USER_WARNING
+                    E_USER_WARNING,
                 );
             }
         }
@@ -609,7 +609,7 @@ abstract class Association
             throw new InvalidArgumentException(sprintf(
                 'Invalid strategy `%s` was provided. Valid options are `(%s)`.',
                 $name,
-                implode(', ', $this->_validStrategies)
+                implode(', ', $this->_validStrategies),
             ));
         }
         $this->_strategy = $name;
@@ -727,7 +727,7 @@ abstract class Association
             if (!($dummy instanceof SelectQuery)) {
                 throw new DatabaseException(sprintf(
                     'Query builder for association `%s` did not return a query.',
-                    $this->getName()
+                    $this->getName(),
                 ));
             }
         }
@@ -739,7 +739,7 @@ abstract class Association
         ) {
             throw new DatabaseException(sprintf(
                 '`%s` association cannot contain() associations when using JOIN strategy.',
-                $this->getName()
+                $this->getName(),
             ));
         }
 
@@ -1014,7 +1014,7 @@ abstract class Association
 
                 return $results;
             },
-            SelectQuery::PREPEND
+            SelectQuery::PREPEND,
         );
     }
 
@@ -1055,7 +1055,7 @@ abstract class Association
             $eagerLoader->setMatching(
                 $options['aliasPath'] . '.' . $alias,
                 $value['queryBuilder'],
-                $value
+                $value,
             );
         }
     }
@@ -1092,7 +1092,7 @@ abstract class Association
                 $msg,
                 $this->_name,
                 implode(', ', $foreignKey),
-                implode(', ', $bindingKey)
+                implode(', ', $bindingKey),
             ));
         }
 

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -151,7 +151,7 @@ class BelongsTo extends Association
         $foreignKeys = (array)$this->getForeignKey();
         $properties = array_combine(
             $foreignKeys,
-            $targetEntity->extract((array)$this->getBindingKey())
+            $targetEntity->extract((array)$this->getBindingKey()),
         );
         $entity->set($properties, ['guard' => false]);
 
@@ -186,7 +186,7 @@ class BelongsTo extends Association
                 $msg,
                 $this->_name,
                 implode(', ', $foreignKey),
-                implode(', ', $bindingKey)
+                implode(', ', $bindingKey),
             ));
         }
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -289,7 +289,7 @@ class BelongsToMany extends Association
             throw new InvalidArgumentException(sprintf(
                 'The `%s` association on `%s` cannot target the same table.',
                 $this->getName(),
-                $source->getAlias()
+                $source->getAlias(),
             ));
         }
 
@@ -417,7 +417,7 @@ class BelongsToMany extends Association
             ) {
                 throw new InvalidArgumentException(
                     "The existing `{$tAlias}` association on `{$junction->getAlias()}` " .
-                    "is incompatible with the `{$this->getName()}` association on `{$source->getAlias()}`"
+                    "is incompatible with the `{$this->getName()}` association on `{$source->getAlias()}`",
                 );
             }
         }
@@ -876,7 +876,7 @@ class BelongsToMany extends Association
         return $this->junction()->getConnection()->transactional(
             function () use ($sourceEntity, $targetEntities, $options) {
                 return $this->_saveLinks($sourceEntity, $targetEntities, $options);
-            }
+            },
         );
     }
 
@@ -935,7 +935,7 @@ class BelongsToMany extends Association
                 foreach ($links as $entity) {
                     $this->_junctionTable->delete($entity, $options);
                 }
-            }
+            },
         );
 
         /** @var array<\Cake\Datasource\EntityInterface> $existing */
@@ -1223,7 +1223,7 @@ class BelongsToMany extends Association
                     ->from([$junctionQueryAlias => $matches])
                     ->innerJoin(
                         [$junction->getAlias() => $junction->getTable()],
-                        $matchesConditions
+                        $matchesConditions,
                     );
 
                 $jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);
@@ -1242,7 +1242,7 @@ class BelongsToMany extends Association
                     /** @psalm-suppress RedundantConditionGivenDocblockType */
                     $inserted = array_combine(
                         array_keys($inserts),
-                        (array)$sourceEntity->get($property)
+                        (array)$sourceEntity->get($property),
                     ) ?: [];
                     $targetEntities = $inserted + $targetEntities;
                 }
@@ -1252,7 +1252,7 @@ class BelongsToMany extends Association
                 $sourceEntity->setDirty($property, false);
 
                 return true;
-            }
+            },
         );
     }
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -173,7 +173,7 @@ class HasMany extends Association
         $foreignKeys = (array)$this->getForeignKey();
         $foreignKeyReference = array_combine(
             $foreignKeys,
-            $entity->extract((array)$this->getBindingKey())
+            $entity->extract((array)$this->getBindingKey()),
         );
 
         $options['_sourceTable'] = $this->getSource();
@@ -287,8 +287,8 @@ class HasMany extends Association
         $currentEntities = array_unique(
             array_merge(
                 (array)$sourceEntity->get($property),
-                $targetEntities
-            )
+                $targetEntities,
+            ),
         );
 
         $sourceEntity->set($property, $currentEntities);
@@ -384,9 +384,9 @@ class HasMany extends Association
                 ->reject(
                     function ($assoc) use ($targetEntities) {
                         return in_array($assoc, $targetEntities);
-                    }
+                    },
                 )
-                ->toList()
+                ->toList(),
             );
         }
 
@@ -478,12 +478,12 @@ class HasMany extends Association
         $exclusions = $exclusions->map(
             function (EntityInterface $ent) use ($primaryKey) {
                 return $ent->extract($primaryKey);
-            }
+            },
         )
         ->filter(
             function ($v) {
                 return !in_array(null, $v, true);
-            }
+            },
         )
         ->toList();
 
@@ -563,8 +563,8 @@ class HasMany extends Association
                 function ($prop) use ($table) {
                     return $table->getSchema()->isNullable($prop);
                 },
-                $properties
-            )
+                $properties,
+            ),
         );
     }
 

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -129,7 +129,7 @@ class HasOne extends Association
         $foreignKeys = (array)$this->getForeignKey();
         $properties = array_combine(
             $foreignKeys,
-            $entity->extract((array)$this->getBindingKey())
+            $entity->extract((array)$this->getBindingKey()),
         );
         $targetEntity->set($properties, ['guard' => false]);
 

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -278,8 +278,8 @@ class SelectLoader
             throw new InvalidArgumentException(
                 sprintf(
                     'You are required to select the "%s" field(s)',
-                    implode(', ', $key)
-                )
+                    implode(', ', $key),
+                ),
             );
         }
     }
@@ -317,7 +317,7 @@ class SelectLoader
 
         return $query->innerJoin(
             [$aliasedTable => $subquery],
-            $conditions
+            $conditions,
         );
     }
 

--- a/src/ORM/Association/Loader/SelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/SelectWithPivotLoader.php
@@ -184,7 +184,7 @@ class SelectWithPivotLoader extends SelectLoader
             if (!isset($result[$this->junctionProperty])) {
                 throw new DatabaseException(sprintf(
                     '`%s` is missing from the belongsToMany results. Results cannot be created.',
-                    $this->junctionProperty
+                    $this->junctionProperty,
                 ));
             }
 

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -281,7 +281,7 @@ class AssociationCollection implements IteratorAggregate
                 $msg = sprintf(
                     'Cannot save `%s`, it is not associated to `%s`.',
                     $alias,
-                    $table->getAlias()
+                    $table->getAlias(),
                 );
                 throw new InvalidArgumentException($msg);
             }

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -155,12 +155,12 @@ class Behavior implements EventListenerInterface
         $config = $this->_resolveMethodAliases(
             'implementedFinders',
             $this->_defaultConfig,
-            $config
+            $config,
         );
         $config = $this->_resolveMethodAliases(
             'implementedMethods',
             $this->_defaultConfig,
-            $config
+            $config,
         );
         $this->_table = $table;
         $this->setConfig($config);
@@ -244,7 +244,7 @@ class Behavior implements EventListenerInterface
                     throw new CakeException(sprintf(
                         'The method `%s` is not callable on class `%s`.',
                         $method,
-                        static::class
+                        static::class,
                     ));
                 }
             }

--- a/src/ORM/Behavior/TimestampBehavior.php
+++ b/src/ORM/Behavior/TimestampBehavior.php
@@ -104,7 +104,7 @@ class TimestampBehavior extends Behavior
             if (!in_array($when, ['always', 'new', 'existing'], true)) {
                 throw new UnexpectedValueException(sprintf(
                     'When should be one of "always", "new" or "existing". The passed value `%s` is invalid.',
-                    $when
+                    $when,
                 ));
             }
             if (
@@ -217,7 +217,7 @@ class TimestampBehavior extends Behavior
         $type = TypeFactory::build($columnType);
         assert(
             $type instanceof DateTimeType,
-            sprintf('TimestampBehavior only supports columns of type `%s`.', DateTimeType::class)
+            sprintf('TimestampBehavior only supports columns of type `%s`.', DateTimeType::class),
         );
 
         $class = $type->getDateTimeClassName();

--- a/src/ORM/Behavior/Translate/EavStrategy.php
+++ b/src/ORM/Behavior/Translate/EavStrategy.php
@@ -82,7 +82,7 @@ class EavStrategy implements TranslateStrategyInterface
         $this->table = $table;
         $this->translationTable = $this->getTableLocator()->get(
             $this->_config['translationTable'],
-            ['allowFallbackClass' => true]
+            ['allowFallbackClass' => true],
         );
 
         $this->setupAssociations();
@@ -212,7 +212,7 @@ class EavStrategy implements TranslateStrategyInterface
                 $field,
                 $locale,
                 $query,
-                $select
+                $select,
             );
 
             if ($changeFilter) {
@@ -226,7 +226,7 @@ class EavStrategy implements TranslateStrategyInterface
         $query->contain($contain);
         $query->formatResults(
             fn (CollectionInterface $results) => $this->rowMapper($results, $locale),
-            $query::PREPEND
+            $query::PREPEND,
         );
     }
 

--- a/src/ORM/Behavior/Translate/ShadowTableStrategy.php
+++ b/src/ORM/Behavior/Translate/ShadowTableStrategy.php
@@ -86,7 +86,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
         $this->table = $table;
         $this->translationTable = $this->getTableLocator()->get(
             $this->_config['translationTable'],
-            ['allowFallbackClass' => true]
+            ['allowFallbackClass' => true],
         );
 
         $this->setupAssociations();
@@ -155,7 +155,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
 
         $query->formatResults(
             fn (CollectionInterface $results) => $this->rowMapper($results, $locale),
-            $query::PREPEND
+            $query::PREPEND,
         );
     }
 
@@ -179,7 +179,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 [
                     'className' => $config['translationTable'],
                     'allowFallbackClass' => true,
-                ]
+                ],
             );
         }
 
@@ -287,7 +287,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 }
 
                 return $c;
-            }
+            },
         );
 
         return $joinRequired;
@@ -339,7 +339,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 if (in_array($field, $mainTableFields, true)) {
                     $expression->setField("{$mainTableAlias}.{$field}");
                 }
-            }
+            },
         );
 
         return $joinRequired;
@@ -426,7 +426,7 @@ class ShadowTableStrategy implements TranslateStrategyInterface
                 [
                     'useSetters' => false,
                     'markNew' => true,
-                ]
+                ],
             );
         }
 

--- a/src/ORM/Behavior/TranslateBehavior.php
+++ b/src/ORM/Behavior/TranslateBehavior.php
@@ -182,7 +182,7 @@ class TranslateBehavior extends Behavior implements PropertyMarshalInterface
     {
         $config = array_diff_key(
             $this->_config,
-            ['implementedFinders', 'implementedMethods', 'strategyClass']
+            ['implementedFinders', 'implementedMethods', 'strategyClass'],
         );
         /** @var class-string<\Cake\ORM\Behavior\Translate\TranslateStrategyInterface> $className */
         $className = $this->getConfig('strategyClass', static::$defaultStrategyClass);

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -212,7 +212,7 @@ class TreeBehavior extends Behavior
 
             $this->_table->updateAll(
                 [$config['level'] => $depth],
-                [$primaryKey => $node->get($primaryKey)]
+                [$primaryKey => $node->get($primaryKey)],
             );
         }
     }
@@ -238,7 +238,7 @@ class TreeBehavior extends Behavior
                     ->where(
                         fn (QueryExpression $exp) => $exp
                             ->gte($config['leftField'], $left + 1)
-                            ->lte($config['leftField'], $right - 1)
+                            ->lte($config['leftField'], $right - 1),
                     );
 
                 $entities = $query->toArray();
@@ -250,7 +250,7 @@ class TreeBehavior extends Behavior
                     ->where(
                         fn (QueryExpression $exp) => $exp
                             ->gte($config['leftField'], $left + 1)
-                            ->lte($config['leftField'], $right - 1)
+                            ->lte($config['leftField'], $right - 1),
                     )
                     ->execute();
             }
@@ -283,7 +283,7 @@ class TreeBehavior extends Behavior
             throw new DatabaseException(sprintf(
                 'Cannot use node `%s` as parent for entity `%s`.',
                 $parent,
-                $entity->get($this->_getPrimaryKey())
+                $entity->get($this->_getPrimaryKey()),
             ));
         }
 
@@ -375,7 +375,7 @@ class TreeBehavior extends Behavior
                     ->eq($config['leftField'], $leftInverse->add($config['leftField']))
                     ->eq($config['rightField'], $rightInverse->add($config['rightField']));
             },
-            fn (QueryExpression $exp) => $exp->lt($config['leftField'], 0)
+            fn (QueryExpression $exp) => $exp->lt($config['leftField'], 0),
         );
     }
 
@@ -396,7 +396,7 @@ class TreeBehavior extends Behavior
             function ($field) {
                 return $this->_table->aliasField($field);
             },
-            [$config['left'], $config['right']]
+            [$config['left'], $config['right']],
         );
 
         $node = $this->_table->get($for, select: [$left, $right]);
@@ -452,7 +452,7 @@ class TreeBehavior extends Behavior
             function ($field) {
                 return $this->_table->aliasField($field);
             },
-            [$config['parent'], $config['left'], $config['right']]
+            [$config['parent'], $config['left'], $config['right']],
         );
 
         if ($query->clause('order') === null) {
@@ -529,7 +529,7 @@ class TreeBehavior extends Behavior
                 assert(is_callable($valuePath) || is_string($valuePath));
 
                 return $nested->printer($valuePath, $keyPath, $spacer);
-            }
+            },
         );
     }
 
@@ -576,7 +576,7 @@ class TreeBehavior extends Behavior
         $primary = $this->_getPrimaryKey();
         $this->_table->updateAll(
             [$config['parent'] => $parent],
-            [$config['parent'] => $node->get($primary)]
+            [$config['parent'] => $node->get($primary)],
         );
         $this->_sync(1, '-', 'BETWEEN ' . ($left + 1) . ' AND ' . ($right - 1));
         $this->_sync(2, '-', "> {$right}");
@@ -844,7 +844,7 @@ class TreeBehavior extends Behavior
 
             $this->_table->updateAll(
                 $fields,
-                [$primaryKey => $node[$primaryKey]]
+                [$primaryKey => $node[$primaryKey]],
             );
         }
 

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -187,7 +187,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
                     '`%s` contains duplicate finder `%s` which is already provided by `%s`.',
                     $class,
                     $finder,
-                    $duplicate[0]
+                    $duplicate[0],
                 );
                 throw new LogicException($error);
             }
@@ -201,7 +201,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
                     '`%s` contains duplicate method `%s` which is already provided by `%s`.',
                     $class,
                     $method,
-                    $duplicate[0]
+                    $duplicate[0],
                 );
                 throw new LogicException($error);
             }
@@ -286,7 +286,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call `%s`, it does not belong to any attached behavior.', $method)
+            sprintf('Cannot call `%s`, it does not belong to any attached behavior.', $method),
         );
     }
 
@@ -313,7 +313,7 @@ class BehaviorRegistry extends ObjectRegistry implements EventDispatcherInterfac
         }
 
         throw new BadMethodCallException(
-            sprintf('Cannot call finder `%s`, it does not belong to any attached behavior.', $type)
+            sprintf('Cannot call finder `%s`, it does not belong to any attached behavior.', $type),
         );
     }
 }

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -134,7 +134,7 @@ class EagerLoader
         if ($queryBuilder) {
             if (!is_string($associations)) {
                 throw new InvalidArgumentException(
-                    'Cannot set containments. To use $queryBuilder, $associations must be a string'
+                    'Cannot set containments. To use $queryBuilder, $associations must be a string',
                 );
             }
 
@@ -304,7 +304,7 @@ class EagerLoader
                 $repository,
                 $alias,
                 $options,
-                ['root' => null]
+                ['root' => null],
             );
         }
 
@@ -358,7 +358,7 @@ class EagerLoader
                     $options;
                 $options = $this->_reformatContain(
                     $options,
-                    $pointer[$table] ?? []
+                    $pointer[$table] ?? [],
                 );
             }
 
@@ -514,7 +514,7 @@ class EagerLoader
         foreach ($extra as $t => $assoc) {
             $eagerLoadable->addAssociation(
                 $t,
-                $this->_normalizeContain($table, $t, $assoc, $paths)
+                $this->_normalizeContain($table, $t, $assoc, $paths),
             );
         }
 
@@ -665,7 +665,7 @@ class EagerLoader
                     'contain' => $contain,
                     'keys' => $keys,
                     'nestKey' => $meta->aliasPath(),
-                ]
+                ],
             );
             $results = array_map($callback, $results);
         }

--- a/src/ORM/Locator/LocatorAwareTrait.php
+++ b/src/ORM/Locator/LocatorAwareTrait.php
@@ -66,7 +66,7 @@ trait LocatorAwareTrait
         $locator = FactoryLocator::get('Table');
         assert(
             $locator instanceof LocatorInterface,
-            '`FactoryLocator` must return an instance of Cake\ORM\LocatorInterface for type `Table`.'
+            '`FactoryLocator` must return an instance of Cake\ORM\LocatorInterface for type `Table`.',
         );
 
         return $this->_tableLocator = $locator;
@@ -89,7 +89,7 @@ trait LocatorAwareTrait
         $alias ??= $this->defaultTable;
         if (!$alias) {
             throw new UnexpectedValueException(
-                'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
+                'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.',
             );
         }
 

--- a/src/ORM/Locator/TableLocator.php
+++ b/src/ORM/Locator/TableLocator.php
@@ -149,7 +149,7 @@ class TableLocator extends AbstractLocator implements LocatorInterface
         if (isset($this->instances[$alias])) {
             throw new DatabaseException(sprintf(
                 'You cannot configure `%s`, it has already been constructed.',
-                $alias
+                $alias,
             ));
         }
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -95,7 +95,7 @@ class Marshaller
                     throw new InvalidArgumentException(sprintf(
                         'Cannot marshal data for `%s` association. It is not associated with `%s`.',
                         (string)$key,
-                        $this->_table->getAlias()
+                        $this->_table->getAlias(),
                     ));
                 }
                 continue;

--- a/src/ORM/Query/CommonQueryTrait.php
+++ b/src/ORM/Query/CommonQueryTrait.php
@@ -66,7 +66,7 @@ trait CommonQueryTrait
     {
         assert(
             $repository instanceof Table,
-            '`$repository` must be an instance of `' . Table::class . '`.'
+            '`$repository` must be an instance of `' . Table::class . '`.',
         );
 
         $this->_repository = $repository;

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -603,7 +603,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
             $table = $this->getRepository();
             throw new RecordNotFoundException(sprintf(
                 'Record not found in table `%s`.',
-                $table->getTable()
+                $table->getTable(),
             ));
         }
 
@@ -1021,7 +1021,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
         $this->_addAssociationsToTypeMap(
             $this->getRepository(),
             $this->getTypeMap(),
-            $loader->getContain()
+            $loader->getContain(),
         );
 
         return $this;

--- a/src/ORM/ResultSetFactory.php
+++ b/src/ORM/ResultSetFactory.php
@@ -147,7 +147,7 @@ class ResultSetFactory
             $matching = $data['matchingAssoc'][$alias];
             $results['_matchingData'][$alias] = array_combine(
                 $keys,
-                array_intersect_key($row, $keys)
+                array_intersect_key($row, $keys),
             );
             if ($data['hydrate']) {
                 $table = $matching['instance'];
@@ -254,7 +254,7 @@ class ResultSetFactory
             throw new InvalidArgumentException(sprintf(
                 'Invalid ResultSet class `%s`. It must implement `%s`',
                 $resultSetClass,
-                ResultSetInterface::class
+                ResultSetInterface::class,
             ));
         }
 

--- a/src/ORM/Rule/ExistsIn.php
+++ b/src/ORM/Rule/ExistsIn.php
@@ -90,7 +90,7 @@ class ExistsIn
                     'ExistsIn rule for `%s` is invalid. `%s` is not associated with `%s`.',
                     implode(', ', $this->_fields),
                     $this->_repository,
-                    $options['repository']::class
+                    $options['repository']::class,
                 ));
             }
             $repository = $table->getAssociation($this->_repository);
@@ -139,11 +139,11 @@ class ExistsIn
 
         $primary = array_map(
             fn ($key) => $target->aliasField($key) . ' IS',
-            $bindingKey
+            $bindingKey,
         );
         $conditions = array_combine(
             $primary,
-            $entity->extract($fields)
+            $entity->extract($fields),
         );
 
         return $target->exists($conditions);

--- a/src/ORM/Rule/LinkConstraint.php
+++ b/src/ORM/Rule/LinkConstraint.php
@@ -66,7 +66,7 @@ class LinkConstraint
     {
         if (!in_array($requiredLinkStatus, [static::STATUS_LINKED, static::STATUS_NOT_LINKED], true)) {
             throw new InvalidArgumentException(
-                'Argument 2 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::STATUS_*` constants.'
+                'Argument 2 is expected to match one of the `\Cake\ORM\Rule\LinkConstraint::STATUS_*` constants.',
             );
         }
 
@@ -88,7 +88,7 @@ class LinkConstraint
         $table = $options['repository'] ?? null;
         if (!($table instanceof Table)) {
             throw new InvalidArgumentException(
-                'Argument 2 is expected to have a `repository` key that holds an instance of `\Cake\ORM\Table`.'
+                'Argument 2 is expected to have a `repository` key that holds an instance of `\Cake\ORM\Table`.',
             );
         }
 
@@ -144,7 +144,7 @@ class LinkConstraint
             throw new InvalidArgumentException(sprintf(
                 'The number of fields is expected to match the number of values, got %d field(s) and %d value(s).',
                 count($fields),
-                count($values)
+                count($values),
             ));
         }
 
@@ -170,14 +170,14 @@ class LinkConstraint
                 'conditions, expected values for `(%s)`, got `(%s)`.',
                 $source->getAlias(),
                 implode(', ', $primaryKey),
-                implode(', ', $entity->extract($primaryKey))
+                implode(', ', $entity->extract($primaryKey)),
             ));
         }
 
         $aliasedPrimaryKey = $this->_aliasFields($primaryKey, $source);
         $conditions = $this->_buildConditions(
             $aliasedPrimaryKey,
-            $entity->extract($primaryKey)
+            $entity->extract($primaryKey),
         );
 
         return $source

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -151,7 +151,7 @@ class RulesChecker extends BaseRulesChecker
             $field,
             $message,
             LinkConstraint::STATUS_LINKED,
-            '_isLinkedTo'
+            '_isLinkedTo',
         );
     }
 
@@ -184,7 +184,7 @@ class RulesChecker extends BaseRulesChecker
             $field,
             $message,
             LinkConstraint::STATUS_NOT_LINKED,
-            '_isNotLinkedTo'
+            '_isNotLinkedTo',
         );
     }
 
@@ -234,19 +234,19 @@ class RulesChecker extends BaseRulesChecker
                 $message = __d(
                     'cake',
                     'Cannot modify row: a constraint for the `{0}` association fails.',
-                    $associationAlias
+                    $associationAlias,
                 );
             } else {
                 $message = sprintf(
                     'Cannot modify row: a constraint for the `%s` association fails.',
-                    $associationAlias
+                    $associationAlias,
                 );
             }
         }
 
         $rule = new LinkConstraint(
             $association,
-            $linkStatus
+            $linkStatus,
         );
 
         return $this->_addError($rule, $ruleName, compact('errorField', 'message'));
@@ -280,7 +280,7 @@ class RulesChecker extends BaseRulesChecker
         return $this->_addError(
             new ValidCount($field),
             '_validCount',
-            compact('count', 'operator', 'errorField', 'message')
+            compact('count', 'operator', 'errorField', 'message'),
         );
     }
 }

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -421,7 +421,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $table = substr((string)end($table), 0, -5) ?: $this->_alias;
             if (!$table) {
                 throw new CakeException(
-                    'You must specify either the `alias` or the `table` option for the constructor.'
+                    'You must specify either the `alias` or the `table` option for the constructor.',
                 );
             }
             $this->_table = Inflector::underscore($table);
@@ -455,7 +455,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $alias = substr((string)end($alias), 0, -5) ?: $this->_table;
             if (!$alias) {
                 throw new CakeException(
-                    'You must specify either the `alias` or the `table` option for the constructor.'
+                    'You must specify either the `alias` or the `table` option for the constructor.',
                 );
             }
             $this->_alias = $alias;
@@ -599,7 +599,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($this->_schema === null) {
             throw new DatabaseException(sprintf(
                 'Unable to check max alias lengths for `%s` without schema.',
-                $this->getAlias()
+                $this->getAlias(),
             ));
         }
 
@@ -616,7 +616,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     'ORM queries generate field aliases using the table name/alias and column name. ' .
                     "The table alias `{$table}` and column `{$name}` create an alias longer than ({$nameLength}). " .
                     'You must change the table schema in the database and shorten either the table or column ' .
-                    'identifier so they fit within the database alias limits.'
+                    'identifier so they fit within the database alias limits.',
                 );
             }
         }
@@ -873,7 +873,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new InvalidArgumentException(sprintf(
                 'The `%s` behavior is not defined on `%s`.',
                 $name,
-                static::class
+                static::class,
             ));
         }
 
@@ -1396,7 +1396,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $fields = array_merge(
                 (array)$keyField,
                 (array)$valueField,
-                (array)$groupField
+                (array)$groupField,
             );
             $columns = $this->getSchema()->columns();
             if (count($fields) === count(array_intersect($fields, $columns))) {
@@ -1406,13 +1406,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $options = $this->_setFieldMatchers(
             compact('keyField', 'valueField', 'groupField', 'valueSeparator'),
-            ['keyField', 'valueField', 'groupField']
+            ['keyField', 'valueField', 'groupField'],
         );
 
         return $query->formatResults(fn (CollectionInterface $results) => $results->combine(
             $options['keyField'],
             $options['valueField'],
-            $options['groupField']
+            $options['groupField'],
         ));
     }
 
@@ -1451,7 +1451,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         return $query->formatResults(fn (CollectionInterface $results) => $results->nest(
             $options['keyField'],
             $options['parentField'],
-            $nestingKey
+            $nestingKey,
         ));
     }
 
@@ -1530,7 +1530,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if ($primaryKey === null) {
             throw new InvalidPrimaryKeyException(sprintf(
                 'Record not found in table `%s` with primary key `[NULL]`.',
-                $this->getTable()
+                $this->getTable(),
             ));
         }
 
@@ -1551,7 +1551,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             throw new InvalidPrimaryKeyException(sprintf(
                 'Record not found in table `%s` with primary key `[%s]`.',
                 $this->getTable(),
-                implode(', ', $primaryKey)
+                implode(', ', $primaryKey),
             ));
         }
         $conditions = array_combine($key, $primaryKey);
@@ -1560,7 +1560,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             deprecationWarning(
                 '5.0.0',
                 'Calling Table::get() with options array is deprecated.'
-                    . ' Use named arguments instead.'
+                    . ' Use named arguments instead.',
             );
 
             $args += $finder;
@@ -1582,7 +1582,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     'get-%s-%s-%s',
                     $this->getConnection()->configName(),
                     $this->getTable(),
-                    json_encode($primaryKey, JSON_THROW_ON_ERROR)
+                    json_encode($primaryKey, JSON_THROW_ON_ERROR),
                 );
             }
             $query->cache($cacheKey, $cache);
@@ -1665,7 +1665,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $entity = $this->_executeTransaction(
             fn () => $this->_processFindOrCreate($search, $callback, $options->getArrayCopy()),
-            $options['atomic']
+            $options['atomic'],
         );
 
         if ($entity && $this->_transactionCommitted($options['atomic'], true)) {
@@ -1858,7 +1858,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             ->where($conditions)
             ->limit(1)
             ->disableHydration()
-            ->toArray()
+            ->toArray(),
         );
     }
 
@@ -1971,7 +1971,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $success = $this->_executeTransaction(
             fn () => $this->_processSave($entity, $options),
-            $options['atomic']
+            $options['atomic'],
         );
 
         if ($success) {
@@ -2052,8 +2052,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     $result instanceof EntityInterface,
                     sprintf(
                         'The beforeSave callback must return `false` or `EntityInterface` instance. Got `%s` instead.',
-                        get_debug_type($result)
-                    )
+                        get_debug_type($result),
+                    ),
                 );
             }
 
@@ -2064,7 +2064,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $this,
             $entity,
             $options['associated'],
-            ['_primary' => false] + $options->getArrayCopy()
+            ['_primary' => false] + $options->getArrayCopy(),
         );
 
         if (!$saved && $options['atomic']) {
@@ -2108,7 +2108,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             $this,
             $entity,
             $options['associated'],
-            ['_primary' => false] + $options->getArrayCopy()
+            ['_primary' => false] + $options->getArrayCopy(),
         );
 
         if (!$success && $options['atomic']) {
@@ -2145,7 +2145,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         if (!$primary) {
             $msg = sprintf(
                 'Cannot insert row in `%s` table, it has no primary key.',
-                $this->getTable()
+                $this->getTable(),
             );
             throw new DatabaseException($msg);
         }
@@ -2169,7 +2169,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                     $msg .= sprintf(
                         'Got (%s), expecting (%s)',
                         implode(', ', $filteredKeys + $entity->extract(array_keys($primary))),
-                        implode(', ', array_keys($primary))
+                        implode(', ', array_keys($primary)),
                     );
                     throw new DatabaseException($msg);
                 }
@@ -2325,7 +2325,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 'atomic' => true,
                 'checkRules' => true,
                 '_primary' => true,
-            ]
+            ],
         );
         $options['_cleanOnSuccess'] = false;
 
@@ -2438,7 +2438,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $success = $this->_executeTransaction(
             fn () => $this->_processDelete($entity, $options),
-            $options['atomic']
+            $options['atomic'],
         );
 
         if ($success && $this->_transactionCommitted($options['atomic'], $options['_primary'])) {
@@ -2593,7 +2593,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $success = $this->_associations->cascadeDelete(
             $entity,
-            ['_primary' => false] + $options->getArrayCopy()
+            ['_primary' => false] + $options->getArrayCopy(),
         );
         if (!$success) {
             return $success;
@@ -2656,7 +2656,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         throw new BadMethodCallException(sprintf(
             'Unknown finder method `%s` on `%s`.',
             $type,
-            static::class
+            static::class,
         ));
     }
 
@@ -2692,7 +2692,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 deprecationWarning(
                     '5.0.0',
                     'Calling finders with options arrays is deprecated.'
-                    . ' Update your finder methods to used named arguments instead.'
+                    . ' Update your finder methods to used named arguments instead.',
                 );
                 $args = $args[0];
             }
@@ -2717,7 +2717,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
             deprecationWarning(
                 '5.0.0',
                 "Calling `{$reflected->getName()}` finder with options array is deprecated."
-                 . ' Use named arguments instead.'
+                 . ' Use named arguments instead.',
             );
 
             $args = $args[0];
@@ -2779,7 +2779,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 throw new BadMethodCallException(sprintf(
                     'Not enough arguments for magic finder. Got %s required %s',
                     count($args),
-                    count($fields)
+                    count($fields),
                 ));
             }
             foreach ($fields as $field) {
@@ -2791,7 +2791,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         if ($hasOr && $hasAnd) {
             throw new BadMethodCallException(
-                'Cannot mix "and" & "or" in a magic finder. Use find() instead.'
+                'Cannot mix "and" & "or" in a magic finder. Use find() instead.',
             );
         }
 
@@ -2831,7 +2831,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         }
 
         throw new BadMethodCallException(
-            sprintf('Unknown method `%s` called on `%s`', $method, static::class)
+            sprintf('Unknown method `%s` called on `%s`', $method, static::class),
         );
     }
 
@@ -2852,7 +2852,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 'You have not defined the `%s` association on `%s`.',
                 $property,
                 $property,
-                static::class
+                static::class,
             ));
         }
 
@@ -3143,11 +3143,11 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
                 'useSetters' => false,
                 'markNew' => $context['newRecord'],
                 'source' => $this->getRegistryAlias(),
-            ]
+            ],
         );
         $fields = array_merge(
             [$context['field']],
-            isset($options['scope']) ? (array)$options['scope'] : []
+            isset($options['scope']) ? (array)$options['scope'] : [],
         );
         $values = $entity->extract($fields);
         foreach ($values as $field) {

--- a/src/Routing/Asset.php
+++ b/src/Routing/Asset.php
@@ -192,7 +192,7 @@ class Asset
         }
         $webPath = static::assetTimestamp(
             static::webroot($path, $options),
-            $optionTimestamp
+            $optionTimestamp,
         );
 
         $path = static::encodeUrl($webPath);
@@ -248,7 +248,7 @@ class Asset
             $filepath = (string)preg_replace(
                 '/^' . preg_quote(static::requestWebroot(), '/') . '/',
                 '',
-                urldecode($path)
+                urldecode($path),
             );
             $webrootPath = Configure::read('App.wwwRoot') . str_replace('/', DIRECTORY_SEPARATOR, $filepath);
             if (is_file($webrootPath)) {

--- a/src/Routing/Middleware/AssetMiddleware.php
+++ b/src/Routing/Middleware/AssetMiddleware.php
@@ -86,7 +86,7 @@ class AssetMiddleware implements MiddlewareInterface
                 ->withStatus(304)
                 ->withHeader(
                     'Last-Modified',
-                    date(DATE_RFC850, $modifiedTime)
+                    date(DATE_RFC850, $modifiedTime),
                 );
         }
 

--- a/src/Routing/Middleware/RoutingMiddleware.php
+++ b/src/Routing/Middleware/RoutingMiddleware.php
@@ -110,7 +110,7 @@ class RoutingMiddleware implements MiddlewareInterface
             return new RedirectResponse(
                 $e->getMessage(),
                 $e->getCode(),
-                $e->getHeaders()
+                $e->getHeaders(),
             );
         }
         $matching = Router::getRouteCollection()->getMiddleware($middleware);

--- a/src/Routing/Route/DashedRoute.php
+++ b/src/Routing/Route/DashedRoute.php
@@ -77,7 +77,7 @@ class DashedRoute extends Route
             $params['action'] = Inflector::variable(str_replace(
                 '-',
                 '_',
-                $params['action']
+                $params['action'],
             ));
         }
 

--- a/src/Routing/Route/EntityRoute.php
+++ b/src/Routing/Route/EntityRoute.php
@@ -75,7 +75,7 @@ class EntityRoute extends Route
                 'Route `%s` expects the URL option `_entity` to be an array or object implementing \ArrayAccess, '
                 . 'but `%s` passed.',
                 $this->template,
-                get_debug_type($entity)
+                get_debug_type($entity),
             ));
         }
     }

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -137,7 +137,7 @@ class Route
                 if (isset($defaults[$key]) && !is_string($defaults[$key])) {
                     throw new CakeException(
                         'Value for `' . $key . '` in $defaults when connecting routes'
-                        . ' must be of type `string` or `null`'
+                        . ' must be of type `string` or `null`',
                     );
                 }
             }
@@ -212,7 +212,7 @@ class Route
         $diff = array_diff((array)$methods, static::VALID_METHODS);
         if ($diff !== []) {
             throw new InvalidArgumentException(
-                sprintf('Invalid HTTP method received. `%s` is invalid.', implode(', ', $diff))
+                sprintf('Invalid HTTP method received. `%s` is invalid.', implode(', ', $diff)),
             );
         }
 
@@ -815,7 +815,7 @@ class Route
             if (!array_key_exists($key, $params)) {
                 throw new InvalidArgumentException(sprintf(
                     'Missing required route key `%s`.',
-                    $key
+                    $key,
                 ));
             }
             $string = $params[$key];
@@ -879,7 +879,7 @@ class Route
             static::PLACEHOLDER_REGEX,
             $this->template,
             $namedElements,
-            PREG_OFFSET_CAPTURE
+            PREG_OFFSET_CAPTURE,
         );
 
         if ($matched) {

--- a/src/Routing/RouteBuilder.php
+++ b/src/Routing/RouteBuilder.php
@@ -723,7 +723,7 @@ class RouteBuilder
             if ($routeClass === null) {
                 throw new InvalidArgumentException(sprintf(
                     'Cannot find route class %s',
-                    $options['routeClass']
+                    $options['routeClass'],
                 ));
             }
 
@@ -741,7 +741,7 @@ class RouteBuilder
                         $param,
                         $val,
                         $param,
-                        $defaults[$param]
+                        $defaults[$param],
                     ));
                 }
             }

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -323,7 +323,7 @@ class RouteCollection
         return array_reduce(
             $this->_paths,
             'array_merge',
-            []
+            [],
         );
     }
 
@@ -360,7 +360,7 @@ class RouteCollection
         if ($merge) {
             $extensions = array_unique(array_merge(
                 $this->_extensions,
-                $extensions
+                $extensions,
             ));
         }
         $this->_extensions = $extensions;
@@ -465,7 +465,7 @@ class RouteCollection
             if (!$this->hasMiddleware($name)) {
                 throw new InvalidArgumentException(sprintf(
                     'The middleware named `%s` has not been registered. Use registerMiddleware() to define it.',
-                    $name
+                    $name,
                 ));
             }
             $out[] = $this->_middleware[$name];

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -325,7 +325,7 @@ class Router
                     'URL filter defined in %s on line %s could not be applied. The filter failed with: %s',
                     $ref->getFileName(),
                     $ref->getStartLine(),
-                    $e->getMessage()
+                    $e->getMessage(),
                 );
                 throw new CakeException($message, (int)$e->getCode(), $e);
             }
@@ -561,7 +561,7 @@ class Router
                 $base = sprintf(
                     '%s://%s',
                     static::$_requestContext['_scheme'],
-                    static::$_requestContext['_host']
+                    static::$_requestContext['_host'],
                 );
                 if (!empty(static::$_requestContext['_port'])) {
                     $base .= ':' . static::$_requestContext['_port'];
@@ -614,7 +614,7 @@ class Router
         unset(
             $params['pass'],
             $params['_matchedRoute'],
-            $params['_name']
+            $params['_name'],
         );
         if (!$route && $template) {
             // Locate the route that was used to match this route
@@ -792,7 +792,7 @@ class Router
         foreach (['plugin', 'prefix', 'controller', 'action'] as $key) {
             if (array_key_exists($key, $url)) {
                 throw new InvalidArgumentException(
-                    "`{$key}` cannot be used when defining route targets with a string route path."
+                    "`{$key}` cannot be used when defining route targets with a string route path.",
                 );
             }
         }
@@ -856,13 +856,13 @@ class Router
                 if (str_contains($param, '=')) {
                     if (!preg_match('/(?<key>.+?)=(?<value>.*)/', $param, $paramMatches)) {
                         throw new InvalidArgumentException(
-                            "Could not parse a key=value from `{$param}` in route path `{$url}`."
+                            "Could not parse a key=value from `{$param}` in route path `{$url}`.",
                         );
                     }
                     $paramKey = $paramMatches['key'];
                     if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $paramKey)) {
                         throw new InvalidArgumentException(
-                            "Param key `{$paramKey}` is not valid in route path `{$url}`."
+                            "Param key `{$paramKey}` is not valid in route path `{$url}`.",
                         );
                     }
                     $defaults[$paramKey] = trim($paramMatches['value'], '\'"');

--- a/src/TestSuite/Constraint/Email/MailSubjectContains.php
+++ b/src/TestSuite/Constraint/Email/MailSubjectContains.php
@@ -35,7 +35,7 @@ class MailSubjectContains extends MailConstraintBase
     {
         if (!is_string($other)) {
             throw new InvalidArgumentException(
-                'Invalid data type, must be a string.'
+                'Invalid data type, must be a string.',
             );
         }
         $messages = $this->getMessages();

--- a/src/TestSuite/Constraint/EventFired.php
+++ b/src/TestSuite/Constraint/EventFired.php
@@ -44,7 +44,7 @@ class EventFired extends Constraint
 
         if ($this->_eventManager->getEventList() === null) {
             throw new AssertionFailedError(
-                'The event manager you are asserting against is not configured to track events.'
+                'The event manager you are asserting against is not configured to track events.',
             );
         }
     }

--- a/src/TestSuite/Constraint/EventFiredWith.php
+++ b/src/TestSuite/Constraint/EventFiredWith.php
@@ -52,7 +52,7 @@ class EventFiredWith extends Constraint
 
         if ($this->_eventManager->getEventList() === null) {
             throw new AssertionFailedError(
-                'The event manager you are asserting against is not configured to track events.'
+                'The event manager you are asserting against is not configured to track events.',
             );
         }
     }
@@ -92,7 +92,7 @@ class EventFiredWith extends Constraint
             throw new AssertionFailedError(sprintf(
                 'Event `%s` was fired %d times, cannot make data assertion',
                 $other,
-                count($events)
+                count($events),
             ));
         }
 

--- a/src/TestSuite/Constraint/Response/HeaderContains.php
+++ b/src/TestSuite/Constraint/Response/HeaderContains.php
@@ -44,7 +44,7 @@ class HeaderContains extends HeaderEquals
         return sprintf(
             "is in header '%s' (`%s`)",
             $this->headerName,
-            $this->response->getHeaderLine($this->headerName)
+            $this->response->getHeaderLine($this->headerName),
         );
     }
 }

--- a/src/TestSuite/Constraint/Response/HeaderNotContains.php
+++ b/src/TestSuite/Constraint/Response/HeaderNotContains.php
@@ -44,7 +44,7 @@ class HeaderNotContains extends HeaderContains
         return sprintf(
             "is not in header '%s' (`%s`)",
             $this->headerName,
-            $this->response->getHeaderLine($this->headerName)
+            $this->response->getHeaderLine($this->headerName),
         );
     }
 }

--- a/src/TestSuite/Fixture/Extension/PHPUnitExtension.php
+++ b/src/TestSuite/Fixture/Extension/PHPUnitExtension.php
@@ -35,7 +35,7 @@ class PHPUnitExtension implements Extension
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
         $facade->registerSubscriber(
-            new PHPUnitStartedSubscriber()
+            new PHPUnitStartedSubscriber(),
         );
     }
 }

--- a/src/TestSuite/Fixture/FixtureHelper.php
+++ b/src/TestSuite/Fixture/FixtureHelper.php
@@ -141,7 +141,7 @@ class FixtureHelper
                 } else {
                     ConnectionHelper::runWithoutConstraints(
                         $connection,
-                        fn (Connection $connection) => $this->insertConnection($connection, $groupFixtures)
+                        fn (Connection $connection) => $this->insertConnection($connection, $groupFixtures),
                     );
                 }
             } else {
@@ -167,7 +167,7 @@ class FixtureHelper
                     'Unable to insert rows for table `%s`.'
                         . " Fixture records might have invalid data or unknown constraints.\n%s",
                     $fixture->sourceName(),
-                    $exception->getMessage()
+                    $exception->getMessage(),
                 );
                 throw new CakeException($message);
             }
@@ -196,7 +196,7 @@ class FixtureHelper
                     $helper = new ConnectionHelper();
                     $helper->runWithoutConstraints(
                         $connection,
-                        fn (Connection $connection) => $this->truncateConnection($connection, $groupFixtures)
+                        fn (Connection $connection) => $this->truncateConnection($connection, $groupFixtures),
                     );
                 }
             } else {
@@ -222,7 +222,7 @@ class FixtureHelper
                     'Unable to truncate table `%s`.'
                         . " Fixture records might have invalid data or unknown contraints.\n%s",
                     $fixture->sourceName(),
-                    $exception->getMessage()
+                    $exception->getMessage(),
                 );
                 throw new CakeException($message);
             }

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -158,7 +158,7 @@ class SchemaLoader
                 if (!is_string($name)) {
                     throw new InvalidArgumentException(
                         sprintf('`%s` is not a valid table name. Either use a string key for the table definition'
-                            . "(`'articles' => [...]`) or define the `table` key in the table definition.", $name)
+                            . "(`'articles' => [...]`) or define the `table` key in the table definition.", $name),
                     );
                 }
                 $schema = new TableSchema($name, $table['columns']);

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -77,7 +77,7 @@ class TestFixture implements FixtureInterface
                 $message = sprintf(
                     'Invalid datasource name `%s` for `%s` fixture. Fixture datasource names must begin with `test`.',
                     $connection,
-                    static::class
+                    static::class,
                 );
                 throw new CakeException($message);
             }
@@ -157,7 +157,7 @@ class TestFixture implements FixtureInterface
             $message = sprintf(
                 'Cannot describe schema for table `%s` for fixture `%s`. The table does not exist.',
                 $this->table,
-                static::class
+                static::class,
             );
             throw new CakeException($message, null, $e);
         }

--- a/src/TestSuite/Fixture/TransactionFixtureStrategy.php
+++ b/src/TestSuite/Fixture/TransactionFixtureStrategy.php
@@ -56,14 +56,14 @@ class TransactionFixtureStrategy implements FixtureStrategyInterface
             if ($connection instanceof Connection) {
                 assert(
                     $connection->inTransaction() === false,
-                    'Cannot start transaction strategy inside a transaction. This is most likely a bug.'
+                    'Cannot start transaction strategy inside a transaction. This is most likely a bug.',
                 );
                 $connection->enableSavePoints();
                 if (!$connection->isSavePointsEnabled()) {
                     throw new DatabaseException(
                         "Could not enable save points for the `{$connection->configName()}` connection. " .
                             'Your database needs to support savepoints in order to use ' .
-                            'TransactionFixtureStrategy.'
+                            'TransactionFixtureStrategy.',
                     );
                 }
 

--- a/src/TestSuite/Fixture/TransactionStrategy.php
+++ b/src/TestSuite/Fixture/TransactionStrategy.php
@@ -61,14 +61,14 @@ class TransactionStrategy implements FixtureStrategyInterface
                 assert(
                     $connection->inTransaction() === false,
                     'Cannot start transaction strategy inside a transaction. ' .
-                    'Ensure you have closed all open transactions.'
+                    'Ensure you have closed all open transactions.',
                 );
                 $connection->enableSavePoints();
                 if (!$connection->isSavePointsEnabled()) {
                     throw new DatabaseException(
                         "Could not enable save points for the `{$connection->configName()}` connection. " .
                             'Your database needs to support savepoints in order to use ' .
-                            'TransactionStrategy.'
+                            'TransactionStrategy.',
                     );
                 }
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -610,7 +610,7 @@ trait IntegrationTestTrait
             $controller = $event->getSubject();
             $this->_flashMessages = Hash::merge(
                 $this->_flashMessages,
-                $controller->getRequest()->getSession()->read('Flash')
+                $controller->getRequest()->getSession()->read('Flash'),
             );
         };
         $events->on('Controller.beforeRedirect', ['priority' => -100], $flashCapture);
@@ -928,7 +928,7 @@ trait IntegrationTestTrait
             $this->assertThat(
                 Router::url($url, true),
                 new HeaderEquals($this->_response, 'Location'),
-                $verboseMessage
+                $verboseMessage,
             );
         }
     }
@@ -1303,7 +1303,7 @@ trait IntegrationTestTrait
         $this->assertThat(
             $expected,
             new FlashParamEquals($this->_requestSession, $key, 'message', $at),
-            $verboseMessage
+            $verboseMessage,
         );
     }
 
@@ -1321,7 +1321,7 @@ trait IntegrationTestTrait
         $this->assertThat(
             $expected,
             new FlashParamEquals($this->_requestSession, $key, 'element'),
-            $verboseMessage
+            $verboseMessage,
         );
     }
 
@@ -1340,7 +1340,7 @@ trait IntegrationTestTrait
         $this->assertThat(
             $expected,
             new FlashParamEquals($this->_requestSession, $key, 'element', $at),
-            $verboseMessage
+            $verboseMessage,
         );
     }
 
@@ -1431,7 +1431,7 @@ trait IntegrationTestTrait
         $this->_cookieEncryptionKey = $key;
         $this->assertThat(
             $expected,
-            new CookieEncryptedEquals($this->_response, $name, $encrypt, $this->_getCookieEncryptionKey())
+            new CookieEncryptedEquals($this->_response, $name, $encrypt, $this->_getCookieEncryptionKey()),
         );
     }
 

--- a/src/TestSuite/MiddlewareDispatcher.php
+++ b/src/TestSuite/MiddlewareDispatcher.php
@@ -111,7 +111,7 @@ class MiddlewareDispatcher
         }
         $environment = array_merge(
             array_merge($_SERVER, ['REQUEST_URI' => $spec['url']]),
-            $spec['environment']
+            $spec['environment'],
         );
         if (str_contains($environment['PHP_SELF'], 'phpunit')) {
             $environment['PHP_SELF'] = '/';
@@ -121,7 +121,7 @@ class MiddlewareDispatcher
             $spec['query'],
             $spec['post'],
             $spec['cookies'],
-            $spec['files']
+            $spec['files'],
         );
 
         return $request

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -142,7 +142,7 @@ abstract class TestCase extends BaseTestCase
 
                 return true;
             },
-            $errorLevel
+            $errorLevel,
         );
 
         try {
@@ -184,7 +184,7 @@ abstract class TestCase extends BaseTestCase
                 }
 
                 return false;
-            }
+            },
         );
         try {
             $callable();
@@ -725,7 +725,7 @@ abstract class TestCase extends BaseTestCase
                         $val = str_replace(
                             ['.*', '.+'],
                             ['.*?', '.+?'],
-                            $matches[1]
+                            $matches[1],
                         );
                         $quotes = $val !== $matches[1] ? '["\']' : '["\']?';
 
@@ -788,7 +788,7 @@ abstract class TestCase extends BaseTestCase
                 $this->assertMatchesRegularExpression(
                     $expression,
                     (string)$string,
-                    sprintf('Item #%d / regex #%d failed: %s', $itemNum, $i, $description)
+                    sprintf('Item #%d / regex #%d failed: %s', $itemNum, $i, $description),
                 );
 
                 return false;
@@ -961,9 +961,9 @@ abstract class TestCase extends BaseTestCase
                     'Adding non-existent methods (%s) to model `%s` ' .
                     'when mocking will not work in future PHPUnit versions.',
                     implode(',', $nonExistingMethods),
-                    $alias
+                    $alias,
                 ),
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
             $builder->addMethods($nonExistingMethods);
         }

--- a/src/Utility/CookieCryptTrait.php
+++ b/src/Utility/CookieCryptTrait.php
@@ -81,7 +81,7 @@ trait CookieCryptTrait
         if (!in_array($encrypt, $this->_validCiphers, true)) {
             $msg = sprintf(
                 'Invalid encryption cipher. Must be one of %s or false.',
-                implode(', ', $this->_validCiphers)
+                implode(', ', $this->_validCiphers),
             );
             throw new InvalidArgumentException($msg);
         }

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -95,12 +95,12 @@ class Filesystem
                 }
 
                 return true;
-            }
+            },
         );
 
         $flatten = new RecursiveIteratorIterator(
             $dirFilter,
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
 
         if ($filter === null) {
@@ -204,7 +204,7 @@ class Filesystem
         /** @var \RecursiveDirectoryIterator<\SplFileInfo> $iterator Replace type for psalm */
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
 
         $result = true;
@@ -254,13 +254,13 @@ class Filesystem
             if ($fileInfo->isDir()) {
                 $result = $result && $this->copyDir(
                     $fileInfo->getPathname(),
-                    $destination . DIRECTORY_SEPARATOR . $fileInfo->getFilename()
+                    $destination . DIRECTORY_SEPARATOR . $fileInfo->getFilename(),
                 );
             } else {
                 // phpcs:ignore
                 $result = $result && @copy(
                     $fileInfo->getPathname(),
-                    $destination . DIRECTORY_SEPARATOR . $fileInfo->getFilename()
+                    $destination . DIRECTORY_SEPARATOR . $fileInfo->getFilename(),
                 );
             }
         }

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -230,7 +230,7 @@ class Hash
             '/(\[ (?P<attr>[^=><!]+?) (\s* (?P<op>[><!]?[=]|[><]) \s* (?P<val>(?:\/.*?\/ | [^\]]+)) )? \])/x',
             $selector,
             $conditions,
-            PREG_SET_ORDER
+            PREG_SET_ORDER,
         );
 
         foreach ($conditions as $cond) {
@@ -507,7 +507,7 @@ class Hash
 
         if (is_array($keys) && count($keys) !== count($vals)) {
             throw new InvalidArgumentException(
-                '`Hash::combine()` needs an equal number of keys + values.'
+                '`Hash::combine()` needs an equal number of keys + values.',
             );
         }
 

--- a/src/Utility/Inflector.php
+++ b/src/Utility/Inflector.php
@@ -249,7 +249,7 @@ class Inflector
         } elseif ($type === 'uninflected') {
             static::$_uninflected = array_merge(
                 $rules,
-                static::$_uninflected
+                static::$_uninflected,
             );
         } else {
             static::${$var} = $rules + static::${$var};

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -72,7 +72,7 @@ class Security
             throw new InvalidArgumentException(sprintf(
                 'The hash type `%s` was not found. Available algorithms are: `%s`.',
                 $algorithm,
-                implode(', ', $availableAlgorithms)
+                implode(', ', $availableAlgorithms),
             ));
         }
 
@@ -128,7 +128,7 @@ class Security
         return substr(
             bin2hex(Security::randomBytes((int)ceil($length / 2))),
             0,
-            $length
+            $length,
         );
     }
 
@@ -177,7 +177,7 @@ class Security
         }
         throw new InvalidArgumentException(
             'No compatible crypto engine available. ' .
-            'Load the openssl extension.'
+            'Load the openssl extension.',
         );
     }
 
@@ -222,7 +222,7 @@ class Security
     {
         if (mb_strlen($key, '8bit') < 32) {
             throw new InvalidArgumentException(
-                sprintf('Invalid key for %s, key must be at least 256 bits (32 bytes) long.', $method)
+                sprintf('Invalid key for %s, key must be at least 256 bits (32 bytes) long.', $method),
             );
         }
     }
@@ -286,7 +286,7 @@ class Security
     {
         if (static::$_salt === null) {
             throw new CakeException(
-                'Salt not set. Use Security::setSalt() to set one, ideally in `config/bootstrap.php`.'
+                'Salt not set. Use Security::setSalt() to set one, ideally in `config/bootstrap.php`.',
             );
         }
 

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -81,7 +81,7 @@ class Text
             // 48 bits for "node"
             random_int(0, 65535),
             random_int(0, 65535),
-            random_int(0, 65535)
+            random_int(0, 65535),
         );
     }
 
@@ -206,13 +206,13 @@ class Text
             '/(?<!%s)%s%%s%s/',
             preg_quote($options['escape'], '/'),
             str_replace('%', '%%', preg_quote($options['before'], '/')),
-            str_replace('%', '%%', preg_quote($options['after'], '/'))
+            str_replace('%', '%%', preg_quote($options['after'], '/')),
         );
 
         $dataKeys = array_keys($data);
         $hashKeys = array_map(
             fn ($str) => hash('xxh128', $str),
-            $dataKeys
+            $dataKeys,
         );
         /** @var array<string, string> $tempData */
         $tempData = array_combine($dataKeys, $hashKeys);
@@ -270,7 +270,7 @@ class Text
                     '/[\s]*[a-z]+=(")(%s%s%s[\s]*)+\\1/i',
                     preg_quote($options['before'], '/'),
                     $clean['word'],
-                    preg_quote($options['after'], '/')
+                    preg_quote($options['after'], '/'),
                 );
                 $str = (string)preg_replace($kleenex, $clean['replacement'], $str);
                 if ($clean['andText']) {
@@ -294,7 +294,7 @@ class Text
                     $clean['gap'],
                     preg_quote($options['before'], '/'),
                     $clean['word'],
-                    preg_quote($options['after'], '/')
+                    preg_quote($options['after'], '/'),
                 );
                 $str = (string)preg_replace($kleenex, $clean['replacement'], $str);
                 break;
@@ -518,7 +518,7 @@ class Text
             sprintf($options['regex'], $phrase),
             $options['format'],
             $text,
-            $options['limit']
+            $options['limit'],
         );
     }
 
@@ -610,7 +610,7 @@ class Text
                     if (
                         !preg_match(
                             '/img|br|input|hr|area|base|basefont|col|frame|isindex|link|meta|param/i',
-                            $tag[2]
+                            $tag[2],
                         )
                     ) {
                         if (preg_match('/<[\w]+[^>]*>/', $tag[0])) {
@@ -718,7 +718,7 @@ class Text
 
                 return str_repeat(' ', $strlen($utf8, 'UTF-8'));
             },
-            $text
+            $text,
         );
 
         return $strlen($replace);

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -159,7 +159,7 @@ class Xml
                 }
 
                 return $xml;
-            }
+            },
         );
     }
 
@@ -191,7 +191,7 @@ class Xml
                 }
 
                 return $xml;
-            }
+            },
         );
     }
 

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -880,7 +880,7 @@ class Validation
 
         if ($backingType === null) {
             throw new InvalidArgumentException(
-                'The `$enumClassName` argument must be the classname of a valid backed enum.'
+                'The `$enumClassName` argument must be the classname of a valid backed enum.',
             );
         }
 
@@ -1527,7 +1527,7 @@ class Validation
     {
         if (!isset($options['height']) && !isset($options['width'])) {
             throw new InvalidArgumentException(
-                'Invalid image size validation parameters! Missing `width` and / or `height`.'
+                'Invalid image size validation parameters! Missing `width` and / or `height`.',
             );
         }
 
@@ -1629,7 +1629,7 @@ class Validation
         if ($options['type'] !== 'latLong') {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported coordinate type `%s`. Use `latLong` instead.',
-                $options['type']
+                $options['type'],
             ));
         }
         $pattern = '/^' . self::$_pattern['latitude'] . ',\s*' . self::$_pattern['longitude'] . '$/';
@@ -1856,7 +1856,7 @@ class Validation
                     $value['hour'],
                     $value['minute'],
                     $value['second'],
-                    $value['microsecond']
+                    $value['microsecond'],
                 );
             }
         }

--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -135,7 +135,7 @@ class ValidationRule
                 'Unable to call method `%s` in `%s` provider for field `%s`',
                 $method,
                 $this->_provider,
-                $context['field']
+                $context['field'],
             );
             throw new InvalidArgumentException($message);
         }

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -494,7 +494,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             }
             if (!is_string($name)) {
                 throw new InvalidArgumentException(
-                    'You cannot add validation rules without a `name` key. Update rules array to have string keys.'
+                    'You cannot add validation rules without a `name` key. Update rules array to have string keys.',
                 );
             }
 
@@ -1224,14 +1224,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = sprintf(
                     'The length of the provided value must be between `%s` and `%s`, inclusively',
                     $lowerBound,
-                    $upperBound
+                    $upperBound,
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The length of the provided value must be between `{0}` and `{1}`, inclusively',
                     $lowerBound,
-                    $upperBound
+                    $upperBound,
                 );
             }
         }
@@ -1274,19 +1274,19 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 } else {
                     $message = sprintf(
                         'The provided value must be a valid credit card number of these types: `%s`',
-                        $typeEnumeration
+                        $typeEnumeration,
                     );
                 }
             } elseif ($type === 'all') {
                 $message = __d(
                     'cake',
-                    'The provided value must be a valid credit card number of any type'
+                    'The provided value must be a valid credit card number of any type',
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be a valid credit card number of these types: `{0}`',
-                    $typeEnumeration
+                    $typeEnumeration,
                 );
             }
         }
@@ -1582,7 +1582,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = __d(
                     'cake',
                     'The provided value must be equal to the one of field `{0}`',
-                    $secondField
+                    $secondField,
                 );
             }
         }
@@ -1619,7 +1619,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = __d(
                     'cake',
                     'The provided value must not be equal to the one of field `{0}`',
-                    $secondField
+                    $secondField,
                 );
             }
         }
@@ -1656,7 +1656,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = __d(
                     'cake',
                     'The provided value must be greater than the one of field `{0}`',
-                    $secondField
+                    $secondField,
                 );
             }
         }
@@ -1690,13 +1690,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!$this->_useI18n) {
                 $message = sprintf(
                     'The provided value must be greater than or equal to the one of field `%s`',
-                    $secondField
+                    $secondField,
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be greater than or equal to the one of field `{0}`',
-                    $secondField
+                    $secondField,
                 );
             }
         }
@@ -1733,7 +1733,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = __d(
                     'cake',
                     'The provided value must be less than the one of field `{0}`',
-                    $secondField
+                    $secondField,
                 );
             }
         }
@@ -1767,13 +1767,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!$this->_useI18n) {
                 $message = sprintf(
                     'The provided value must be less than or equal to the one of field `%s`',
-                    $secondField
+                    $secondField,
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be less than or equal to the one of field `{0}`',
-                    $secondField
+                    $secondField,
                 );
             }
         }
@@ -1808,13 +1808,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!$this->_useI18n) {
                 $message = sprintf(
                     'The provided value must be a date of one of these formats: `%s`',
-                    $formatEnumeration
+                    $formatEnumeration,
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be a date of one of these formats: `{0}`',
-                    $formatEnumeration
+                    $formatEnumeration,
                 );
             }
         }
@@ -1849,13 +1849,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             if (!$this->_useI18n) {
                 $message = sprintf(
                     'The provided value must be a date and time of one of these formats: `%s`',
-                    $formatEnumeration
+                    $formatEnumeration,
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be a date and time of one of these formats: `{0}`',
-                    $formatEnumeration
+                    $formatEnumeration,
                 );
             }
         }
@@ -1980,13 +1980,13 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
             } elseif ($places === null) {
                 $message = __d(
                     'cake',
-                    'The provided value must be decimal with any number of decimal places, including none'
+                    'The provided value must be decimal with any number of decimal places, including none',
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be decimal with `{0}` decimal places',
-                    $places
+                    $places,
                 );
             }
         }
@@ -2050,7 +2050,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     ) {
         if (!in_array(BackedEnum::class, (array)class_implements($enumClassName), true)) {
             throw new InvalidArgumentException(
-                'The `$enumClassName` argument must be the classname of a valid backed enum.'
+                'The `$enumClassName` argument must be the classname of a valid backed enum.',
             );
         }
 
@@ -2372,14 +2372,14 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = sprintf(
                     'The provided value must be between `%s` and `%s`, inclusively',
                     $lowerBound,
-                    $upperBound
+                    $upperBound,
                 );
             } else {
                 $message = __d(
                     'cake',
                     'The provided value must be between `{0}` and `{1}`, inclusively',
                     $lowerBound,
-                    $upperBound
+                    $upperBound,
                 );
             }
         }
@@ -2471,7 +2471,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
                 $message = __d(
                     'cake',
                     'The provided value must be one of: `{0}`',
-                    $listEnumeration
+                    $listEnumeration,
                 );
             }
         }

--- a/src/Validation/ValidatorAwareTrait.php
+++ b/src/Validation/ValidatorAwareTrait.php
@@ -132,8 +132,8 @@ trait ValidatorAwareTrait
                 'The `%s::%s()` validation method must return an instance of `%s`.',
                 static::class,
                 $method,
-                Validator::class
-            )
+                Validator::class,
+            ),
         );
 
         return $validator;

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -178,7 +178,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
                 throw new BadMethodCallException(sprintf(
                     'Class `%s` does not have a `%s` method.',
                     static::class,
-                    $this->action
+                    $this->action,
                 ));
             }
 
@@ -195,7 +195,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
             $name = substr($name, 0, -4);
             if (!$builder->getTemplatePath()) {
                 $builder->setTemplatePath(
-                    static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $name)
+                    static::TEMPLATE_FOLDER . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $name),
                 );
             }
             $template = $builder->getTemplate();
@@ -210,7 +210,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
                     $attributes['file'],
                     $attributes['paths'],
                     null,
-                    $e
+                    $e,
                 );
             }
         };
@@ -270,7 +270,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
                 'Could not render cell - %s [%s, line %d]',
                 $e->getMessage(),
                 $e->getFile(),
-                $e->getLine()
+                $e->getLine(),
             ), E_USER_WARNING);
 
             return '';
@@ -280,7 +280,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
                 'Could not render cell - %s [%s, line %d]',
                 $e->getMessage(),
                 $e->getFile(),
-                $e->getLine()
+                $e->getLine(),
             ), 0, $e);
         }
     }

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -299,7 +299,7 @@ class ArrayContext implements ContextInterface
 
         return array_intersect_key(
             (array)$schema,
-            array_flip(static::VALID_ATTRIBUTES)
+            array_flip(static::VALID_ATTRIBUTES),
         );
     }
 

--- a/src/View/Form/ContextFactory.php
+++ b/src/View/Form/ContextFactory.php
@@ -155,7 +155,7 @@ class ContextFactory
             throw new CakeException(sprintf(
                 'No context provider found for value of type `%s`.'
                 . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.',
-                get_debug_type($data['entity'])
+                get_debug_type($data['entity']),
             ));
         }
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -372,7 +372,7 @@ class EntityContext implements ContextInterface
         }
         throw new CakeException(sprintf(
             'Unable to fetch property `%s`.',
-            implode('.', $path)
+            implode('.', $path),
         ));
     }
 
@@ -398,7 +398,7 @@ class EntityContext implements ContextInterface
         if ($oneElement && $this->_isCollection) {
             throw new CakeException(sprintf(
                 'Unable to fetch property `%s`.',
-                implode('.', $path)
+                implode('.', $path),
             ));
         }
         $entity = $this->_context['entity'];
@@ -438,7 +438,7 @@ class EntityContext implements ContextInterface
         }
         throw new CakeException(sprintf(
             'Unable to fetch property `%s`.',
-            implode('.', $path)
+            implode('.', $path),
         ));
     }
 
@@ -697,7 +697,7 @@ class EntityContext implements ContextInterface
 
         return array_intersect_key(
             (array)$table->getSchema()->getColumn(array_pop($parts)),
-            array_flip(static::VALID_ATTRIBUTES)
+            array_flip(static::VALID_ATTRIBUTES),
         );
     }
 

--- a/src/View/Form/FormContext.php
+++ b/src/View/Form/FormContext.php
@@ -55,7 +55,7 @@ class FormContext implements ContextInterface
     {
         assert(
             isset($context['entity']) && $context['entity'] instanceof Form,
-            "`\$context['entity']` must be an instance of " . Form::class
+            "`\$context['entity']` must be an instance of " . Form::class,
         );
 
         $this->_form = $context['entity'];
@@ -207,7 +207,7 @@ class FormContext implements ContextInterface
     {
         return array_intersect_key(
             (array)$this->_form->getSchema()->field($field),
-            array_flip(static::VALID_ATTRIBUTES)
+            array_flip(static::VALID_ATTRIBUTES),
         );
     }
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -289,7 +289,7 @@ class BreadcrumbsHelper extends Helper
 
             $separator['attrs'] = $templater->formatAttributes(
                 $separator,
-                ['innerAttrs', 'separator']
+                ['innerAttrs', 'separator'],
             );
 
             $separatorString = $this->formatTemplate('separator', $separator);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -624,7 +624,7 @@ class FormHelper extends Helper
 
         $tokenData = $this->formProtector->buildTokenData(
             $this->_lastAction,
-            $this->_getFormProtectorSessionId()
+            $this->_getFormProtectorSessionId(),
         );
         $tokenFields = array_merge($secureAttributes, [
             'value' => $tokenData['fields'],
@@ -683,7 +683,7 @@ class FormHelper extends Helper
         $session->start();
 
         return new FormProtector(
-            $formTokenData
+            $formTokenData,
         );
     }
 
@@ -917,7 +917,7 @@ class FormHelper extends Helper
 
         $fields = array_merge(
             Hash::normalize($modelFields),
-            Hash::normalize($fields)
+            Hash::normalize($fields),
         );
 
         return $this->controls($fields, $options);
@@ -985,7 +985,7 @@ class FormHelper extends Helper
         if ($legend === true) {
             $isCreate = $context->isCreate();
             $modelName = Inflector::humanize(
-                Inflector::singularize($this->_View->getRequest()->getParam('controller'))
+                Inflector::singularize($this->_View->getRequest()->getParam('controller')),
             );
             if (!$isCreate) {
                 $legend = __d('cake', 'Edit {0}', $modelName);
@@ -1230,7 +1230,7 @@ class FormHelper extends Helper
             case 'input':
                 throw new InvalidArgumentException(sprintf(
                     'Invalid type `input` used for field `%s`.',
-                    $fieldName
+                    $fieldName,
                 ));
 
             default:
@@ -1335,7 +1335,7 @@ class FormHelper extends Helper
         $fieldName = array_slice(explode('.', $fieldName), -1)[0];
 
         $varName = Inflector::variable(
-            $pluralize ? Inflector::pluralize($fieldName) : $fieldName
+            $pluralize ? Inflector::pluralize($fieldName) : $fieldName,
         );
         $varOptions = $this->_View->get($varName);
         if (!is_iterable($varOptions)) {
@@ -1706,14 +1706,14 @@ class FormHelper extends Helper
 
         $options = $this->_initInputField($fieldName, array_merge(
             $options,
-            ['secure' => static::SECURE_SKIP]
+            ['secure' => static::SECURE_SKIP],
         ));
 
         if ($secure === true && $this->formProtector) {
             $this->formProtector->addField(
                 $options['name'],
                 true,
-                $options['val'] === false ? '0' : (string)$options['val']
+                $options['val'] === false ? '0' : (string)$options['val'],
             );
         }
 
@@ -1977,7 +1977,7 @@ class FormHelper extends Helper
         if (isset($options['name']) && $this->formProtector) {
             $this->formProtector->addField(
                 $options['name'],
-                $options['secure']
+                $options['secure'],
             );
         }
         unset($options['secure']);
@@ -2428,7 +2428,7 @@ class FormHelper extends Helper
             if (is_array($first)) {
                 $disabled = array_filter(
                     $options['options'],
-                    fn ($i) => in_array($i['value'], $options['disabled'], true)
+                    fn ($i) => in_array($i['value'], $options['disabled'], true),
                 );
 
                 return $disabled !== [];
@@ -2597,7 +2597,7 @@ class FormHelper extends Helper
             throw new InvalidArgumentException(sprintf(
                 'Invalid value source(s): %s. Valid values are: %s.',
                 implode(', ', $diff),
-                implode(', ', $this->supportedValueSources)
+                implode(', ', $this->supportedValueSources),
             ));
         }
     }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -1053,7 +1053,7 @@ class HtmlHelper extends Helper
         if (isset($options['poster'])) {
             $options['poster'] = $this->Url->assetUrl(
                 $options['poster'],
-                ['pathPrefix' => Configure::read('App.imageBaseUrl')] + $options
+                ['pathPrefix' => Configure::read('App.imageBaseUrl')] + $options,
             );
         }
         $text = $options['text'];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -113,7 +113,7 @@ class PaginatorHelper extends Helper
         unset($query['page'], $query['limit'], $query['sort'], $query['direction']);
         $this->setConfig(
             'options.url',
-            array_merge($this->_View->getRequest()->getParam('pass', []), ['?' => $query])
+            array_merge($this->_View->getRequest()->getParam('pass', []), ['?' => $query]),
         );
     }
 
@@ -276,7 +276,7 @@ class PaginatorHelper extends Helper
 
         $url = $this->generateUrl(
             ['page' => $this->paginated()->currentPage() + $options['step']],
-            $options['url']
+            $options['url'],
         );
 
         $out = $templater->format($template, [
@@ -503,7 +503,7 @@ class PaginatorHelper extends Helper
 
         $options += array_intersect_key(
             $paging,
-            ['page' => null, 'limit' => null, 'sort' => null, 'direction' => null]
+            ['page' => null, 'limit' => null, 'sort' => null, 'direction' => null],
         );
 
         if (!empty($options['page']) && $options['page'] === 1) {
@@ -733,7 +733,7 @@ class PaginatorHelper extends Helper
         $end = max(1 + $options['modulus'], $params['currentPage'] + $half);
         $start = min(
             $params['pageCount'] - $options['modulus'],
-            $params['currentPage'] - $half - $options['modulus'] % 2
+            $params['currentPage'] - $half - $options['modulus'] % 2,
         );
 
         if ($options['first']) {
@@ -1074,8 +1074,8 @@ class PaginatorHelper extends Helper
                 $this->generateUrl(
                     ['page' => $this->paginated()->currentPage() - 1],
                     [],
-                    ['escape' => false, 'fullBase' => true]
-                )
+                    ['escape' => false, 'fullBase' => true],
+                ),
             );
         }
 
@@ -1085,15 +1085,15 @@ class PaginatorHelper extends Helper
                 $this->generateUrl(
                     ['page' => $this->paginated()->currentPage() + 1],
                     [],
-                    ['escape' => false, 'fullBase' => true]
-                )
+                    ['escape' => false, 'fullBase' => true],
+                ),
             );
         }
 
         if ($options['first']) {
             $links[] = $this->Html->meta(
                 'first',
-                $this->generateUrl(['page' => 1], [], ['escape' => false, 'fullBase' => true])
+                $this->generateUrl(['page' => 1], [], ['escape' => false, 'fullBase' => true]),
             );
         }
 
@@ -1103,8 +1103,8 @@ class PaginatorHelper extends Helper
                 $this->generateUrl(
                     ['page' => $this->paginated()->pageCount()],
                     [],
-                    ['escape' => false, 'fullBase' => true]
-                )
+                    ['escape' => false, 'fullBase' => true],
+                ),
             );
         }
 

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -106,13 +106,13 @@ class TextHelper extends Helper
         $text = (string)preg_replace_callback(
             $pattern,
             [&$this, '_insertPlaceHolder'],
-            $text
+            $text,
         );
         // phpcs:disable Generic.Files.LineLength
         $text = preg_replace_callback(
             '#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www\.[^\s\n\%\ <]+[^\s<\n\%\,\.\ ](?<!\))#i',
             [&$this, '_insertPlaceHolder'],
-            $text
+            $text,
         );
         // phpcs:enable Generic.Files.LineLength
         if ($options['escape']) {
@@ -242,7 +242,7 @@ class TextHelper extends Helper
         $text = preg_replace_callback(
             '/(?<=\s|^|\(|\>|\;)(' . $atom . '*(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[\p{L}0-9-]+)+)/ui',
             [&$this, '_insertPlaceholder'],
-            $text
+            $text,
         );
         if ($options['escape']) {
             $text = h($text);

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -332,7 +332,7 @@ class TimeHelper extends Helper
                 $element['tag'],
                 $this->templater()->formatAttributes($element, ['tag']),
                 $relativeDate,
-                $element['tag']
+                $element['tag'],
             );
         }
 

--- a/src/View/SerializedView.php
+++ b/src/View/SerializedView.php
@@ -82,7 +82,7 @@ abstract class SerializedView extends View
                 throw new SerializationFailureException(
                     'Serialization of View data failed.',
                     null,
-                    $e
+                    $e,
                 );
             }
         }

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -185,7 +185,7 @@ class StringTemplate
 
             assert(
                 is_string($template),
-                sprintf('Template for `%s` must be of type `string`, but is `%s`', $name, gettype($template))
+                sprintf('Template for `%s` must be of type `string`, but is `%s`', $name, gettype($template)),
             );
 
             $template = str_replace('%', '%%', $template);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -357,7 +357,7 @@ class View implements EventDispatcherInterface
 
         $this->setConfig(array_diff_key(
             $viewOptions,
-            array_flip($this->_passedVars)
+            array_flip($this->_passedVars),
         ));
 
         $request ??= Router::getRequest() ?: new ServerRequest(['base' => '', 'url' => '', 'webroot' => '/']);
@@ -661,7 +661,7 @@ class View implements EventDispatcherInterface
             $options['cache'] = $this->_elementCache(
                 $name,
                 $data,
-                array_diff_key($options, ['callbacks' => false, 'plugin' => null, 'ignoreMissing' => null])
+                array_diff_key($options, ['callbacks' => false, 'plugin' => null, 'ignoreMissing' => null]),
             );
         }
 
@@ -789,7 +789,7 @@ class View implements EventDispatcherInterface
             if (!$this->layout) {
                 throw new CakeException(
                     'View::$layout must be a non-empty string.' .
-                    'To disable layout rendering use method `View::disableAutoLayout()` instead.'
+                    'To disable layout rendering use method `View::disableAutoLayout()` instead.',
                 );
             }
 
@@ -880,7 +880,7 @@ class View implements EventDispatcherInterface
                 $data = array_combine($name, $value);
                 if ($data === false) {
                     throw new CakeException(
-                        'Invalid data provided for array_combine() to work: Both $name and $value require same count.'
+                        'Invalid data provided for array_combine() to work: Both $name and $value require same count.',
                     );
                 }
             } else {
@@ -1063,7 +1063,7 @@ class View implements EventDispatcherInterface
                     $defaultPath = $paths[0] . static::TYPE_ELEMENT . DIRECTORY_SEPARATOR;
                     throw new LogicException(sprintf(
                         'You cannot extend an element which does not exist (%s).',
-                        $defaultPath . $name . $this->_ext
+                        $defaultPath . $name . $this->_ext,
                     ));
                 }
                 break;
@@ -1162,7 +1162,7 @@ class View implements EventDispatcherInterface
         if ($initialBlocks !== $remainingBlocks) {
             throw new LogicException(sprintf(
                 'The `%s` block was left open. Blocks are not allowed to cross files.',
-                (string)$this->Blocks->active()
+                (string)$this->Blocks->active(),
             ));
         }
 
@@ -1408,7 +1408,7 @@ class View implements EventDispatcherInterface
         if ($absolute === false || !str_starts_with($absolute, $path)) {
             throw new InvalidArgumentException(sprintf(
                 'Cannot use `%s` as a template, it is not within any view template path.',
-                $file
+                $file,
             ));
         }
 
@@ -1454,7 +1454,7 @@ class View implements EventDispatcherInterface
             if (!$this->layout) {
                 throw new CakeException(
                     'View::$layout must be a non-empty string.' .
-                    'To disable layout rendering use method `View::disableAutoLayout()` instead.'
+                    'To disable layout rendering use method `View::disableAutoLayout()` instead.',
                 );
             }
             $name = $this->layout;
@@ -1552,7 +1552,7 @@ class View implements EventDispatcherInterface
 
                 array_unshift(
                     $paths,
-                    $path . $basePath
+                    $path . $basePath,
                 );
             }
         }
@@ -1609,7 +1609,7 @@ class View implements EventDispatcherInterface
             $themePaths,
             $pluginPaths,
             $templatePaths,
-            App::core('templates')
+            App::core('templates'),
         );
 
         if ($plugin !== null) {
@@ -1651,7 +1651,7 @@ class View implements EventDispatcherInterface
         $keys = array_merge(
             [$pluginKey, $elementKey],
             array_keys($options),
-            array_keys($data)
+            array_keys($data),
         );
         $config = [
             'config' => $this->elementCache,

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -651,7 +651,7 @@ class ViewBuilder implements JsonSerializable
                 'Failed serializing the `%s` %s in the `%s` view var',
                 is_resource($item) ? get_resource_type($item) : $item::class,
                 is_resource($item) ? 'resource' : 'object',
-                $key
+                $key,
             ));
         }
     }

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -66,7 +66,7 @@ trait ViewVarsTrait
         return $builder->build(
             $this->request ?? null,
             $this->response ?? null,
-            $this instanceof EventDispatcherInterface ? $this->getEventManager() : null
+            $this instanceof EventDispatcherInterface ? $this->getEventManager() : null,
         );
     }
 

--- a/src/View/Widget/BasicWidget.php
+++ b/src/View/Widget/BasicWidget.php
@@ -105,7 +105,7 @@ class BasicWidget implements WidgetInterface
             'templateVars' => $data['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $data,
-                ['name', 'type']
+                ['name', 'type'],
             ),
         ]);
     }

--- a/src/View/Widget/CheckboxWidget.php
+++ b/src/View/Widget/CheckboxWidget.php
@@ -67,7 +67,7 @@ class CheckboxWidget extends BasicWidget
 
         $attrs = $this->_templates->formatAttributes(
             $data,
-            ['name', 'value']
+            ['name', 'value'],
         );
 
         return $this->_templates->format('checkbox', [

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -116,7 +116,7 @@ class DateTimeWidget extends BasicWidget
         if (!isset($this->formatMap[$data['type']])) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid type `%s` for input tag, expected datetime-local, date, time, month or week',
-                $data['type']
+                $data['type'],
             ));
         }
 
@@ -131,7 +131,7 @@ class DateTimeWidget extends BasicWidget
             'templateVars' => $data['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $data,
-                ['name', 'type']
+                ['name', 'type'],
             ),
         ]);
     }

--- a/src/View/Widget/FileWidget.php
+++ b/src/View/Widget/FileWidget.php
@@ -64,7 +64,7 @@ class FileWidget extends BasicWidget
             'templateVars' => $data['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $data,
-                ['name']
+                ['name'],
             ),
         ]);
     }

--- a/src/View/Widget/MultiCheckboxWidget.php
+++ b/src/View/Widget/MultiCheckboxWidget.php
@@ -174,7 +174,7 @@ class MultiCheckboxWidget extends BasicWidget
                 if (isset($data['id'])) {
                     $checkbox['id'] = $data['id'] . '-' . trim(
                         $this->_idSuffix((string)$checkbox['value']),
-                        '-'
+                        '-',
                     );
                 } else {
                     $checkbox['id'] = $this->_id($checkbox['name'], (string)$checkbox['value']);
@@ -201,7 +201,7 @@ class MultiCheckboxWidget extends BasicWidget
             'templateVars' => $checkbox['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $checkbox,
-                ['name', 'value', 'text', 'options', 'label', 'val', 'type']
+                ['name', 'value', 'text', 'options', 'label', 'val', 'type'],
             ),
         ]);
 

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -174,7 +174,7 @@ class RadioWidget extends BasicWidget
             if (isset($data['id'])) {
                 $radio['id'] = $data['id'] . '-' . rtrim(
                     $this->_idSuffix((string)$radio['value']),
-                    '-'
+                    '-',
                 );
             } else {
                 $radio['id'] = $this->_id((string)$radio['name'], (string)$radio['value']);
@@ -207,7 +207,7 @@ class RadioWidget extends BasicWidget
             'templateVars' => $radio['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $radio + $data,
-                ['name', 'value', 'text', 'options', 'label', 'val', 'type']
+                ['name', 'value', 'text', 'options', 'label', 'val', 'type'],
             ),
         ]);
 
@@ -216,7 +216,7 @@ class RadioWidget extends BasicWidget
             $data['label'],
             $input,
             $context,
-            $escape
+            $escape,
         );
 
         if (

--- a/src/View/Widget/TextareaWidget.php
+++ b/src/View/Widget/TextareaWidget.php
@@ -72,7 +72,7 @@ class TextareaWidget extends BasicWidget
             'templateVars' => $data['templateVars'],
             'attrs' => $this->_templates->formatAttributes(
                 $data,
-                ['name', 'val']
+                ['name', 'val'],
             ),
         ]);
     }

--- a/src/View/Widget/WidgetLocator.php
+++ b/src/View/Widget/WidgetLocator.php
@@ -128,8 +128,8 @@ class WidgetLocator
                     sprintf(
                         'Widget objects must implement `%s`. Got `%s` instance instead.',
                         WidgetInterface::class,
-                        get_debug_type($widget)
-                    )
+                        get_debug_type($widget),
+                    ),
                 );
             }
 

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -155,7 +155,7 @@ class XmlView extends SerializedView
         $result = Xml::fromArray($data, $options)->saveXML();
         if ($result === false) {
             throw new SerializationFailureException(
-                'XML serialization of View data failed.'
+                'XML serialization of View data failed.',
             );
         }
 


### PR DESCRIPTION
> c cs-c -- src/ --sniffs=SlevomatCodingStandard.Functions.RequireTrailingCommaInCall

Question:
Do we want to start having trailing commas not just for arrays but also multi line function calls?

The benefit here would be less merge issues and conflicts down the line from here on, since adding a param, or removing, wouldnt touch the previous line anymore.
Also diffs are cleaner to read IMO.