### PR TITLE
Warn about non applied pagination config

### DIFF
--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -274,6 +274,11 @@ class NumericPaginator implements PaginatorInterface
             }
 
             $query = $object->find($type, ...$args);
+        } elseif (!empty($options['finder'])) {
+            triggerWarning(sprintf(
+                'Custom finder `%s` from pagination config cannot be applied to a custom build query object',
+                $options['finder'],
+            ));
         }
 
         $query->applyOptions($queryOptions);

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -276,7 +276,8 @@ class NumericPaginator implements PaginatorInterface
             $query = $object->find($type, ...$args);
         } elseif (!empty($options['finder'])) {
             triggerWarning(sprintf(
-                'Finder option (`%s`) from pagination config is not applied when a `SelectQuery` instance is passed to `paginate()`',
+                'Finder option (`%s`) from pagination config is not applied'
+                        . ' when a `SelectQuery` instance is passed to `paginate()`',
                 $options['finder'],
             ));
         }

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -276,7 +276,7 @@ class NumericPaginator implements PaginatorInterface
             $query = $object->find($type, ...$args);
         } elseif (!empty($options['finder'])) {
             triggerWarning(sprintf(
-                'Custom finder `%s` from pagination config cannot be applied to a custom build query object',
+                'Finder option (`%s`) from pagination config is not applied when a `SelectQuery` instance is passed to `paginate()`',
                 $options['finder'],
             ));
         }


### PR DESCRIPTION
Refs https://github.com/cakephp/docs/pull/7968

    protected array $paginate = [
        'finder' => 'foo',

would be working for

    $banks = $this->paginate('Banks');

but not for

    $query = $this->Banks->find();
    $banks = $this->paginate($query);

and that without any hint/notice.
Only debugging it very deeply into the paginator code you find out why.

So if you refactor your code to modern 5.1 (baked) code you can lose this filter without any clue that it happened.

I suggest the following warning or error or alike:

> Custom finder `foo` from pagination config cannot be applied to a custom build query object - /shared/httpd/app/vendor/cakephp/cakephp/src/Datasource/Paging/NumericPaginator.php, line: 223

Maybe we can rephrase it to `to a manually built SelectQuery object` ?