### PR TITLE
6.x: rename _accessible to patchable

### DIFF
--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -150,26 +150,26 @@ interface EntityInterface extends ArrayAccess, JsonSerializable, Stringable
      * Stores whether a field value can be changed or set in this entity.
      *
      * @param array<string>|string $field single or list of fields to change its accessibility
-     * @param bool $set true marks the field as accessible, false will
+     * @param bool $set true marks the field as patchable, false will
      * mark it as protected.
      * @return $this
      */
-    public function setAccess(array|string $field, bool $set);
+    public function setPatchable(array|string $field, bool $set);
 
     /**
-     * Accessible configuration for this entity.
+     * Patchable configuration for this entity.
      *
      * @return array<bool>
      */
-    public function getAccessible(): array;
+    public function getPatchable(): array;
 
     /**
-     * Checks if a field is accessible
+     * Checks if a field can be patched
      *
      * @param string $field Field name to check
      * @return bool
      */
-    public function isAccessible(string $field): bool;
+    public function isPatchable(string $field): bool;
 
     /**
      * Sets the source alias

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -235,7 +235,7 @@ interface RepositoryInterface
     public function newEntities(array $data, array $options = []): array;
 
     /**
-     * Merges the passed `$data` into `$entity` respecting the accessible
+     * Merges the passed `$data` into `$entity` respecting the patchable
      * fields configured on the entity. Returns the same entity after being
      * altered.
      *
@@ -255,7 +255,7 @@ interface RepositoryInterface
 
     /**
      * Merges each of the elements passed in `$data` into the entities
-     * found in `$entities` respecting the accessible fields configured on the entities.
+     * found in `$entities` respecting the patchable fields configured on the entities.
      * Merging is done by matching the primary key in each of the elements in `$data`
      * and `$entities`.
      *

--- a/src/Http/Session/DatabaseSession.php
+++ b/src/Http/Session/DatabaseSession.php
@@ -157,7 +157,7 @@ class DatabaseSession implements SessionHandlerInterface
             $pkField => $id,
             'data' => $data,
             'expires' => time() + $this->_timeout,
-        ], ['accessibleFields' => [$pkField => true]]);
+        ], ['patchableFields' => [$pkField => true]]);
 
         return (bool)$this->_table->save($session);
     }

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -35,7 +35,7 @@ class Entity implements EntityInterface, InvalidPropertyInterface
      * - useSetters: whether use internal setters for properties or not
      * - markClean: whether to mark all properties as clean after setting them
      * - markNew: whether this instance has not yet been persisted
-     * - guard: whether to prevent inaccessible properties from being set (default: false)
+     * - guard: whether to prevent unpatchable properties from being set (default: false)
      * - source: A string representing the alias of the repository this entity came from
      *
      * ### Example:

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -147,8 +147,8 @@ class Marshaller
      *   Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well. Defaults to null.
      * - fields: An allowed list of fields to be assigned to the entity. If not present,
-     *   the accessible fields list in the entity will be used. Defaults to null.
-     * - accessibleFields: A list of fields to allow or deny in entity accessible fields. Defaults to null
+     *   the patchable fields list in the entity will be used. Defaults to null.
+     * - patchableFields: A list of fields to allow or deny in entity patchable fields. Defaults to null
      * - forceNew: When enabled, belongsToMany associations will have 'new' entities created
      *   when primary key values are set, and a record does not already exist. Normally primary key
      *   on missing entities would be ignored. Defaults to false.
@@ -166,7 +166,7 @@ class Marshaller
      * ```
      * $result = $marshaller->one($data, [
      *   'associated' => [
-     *     'Tags' => ['accessibleFields' => ['*' => true]]
+     *     'Tags' => ['patchableFields' => ['*' => true]]
      *   ]
      * ]);
      * ```
@@ -185,7 +185,7 @@ class Marshaller
      * @param array<string, mixed> $options List of options
      * @return \Cake\Datasource\EntityInterface
      * @see \Cake\ORM\Table::newEntity()
-     * @see \Cake\ORM\Entity::$_accessible
+     * @see \Cake\ORM\Entity::$patchable
      */
     public function one(array $data, array $options = []): EntityInterface
     {
@@ -194,9 +194,9 @@ class Marshaller
         $primaryKey = (array)$this->_table->getPrimaryKey();
         $entity = $this->_table->newEmptyEntity();
 
-        if (isset($options['accessibleFields'])) {
-            foreach ((array)$options['accessibleFields'] as $key => $value) {
-                $entity->setAccess($key, $value);
+        if (isset($options['patchableFields'])) {
+            foreach ((array)$options['patchableFields'] as $key => $value) {
+                $entity->setPatchable($key, $value);
             }
         }
         $errors = $this->_validate($data, $options['validate'], true);
@@ -345,8 +345,8 @@ class Marshaller
      *   Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well. Defaults to null.
      * - fields: An allowed list of fields to be assigned to the entity. If not present,
-     *   the accessible fields list in the entity will be used. Defaults to null.
-     * - accessibleFields: A list of fields to allow or deny in entity accessible fields. Defaults to null
+     *   the patchable fields list in the entity will be used. Defaults to null.
+     * - patchableFields: A list of fields to allow or deny in entity patchable fields. Defaults to null
      * - forceNew: When enabled, belongsToMany associations will have 'new' entities created
      *   when primary key values are set, and a record does not already exist. Normally primary key
      *   on missing entities would be ignored. Defaults to false.
@@ -355,7 +355,7 @@ class Marshaller
      * @param array<string, mixed> $options List of options
      * @return array<\Cake\Datasource\EntityInterface> An array of hydrated records.
      * @see \Cake\ORM\Table::newEntities()
-     * @see \Cake\ORM\Entity::$_accessible
+     * @see \Cake\ORM\Entity::$patchable
      */
     public function many(array $data, array $options = []): array
     {
@@ -521,8 +521,8 @@ class Marshaller
      * - validate: Whether to validate data before hydrating the entities. Can
      *   also be set to a string to use a specific validator. Defaults to true/default.
      * - fields: An allowed list of fields to be assigned to the entity. If not present
-     *   the accessible fields list in the entity will be used.
-     * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *   the patchable fields list in the entity will be used.
+     * - patchableFields: A list of fields to allow or deny in entity patchable fields.
      *
      * The above options can be used in each nested `associated` array. In addition to the above
      * options you can also use the `onlyIds` option for HasMany and BelongsToMany associations.
@@ -549,7 +549,7 @@ class Marshaller
      * @param array $data key value list of fields to be merged into the entity
      * @param array<string, mixed> $options List of options.
      * @return \Cake\Datasource\EntityInterface
-     * @see \Cake\ORM\Entity::$_accessible
+     * @see \Cake\ORM\Entity::$patchable
      */
     public function merge(EntityInterface $entity, array $data, array $options = []): EntityInterface
     {
@@ -562,9 +562,9 @@ class Marshaller
             $keys = $entity->extract((array)$this->_table->getPrimaryKey());
         }
 
-        if (isset($options['accessibleFields'])) {
-            foreach ((array)$options['accessibleFields'] as $key => $value) {
-                $entity->setAccess($key, $value);
+        if (isset($options['patchableFields'])) {
+            foreach ((array)$options['patchableFields'] as $key => $value) {
+                $entity->setPatchable($key, $value);
             }
         }
 
@@ -662,15 +662,15 @@ class Marshaller
      *   also be set to a string to use a specific validator. Defaults to true/default.
      * - associated: Associations listed here will be marshalled as well.
      * - fields: An allowed list of fields to be assigned to the entity. If not present,
-     *   the accessible fields list in the entity will be used.
-     * - accessibleFields: A list of fields to allow or deny in entity accessible fields.
+     *   the patchable fields list in the entity will be used.
+     * - patchableFields: A list of fields to allow or deny in entity patchable fields.
      *
      * @param iterable<\Cake\Datasource\EntityInterface> $entities the entities that will get the
      *   data merged in
      * @param array $data list of arrays to be merged into the entities
      * @param array<string, mixed> $options List of options.
      * @return array<\Cake\Datasource\EntityInterface>
-     * @see \Cake\ORM\Entity::$_accessible
+     * @see \Cake\ORM\Entity::$patchable
      */
     public function mergeMany(iterable $entities, array $data, array $options = []): array
     {
@@ -841,8 +841,8 @@ class Marshaller
         $associated = $options['associated'] ?? [];
         $extra = [];
         foreach ($original as $entity) {
-            // Mark joinData as accessible so we can marshal it properly.
-            $entity->setAccess('_joinData', true);
+            // Mark joinData as patchable so we can marshal it properly.
+            $entity->setPatchable('_joinData', true);
 
             $joinData = $entity->get('_joinData');
             if ($joinData instanceof EntityInterface) {
@@ -858,7 +858,7 @@ class Marshaller
             $nested = (array)$associated['_joinData'];
         }
 
-        $options['accessibleFields'] = ['_joinData' => true];
+        $options['patchableFields'] = ['_joinData' => true];
 
         $records = $this->mergeMany($original, $value, $options);
         foreach ($records as $record) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1682,8 +1682,8 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
 
         $entity = $this->newEmptyEntity();
         if ($options['defaults'] && is_array($search)) {
-            $accessibleFields = array_combine(array_keys($search), array_fill(0, count($search), true));
-            $entity = $this->patchEntity($entity, $search, ['accessibleFields' => $accessibleFields]);
+            $patchableFields = array_combine(array_keys($search), array_fill(0, count($search), true));
+            $entity = $this->patchEntity($entity, $search, ['patchableFields' => $patchableFields]);
         }
         if ($callback !== null) {
             $entity = $callback($entity) ?: $entity;
@@ -2853,13 +2853,13 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * ```
      *
      * The `fields` option lets remove or restrict input data from ending up in
-     * the entity. If you'd like to relax the entity's default accessible fields,
-     * you can use the `accessibleFields` option:
+     * the entity. If you'd like to relax the entity's default patchable fields,
+     * you can use the `patchableFields` option:
      *
      * ```
      * $article = $this->Articles->newEntity(
      *   $this->request->getData(),
-     *   ['accessibleFields' => ['protected_field' => true]]
+     *   ['patchableFields' => ['protected_field' => true]]
      * );
      * ```
      *
@@ -2953,7 +2953,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      * ```
      * $article = $this->Articles->patchEntity($article, $this->request->getData(), [
      *   'associated' => [
-     *     'Tags' => ['accessibleFields' => ['*' => true]]
+     *     'Tags' => ['patchableFields' => ['*' => true]]
      *   ]
      * ]);
      * ```

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -59,7 +59,7 @@ class EntityTest extends TestCase
     public function testSetMultiplePropertiesNoSetters(): void
     {
         $entity = new Entity();
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
 
         $entity->set(['foo' => 'bar', 'id' => 1], ['asOriginal' => true]);
         $this->assertSame('bar', $entity->foo);
@@ -206,7 +206,7 @@ class EntityTest extends TestCase
                 return ['c', 'd'];
             }
         };
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->set(['name' => 'Jones', 'stuff' => ['a', 'b']]);
         $this->assertSame('Dr. Jones', $entity->name);
         $this->assertEquals(['c', 'd'], $entity->stuff);
@@ -228,7 +228,7 @@ class EntityTest extends TestCase
                 throw new Exception('_setStuff should not have been called');
             }
         };
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
 
         $entity->set('name', 'Jones', ['setter' => false]);
         $this->assertSame('Jones', $entity->name);
@@ -590,7 +590,7 @@ class EntityTest extends TestCase
         $entity = $this->getMockBuilder(Entity::class)
             ->onlyMethods(['set'])
             ->getMock();
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
 
         $entity->expects($this->exactly(2))
             ->method('set')
@@ -988,7 +988,7 @@ class EntityTest extends TestCase
                 return 'Jose';
             }
         };
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
         $expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
         $this->assertEquals($expected, $entity->toArray());
@@ -1056,7 +1056,7 @@ class EntityTest extends TestCase
                 return 'Jose';
             }
         };
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->set(['email' => 'mark@example.com']);
 
         $entity->setVirtual(['name']);
@@ -1284,141 +1284,141 @@ class EntityTest extends TestCase
     }
 
     /**
-     * Tests getAccessible() method
+     * Tests getPatchable() method
      */
-    public function testGetAccessible(): void
+    public function testGetPatchable(): void
     {
         $entity = new Entity();
-        $entity->setAccess('*', false);
-        $entity->setAccess('bar', true);
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('bar', true);
 
-        $accessible = $entity->getAccessible();
+        $patchable = $entity->getPatchable();
         $expected = [
             '*' => false,
             'bar' => true,
         ];
-        $this->assertSame($expected, $accessible);
+        $this->assertSame($expected, $patchable);
     }
 
     /**
-     * Tests isAccessible() and setAccess() methods
+     * Tests isPatchable() and setPatchable() methods
      */
-    public function testIsAccessible(): void
+    public function testIsPatchable(): void
     {
         $entity = new Entity();
-        $entity->setAccess('*', false);
-        $this->assertFalse($entity->isAccessible('foo'));
-        $this->assertFalse($entity->isAccessible('bar'));
+        $entity->setPatchable('*', false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
 
-        $this->assertSame($entity, $entity->setAccess('foo', true));
-        $this->assertTrue($entity->isAccessible('foo'));
-        $this->assertFalse($entity->isAccessible('bar'));
+        $this->assertSame($entity, $entity->setPatchable('foo', true));
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
 
-        $this->assertSame($entity, $entity->setAccess('bar', true));
-        $this->assertTrue($entity->isAccessible('foo'));
-        $this->assertTrue($entity->isAccessible('bar'));
+        $this->assertSame($entity, $entity->setPatchable('bar', true));
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
 
-        $this->assertSame($entity, $entity->setAccess('foo', false));
-        $this->assertFalse($entity->isAccessible('foo'));
-        $this->assertTrue($entity->isAccessible('bar'));
+        $this->assertSame($entity, $entity->setPatchable('foo', false));
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
 
-        $this->assertSame($entity, $entity->setAccess('bar', false));
-        $this->assertFalse($entity->isAccessible('foo'));
-        $this->assertFalse($entity->isAccessible('bar'));
+        $this->assertSame($entity, $entity->setPatchable('bar', false));
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
     }
 
     /**
      * Tests that an array can be used to set
      */
-    public function testAccessibleAsArray(): void
+    public function testPatchableAsArray(): void
     {
         $entity = new Entity();
-        $entity->setAccess(['foo', 'bar', 'baz'], true);
-        $this->assertTrue($entity->isAccessible('foo'));
-        $this->assertTrue($entity->isAccessible('bar'));
-        $this->assertTrue($entity->isAccessible('baz'));
+        $entity->setPatchable(['foo', 'bar', 'baz'], true);
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
 
-        $entity->setAccess('foo', false);
-        $this->assertFalse($entity->isAccessible('foo'));
-        $this->assertTrue($entity->isAccessible('bar'));
-        $this->assertTrue($entity->isAccessible('baz'));
+        $entity->setPatchable('foo', false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
 
-        $entity->setAccess(['foo', 'bar', 'baz'], false);
-        $this->assertFalse($entity->isAccessible('foo'));
-        $this->assertFalse($entity->isAccessible('bar'));
-        $this->assertFalse($entity->isAccessible('baz'));
+        $entity->setPatchable(['foo', 'bar', 'baz'], false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+        $this->assertFalse($entity->isPatchable('baz'));
     }
 
     /**
-     * Tests that a wildcard can be used for setting accessible properties
+     * Tests that a wildcard can be used for setting patchable properties
      */
-    public function testAccessibleWildcard(): void
+    public function testPatchableWildcard(): void
     {
         $entity = new Entity();
-        $entity->setAccess(['foo', 'bar', 'baz'], true);
-        $this->assertTrue($entity->isAccessible('foo'));
-        $this->assertTrue($entity->isAccessible('bar'));
-        $this->assertTrue($entity->isAccessible('baz'));
+        $entity->setPatchable(['foo', 'bar', 'baz'], true);
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
 
-        $entity->setAccess('*', false);
-        $this->assertFalse($entity->isAccessible('foo'));
-        $this->assertFalse($entity->isAccessible('bar'));
-        $this->assertFalse($entity->isAccessible('baz'));
-        $this->assertFalse($entity->isAccessible('newOne'));
+        $entity->setPatchable('*', false);
+        $this->assertFalse($entity->isPatchable('foo'));
+        $this->assertFalse($entity->isPatchable('bar'));
+        $this->assertFalse($entity->isPatchable('baz'));
+        $this->assertFalse($entity->isPatchable('newOne'));
 
-        $entity->setAccess('*', true);
-        $this->assertTrue($entity->isAccessible('foo'));
-        $this->assertTrue($entity->isAccessible('bar'));
-        $this->assertTrue($entity->isAccessible('baz'));
-        $this->assertTrue($entity->isAccessible('newOne2'));
+        $entity->setPatchable('*', true);
+        $this->assertTrue($entity->isPatchable('foo'));
+        $this->assertTrue($entity->isPatchable('bar'));
+        $this->assertTrue($entity->isPatchable('baz'));
+        $this->assertTrue($entity->isPatchable('newOne2'));
     }
 
     /**
-     * Tests that only accessible properties can be set
+     * Tests that only patchable properties can be set
      */
-    public function testSetWithAccessible(): void
+    public function testSetWithPatchable(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
         $options = ['guard' => true];
-        $entity->setAccess('*', false);
-        $entity->setAccess('foo', true);
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('foo', true);
         $entity->set('bar', 3, $options);
         $entity->set('foo', 4, $options);
         $this->assertSame(2, $entity->get('bar'));
         $this->assertSame(4, $entity->get('foo'));
 
-        $entity->setAccess('bar', true);
+        $entity->setPatchable('bar', true);
         $entity->set('bar', 3, $options);
         $this->assertSame(3, $entity->get('bar'));
     }
 
     /**
-     * Tests that only accessible properties can be set
+     * Tests that only patchable properties can be set
      */
-    public function testSetWithAccessibleWithArray(): void
+    public function testSetWithPatchableWithArray(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
         $options = ['guard' => true];
-        $entity->setAccess('*', false);
-        $entity->setAccess('foo', true);
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('foo', true);
         $entity->set(['bar' => 3, 'foo' => 4], $options);
         $this->assertSame(2, $entity->get('bar'));
         $this->assertSame(4, $entity->get('foo'));
 
-        $entity->setAccess('bar', true);
+        $entity->setPatchable('bar', true);
         $entity->set(['bar' => 3, 'foo' => 5], $options);
         $this->assertSame(3, $entity->get('bar'));
         $this->assertSame(5, $entity->get('foo'));
     }
 
     /**
-     * Test that accessible() and single property setting works.
+     * Test that patchable() and single property setting works.
      */
-    public function testSetWithAccessibleSingleProperty(): void
+    public function testSetWithPatchableSingleProperty(): void
     {
         $entity = new Entity(['foo' => 1, 'bar' => 2]);
-        $entity->setAccess('*', false);
-        $entity->setAccess('title', true);
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('title', true);
 
         $entity->set(['title' => 'test', 'body' => 'Nope']);
         $this->assertSame('test', $entity->title);
@@ -1447,8 +1447,8 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(['foo' => 'bar'], ['markClean' => true]);
         $entity->somethingElse = 'value';
-        $entity->setAccess('id', false);
-        $entity->setAccess('name', true);
+        $entity->setPatchable('id', false);
+        $entity->setPatchable('name', true);
         $entity->setVirtual(['baz']);
         $entity->setDirty('foo', true);
         $entity->setError('foo', ['An error']);
@@ -1460,7 +1460,7 @@ class EntityTest extends TestCase
             'somethingElse' => 'value',
             'baz' => null,
             '[new]' => true,
-            '[accessible]' => ['*' => true, 'id' => false, 'name' => true],
+            '[patchable]' => ['*' => true, 'id' => false, 'name' => true],
             '[dirty]' => ['somethingElse' => true, 'foo' => true],
             '[original]' => [],
             '[originalFields]' => ['foo'],

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -272,7 +272,7 @@ class MarshallerTest extends TestCase
     /**
      * Test one() follows mass-assignment rules.
      */
-    public function testOneAccessibleProperties(): void
+    public function testOnePatchableProperties(): void
     {
         $data = [
             'title' => 'My title',
@@ -290,9 +290,9 @@ class MarshallerTest extends TestCase
     }
 
     /**
-     * Test one() supports accessibleFields option
+     * Test one() supports patchableFields option
      */
-    public function testOneAccessibleFieldsOption(): void
+    public function testOnePatchableFieldsOption(): void
     {
         $data = [
             'title' => 'My title',
@@ -304,14 +304,14 @@ class MarshallerTest extends TestCase
 
         $marshall = new Marshaller($this->articles);
 
-        $result = $marshall->one($data, ['accessibleFields' => ['body' => false]]);
+        $result = $marshall->one($data, ['patchableFields' => ['body' => false]]);
         $this->assertNull($result->body);
 
-        $result = $marshall->one($data, ['accessibleFields' => ['author_id' => true]]);
+        $result = $marshall->one($data, ['patchableFields' => ['author_id' => true]]);
         $this->assertSame($data['author_id'], $result->author_id);
         $this->assertNull($result->not_in_schema);
 
-        $result = $marshall->one($data, ['accessibleFields' => ['*' => true]]);
+        $result = $marshall->one($data, ['patchableFields' => ['*' => true]]);
         $this->assertSame($data['author_id'], $result->author_id);
         $this->assertTrue($result->not_in_schema);
     }
@@ -370,7 +370,7 @@ class MarshallerTest extends TestCase
             'username' => 'Jenny',
         ]);
         // Make the entity think it is new.
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
         $entity = $marshall->merge($entity, $data, ['associated' => ['Articles']]);
         $this->assertTrue($entity->isDirty('username'));
@@ -378,9 +378,9 @@ class MarshallerTest extends TestCase
     }
 
     /**
-     * Test one() supports accessibleFields option for associations
+     * Test one() supports patchableFields option for associations
      */
-    public function testOneAccessibleFieldsOptionForAssociations(): void
+    public function testOnePatchableFieldsOptionForAssociations(): void
     {
         $data = [
             'title' => 'My title',
@@ -397,9 +397,9 @@ class MarshallerTest extends TestCase
 
         $result = $marshall->one($data, [
             'associated' => [
-                'Users' => ['accessibleFields' => ['id' => true]],
+                'Users' => ['patchableFields' => ['id' => true]],
             ],
-            'accessibleFields' => ['body' => false, 'user' => true],
+            'patchableFields' => ['body' => false, 'user' => true],
         ]);
         $this->assertNull($result->body);
         $this->assertNull($result->user->username);
@@ -1295,7 +1295,7 @@ class MarshallerTest extends TestCase
             'title' => 'Foo',
             'body' => 'My Content',
         ]);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->setNew(false);
         $entity->clean();
         $result = $marshall->merge($entity, $data, []);
@@ -1307,9 +1307,9 @@ class MarshallerTest extends TestCase
     }
 
     /**
-     * Test merge() with accessibleFields options
+     * Test merge() with patchableFields options
      */
-    public function testMergeAccessibleFields(): void
+    public function testMergePatchableFields(): void
     {
         $data = [
             'title' => 'My title',
@@ -1322,14 +1322,14 @@ class MarshallerTest extends TestCase
             'title' => 'Foo',
             'body' => 'My Content',
         ]);
-        $entity->setAccess('*', false);
+        $entity->setPatchable('*', false);
         $entity->setNew(false);
         $entity->clean();
-        $result = $marshall->merge($entity, $data, ['accessibleFields' => ['body' => true]]);
+        $result = $marshall->merge($entity, $data, ['patchableFields' => ['body' => true]]);
 
         $this->assertSame($entity, $result);
         $this->assertEquals(['title' => 'Foo', 'body' => 'New content'], $result->toArray());
-        $this->assertTrue($entity->isAccessible('body'));
+        $this->assertTrue($entity->isPatchable('body'));
     }
 
     /**
@@ -1355,7 +1355,7 @@ class MarshallerTest extends TestCase
     {
         $marshall = new Marshaller($this->articles);
         $entity = new Entity();
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         $entity = $marshall->merge($entity, ['author_id' => $value]);
@@ -1378,7 +1378,7 @@ class MarshallerTest extends TestCase
             'title' => 'Foo',
             'body' => null,
         ]);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->setNew(false);
         $entity->clean();
         $marshall->merge($entity, $data, []);
@@ -1396,7 +1396,7 @@ class MarshallerTest extends TestCase
             'comment' => 'foo',
             'created' => $created,
         ]);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->setNew(false);
         $entity->clean();
 
@@ -1411,7 +1411,7 @@ class MarshallerTest extends TestCase
     }
 
     /**
-     * Tests that merge respects the entity accessible methods
+     * Tests that merge respects the entity patchable methods
      */
     public function testMergeWhitelist(): void
     {
@@ -1425,8 +1425,8 @@ class MarshallerTest extends TestCase
             'title' => 'Foo',
             'body' => 'My Content',
         ]);
-        $entity->setAccess('*', false);
-        $entity->setAccess('author_id', true);
+        $entity->setPatchable('*', false);
+        $entity->setPatchable('author_id', true);
         $entity->setNew(false);
         $entity->clean();
 
@@ -1479,8 +1479,8 @@ class MarshallerTest extends TestCase
            'user' => $user,
         ]);
 
-        $user->setAccess('*', true);
-        $article->setAccess('*', true);
+        $user->setPatchable('*', true);
+        $article->setPatchable('*', true);
 
         $data = [
             'title' => 'Chelsea',
@@ -1513,7 +1513,7 @@ class MarshallerTest extends TestCase
             'author_id' => 1,
             'crazy' => true,
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
         $result = $marshall->merge($entity, $data, []);
 
@@ -1541,8 +1541,8 @@ class MarshallerTest extends TestCase
             'title' => 'My Title',
             'user' => $user,
         ]);
-        $user->setAccess('*', true);
-        $entity->setAccess('*', true);
+        $user->setPatchable('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         $data = [
@@ -1571,7 +1571,7 @@ class MarshallerTest extends TestCase
         $entity = new Entity([
             'title' => 'My Title',
         ]);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         $data = [
@@ -1608,8 +1608,8 @@ class MarshallerTest extends TestCase
            'user' => $user,
         ]);
 
-        $user->setAccess('*', true);
-        $article->setAccess('*', true);
+        $user->setPatchable('*', true);
+        $article->setPatchable('*', true);
 
         $data = [
             'title' => 'Chelsea',
@@ -1640,10 +1640,10 @@ class MarshallerTest extends TestCase
             'comments' => [$comment1, $comment2],
         ]);
 
-        $user->setAccess('*', true);
-        $comment1->setAccess('*', true);
-        $comment2->setAccess('*', true);
-        $entity->setAccess('*', true);
+        $user->setPatchable('*', true);
+        $comment1->setPatchable('*', true);
+        $comment2->setPatchable('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         $data = [
@@ -1770,7 +1770,7 @@ class MarshallerTest extends TestCase
             'title' => 'Haz moar tags',
             'tags' => ['_ids' => [1, 2, 3]],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         $marshall = new Marshaller($this->articles);
@@ -1802,7 +1802,7 @@ class MarshallerTest extends TestCase
             'title' => 'Haz moar tags',
             'tags' => ['_ids' => [1, 2, 3]],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         // Adding a forced join to have another table with the same column names
@@ -1839,7 +1839,7 @@ class MarshallerTest extends TestCase
             'title' => 'Haz moar tags',
             'tags' => ['_ids' => [1, 2, 3]],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->clean();
 
         $marshall = new Marshaller($this->articles);
@@ -1882,7 +1882,7 @@ class MarshallerTest extends TestCase
                 ['id' => 2],
             ],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $marshall = new Marshaller($this->articles);
         $result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
 
@@ -1911,7 +1911,7 @@ class MarshallerTest extends TestCase
             'title' => 'Haz moar tags',
             'tags' => ['_ids' => ''],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $marshall = new Marshaller($this->articles);
         $result = $marshall->merge($entity, $data, ['associated' => ['Tags']]);
         $this->assertCount(0, $result->tags);
@@ -1953,7 +1953,7 @@ class MarshallerTest extends TestCase
                 ['name' => 'awesome'],
             ],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $marshall = new Marshaller($this->articles);
         $result = $marshall->merge($entity, $data, [
             'associated' => ['Tags' => ['onlyIds' => true]],
@@ -1982,7 +1982,7 @@ class MarshallerTest extends TestCase
                 '_ids' => [3],
             ],
         ];
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $marshall = new Marshaller($this->articles);
         $result = $marshall->merge($entity, $data, [
             'associated' => ['Tags' => ['ids' => true]],
@@ -2020,9 +2020,9 @@ class MarshallerTest extends TestCase
 
     /**
      * Test merging the _joinData entity for belongstomany associations when * is not
-     * accessible.
+     * patchable.
      */
-    public function testMergeBelongsToManyJoinDataNotAccessible(): void
+    public function testMergeBelongsToManyJoinDataNotPatchable(): void
     {
         $this->getTableLocator()->clear();
         $articles = $this->getTableLocator()->get('Articles');
@@ -2031,9 +2031,9 @@ class MarshallerTest extends TestCase
         ]);
 
         $entity = $articles->get(1, ...['contain' => 'Tags']);
-        // Make only specific fields accessible, but not _joinData.
-        $entity->tags[0]->setAccess('*', false);
-        $entity->tags[0]->setAccess(['article_id', 'tag_id'], true);
+        // Make only specific fields patchable, but not _joinData.
+        $entity->tags[0]->setPatchable('*', false);
+        $entity->tags[0]->setPatchable(['article_id', 'tag_id'], true);
 
         $data = [
             'title' => 'Haz data',
@@ -2243,7 +2243,7 @@ class MarshallerTest extends TestCase
         $options = ['associated' => ['Tags._joinData']];
         $marshall = new Marshaller($this->articles);
         $entity = $marshall->one($data, $options);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
 
         $data = [
             'title' => 'Haz data',
@@ -2307,7 +2307,7 @@ class MarshallerTest extends TestCase
         $options = ['associated' => ['Tags._joinData.Users']];
         $marshall = new Marshaller($this->articles);
         $entity = $marshall->one($data, $options);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
 
         $data = [
             'title' => 'Haz data',
@@ -2352,7 +2352,7 @@ class MarshallerTest extends TestCase
     public function testMergeBelongsToManyIdsRetainJoinData(): void
     {
         $entity = $this->articles->get(1, ...['contain' => ['Tags']]);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $original = $entity->tags[0]->_joinData;
 
         $this->assertInstanceOf(Entity::class, $entity->tags[0]->_joinData);
@@ -2631,7 +2631,7 @@ class MarshallerTest extends TestCase
             'body' => 'My content',
             'author_id' => 2,
         ]);
-        $entity->setAccess('*', false);
+        $entity->setPatchable('*', false);
         $entity->setNew(false);
         $entity->clean();
         $result = $marshall->merge($entity, $data, ['fields' => ['title', 'body']]);
@@ -2644,7 +2644,7 @@ class MarshallerTest extends TestCase
 
         $this->assertSame($entity, $result);
         $this->assertEquals($expected, $result->toArray());
-        $this->assertFalse($entity->isAccessible('*'));
+        $this->assertFalse($entity->isPatchable('*'));
     }
 
     /**
@@ -2739,8 +2739,8 @@ class MarshallerTest extends TestCase
             'tile' => 'My Title',
             'user' => $user,
         ]);
-        $user->setAccess('*', true);
-        $entity->setAccess('*', true);
+        $user->setPatchable('*', true);
+        $entity->setPatchable('*', true);
 
         $data = [
             'body' => 'My Content',
@@ -2852,7 +2852,7 @@ class MarshallerTest extends TestCase
         $options = ['associated' => ['Tags' => ['associated' => ['_joinData']]]];
         $marshall = new Marshaller($this->articles);
         $entity = $marshall->one($data, $options);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
 
         $data = [
             'title' => 'Haz data',
@@ -3011,7 +3011,7 @@ class MarshallerTest extends TestCase
         ]);
         $this->assertEmpty($entity->getInvalid());
 
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->setNew(false);
         $entity->clean();
 
@@ -3051,7 +3051,7 @@ class MarshallerTest extends TestCase
             'body' => 'My Content',
             'author_id' => 1,
         ]);
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->setNew(true);
         $entity->clean();
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2751,7 +2751,7 @@ class TableTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $entity = $table->get(1);
 
-        $entity->setAccess('*', true);
+        $entity->setPatchable('*', true);
         $entity->set($entity->toArray());
         $this->assertSame($entity, $table->save($entity));
     }
@@ -5662,7 +5662,7 @@ class TableTest extends TestCase
     /**
      * Test that findOrCreate allows patching of all $search keys
      */
-    public function testFindOrCreateAccessibleFields(): void
+    public function testFindOrCreatePatchableFields(): void
     {
         $articles = $this->getTableLocator()->get('Articles');
         $articles->setEntityClass(ProtectedEntity::class);

--- a/tests/test_app/TestApp/Model/Entity/OpenArticleEntity.php
+++ b/tests/test_app/TestApp/Model/Entity/OpenArticleEntity.php
@@ -10,7 +10,7 @@ use Cake\ORM\Entity;
  */
 class OpenArticleEntity extends Entity
 {
-    protected array $_accessible = [
+    protected array $patchable = [
         '*' => true,
     ];
 }

--- a/tests/test_app/TestApp/Model/Entity/OpenTag.php
+++ b/tests/test_app/TestApp/Model/Entity/OpenTag.php
@@ -10,7 +10,7 @@ use Cake\ORM\Entity;
  */
 class OpenTag extends Entity
 {
-    protected array $_accessible = [
+    protected array $patchable = [
         'tag' => true,
     ];
 }

--- a/tests/test_app/TestApp/Model/Entity/ProtectedArticle.php
+++ b/tests/test_app/TestApp/Model/Entity/ProtectedArticle.php
@@ -10,7 +10,7 @@ use Cake\ORM\Entity;
  */
 class ProtectedArticle extends Entity
 {
-    protected array $_accessible = [
+    protected array $patchable = [
         'title' => true,
         'body' => true,
     ];

--- a/tests/test_app/TestApp/Model/Entity/ProtectedEntity.php
+++ b/tests/test_app/TestApp/Model/Entity/ProtectedEntity.php
@@ -7,7 +7,7 @@ use Cake\ORM\Entity;
 
 class ProtectedEntity extends Entity
 {
-    protected array $_accessible = [
+    protected array $patchable = [
         'id' => true,
         'title' => false,
     ];

--- a/tests/test_app/TestApp/Model/Entity/Session.php
+++ b/tests/test_app/TestApp/Model/Entity/Session.php
@@ -10,7 +10,7 @@ use Cake\ORM\Entity;
  */
 class Session extends Entity
 {
-    protected array $_accessible = [
+    protected array $patchable = [
         'id' => false,
         '*' => true,
     ];

--- a/tests/test_app/TestApp/Model/Entity/TranslateBakedArticle.php
+++ b/tests/test_app/TestApp/Model/Entity/TranslateBakedArticle.php
@@ -10,7 +10,7 @@ class TranslateBakedArticle extends Entity
 {
     use TranslateTrait;
 
-    protected array $_accessible = [
+    protected array $patchable = [
         'title' => true,
         'body' => true,
     ];


### PR DESCRIPTION
Resolves #17375 

The following Rector configs need to be created to help users upgrade to this new name:

* Rename EntityInterface methods
  - `setAccess` => `setPatchable`
  - `getAccessible` => `getPatchable`
  - `isAccessible` => `isPatchable`
* Rename EntityTrait property `_accessible` => `patchable`
* Rename Marshaller/ORM method option `accessibleFields` => `patchableFields`