### PR TITLE
Fix up 5xx to 4xx for externally invoked bad URLs.

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1348,7 +1348,7 @@ class View implements EventDispatcherInterface
         $name ??= $this->template;
 
         if (!$name) {
-            throw new CakeException('Template name not provided');
+            throw new MissingTemplateException('');
         }
 
         [$plugin, $name] = $this->pluginSplit($name);

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1140,7 +1140,7 @@ class ViewTest extends TestCase
     public function testGetTemplateException(): void
     {
         $this->expectException(CakeException::class);
-        $this->expectExceptionMessage('Template name not provided');
+        $this->expectExceptionMessage('Template file `` could not be found.');
         $view = new View();
         $view->render();
     }


### PR DESCRIPTION
I am separating logs by code (4xx vs 5xx) so I get alerted only about internal errors

But
```
domain.example/+
```
and alike are triggering internal errors due to
```php
        if (!$name) {
            throw new CakeException('Template name not provided');
        }
```
So my 5xx logs are filling up and reporting those externally triggered URL issues.

I wonder if we can rename this to a 4xx exception here instead of 5xx one?