### PR TITLE
Fix CS as per trailing comma rules.

### DIFF
--- a/src/Collection/CollectionInterface.php
+++ b/src/Collection/CollectionInterface.php
@@ -398,7 +398,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
     public function sortBy(
         callable|string $path,
         int $order = SORT_DESC,
-        int $sort = SORT_NUMERIC
+        int $sort = SORT_NUMERIC,
     ): CollectionInterface;
 
     /**
@@ -737,7 +737,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
     public function combine(
         callable|string $keyPath,
         callable|string $valuePath,
-        callable|string|null $groupPath = null
+        callable|string|null $groupPath = null,
     ): CollectionInterface;
 
     /**
@@ -754,7 +754,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
     public function nest(
         callable|string $idPath,
         callable|string $parentPath,
-        string $nestingKey = 'children'
+        string $nestingKey = 'children',
     ): CollectionInterface;
 
     /**
@@ -920,7 +920,7 @@ interface CollectionInterface extends Iterator, JsonSerializable, Countable
      */
     public function listNested(
         string|int $order = 'desc',
-        callable|string $nestingKey = 'children'
+        callable|string $nestingKey = 'children',
     ): CollectionInterface;
 
     /**

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -640,7 +640,7 @@ trait CollectionTrait
     public function combine(
         callable|string $keyPath,
         callable|string $valuePath,
-        callable|string|null $groupPath = null
+        callable|string|null $groupPath = null,
     ): CollectionInterface {
         $options = [
             'keyPath' => $this->_propertyExtractor($keyPath),
@@ -711,7 +711,7 @@ trait CollectionTrait
     public function nest(
         callable|string $idPath,
         callable|string $parentPath,
-        string $nestingKey = 'children'
+        string $nestingKey = 'children',
     ): CollectionInterface {
         $parents = [];
         $idPath = $this->_propertyExtractor($idPath);
@@ -835,7 +835,7 @@ trait CollectionTrait
      */
     public function listNested(
         string|int $order = 'desc',
-        callable|string $nestingKey = 'children'
+        callable|string $nestingKey = 'children',
     ): CollectionInterface {
         if (is_string($order)) {
             $order = strtolower($order);

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -67,7 +67,7 @@ class SortIterator extends Collection
         iterable $items,
         callable|string $callback,
         int $dir = SORT_DESC,
-        int $type = SORT_NUMERIC
+        int $type = SORT_NUMERIC,
     ) {
         if (!is_array($items)) {
             $items = iterator_to_array((new Collection($items))->unwrap(), false);

--- a/src/Collection/Iterator/TreeIterator.php
+++ b/src/Collection/Iterator/TreeIterator.php
@@ -48,7 +48,7 @@ class TreeIterator extends RecursiveIteratorIterator implements CollectionInterf
     public function __construct(
         RecursiveIterator $items,
         int $mode = RecursiveIteratorIterator::SELF_FIRST,
-        int $flags = 0
+        int $flags = 0,
     ) {
         parent::__construct($items, $mode, $flags);
         $this->_mode = $mode;
@@ -95,7 +95,7 @@ class TreeIterator extends RecursiveIteratorIterator implements CollectionInterf
     public function printer(
         callable|string $valuePath,
         callable|string|null $keyPath = null,
-        string $spacer = '__'
+        string $spacer = '__',
     ): TreePrinter {
         if (!$keyPath) {
             $counter = 0;

--- a/src/Collection/Iterator/TreePrinter.php
+++ b/src/Collection/Iterator/TreePrinter.php
@@ -76,7 +76,7 @@ class TreePrinter extends RecursiveIteratorIterator implements CollectionInterfa
         callable|string $valuePath,
         callable|string $keyPath,
         string $spacer,
-        int $mode = RecursiveIteratorIterator::SELF_FIRST
+        int $mode = RecursiveIteratorIterator::SELF_FIRST,
     ) {
         parent::__construct($items, $mode);
         $this->_value = $this->_propertyExtractor($valuePath);

--- a/src/Console/CommandRunner.php
+++ b/src/Console/CommandRunner.php
@@ -86,7 +86,7 @@ class CommandRunner implements EventDispatcherInterface
     public function __construct(
         ConsoleApplicationInterface $app,
         string $root = 'cake',
-        ?CommandFactoryInterface $factory = null
+        ?CommandFactoryInterface $factory = null,
     ) {
         $this->app = $app;
         $this->root = $root;

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -76,7 +76,7 @@ class ConsoleInputArgument
         string $help = '',
         bool $required = false,
         array $choices = [],
-        ?string $default = null
+        ?string $default = null,
     ) {
         if (is_array($name) && isset($name['name'])) {
             foreach ($name as $key => $value) {

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -113,7 +113,7 @@ class ConsoleInputOption
         array $choices = [],
         bool $multiple = false,
         bool $required = false,
-        ?string $prompt = null
+        ?string $prompt = null,
     ) {
         $this->_name = $name;
         $this->_short = $short;

--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -119,7 +119,7 @@ class ConsoleIo
         ?ConsoleOutput $out = null,
         ?ConsoleOutput $err = null,
         ?ConsoleInput $in = null,
-        ?HelperRegistry $helpers = null
+        ?HelperRegistry $helpers = null,
     ) {
         $this->_out = $out ?: new ConsoleOutput('php://stdout');
         $this->_err = $err ?: new ConsoleOutput('php://stderr');

--- a/src/Console/Exception/MissingOptionException.php
+++ b/src/Console/Exception/MissingOptionException.php
@@ -50,7 +50,7 @@ class MissingOptionException extends ConsoleException
         string $requested = '',
         array $suggestions = [],
         ?int $code = null,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         $this->suggestions = $suggestions;
         $this->requested = $requested;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -862,7 +862,7 @@ class Controller implements EventListenerInterface, EventDispatcherInterface
      */
     public function paginate(
         RepositoryInterface|QueryInterface|string|null $object = null,
-        array $settings = []
+        array $settings = [],
     ): PaginatedInterface {
         if (!is_object($object)) {
             $object = $this->fetchTable($object);

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -301,7 +301,7 @@ class Connection implements ConnectionInterface
     public function selectQuery(
         ExpressionInterface|Closure|array|string|float|int $fields = [],
         array|string $table = [],
-        array $types = []
+        array $types = [],
     ): SelectQuery {
         return $this->queryFactory()->select($fields, $table, $types);
     }
@@ -332,7 +332,7 @@ class Connection implements ConnectionInterface
         ExpressionInterface|string|null $table = null,
         array $values = [],
         array $conditions = [],
-        array $types = []
+        array $types = [],
     ): UpdateQuery {
         return $this->queryFactory()->update($table, $values, $conditions, $types);
     }

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -370,7 +370,7 @@ abstract class Driver
     protected function createQueryException(
         PDOException $exception,
         StatementInterface $statement,
-        ?array $params = null
+        ?array $params = null,
     ): QueryException {
         $loggedQuery = new LoggedQuery();
         $loggedQuery->setContext([

--- a/src/Database/Expression/AggregateExpression.php
+++ b/src/Database/Expression/AggregateExpression.php
@@ -143,7 +143,7 @@ class AggregateExpression extends FunctionExpression implements WindowInterface
         ExpressionInterface|string|int|null $startOffset,
         string $startDirection,
         ExpressionInterface|string|int|null $endOffset,
-        string $endDirection
+        string $endDirection,
     ) {
         $this->getWindow()->frame($type, $startOffset, $startDirection, $endOffset, $endDirection);
 

--- a/src/Database/Expression/ComparisonExpression.php
+++ b/src/Database/Expression/ComparisonExpression.php
@@ -80,7 +80,7 @@ class ComparisonExpression implements ExpressionInterface, FieldInterface
         ExpressionInterface|string $field,
         mixed $value,
         ?string $type = null,
-        string $operator = '='
+        string $operator = '=',
     ) {
         $this->_type = $type;
         $this->setField($field);

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -36,7 +36,7 @@ class OrderByExpression extends QueryExpression
     public function __construct(
         ExpressionInterface|array|string $conditions = [],
         TypeMap|array $types = [],
-        string $conjunction = ''
+        string $conjunction = '',
     ) {
         parent::__construct($conditions, $types, $conjunction);
     }

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -68,7 +68,7 @@ class QueryExpression implements ExpressionInterface, Countable
     public function __construct(
         ExpressionInterface|array|string $conditions = [],
         TypeMap|array $types = [],
-        string $conjunction = 'AND'
+        string $conjunction = 'AND',
     ) {
         $this->setTypeMap($types);
         $this->setConjunction(strtoupper($conjunction));
@@ -301,7 +301,7 @@ class QueryExpression implements ExpressionInterface, Countable
     public function in(
         ExpressionInterface|string $field,
         ExpressionInterface|array|string $values,
-        ?string $type = null
+        ?string $type = null,
     ) {
         $type ??= $this->_calculateType($field);
         $type = $type ?: 'string';
@@ -355,7 +355,7 @@ class QueryExpression implements ExpressionInterface, Countable
     public function notIn(
         ExpressionInterface|string $field,
         ExpressionInterface|array|string $values,
-        ?string $type = null
+        ?string $type = null,
     ) {
         $type ??= $this->_calculateType($field);
         $type = $type ?: 'string';
@@ -377,7 +377,7 @@ class QueryExpression implements ExpressionInterface, Countable
     public function notInOrNull(
         ExpressionInterface|string $field,
         ExpressionInterface|array|string $values,
-        ?string $type = null
+        ?string $type = null,
     ) {
         $or = new static([], [], 'OR');
         $or

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -48,7 +48,7 @@ class TupleComparison extends ComparisonExpression
         ExpressionInterface|array|string $fields,
         ExpressionInterface|array $values,
         array $types = [],
-        string $conjunction = '='
+        string $conjunction = '=',
     ) {
         $this->types = $types;
         $this->setField($fields);

--- a/src/Database/Expression/WindowExpression.php
+++ b/src/Database/Expression/WindowExpression.php
@@ -172,7 +172,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
         ExpressionInterface|string|int|null $startOffset,
         string $startDirection,
         ExpressionInterface|string|int|null $endOffset,
-        string $endDirection
+        string $endDirection,
     ) {
         $this->frame = [
             'type' => $type,
@@ -309,7 +309,7 @@ class WindowExpression implements ExpressionInterface, WindowInterface
     protected function buildOffsetSql(
         ValueBinder $binder,
         ExpressionInterface|string|int|null $offset,
-        string $direction
+        string $direction,
     ): string {
         if ($offset === 0) {
             return 'CURRENT ROW';

--- a/src/Database/Expression/WindowInterface.php
+++ b/src/Database/Expression/WindowInterface.php
@@ -149,7 +149,7 @@ interface WindowInterface
         ExpressionInterface|string|int|null $startOffset,
         string $startDirection,
         ExpressionInterface|string|int|null $endOffset,
-        string $endDirection
+        string $endDirection,
     );
 
     /**

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -167,7 +167,7 @@ class FunctionsBuilder
     public function datePart(
         string $part,
         ExpressionInterface|string $expression,
-        array $types = []
+        array $types = [],
     ): FunctionExpression {
         return $this->extract($part, $expression, $types);
     }
@@ -200,7 +200,7 @@ class FunctionsBuilder
         ExpressionInterface|string $expression,
         string|int $value,
         string $unit,
-        array $types = []
+        array $types = [],
     ): FunctionExpression {
         if (!is_numeric($value)) {
             $value = 0;
@@ -278,7 +278,7 @@ class FunctionsBuilder
         ExpressionInterface|string $expression,
         int $offset,
         mixed $default = null,
-        ?string $type = null
+        ?string $type = null,
     ): AggregateExpression {
         $params = $this->toLiteralParam($expression) + [$offset => 'literal'];
         if ($default !== null) {
@@ -306,7 +306,7 @@ class FunctionsBuilder
         ExpressionInterface|string $expression,
         int $offset,
         mixed $default = null,
-        ?string $type = null
+        ?string $type = null,
     ): AggregateExpression {
         $params = $this->toLiteralParam($expression) + [$offset => 'literal'];
         if ($default !== null) {
@@ -332,7 +332,7 @@ class FunctionsBuilder
     public function jsonValue(
         ExpressionInterface|string $expression,
         string $jsonPath,
-        array $types = []
+        array $types = [],
     ): FunctionExpression {
         $params = $this->toLiteralParam($expression) + [$jsonPath];
 
@@ -355,7 +355,7 @@ class FunctionsBuilder
         string $name,
         array $params = [],
         array $types = [],
-        string $return = 'float'
+        string $return = 'float',
     ): AggregateExpression {
         return new AggregateExpression($name, $params, $types, $return);
     }

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -40,7 +40,7 @@ class IdentifierQuoter
      */
     public function __construct(
         protected string $startQuote,
-        protected string $endQuote
+        protected string $endQuote,
     ) {
     }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -667,7 +667,7 @@ abstract class Query implements ExpressionInterface, Stringable
     public function leftJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions = [],
-        array $types = []
+        array $types = [],
     ) {
         $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
 
@@ -692,7 +692,7 @@ abstract class Query implements ExpressionInterface, Stringable
     public function rightJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions = [],
-        array $types = []
+        array $types = [],
     ) {
         $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
 
@@ -717,7 +717,7 @@ abstract class Query implements ExpressionInterface, Stringable
     public function innerJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions = [],
-        array $types = []
+        array $types = [],
     ) {
         $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
 
@@ -736,7 +736,7 @@ abstract class Query implements ExpressionInterface, Stringable
     protected function _makeJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions,
-        string $type
+        string $type,
     ): array {
         $alias = $table;
 
@@ -893,7 +893,7 @@ abstract class Query implements ExpressionInterface, Stringable
     public function where(
         ExpressionInterface|Closure|array|string|null $conditions = null,
         array $types = [],
-        bool $overwrite = false
+        bool $overwrite = false,
     ) {
         if ($overwrite) {
             $this->_parts['where'] = $this->newExpr();
@@ -1733,7 +1733,7 @@ abstract class Query implements ExpressionInterface, Stringable
         string $part,
         ExpressionInterface|Closure|array|string|null $append,
         string $conjunction,
-        array $types
+        array $types,
     ): void {
         /** @var \Cake\Database\Expression\QueryExpression $expression */
         $expression = $this->_parts[$part] ?: $this->newExpr();

--- a/src/Database/Query/QueryFactory.php
+++ b/src/Database/Query/QueryFactory.php
@@ -46,7 +46,7 @@ class QueryFactory
     public function select(
         ExpressionInterface|Closure|array|string|float|int $fields = [],
         array|string $table = [],
-        array $types = []
+        array $types = [],
     ): SelectQuery {
         $query = new SelectQuery($this->connection);
 
@@ -97,7 +97,7 @@ class QueryFactory
         ExpressionInterface|string|null $table = null,
         array $values = [],
         array $conditions = [],
-        array $types = []
+        array $types = [],
     ): UpdateQuery {
         $query = new UpdateQuery($this->connection);
 

--- a/src/Database/Query/SelectQuery.php
+++ b/src/Database/Query/SelectQuery.php
@@ -409,7 +409,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function leftJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions = [],
-        array $types = []
+        array $types = [],
     ) {
         $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_LEFT), $types);
 
@@ -434,7 +434,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function rightJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions = [],
-        array $types = []
+        array $types = [],
     ) {
         $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_RIGHT), $types);
 
@@ -459,7 +459,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function innerJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions = [],
-        array $types = []
+        array $types = [],
     ) {
         $this->join($this->_makeJoin($table, $conditions, static::JOIN_TYPE_INNER), $types);
 
@@ -478,7 +478,7 @@ class SelectQuery extends Query implements IteratorAggregate
     protected function _makeJoin(
         array|string $table,
         ExpressionInterface|Closure|array|string $conditions,
-        string $type
+        string $type,
     ): array {
         $alias = $table;
 
@@ -587,7 +587,7 @@ class SelectQuery extends Query implements IteratorAggregate
     public function having(
         ExpressionInterface|Closure|array|string|null $conditions = null,
         array $types = [],
-        bool $overwrite = false
+        bool $overwrite = false,
     ) {
         if ($overwrite) {
             $this->_parts['having'] = $this->newExpr();

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -351,7 +351,7 @@ class QueryCompiler
         string $operation,
         array $parts,
         Query $query,
-        ValueBinder $binder
+        ValueBinder $binder,
     ): string {
         $setOperationsOrderBy = $query
             ->getConnection()

--- a/src/Database/Schema/SchemaDialect.php
+++ b/src/Database/Schema/SchemaDialect.php
@@ -129,7 +129,7 @@ abstract class SchemaDialect
     protected function _getTypeSpecificColumnSql(
         string $columnType,
         TableSchemaInterface $schema,
-        string $column
+        string $column,
     ): ?string {
         if (!TypeFactory::getMap($columnType)) {
             return null;
@@ -283,7 +283,7 @@ abstract class SchemaDialect
         TableSchema $schema,
         array $columns,
         array $constraints,
-        array $indexes
+        array $indexes,
     ): array;
 
     /**

--- a/src/Database/Schema/SqlserverSchemaDialect.php
+++ b/src/Database/Schema/SqlserverSchemaDialect.php
@@ -111,7 +111,7 @@ class SqlserverSchemaDialect extends SchemaDialect
         string $col,
         ?int $length = null,
         ?int $precision = null,
-        ?int $scale = null
+        ?int $scale = null,
     ): array {
         $col = strtolower($col);
 

--- a/src/Database/Type/EnumType.php
+++ b/src/Database/Type/EnumType.php
@@ -53,7 +53,7 @@ class EnumType extends BaseType
      */
     public function __construct(
         string $name,
-        string $enumClassName
+        string $enumClassName,
     ) {
         parent::__construct($name);
         $this->enumClassName = $enumClassName;

--- a/src/Datasource/Paging/NumericPaginator.php
+++ b/src/Datasource/Paging/NumericPaginator.php
@@ -202,7 +202,7 @@ class NumericPaginator implements PaginatorInterface
     public function paginate(
         mixed $target,
         array $params = [],
-        array $settings = []
+        array $settings = [],
     ): PaginatedInterface {
         $query = null;
         if ($target instanceof QueryInterface) {

--- a/src/Datasource/Paging/PaginatorInterface.php
+++ b/src/Datasource/Paging/PaginatorInterface.php
@@ -32,6 +32,6 @@ interface PaginatorInterface
     public function paginate(
         mixed $target,
         array $params = [],
-        array $settings = []
+        array $settings = [],
     ): PaginatedInterface;
 }

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -112,7 +112,7 @@ interface RepositoryInterface
         array|string $finder = 'all',
         CacheInterface|string|null $cache = null,
         Closure|string|null $cacheKey = null,
-        mixed ...$args
+        mixed ...$args,
     ): EntityInterface;
 
     /**

--- a/src/Datasource/RulesAwareTrait.php
+++ b/src/Datasource/RulesAwareTrait.php
@@ -50,7 +50,7 @@ trait RulesAwareTrait
     public function checkRules(
         EntityInterface $entity,
         string $operation = RulesChecker::CREATE,
-        ArrayObject|array|null $options = null
+        ArrayObject|array|null $options = null,
     ): bool {
         $rules = $this->rulesChecker();
         $options = $options ?: new ArrayObject();

--- a/src/Error/ErrorLogger.php
+++ b/src/Error/ErrorLogger.php
@@ -91,7 +91,7 @@ class ErrorLogger implements ErrorLoggerInterface
     public function logException(
         Throwable $exception,
         ?ServerRequestInterface $request = null,
-        bool $includeTrace = false
+        bool $includeTrace = false,
     ): void {
         $message = $this->getMessage($exception, false, $includeTrace);
 

--- a/src/Error/ErrorLoggerInterface.php
+++ b/src/Error/ErrorLoggerInterface.php
@@ -37,7 +37,7 @@ interface ErrorLoggerInterface
     public function logException(
         Throwable $exception,
         ?ServerRequestInterface $request = null,
-        bool $includeTrace = false
+        bool $includeTrace = false,
     ): void;
 
     /**
@@ -51,6 +51,6 @@ interface ErrorLoggerInterface
     public function logError(
         PhpError $error,
         ?ServerRequestInterface $request = null,
-        bool $includeTrace = false
+        bool $includeTrace = false,
     ): void;
 }

--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -112,7 +112,7 @@ class ErrorTrap
         int $code,
         string $description,
         ?string $file = null,
-        ?int $line = null
+        ?int $line = null,
     ): bool {
         if (!(error_reporting() & $code)) {
             return false;

--- a/src/Error/FatalErrorException.php
+++ b/src/Error/FatalErrorException.php
@@ -36,7 +36,7 @@ class FatalErrorException extends CakeException
         ?int $code = null,
         ?string $file = null,
         ?int $line = null,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
         if ($file) {

--- a/src/Error/PhpError.php
+++ b/src/Error/PhpError.php
@@ -92,7 +92,7 @@ class PhpError
         string $message,
         ?string $file = null,
         ?int $line = null,
-        array $trace = []
+        array $trace = [],
     ) {
         if (version_compare(PHP_VERSION, '8.4.0-dev', '<')) {
             $this->levelMap[E_STRICT] = 'strict';

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -101,7 +101,7 @@ class EventManager implements EventManagerInterface
     public function on(
         EventListenerInterface|string $eventKey,
         callable|array $options = [],
-        ?callable $callable = null
+        ?callable $callable = null,
     ) {
         if ($eventKey instanceof EventListenerInterface) {
             $this->_attachSubscriber($eventKey);
@@ -154,7 +154,7 @@ class EventManager implements EventManagerInterface
      */
     public function off(
         EventListenerInterface|callable|string $eventKey,
-        EventListenerInterface|callable|null $callable = null
+        EventListenerInterface|callable|null $callable = null,
     ) {
         if ($eventKey instanceof EventListenerInterface) {
             $this->_detachSubscriber($eventKey);
@@ -236,7 +236,7 @@ class EventManager implements EventManagerInterface
      */
     protected function normalizeHandlers(
         EventListenerInterface $subscriber,
-        callable|array|string $handlers
+        callable|array|string $handlers,
     ): array {
         // Check if an array of handlers not single handler config array
         if (is_array($handlers) && !isset($handlers['callable'])) {
@@ -264,7 +264,7 @@ class EventManager implements EventManagerInterface
      */
     protected function normalizeHandler(
         EventListenerInterface $subscriber,
-        callable|array|string $handler
+        callable|array|string $handler,
     ): array {
         $callable = $handler;
         $settings = [];

--- a/src/Event/EventManagerInterface.php
+++ b/src/Event/EventManagerInterface.php
@@ -60,7 +60,7 @@ interface EventManagerInterface
     public function on(
         EventListenerInterface|string $eventKey,
         callable|array $options = [],
-        ?callable $callable = null
+        ?callable $callable = null,
     );
 
     /**
@@ -97,7 +97,7 @@ interface EventManagerInterface
      */
     public function off(
         EventListenerInterface|callable|string $eventKey,
-        EventListenerInterface|callable|null $callable = null
+        EventListenerInterface|callable|null $callable = null,
     );
 
     /**

--- a/src/Form/FormProtector.php
+++ b/src/Form/FormProtector.php
@@ -502,7 +502,7 @@ class FormProtector
         array $expectedFields = [],
         string $intKeyMessage = '',
         string $stringKeyMessage = '',
-        string $missingMessage = ''
+        string $missingMessage = '',
     ): array {
         $messages = $this->matchExistingFields($dataFields, $expectedFields, $intKeyMessage, $stringKeyMessage);
         $expectedFieldsMessage = $this->debugExpectedFields($expectedFields, $missingMessage);
@@ -528,7 +528,7 @@ class FormProtector
         array $dataFields,
         array &$expectedFields,
         string $intKeyMessage,
-        string $stringKeyMessage
+        string $stringKeyMessage,
     ): array {
         $messages = [];
         foreach ($dataFields as $key => $value) {

--- a/src/Http/BaseApplication.php
+++ b/src/Http/BaseApplication.php
@@ -106,7 +106,7 @@ abstract class BaseApplication implements
     public function __construct(
         string $configDir,
         ?EventManagerInterface $eventManager = null,
-        ?ControllerFactoryInterface $controllerFactory = null
+        ?ControllerFactoryInterface $controllerFactory = null,
     ) {
         $this->configDir = rtrim($configDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         $this->plugins = new PluginCollection();
@@ -341,7 +341,7 @@ abstract class BaseApplication implements
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function handle(
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
     ): ResponseInterface {
         $container = $this->getContainer();
         $container->add(ServerRequest::class, $request);

--- a/src/Http/Client/FormDataPart.php
+++ b/src/Http/Client/FormDataPart.php
@@ -69,7 +69,7 @@ class FormDataPart implements Stringable
         protected string $name,
         protected string $value,
         protected string $disposition = 'form-data',
-        protected ?string $charset = null
+        protected ?string $charset = null,
     ) {
     }
 

--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -45,7 +45,7 @@ class Request extends Message implements RequestInterface
         UriInterface|string $url = '',
         string $method = self::METHOD_GET,
         array $headers = [],
-        array|string|null $data = null
+        array|string|null $data = null,
     ) {
         $this->setMethod($method);
         $this->uri = $this->createUri($url);

--- a/src/Http/Cookie/Cookie.php
+++ b/src/Http/Cookie/Cookie.php
@@ -154,7 +154,7 @@ class Cookie implements CookieInterface
         ?string $domain = null,
         ?bool $secure = null,
         ?bool $httpOnly = null,
-        SameSiteEnum|string|null $sameSite = null
+        SameSiteEnum|string|null $sameSite = null,
     ) {
         $this->validateName($name);
         $this->name = $name;

--- a/src/Http/Middleware/CsrfProtectionMiddleware.php
+++ b/src/Http/Middleware/CsrfProtectionMiddleware.php
@@ -329,7 +329,7 @@ class CsrfProtectionMiddleware implements MiddlewareInterface
     protected function _addTokenCookie(
         string $token,
         ServerRequestInterface $request,
-        ResponseInterface $response
+        ResponseInterface $response,
     ): ResponseInterface {
         $cookie = $this->_createCookie($token, $request);
         if ($response instanceof Response) {

--- a/src/Http/MiddlewareApplication.php
+++ b/src/Http/MiddlewareApplication.php
@@ -49,7 +49,7 @@ abstract class MiddlewareApplication implements HttpApplicationInterface
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function handle(
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
     ): ResponseInterface {
         return new Response(['body' => 'Not found', 'status' => 404]);
     }

--- a/src/Http/Runner.php
+++ b/src/Http/Runner.php
@@ -51,7 +51,7 @@ class Runner implements RequestHandlerInterface
     public function run(
         MiddlewareQueue $queue,
         ServerRequestInterface $request,
-        ?RequestHandlerInterface $fallbackHandler = null
+        ?RequestHandlerInterface $fallbackHandler = null,
     ): ResponseInterface {
         $this->queue = $queue;
         $this->queue->rewind();

--- a/src/Http/Server.php
+++ b/src/Http/Server.php
@@ -80,7 +80,7 @@ class Server implements EventDispatcherInterface
      */
     public function run(
         ?ServerRequestInterface $request = null,
-        ?MiddlewareQueue $middlewareQueue = null
+        ?MiddlewareQueue $middlewareQueue = null,
     ): ResponseInterface {
         $this->bootstrap();
 

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -51,7 +51,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         ?array $query = null,
         ?array $parsedBody = null,
         ?array $cookies = null,
-        ?array $files = null
+        ?array $files = null,
     ): ServerRequest {
         $server = normalizeServer($server ?? $_SERVER);
         ['uri' => $uri, 'base' => $base, 'webroot' => $webroot] = UriFactory::marshalUriAndBaseFromSapi($server);

--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -270,7 +270,7 @@ class Session
      */
     public function engine(
         SessionHandlerInterface|string|null $class = null,
-        array $options = []
+        array $options = [],
     ): ?SessionHandlerInterface {
         if ($class === null) {
             return $this->_engine;

--- a/src/Http/UploadedFileFactory.php
+++ b/src/Http/UploadedFileFactory.php
@@ -47,7 +47,7 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
         ?int $size = null,
         int $error = UPLOAD_ERR_OK,
         ?string $clientFilename = null,
-        ?string $clientMediaType = null
+        ?string $clientMediaType = null,
     ): UploadedFileInterface {
         $size ??= $stream->getSize() ?? 0;
 

--- a/src/I18n/Date.php
+++ b/src/I18n/Date.php
@@ -238,7 +238,7 @@ class Date extends ChronosDate implements JsonSerializable, Stringable
      */
     public function i18nFormat(
         string|int|null $format = null,
-        ?string $locale = null
+        ?string $locale = null,
     ): string|int {
         if ($format === DateTime::UNIX_TIMESTAMP_FORMAT) {
             throw new InvalidArgumentException('UNIT_TIMESTAMP_FORMAT is not supported for Date.');

--- a/src/I18n/DateFormatTrait.php
+++ b/src/I18n/DateFormatTrait.php
@@ -48,7 +48,7 @@ trait DateFormatTrait
     protected function _formatObject(
         DateTimeInterface $date,
         array|string $format,
-        ?string $locale
+        ?string $locale,
     ): string {
         $pattern = '';
 
@@ -133,7 +133,7 @@ trait DateFormatTrait
     protected static function _parseDateTime(
         string $time,
         array|string $format,
-        DateTimeZone|string|null $tz = null
+        DateTimeZone|string|null $tz = null,
     ): ?static {
         $pattern = '';
 

--- a/src/I18n/DateTime.php
+++ b/src/I18n/DateTime.php
@@ -280,7 +280,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
     public static function parseDateTime(
         string $time,
         array|string|int|null $format = null,
-        DateTimeZone|string|null $tz = null
+        DateTimeZone|string|null $tz = null,
     ): ?static {
         $format ??= static::$_toStringFormat;
         $format = is_int($format) ? [$format, $format] : $format;
@@ -428,7 +428,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
     public function i18nFormat(
         array|string|int|null $format = null,
         DateTimeZone|string|null $timezone = null,
-        ?string $locale = null
+        ?string $locale = null,
     ): string|int {
         if ($format === DateTime::UNIX_TIMESTAMP_FORMAT) {
             return $this->getTimestamp();
@@ -523,7 +523,7 @@ class DateTime extends Chronos implements JsonSerializable, Stringable
     public static function listTimezones(
         string|int|null $filter = null,
         ?string $country = null,
-        array|bool $options = []
+        array|bool $options = [],
     ): array {
         if (is_bool($options)) {
             $options = [

--- a/src/I18n/Package.php
+++ b/src/I18n/Package.php
@@ -54,7 +54,7 @@ class Package
     public function __construct(
         string $formatter = 'default',
         ?string $fallback = null,
-        array $messages = []
+        array $messages = [],
     ) {
         $this->formatter = $formatter;
         $this->fallback = $fallback;

--- a/src/I18n/RelativeTimeFormatter.php
+++ b/src/I18n/RelativeTimeFormatter.php
@@ -39,7 +39,7 @@ class RelativeTimeFormatter implements DifferenceFormatterInterface
     public function diffForHumans(
         ChronosDate|DateTimeInterface $first,
         ChronosDate|DateTimeInterface|null $second = null,
-        bool $absolute = false
+        bool $absolute = false,
     ): string {
         $isNow = $second === null;
         if ($second === null) {

--- a/src/I18n/Time.php
+++ b/src/I18n/Time.php
@@ -190,7 +190,7 @@ class Time extends ChronosTime implements JsonSerializable, Stringable
      */
     public function i18nFormat(
         string|int|null $format = null,
-        ?string $locale = null
+        ?string $locale = null,
     ): string|int {
         if ($format === DateTime::UNIX_TIMESTAMP_FORMAT) {
             throw new InvalidArgumentException('UNIT_TIMESTAMP_FORMAT is not supported for Time.');

--- a/src/I18n/Translator.php
+++ b/src/I18n/Translator.php
@@ -68,7 +68,7 @@ class Translator
         string $locale,
         Package $package,
         FormatterInterface $formatter,
-        ?Translator $fallback = null
+        ?Translator $fallback = null,
     ) {
         $this->locale = $locale;
         $this->package = $package;

--- a/src/I18n/TranslatorRegistry.php
+++ b/src/I18n/TranslatorRegistry.php
@@ -103,7 +103,7 @@ class TranslatorRegistry
     public function __construct(
         PackageLocator $packages,
         FormatterLocator $formatters,
-        string $locale
+        string $locale,
     ) {
         $this->packages = $packages;
         $this->formatters = $formatters;

--- a/src/I18n/functions.php
+++ b/src/I18n/functions.php
@@ -215,7 +215,7 @@ function __dxn(
     string $singular,
     string $plural,
     int $count,
-    mixed ...$args
+    mixed ...$args,
 ): string {
     if (!$singular) {
         return '';

--- a/src/I18n/functions_global.php
+++ b/src/I18n/functions_global.php
@@ -178,7 +178,7 @@ if (!function_exists('__dxn')) {
         string $singular,
         string $plural,
         int $count,
-        mixed ...$args
+        mixed ...$args,
     ): string {
         return cake__dxn($domain, $context, $singular, $plural, $count, ...$args);
     }

--- a/src/Log/LogTrait.php
+++ b/src/Log/LogTrait.php
@@ -36,7 +36,7 @@ trait LogTrait
     public function log(
         Stringable|string $message,
         string|int $level = LogLevel::ERROR,
-        array|string $context = []
+        array|string $context = [],
     ): bool {
         return Log::write($level, $message, $context);
     }

--- a/src/Mailer/Transport/MailTransport.php
+++ b/src/Mailer/Transport/MailTransport.php
@@ -85,7 +85,7 @@ class MailTransport extends AbstractTransport
         string $subject,
         string $message,
         string $headers = '',
-        string $params = ''
+        string $params = '',
     ): void {
         // phpcs:disable
         if (!@mail($to, $subject, $message, $headers, $params)) {

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -213,7 +213,7 @@ class Socket
         string &$errStr,
         int $timeout,
         int $connectAs,
-        $context
+        $context,
     ) {
         $resource = stream_socket_client(
             $remoteSocketTarget,

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -878,7 +878,7 @@ abstract class Association
      */
     public function updateAll(
         QueryExpression|Closure|array|string $fields,
-        QueryExpression|Closure|array|string|null $conditions
+        QueryExpression|Closure|array|string|null $conditions,
     ): int {
         $expression = $this->find()
             ->where($conditions)

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -724,7 +724,7 @@ class BelongsToMany extends Association
     protected function _saveTarget(
         EntityInterface $parentEntity,
         array $entities,
-        array $options
+        array $options,
     ): EntityInterface|false {
         $joinAssociations = false;
         if (isset($options['associated']) && is_array($options['associated'])) {
@@ -1272,7 +1272,7 @@ class BelongsToMany extends Association
         SelectQuery $existing,
         array $jointEntities,
         array $targetEntities,
-        array $options = []
+        array $options = [],
     ): array|false {
         $junction = $this->junction();
         $target = $this->getTarget();

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -212,7 +212,7 @@ class HasMany extends Association
         array $foreignKeyReference,
         EntityInterface $parentEntity,
         array $entities,
-        array $options
+        array $options,
     ): bool {
         $foreignKey = array_keys($foreignKeyReference);
         $table = $this->getTarget();
@@ -471,7 +471,7 @@ class HasMany extends Association
         EntityInterface $entity,
         Table $target,
         iterable $remainingEntities = [],
-        array $options = []
+        array $options = [],
     ): bool {
         $primaryKey = (array)$target->getPrimaryKey();
         $exclusions = new Collection($remainingEntities);

--- a/src/ORM/Association/Loader/SelectLoader.php
+++ b/src/ORM/Association/Loader/SelectLoader.php
@@ -355,7 +355,7 @@ class SelectLoader
         SelectQuery $query,
         array $keys,
         mixed $filter,
-        string $operator
+        string $operator,
     ): TupleComparison {
         $types = [];
         $defaults = $query->getDefaultTypes();

--- a/src/ORM/AssociationCollection.php
+++ b/src/ORM/AssociationCollection.php
@@ -268,7 +268,7 @@ class AssociationCollection implements IteratorAggregate
         EntityInterface $entity,
         array $associations,
         array $options,
-        bool $owningSide
+        bool $owningSide,
     ): bool {
         unset($options['associated']);
         foreach ($associations as $alias => $nested) {
@@ -309,7 +309,7 @@ class AssociationCollection implements IteratorAggregate
         Association $association,
         EntityInterface $entity,
         array $nested,
-        array $options
+        array $options,
     ): bool {
         if (!$entity->isDirty($association->getProperty())) {
             return true;

--- a/src/ORM/Behavior/CounterCacheBehavior.php
+++ b/src/ORM/Behavior/CounterCacheBehavior.php
@@ -220,7 +220,7 @@ class CounterCacheBehavior extends Behavior
         EventInterface $event,
         EntityInterface $entity,
         Association $assoc,
-        array $settings
+        array $settings,
     ): void {
         /** @var list<string> $foreignKeys */
         $foreignKeys = (array)$assoc->getForeignKey();

--- a/src/ORM/Behavior/TreeBehavior.php
+++ b/src/ORM/Behavior/TreeBehavior.php
@@ -489,7 +489,7 @@ class TreeBehavior extends Behavior
         SelectQuery $query,
         Closure|string|null $keyPath = null,
         Closure|string|null $valuePath = null,
-        ?string $spacer = null
+        ?string $spacer = null,
     ): SelectQuery {
         $left = $this->_table->aliasField($this->getConfig('left'));
 
@@ -516,7 +516,7 @@ class TreeBehavior extends Behavior
         SelectQuery $query,
         Closure|string|null $keyPath = null,
         Closure|string|null $valuePath = null,
-        ?string $spacer = null
+        ?string $spacer = null,
     ): SelectQuery {
         return $query->formatResults(
             function (CollectionInterface $results) use ($keyPath, $valuePath, $spacer) {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -755,7 +755,7 @@ class EagerLoader
         string $alias,
         Association $assoc,
         bool $asMatching = false,
-        ?string $targetProperty = null
+        ?string $targetProperty = null,
     ): void {
         $this->_joinsMap[$alias] = new EagerLoadable($alias, [
             'aliasPath' => $alias,

--- a/src/ORM/Exception/PersistenceFailedException.php
+++ b/src/ORM/Exception/PersistenceFailedException.php
@@ -49,7 +49,7 @@ class PersistenceFailedException extends CakeException
         EntityInterface $entity,
         array|string $message,
         ?int $code = null,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         $this->_entity = $entity;
         if (is_array($message)) {

--- a/src/ORM/LazyEagerLoader.php
+++ b/src/ORM/LazyEagerLoader.php
@@ -141,7 +141,7 @@ class LazyEagerLoader
         array $entities,
         SelectQuery $query,
         array $associations,
-        Table $source
+        Table $source,
     ): array {
         $injected = [];
         $properties = $this->_getPropertyMap($source, $associations);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -108,10 +108,10 @@ class Marshaller
             if (isset($options['isMerge'])) {
                 $callback = function (
                     $value,
-                    EntityInterface $entity
+                    EntityInterface $entity,
                 ) use (
                     $assoc,
-                    $nested
+                    $nested,
                 ): array|EntityInterface|null {
                     $options = $nested + ['associated' => [], 'association' => $assoc];
 
@@ -756,7 +756,7 @@ class Marshaller
         EntityInterface|array|null $original,
         Association $assoc,
         mixed $value,
-        array $options
+        array $options,
     ): EntityInterface|array|null {
         if (!$original) {
             return $this->_marshalAssociation($assoc, $value, $options);

--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -796,7 +796,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      */
     public function select(
         ExpressionInterface|Table|Association|Closure|array|string|float|int $fields = [],
-        bool $overwrite = false
+        bool $overwrite = false,
     ) {
         if ($fields instanceof Association) {
             $fields = $fields->getTarget();
@@ -824,7 +824,7 @@ class SelectQuery extends DbSelectQuery implements JsonSerializable, QueryInterf
      * @return $this
      */
     public function selectAlso(
-        ExpressionInterface|Table|Association|Closure|array|string|float|int $fields
+        ExpressionInterface|Table|Association|Closure|array|string|float|int $fields,
     ) {
         $this->select($fields);
         $this->_autoFields = true;

--- a/src/ORM/RulesChecker.php
+++ b/src/ORM/RulesChecker.php
@@ -100,7 +100,7 @@ class RulesChecker extends BaseRulesChecker
     public function existsIn(
         array|string $field,
         Table|Association|string $table,
-        array|string|null $message = null
+        array|string|null $message = null,
     ): RuleInvoker {
         $options = [];
         if (is_array($message)) {
@@ -144,7 +144,7 @@ class RulesChecker extends BaseRulesChecker
     public function isLinkedTo(
         Association|string $association,
         ?string $field = null,
-        ?string $message = null
+        ?string $message = null,
     ): RuleInvoker {
         return $this->_addLinkConstraintRule(
             $association,
@@ -177,7 +177,7 @@ class RulesChecker extends BaseRulesChecker
     public function isNotLinkedTo(
         Association|string $association,
         ?string $field = null,
-        ?string $message = null
+        ?string $message = null,
     ): RuleInvoker {
         return $this->_addLinkConstraintRule(
             $association,
@@ -210,7 +210,7 @@ class RulesChecker extends BaseRulesChecker
         ?string $errorField,
         ?string $message,
         string $linkStatus,
-        string $ruleName
+        string $ruleName,
     ): RuleInvoker {
         if ($association instanceof Association) {
             $associationAlias = $association->getName();
@@ -265,7 +265,7 @@ class RulesChecker extends BaseRulesChecker
         string $field,
         int $count = 0,
         string $operator = '>',
-        ?string $message = null
+        ?string $message = null,
     ): RuleInvoker {
         if (!$message) {
             if ($this->_useI18n) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1382,7 +1382,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         Closure|array|string|null $keyField = null,
         Closure|array|string|null $valueField = null,
         Closure|array|string|null $groupField = null,
-        string $valueSeparator = ' '
+        string $valueSeparator = ' ',
     ): SelectQuery {
         $keyField ??= $this->getPrimaryKey();
         $valueField ??= $this->getDisplayField();
@@ -1442,7 +1442,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         SelectQuery $query,
         Closure|array|string|null $keyField = null,
         Closure|array|string $parentField = 'parent_id',
-        string $nestingKey = 'children'
+        string $nestingKey = 'children',
     ): SelectQuery {
         $keyField ??= $this->getPrimaryKey();
 
@@ -1525,7 +1525,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
         array|string $finder = 'all',
         CacheInterface|string|null $cache = null,
         Closure|string|null $cacheKey = null,
-        mixed ...$args
+        mixed ...$args,
     ): EntityInterface {
         if ($primaryKey === null) {
             throw new InvalidPrimaryKeyException(sprintf(
@@ -1656,7 +1656,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     public function findOrCreate(
         SelectQuery|callable|array $search,
         ?callable $callback = null,
-        array $options = []
+        array $options = [],
     ): EntityInterface {
         $options = new ArrayObject($options + [
             'atomic' => true,
@@ -1691,7 +1691,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
     protected function _processFindOrCreate(
         SelectQuery|callable|array $search,
         ?callable $callback = null,
-        array $options = []
+        array $options = [],
     ): EntityInterface|array {
         $query = $this->_getFindOrCreateQuery($search);
 
@@ -1814,7 +1814,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function updateAll(
         QueryExpression|Closure|array|string $fields,
-        QueryExpression|Closure|array|string|null $conditions
+        QueryExpression|Closure|array|string|null $conditions,
     ): int {
         $statement = $this->updateQuery()
             ->set($fields)
@@ -1950,7 +1950,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function save(
         EntityInterface $entity,
-        array $options = []
+        array $options = [],
     ): EntityInterface|false {
         $options = new ArrayObject($options + [
             'atomic' => true,
@@ -2282,7 +2282,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     public function saveMany(
         iterable $entities,
-        array $options = []
+        array $options = [],
     ): iterable|false {
         try {
             return $this->_saveMany($entities, $options);
@@ -2318,7 +2318,7 @@ class Table implements RepositoryInterface, EventListenerInterface, EventDispatc
      */
     protected function _saveMany(
         iterable $entities,
-        array $options = []
+        array $options = [],
     ): iterable {
         $options = new ArrayObject(
             $options + [

--- a/src/TestSuite/Fixture/SchemaLoader.php
+++ b/src/TestSuite/Fixture/SchemaLoader.php
@@ -48,7 +48,7 @@ class SchemaLoader
         array|string $paths,
         string $connectionName = 'test',
         bool $dropTables = true,
-        bool $truncateTables = false
+        bool $truncateTables = false,
     ): void {
         $files = (array)$paths;
 

--- a/src/TestSuite/IntegrationTestTrait.php
+++ b/src/TestSuite/IntegrationTestTrait.php
@@ -378,7 +378,7 @@ trait IntegrationTestTrait
         string $name,
         array|string $value,
         string|false $encrypt = 'aes',
-        ?string $key = null
+        ?string $key = null,
     ): void {
         $this->_cookieEncryptionKey = $key;
         $this->_cookie[$name] = $this->_encrypt($value, $encrypt);
@@ -1423,7 +1423,7 @@ trait IntegrationTestTrait
         string $name,
         string $encrypt = 'aes',
         ?string $key = null,
-        string $message = ''
+        string $message = '',
     ): void {
         $verboseMessage = $this->extractVerboseMessage($message);
         $this->assertThat($name, new CookieSet($this->_response), $verboseMessage);

--- a/src/TestSuite/LogTestTrait.php
+++ b/src/TestSuite/LogTestTrait.php
@@ -95,7 +95,7 @@ trait LogTestTrait
         string $level,
         string $expectedMessage,
         ?string $scope = null,
-        string $failMsg = ''
+        string $failMsg = '',
     ): void {
         $this->_expectLogMessage($level, $expectedMessage, $scope, $failMsg);
     }
@@ -112,7 +112,7 @@ trait LogTestTrait
         string $level,
         string $expectedMessage,
         ?string $scope = null,
-        string $failMsg = ''
+        string $failMsg = '',
     ): void {
         $this->_expectLogMessage($level, $expectedMessage, $scope, $failMsg, true);
     }
@@ -131,7 +131,7 @@ trait LogTestTrait
         string $expectedMessage,
         ?string $scope,
         string $failMsg = '',
-        bool $contains = false
+        bool $contains = false,
     ): void {
         $messageFound = false;
         $expectedMessage = sprintf('%s: %s', $level, $expectedMessage);

--- a/src/TestSuite/PHPUnitConsecutiveTrait.php
+++ b/src/TestSuite/PHPUnitConsecutiveTrait.php
@@ -44,7 +44,7 @@ trait PHPUnitConsecutiveTrait
                     &$mockedMethodCall,
                     &$callbackCall,
                     $index,
-                    $numberOfArguments
+                    $numberOfArguments,
                 ): bool {
                     $expected = $argumentList[$index][$mockedMethodCall] ?? null;
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -408,7 +408,7 @@ abstract class TestCase extends BaseTestCase
         string $dataKey,
         mixed $dataValue,
         ?EventManager $eventManager = null,
-        string $message = ''
+        string $message = '',
     ): void {
         if (!$eventManager) {
             $eventManager = EventManager::instance();
@@ -530,7 +530,7 @@ abstract class TestCase extends BaseTestCase
         string $needle,
         string $haystack,
         string $message = '',
-        bool $ignoreCase = false
+        bool $ignoreCase = false,
     ): void {
         $needle = str_replace(["\r\n", "\r"], "\n", $needle);
         $haystack = str_replace(["\r\n", "\r"], "\n", $haystack);
@@ -556,7 +556,7 @@ abstract class TestCase extends BaseTestCase
         string $needle,
         string $haystack,
         string $message = '',
-        bool $ignoreCase = false
+        bool $ignoreCase = false,
     ): void {
         $needle = str_replace(["\r\n", "\r"], "\n", $needle);
         $haystack = str_replace(["\r\n", "\r"], "\n", $haystack);
@@ -579,7 +579,7 @@ abstract class TestCase extends BaseTestCase
     public function assertEqualsSql(
         string $expected,
         string $actual,
-        string $message = ''
+        string $message = '',
     ): void {
         $this->assertEquals($expected, preg_replace('/[`"\[\]]/', '', $actual), $message);
     }
@@ -813,7 +813,7 @@ abstract class TestCase extends BaseTestCase
         array $assertions,
         string $string,
         bool $fullDebug = false,
-        array|string $regex = ''
+        array|string $regex = '',
     ): string|false {
         $asserts = $assertions['attrs'];
         $explains = $assertions['explains'];

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -353,7 +353,7 @@ class Hash
         string $op,
         ArrayAccess|array $data,
         array $path,
-        mixed $values = null
+        mixed $values = null,
     ): ArrayAccess|array {
         $_list = &$data;
 
@@ -471,7 +471,7 @@ class Hash
         array $data,
         array|string|null $keyPath,
         array|string|null $valuePath = null,
-        ?string $groupPath = null
+        ?string $groupPath = null,
     ): array {
         if (!$data) {
             return [];
@@ -996,7 +996,7 @@ class Hash
         array $data,
         string $path,
         string|int $dir = 'asc',
-        array|string $type = 'regular'
+        array|string $type = 'regular',
     ): array {
         if (!$data) {
             return [];

--- a/src/Utility/Text.php
+++ b/src/Utility/Text.php
@@ -99,7 +99,7 @@ class Text
         string $data,
         string $separator = ',',
         string $leftBound = '(',
-        string $rightBound = ')'
+        string $rightBound = ')',
     ): array {
         if (!$data) {
             return [];

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -315,7 +315,7 @@ class Xml
         DOMDocument $dom,
         DOMDocument|DOMElement $node,
         mixed $data,
-        string $format
+        string $format,
     ): void {
         if (!$data || !is_array($data)) {
             return;

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -250,7 +250,7 @@ class Validation
         mixed $check,
         array|string $type = 'fast',
         bool $deep = false,
-        ?string $regex = null
+        ?string $regex = null,
     ): bool {
         if (!is_string($check) && !is_int($check)) {
             return false;

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -528,7 +528,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         Validator $validator,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         $extra = array_filter(['message' => $message, 'on' => $when]);
 
@@ -576,7 +576,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         Validator $validator,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         $extra = array_filter(['message' => $message, 'on' => $when]);
 
@@ -751,7 +751,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         ?int $flags = null,
         Closure|string|bool $when = true,
-        ?string $message = null
+        ?string $message = null,
     ) {
         $this->field($field)->allowEmpty($when);
         if ($message) {
@@ -1028,7 +1028,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
     protected function _convertValidatorToArray(
         string $fieldName,
         array $defaults = [],
-        array|string|int $settings = []
+        array|string|int $settings = [],
     ): array {
         if (!is_array($settings)) {
             $fieldName = (string)$settings;
@@ -1211,7 +1211,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         array $range,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if (count($range) !== 2) {
             throw new InvalidArgumentException('The $range argument requires 2 numbers');
@@ -1259,7 +1259,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         array|string $type = 'all',
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if (is_array($type)) {
             $typeEnumeration = implode(', ', $type);
@@ -1313,7 +1313,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         float|int $value,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1345,7 +1345,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         float|int $value,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1377,7 +1377,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         float|int $value,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1409,7 +1409,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         float|int $value,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1441,7 +1441,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         mixed $value,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1473,7 +1473,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         mixed $value,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1507,7 +1507,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1540,7 +1540,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1573,7 +1573,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1610,7 +1610,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1647,7 +1647,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1684,7 +1684,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1724,7 +1724,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1761,7 +1761,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $secondField,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1800,7 +1800,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         array $formats = ['ymd'],
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         $formatEnumeration = implode(', ', $formats);
 
@@ -1841,7 +1841,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         array $formats = ['ymd'],
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         $formatEnumeration = implode(', ', $formats);
 
@@ -1909,7 +1909,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $type = 'datetime',
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -1968,7 +1968,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         ?int $places = null,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -2013,7 +2013,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         bool $checkMX = false,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -2046,7 +2046,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         string $enumClassName,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if (!in_array(BackedEnum::class, (array)class_implements($enumClassName), true)) {
             throw new InvalidArgumentException(
@@ -2525,7 +2525,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         array $options,
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             if (!$this->_useI18n) {
@@ -2830,7 +2830,7 @@ class Validator implements ArrayAccess, IteratorAggregate, Countable
         string $field,
         array $options = [],
         ?string $message = null,
-        Closure|string|null $when = null
+        Closure|string|null $when = null,
     ) {
         if ($message === null) {
             $message = 'The provided value must be a set of multiple options';

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -120,7 +120,7 @@ abstract class Cell implements EventDispatcherInterface, Stringable
         ServerRequest $request,
         Response $response,
         ?EventManagerInterface $eventManager = null,
-        array $cellOptions = []
+        array $cellOptions = [],
     ) {
         if ($eventManager !== null) {
             $this->setEventManager($eventManager);

--- a/src/View/Exception/MissingCellTemplateException.php
+++ b/src/View/Exception/MissingCellTemplateException.php
@@ -45,7 +45,7 @@ class MissingCellTemplateException extends MissingTemplateException
         string $file,
         array $paths = [],
         ?int $code = null,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         $this->name = $name;
 

--- a/src/View/Helper/BreadcrumbsHelper.php
+++ b/src/View/Helper/BreadcrumbsHelper.php
@@ -188,7 +188,7 @@ class BreadcrumbsHelper extends Helper
         string $matchingTitle,
         string $title,
         array|string|null $url = null,
-        array $options = []
+        array $options = [],
     ) {
         $key = $this->findCrumb($matchingTitle);
 
@@ -222,7 +222,7 @@ class BreadcrumbsHelper extends Helper
         string $matchingTitle,
         string $title,
         array|string|null $url = null,
-        array $options = []
+        array $options = [],
     ) {
         $key = $this->findCrumb($matchingTitle);
 

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -744,7 +744,7 @@ class HtmlHelper extends Helper
         array|bool|null $oddTrOptions = null,
         array|bool|null $evenTrOptions = null,
         bool $useCount = false,
-        bool $continueOddEven = true
+        bool $continueOddEven = true,
     ): string {
         if (!is_array($data)) {
             $data = [[$data]];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -462,7 +462,7 @@ class PaginatorHelper extends Helper
     public function generateUrl(
         array $options = [],
         array $url = [],
-        array $urlOptions = []
+        array $urlOptions = [],
     ): string {
         $urlOptions += [
             'escape' => true,

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -71,7 +71,7 @@ class TimeHelper extends Helper
      */
     public function fromString(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): DateTime {
         $time = new DateTime($dateString);
         if ($timezone !== null) {
@@ -92,7 +92,7 @@ class TimeHelper extends Helper
     public function nice(
         ChronosDate|DateTimeInterface|string|int|null $dateString = null,
         DateTimeZone|string|null $timezone = null,
-        ?string $locale = null
+        ?string $locale = null,
     ): string {
         $timezone = $this->_getTimezone($timezone);
 
@@ -108,7 +108,7 @@ class TimeHelper extends Helper
      */
     public function isToday(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isToday();
     }
@@ -122,7 +122,7 @@ class TimeHelper extends Helper
      */
     public function isFuture(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isFuture();
     }
@@ -136,7 +136,7 @@ class TimeHelper extends Helper
      */
     public function isPast(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isPast();
     }
@@ -150,7 +150,7 @@ class TimeHelper extends Helper
      */
     public function isThisWeek(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isThisWeek();
     }
@@ -164,7 +164,7 @@ class TimeHelper extends Helper
      */
     public function isThisMonth(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isThisMonth();
     }
@@ -178,7 +178,7 @@ class TimeHelper extends Helper
      */
     public function isThisYear(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isThisYear();
     }
@@ -192,7 +192,7 @@ class TimeHelper extends Helper
      */
     public function wasYesterday(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isYesterday();
     }
@@ -206,7 +206,7 @@ class TimeHelper extends Helper
      */
     public function isTomorrow(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isTomorrow();
     }
@@ -221,7 +221,7 @@ class TimeHelper extends Helper
      */
     public function toQuarter(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        bool $range = false
+        bool $range = false,
     ): array|int {
         return (new DateTime($dateString))->toQuarter($range);
     }
@@ -236,7 +236,7 @@ class TimeHelper extends Helper
      */
     public function toUnix(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): string {
         return (new DateTime($dateString, $timezone))->toUnixString();
     }
@@ -251,7 +251,7 @@ class TimeHelper extends Helper
      */
     public function toAtom(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): string {
         $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
 
@@ -267,7 +267,7 @@ class TimeHelper extends Helper
      */
     public function toRss(
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): string {
         $timezone = $this->_getTimezone($timezone) ?: date_default_timezone_get();
 
@@ -293,7 +293,7 @@ class TimeHelper extends Helper
      */
     public function timeAgoInWords(
         ChronosDate|DateTimeInterface|string|int $dateTime,
-        array $options = []
+        array $options = [],
     ): string {
         $element = null;
         $options += [
@@ -352,7 +352,7 @@ class TimeHelper extends Helper
     public function wasWithinLast(
         string $timeInterval,
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->wasWithinLast($timeInterval);
     }
@@ -370,7 +370,7 @@ class TimeHelper extends Helper
     public function isWithinNext(
         string $timeInterval,
         ChronosDate|DateTimeInterface|string|int $dateString,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): bool {
         return (new DateTime($dateString, $timezone))->isWithinNext($timeInterval);
     }
@@ -406,7 +406,7 @@ class TimeHelper extends Helper
         ChronosDate|DateTimeInterface|string|int|null $date,
         array|string|int|null $format = null,
         string|false $invalid = false,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): string|int|false {
         return $this->i18nFormat($date, $format, $invalid, $timezone);
     }
@@ -427,7 +427,7 @@ class TimeHelper extends Helper
         ChronosDate|DateTimeInterface|string|int|null $date,
         array|string|int|null $format = null,
         string|false $invalid = false,
-        DateTimeZone|string|null $timezone = null
+        DateTimeZone|string|null $timezone = null,
     ): string|int|false {
         if ($date === null) {
             return $invalid;

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -354,7 +354,7 @@ class StringTemplate
     public function addClass(
         mixed $input,
         array|string|false|null $newClass,
-        string $useIndex = 'class'
+        string $useIndex = 'class',
     ): array|string|null {
         // NOOP
         if (!$newClass) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -338,7 +338,7 @@ class View implements EventDispatcherInterface
         ?ServerRequest $request = null,
         ?Response $response = null,
         ?EventManagerInterface $eventManager = null,
-        array $viewOptions = []
+        array $viewOptions = [],
     ) {
         if ($eventManager !== null) {
             // Set the event manager before accessing the helper registry below

--- a/src/View/ViewBuilder.php
+++ b/src/View/ViewBuilder.php
@@ -565,7 +565,7 @@ class ViewBuilder implements JsonSerializable
     public function build(
         ?ServerRequest $request = null,
         ?Response $response = null,
-        ?EventManagerInterface $events = null
+        ?EventManagerInterface $events = null,
     ): View {
         $className = $this->_className ?? App::className('App', 'View', 'View') ?? View::class;
         if ($className === 'View') {

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -184,7 +184,7 @@ class DateTimeWidget extends BasicWidget
      */
     protected function formatDateTime(
         ChronosDate|ChronosTime|DateTimeInterface|string|int|null $value,
-        array $options
+        array $options,
     ): string {
         if ($value === '' || $value === null) {
             return '';

--- a/src/View/Widget/RadioWidget.php
+++ b/src/View/Widget/RadioWidget.php
@@ -156,7 +156,7 @@ class RadioWidget extends BasicWidget
         string|int $val,
         array|string|int $text,
         array $data,
-        ContextInterface $context
+        ContextInterface $context,
     ): string {
         $escape = $data['escape'];
         if (is_array($text) && isset($text['text'], $text['value'])) {
@@ -252,7 +252,7 @@ class RadioWidget extends BasicWidget
         array|string|bool|null $label,
         string $input,
         ContextInterface $context,
-        bool $escape
+        bool $escape,
     ): string|false {
         if (isset($radio['label'])) {
             $label = $radio['label'];

--- a/src/View/Widget/SelectBoxWidget.php
+++ b/src/View/Widget/SelectBoxWidget.php
@@ -211,7 +211,7 @@ class SelectBoxWidget extends BasicWidget
         ?array $disabled,
         mixed $selected,
         array $templateVars,
-        bool $escape
+        bool $escape,
     ): string {
         $opts = $optgroup;
         $attrs = [];
@@ -247,7 +247,7 @@ class SelectBoxWidget extends BasicWidget
         ?array $disabled,
         mixed $selected,
         array $templateVars,
-        bool $escape
+        bool $escape,
     ): array {
         $out = [];
         foreach ($options as $key => $val) {

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -598,7 +598,7 @@ class CacheTest extends TestCase
         ]);
         $this->assertInstanceOf(
             TestAppCacheEngine::class,
-            Cache::pool('unconfigTest')
+            Cache::pool('unconfigTest'),
         );
         $this->assertTrue(Cache::drop('unconfigTest'));
     }

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -190,7 +190,7 @@ class MemcachedEngineTest extends TestCase
     {
         $this->skipIf(
             !Memcached::HAVE_JSON,
-            'Memcached extension is not compiled with json support'
+            'Memcached extension is not compiled with json support',
         );
 
         $Memcached = new MemcachedEngine();
@@ -212,7 +212,7 @@ class MemcachedEngineTest extends TestCase
     {
         $this->skipIf(
             !Memcached::HAVE_IGBINARY,
-            'Memcached extension is not compiled with igbinary support'
+            'Memcached extension is not compiled with igbinary support',
         );
 
         $Memcached = new MemcachedEngine();
@@ -234,7 +234,7 @@ class MemcachedEngineTest extends TestCase
     {
         $this->skipIf(
             !defined('Memcached::HAVE_MSGPACK') || !Memcached::HAVE_MSGPACK,
-            'Memcached extension is not compiled with msgpack support'
+            'Memcached extension is not compiled with msgpack support',
         );
 
         $Memcached = new MemcachedEngine();
@@ -256,7 +256,7 @@ class MemcachedEngineTest extends TestCase
     {
         $this->skipIf(
             (bool)Memcached::HAVE_JSON,
-            'Memcached extension is compiled with json support'
+            'Memcached extension is compiled with json support',
         );
 
         $Memcached = new MemcachedEngine();
@@ -279,11 +279,11 @@ class MemcachedEngineTest extends TestCase
     {
         $this->skipIf(
             !defined('Memcached::HAVE_MSGPACK'),
-            'Memcached::HAVE_MSGPACK constant is not available in Memcached below 3.0.0'
+            'Memcached::HAVE_MSGPACK constant is not available in Memcached below 3.0.0',
         );
         $this->skipIf(
             (bool)Memcached::HAVE_MSGPACK,
-            'Memcached extension is compiled with msgpack support'
+            'Memcached extension is compiled with msgpack support',
         );
 
         $Memcached = new MemcachedEngine();
@@ -306,7 +306,7 @@ class MemcachedEngineTest extends TestCase
     {
         $this->skipIf(
             (bool)Memcached::HAVE_IGBINARY,
-            'Memcached extension is compiled with igbinary support'
+            'Memcached extension is compiled with igbinary support',
         );
 
         $Memcached = new MemcachedEngine();
@@ -332,7 +332,7 @@ class MemcachedEngineTest extends TestCase
         $this->expectExceptionMessage('Memcached extension is not build with SASL support');
         $this->skipIf(
             method_exists(Memcached::class, 'setSaslAuthData'),
-            'Cannot test exception when sasl has been compiled in.'
+            'Cannot test exception when sasl has been compiled in.',
         );
         $MemcachedEngine = new MemcachedEngine();
         $config = [

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -275,7 +275,7 @@ class RedisEngineTest extends TestCase
                 null,
                 0,
                 0.0,
-                $context
+                $context,
             )
             ->willReturn(true);
 
@@ -313,7 +313,7 @@ class RedisEngineTest extends TestCase
                 $Redis->getConfig('server'),
                 (int)$this->port,
                 (int)$Redis->getConfig('timeout'),
-                $expectedPersistentId
+                $expectedPersistentId,
             )
             ->willReturn(true);
 
@@ -340,7 +340,7 @@ class RedisEngineTest extends TestCase
                 'tls://' . $Redis->getConfig('server'),
                 (int)$this->port,
                 (int)$Redis->getConfig('timeout'),
-                $expectedPersistentId
+                $expectedPersistentId,
             )
             ->willReturn(true);
 
@@ -387,7 +387,7 @@ class RedisEngineTest extends TestCase
                 $expectedPersistentId,
                 0,
                 0.0,
-                $context
+                $context,
             )
             ->willReturn(true);
 

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -1140,7 +1140,7 @@ class CollectionTest extends TestCase
         $matched = $collection->match(['thing.parent_id' => 10]);
         $this->assertEquals(
             [0 => $items[0], 2 => $items[2]],
-            $matched->toArray()
+            $matched->toArray(),
         );
 
         $matched = $collection->match(['thing.parent_id' => 500]);
@@ -1164,13 +1164,13 @@ class CollectionTest extends TestCase
         $matched = $collection->firstMatch(['thing.parent_id' => 10]);
         $this->assertEquals(
             ['id' => 1, 'name' => 'foo', 'thing' => ['parent_id' => 10]],
-            $matched
+            $matched,
         );
 
         $matched = $collection->firstMatch(['thing.parent_id' => 10, 'name' => 'baz']);
         $this->assertEquals(
             ['id' => 3, 'name' => 'baz', 'thing' => ['parent_id' => 10]],
-            $matched
+            $matched,
         );
     }
 
@@ -1354,7 +1354,7 @@ class CollectionTest extends TestCase
             },
             function ($value, $key) {
                 return $key . '-' . $value['id'];
-            }
+            },
         );
         $this->assertEquals($expected, $collection->toArray());
 
@@ -1748,7 +1748,7 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(InsertIterator::class, $iterator);
         $this->assertEquals(
             [['a' => 1, 'c' => 3], ['b' => 2, 'c' => 4]],
-            iterator_to_array($iterator)
+            iterator_to_array($iterator),
         );
     }
 

--- a/tests/TestCase/Command/I18nExtractCommandTest.php
+++ b/tests/TestCase/Command/I18nExtractCommandTest.php
@@ -69,7 +69,7 @@ class I18nExtractCommandTest extends TestCase
             '--merge=no ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates' . DS . 'Pages ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -139,7 +139,7 @@ class I18nExtractCommandTest extends TestCase
             [
                 TEST_APP . 'templates' . DS,
                 'D',
-            ]
+            ],
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -155,7 +155,7 @@ class I18nExtractCommandTest extends TestCase
             '--merge=yes ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates' . DS . 'Pages ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -173,7 +173,7 @@ class I18nExtractCommandTest extends TestCase
             '--extract-core=no ' .
             '--exclude=Pages,Layout ' .
             '--paths=' . TEST_APP . 'templates' . DS . ' ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -197,7 +197,7 @@ class I18nExtractCommandTest extends TestCase
             '--no-location=true ' .
             '--exclude=Pages,Layout ' .
             '--paths=' . TEST_APP . 'templates' . DS . ' ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -219,7 +219,7 @@ class I18nExtractCommandTest extends TestCase
             '--exclude=Pages,Layout ' .
             '--paths=' . TEST_APP . 'templates/Pages,' .
                 TEST_APP . 'templates/Posts ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $result = file_get_contents($this->path . DS . 'default.pot');
@@ -239,7 +239,7 @@ class I18nExtractCommandTest extends TestCase
             '--extract-core=no ' .
             '--exclude-plugins=true ' .
             '--paths=' . TEST_APP . 'TestApp/ ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
 
@@ -258,7 +258,7 @@ class I18nExtractCommandTest extends TestCase
             'i18n extract ' .
             '--extract-core=no ' .
             '--plugin=TestPlugin ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
 
@@ -279,7 +279,7 @@ class I18nExtractCommandTest extends TestCase
             'i18n extract ' .
             '--extract-core=no ' .
             '--plugin=Company/TestPluginThree ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
 
@@ -303,7 +303,7 @@ class I18nExtractCommandTest extends TestCase
             '--extract-core=no ' .
             '--overwrite ' .
             '--paths=' . TEST_APP . 'TestApp/ ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
 
@@ -320,7 +320,7 @@ class I18nExtractCommandTest extends TestCase
             'i18n extract ' .
             '--extract-core=yes ' .
             '--paths=' . TEST_APP . 'TestApp/ ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
 
@@ -347,7 +347,7 @@ class I18nExtractCommandTest extends TestCase
             '--merge=no ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates/Pages ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertErrorContains('Invalid marker content in');
@@ -363,7 +363,7 @@ class I18nExtractCommandTest extends TestCase
             'i18n extract ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -382,7 +382,7 @@ class I18nExtractCommandTest extends TestCase
             'i18n extract ' .
             '--extract-core=no ' .
             '--paths=' . TEST_APP . 'templates,' . TEST_APP . 'unknown ' .
-            '--output=' . $this->path . DS
+            '--output=' . $this->path . DS,
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');
@@ -414,7 +414,7 @@ class I18nExtractCommandTest extends TestCase
                 '',
                 'D',
                 $this->path . DS,
-            ]
+            ],
         );
         $this->assertExitSuccess();
         $this->assertFileExists($this->path . DS . 'default.pot');

--- a/tests/TestCase/Command/PluginLoadCommandTest.php
+++ b/tests/TestCase/Command/PluginLoadCommandTest.php
@@ -98,7 +98,7 @@ class PluginLoadCommandTest extends TestCase
         $this->assertSame(['onlyDebug' => true, 'onlyCli' => true], $config['Company/TestPluginThree']);
         $this->assertSame(
             ['bootstrap' => false, 'console' => false, 'middleware' => false, 'routes' => false, 'services' => false],
-            $config['TestPluginTwo']
+            $config['TestPluginTwo'],
         );
     }
 

--- a/tests/TestCase/Command/RoutesCommandTest.php
+++ b/tests/TestCase/Command/RoutesCommandTest.php
@@ -142,7 +142,7 @@ class RoutesCommandTest extends TestCase
     {
         Configure::write('TestApp.routes', function ($routes): void {
             $routes->connect(
-                new Route('/a/route/sorted', [], ['_name' => '_aRoute'])
+                new Route('/a/route/sorted', [], ['_name' => '_aRoute']),
             );
         });
 
@@ -316,24 +316,24 @@ class RoutesCommandTest extends TestCase
     {
         Configure::write('TestApp.routes', function ($builder): void {
             $builder->connect(
-                new Route('/unique-path', [], ['_name' => '_aRoute'])
+                new Route('/unique-path', [], ['_name' => '_aRoute']),
             );
             $builder->connect(
-                new Route('/unique-path', [], ['_name' => '_bRoute'])
-            );
-
-            $builder->connect(
-                new Route('/blog', ['_method' => 'GET'], ['_name' => 'blog-get'])
-            );
-            $builder->connect(
-                new Route('/blog', [], ['_name' => 'blog-all'])
+                new Route('/unique-path', [], ['_name' => '_bRoute']),
             );
 
             $builder->connect(
-                new Route('/events', ['_method' => ['POST', 'PUT']], ['_name' => 'events-post'])
+                new Route('/blog', ['_method' => 'GET'], ['_name' => 'blog-get']),
             );
             $builder->connect(
-                new Route('/events', ['_method' => 'GET'], ['_name' => 'events-get'])
+                new Route('/blog', [], ['_name' => 'blog-all']),
+            );
+
+            $builder->connect(
+                new Route('/events', ['_method' => ['POST', 'PUT']], ['_name' => 'events-post']),
+            );
+            $builder->connect(
+                new Route('/events', ['_method' => 'GET'], ['_name' => 'events-get']),
             );
         });
 

--- a/tests/TestCase/Console/Command/HelpCommandTest.php
+++ b/tests/TestCase/Console/Command/HelpCommandTest.php
@@ -76,11 +76,11 @@ class HelpCommandTest extends TestCase
         $this->assertOutputContains('- sample', 'plugin command should appear');
         $this->assertOutputNotContains(
             '- test_plugin.sample',
-            'only short alias for plugin command.'
+            'only short alias for plugin command.',
         );
         $this->assertOutputNotContains(
             ' - abstract',
-            'Abstract command classes should not appear.'
+            'Abstract command classes should not appear.',
         );
         $this->assertOutputContains('<info>App</info>', 'app header should appear');
         $this->assertOutputContains('- sample', 'app shell');

--- a/tests/TestCase/Console/CommandCollectionTest.php
+++ b/tests/TestCase/Console/CommandCollectionTest.php
@@ -233,18 +233,18 @@ class CommandCollectionTest extends TestCase
         $this->assertArrayHasKey(
             'example',
             $result,
-            'Used short name for unique plugin shell'
+            'Used short name for unique plugin shell',
         );
         $this->assertArrayHasKey(
             'test_plugin.example',
             $result,
-            'Long names are stored for unique shells'
+            'Long names are stored for unique shells',
         );
         $this->assertArrayNotHasKey('sample', $result, 'Existing command not output');
         $this->assertArrayHasKey(
             'test_plugin.sample',
             $result,
-            'Duplicate shell was given a full alias'
+            'Duplicate shell was given a full alias',
         );
         $this->assertSame(ExampleCommand::class, $result['example']);
         $this->assertSame($result['example'], $result['test_plugin.example']);
@@ -254,12 +254,12 @@ class CommandCollectionTest extends TestCase
         $this->assertArrayHasKey(
             'company',
             $result,
-            'Used short name for unique plugin shell'
+            'Used short name for unique plugin shell',
         );
         $this->assertArrayHasKey(
             'company/test_plugin_three.company',
             $result,
-            'Long names are stored as well'
+            'Long names are stored as well',
         );
         $this->assertSame($result['company'], $result['company/test_plugin_three.company']);
         $this->clearPlugins();

--- a/tests/TestCase/Console/CommandRunnerTest.php
+++ b/tests/TestCase/Console/CommandRunnerTest.php
@@ -102,7 +102,7 @@ class CommandRunnerTest extends TestCase
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString(
             'Unknown command `cake nope`. Run `cake --help` to get the list of commands.',
-            $messages
+            $messages,
         );
     }
 
@@ -119,7 +119,7 @@ class CommandRunnerTest extends TestCase
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString(
             'Unknown command `cake s/pec[ial`. Run `cake --help` to get the list of commands.',
-            $messages
+            $messages,
         );
     }
 
@@ -139,7 +139,7 @@ class CommandRunnerTest extends TestCase
             "Other valid choices:\n" .
             "\n" .
             '- help',
-            $messages
+            $messages,
         );
     }
 

--- a/tests/TestCase/Console/CommandTest.php
+++ b/tests/TestCase/Console/CommandTest.php
@@ -137,7 +137,7 @@ class CommandTest extends TestCase
 
         $this->assertSame(
             CommandInterface::CODE_SUCCESS,
-            $command->run(['-h'], $this->getMockIo($output))
+            $command->run(['-h'], $this->getMockIo($output)),
         );
         $messages = implode("\n", $output->messages());
         $this->assertStringNotContainsString('Demo', $messages);
@@ -155,7 +155,7 @@ class CommandTest extends TestCase
 
         $this->assertSame(
             CommandInterface::CODE_SUCCESS,
-            $command->run(['--help'], $this->getMockIo($output))
+            $command->run(['--help'], $this->getMockIo($output)),
         );
         $messages = implode("\n", $output->messages());
         $this->assertStringNotContainsString('Demo', $messages);
@@ -217,7 +217,7 @@ class CommandTest extends TestCase
         $messages = implode("\n", $output->messages());
         $this->assertStringContainsString(
             'Error: Missing required argument. The `name` argument is required',
-            $messages
+            $messages,
         );
     }
 

--- a/tests/TestCase/Console/ConsoleInputTest.php
+++ b/tests/TestCase/Console/ConsoleInputTest.php
@@ -48,7 +48,7 @@ class ConsoleInputTest extends TestCase
     {
         $this->skipIf(
             (bool)env('GITHUB_ACTIONS'),
-            'Skip test for ConsoleInput::dataAvailable() on Github VM as stream_select() incorrectly return 1 even though no data is available on STDIN.'
+            'Skip test for ConsoleInput::dataAvailable() on Github VM as stream_select() incorrectly return 1 even though no data is available on STDIN.',
         );
 
         try {
@@ -56,7 +56,7 @@ class ConsoleInputTest extends TestCase
         } catch (ConsoleException) {
             $this->markTestSkipped(
                 'stream_select raised an exception. ' .
-                'This can happen when FD_SETSIZE is too small.'
+                'This can happen when FD_SETSIZE is too small.',
             );
         }
     }

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -177,8 +177,8 @@ class ConsoleIoTest extends TestCase
                     ['Just a test', 1],
                     [['Just', 'a', 'test'], 1],
                     [['Just', 'a', 'test'], 2],
-                    ['', 1]
-                )
+                    ['', 1],
+                ),
             );
 
         $this->io->out('Just a test');
@@ -198,8 +198,8 @@ class ConsoleIoTest extends TestCase
                 ...self::withConsecutive(
                     ['Verbose', 1],
                     ['Normal', 1],
-                    ['Quiet', 1]
-                )
+                    ['Quiet', 1],
+                ),
             );
 
         $this->io->level(ConsoleIo::VERBOSE);
@@ -220,8 +220,8 @@ class ConsoleIoTest extends TestCase
                 ...self::withConsecutive(
                     ['Verbose', 1],
                     ['Normal', 1],
-                    ['Quiet', 1]
-                )
+                    ['Quiet', 1],
+                ),
             );
 
         $this->io->level(ConsoleIo::VERBOSE);
@@ -241,8 +241,8 @@ class ConsoleIoTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['Quiet', 1],
-                    ['Quiet', 1]
-                )
+                    ['Quiet', 1],
+                ),
             );
 
         $this->io->level(ConsoleIo::QUIET);
@@ -266,8 +266,8 @@ class ConsoleIoTest extends TestCase
                     ['Just a test', 1],
                     [['Just', 'a', 'test'], 1],
                     [['Just', 'a', 'test'], 2],
-                    ['', 1]
-                )
+                    ['', 1],
+                ),
             );
 
         $this->io->err('Just a test');
@@ -346,8 +346,8 @@ class ConsoleIoTest extends TestCase
                     ['', 0],
                     ['', true],
                     [$bar, 1],
-                    ['', true]
-                )
+                    ['', true],
+                ),
             );
 
         $this->io->hr();
@@ -369,15 +369,15 @@ class ConsoleIoTest extends TestCase
                     [str_repeat("\x08", $number), 0],
                     ['Less text', 0],
                     [str_repeat(' ', $number - 9), 0],
-                    [PHP_EOL, 0]
-                )
+                    [PHP_EOL, 0],
+                ),
             )
             ->willReturn(
                 $number,
                 9,
                 9,
                 1,
-                0
+                0,
             );
 
         $this->io->out('Some <info>text</info> I want to overwrite', 0);
@@ -404,8 +404,8 @@ class ConsoleIoTest extends TestCase
                     // Backspaces
                     [str_repeat("\x08", $length), 0],
                     ['12', 0],
-                    [str_repeat(' ', $length - 2), 0]
-                )
+                    [str_repeat(' ', $length - 2), 0],
+                ),
             )
             ->willReturn(
                 $length,
@@ -414,7 +414,7 @@ class ConsoleIoTest extends TestCase
                 $length - 3,
                 $length,
                 2,
-                $length - 2
+                $length - 2,
             );
 
         $this->io->out('12345');
@@ -437,15 +437,15 @@ class ConsoleIoTest extends TestCase
                     ['123', 0],
                     // Backspaces
                     [str_repeat("\x08", 3), 0],
-                    ['12345', 0]
-                )
+                    ['12345', 0],
+                ),
             )
             ->willReturn(
                 1,
                 1,
                 3,
                 3,
-                5
+                5,
             );
 
         $this->io->out('1');
@@ -598,8 +598,8 @@ class ConsoleIoTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     [ "<{$method}>Just a test</{$method}>", 1],
-                    [["<{$method}>Just</{$method}>", "<{$method}>a test</{$method}>"], 1]
-                )
+                    [["<{$method}>Just</{$method}>", "<{$method}>a test</{$method}>"], 1],
+                ),
             );
 
         $this->io->{$method}('Just a test');
@@ -617,8 +617,8 @@ class ConsoleIoTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     [ "<{$method}>Just a test</{$method}>", 1],
-                    [["<{$method}>Just</{$method}>", "<{$method}>a test</{$method}>"], 1]
-                )
+                    [["<{$method}>Just</{$method}>", "<{$method}>a test</{$method}>"], 1],
+                ),
             );
 
         $this->io->{$method}('Just a test');
@@ -789,7 +789,7 @@ class ConsoleIoTest extends TestCase
         $this->assertStringEqualsFile(
             $file,
             'newest content',
-            'overwrite state replaces parameter'
+            'overwrite state replaces parameter',
         );
     }
 }

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -160,7 +160,7 @@ class ConsoleOptionParserTest extends TestCase
         $this->assertSame(
             ['test' => 'default value', 'help' => false],
             $result[0],
-            'Default value did not parse out'
+            'Default value did not parse out',
         );
 
         $parser = new ConsoleOptionParser('test', false);
@@ -201,7 +201,7 @@ class ConsoleOptionParserTest extends TestCase
                 'help' => false,
             ],
             $result[0],
-            'Short parameter did not parse out'
+            'Short parameter did not parse out',
         );
     }
 
@@ -328,13 +328,13 @@ class ConsoleOptionParserTest extends TestCase
         $result = $parser->parse(['--test', '--no-default', 'value'], $this->io);
         $this->assertSame(
             ['test' => 'default value', 'no-default' => 'value', 'help' => false],
-            $result[0]
+            $result[0],
         );
 
         $result = $parser->parse(['--no-default', 'value'], $this->io);
         $this->assertSame(
             ['no-default' => 'value', 'help' => false, 'test' => 'default value'],
-            $result[0]
+            $result[0],
         );
     }
 
@@ -517,7 +517,7 @@ class ConsoleOptionParserTest extends TestCase
                 "Other valid choices:\n" .
                 "\n" .
                 '- help',
-                $e->getFullMessage()
+                $e->getFullMessage(),
             );
         }
     }
@@ -648,7 +648,7 @@ class ConsoleOptionParserTest extends TestCase
         $this->assertSame([0, 1, 2], array_keys($result));
         $this->assertEquals(
             ['other', 'name', 'bag'],
-            $parser->argumentNames()
+            $parser->argumentNames(),
         );
     }
 

--- a/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
+++ b/tests/TestCase/Controller/Component/FormProtectionComponentTest.php
@@ -117,7 +117,7 @@ class FormProtectionComponentTest extends TestCase
         $fields = hash_hmac(
             'sha1',
             '/subfolder/articles/index' . serialize($fields) . $unlocked . 'cli',
-            Security::getSalt()
+            Security::getSalt(),
         );
         $fields .= urlencode(':id');
 

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -201,7 +201,7 @@ class ComponentRegistryTest extends TestCase
         $this->assertSame(
             $instance,
             $this->Components->FormProtection,
-            'Instance in registry should be the same as previously loaded'
+            'Instance in registry should be the same as previously loaded',
         );
         $this->assertCount(1, $eventManager->listeners('Controller.startup'));
 

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -179,7 +179,7 @@ class ComponentTest extends TestCase
     {
         $Component = new ConfiguredComponent(
             new ComponentRegistry(new Controller(new ServerRequest())),
-            ['chicken' => 'soup']
+            ['chicken' => 'soup'],
         );
         $this->assertEquals(['chicken' => 'soup'], $Component->configCopy);
         $this->assertEquals(['chicken' => 'soup'], $Component->getConfig());
@@ -193,7 +193,7 @@ class ComponentTest extends TestCase
         $Component = new ConfiguredComponent(
             new ComponentRegistry(new Controller(new ServerRequest())),
             [],
-            ['Apple', 'Banana', 'Orange']
+            ['Apple', 'Banana', 'Orange'],
         );
         $this->assertInstanceOf(AppleComponent::class, $Component->Apple, 'class is wrong');
         $this->assertInstanceOf(OrangeComponent::class, $Component->Orange, 'class is wrong');
@@ -219,7 +219,7 @@ class ComponentTest extends TestCase
         $Component = new ConfiguredComponent(
             new ComponentRegistry(new Controller(new ServerRequest())),
             [],
-            ['Configured' => ['foo' => 'bar']]
+            ['Configured' => ['foo' => 'bar']],
         );
         $this->assertInstanceOf(ConfiguredComponent::class, $Component->Configured, 'class is wrong');
         $this->assertNotSame($Component, $Component->Configured, 'Component instance was reused');

--- a/tests/TestCase/Controller/ControllerFactoryTest.php
+++ b/tests/TestCase/Controller/ControllerFactoryTest.php
@@ -93,7 +93,7 @@ class ControllerFactoryTest extends TestCase
         $result = $this->factory->create($request);
         $this->assertInstanceOf(
             PostsController::class,
-            $result
+            $result,
         );
         $this->assertSame($request, $result->getRequest());
     }
@@ -114,7 +114,7 @@ class ControllerFactoryTest extends TestCase
         $result = $this->factory->create($request);
         $this->assertInstanceOf(
             SubPostsController::class,
-            $result
+            $result,
         );
         $this->assertSame($request, $result->getRequest());
     }
@@ -135,7 +135,7 @@ class ControllerFactoryTest extends TestCase
         $result = $this->factory->create($request);
         $this->assertInstanceOf(
             TestPluginController::class,
-            $result
+            $result,
         );
         $this->assertSame($request, $result->getRequest());
     }
@@ -156,7 +156,7 @@ class ControllerFactoryTest extends TestCase
         $result = $this->factory->create($request);
         $this->assertInstanceOf(
             OvensController::class,
-            $result
+            $result,
         );
         $this->assertSame($request, $result->getRequest());
     }
@@ -178,7 +178,7 @@ class ControllerFactoryTest extends TestCase
         $result = $this->factory->create($request);
         $this->assertInstanceOf(
             CommentsController::class,
-            $result
+            $result,
         );
         $this->assertSame($request, $result->getRequest());
     }
@@ -557,7 +557,7 @@ class ControllerFactoryTest extends TestCase
 
         $this->expectException(InvalidParameterException::class);
         $this->expectExceptionMessage(
-            'Failed to inject dependency from service container for parameter `dep` with type `stdClass` in action `Dependencies::requiredDep()`'
+            'Failed to inject dependency from service container for parameter `dep` with type `stdClass` in action `Dependencies::requiredDep()`',
         );
         $this->factory->invoke($controller);
     }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -102,7 +102,7 @@ class ControllerTest extends TestCase
 
         $this->assertInstanceOf(
             ArticlesTable::class,
-            $Controller->Articles
+            $Controller->Articles,
         );
     }
 
@@ -130,7 +130,7 @@ class ControllerTest extends TestCase
         $result = $Controller->fetchTable('Articles');
         $this->assertInstanceOf(
             ArticlesTable::class,
-            $result
+            $result,
         );
     }
 
@@ -169,7 +169,7 @@ class ControllerTest extends TestCase
         $result = $Controller->fetchTable('TestPlugin.TestPluginComments');
         $this->assertInstanceOf(
             TestPluginCommentsTable::class,
-            $result
+            $result,
         );
     }
 
@@ -281,7 +281,7 @@ class ControllerTest extends TestCase
         $this->assertSame(
             'application/xml; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            'Has correct header'
+            'Has correct header',
         );
         $this->assertStringContainsString('<?xml', $response->getBody() . '');
     }
@@ -317,7 +317,7 @@ class ControllerTest extends TestCase
         $this->assertSame(
             'text/html; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            'Should not be XML response.'
+            'Should not be XML response.',
         );
         $this->assertStringContainsString('hello world', $response->getBody() . '');
     }
@@ -685,7 +685,7 @@ class ControllerTest extends TestCase
 
         $results = $Controller->paginate(
             $this->getTableLocator()->get('Posts'),
-            ['scope' => 'posts', 'className' => 'Numeric']
+            ['scope' => 'posts', 'className' => 'Numeric'],
         );
         $this->assertInstanceOf(PaginatedInterface::class, $results);
         $this->assertCount(1, $results);
@@ -698,7 +698,7 @@ class ControllerTest extends TestCase
 
         $results = $Controller->paginate(
             $this->getTableLocator()->get('Posts'),
-            ['className' => 'Simple']
+            ['className' => 'Simple'],
         );
         $this->assertInstanceOf(PaginatedInterface::class, $results);
 
@@ -869,7 +869,7 @@ class ControllerTest extends TestCase
 
         $this->assertEquals(
             ['testId' => '1', 'test2Id' => '2'],
-            $controller->getRequest()->getData()
+            $controller->getRequest()->getData(),
         );
     }
 
@@ -881,7 +881,7 @@ class ControllerTest extends TestCase
         $this->expectException(AssertionError::class);
         $this->expectExceptionMessage(
             'Controller actions can only return Response instance or null. '
-                . 'Got string instead.'
+                . 'Got string instead.',
         );
 
         $url = new ServerRequest([
@@ -1048,11 +1048,11 @@ class ControllerTest extends TestCase
         $Controller->getEventManager()->on('Controller.beforeRender', function ($event): void {
             $this->assertSame(
                 '/Element/test_element',
-                $event->getSubject()->viewBuilder()->getTemplate()
+                $event->getSubject()->viewBuilder()->getTemplate(),
             );
             $this->assertSame(
                 'default',
-                $event->getSubject()->viewBuilder()->getLayout()
+                $event->getSubject()->viewBuilder()->getLayout(),
             );
 
             $event->getSubject()->viewBuilder()

--- a/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/AuthSecurityExceptionTest.php
@@ -46,7 +46,7 @@ class AuthSecurityExceptionTest extends TestCase
         $this->assertSame(
             'auth',
             $this->authSecurityException->getType(),
-            '::getType should always return the type of `auth`.'
+            '::getType should always return the type of `auth`.',
         );
     }
 }

--- a/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
+++ b/tests/TestCase/Controller/Exception/SecurityExceptionTest.php
@@ -46,7 +46,7 @@ class SecurityExceptionTest extends TestCase
         $this->assertSame(
             'secure',
             $this->securityException->getType(),
-            '::getType should always return the type of `secure`.'
+            '::getType should always return the type of `secure`.',
         );
     }
 
@@ -60,7 +60,7 @@ class SecurityExceptionTest extends TestCase
         $this->assertSame(
             $sampleMessage,
             $this->securityException->getMessage(),
-            '::getMessage should always return the message set.'
+            '::getMessage should always return the message set.',
         );
     }
 
@@ -74,7 +74,7 @@ class SecurityExceptionTest extends TestCase
         $this->assertSame(
             $sampleReason,
             $this->securityException->getReason(),
-            '::getReason should always return the reason set.'
+            '::getReason should always return the reason set.',
         );
     }
 }

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -114,7 +114,7 @@ class AppTest extends TestCase
         $return = TestApp::shortName(
             'TestApp/Nested/Controller/PagesController',
             'Controller',
-            'Controller'
+            'Controller',
         );
         $this->assertSame('Pages', $return);
 

--- a/tests/TestCase/Core/FunctionsGlobalTest.php
+++ b/tests/TestCase/Core/FunctionsGlobalTest.php
@@ -274,7 +274,7 @@ class FunctionsGlobalTest extends TestCase
         });
         $this->assertMatchesRegularExpression(
             '/This is deprecated \w+\n(.*?)[\/\\\]FunctionsGlobalTest.php, line\: \d+/',
-            $error->getMessage()
+            $error->getMessage(),
         );
     }
 
@@ -288,7 +288,7 @@ class FunctionsGlobalTest extends TestCase
         });
         $this->assertMatchesRegularExpression(
             '/This is going away too \w+\n(.*?)[\/\\\]TestCase.php, line\: \d+/',
-            $error->getMessage()
+            $error->getMessage(),
         );
     }
 

--- a/tests/TestCase/Core/InstanceConfigTraitTest.php
+++ b/tests/TestCase/Core/InstanceConfigTraitTest.php
@@ -53,7 +53,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'runtime config should match the defaults if not overridden'
+            'runtime config should match the defaults if not overridden',
         );
     }
 
@@ -65,13 +65,13 @@ class InstanceConfigTraitTest extends TestCase
         $this->assertSame(
             'string',
             $this->object->getConfig('some'),
-            'should return the key value only'
+            'should return the key value only',
         );
 
         $this->assertSame(
             ['nested' => 'value', 'other' => 'value'],
             $this->object->getConfig('a'),
-            'should return the key value only'
+            'should return the key value only',
         );
     }
 
@@ -83,7 +83,7 @@ class InstanceConfigTraitTest extends TestCase
         $this->assertSame(
             'value',
             $this->object->getConfig('a.nested'),
-            'should return the nested value only'
+            'should return the nested value only',
         );
     }
 
@@ -94,12 +94,12 @@ class InstanceConfigTraitTest extends TestCase
     {
         $this->assertSame(
             'default',
-            $this->object->getConfig('nonexistent', 'default')
+            $this->object->getConfig('nonexistent', 'default'),
         );
 
         $this->assertSame(
             'my-default',
-            $this->object->getConfig('nested.nonexistent', 'my-default')
+            $this->object->getConfig('nested.nonexistent', 'my-default'),
         );
     }
 
@@ -112,19 +112,19 @@ class InstanceConfigTraitTest extends TestCase
         $this->assertSame(
             'bar',
             $this->object->getConfig('foo'),
-            'should return the same value just set'
+            'should return the same value just set',
         );
 
         $return = $this->object->setConfig('some', 'zum');
         $this->assertSame(
             'zum',
             $this->object->getConfig('some'),
-            'should return the overwritten value'
+            'should return the overwritten value',
         );
         $this->assertSame(
             $this->object,
             $return,
-            'write operations should return the instance'
+            'write operations should return the instance',
         );
 
         $this->assertSame(
@@ -134,7 +134,7 @@ class InstanceConfigTraitTest extends TestCase
                 'foo' => 'bar',
             ],
             $this->object->getConfig(),
-            'updates should be merged with existing config'
+            'updates should be merged with existing config',
         );
     }
 
@@ -147,14 +147,14 @@ class InstanceConfigTraitTest extends TestCase
         $this->assertSame(
             'bar',
             $this->object->getConfig('new.foo'),
-            'should return the same value just set'
+            'should return the same value just set',
         );
 
         $this->object->setConfig('a.nested', 'zum');
         $this->assertSame(
             'zum',
             $this->object->getConfig('a.nested'),
-            'should return the overwritten value'
+            'should return the overwritten value',
         );
 
         $this->assertSame(
@@ -164,7 +164,7 @@ class InstanceConfigTraitTest extends TestCase
                 'new' => ['foo' => 'bar'],
             ],
             $this->object->getConfig(),
-            'updates should be merged with existing config'
+            'updates should be merged with existing config',
         );
     }
 
@@ -177,7 +177,7 @@ class InstanceConfigTraitTest extends TestCase
         $this->assertSame(
             'bar',
             $this->object->getConfig('foo'),
-            'should return the same value just set'
+            'should return the same value just set',
         );
 
         $this->assertSame(
@@ -187,14 +187,14 @@ class InstanceConfigTraitTest extends TestCase
                 'foo' => 'bar',
             ],
             $this->object->getConfig(),
-            'updates should be merged with existing config'
+            'updates should be merged with existing config',
         );
 
         $this->object->setConfig(['new.foo' => 'bar']);
         $this->assertSame(
             'bar',
             $this->object->getConfig('new.foo'),
-            'should return the same value just set'
+            'should return the same value just set',
         );
 
         $this->assertSame(
@@ -205,7 +205,7 @@ class InstanceConfigTraitTest extends TestCase
                 'new' => ['foo' => 'bar'],
             ],
             $this->object->getConfig(),
-            'updates should be merged with existing config'
+            'updates should be merged with existing config',
         );
 
         $this->object->setConfig(['multiple' => 'different', 'a.values.to' => 'set']);
@@ -219,7 +219,7 @@ class InstanceConfigTraitTest extends TestCase
                 'multiple' => 'different',
             ],
             $this->object->getConfig(),
-            'updates should be merged with existing config'
+            'updates should be merged with existing config',
         );
     }
 
@@ -229,7 +229,7 @@ class InstanceConfigTraitTest extends TestCase
         $this->assertSame(
             'bar',
             $this->object->getConfigOrFail('foo'),
-            'should return the same value just set'
+            'should return the same value just set',
         );
     }
 
@@ -255,7 +255,7 @@ class InstanceConfigTraitTest extends TestCase
                 'new' => 'bar',
             ],
             $this->object->getConfig(),
-            'When merging a scalar property will be overwritten with an array'
+            'When merging a scalar property will be overwritten with an array',
         );
     }
 
@@ -287,7 +287,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'Merging should not delete untouched array values'
+            'Merging should not delete untouched array values',
         );
     }
 
@@ -308,7 +308,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'Should act the same as having passed the equivalent array to the config function'
+            'Should act the same as having passed the equivalent array to the config function',
         );
 
         $this->object->setConfig(['a.nextra' => 'value']);
@@ -324,7 +324,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'Merging should not delete untouched array values'
+            'Merging should not delete untouched array values',
         );
     }
 
@@ -345,7 +345,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'First access should act like any subsequent access'
+            'First access should act like any subsequent access',
         );
     }
 
@@ -364,7 +364,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'If explicitly no-merge, array values should be overwritten'
+            'If explicitly no-merge, array values should be overwritten',
         );
     }
 
@@ -389,7 +389,7 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'When merging a scalar property will be overwritten with an array'
+            'When merging a scalar property will be overwritten with an array',
         );
     }
 
@@ -408,7 +408,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
             $object->getConfig(),
-            'default config should be returned'
+            'default config should be returned',
         );
 
         $object->setConfig('throw.me', 'an exception');
@@ -422,13 +422,13 @@ class InstanceConfigTraitTest extends TestCase
         $this->object->setConfig('foo', null);
         $this->assertNull(
             $this->object->getConfig('foo'),
-            'setting a new key to null should have no effect'
+            'setting a new key to null should have no effect',
         );
 
         $this->object->setConfig('some', null);
         $this->assertNull(
             $this->object->getConfig('some'),
-            'should delete the existing value'
+            'should delete the existing value',
         );
 
         $this->assertSame(
@@ -436,7 +436,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => ['nested' => 'value', 'other' => 'value'],
             ],
             $this->object->getConfig(),
-            'deleted keys should not be present'
+            'deleted keys should not be present',
         );
     }
 
@@ -448,13 +448,13 @@ class InstanceConfigTraitTest extends TestCase
         $this->object->setConfig('new.foo', null);
         $this->assertNull(
             $this->object->getConfig('new.foo'),
-            'setting a new key to null should have no effect'
+            'setting a new key to null should have no effect',
         );
 
         $this->object->setConfig('a.nested', null);
         $this->assertNull(
             $this->object->getConfig('a.nested'),
-            'should delete the existing value'
+            'should delete the existing value',
         );
         $this->assertSame(
             [
@@ -464,13 +464,13 @@ class InstanceConfigTraitTest extends TestCase
                 ],
             ],
             $this->object->getConfig(),
-            'deleted keys should not be present'
+            'deleted keys should not be present',
         );
 
         $this->object->setConfig('a.other', null);
         $this->assertNull(
             $this->object->getConfig('a.other'),
-            'should delete the existing value'
+            'should delete the existing value',
         );
         $this->assertSame(
             [
@@ -478,7 +478,7 @@ class InstanceConfigTraitTest extends TestCase
                 'a' => [],
             ],
             $this->object->getConfig(),
-            'deleted keys should not be present'
+            'deleted keys should not be present',
         );
     }
 
@@ -490,14 +490,14 @@ class InstanceConfigTraitTest extends TestCase
         $this->object->setConfig('a', null);
         $this->assertNull(
             $this->object->getConfig('a'),
-            'should delete the existing value'
+            'should delete the existing value',
         );
         $this->assertSame(
             [
                 'some' => 'string',
             ],
             $this->object->getConfig(),
-            'deleted keys should not be present'
+            'deleted keys should not be present',
         );
     }
 

--- a/tests/TestCase/Core/ServiceProviderTest.php
+++ b/tests/TestCase/Core/ServiceProviderTest.php
@@ -34,7 +34,7 @@ class ServiceProviderTest extends TestCase
 
         $this->assertTrue(
             $container->has('boot'),
-            'Should have service defined in bootstrap.'
+            'Should have service defined in bootstrap.',
         );
         $this->assertSame('boot', $container->get('boot')->name);
     }

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -156,7 +156,7 @@ class ConnectionTest extends TestCase
         $this->expectException(MissingExtensionException::class);
         $this->expectExceptionMessageMatches(
             '/Database driver `.+` cannot be used due to a missing PHP extension or unmet dependency\. ' .
-            'Requested by connection `custom_connection_name`/'
+            'Requested by connection `custom_connection_name`/',
         );
         $driver = new class extends StubDriver {
             public function enabled(): bool
@@ -301,9 +301,9 @@ class ConnectionTest extends TestCase
         $this->assertStringStartsWith(
             sprintf(
                 'Connection to %s could not be established:',
-                App::shortName($connection->getDriver()::class, 'Database/Driver')
+                App::shortName($connection->getDriver()::class, 'Database/Driver'),
             ),
-            $e->getMessage()
+            $e->getMessage(),
         );
         $this->assertInstanceOf('PDOException', $e->getPrevious());
     }
@@ -393,7 +393,7 @@ class ConnectionTest extends TestCase
         $result = $this->connection->insert(
             'things',
             $data,
-            ['id' => 'integer', 'title' => 'string', 'body' => 'string']
+            ['id' => 'integer', 'title' => 'string', 'body' => 'string'],
         );
         $this->assertInstanceOf(StatementInterface::class, $result);
         $result->closeCursor();
@@ -413,7 +413,7 @@ class ConnectionTest extends TestCase
         $query = $this->connection->insertQuery(
             'things',
             $data,
-            ['id' => 'integer', 'title' => 'string', 'body' => 'string']
+            ['id' => 'integer', 'title' => 'string', 'body' => 'string'],
         );
         $result = $query->execute();
         $this->assertInstanceOf(StatementInterface::class, $result);
@@ -434,7 +434,7 @@ class ConnectionTest extends TestCase
         $result = $this->connection->insert(
             'things',
             $data,
-            ['integer', 'string', 'string']
+            ['integer', 'string', 'string'],
         );
         $result->closeCursor();
         $this->assertInstanceOf(StatementInterface::class, $result);
@@ -841,7 +841,7 @@ class ConnectionTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
-            'SQLServer fails when this test is included.'
+            'SQLServer fails when this test is included.',
         );
         $this->connection->enableSavePoints(false);
         $this->assertFalse($this->connection->isSavePointsEnabled());
@@ -1194,7 +1194,7 @@ class ConnectionTest extends TestCase
             ->method('execute')
             ->willReturnOnConsecutiveCalls(
                 $this->throwException(new Exception('server gone away')),
-                $statement
+                $statement,
             );
 
         $res = $conn->execute('SELECT 1');

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -115,7 +115,7 @@ class MysqlTest extends TestCase
         $connection->expects($this->exactly(3))
             ->method('exec')
             ->with(
-                ...self::withConsecutive(['Execute this'], ['this too'], ["SET time_zone = 'Antarctica'"])
+                ...self::withConsecutive(['Execute this'], ['this too'], ["SET time_zone = 'Antarctica'"]),
             );
 
         $driver->expects($this->once())->method('createPdo')
@@ -234,7 +234,7 @@ class MysqlTest extends TestCase
         foreach ($featureVersions[$serverType] as $feature => $version) {
             $this->assertSame(
                 version_compare($driver->version(), $version, '>='),
-                $driver->supports(DriverFeatureEnum::from($feature))
+                $driver->supports(DriverFeatureEnum::from($feature)),
             );
         }
 

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -72,8 +72,8 @@ class PostgresTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['SET NAMES utf8'],
-                    ['SET search_path TO public']
-                )
+                    ['SET search_path TO public'],
+                ),
             );
 
         $driver->expects($this->once())->method('createPdo')
@@ -131,8 +131,8 @@ class PostgresTest extends TestCase
                     ['SET search_path TO fooblic'],
                     ['Execute this'],
                     ['this too'],
-                    ['SET timezone = Antarctica']
-                )
+                    ['SET timezone = Antarctica'],
+                ),
             );
 
         $driver->expects($this->once())->method('createPdo')

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -106,7 +106,7 @@ class SqliteTest extends TestCase
         $connection->expects($this->exactly(2))
             ->method('exec')
             ->with(
-                ...self::withConsecutive(['Execute this'], ['this too'])
+                ...self::withConsecutive(['Execute this'], ['this too']),
             );
 
         $driver->expects($this->once())->method('createPdo')
@@ -209,7 +209,7 @@ class SqliteTest extends TestCase
         foreach ($featureVersions as $feature => $version) {
             $this->assertSame(
                 version_compare($driver->version(), $version, '>='),
-                $driver->supports(DriverFeatureEnum::from($feature))
+                $driver->supports(DriverFeatureEnum::from($feature)),
             );
         }
 

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -172,8 +172,8 @@ class SqlserverTest extends TestCase
                     ['Execute this'],
                     ['this too'],
                     ['SET config1 value1'],
-                    ['SET config2 value2']
-                )
+                    ['SET config2 value2'],
+                ),
             );
 
         $driver->expects($this->once())->method('createPdo')
@@ -265,7 +265,7 @@ class SqlserverTest extends TestCase
                         PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE => PDO::SQLSRV_CURSOR_BUFFERED,
                     ]],
                     ['', []],
-                )
+                ),
             )
             ->willReturn($statement);
 
@@ -439,7 +439,7 @@ class SqlserverTest extends TestCase
                 '(ROW_NUMBER() OVER (ORDER BY (SELECT count(*) FROM articles a WHERE (a.id = articles.id AND a.published = :c2)) ASC)) AS _cake_page_rownum_ FROM articles' .
             ') _cake_paging_ ' .
             'WHERE _cake_paging_._cake_page_rownum_ > 10',
-            $query->sql()
+            $query->sql(),
         );
     }
 
@@ -536,7 +536,7 @@ class SqlserverTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Exceeded maximum number of parameters (2100) for prepared statements in Sql Server'
+            'Exceeded maximum number of parameters (2100) for prepared statements in Sql Server',
         );
         $connection->getDriver()->prepare($query);
     }

--- a/tests/TestCase/Database/DriverTest.php
+++ b/tests/TestCase/Database/DriverTest.php
@@ -81,7 +81,7 @@ class DriverTest extends TestCase
         } catch (Exception $e) {
             $this->assertStringContainsString(
                 'Please pass "username" instead of "login" for connecting to the database',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
     }
@@ -350,7 +350,7 @@ class DriverTest extends TestCase
                 'a' => 1,
                 'b' => new DateTime('2013-01-01'),
             ],
-            ['b' => 'date']
+            ['b' => 'date'],
         );
 
         $messages = Log::engine('queries')->read();

--- a/tests/TestCase/Database/Expression/AggregateExpressionTest.php
+++ b/tests/TestCase/Database/Expression/AggregateExpressionTest.php
@@ -42,7 +42,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
         $f = (new AggregateExpression('MyFunction'))->over('name');
         $this->assertEqualsSql(
             'MyFunction() OVER name',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
     }
 
@@ -54,7 +54,7 @@ class AggregateExpressionTest extends FunctionExpressionTest
         $f = (new AggregateExpression('MyFunction'))->filter(['this' => new IdentifierExpression('that')]);
         $this->assertEqualsSql(
             'MyFunction() FILTER (WHERE this = that)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f->filter(function (QueryExpression $q) {
@@ -62,13 +62,13 @@ class AggregateExpressionTest extends FunctionExpressionTest
         });
         $this->assertEqualsSql(
             'MyFunction() FILTER (WHERE (this = that AND this2 = that2))',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f->over();
         $this->assertEqualsSql(
             'MyFunction() FILTER (WHERE (this = that AND this2 = that2)) OVER ()',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
     }
 
@@ -80,49 +80,49 @@ class AggregateExpressionTest extends FunctionExpressionTest
         $f = (new AggregateExpression('MyFunction'))->partition('test');
         $this->assertEqualsSql(
             'MyFunction() OVER (PARTITION BY test)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->orderBy('test');
         $this->assertEqualsSql(
             'MyFunction() OVER (ORDER BY test)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null);
         $this->assertEqualsSql(
             'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null, null);
         $this->assertEqualsSql(
             'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->rows(null);
         $this->assertEqualsSql(
             'MyFunction() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->rows(null, null);
         $this->assertEqualsSql(
             'MyFunction() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->groups(null);
         $this->assertEqualsSql(
             'MyFunction() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->groups(null, null);
         $this->assertEqualsSql(
             'MyFunction() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->frame(
@@ -130,35 +130,35 @@ class AggregateExpressionTest extends FunctionExpressionTest
             2,
             AggregateExpression::PRECEDING,
             1,
-            AggregateExpression::PRECEDING
+            AggregateExpression::PRECEDING,
         );
         $this->assertEqualsSql(
             'MyFunction() OVER (RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->excludeCurrent();
         $this->assertEqualsSql(
             'MyFunction() OVER ()',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null)->excludeCurrent();
         $this->assertEqualsSql(
             'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null)->excludeGroup();
         $this->assertEqualsSql(
             'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
 
         $f = (new AggregateExpression('MyFunction'))->range(null)->excludeTies();
         $this->assertEqualsSql(
             'MyFunction() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)',
-            $f->sql(new ValueBinder())
+            $f->sql(new ValueBinder()),
         );
     }
 

--- a/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
+++ b/tests/TestCase/Database/Expression/CaseStatementExpressionTest.php
@@ -59,7 +59,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE CUSTOM(:param0) WHEN CUSTOM(:param1) THEN CUSTOM(:param2) ELSE CUSTOM(:param3) END',
-            $sql
+            $sql,
         );
     }
 
@@ -76,7 +76,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE CUSTOM(:param0) WHEN CUSTOM(:param1) THEN CUSTOM(:param2) ELSE CUSTOM(:param3) END',
-            $sql
+            $sql,
         );
     }
 
@@ -93,7 +93,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN Table.column = (CUSTOM(:param0)) THEN CUSTOM(:param1) ELSE CUSTOM(:param2) END',
-            $sql
+            $sql,
         );
     }
 
@@ -372,7 +372,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -402,7 +402,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c4',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -425,7 +425,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -455,7 +455,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c4',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -484,7 +484,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -514,7 +514,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c4',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -543,7 +543,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN Table.column_a = :c0 THEN :c1 WHEN Table.column_b = :c2 THEN :c3 ELSE :c4 END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -573,7 +573,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c4',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -582,7 +582,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'When using an array for the `$when` argument, the `$type` ' .
-            'argument must be an array too, `string` given.'
+            'argument must be an array too, `string` given.',
         );
 
         (new CaseStatementExpression())
@@ -595,7 +595,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'When using a non-array value for the `$when` argument, ' .
-            'the `$type` argument must be a string, `array` given.'
+            'the `$type` argument must be a string, `array` given.',
         );
 
         (new CaseStatementExpression())
@@ -653,7 +653,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c5',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
 
         $this->assertSame($typeMap, $expression->getTypeMap());
@@ -673,7 +673,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -693,7 +693,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c2',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -707,7 +707,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -727,7 +727,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c2',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -741,7 +741,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN :c0 THEN :c1 ELSE NULL END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -756,7 +756,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c1',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -765,7 +765,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'When using an array for the `$when` argument, the `$type` ' .
-            'argument must be an array too, `string` given.'
+            'argument must be an array too, `string` given.',
         );
 
         (new CaseStatementExpression())
@@ -783,7 +783,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE WHEN :c0 THEN :c1 ELSE NULL END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -798,7 +798,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c1',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -812,7 +812,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -832,7 +832,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c2',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -846,7 +846,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -866,7 +866,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c2',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -881,7 +881,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE :c3 END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -906,7 +906,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c3',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -921,7 +921,7 @@ class CaseStatementExpressionTest extends TestCase
         $sql = $expression->sql($valueBinder);
         $this->assertSame(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE :c3 END',
-            $sql
+            $sql,
         );
         $this->assertSame(
             [
@@ -946,7 +946,7 @@ class CaseStatementExpressionTest extends TestCase
                     'placeholder' => 'c3',
                 ],
             ],
-            $valueBinder->bindings()
+            $valueBinder->bindings(),
         );
     }
 
@@ -958,7 +958,7 @@ class CaseStatementExpressionTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The `$clause` argument must be one of `value`, `when`, `else`, the given value `invalid` is invalid.'
+            'The `$clause` argument must be one of `value`, `when`, `else`, the given value `invalid` is invalid.',
         );
 
         (new CaseStatementExpression())->clause('invalid');
@@ -968,7 +968,7 @@ class CaseStatementExpressionTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The `$clause` argument must be one of `when`, `then`, the given value `invalid` is invalid.'
+            'The `$clause` argument must be one of `when`, `then`, the given value `invalid` is invalid.',
         );
 
         (new WhenThenExpression())->clause('invalid');
@@ -1015,7 +1015,7 @@ class CaseStatementExpressionTest extends TestCase
 
         $this->assertEquals(
             new QueryExpression($when),
-            $expression->clause('when')[0]->clause('when')
+            $expression->clause('when')[0]->clause('when'),
         );
     }
 
@@ -1080,7 +1080,7 @@ class CaseStatementExpressionTest extends TestCase
             'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
             'ELSE :c4 ' .
             'END',
-            $sql
+            $sql,
         );
     }
 
@@ -1146,7 +1146,7 @@ class CaseStatementExpressionTest extends TestCase
             'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
             'ELSE :c4 ' .
             'END',
-            $sql
+            $sql,
         );
     }
 
@@ -1179,7 +1179,7 @@ class CaseStatementExpressionTest extends TestCase
             'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
             'ELSE :c4 ' .
             'END',
-            $sql
+            $sql,
         );
     }
 
@@ -1188,7 +1188,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage(
             '`when()` callables must return an instance of ' .
-            '`\Cake\Database\Expression\WhenThenExpression`, `null` given.'
+            '`\Cake\Database\Expression\WhenThenExpression`, `null` given.',
         );
 
         $this->deprecated(function (): void {
@@ -1212,7 +1212,7 @@ class CaseStatementExpressionTest extends TestCase
                         'Table.column_a' => true,
                         'Table.column_b IS' => null,
                     ])
-                    ->then(1)
+                    ->then(1),
             )
             ->when(
                 (new WhenThenExpression())
@@ -1220,7 +1220,7 @@ class CaseStatementExpressionTest extends TestCase
                         'Table.column_c' => true,
                         'Table.column_d IS NOT' => null,
                     ])
-                    ->then(2)
+                    ->then(2),
             )
             ->else(3);
 
@@ -1232,7 +1232,7 @@ class CaseStatementExpressionTest extends TestCase
             'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
             'ELSE :c4 ' .
             'END',
-            $sql
+            $sql,
         );
     }
 
@@ -1245,7 +1245,7 @@ class CaseStatementExpressionTest extends TestCase
                         'Table.column_a' => true,
                         'Table.column_b IS' => null,
                     ])
-                    ->then(1)
+                    ->then(1),
             )
             ->when(
                 (new CustomWhenThenExpression())
@@ -1253,7 +1253,7 @@ class CaseStatementExpressionTest extends TestCase
                         'Table.column_c' => true,
                         'Table.column_d IS NOT' => null,
                     ])
-                    ->then(2)
+                    ->then(2),
             )
             ->else(3);
 
@@ -1265,7 +1265,7 @@ class CaseStatementExpressionTest extends TestCase
             'WHEN (Table.column_c = :c2 AND (Table.column_d) IS NOT NULL) THEN :c3 ' .
             'ELSE :c4 ' .
             'END',
-            $sql
+            $sql,
         );
     }
 
@@ -1366,7 +1366,7 @@ class CaseStatementExpressionTest extends TestCase
         if ($sqlValue) {
             $this->assertEqualsSql(
                 "CASE {$sqlValue} WHEN :c0 THEN :c1 ELSE NULL END",
-                $sql
+                $sql,
             );
 
             $this->assertSame(
@@ -1382,12 +1382,12 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c1',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         } else {
             $this->assertEqualsSql(
                 'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
-                $sql
+                $sql,
             );
 
             $this->assertSame(
@@ -1408,7 +1408,7 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c2',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         }
     }
@@ -1550,7 +1550,7 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c2',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         }
     }
@@ -1667,7 +1667,7 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c1',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         }
     }
@@ -1711,7 +1711,7 @@ class CaseStatementExpressionTest extends TestCase
         if ($sqlValue) {
             $this->assertEqualsSql(
                 "CASE WHEN :c0 THEN {$sqlValue} ELSE NULL END",
-                $sql
+                $sql,
             );
 
             $this->assertSame(
@@ -1722,12 +1722,12 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c0',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         } else {
             $this->assertEqualsSql(
                 'CASE WHEN :c0 THEN :c1 ELSE NULL END',
-                $sql
+                $sql,
             );
 
             $this->assertSame(
@@ -1743,7 +1743,7 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c1',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         }
     }
@@ -1788,7 +1788,7 @@ class CaseStatementExpressionTest extends TestCase
         if ($sqlValue) {
             $this->assertEqualsSql(
                 "CASE WHEN :c0 THEN :c1 ELSE {$sqlValue} END",
-                $sql
+                $sql,
             );
 
             $this->assertSame(
@@ -1804,12 +1804,12 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c1',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         } else {
             $this->assertEqualsSql(
                 'CASE WHEN :c0 THEN :c1 ELSE :c2 END',
-                $sql
+                $sql,
             );
 
             $this->assertSame(
@@ -1830,7 +1830,7 @@ class CaseStatementExpressionTest extends TestCase
                         'placeholder' => 'c2',
                     ],
                 ],
-                $valueBinder->bindings()
+                $valueBinder->bindings(),
             );
         }
     }
@@ -1865,7 +1865,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'The `$value` argument must be either `null`, a scalar value, an object, ' .
-            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `{$typeName}` given."
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `{$typeName}` given.",
         );
 
         new CaseStatementExpression($value);
@@ -1875,7 +1875,7 @@ class CaseStatementExpressionTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The `$when` argument must be a non-empty array'
+            'The `$when` argument must be a non-empty array',
         );
 
         (new CaseStatementExpression())
@@ -1909,7 +1909,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'The `$result` argument must be either `null`, a scalar value, an object, ' .
-            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `{$typeName}` given."
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `{$typeName}` given.",
         );
 
         (new CaseStatementExpression())
@@ -1973,7 +1973,7 @@ class CaseStatementExpressionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'The `$result` argument must be either `null`, a scalar value, an object, ' .
-            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `{$typeName}` given."
+            "or an instance of `\\Cake\\Database\\ExpressionInterface`, `{$typeName}` given.",
         );
 
         (new CaseStatementExpression())
@@ -2064,7 +2064,7 @@ class CaseStatementExpressionTest extends TestCase
 
             $expression->traverse(
                 function (): void {
-                }
+                },
             );
         });
     }

--- a/tests/TestCase/Database/Expression/FunctionExpressionTest.php
+++ b/tests/TestCase/Database/Expression/FunctionExpressionTest.php
@@ -105,7 +105,7 @@ class FunctionExpressionTest extends TestCase
         $function = new $this->expressionClass('MyFunction', [$query]);
         $this->assertSame(
             'MyFunction((SELECT column))',
-            preg_replace('/[`"\[\]]/', '', $function->sql($binder))
+            preg_replace('/[`"\[\]]/', '', $function->sql($binder)),
         );
     }
 

--- a/tests/TestCase/Database/Expression/QueryExpressionTest.php
+++ b/tests/TestCase/Database/Expression/QueryExpressionTest.php
@@ -132,7 +132,7 @@ class QueryExpressionTest extends TestCase
             [
                 'Users.username' => 'string',
                 'Users.active' => 'boolean',
-            ]
+            ],
         );
 
         $result = $expr->sql($binder);
@@ -249,7 +249,7 @@ class QueryExpressionTest extends TestCase
         $expr->notInOrNull('test', ['one', 'two']);
         $this->assertEqualsSql(
             '(test NOT IN (:c0,:c1) OR (test) IS NULL)',
-            $expr->sql(new ValueBinder())
+            $expr->sql(new ValueBinder()),
         );
     }
 
@@ -262,7 +262,7 @@ class QueryExpressionTest extends TestCase
 
         $this->assertEqualsSql(
             'CASE WHEN :c0 THEN :c1 ELSE NULL END',
-            $expression->sql(new ValueBinder())
+            $expression->sql(new ValueBinder()),
         );
     }
 
@@ -275,7 +275,7 @@ class QueryExpressionTest extends TestCase
 
         $this->assertEqualsSql(
             'CASE NULL WHEN :c0 THEN :c1 ELSE NULL END',
-            $expression->sql(new ValueBinder())
+            $expression->sql(new ValueBinder()),
         );
     }
 
@@ -290,7 +290,7 @@ class QueryExpressionTest extends TestCase
 
         $this->assertEqualsSql(
             'CASE :c0 WHEN :c1 THEN :c2 ELSE NULL END',
-            $expression->sql($valueBinder)
+            $expression->sql($valueBinder),
         );
 
         $this->assertSame(
@@ -299,7 +299,7 @@ class QueryExpressionTest extends TestCase
                 'type' => 'integer',
                 'placeholder' => 'c0',
             ],
-            $valueBinder->bindings()[':c0']
+            $valueBinder->bindings()[':c0'],
         );
     }
 }

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -77,7 +77,7 @@ class TupleComparisonTest extends TestCase
             ['field1', 'field2'],
             [[1, 2], [3, 4]],
             ['integer', 'integer'],
-            'IN'
+            'IN',
         );
         $binder = new ValueBinder();
         $this->assertSame('(field1, field2) IN ((:tuple0,:tuple1), (:tuple2,:tuple3))', $f->sql($binder));
@@ -110,7 +110,7 @@ class TupleComparisonTest extends TestCase
             ['field1', $field2],
             [[1, 2], [3, $value1]],
             ['integer', 'integer'],
-            'IN'
+            'IN',
         );
         $expressions = [];
         $f->traverse($collector);
@@ -152,7 +152,7 @@ class TupleComparisonTest extends TestCase
             ['field1', 'field2'],
             [1, 1],
             ['integer', 'integer'],
-            'IN'
+            'IN',
         );
     }
 
@@ -165,7 +165,7 @@ class TupleComparisonTest extends TestCase
             ['field1', 'field2'],
             [[1, 1], [2, 2]],
             ['integer', 'integer'],
-            '='
+            '=',
         );
     }
 }

--- a/tests/TestCase/Database/Expression/WindowExpressionTest.php
+++ b/tests/TestCase/Database/Expression/WindowExpressionTest.php
@@ -49,19 +49,19 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->partition('test');
         $this->assertEqualsSql(
             'PARTITION BY test',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w->partition(new IdentifierExpression('identifier'));
         $this->assertEqualsSql(
             'PARTITION BY test, identifier',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->partition(new AggregateExpression('MyAggregate', ['param']));
         $this->assertEqualsSql(
             'PARTITION BY MyAggregate(:param0)',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->partition(function (QueryExpression $expr) {
@@ -69,7 +69,7 @@ class WindowExpressionTest extends TestCase
         });
         $this->assertEqualsSql(
             'PARTITION BY MyAggregate(:param0)',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 
@@ -81,19 +81,19 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->orderBy('test');
         $this->assertEqualsSql(
             'ORDER BY test',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w->orderBy(['test2' => 'DESC']);
         $this->assertEqualsSql(
             'ORDER BY test, test2 DESC',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w->partition('test');
         $this->assertEqualsSql(
             'PARTITION BY test ORDER BY test, test2 DESC',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())
@@ -105,7 +105,7 @@ class WindowExpressionTest extends TestCase
             });
         $this->assertEqualsSql(
             'ORDER BY test, test2, test3 DESC',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 
@@ -114,7 +114,7 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->order('test');
         $this->assertEqualsSql(
             'ORDER BY test',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 
@@ -126,55 +126,55 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->range(null);
         $this->assertEqualsSql(
             'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(0);
         $this->assertEqualsSql(
             'RANGE BETWEEN CURRENT ROW AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(2);
         $this->assertEqualsSql(
             'RANGE BETWEEN 2 PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(null, null);
         $this->assertEqualsSql(
             'RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(0, null);
         $this->assertEqualsSql(
             'RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(0, 0);
         $this->assertEqualsSql(
             'RANGE BETWEEN CURRENT ROW AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(1, 2);
         $this->assertEqualsSql(
             'RANGE BETWEEN 1 PRECEDING AND 2 FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range("'1 day'", "'10 days'");
         $this->assertRegExpSql(
             "RANGE BETWEEN '1 day' PRECEDING AND '10 days' FOLLOWING",
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(new QueryExpression("'1 day'"), new QueryExpression("'10 days'"));
         $this->assertRegExpSql(
             "RANGE BETWEEN '1 day' PRECEDING AND '10 days' FOLLOWING",
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->frame(
@@ -182,11 +182,11 @@ class WindowExpressionTest extends TestCase
             2,
             WindowExpression::PRECEDING,
             1,
-            WindowExpression::PRECEDING
+            WindowExpression::PRECEDING,
         );
         $this->assertEqualsSql(
             'RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 
@@ -198,43 +198,43 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->rows(null);
         $this->assertEqualsSql(
             'ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->rows(0);
         $this->assertEqualsSql(
             'ROWS BETWEEN CURRENT ROW AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->rows(2);
         $this->assertEqualsSql(
             'ROWS BETWEEN 2 PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->rows(null, null);
         $this->assertEqualsSql(
             'ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->rows(0, null);
         $this->assertEqualsSql(
             'ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->rows(0, 0);
         $this->assertEqualsSql(
             'ROWS BETWEEN CURRENT ROW AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->rows(1, 2);
         $this->assertEqualsSql(
             'ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->frame(
@@ -242,12 +242,12 @@ class WindowExpressionTest extends TestCase
             2,
             WindowExpression::PRECEDING,
             1,
-            WindowExpression::PRECEDING
+            WindowExpression::PRECEDING,
         );
         $b = new ValueBinder();
         $this->assertEqualsSql(
             'ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING',
-            $w->sql($b)
+            $w->sql($b),
         );
     }
 
@@ -259,43 +259,43 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->groups(null);
         $this->assertEqualsSql(
             'GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->groups(0);
         $this->assertEqualsSql(
             'GROUPS BETWEEN CURRENT ROW AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->groups(2);
         $this->assertEqualsSql(
             'GROUPS BETWEEN 2 PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->groups(null, null);
         $this->assertEqualsSql(
             'GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->groups(0, null);
         $this->assertEqualsSql(
             'GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->groups(0, 0);
         $this->assertEqualsSql(
             'GROUPS BETWEEN CURRENT ROW AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->groups(1, 2);
         $this->assertEqualsSql(
             'GROUPS BETWEEN 1 PRECEDING AND 2 FOLLOWING',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->frame(
@@ -303,12 +303,12 @@ class WindowExpressionTest extends TestCase
             2,
             WindowExpression::PRECEDING,
             1,
-            WindowExpression::PRECEDING
+            WindowExpression::PRECEDING,
         );
         $b = new ValueBinder();
         $this->assertEqualsSql(
             'GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING',
-            $w->sql($b)
+            $w->sql($b),
         );
     }
 
@@ -320,25 +320,25 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->excludeCurrent();
         $this->assertEqualsSql(
             '',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(null)->excludeCurrent();
         $this->assertEqualsSql(
             'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(null)->excludeGroup();
         $this->assertEqualsSql(
             'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE GROUP',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->range(null)->excludeTies();
         $this->assertEqualsSql(
             'RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 
@@ -350,25 +350,25 @@ class WindowExpressionTest extends TestCase
         $w = (new WindowExpression())->partition('test')->range(null);
         $this->assertEqualsSql(
             'PARTITION BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->orderBy('test')->range(null);
         $this->assertEqualsSql(
             'ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->partition('test')->orderBy('test')->range(null);
         $this->assertEqualsSql(
             'PARTITION BY test ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w = (new WindowExpression())->partition('test')->orderBy('test')->range(null)->excludeCurrent();
         $this->assertEqualsSql(
             'PARTITION BY test ORDER BY test RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 
@@ -384,20 +384,20 @@ class WindowExpressionTest extends TestCase
         $this->assertTrue($w->isNamedOnly());
         $this->assertEqualsSql(
             'name',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w->name('new_name');
         $this->assertEqualsSql(
             'new_name',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
 
         $w->orderBy('test');
         $this->assertFalse($w->isNamedOnly());
         $this->assertEqualsSql(
             'new_name ORDER BY test',
-            $w->sql(new ValueBinder())
+            $w->sql(new ValueBinder()),
         );
     }
 

--- a/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingIntegrationTest.php
@@ -118,7 +118,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
         $result = $this->connection->selectQuery('id', 'ordered_uuid_items')
             ->where(
                 ['id' => ['48298a29-81c0-4c26-a7fb-413140cf8569', '482b7756-8da0-419a-b21f-27da40cf8569']],
-                ['id' => 'ordered_uuid[]']
+                ['id' => 'ordered_uuid[]'],
             )
             ->orderBy('id')
             ->execute()
@@ -141,7 +141,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
                     'id',
                     '482b7756-8da0-419a-b21f-27da40cf8569',
                     '48298a29-81c0-4c26-a7fb-413140cf8569',
-                    'ordered_uuid'
+                    'ordered_uuid',
                 );
             })
             ->execute()
@@ -161,7 +161,7 @@ class ExpressionTypeCastingIntegrationTest extends TestCase
                 return $exp->eq(
                     'id',
                     $q->func()->concat(['48298a29-81c0-4c26-a7fb', '-413140cf8569'], []),
-                    'ordered_uuid'
+                    'ordered_uuid',
                 );
             })
             ->execute()

--- a/tests/TestCase/Database/ExpressionTypeCastingTest.php
+++ b/tests/TestCase/Database/ExpressionTypeCastingTest.php
@@ -133,7 +133,7 @@ class ExpressionTypeCastingTest extends TestCase
         $sql = $values->sql($binder);
         $this->assertSame(
             ' VALUES ((CONCAT(:param0, :param1))), ((CONCAT(:param2, :param3)))',
-            $sql
+            $sql,
         );
         $this->assertSame('foo', $binder->bindings()[':param0']['value']);
         $this->assertSame('bar', $binder->bindings()[':param2']['value']);

--- a/tests/TestCase/Database/Query/DeleteQueryTest.php
+++ b/tests/TestCase/Database/Query/DeleteQueryTest.php
@@ -181,7 +181,7 @@ class DeleteQueryTest extends TestCase
                 '\)' .
             '\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -216,7 +216,7 @@ class DeleteQueryTest extends TestCase
         $this->assertQuotedQuery(
             'DELETE IGNORE FROM <authors> WHERE 1 = 1',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new DeleteQuery($this->connection);
@@ -227,7 +227,7 @@ class DeleteQueryTest extends TestCase
         $this->assertQuotedQuery(
             'DELETE IGNORE QUICK FROM <authors> WHERE 1 = 1',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 }

--- a/tests/TestCase/Database/Query/InsertQueryTest.php
+++ b/tests/TestCase/Database/Query/InsertQueryTest.php
@@ -116,7 +116,7 @@ class InsertQueryTest extends TestCase
             'INSERT INTO <articles> \(<title>\) (OUTPUT INSERTED\.\* )?' .
             'VALUES \(:c0\)',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -137,7 +137,7 @@ class InsertQueryTest extends TestCase
             'INSERT INTO <articles> \(<title>, <body>\) (OUTPUT INSERTED\.\* )?' .
             'VALUES \(:c0, :c1\)',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute();
@@ -176,7 +176,7 @@ class InsertQueryTest extends TestCase
             'INSERT INTO <articles> \(<123>\) (OUTPUT INSERTED\.\* )?' .
             'VALUES \(:c0\)',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -197,7 +197,7 @@ class InsertQueryTest extends TestCase
             'INSERT INTO <articles> \(<title>, <body>\) (OUTPUT INSERTED\.\* )?' .
             'VALUES \(:c0, :c1\)',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute();
@@ -274,7 +274,7 @@ class InsertQueryTest extends TestCase
         $query = new InsertQuery($this->connection);
         $query->insert(
             ['title', 'body', 'author_id'],
-            ['title' => 'string', 'body' => 'string', 'author_id' => 'integer']
+            ['title' => 'string', 'body' => 'string', 'author_id' => 'integer'],
         )
         ->into('articles')
         ->values($select);
@@ -283,12 +283,12 @@ class InsertQueryTest extends TestCase
         $this->assertQuotedQuery(
             'INSERT INTO <articles> \(<title>, <body>, <author_id>\) (OUTPUT INSERTED\.\* )?SELECT',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
         $this->assertQuotedQuery(
             "SELECT <name>, 'some text', 99 FROM <authors>",
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
         $result = $query->execute();
         $result->closeCursor();
@@ -421,7 +421,7 @@ class InsertQueryTest extends TestCase
         $this->assertQuotedQuery(
             'INSERT IGNORE INTO <articles> \(<title>\) (OUTPUT INSERTED\.\* )?',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new InsertQuery($this->connection);
@@ -433,7 +433,7 @@ class InsertQueryTest extends TestCase
         $this->assertQuotedQuery(
             'INSERT IGNORE LOW_PRIORITY INTO <articles> \(<title>\) (OUTPUT INSERTED\.\* )?',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 

--- a/tests/TestCase/Database/Query/SelectQueryTest.php
+++ b/tests/TestCase/Database/Query/SelectQueryTest.php
@@ -186,7 +186,7 @@ class SelectQueryTest extends TestCase
         $result = $query->from('comments')->execute();
         $this->assertEquals(
             ['foo' => 'First Comment for First Article', 'text' => 'First Comment for First Article', 'article_id' => 1],
-            $result->fetch('assoc')
+            $result->fetch('assoc'),
         );
         $result->closeCursor();
 
@@ -217,11 +217,11 @@ class SelectQueryTest extends TestCase
             ->execute();
         $this->assertEquals(
             ['text' => 'Third Article Body', 'author_id' => 1, 'name' => 'nate'],
-            $result->fetch('assoc')
+            $result->fetch('assoc'),
         );
         $this->assertEquals(
             ['text' => 'Third Article Body', 'author_id' => 1, 'name' => 'mariano'],
-            $result->fetch('assoc')
+            $result->fetch('assoc'),
         );
         $result->closeCursor();
     }
@@ -364,7 +364,7 @@ class SelectQueryTest extends TestCase
             ->execute();
         $this->assertEquals(
             ['title' => 'First Article', 'name' => 'Second Comment for First Article'],
-            $result->fetch('assoc')
+            $result->fetch('assoc'),
         );
         $result->closeCursor();
     }
@@ -393,7 +393,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlite,
-            'SQLite does not support RIGHT joins'
+            'SQLite does not support RIGHT joins',
         );
         $query = new SelectQuery($this->connection);
         $time = new DateTime('2007-03-18 10:45:23');
@@ -407,7 +407,7 @@ class SelectQueryTest extends TestCase
         $this->assertCount(6, $rows);
         $this->assertEquals(
             ['title' => null, 'name' => 'First Comment for First Article'],
-            $rows[0]
+            $rows[0],
         );
         $result->closeCursor();
     }
@@ -452,7 +452,7 @@ class SelectQueryTest extends TestCase
             ->execute();
         $this->assertEquals(
             ['name' => 'mariano', 'commentary' => 'Second Comment for First Article'],
-            $result->fetch('assoc')
+            $result->fetch('assoc'),
         );
         $result->closeCursor();
     }
@@ -626,7 +626,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \(\(<title>\) IS NOT NULL AND \(<user_id>\) IS NULL\)',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -667,7 +667,7 @@ class SelectQueryTest extends TestCase
                     'created >' => new DateTime('2007-03-18 10:40:00'),
                     'created <' => new DateTime('2007-03-18 10:46:00'),
                 ],
-                ['created' => 'datetime']
+                ['created' => 'datetime'],
             )
             ->execute();
         $rows = $result->fetchAll('assoc');
@@ -684,7 +684,7 @@ class SelectQueryTest extends TestCase
                     'id' => '3',
                     'created <' => new DateTime('2013-01-01 12:00'),
                 ],
-                ['created' => 'datetime', 'id' => 'integer']
+                ['created' => 'datetime', 'id' => 'integer'],
             )
             ->execute();
         $rows = $result->fetchAll('assoc');
@@ -701,7 +701,7 @@ class SelectQueryTest extends TestCase
                     'id' => '1',
                     'created <' => new DateTime('2013-01-01 12:00'),
                 ],
-                ['created' => 'datetime', 'id' => 'integer']
+                ['created' => 'datetime', 'id' => 'integer'],
             )
             ->execute();
         $rows = $result->fetchAll('assoc');
@@ -943,7 +943,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <comments> WHERE \(<id> = :c0 OR <id> = :c1\)',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -1153,7 +1153,7 @@ class SelectQueryTest extends TestCase
                 return $exp->in(
                     'created',
                     [new DateTime('2007-03-18 10:45:23'), new DateTime('2007-03-18 10:47:23')],
-                    'datetime'
+                    'datetime',
                 );
             })
             ->execute();
@@ -1171,7 +1171,7 @@ class SelectQueryTest extends TestCase
                 return $exp->notIn(
                     'created',
                     [new DateTime('2007-03-18 10:45:23'), new DateTime('2007-03-18 10:47:23')],
-                    'datetime'
+                    'datetime',
                 );
             })
             ->execute();
@@ -1223,7 +1223,7 @@ class SelectQueryTest extends TestCase
                 return $exp->in(
                     'created',
                     $q->newExpr("'2007-03-18 10:45:23'"),
-                    'datetime'
+                    'datetime',
                 );
             })
             ->execute();
@@ -1240,7 +1240,7 @@ class SelectQueryTest extends TestCase
                 return $exp->notIn(
                     'created',
                     $q->newExpr("'2007-03-18 10:45:23'"),
-                    'datetime'
+                    'datetime',
                 );
             })
             ->execute();
@@ -1310,7 +1310,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \(<id> = :c0 AND <title> = :c1 AND <author_id> = :c2\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -1527,7 +1527,7 @@ class SelectQueryTest extends TestCase
             ->from('comments')
             ->where(function (ExpressionInterface $exp) {
                 return $exp->not(
-                    $exp->and(['id' => 2, 'created' => new DateTime('2007-03-18 10:47:23')], ['created' => 'datetime'])
+                    $exp->and(['id' => 2, 'created' => new DateTime('2007-03-18 10:47:23')], ['created' => 'datetime']),
                 );
             })
             ->execute();
@@ -1543,7 +1543,7 @@ class SelectQueryTest extends TestCase
             ->from('comments')
             ->where(function (ExpressionInterface $exp) {
                 return $exp->not(
-                    $exp->and(['id' => 2, 'created' => new DateTime('2012-12-21 12:00')], ['created' => 'datetime'])
+                    $exp->and(['id' => 2, 'created' => new DateTime('2012-12-21 12:00')], ['created' => 'datetime']),
                 );
             })
             ->execute();
@@ -1588,7 +1588,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE <id> IN \\(:c0,:c1\\)',
             $sql,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute()->fetchAll('assoc');
@@ -1608,7 +1608,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE 1=0',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $statement = $query->execute();
@@ -1629,7 +1629,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE <id> NOT IN \\(:c0,:c1\\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute()->fetchAll('assoc');
@@ -1650,7 +1650,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \(<id>\) IS NOT NULL',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute()->fetchAll('assoc');
@@ -1670,7 +1670,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \\(<id> NOT IN \\(:c0,:c1\\) OR \\(<id>\\) IS NULL\\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute()->fetchAll('assoc');
@@ -1691,7 +1691,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE \(<id>\) IS NOT NULL',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute()->fetchAll('assoc');
@@ -1812,7 +1812,7 @@ class SelectQueryTest extends TestCase
         $this->expectExceptionMessage(
             "Passing extra expressions by associative array (`'id' => 'desc -- Comment'`) " .
             'is not allowed to avoid potential SQL injection. ' .
-            'Use QueryExpression or numeric array instead.'
+            'Use QueryExpression or numeric array instead.',
         );
 
         $query = new SelectQuery($this->connection);
@@ -1842,7 +1842,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT \* FROM <articles> ORDER BY <id> ASC',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -1856,7 +1856,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT \* FROM <articles> ORDER BY id % 2 = 0, <title> ASC',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -1870,7 +1870,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT \* FROM <articles> ORDER BY a \+ b',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -1884,7 +1884,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT \* FROM <articles> ORDER BY SUM\(a\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -1909,7 +1909,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> ORDER BY <id> ASC',
             $sql,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -1947,7 +1947,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> ORDER BY CASE WHEN <author_id> = :c0 THEN :c1 ELSE <id> END ASC, <id> ASC',
             $sql,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -1971,7 +1971,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> ORDER BY <id> DESC',
             $sql,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -2009,7 +2009,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> ORDER BY CASE WHEN <author_id> = :c0 THEN :c1 ELSE <id> END DESC, <id> DESC',
             $sql,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -2092,7 +2092,7 @@ class SelectQueryTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertEquals(
             [3, 1],
-            collection($results)->sortBy('author_id')->extract('author_id')->toList()
+            collection($results)->sortBy('author_id')->extract('author_id')->toList(),
         );
 
         $query = new SelectQuery($this->connection);
@@ -2106,7 +2106,7 @@ class SelectQueryTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertEquals(
             [3, 1],
-            collection($results)->sortBy('author_id')->extract('author_id')->toList()
+            collection($results)->sortBy('author_id')->extract('author_id')->toList(),
         );
     }
 
@@ -2125,7 +2125,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT DISTINCTROW <city>, <state>, <country> FROM <addresses>',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -2136,7 +2136,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT DISTINCTROW SQL_NO_CACHE <city>, <state>, <country> FROM <addresses>',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -2148,7 +2148,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT DISTINCTROW SQL_NO_CACHE <city>, <state>, <country> FROM <addresses>',
             $result->sql(),
-            true
+            true,
         );
 
         $query = new SelectQuery($this->connection);
@@ -2159,7 +2159,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT TOP 10 <city>, <state>, <country> FROM <addresses>',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new SelectQuery($this->connection);
@@ -2170,7 +2170,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT EXPRESSION <city>, <state>, <country> FROM <addresses>',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -2266,7 +2266,7 @@ class SelectQueryTest extends TestCase
             'SELECT id FROM authors Authors WHERE ' .
             '(FUNC( Authors.id) = :c0 AND (FUNC( Authors.id)) IS NOT NULL) ' .
             'HAVING COUNT(DISTINCT Authors.id) = :c1',
-            trim($query->sql())
+            trim($query->sql()),
         );
     }
 
@@ -2421,7 +2421,7 @@ class SelectQueryTest extends TestCase
                 ['id' => '6', 'ids_added' => '4'],
                 ['id' => '2', 'ids_added' => '5'],
             ],
-            $result->fetchAll('assoc')
+            $result->fetchAll('assoc'),
         );
     }
 
@@ -2655,7 +2655,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY),
-            'Driver does not support ORDER BY on UNIONed queries.'
+            'Driver does not support ORDER BY on UNIONed queries.',
         );
 
         $union = (new SelectQuery($this->connection))
@@ -2709,7 +2709,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::INTERSECT),
-            'Driver does not support INTERSECT clause.'
+            'Driver does not support INTERSECT clause.',
         );
 
         $intersect = (new SelectQuery($this->connection))->select(['id', 'comment'])->from(['c' => 'comments'])->where(['article_id' => 1]);
@@ -2758,11 +2758,11 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::INTERSECT),
-            'Driver does not support INTERSECT clause.'
+            'Driver does not support INTERSECT clause.',
         );
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::SET_OPERATIONS_ORDER_BY),
-            'Driver does not support ORDER BY on INTERSECTed queries.'
+            'Driver does not support ORDER BY on INTERSECTed queries.',
         );
         $intersect = (new SelectQuery($this->connection))
             ->select(['id', 'comment'])
@@ -2787,7 +2787,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::INTERSECT_ALL),
-            'Driver does not support INTERSECT ALL clause.'
+            'Driver does not support INTERSECT ALL clause.',
         );
         $intersect = (new SelectQuery($this->connection))->select(['id', 'comment'])->from(['c' => 'comments'])->where(['article_id' => 1]);
         $query = new SelectQuery($this->connection);
@@ -2960,7 +2960,7 @@ class SelectQueryTest extends TestCase
         $result = $query->select(
             function ($q) {
                 return ['total' => $q->func()->count('*')];
-            }
+            },
         )
             ->from('comments')
             ->execute();
@@ -3003,7 +3003,7 @@ class SelectQueryTest extends TestCase
         $this->assertWithinRange(
             date('U'),
             (new DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
-            10
+            10,
         );
 
         $query = new SelectQuery($this->connection);
@@ -3013,7 +3013,7 @@ class SelectQueryTest extends TestCase
         $this->assertWithinRange(
             date('U'),
             (new DateTime($result->fetchAll('assoc')[0]['d']))->format('U'),
-            10
+            10,
         );
 
         $query = new SelectQuery($this->connection);
@@ -3082,7 +3082,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
-            'This test fails sporadically in SQLServer'
+            'This test fails sporadically in SQLServer',
         );
 
         $query = (new SelectQuery($this->connection))
@@ -3093,8 +3093,8 @@ class SelectQueryTest extends TestCase
                     ['id', 'user_id'],
                     [[1, 1]],
                     ['integer', 'integer'],
-                    'IN'
-                )
+                    'IN',
+                ),
             );
 
         $result = $query->all()[0];
@@ -3122,7 +3122,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
-            'This test fails sporadically in SQLServer'
+            'This test fails sporadically in SQLServer',
         );
 
         $query = (new SelectQuery($this->connection))
@@ -3133,8 +3133,8 @@ class SelectQueryTest extends TestCase
                     ['id', 'user_id'],
                     [[1, 1]],
                     [],
-                    'IN'
-                )
+                    'IN',
+                ),
             );
 
         $result = $query->all()[0];
@@ -3537,8 +3537,8 @@ class SelectQueryTest extends TestCase
             ->with(
                 new CommonTableExpression(
                     'cte',
-                    new SelectQuery($this->connection)
-                )
+                    new SelectQuery($this->connection),
+                ),
             )
             ->with(function (CommonTableExpression $cte, Query $query) {
                 return $cte
@@ -3627,15 +3627,15 @@ class SelectQueryTest extends TestCase
         $query
             ->innerJoin(
                 ['alias_inner' => new SelectQuery($this->connection)],
-                ['alias_inner.fk = parent.pk']
+                ['alias_inner.fk = parent.pk'],
             )
             ->leftJoin(
                 ['alias_left' => new SelectQuery($this->connection)],
-                ['alias_left.fk = parent.pk']
+                ['alias_left.fk = parent.pk'],
             )
             ->rightJoin(
                 ['alias_right' => new SelectQuery($this->connection)],
-                ['alias_right.fk = parent.pk']
+                ['alias_right.fk = parent.pk'],
             );
 
         $clause = $query->clause('join');
@@ -3822,7 +3822,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertNotSame(
             $query->clause('select')['title'],
-            $dupe->clause('select')['title']
+            $dupe->clause('select')['title'],
         );
         $this->assertEquals($query->clause('order'), $dupe->clause('order'));
         $this->assertNotSame($query->clause('order'), $dupe->clause('order'));
@@ -3832,7 +3832,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertNotSame(
             $query->getSelectTypeMap(),
-            $dupe->getSelectTypeMap()
+            $dupe->getSelectTypeMap(),
         );
     }
 
@@ -4148,7 +4148,7 @@ class SelectQueryTest extends TestCase
         $subquery = new SelectQuery($connection);
         $subquery
             ->select(
-                $subquery->newExpr()->case()->when(['a.published' => 'N'])->then(1)->else(0)
+                $subquery->newExpr()->case()->when(['a.published' => 'N'])->then(1)->else(0),
             )
             ->from(['a' => 'articles'])
             ->where([
@@ -4171,7 +4171,7 @@ class SelectQueryTest extends TestCase
                 'WHERE a\.id = articles\.id' .
             '\) DESC, <id> ASC',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $this->assertEquals(
@@ -4186,7 +4186,7 @@ class SelectQueryTest extends TestCase
                     'id' => 2,
                 ],
             ],
-            $query->execute()->fetchAll('assoc')
+            $query->execute()->fetchAll('assoc'),
         );
     }
 
@@ -4249,7 +4249,7 @@ class SelectQueryTest extends TestCase
                 'SELECT count\(\*\) FROM <articles> <b> WHERE \(b\.id = articles\.id AND <b>\.<published> = :c2\)' .
             '\) DESC, <id> ASC',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $this->assertSame(
@@ -4270,7 +4270,7 @@ class SelectQueryTest extends TestCase
                     'computedB' => 0,
                 ],
             ],
-            $query->execute()->fetchAll('assoc')
+            $query->execute()->fetchAll('assoc'),
         );
 
         $this->assertSame(
@@ -4291,7 +4291,7 @@ class SelectQueryTest extends TestCase
                     'placeholder' => 'c2',
                 ],
             ],
-            $query->getValueBinder()->bindings()
+            $query->getValueBinder()->bindings(),
         );
     }
 
@@ -4385,7 +4385,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE <id> IN \(:c0,:c1,:c2\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = (new SelectQuery($this->connection))
@@ -4396,7 +4396,7 @@ class SelectQueryTest extends TestCase
         $this->assertQuotedQuery(
             'SELECT <id> FROM <articles> WHERE <id> IN \(:c0,:c1,:c2\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -4415,7 +4415,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             'SELECT id FROM profiles WHERE CONCAT\(first_name, " ", last_name\) in \(:c0,:c1\)',
-            $query->sql()
+            $query->sql(),
         );
 
         $query = (new SelectQuery($this->connection))
@@ -4425,7 +4425,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             'SELECT id FROM profiles WHERE CONCAT\(first_name, " ", last_name\) in \(:c0,:c1\)',
-            $query->sql()
+            $query->sql(),
         );
 
         $query = (new SelectQuery($this->connection))
@@ -4435,7 +4435,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             'SELECT id FROM profiles WHERE CONCAT\(first_name, " ", last_name\) not in \(:c0,:c1\)',
-            $query->sql()
+            $query->sql(),
         );
 
         $query = (new SelectQuery($this->connection))
@@ -4445,7 +4445,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             'SELECT id FROM profiles WHERE CONCAT\(first_name, " ", last_name\) not in \(:c0,:c1\)',
-            $query->sql()
+            $query->sql(),
         );
     }
 }

--- a/tests/TestCase/Database/Query/UpdateQueryTest.php
+++ b/tests/TestCase/Database/Query/UpdateQueryTest.php
@@ -102,7 +102,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE <articles> SET <title> = :c0 , <body> = :c1',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $this->assertQuotedQuery(' WHERE <id> = :c2$', $result, !$this->autoQuote);
@@ -128,7 +128,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE <articles> SET <title> = :c0 , <body> = :c1',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
         $this->assertQuotedQuery('WHERE <id> = :', $result, !$this->autoQuote);
 
@@ -154,7 +154,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE <comments> SET <article_id> = <user_id> WHERE <id> = :',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $result = $query->execute();
@@ -181,7 +181,7 @@ class UpdateQueryTest extends TestCase
 
         $this->assertEqualsSql(
             'UPDATE comments SET updated = (SELECT created FROM comments c WHERE c.id = comments.id)',
-            $query->sql(new ValueBinder())
+            $query->sql(new ValueBinder()),
         );
 
         $result = $query->execute();
@@ -210,7 +210,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE <comments> SET <comment> = :c0 , <created> = :c1',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $this->assertQuotedQuery(' WHERE <id> = :c2$', $result, !$this->autoQuote);
@@ -242,7 +242,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE <comments> SET <comment> = :c0 , <created> = :c1',
             $result,
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $this->assertQuotedQuery(' WHERE <id> = :c2$', $result, !$this->autoQuote);
@@ -286,7 +286,7 @@ class UpdateQueryTest extends TestCase
                 '\)' .
             '\)',
             $query->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 
@@ -411,7 +411,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE TOP 10 PERCENT <authors> SET <name> = :c0',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new UpdateQuery($this->connection);
@@ -422,7 +422,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE TOP 10 PERCENT FOO <authors> SET <name> = :c0',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $query = new UpdateQuery($this->connection);
@@ -433,7 +433,7 @@ class UpdateQueryTest extends TestCase
         $this->assertQuotedQuery(
             'UPDATE TOP 10 PERCENT <authors> SET <name> = :c0',
             $result->sql(),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
     }
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -150,8 +150,8 @@ class QueryTest extends TestCase
             ->with(
                 new CommonTableExpression(
                     'cte',
-                    $this->newQuery()
-                )
+                    $this->newQuery(),
+                ),
             )
             ->with(function (CommonTableExpression $cte, Query $query) {
                 return $cte
@@ -205,15 +205,15 @@ class QueryTest extends TestCase
         $this->query
             ->innerJoin(
                 ['alias_inner' => $this->newQuery()],
-                ['alias_inner.fk = parent.pk']
+                ['alias_inner.fk = parent.pk'],
             )
             ->leftJoin(
                 ['alias_left' => $this->newQuery()],
-                ['alias_left.fk = parent.pk']
+                ['alias_left.fk = parent.pk'],
             )
             ->rightJoin(
                 ['alias_right' => $this->newQuery()],
-                ['alias_right.fk = parent.pk']
+                ['alias_right.fk = parent.pk'],
             );
 
         $clause = $this->query->clause('join');

--- a/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CaseExpressionQueryTest.php
@@ -219,7 +219,7 @@ class CaseExpressionQueryTest extends TestCase
                 return $exp->gt(
                     $query->func()->sum($expression),
                     2,
-                    'integer'
+                    'integer',
                 );
             });
 

--- a/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/CommonTableExpressionQueryTest.php
@@ -55,7 +55,7 @@ class CommonTableExpressionQueryTest extends TestCase
 
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::CTE),
-            'The current driver does not support common table expressions.'
+            'The current driver does not support common table expressions.',
         );
     }
 
@@ -80,7 +80,7 @@ class CommonTableExpressionQueryTest extends TestCase
         $this->assertRegExpSql(
             'WITH <cte> AS \(SELECT 1 AS <col>\) SELECT <col> FROM <cte>',
             $query->sql(new ValueBinder()),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         $expected = [
@@ -108,7 +108,7 @@ class CommonTableExpressionQueryTest extends TestCase
 
         $this->assertEqualsSql(
             'WITH cte AS (SELECT 1 AS col) SELECT col FROM cte',
-            $query->sql(new ValueBinder())
+            $query->sql(new ValueBinder()),
         );
 
         $query
@@ -116,7 +116,7 @@ class CommonTableExpressionQueryTest extends TestCase
             ->from('cte2', true);
         $this->assertEqualsSql(
             'WITH cte2 AS () SELECT col FROM cte2',
-            $query->sql(new ValueBinder())
+            $query->sql(new ValueBinder()),
         );
     }
 
@@ -164,7 +164,7 @@ class CommonTableExpressionQueryTest extends TestCase
         }
         $this->assertEqualsSql(
             $expectedSql,
-            $query->sql(new ValueBinder())
+            $query->sql(new ValueBinder()),
         );
 
         $expected = [
@@ -191,7 +191,7 @@ class CommonTableExpressionQueryTest extends TestCase
     {
         $this->skipIf(
             ($this->connection->getDriver() instanceof Mysql),
-            '`WITH ... INSERT INTO` syntax is not supported in MySQL.'
+            '`WITH ... INSERT INTO` syntax is not supported in MySQL.',
         );
 
         // test initial state
@@ -213,14 +213,14 @@ class CommonTableExpressionQueryTest extends TestCase
             ->into('articles')
             ->values(
                 $this->connection
-                    ->selectQuery(fields: '*', table: 'cte')
+                    ->selectQuery(fields: '*', table: 'cte'),
             );
 
         $this->assertRegExpSql(
             "WITH <cte>\(<title>, <body>\) AS \(SELECT 'Fourth Article', 'Fourth Article Body'\) " .
                 'INSERT INTO <articles> \(<title>, <body>\)',
             $query->sql(new ValueBinder()),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         // run insert
@@ -249,7 +249,7 @@ class CommonTableExpressionQueryTest extends TestCase
     {
         $this->skipIf(
             ($this->connection->getDriver() instanceof Sqlserver),
-            '`INSERT INTO ... WITH` syntax is not supported in SQL Server.'
+            '`INSERT INTO ... WITH` syntax is not supported in SQL Server.',
         );
 
         $query = $this->connection->insertQuery(table: 'articles')
@@ -263,14 +263,14 @@ class CommonTableExpressionQueryTest extends TestCase
                             ->query($query->newExpr("SELECT 'Fourth Article', 'Fourth Article Body'"));
                     })
                     ->select('*')
-                    ->from('cte')
+                    ->from('cte'),
             );
 
         $this->assertRegExpSql(
             'INSERT INTO <articles> \(<title>, <body>\) ' .
                 "WITH <cte>\(<title>, <body>\) AS \(SELECT 'Fourth Article', 'Fourth Article Body'\) SELECT \* FROM <cte>",
             $query->sql(new ValueBinder()),
-            !$this->autoQuote
+            !$this->autoQuote,
         );
 
         // run insert
@@ -299,7 +299,7 @@ class CommonTableExpressionQueryTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Mysql && $this->connection->getDriver()->isMariadb(),
-            'MariaDB does not support CTEs in UPDATE query.'
+            'MariaDB does not support CTEs in UPDATE query.',
         );
 
         // test initial state
@@ -327,14 +327,14 @@ class CommonTableExpressionQueryTest extends TestCase
                     'articles.id',
                     $query
                         ->getConnection()
-                        ->selectQuery('cte.id', 'cte')
+                        ->selectQuery('cte.id', 'cte'),
                 );
             });
 
         $this->assertEqualsSql(
             'WITH cte AS (SELECT articles.id FROM articles WHERE articles.id != :c0) ' .
                 'UPDATE articles SET published = :c1 WHERE id IN (SELECT cte.id FROM cte)',
-            $query->sql(new ValueBinder())
+            $query->sql(new ValueBinder()),
         );
 
         // run update
@@ -355,7 +355,7 @@ class CommonTableExpressionQueryTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Mysql && $this->connection->getDriver()->isMariadb(),
-            'MariaDB does not support CTEs in DELETE query.'
+            'MariaDB does not support CTEs in DELETE query.',
         );
 
         // test initial state
@@ -381,14 +381,14 @@ class CommonTableExpressionQueryTest extends TestCase
                     'a.id',
                     $query
                         ->getConnection()
-                        ->selectQuery('cte.id', 'cte')
+                        ->selectQuery('cte.id', 'cte'),
                 );
             });
 
         $this->assertEqualsSql(
             'WITH cte AS (SELECT articles.id FROM articles WHERE articles.id != :c0) ' .
                 'DELETE FROM articles WHERE id IN (SELECT cte.id FROM cte)',
-            $query->sql(new ValueBinder())
+            $query->sql(new ValueBinder()),
         );
 
         // run delete

--- a/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
+++ b/tests/TestCase/Database/QueryTests/TupleComparisonQueryTest.php
@@ -83,7 +83,7 @@ class TupleComparisonQueryTest extends TestCase
         ) {
             $this->expectException(InvalidArgumentException::class);
             $this->expectExceptionMessage(
-                'Tuple comparison transform only supports the `IN` and `=` operators, `NOT IN` given.'
+                'Tuple comparison transform only supports the `IN` and `=` operators, `NOT IN` given.',
             );
         } else {
             $this->markTestSkipped('Tuple comparisons are only being transformed for Sqlite and Sqlserver.');
@@ -97,11 +97,11 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     $this->connection->selectQuery(
                         ['ArticlesAlias.id', 'ArticlesAlias.author_id'],
-                        ['ArticlesAlias' => 'articles']
+                        ['ArticlesAlias' => 'articles'],
                     )
                     ->where(['ArticlesAlias.author_id' => 1]),
                     [],
-                    'NOT IN'
+                    'NOT IN',
                 ),
             ])
             ->orderByAsc('articles.id')
@@ -123,11 +123,11 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     $this->connection->selectQuery(
                         ['ArticlesAlias.id', 'ArticlesAlias.author_id'],
-                        ['ArticlesAlias' => 'articles']
+                        ['ArticlesAlias' => 'articles'],
                     )
                     ->where(['ArticlesAlias.author_id' => 1]),
                     [],
-                    'IN'
+                    'IN',
                 ),
             ])
             ->orderByAsc('articles.id')
@@ -161,11 +161,11 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     $this->connection->selectQuery(
                         ['ArticlesAlias.id', 'ArticlesAlias.author_id'],
-                        ['ArticlesAlias' => 'articles']
+                        ['ArticlesAlias' => 'articles'],
                     )
                     ->where(['ArticlesAlias.id' => 1]),
                     [],
-                    'IN'
+                    'IN',
                 ),
             ])
             ->setSelectTypeMap($typeMap);
@@ -194,7 +194,7 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     [[1, 1], [3, 1]],
                     ['integer', 'integer'],
-                    'IN'
+                    'IN',
                 ),
             ])
             ->orderByAsc('articles.id')
@@ -226,7 +226,7 @@ class TupleComparisonQueryTest extends TestCase
             // Due to the way tuple comparisons are being translated, the DBMS will
             // not run into a cardinality violation scenario.
             $this->markTestSkipped(
-                'Sqlite and Sqlserver currently do not fail with subqueries returning incompatible results.'
+                'Sqlite and Sqlserver currently do not fail with subqueries returning incompatible results.',
             );
         }
 
@@ -238,11 +238,11 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     $this->connection->selectQuery(
                         ['ArticlesAlias.id', 'ArticlesAlias.author_id'],
-                        ['ArticlesAlias' => 'articles']
+                        ['ArticlesAlias' => 'articles'],
                     )
                     ->where(['ArticlesAlias.author_id' => 1]),
                     [],
-                    '='
+                    '=',
                 ),
             ])
             ->orderByAsc('articles.id')
@@ -264,11 +264,11 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     $this->connection->selectQuery(
                         fields: ['ArticlesAlias.id', 'ArticlesAlias.author_id'],
-                        table: ['ArticlesAlias' => 'articles']
+                        table: ['ArticlesAlias' => 'articles'],
                     )
                     ->where(['ArticlesAlias.id' => 1]),
                     [],
-                    '='
+                    '=',
                 ),
             ])
             ->setSelectTypeMap($typeMap);
@@ -297,7 +297,7 @@ class TupleComparisonQueryTest extends TestCase
                     ['articles.id', 'articles.author_id'],
                     [1, 1],
                     ['integer', 'integer'],
-                    '='
+                    '=',
                 ),
             ])
             ->orderByAsc('articles.id')

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -460,7 +460,7 @@ SQL;
             $this->assertEquals(
                 $definition,
                 $result->getColumn($field),
-                'Field definition does not match for ' . $field
+                'Field definition does not match for ' . $field,
             );
         }
     }
@@ -1584,7 +1584,7 @@ SQL;
         $this->assertEquals(
             $expected,
             $result->getColumn('data'),
-            'Field definition does not match for data'
+            'Field definition does not match for data',
         );
     }
 

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -1276,11 +1276,11 @@ SQL;
         $this->assertTextEquals($expected, $result[0]);
         $this->assertSame(
             'CREATE INDEX "title_idx" ON "schema_articles" ("title")',
-            $result[1]
+            $result[1],
         );
         $this->assertSame(
             'COMMENT ON COLUMN "schema_articles"."title" IS \'This is the title\'',
-            $result[2]
+            $result[2],
         );
     }
 

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -577,11 +577,11 @@ SQL;
         $this->assertEquals($expected['primary'], $result->getConstraint('primary'));
         $this->assertEquals(
             $expected['title_idx'],
-            $result->getConstraint('title_idx')
+            $result->getConstraint('title_idx'),
         );
         $this->assertEquals(
             $expected['author_id_0_fk'],
-            $result->getConstraint('author_id_0_fk')
+            $result->getConstraint('author_id_0_fk'),
         );
         $this->assertEquals($expected['unique_id_idx'], $result->getConstraint('unique_id_idx'));
 
@@ -1190,7 +1190,7 @@ SQL;
         $this->assertTextEquals($expected, $result[0]);
         $this->assertSame(
             'CREATE INDEX "title_idx" ON "articles" ("title")',
-            $result[1]
+            $result[1],
         );
     }
 

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -1138,7 +1138,7 @@ SQL;
         $this->assertSame(str_replace("\r\n", "\n", $expected), str_replace("\r\n", "\n", $result[0]));
         $this->assertSame(
             'CREATE INDEX [title_idx] ON [schema_articles] ([title])',
-            $result[1]
+            $result[1],
         );
     }
 
@@ -1184,7 +1184,7 @@ SQL;
         $this->assertSame(
             "IF EXISTS (SELECT * FROM sys.identity_columns WHERE OBJECT_NAME(OBJECT_ID) = 'schema_articles' AND last_value IS NOT NULL) " .
             "DBCC CHECKIDENT('schema_articles', RESEED, 0)",
-            $result[1]
+            $result[1],
         );
     }
 

--- a/tests/TestCase/Database/Schema/TableSchemaTest.php
+++ b/tests/TestCase/Database/Schema/TableSchemaTest.php
@@ -447,7 +447,7 @@ class TableSchemaTest extends TestCase
 
         $this->assertEquals(
             ['author_idx', 'texty'],
-            $table->indexes()
+            $table->indexes(),
         );
     }
 
@@ -544,7 +544,7 @@ class TableSchemaTest extends TestCase
         $connection = $table->getConnection();
         $this->skipIf(
             $connection->getDriver() instanceof Postgres,
-            'Constraints get dropped in postgres for some reason'
+            'Constraints get dropped in postgres for some reason',
         );
 
         $name = 'product_category_fk';

--- a/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
+++ b/tests/TestCase/Database/Type/BinaryUuidTypeTest.php
@@ -60,7 +60,7 @@ class BinaryUuidTypeTest extends TestCase
         preg_match_all(
             $uuidRegex,
             $result,
-            $matches
+            $matches,
         );
 
         $result = $matches[0];

--- a/tests/TestCase/Database/Type/BoolTypeTest.php
+++ b/tests/TestCase/Database/Type/BoolTypeTest.php
@@ -127,7 +127,7 @@ class BoolTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeFractionalTypeTest.php
@@ -122,7 +122,7 @@ class DateTimeFractionalTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
 
         $this->type->setDatabaseTimezone('Asia/Kolkata'); // UTC+5:30
@@ -140,7 +140,7 @@ class DateTimeFractionalTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTimezoneTypeTest.php
@@ -136,7 +136,7 @@ class DateTimeTimezoneTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
 
         $this->type->setDatabaseTimezone('Asia/Kolkata'); // UTC+5:30
@@ -154,7 +154,7 @@ class DateTimeTimezoneTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -136,7 +136,7 @@ class DateTimeTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
 
         $this->type->setDatabaseTimezone('Asia/Kolkata'); // UTC+5:30
@@ -150,7 +150,7 @@ class DateTimeTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -109,7 +109,7 @@ class DateTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/DecimalTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalTypeTest.php
@@ -101,7 +101,7 @@ class DecimalTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/FloatTypeTest.php
+++ b/tests/TestCase/Database/Type/FloatTypeTest.php
@@ -97,7 +97,7 @@ class FloatTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/IntegerTypeTest.php
+++ b/tests/TestCase/Database/Type/IntegerTypeTest.php
@@ -89,7 +89,7 @@ class IntegerTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 
@@ -117,7 +117,7 @@ class IntegerTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -77,7 +77,7 @@ class JsonTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/Type/TimeTypeTest.php
+++ b/tests/TestCase/Database/Type/TimeTypeTest.php
@@ -105,7 +105,7 @@ class TimeTypeTest extends TestCase
         ];
         $this->assertEquals(
             $expected,
-            $this->type->manyToPHP($values, array_keys($values), $this->driver)
+            $this->type->manyToPHP($values, array_keys($values), $this->driver),
         );
     }
 

--- a/tests/TestCase/Database/TypeFactoryTest.php
+++ b/tests/TestCase/Database/TypeFactoryTest.php
@@ -185,7 +185,7 @@ class TypeFactoryTest extends TestCase
     {
         $this->skipIf(
             PHP_INT_SIZE === 4,
-            'This test requires a php version compiled for 64 bits'
+            'This test requires a php version compiled for 64 bits',
         );
         $type = TypeFactory::build('biginteger');
         $integer = time() * time();

--- a/tests/TestCase/Database/ValueBinderTest.php
+++ b/tests/TestCase/Database/ValueBinderTest.php
@@ -149,7 +149,7 @@ class ValueBinderTest extends TestCase
         $statementMock->expects($this->exactly(2))
             ->method('bindValue')
             ->with(
-                ...self::withConsecutive(['c0', 'value0', 'string'], ['c1', 'value1', 'string'])
+                ...self::withConsecutive(['c0', 'value0', 'string'], ['c1', 'value1', 'string']),
             );
 
         $valueBinder->attachTo($statementMock); //empty array shouldn't call statement

--- a/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
+++ b/tests/TestCase/Datasource/Paging/NumericPaginatorTest.php
@@ -150,7 +150,7 @@ class NumericPaginatorTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage(
             'The `order` config must be an associative array.'
-            . ' Found invalid value with numeric key: `PaginatorPosts.title ASC`'
+            . ' Found invalid value with numeric key: `PaginatorPosts.title ASC`',
         );
 
         $settings = [
@@ -171,7 +171,7 @@ class NumericPaginatorTest extends TestCase
             function (): void {
                 $table = $this->getTableLocator()->get('PaginatorPosts');
                 $this->Paginator->paginate($table, [], ['fields' => ['title']]);
-            }
+            },
         );
     }
 }

--- a/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
+++ b/tests/TestCase/Datasource/Paging/PaginatedResultSetTest.php
@@ -34,7 +34,7 @@ class PaginatedResultSetTest extends TestCase
         };
         $paginatedResults = new PaginatedResultSet(
             $resultSet,
-            []
+            [],
         );
 
         $this->assertInstanceOf(ResultSetInterface::class, $paginatedResults->items());
@@ -59,7 +59,7 @@ class PaginatedResultSetTest extends TestCase
 
         $paginatedResults = new PaginatedResultSet(
             $resultSet,
-            []
+            [],
         );
 
         $this->deprecated(function () use ($paginatedResults): void {
@@ -72,7 +72,7 @@ class PaginatedResultSetTest extends TestCase
     {
         $paginatedResults = new PaginatedResultSet(
             new ArrayIterator([1 => 'a', 2 => 'b', 3 => 'c']),
-            []
+            [],
         );
 
         $this->assertEquals('{"1":"a","2":"b","3":"c"}', json_encode($paginatedResults));
@@ -82,7 +82,7 @@ class PaginatedResultSetTest extends TestCase
     {
         $paginatedResults = new PaginatedResultSet(
             new ArrayIterator([1 => 'a', 2 => 'b', 3 => 'c']),
-            ['foo' => 'bar']
+            ['foo' => 'bar'],
         );
 
         $serialized = serialize($paginatedResults);

--- a/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
+++ b/tests/TestCase/Datasource/Paging/PaginatorTestTrait.php
@@ -777,7 +777,7 @@ trait PaginatorTestTrait
         } catch (PageOutOfBoundsException $exception) {
             $this->assertEquals(
                 'Page number `3000` could not be found.',
-                $exception->getMessage()
+                $exception->getMessage(),
             );
 
             $attributes = $exception->getAttributes();
@@ -835,7 +835,7 @@ trait PaginatorTestTrait
         $this->assertEquals(
             $expected,
             $result['order'],
-            'Trusted fields in schema should be prefixed'
+            'Trusted fields in schema should be prefixed',
         );
     }
 
@@ -883,7 +883,7 @@ trait PaginatorTestTrait
         $this->assertEquals(
             $expected,
             $result['order'],
-            'Trusted fields not in schema should not be altered'
+            'Trusted fields not in schema should not be altered',
         );
     }
 

--- a/tests/TestCase/Datasource/RulesCheckerTest.php
+++ b/tests/TestCase/Datasource/RulesCheckerTest.php
@@ -41,7 +41,7 @@ class RulesCheckerTest extends TestCase
                 return false;
             },
             'ruleName',
-            ['errorField' => 'name']
+            ['errorField' => 'name'],
         );
 
         $this->assertTrue($rules->check($entity, RulesChecker::CREATE));
@@ -68,7 +68,7 @@ class RulesCheckerTest extends TestCase
                 return false;
             },
             'ruleName',
-            ['errorField' => 'name']
+            ['errorField' => 'name'],
         );
 
         $this->assertTrue($rules->check($entity, RulesChecker::CREATE));
@@ -95,7 +95,7 @@ class RulesCheckerTest extends TestCase
                 return false;
             },
             'ruleName',
-            ['errorField' => 'name']
+            ['errorField' => 'name'],
         );
 
         $this->assertTrue($rules->check($entity, RulesChecker::UPDATE));
@@ -122,7 +122,7 @@ class RulesCheckerTest extends TestCase
                 return false;
             },
             'ruleName',
-            ['errorField' => 'name']
+            ['errorField' => 'name'],
         );
 
         $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
@@ -143,7 +143,7 @@ class RulesCheckerTest extends TestCase
             function () {
                 return 'worst thing ever';
             },
-            ['errorField' => 'name']
+            ['errorField' => 'name'],
         );
 
         $this->assertFalse($rules->check($entity, RulesChecker::CREATE));
@@ -164,7 +164,7 @@ class RulesCheckerTest extends TestCase
             function () {
                 return false;
             },
-            ['message' => 'this is bad', 'errorField' => 'name']
+            ['message' => 'this is bad', 'errorField' => 'name'],
         );
 
         $this->assertFalse($rules->check($entity, RulesChecker::CREATE));

--- a/tests/TestCase/Error/DebuggerTest.php
+++ b/tests/TestCase/Error/DebuggerTest.php
@@ -333,7 +333,7 @@ TEXT;
     {
         $this->skipIf(
             version_compare(PHP_VERSION, '8.3', '>='),
-            'Due to different get_object_vars() function behavior used in Debugger::exportObject()' // see. https://3v4l.org/DWpRl
+            'Due to different get_object_vars() function behavior used in Debugger::exportObject()', // see. https://3v4l.org/DWpRl
         );
         $subject = new SplFixedArray(2);
         $subject[0] = 'red';
@@ -608,7 +608,7 @@ TEXT;
         $this->assertEquals(
             'CORE' . DS . 'vendor' . DS . 'phpunit' . DS . 'phpunit' . DS . 'src' . DS .
                 'Framework' . DS . 'TestCase.php',
-            $result[0]['file']
+            $result[0]['file'],
         );
     }
 
@@ -787,7 +787,7 @@ EXPECTED;
         $output = Debugger::formatHtmlMessage("Some `code` to <script>alert(\"test\")</script>\nmore");
         $this->assertSame(
             "Some <code>`code`</code> to &lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;<br />\nmore",
-            $output
+            $output,
         );
     }
 

--- a/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
+++ b/tests/TestCase/Error/Middleware/ErrorHandlerMiddlewareTest.php
@@ -253,7 +253,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $logs[0]);
         $this->assertStringContainsString(
             str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
-            $logs[0]
+            $logs[0],
         );
         $this->assertStringContainsString('Request URL: /target/url', $logs[0]);
         $this->assertStringContainsString('Referer URL: /other/path', $logs[0]);
@@ -284,11 +284,11 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $this->assertStringContainsString('[Cake\Http\Exception\NotFoundException] Kaboom!', $logs[0]);
         $this->assertStringContainsString(
             'Caused by: [Cake\Datasource\Exception\RecordNotFoundException]',
-            $logs[0]
+            $logs[0],
         );
         $this->assertStringContainsString(
             str_replace('/', DS, 'vendor/phpunit/phpunit/src/Framework/TestCase.php'),
-            $logs[0]
+            $logs[0],
         );
         $this->assertStringContainsString('Request URL: /target/url', $logs[0]);
         $this->assertStringContainsString('Referer URL: /other/path', $logs[0]);
@@ -330,7 +330,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
         $logs = $this->logger->read();
         $this->assertStringContainsString(
             '[Cake\Http\Exception\MissingControllerException] Controller class `Articles` could not be found.',
-            $logs[0]
+            $logs[0],
         );
         $this->assertStringContainsString('Exception Attributes:', $logs[0]);
         $this->assertStringContainsString("'controller' => 'Articles'", $logs[0]);
@@ -351,7 +351,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             'Exception.beforeRender',
             function (EventInterface $event, Throwable $e, ServerRequestInterface $req) {
                 return 'Response string from event';
-            }
+            },
         );
 
         $result = $middleware->process($request, $handler);
@@ -404,7 +404,7 @@ class ErrorHandlerMiddlewareTest extends TestCase
             new ExceptionTrap([
                 'exceptionRenderer' => WebExceptionRenderer::class,
             ]),
-            $app
+            $app,
         );
 
         $this->assertSame([], Router::routes());

--- a/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
+++ b/tests/TestCase/Error/Renderer/WebExceptionRendererTest.php
@@ -112,7 +112,7 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertInstanceOf(
             PrefixErrorController::class,
-            $ExceptionRenderer->__debugInfo()['controller']
+            $ExceptionRenderer->__debugInfo()['controller'],
         );
     }
 
@@ -138,7 +138,7 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertInstanceOf(
             PluginErrorController::class,
-            $ExceptionRenderer->__debugInfo()['controller']
+            $ExceptionRenderer->__debugInfo()['controller'],
         );
     }
 
@@ -176,7 +176,7 @@ class WebExceptionRendererTest extends TestCase
         $this->assertSame('error400', $controller->viewBuilder()->getTemplate());
         $this->assertSame(
             'Admin' . DIRECTORY_SEPARATOR . 'Error',
-            $controller->viewBuilder()->getTemplatePath()
+            $controller->viewBuilder()->getTemplatePath(),
         );
     }
 
@@ -207,12 +207,12 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertSame(
             'missingWidgetThing',
-            $ExceptionRenderer->__debugInfo()['method']
+            $ExceptionRenderer->__debugInfo()['method'],
         );
         $this->assertSame(
             'widget thing is missing',
             (string)$result->getBody(),
-            'Method declared in subclass converted to error400'
+            'Method declared in subclass converted to error400',
         );
     }
 
@@ -231,7 +231,7 @@ class WebExceptionRendererTest extends TestCase
         $this->assertMatchesRegularExpression(
             '/Not Found/',
             (string)$result->getBody(),
-            'Method declared in error handler not converted to error400. %s'
+            'Method declared in error handler not converted to error400. %s',
         );
     }
 
@@ -245,7 +245,7 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertInstanceOf(
             ErrorController::class,
-            $ExceptionRenderer->__debugInfo()['controller']
+            $ExceptionRenderer->__debugInfo()['controller'],
         );
         $this->assertEquals($exception, $ExceptionRenderer->__debugInfo()['error']);
     }
@@ -261,7 +261,7 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertInstanceOf(
             ErrorController::class,
-            $ExceptionRenderer->__debugInfo()['controller']
+            $ExceptionRenderer->__debugInfo()['controller'],
         );
         $this->assertEquals($exception, $ExceptionRenderer->__debugInfo()['error']);
 
@@ -483,7 +483,7 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertSame(
             'missingController',
-            $ExceptionRenderer->__debugInfo()['template']
+            $ExceptionRenderer->__debugInfo()['template'],
         );
         $this->assertStringContainsString('Missing Controller', $result);
         $this->assertStringContainsString('<em>PostsController</em>', $result);
@@ -505,7 +505,7 @@ class WebExceptionRendererTest extends TestCase
 
         $this->assertSame(
             'missingController',
-            $ExceptionRenderer->__debugInfo()['template']
+            $ExceptionRenderer->__debugInfo()['template'],
         );
         $this->assertStringContainsString('Missing Controller', $result);
         $this->assertStringContainsString('<em>PostsController</em>', $result);
@@ -759,7 +759,7 @@ class WebExceptionRendererTest extends TestCase
             function (EventInterface $event): void {
                 $this->called = true;
                 $event->getSubject()->viewBuilder()->setLayoutPath('boom');
-            }
+            },
         );
         $controller->setRequest(new ServerRequest());
         $ExceptionRenderer->setController($controller);
@@ -788,7 +788,7 @@ class WebExceptionRendererTest extends TestCase
                 $this->called = true;
                 $event->getSubject()->viewBuilder()->setTemplatePath('Error');
                 $event->getSubject()->viewBuilder()->setLayout('does-not-exist');
-            }
+            },
         );
         $controller->setRequest(new ServerRequest());
         $ExceptionRenderer->setController($controller);

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -758,7 +758,7 @@ class EventManagerTest extends TestCase
                 '_generalManager' => '(object) EventManager',
                 '_dispatchedEvents' => null,
             ],
-            $eventManager->__debugInfo()
+            $eventManager->__debugInfo(),
         );
 
         $eventManager->setEventList(new EventList());
@@ -773,7 +773,7 @@ class EventManagerTest extends TestCase
                     'Foo with subject Cake\Test\TestCase\Event\EventManagerTest',
                 ],
             ],
-            $eventManager->__debugInfo()
+            $eventManager->__debugInfo(),
         );
 
         $eventManager->unsetEventList();
@@ -792,7 +792,7 @@ class EventManagerTest extends TestCase
                 '_generalManager' => '(object) EventManager',
                 '_dispatchedEvents' => null,
             ],
-            $eventManager->__debugInfo()
+            $eventManager->__debugInfo(),
         );
 
         $eventManager->off('foo', $func);
@@ -807,7 +807,7 @@ class EventManagerTest extends TestCase
                 '_generalManager' => '(object) EventManager',
                 '_dispatchedEvents' => null,
             ],
-            $eventManager->__debugInfo()
+            $eventManager->__debugInfo(),
         );
 
         $eventManager->on('bar', function (): void {
@@ -831,7 +831,7 @@ class EventManagerTest extends TestCase
                 '_generalManager' => '(object) EventManager',
                 '_dispatchedEvents' => null,
             ],
-            $eventManager->__debugInfo()
+            $eventManager->__debugInfo(),
         );
     }
 
@@ -859,7 +859,7 @@ class EventManagerTest extends TestCase
                     'example with no subject',
                 ],
             ],
-            $eventManager->__debugInfo()
+            $eventManager->__debugInfo(),
         );
     }
 

--- a/tests/TestCase/Form/FormProtectorTest.php
+++ b/tests/TestCase/Form/FormProtectorTest.php
@@ -386,7 +386,7 @@ class FormProtectorTest extends TestCase
         $unlocked = 'Model.username';
         $fields = ['Model.hidden', 'Model.password'];
         $fields = urlencode(
-            hash_hmac('sha1', '/articles/index' . serialize($fields) . $unlocked . 'cli', Security::getSalt())
+            hash_hmac('sha1', '/articles/index' . serialize($fields) . $unlocked . 'cli', Security::getSalt()),
         );
         $debug = 'not used';
 
@@ -718,13 +718,13 @@ class FormProtectorTest extends TestCase
         $this->url = '/posts/index?page=1';
         $this->validate(
             $data,
-            'URL mismatch in POST data (expected `another-url` but found `/posts/index?page=1`)'
+            'URL mismatch in POST data (expected `another-url` but found `/posts/index?page=1`)',
         );
 
         $this->url = '/posts/edit/1';
         $this->validate(
             $data,
-            'URL mismatch in POST data (expected `another-url` but found `/posts/edit/1`)'
+            'URL mismatch in POST data (expected `another-url` but found `/posts/edit/1`)',
         );
     }
 
@@ -810,7 +810,7 @@ class FormProtectorTest extends TestCase
 
         $this->validate(
             $data,
-            'Unexpected field `Model.hidden.some-key` in POST data, Missing field `Model.hidden` in POST data'
+            'Unexpected field `Model.hidden.some-key` in POST data, Missing field `Model.hidden` in POST data',
         );
     }
 

--- a/tests/TestCase/Http/BaseApplicationTest.php
+++ b/tests/TestCase/Http/BaseApplicationTest.php
@@ -116,15 +116,15 @@ class BaseApplicationTest extends TestCase
 
         $this->assertSame(
             TEST_APP . 'Plugin' . DS . 'PluginJs' . DS,
-            $plugin->getPath()
+            $plugin->getPath(),
         );
         $this->assertSame(
             TEST_APP . 'Plugin' . DS . 'PluginJs' . DS . 'config' . DS,
-            $plugin->getConfigPath()
+            $plugin->getConfigPath(),
         );
         $this->assertSame(
             TEST_APP . 'Plugin' . DS . 'PluginJs' . DS . 'src' . DS,
-            $plugin->getClassPath()
+            $plugin->getClassPath(),
         );
     }
 
@@ -213,15 +213,15 @@ class BaseApplicationTest extends TestCase
         $app->pluginBootstrap();
         $this->assertTrue(
             Configure::check('Named.bootstrap'),
-            'Plugin bootstrap should be run'
+            'Plugin bootstrap should be run',
         );
         $this->assertTrue(
             Configure::check('PluginTest.test_plugin.bootstrap'),
-            'Nested plugin should have bootstrap run'
+            'Nested plugin should have bootstrap run',
         );
         $this->assertTrue(
             Configure::check('PluginTest.test_plugin_two.bootstrap'),
-            'Nested plugin should have bootstrap run'
+            'Nested plugin should have bootstrap run',
         );
     }
 

--- a/tests/TestCase/Http/Client/Adapter/CurlTest.php
+++ b/tests/TestCase/Http/Client/Adapter/CurlTest.php
@@ -102,7 +102,7 @@ class CurlTest extends TestCase
         $request = new Request(
             'http://localhost/things',
             'GET',
-            ['Cookie' => 'testing=value']
+            ['Cookie' => 'testing=value'],
         );
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
@@ -134,7 +134,7 @@ class CurlTest extends TestCase
             'http://localhost/things',
             'GET',
             ['Cookie' => 'testing=value'],
-            '{"some":"body"}'
+            '{"some":"body"}',
         );
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
@@ -166,7 +166,7 @@ class CurlTest extends TestCase
             'http://localhost/things',
             'POST',
             ['Cookie' => 'testing=value'],
-            ['name' => 'cakephp', 'yes' => 1]
+            ['name' => 'cakephp', 'yes' => 1],
         );
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
@@ -196,7 +196,7 @@ class CurlTest extends TestCase
         $request = new Request(
             'http://localhost/things',
             'PUT',
-            ['Cookie' => 'testing=value']
+            ['Cookie' => 'testing=value'],
         );
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
@@ -227,7 +227,7 @@ class CurlTest extends TestCase
             'http://localhost/things',
             'POST',
             ['Content-type' => 'application/json'],
-            $content
+            $content,
         );
         $result = $this->curl->buildOptions($request, $options);
         $expected = [
@@ -319,7 +319,7 @@ class CurlTest extends TestCase
         $request = new Request(
             'http://localhost/things',
             'HEAD',
-            ['Cookie' => 'testing=value']
+            ['Cookie' => 'testing=value'],
         );
         $result = $this->curl->buildOptions($request, $options);
         $expected = [

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -120,7 +120,7 @@ class StreamTest extends TestCase
                 'User-Agent' => 'CakePHP TestSuite',
                 'Content-Type' => 'application/json',
                 'Cookie' => 'a=b; c=do%20it',
-            ]
+            ],
         );
 
         $options = [
@@ -149,7 +149,7 @@ class StreamTest extends TestCase
             'http://localhost',
             'GET',
             ['Content-Type' => 'application/json'],
-            $content
+            $content,
         );
 
         $options = [
@@ -177,7 +177,7 @@ class StreamTest extends TestCase
             [
                 'Content-Type' => 'application/json',
             ],
-            ['a' => 'my value']
+            ['a' => 'my value'],
         );
 
         $this->stream->send($request, []);
@@ -201,7 +201,7 @@ class StreamTest extends TestCase
             'http://localhost',
             'GET',
             ['Content-Type' => 'application/json'],
-            ['upload' => fopen(CORE_PATH . 'VERSION.txt', 'r')]
+            ['upload' => fopen(CORE_PATH . 'VERSION.txt', 'r')],
         );
 
         $this->stream->send($request, []);

--- a/tests/TestCase/Http/Client/Auth/OauthTest.php
+++ b/tests/TestCase/Http/Client/Auth/OauthTest.php
@@ -123,7 +123,7 @@ class OauthTest extends TestCase
         $this->assertStringContainsString('GET&', $result, 'method was missing.');
         $this->assertStringContainsString(
             'http%3A%2F%2Fexample.com%2Fsearch&',
-            $result
+            $result,
         );
         $this->assertStringContainsString(
             'cat%3D2%26oauth_consumer_key%3Dconsumer-key' .
@@ -133,7 +133,7 @@ class OauthTest extends TestCase
             '%26oauth_token%3Dtoken' .
             '%26oauth_version%3D1.0' .
             '%26q%3Dpogo',
-            $result
+            $result,
         );
     }
 
@@ -159,7 +159,7 @@ class OauthTest extends TestCase
                         'value' => 'one two',
                     ],
                 ],
-            ]
+            ],
         );
 
         $auth = new Oauth();
@@ -176,7 +176,7 @@ class OauthTest extends TestCase
         $this->assertStringContainsString('POST&', $result, 'method was missing.');
         $this->assertStringContainsString(
             'http%3A%2F%2Fexample.com%2Fsearch&',
-            $result
+            $result,
         );
         $this->assertStringContainsString(
             '&oauth_consumer_key%3Dconsumer-key' .
@@ -188,7 +188,7 @@ class OauthTest extends TestCase
             '%26q%3Dpogo' .
             '%26search%5Bfilters%5D%5Bfield%5D%3Ddate' .
             '%26search%5Bfilters%5D%5Bvalue%5D%3Done%20two',
-            $result
+            $result,
         );
     }
 
@@ -212,7 +212,7 @@ class OauthTest extends TestCase
                 'address' => 'post',
                 'zed' => 'last',
                 'tags' => ['oauth', 'cake'],
-            ]
+            ],
         );
 
         $auth = new Oauth();
@@ -229,7 +229,7 @@ class OauthTest extends TestCase
         $this->assertStringContainsString('POST&', $result, 'method was missing.');
         $this->assertStringContainsString(
             'http%3A%2F%2Fexample.com%2Fsearch&',
-            $result
+            $result,
         );
         $this->assertStringContainsString(
             '&address%3Dpost' .
@@ -243,7 +243,7 @@ class OauthTest extends TestCase
             '%26tags%3Dcake' .
             '%26tags%3Doauth' .
             '%26zed%3Dlast',
-            $result
+            $result,
         );
     }
 
@@ -264,7 +264,7 @@ class OauthTest extends TestCase
             [
                 'Content-Type' => 'application/xml',
             ],
-            '<xml>stuff</xml>'
+            '<xml>stuff</xml>',
         );
 
         $auth = new Oauth();
@@ -281,7 +281,7 @@ class OauthTest extends TestCase
         $this->assertStringContainsString('POST&', $result, 'method was missing.');
         $this->assertStringContainsString(
             'http%3A%2F%2Fexample.com%2Fsearch&',
-            $result
+            $result,
         );
         $this->assertStringContainsString(
             'oauth_consumer_key%3Dconsumer-key' .
@@ -291,7 +291,7 @@ class OauthTest extends TestCase
             '%26oauth_token%3Dtoken' .
             '%26oauth_version%3D1.0' .
             '%26q%3Dpogo',
-            $result
+            $result,
         );
     }
 
@@ -307,7 +307,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacation.jpg', 'size' => 'original']
+            ['file' => 'vacation.jpg', 'size' => 'original'],
         );
 
         $options = [
@@ -332,7 +332,7 @@ class OauthTest extends TestCase
     {
         $request = new Request(
             'http://photos.example.net/photos',
-            'GET'
+            'GET',
         );
 
         $options = [
@@ -362,7 +362,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
         $privateKey = $this->privateKeyString;
 
@@ -393,7 +393,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
 
         $options = [
@@ -421,7 +421,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
         $privateKey = fopen(TEST_APP . DS . 'config' . DS . 'key.pem', 'r');
 
@@ -451,7 +451,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
         $privateKey = fopen(TEST_APP . DS . 'config' . DS . 'key_with_passphrase.pem', 'r');
         $passphrase = 'fancy-cakephp-passphrase';
@@ -483,7 +483,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
         $privateKey = $this->privateKeyStringEnc;
         $passphrase = 'fancy-cakephp-passphrase';
@@ -517,7 +517,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
         $privateKey = fopen(TEST_APP . DS . 'config' . DS . 'key_with_passphrase.pem', 'r');
         $passphrase = fopen(TEST_APP . DS . 'config' . DS . 'key_passphrase_lf', 'r');
@@ -553,7 +553,7 @@ class OauthTest extends TestCase
             'http://photos.example.net/photos',
             'GET',
             [],
-            ['file' => 'vacaction.jpg', 'size' => 'original']
+            ['file' => 'vacaction.jpg', 'size' => 'original'],
         );
         $privateKey = $this->privateKeyStringEnc;
         $passphrase = fopen(TEST_APP . DS . 'config' . DS . 'key_passphrase_lf', 'r');
@@ -579,7 +579,7 @@ class OauthTest extends TestCase
     {
         $this->assertMatchesRegularExpression(
             '/oauth_signature="[a-zA-Z0-9\/=+]+"/',
-            urldecode($result)
+            urldecode($result),
         );
     }
 }

--- a/tests/TestCase/Http/Client/FormDataTest.php
+++ b/tests/TestCase/Http/Client/FormDataTest.php
@@ -191,7 +191,7 @@ class FormDataTest extends TestCase
             filesize(CORE_PATH . 'VERSION.txt'),
             0,
             'VERSION.txt',
-            'text/plain'
+            'text/plain',
         );
 
         $data = new FormData();

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -137,7 +137,7 @@ class RequestTest extends TestCase
         $this->assertSame(
             'a=b&c=d&e%5B0%5D=f&e%5B1%5D=g',
             $request->getBody()->__toString(),
-            'Body should be serialized'
+            'Body should be serialized',
         );
     }
 

--- a/tests/TestCase/Http/Client/ResponseTest.php
+++ b/tests/TestCase/Http/Client/ResponseTest.php
@@ -42,11 +42,11 @@ class ResponseTest extends TestCase
         $this->assertSame('OK', $response->getReasonPhrase());
         $this->assertSame(
             'text/html;charset="UTF-8"',
-            $response->getHeaderLine('content-type')
+            $response->getHeaderLine('content-type'),
         );
         $this->assertSame(
             'Tue, 25 Dec 2012 04:43:47 GMT',
-            $response->getHeaderLine('Date')
+            $response->getHeaderLine('Date'),
         );
         $this->assertSame('winner!', '' . $response->getBody());
     }
@@ -67,16 +67,16 @@ class ResponseTest extends TestCase
         $this->assertSame('1.0', $response->getProtocolVersion());
         $this->assertSame(
             'text/html;charset="UTF-8"',
-            $response->getHeaderLine('content-type')
+            $response->getHeaderLine('content-type'),
         );
         $this->assertSame(
             'Tue, 25 Dec 2012 04:43:47 GMT',
-            $response->getHeaderLine('Date')
+            $response->getHeaderLine('Date'),
         );
 
         $this->assertSame(
             'text/html;charset="UTF-8"',
-            $response->getHeaderLine('Content-Type')
+            $response->getHeaderLine('Content-Type'),
         );
 
         $headers = [
@@ -339,7 +339,7 @@ XML;
         $this->assertTrue($result['secure']);
         $this->assertSame(
             strtotime('Wed, 09-Jun-2021 10:18:14 GMT'),
-            $result['expires']
+            $result['expires'],
         );
         $this->assertSame('/', $result['path']);
 

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -272,7 +272,7 @@ class ClientTest extends TestCase
                 $this->assertEmpty($request->getHeaderLine('Content-Type'), 'Should have no content-type set');
                 $this->assertSame(
                     'http://cakephp.org/search',
-                    $request->getUri() . ''
+                    $request->getUri() . '',
                 );
 
                 return true;
@@ -303,7 +303,7 @@ class ClientTest extends TestCase
                 $this->assertSame(Request::METHOD_GET, $request->getMethod());
                 $this->assertSame(
                     'http://cakephp.org/search?q=hi%20there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
-                    $request->getUri() . ''
+                    $request->getUri() . '',
                 );
 
                 return true;
@@ -336,7 +336,7 @@ class ClientTest extends TestCase
             ->with($this->callback(function ($request) {
                 $this->assertSame(
                     'http://cakephp.org/search?q=hi+there&Category%5Bid%5D%5B0%5D=2&Category%5Bid%5D%5B1%5D=3',
-                    $request->getUri() . ''
+                    $request->getUri() . '',
                 );
 
                 return true;
@@ -777,8 +777,8 @@ class ClientTest extends TestCase
                         return true;
                     }),
                     [],
-                    ]
-                )
+                    ],
+                ),
             )
             ->willReturn([$redirect], [$redirect2], [$response]);
 
@@ -832,7 +832,7 @@ class ClientTest extends TestCase
             'http://cakephp.org/test.html',
             Request::METHOD_GET,
             'php://temp',
-            $headers
+            $headers,
         );
         $result = $http->sendRequest($request);
 
@@ -847,7 +847,7 @@ class ClientTest extends TestCase
             'HttpClient.beforeSend',
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) use (&$eventTriggered): void {
                 $eventTriggered = true;
-            }
+            },
         );
 
         Client::addMockResponse('GET', 'http://foo.test', new Response(body: 'test'));
@@ -866,7 +866,7 @@ class ClientTest extends TestCase
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
                 $event->setRequest(new Request('http://bar.test'));
                 $event->setAdapterOptions(['some' => 'value']);
-            }
+            },
         );
 
         Client::addMockResponse(
@@ -877,7 +877,7 @@ class ClientTest extends TestCase
                 $this->assertSame(['some' => 'value'], $options);
 
                 return true;
-            }]
+            }],
         );
 
         $response = $client->get('http://foo.test');
@@ -892,14 +892,14 @@ class ClientTest extends TestCase
             'HttpClient.beforeSend',
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) {
                 return new Response(body: 'short circuit');
-            }
+            },
         );
 
         $client->getEventManager()->on(
             'HttpClient.afterSend',
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects): void {
                 $this->assertFalse($event->getData('requestSent'));
-            }
+            },
         );
 
         $response = $client->get('http://foo.test');
@@ -914,7 +914,7 @@ class ClientTest extends TestCase
             'HttpClient.afterSend',
             function (ClientEvent $event, Request $request, array $adapterOptions, int $redirects) {
                 return new Response(body: 'modified response');
-            }
+            },
         );
 
         Client::addMockResponse('GET', 'http://foo.test', new Response(body: 'response text'));
@@ -953,8 +953,8 @@ class ClientTest extends TestCase
 
                         return true;
                     }),
-                    ]
-                )
+                    ],
+                ),
             )
             ->willReturn([$redirect], [$response]);
 

--- a/tests/TestCase/Http/ContentTypeNegotiationTest.php
+++ b/tests/TestCase/Http/ContentTypeNegotiationTest.php
@@ -96,7 +96,7 @@ class ContentTypeNegotiationTest extends TestCase
         $request = $request->withEnv('HTTP_ACCEPT', 'application/json');
         $this->assertEquals(
             'application/json',
-            $content->preferredType($request, ['text/html', 'application/json'])
+            $content->preferredType($request, ['text/html', 'application/json']),
         );
     }
 
@@ -119,7 +119,7 @@ class ContentTypeNegotiationTest extends TestCase
 
         $request = $request->withEnv(
             'HTTP_ACCEPT',
-            'application/pdf;q=0.3,application/json;q=0.5,application/xml;q=0.5'
+            'application/pdf;q=0.3,application/json;q=0.5,application/xml;q=0.5',
         );
         $result = $content->parseAccept($request);
         $expected = [

--- a/tests/TestCase/Http/Cookie/CookieCollectionTest.php
+++ b/tests/TestCase/Http/Cookie/CookieCollectionTest.php
@@ -233,7 +233,7 @@ class CookieCollectionTest extends TestCase
         $this->assertSame(
             '2031-06-09 10:18:14',
             $new->get('expiring')->getExpiry()->format('Y-m-d H:i:s'),
-            'Has expiry'
+            'Has expiry',
         );
         $session = $new->get('session');
         $this->assertNull($session->getExpiry(), 'No expiry');
@@ -243,7 +243,7 @@ class CookieCollectionTest extends TestCase
         $this->assertLessThanOrEqual(
             (new DateTime('60 seconds'))->format('Y-m-d H:i:s'),
             $maxage->getExpiry()->format('Y-m-d H:i:s'),
-            'Has max age'
+            'Has max age',
         );
     }
 

--- a/tests/TestCase/Http/FlashMessageTest.php
+++ b/tests/TestCase/Http/FlashMessageTest.php
@@ -71,7 +71,7 @@ class FlashMessageTest extends TestCase
 
         $this->Flash->set(
             'This is a test message',
-            ['element' => 'test', 'params' => ['foo' => 'bar']]
+            ['element' => 'test', 'params' => ['foo' => 'bar']],
         );
         $expected[] = [
             'message' => 'This is a test message',
@@ -109,12 +109,12 @@ class FlashMessageTest extends TestCase
     {
         $this->Flash = new FlashMessage(
             $this->Session,
-            ['params' => ['foo' => 'bar']]
+            ['params' => ['foo' => 'bar']],
         );
 
         $this->Flash->set(
             'This is a test message',
-            ['params' => ['username' => 'ADmad']]
+            ['params' => ['username' => 'ADmad']],
         );
         $expected[] = [
             'message' => 'This is a test message',
@@ -143,7 +143,7 @@ class FlashMessageTest extends TestCase
 
         $this->Flash->set(
             'This is a <b>test</b> message',
-            ['escape' => false, 'params' => ['foo' => 'bar']]
+            ['escape' => false, 'params' => ['foo' => 'bar']],
         );
         $expected = [
             [
@@ -158,7 +158,7 @@ class FlashMessageTest extends TestCase
 
         $this->Flash->set(
             'This is a test message',
-            ['key' => 'escaped', 'escape' => false, 'params' => ['foo' => 'bar', 'escape' => true]]
+            ['key' => 'escaped', 'escape' => false, 'params' => ['foo' => 'bar', 'escape' => true]],
         );
         $expected = [
             [
@@ -251,7 +251,7 @@ class FlashMessageTest extends TestCase
 
         $this->Flash->setExceptionMessage(
             new Exception('This is a test message'),
-            ['element' => 'default', 'clear' => true]
+            ['element' => 'default', 'clear' => true],
         );
         $expected = [
             [

--- a/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/BodyParserMiddlewareTest.php
@@ -98,7 +98,7 @@ class BodyParserMiddlewareTest extends TestCase
         $this->assertEquals(
             ['application/xml', 'text/xml'],
             array_keys($parser->getParsers()),
-            'Default XML parsers are not set.'
+            'Default XML parsers are not set.',
         );
     }
 
@@ -114,7 +114,7 @@ class BodyParserMiddlewareTest extends TestCase
         $this->assertEquals(
             ['application/json', 'text/json'],
             array_keys($parser->getParsers()),
-            'Default JSON parsers are not set.'
+            'Default JSON parsers are not set.',
         );
     }
 

--- a/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/EncryptedCookieMiddlewareTest.php
@@ -57,7 +57,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $this->middleware = new EncryptedCookieMiddleware(
             ['secret', 'ninja'],
             $this->_getCookieEncryptionKey(),
-            'aes'
+            'aes',
         );
     }
 
@@ -102,7 +102,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $middleware = new EncryptedCookieMiddleware(
             ['secret'],
             $this->_getCookieEncryptionKey(),
-            'aes'
+            'aes',
         );
         $middleware->process($request, $handler);
     }
@@ -141,7 +141,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $this->assertTrue($cookies->has('ninja'));
         $this->assertSame(
             'shuriken',
-            $this->_decrypt($cookies->get('ninja')->getValue(), 'aes')
+            $this->_decrypt($cookies->get('ninja')->getValue(), 'aes'),
         );
     }
 
@@ -160,7 +160,7 @@ class EncryptedCookieMiddlewareTest extends TestCase
         $this->assertNotSame('shuriken', $response->getCookie('ninja'));
         $this->assertSame(
             'shuriken',
-            $this->_decrypt($response->getCookie('ninja')['value'], 'aes')
+            $this->_decrypt($response->getCookie('ninja')['value'], 'aes'),
         );
     }
 }

--- a/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
+++ b/tests/TestCase/Http/Middleware/HttpsEnforcerMiddlewareTest.php
@@ -144,7 +144,7 @@ class HttpsEnforcerMiddlewareTest extends TestCase
                 'location' => ['https://localhost/foo'],
                 'X-Foo' => ['bar'],
             ],
-            $result->getHeaders()
+            $result->getHeaders(),
         );
     }
 

--- a/tests/TestCase/Http/ResponseTest.php
+++ b/tests/TestCase/Http/ResponseTest.php
@@ -117,15 +117,15 @@ class ResponseTest extends TestCase
 
         $this->assertSame(
             'application/pdf',
-            $response->withType('pdf')->getType()
+            $response->withType('pdf')->getType(),
         );
         $this->assertSame(
             'custom/stuff',
-            $response->withType('custom/stuff')->getType()
+            $response->withType('custom/stuff')->getType(),
         );
         $this->assertSame(
             'application/json',
-            $response->withType('json')->getType()
+            $response->withType('json')->getType(),
         );
     }
 
@@ -156,7 +156,7 @@ class ResponseTest extends TestCase
         $this->assertSame(
             'text/html; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            'Default content-type should match'
+            'Default content-type should match',
         );
 
         $new = $response->withType('pdf');
@@ -165,7 +165,7 @@ class ResponseTest extends TestCase
         $this->assertSame(
             'text/html; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            'Original object should not be modified'
+            'Original object should not be modified',
         );
         $this->assertSame('application/pdf', $new->getHeaderLine('Content-Type'));
 
@@ -183,17 +183,17 @@ class ResponseTest extends TestCase
         $this->assertSame(
             'application/json',
             $response->withType('application/json')->getHeaderLine('Content-Type'),
-            'Should not add charset to explicit type'
+            'Should not add charset to explicit type',
         );
         $this->assertSame(
             'custom/stuff',
             $response->withType('custom/stuff')->getHeaderLine('Content-Type'),
-            'Should allow arbitrary types'
+            'Should allow arbitrary types',
         );
         $this->assertSame(
             'text/html; charset=UTF-8',
             $response->withType('text/html; charset=UTF-8')->getHeaderLine('Content-Type'),
-            'Should allow charset types'
+            'Should allow charset types',
         );
     }
 
@@ -241,7 +241,7 @@ class ResponseTest extends TestCase
         $this->assertSame('', $new->getType());
         $this->assertFalse(
             $new->hasHeader('Content-Type'),
-            'Type should not be retained because of status code.'
+            'Type should not be retained because of status code.',
         );
 
         $response = new Response();
@@ -765,7 +765,7 @@ class ResponseTest extends TestCase
             $expiry,
             '/test',
             '',
-            true
+            true,
         );
 
         $new = $response->withCookie($cookie);
@@ -833,7 +833,7 @@ class ResponseTest extends TestCase
         $cookie = Cookie::create(
             $options['name'],
             $options['value'],
-            $options['options']
+            $options['options'],
         );
 
         $response = new Response();
@@ -1042,20 +1042,20 @@ class ResponseTest extends TestCase
             [
                 'name' => 'something_special.css',
                 'download' => true,
-            ]
+            ],
         );
         $this->assertSame(
             'text/html; charset=UTF-8',
             $response->getHeaderLine('Content-Type'),
-            'No mutation'
+            'No mutation',
         );
         $this->assertSame(
             'text/css; charset=UTF-8',
-            $new->getHeaderLine('Content-Type')
+            $new->getHeaderLine('Content-Type'),
         );
         $this->assertSame(
             'attachment; filename="something_special.css"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
@@ -1078,7 +1078,7 @@ class ResponseTest extends TestCase
         $this->assertSame('text/html; charset=UTF-8', $new->getHeaderLine('Content-Type'));
         $this->assertSame(
             'attachment; filename="no_section.ini"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
         $body = $new->getBody();
@@ -1098,7 +1098,7 @@ class ResponseTest extends TestCase
         $this->assertSame('application/octet-stream', $new->getHeaderLine('Content-Type'));
         $this->assertSame(
             'attachment; filename="no_section.ini"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
     }
 
@@ -1125,7 +1125,7 @@ class ResponseTest extends TestCase
         ]);
         $this->assertSame(
             'text/html; charset=UTF-8',
-            $new->getHeaderLine('Content-Type')
+            $new->getHeaderLine('Content-Type'),
         );
         $this->assertFalse($new->hasHeader('Content-Disposition'));
         $this->assertFalse($new->hasHeader('Content-Transfer-Encoding'));
@@ -1183,11 +1183,11 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withFile(
             TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css',
-            ['download' => true]
+            ['download' => true],
         );
         $this->assertSame(
             'attachment; filename="test_asset.css"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
@@ -1204,12 +1204,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withFile(
             TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css',
-            ['download' => true]
+            ['download' => true],
         );
 
         $this->assertSame(
             'attachment; filename="test_asset.css"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
@@ -1248,12 +1248,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withFile(
             TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css',
-            ['download' => true]
+            ['download' => true],
         );
 
         $this->assertSame(
             'attachment; filename="test_asset.css"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));
@@ -1271,12 +1271,12 @@ class ResponseTest extends TestCase
         $response = new Response();
         $new = $response->withFile(
             TEST_APP . 'vendor' . DS . 'css' . DS . 'test_asset.css',
-            ['download' => true]
+            ['download' => true],
         );
 
         $this->assertSame(
             'attachment; filename="test_asset.css"',
-            $new->getHeaderLine('Content-Disposition')
+            $new->getHeaderLine('Content-Disposition'),
         );
         $this->assertSame('binary', $new->getHeaderLine('Content-Transfer-Encoding'));
         $this->assertSame('bytes', $new->getHeaderLine('Accept-Ranges'));

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -915,7 +915,7 @@ class ServerRequestFactoryTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals(
             $data['SERVER'] ?? null,
-            $data['GET'] ?? null
+            $data['GET'] ?? null,
         );
         $uri = $request->getUri();
 
@@ -990,7 +990,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_METHOD' => 'POST'],
             [],
-            ['_method' => 'PUT']
+            ['_method' => 'PUT'],
         );
         $this->assertSame('PUT', $request->getEnv('REQUEST_METHOD'));
         $this->assertSame('POST', $request->getEnv('ORIGINAL_REQUEST_METHOD'));
@@ -1026,7 +1026,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = ServerRequestFactory::fromGlobals(
             ['REQUEST_METHOD' => 'POST'],
             [],
-            $body
+            $body,
         );
         $this->assertEmpty($request->getParsedBody());
 
@@ -1036,7 +1036,7 @@ class ServerRequestFactoryTest extends TestCase
                 'HTTP_X_HTTP_METHOD_OVERRIDE' => 'GET',
             ],
             [],
-            ['foo' => 'bar']
+            ['foo' => 'bar'],
         );
         $this->assertEmpty($request->getParsedBody());
     }
@@ -1129,7 +1129,7 @@ class ServerRequestFactoryTest extends TestCase
                     17178,
                     0,
                     'born on.txt',
-                    'text/plain'
+                    'text/plain',
                 ),
             ],
             'pictures' => [
@@ -1140,7 +1140,7 @@ class ServerRequestFactoryTest extends TestCase
                         17188,
                         0,
                         'a-file.png',
-                        'image/png'
+                        'image/png',
                     ),
                 ],
                 1 => [
@@ -1150,7 +1150,7 @@ class ServerRequestFactoryTest extends TestCase
                         2010,
                         0,
                         'a-moose.png',
-                        'image/jpg'
+                        'image/jpg',
                     ),
                 ],
             ],
@@ -1161,7 +1161,7 @@ class ServerRequestFactoryTest extends TestCase
                     1490,
                     0,
                     'scratch.text',
-                    'text/plain'
+                    'text/plain',
                 ),
             ],
         ];
@@ -1314,7 +1314,7 @@ class ServerRequestFactoryTest extends TestCase
                 1,
                 0,
                 'flat.txt',
-                'text/plain'
+                'text/plain',
             ),
             'nested' => [
                 'name' => 'nested',
@@ -1323,7 +1323,7 @@ class ServerRequestFactoryTest extends TestCase
                     12,
                     0,
                     'nested.txt',
-                    'text/plain'
+                    'text/plain',
                 ),
             ],
             'deep' => [
@@ -1334,7 +1334,7 @@ class ServerRequestFactoryTest extends TestCase
                         12345,
                         0,
                         'deep-1.txt',
-                        'text/plain'
+                        'text/plain',
                     ),
                 ],
                 1 => [
@@ -1344,7 +1344,7 @@ class ServerRequestFactoryTest extends TestCase
                         123456,
                         0,
                         'deep-2.txt',
-                        'text/plain'
+                        'text/plain',
                     ),
                 ],
             ],
@@ -1353,7 +1353,7 @@ class ServerRequestFactoryTest extends TestCase
                 123,
                 0,
                 'numeric.txt',
-                'text/plain'
+                'text/plain',
             ),
             1 => [
                 'name' => 'numeric nested',
@@ -1362,7 +1362,7 @@ class ServerRequestFactoryTest extends TestCase
                     1234,
                     0,
                     'numeric-nested.txt',
-                    'text/plain'
+                    'text/plain',
                 ),
             ],
         ];

--- a/tests/TestCase/Http/ServerRequestTest.php
+++ b/tests/TestCase/Http/ServerRequestTest.php
@@ -239,7 +239,7 @@ class ServerRequestTest extends TestCase
             123,
             UPLOAD_ERR_OK,
             'test.php',
-            'text/plain'
+            'text/plain',
         );
         $request = new ServerRequest(['files' => ['avatar' => $file]]);
         $this->assertSame(['avatar' => $file], $request->getUploadedFiles());
@@ -268,7 +268,7 @@ class ServerRequestTest extends TestCase
             123,
             UPLOAD_ERR_OK,
             'test.php',
-            'text/plain'
+            'text/plain',
         );
         $request = new ServerRequest();
         $new = $request->withUploadedFiles(['picture' => $file]);
@@ -288,7 +288,7 @@ class ServerRequestTest extends TestCase
             123,
             UPLOAD_ERR_OK,
             'test.php',
-            'text/plain'
+            'text/plain',
         );
         $request = new ServerRequest();
         $new = $request->withUploadedFiles(['picture' => $file]);
@@ -384,7 +384,7 @@ class ServerRequestTest extends TestCase
 
         $request = $request->withEnv(
             'HTTP_X_FORWARDED_FOR',
-            'spoof.fake.ip, real.ip, 192.168.1.0, 192.168.1.2, 192.168.1.3'
+            'spoof.fake.ip, real.ip, 192.168.1.0, 192.168.1.2, 192.168.1.3',
         );
         $this->assertSame('192.168.1.3', $request->clientIp());
 
@@ -1296,7 +1296,7 @@ class ServerRequestTest extends TestCase
         $this->assertInstanceOf(
             ServerRequest::class,
             $request->withParam('some', 'thing'),
-            'Method has not returned $this'
+            'Method has not returned $this',
         );
 
         $request = $request->withParam('Post.null', null);
@@ -1718,11 +1718,11 @@ class ServerRequestTest extends TestCase
         $result = $request->withData('Model.field.new_value', 'new value');
         $this->assertSame(
             'new value',
-            $result->getData('Model.field.new_value')
+            $result->getData('Model.field.new_value'),
         );
         $this->assertSame(
             'new value',
-            $result->getData()['Model']['field']['new_value']
+            $result->getData()['Model']['field']['new_value'],
         );
     }
 
@@ -1851,7 +1851,7 @@ class ServerRequestTest extends TestCase
         $this->assertSame(
             '/articles/view/1?comments=1&open=0',
             $request->getRequestTarget(),
-            'Should not include basedir.'
+            'Should not include basedir.',
         );
 
         $new = $request->withRequestTarget('/articles/view/3');
@@ -1859,7 +1859,7 @@ class ServerRequestTest extends TestCase
         $this->assertSame(
             '/articles/view/1?comments=1&open=0',
             $request->getRequestTarget(),
-            'should be unchanged.'
+            'should be unchanged.',
         );
         $this->assertSame('/articles/view/3', $new->getRequestTarget(), 'reflects method call');
     }

--- a/tests/TestCase/Http/ServerTest.php
+++ b/tests/TestCase/Http/ServerTest.php
@@ -113,12 +113,12 @@ class ServerTest extends TestCase
         $this->assertSame(
             'source header',
             $res->getHeaderLine('X-testing'),
-            'Input response is carried through out middleware'
+            'Input response is carried through out middleware',
         );
         $this->assertSame(
             'request header',
             $res->getHeaderLine('X-pass'),
-            'Request is used in middleware'
+            'Request is used in middleware',
         );
     }
 
@@ -145,12 +145,12 @@ class ServerTest extends TestCase
         $this->assertSame(
             'source header',
             $res->getHeaderLine('X-testing'),
-            'Input response is carried through out middleware'
+            'Input response is carried through out middleware',
         );
         $this->assertSame(
             'request header',
             $res->getHeaderLine('X-pass'),
-            'Request is used in middleware'
+            'Request is used in middleware',
         );
     }
 
@@ -168,7 +168,7 @@ class ServerTest extends TestCase
         $this->assertSame(
             'globalvalue',
             $res->getHeaderLine('X-pass'),
-            'Default request is made from server'
+            'Default request is made from server',
         );
     }
 
@@ -203,12 +203,12 @@ class ServerTest extends TestCase
         $this->assertSame(
             200,
             $res->getStatusCode(),
-            'Application was expected to be executed'
+            'Application was expected to be executed',
         );
         $this->assertSame(
             'source header',
             $res->getHeaderLine('X-testing'),
-            'Application was expected to be executed'
+            'Application was expected to be executed',
         );
     }
 
@@ -227,12 +227,12 @@ class ServerTest extends TestCase
         $this->assertSame(
             200,
             $res->getStatusCode(),
-            'Application was expected to be executed'
+            'Application was expected to be executed',
         );
         $this->assertSame(
             'source header',
             $res->getHeaderLine('X-testing'),
-            'Application was expected to be executed'
+            'Application was expected to be executed',
         );
     }
 
@@ -409,7 +409,7 @@ class ServerTest extends TestCase
                 $triggered = true;
                 $this->assertInstanceOf(ServerRequest::class, $request);
                 $this->assertInstanceOf(Response::class, $response);
-            }
+            },
         );
 
         $emitter = new class extends ResponseEmitter {

--- a/tests/TestCase/I18n/DateTest.php
+++ b/tests/TestCase/I18n/DateTest.php
@@ -228,7 +228,7 @@ class DateTest extends TestCase
                 'timezone' => 'America/Vancouver',
                 'end' => '+1month',
                 'format' => 'dd-MM-YYYY',
-            ]
+            ],
         );
         $this->assertSame('on 31-07-1990', $result);
     }
@@ -421,13 +421,13 @@ class DateTest extends TestCase
 
         $date = new Date('-1 month -1 week -6 days');
         $result = $date->timeAgoInWords(
-            ['end' => '1 year', 'accuracy' => ['month' => 'month']]
+            ['end' => '1 year', 'accuracy' => ['month' => 'month']],
         );
         $this->assertSame('1 month ago', $result);
 
         $date = new Date('-1 years -2 weeks -3 days');
         $result = $date->timeAgoInWords(
-            ['accuracy' => ['year' => 'year']]
+            ['accuracy' => ['year' => 'year']],
         );
         $expected = 'on ' . $date->format('n/j/y');
         $this->assertSame($expected, $result);

--- a/tests/TestCase/I18n/DateTimeTest.php
+++ b/tests/TestCase/I18n/DateTimeTest.php
@@ -171,7 +171,7 @@ class DateTimeTest extends TestCase
                 'timezone' => 'America/Vancouver',
                 'end' => '+1month',
                 'format' => 'dd-MM-YYYY HH:mm:ss',
-            ]
+            ],
         );
         $this->assertSame('on 31-07-1990 13:33:00', $result);
     }
@@ -325,13 +325,13 @@ class DateTimeTest extends TestCase
 
         $time = new DateTime('-1 month -1 week -6 days');
         $result = $time->timeAgoInWords(
-            ['end' => '1 year', 'accuracy' => ['month' => 'month']]
+            ['end' => '1 year', 'accuracy' => ['month' => 'month']],
         );
         $this->assertSame('1 month ago', $result);
 
         $time = new DateTime('-1 years -2 weeks -3 days');
         $result = $time->timeAgoInWords(
-            ['accuracy' => ['year' => 'year']]
+            ['accuracy' => ['year' => 'year']],
         );
         $expected = 'on ' . $time->format('n/j/y');
         $this->assertSame($expected, $result);

--- a/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
+++ b/tests/TestCase/I18n/Formatter/IcuFormatterTest.php
@@ -44,7 +44,7 @@ class IcuFormatterTest extends TestCase
         $result = $formatter->format(
             '1 Orange',
             '{0, number} {1}',
-            [1.0, 'Orange']
+            [1.0, 'Orange'],
         );
         $this->assertSame('1 Orange', $result);
     }

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -167,19 +167,19 @@ class I18nTest extends TestCase
         $translator = I18n::getTranslator('test_plugin');
         $this->assertSame(
             'Plural Rule 1 (from plugin)',
-            $translator->translate('Plural Rule 1')
+            $translator->translate('Plural Rule 1'),
         );
 
         $translator = I18n::getTranslator('company/test_plugin_three');
         $this->assertSame(
             'String 1 (from plugin three)',
-            $translator->translate('String 1')
+            $translator->translate('String 1'),
         );
 
         $translator = I18n::getTranslator('company/test_plugin_three.custom');
         $this->assertSame(
             'String 2 (from plugin three)',
-            $translator->translate('String 2')
+            $translator->translate('String 2'),
         );
     }
 
@@ -197,19 +197,19 @@ class I18nTest extends TestCase
         $translator = I18n::getTranslator('test_theme');
         $this->assertSame(
             'translated',
-            $translator->translate('A Message')
+            $translator->translate('A Message'),
         );
 
         $translator = I18n::getTranslator('test_plugin_two');
         $this->assertSame(
             'Test Message (from app)',
-            $translator->translate('Test Message')
+            $translator->translate('Test Message'),
         );
 
         $translator = I18n::getTranslator('test_plugin_two.custom');
         $this->assertSame(
             'Test Custom (from test plugin two)',
-            $translator->translate('Test Custom')
+            $translator->translate('Test Custom'),
         );
     }
 
@@ -431,20 +431,20 @@ class I18nTest extends TestCase
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __x('communication', 'letters', ['Thomas', 'Sara'])
+            __x('communication', 'letters', ['Thomas', 'Sara']),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __x('communication', 'letter', ['Thomas'])
+            __x('communication', 'letter', ['Thomas']),
         );
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __x('communication', 'letters', 'Thomas', 'Sara')
+            __x('communication', 'letters', 'Thomas', 'Sara'),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __x('communication', 'letter', 'Thomas')
+            __x('communication', 'letter', 'Thomas'),
         );
     }
 
@@ -527,20 +527,20 @@ class I18nTest extends TestCase
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __xn('communication', 'letter', 'letters', 2, ['Thomas', 'Sara'])
+            __xn('communication', 'letter', 'letters', 2, ['Thomas', 'Sara']),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __xn('communication', 'letter', 'letters', 1, ['Thomas'])
+            __xn('communication', 'letter', 'letters', 1, ['Thomas']),
         );
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __xn('communication', 'letter', 'letters', 2, 'Thomas', 'Sara')
+            __xn('communication', 'letter', 'letters', 2, 'Thomas', 'Sara'),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __xn('communication', 'letter', 'letters', 1, 'Thomas')
+            __xn('communication', 'letter', 'letters', 1, 'Thomas'),
         );
     }
 
@@ -580,20 +580,20 @@ class I18nTest extends TestCase
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __dx('custom', 'communication', 'letters', ['Thomas', 'Sara'])
+            __dx('custom', 'communication', 'letters', ['Thomas', 'Sara']),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __dx('custom', 'communication', 'letter', ['Thomas'])
+            __dx('custom', 'communication', 'letter', ['Thomas']),
         );
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __dx('custom', 'communication', 'letters', 'Thomas', 'Sara')
+            __dx('custom', 'communication', 'letters', 'Thomas', 'Sara'),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __dx('custom', 'communication', 'letter', 'Thomas')
+            __dx('custom', 'communication', 'letter', 'Thomas'),
         );
     }
 
@@ -629,29 +629,29 @@ class I18nTest extends TestCase
         }, 'en_US');
         $this->assertSame(
             'The letters A and B',
-            __dxn('custom', 'character', 'letter', 'letters', 2, ['A', 'B'])
+            __dxn('custom', 'character', 'letter', 'letters', 2, ['A', 'B']),
         );
         $this->assertSame(
             'The letter A',
-            __dxn('custom', 'character', 'letter', 'letters', 1, ['A'])
+            __dxn('custom', 'character', 'letter', 'letters', 1, ['A']),
         );
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __dxn('custom', 'communication', 'letter', 'letters', 2, ['Thomas', 'Sara'])
+            __dxn('custom', 'communication', 'letter', 'letters', 2, ['Thomas', 'Sara']),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __dxn('custom', 'communication', 'letter', 'letters', 1, ['Thomas'])
+            __dxn('custom', 'communication', 'letter', 'letters', 1, ['Thomas']),
         );
 
         $this->assertSame(
             'She wrote a letter to Thomas and Sara',
-            __dxn('custom', 'communication', 'letter', 'letters', 2, 'Thomas', 'Sara')
+            __dxn('custom', 'communication', 'letter', 'letters', 2, 'Thomas', 'Sara'),
         );
         $this->assertSame(
             'She wrote a letter to Thomas',
-            __dxn('custom', 'communication', 'letter', 'letters', 1, 'Thomas')
+            __dxn('custom', 'communication', 'letter', 'letters', 1, 'Thomas'),
         );
     }
 

--- a/tests/TestCase/Log/Engine/BaseLogTest.php
+++ b/tests/TestCase/Log/Engine/BaseLogTest.php
@@ -51,7 +51,7 @@ class BaseLogTest extends TestCase
             $this->assertStringContainsString(
                 $needle,
                 $haystack,
-                'Formatted log message does not contain unescaped unicode character.'
+                'Formatted log message does not contain unescaped unicode character.',
             );
         }
     }
@@ -85,7 +85,7 @@ class BaseLogTest extends TestCase
             LogLevel::INFO,
             '1: {string}, 2: {bool}, 3: {json}, 4: {not a placeholder}, 5: {array}, '
             . '6: {array-obj} 7: {obj}, 8: {debug-info} 9: {valid-ph-not-in-context}',
-            $context
+            $context,
         );
 
         $message = $this->logger->getMessage();
@@ -99,49 +99,49 @@ class BaseLogTest extends TestCase
         $this->assertStringContainsString('7: [unhandled value of type Closure]', $message);
         $this->assertStringContainsString(
             '8: ' . json_encode(ConnectionManager::get('test')->__debugInfo(), JSON_UNESCAPED_UNICODE),
-            $message
+            $message,
         );
         $this->assertStringContainsString('9: {valid-ph-not-in-context}', $message);
 
         $this->logger->log(
             LogLevel::INFO,
             '1: {to-string}',
-            $context
+            $context,
         );
         $this->assertSame('1: response body', $this->logger->getMessage());
 
         $this->logger->log(
             LogLevel::INFO,
             'no placeholder holders',
-            $context
+            $context,
         );
         $this->assertSame('no placeholder holders', $this->logger->getMessage());
 
         $this->logger->log(
             LogLevel::INFO,
             '{to-array}',
-            $context
+            $context,
         );
         $this->assertSame('["my-type"]', $this->logger->getMessage());
 
         $this->logger->log(
             LogLevel::INFO,
             '\{string}',
-            ['string' => 'a-string']
+            ['string' => 'a-string'],
         );
         $this->assertSame('\{string}', $this->logger->getMessage());
 
         $this->logger->log(
             LogLevel::INFO,
             '1: {_ph1}, 2: {0ph2}',
-            ['_ph1' => '1st-string', '0ph2' => '2nd-string']
+            ['_ph1' => '1st-string', '0ph2' => '2nd-string'],
         );
         $this->assertSame('1: 1st-string, 2: 2nd-string', $this->logger->getMessage());
 
         $this->logger->log(
             LogLevel::INFO,
             '{0}',
-            ['val']
+            ['val'],
         );
         $this->assertSame('val', $this->logger->getMessage());
     }

--- a/tests/TestCase/Log/Engine/SyslogLogTest.php
+++ b/tests/TestCase/Log/Engine/SyslogLogTest.php
@@ -78,8 +78,8 @@ class SyslogLogTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     [LOG_DEBUG, 'debug: Foo'],
-                    [LOG_DEBUG, 'debug: Bar']
-                )
+                    [LOG_DEBUG, 'debug: Bar'],
+                ),
             );
         $log->log('debug', "Foo\nBar");
     }

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -42,8 +42,8 @@ class LogTraitTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['error', 'Testing'],
-                    ['debug', 'message']
-                )
+                    ['debug', 'message'],
+                ),
             );
 
         Log::setConfig('trait_test', ['engine' => $mock]);

--- a/tests/TestCase/Mailer/MailerTest.php
+++ b/tests/TestCase/Mailer/MailerTest.php
@@ -355,7 +355,7 @@ class MailerTest extends TestCase
         $this->assertInstanceOf(Mailer::class, $result);
         $this->assertSame(
             ['ApplicationWithDefaultRoutes.php' => ['file' => APP . 'ApplicationWithDefaultRoutes.php', 'mimetype' => 'text/plain']],
-            $result->getMessage()->getAttachments()
+            $result->getMessage()->getAttachments(),
         );
     }
 
@@ -454,7 +454,7 @@ class MailerTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
-            'Transport was not defined. You must set on using setTransport() or set `transport` option in your mailer profile.'
+            'Transport was not defined. You must set on using setTransport() or set `transport` option in your mailer profile.',
         );
         $this->mailer->setTo('cake@cakephp.org');
         $this->mailer->setFrom('cake@cakephp.org');
@@ -1332,7 +1332,7 @@ class MailerTest extends TestCase
         foreach ($lines as $line) {
             $this->assertTrue(
                 strlen($line) <= Message::LINE_LENGTH_MUST,
-                'Line length exceeds the max. limit of Message::LINE_LENGTH_MUST'
+                'Line length exceeds the max. limit of Message::LINE_LENGTH_MUST',
             );
         }
     }

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -874,7 +874,7 @@ HTML;
             filesize(__FILE__),
             UPLOAD_ERR_OK,
             'MessageTest.php',
-            'text/x-php'
+            'text/x-php',
         );
 
         $this->message->setAttachments([
@@ -937,7 +937,7 @@ HTML;
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'File must be a filepath or UploadedFileInterface instance. Found `boolean` instead.'
+            'File must be a filepath or UploadedFileInterface instance. Found `boolean` instead.',
         );
 
         $this->message->setAttachments(['cake.icon.gif' => [
@@ -1020,7 +1020,7 @@ HTML;
             filesize(__FILE__),
             UPLOAD_ERR_OK,
             'MessageTest.php',
-            'text/x-php'
+            'text/x-php',
         );
         $chunks = base64_encode(file_get_contents(__FILE__));
 
@@ -1300,7 +1300,7 @@ HTML;
         foreach ($lines as $line) {
             $this->assertTrue(
                 strlen($line) <= Message::LINE_LENGTH_MUST,
-                'Line length exceeds the max. limit of Message::LINE_LENGTH_MUST'
+                'Line length exceeds the max. limit of Message::LINE_LENGTH_MUST',
             );
         }
     }

--- a/tests/TestCase/Mailer/Transport/MailTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/MailTransportTest.php
@@ -104,7 +104,7 @@ class MailTransportTest extends TestCase
                 $encoded,
                 implode($eol, ['First Line', 'Second Line', '.Third Line', '', '']),
                 $data,
-                '-f'
+                '-f',
             );
 
         $result = $this->MailTransport->send($message);

--- a/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/SmtpTransportTest.php
@@ -97,7 +97,7 @@ class SmtpTransportTest extends TestCase
                 "220 Welcome message\r\n",
                 "250 Accepted\r\n",
                 "220 Server ready\r\n",
-                "250 Accepted\r\n"
+                "250 Accepted\r\n",
             );
         $this->socket->expects($this->exactly(3))
             ->method('write')
@@ -105,8 +105,8 @@ class SmtpTransportTest extends TestCase
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
                     ["STARTTLS\r\n"],
-                    ["EHLO localhost\r\n"]
-                )
+                    ["EHLO localhost\r\n"],
+                ),
             );
         $this->socket->expects($this->once())->method('enableCrypto')
             ->with('tls');
@@ -127,15 +127,15 @@ class SmtpTransportTest extends TestCase
             ->willReturn(
                 "220 Welcome message\r\n",
                 "250 Accepted\r\n",
-                "500 5.3.3 Unrecognized command\r\n"
+                "500 5.3.3 Unrecognized command\r\n",
             );
         $this->socket->expects($this->exactly(2))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                    ["STARTTLS\r\n"]
-                )
+                    ["STARTTLS\r\n"],
+                ),
             );
 
         $e = null;
@@ -165,7 +165,7 @@ class SmtpTransportTest extends TestCase
                 "220 Welcome message\r\n",
                 "250 Accepted\r\n",
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
-                "504 5.7.4 Unrecognized authentication type\r\n"
+                "504 5.7.4 Unrecognized authentication type\r\n",
             );
         $this->socket->expects($this->exactly(3))
             ->method('write')
@@ -173,8 +173,8 @@ class SmtpTransportTest extends TestCase
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
-                    ["AUTH LOGIN\r\n"]
-                )
+                    ["AUTH LOGIN\r\n"],
+                ),
             );
 
         $this->socket->expects($this->once())->method('connect')->willReturn(true);
@@ -198,8 +198,8 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                    ["AUTH PLAIN {$this->credentialsEncoded}\r\n"]
-                )
+                    ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -218,7 +218,7 @@ class SmtpTransportTest extends TestCase
                 "250 Accepted\r\n250 AUTH LOGIN\r\n",
                 "334 Login\r\n",
                 "334 Pass\r\n",
-                "235 OK\r\n"
+                "235 OK\r\n",
             );
         $this->socket->expects($this->exactly(4))
             ->method('write')
@@ -227,8 +227,8 @@ class SmtpTransportTest extends TestCase
                     ["EHLO localhost\r\n"],
                     ["AUTH LOGIN\r\n"],
                     ["bWFyaw==\r\n"],
-                    ["c3Rvcnk=\r\n"]
-                )
+                    ["c3Rvcnk=\r\n"],
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -246,15 +246,15 @@ class SmtpTransportTest extends TestCase
             ->willReturn(
                 "220 Welcome message\r\n",
                 "200 Not Accepted\r\n",
-                "250 Accepted\r\n"
+                "250 Accepted\r\n",
             );
         $this->socket->expects($this->exactly(2))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                    ["HELO localhost\r\n"]
-                )
+                    ["HELO localhost\r\n"],
+                ),
             );
 
         $this->socket->expects($this->once())->method('connect')->willReturn(true);
@@ -271,15 +271,15 @@ class SmtpTransportTest extends TestCase
             ->willReturn(
                 "220 Welcome message\r\n",
                 "200 Not Accepted\r\n",
-                "200 Not Accepted\r\n"
+                "200 Not Accepted\r\n",
             );
         $this->socket->expects($this->exactly(2))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                    ["HELO localhost\r\n"]
-                )
+                    ["HELO localhost\r\n"],
+                ),
             );
         $this->socket->expects($this->once())->method('connect')->willReturn(true);
 
@@ -316,7 +316,7 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                )
+                ),
             );
 
         $this->SmtpTransport->setConfig(['authType' => SmtpTransport::AUTH_XOAUTH2]);
@@ -342,7 +342,7 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                )
+                ),
             );
 
         $this->SmtpTransport->setConfig(['authType' => 'invalid']);
@@ -367,7 +367,7 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["EHLO localhost\r\n"],
-                )
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -413,7 +413,7 @@ class SmtpTransportTest extends TestCase
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
                 "334 Login\r\n",
                 "334 Pass\r\n",
-                "235 OK\r\n"
+                "235 OK\r\n",
             );
         $this->socket->expects($this->exactly(4))
             ->method('write')
@@ -422,8 +422,8 @@ class SmtpTransportTest extends TestCase
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
                     ["AUTH LOGIN\r\n"],
                     ["bWFyaw==\r\n"],
-                    ["c3Rvcnk=\r\n"]
-                )
+                    ["c3Rvcnk=\r\n"],
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -438,20 +438,20 @@ class SmtpTransportTest extends TestCase
         $authString = base64_encode(sprintf(
             "user=%s\1auth=Bearer %s\1\1",
             $this->credentials['username'],
-            $this->credentials['password']
+            $this->credentials['password'],
         ));
 
         $this->socket->expects($this->exactly(1))
             ->method('read')
             ->willReturn(
-                "235 OK\r\n"
+                "235 OK\r\n",
             );
         $this->socket->expects($this->exactly(1))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["AUTH XOAUTH2 {$authString}\r\n"],
-                )
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -471,15 +471,15 @@ class SmtpTransportTest extends TestCase
             ->method('read')
             ->willReturn(
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
-                "500 5.3.3 Unrecognized command\r\n"
+                "500 5.3.3 Unrecognized command\r\n",
             );
         $this->socket->expects($this->exactly(2))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
-                    ["AUTH LOGIN\r\n"]
-                )
+                    ["AUTH LOGIN\r\n"],
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -498,15 +498,15 @@ class SmtpTransportTest extends TestCase
             ->method('read')
             ->willReturn(
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
-                "502 5.3.3 Command not implemented\r\n"
+                "502 5.3.3 Command not implemented\r\n",
             );
         $this->socket->expects($this->exactly(2))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
-                    ["AUTH LOGIN\r\n"]
-                )
+                    ["AUTH LOGIN\r\n"],
+                ),
             );
         $this->SmtpTransport->setConfig($this->credentials);
         $this->SmtpTransport->auth();
@@ -524,15 +524,15 @@ class SmtpTransportTest extends TestCase
             ->method('read')
             ->willReturn(
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
-                "503 5.5.1 Already authenticated\r\n"
+                "503 5.5.1 Already authenticated\r\n",
             );
         $this->socket->expects($this->exactly(2))
             ->method('write')
             ->with(
                 ...self::withConsecutive(
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
-                    ["AUTH LOGIN\r\n"]
-                )
+                    ["AUTH LOGIN\r\n"],
+                ),
             );
         $this->SmtpTransport->setConfig($this->credentials);
         $this->SmtpTransport->auth();
@@ -548,7 +548,7 @@ class SmtpTransportTest extends TestCase
             ->willReturn(
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
                 "334 Login\r\n",
-                "535 5.7.8 Authentication failed\r\n"
+                "535 5.7.8 Authentication failed\r\n",
             );
         $this->socket->expects($this->exactly(3))
             ->method('write')
@@ -556,8 +556,8 @@ class SmtpTransportTest extends TestCase
                 ...self::withConsecutive(
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
                     ["AUTH LOGIN\r\n"],
-                    ["bWFyaw==\r\n"]
-                )
+                    ["bWFyaw==\r\n"],
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -585,7 +585,7 @@ class SmtpTransportTest extends TestCase
                 "504 5.7.4 Unrecognized Authentication Type\r\n",
                 "334 Login\r\n",
                 "334 Pass\r\n",
-                "535 5.7.8 Authentication failed\r\n"
+                "535 5.7.8 Authentication failed\r\n",
             );
         $this->socket->expects($this->exactly(4))
             ->method('write')
@@ -594,8 +594,8 @@ class SmtpTransportTest extends TestCase
                     ["AUTH PLAIN {$this->credentialsEncoded}\r\n"],
                     ["AUTH LOGIN\r\n"],
                     ["bWFyaw==\r\n"],
-                    ["c3Rvcnk=\r\n"]
-                )
+                    ["c3Rvcnk=\r\n"],
+                ),
             );
 
         $this->SmtpTransport->setConfig($this->credentials);
@@ -633,8 +633,8 @@ class SmtpTransportTest extends TestCase
                     ["RCPT TO:<cake@cakephp.org>\r\n"],
                     ["RCPT TO:<mark@cakephp.org>\r\n"],
                     ["RCPT TO:<juan@cakephp.org>\r\n"],
-                    ["RCPT TO:<phpnut@cakephp.org>\r\n"]
-                )
+                    ["RCPT TO:<phpnut@cakephp.org>\r\n"],
+                ),
             );
 
         $this->SmtpTransport->sendRcpt($message);
@@ -657,8 +657,8 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["MAIL FROM:<pleasereply@cakephp.org>\r\n"],
-                    ["RCPT TO:<cake@cakephp.org>\r\n"]
-                )
+                    ["RCPT TO:<cake@cakephp.org>\r\n"],
+                ),
             );
         $this->SmtpTransport->sendRcpt($message);
     }
@@ -703,7 +703,7 @@ class SmtpTransportTest extends TestCase
             ->method('read')
             ->willReturn(
                 "354 OK\r\n",
-                "250 OK\r\n"
+                "250 OK\r\n",
             );
 
         $this->socket->expects($this->exactly(2))
@@ -711,8 +711,8 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["DATA\r\n"],
-                    [$data]
-                )
+                    [$data],
+                ),
             );
 
         $this->SmtpTransport->sendData($message);
@@ -767,7 +767,7 @@ class SmtpTransportTest extends TestCase
                 "250-AUTH=PLAIN LOGIN\r\n",
                 "250-ENHANCEDSTATUSCODES\r\n",
                 "250-8BITMIME\r\n",
-                "250 DSN\r\n"
+                "250 DSN\r\n",
             );
         $this->socket->expects($this->once())->method('write')->with("EHLO localhost\r\n");
         $this->SmtpTransport->connect();
@@ -802,8 +802,8 @@ class SmtpTransportTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ["MAIL FROM:<noreply@cakephp.org>\r\n"],
-                    ["RCPT TO:<cake@cakephp.org>\r\n"]
-                )
+                    ["RCPT TO:<cake@cakephp.org>\r\n"],
+                ),
             );
         $this->socket->expects($this->exactly(2))
             ->method('read')
@@ -865,7 +865,7 @@ class SmtpTransportTest extends TestCase
             ->method('isConnected')
             ->willReturn(
                 true,
-                false
+                false,
             );
 
         $this->assertTrue($this->SmtpTransport->connected());
@@ -944,7 +944,7 @@ class SmtpTransportTest extends TestCase
                 "250 OK\r\n",
                 "250 OK\r\n",
                 "354 OK\r\n",
-                "250 OK\r\n"
+                "250 OK\r\n",
             );
         $this->socket->expects($this->exactly(10))
             ->method('write')
@@ -960,8 +960,8 @@ class SmtpTransportTest extends TestCase
                     ["MAIL FROM:<noreply@cakephp.org>\r\n"],
                     ["RCPT TO:<cake@cakephp.org>\r\n"],
                     ["DATA\r\n"],
-                    [$this->stringContains('First Line')]
-                )
+                    [$this->stringContains('First Line')],
+                ),
             );
 
         $this->socket->expects($this->once())->method('connect')->willReturn(true);
@@ -994,7 +994,7 @@ class SmtpTransportTest extends TestCase
                 "250 OK\r\n",
                 "250 OK\r\n",
                 "354 OK\r\n",
-                "250 OK\r\n"
+                "250 OK\r\n",
             );
 
         $this->socket->expects($this->atLeast(6))
@@ -1006,8 +1006,8 @@ class SmtpTransportTest extends TestCase
                     ["RCPT TO:<cake@cakephp.org>\r\n"],
                     ["DATA\r\n"],
                     [$this->stringContains('First Line')],
-                    ["QUIT\r\n"]
-                )
+                    ["QUIT\r\n"],
+                ),
             );
 
         $this->socket->expects($this->once())->method('disconnect');
@@ -1050,8 +1050,8 @@ class SmtpTransportTest extends TestCase
                     ["MAIL FROM:<noreply@cakephp.org>\r\n"],
                     ["RCPT TO:<cake@cakephp.org>\r\n"],
                     ["DATA\r\n"],
-                    [$this->stringContains('First Line')]
-                )
+                    [$this->stringContains('First Line')],
+                ),
             );
 
         $this->expectException(SocketException::class);
@@ -1070,7 +1070,7 @@ class SmtpTransportTest extends TestCase
             ->method('read')
             ->willReturn(
                 "220 Welcome message\r\n",
-                "250 OK\r\n"
+                "250 OK\r\n",
             );
         $this->socket->expects($this->once())
             ->method('write')

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -259,7 +259,7 @@ class SocketTest extends TestCase
         $this->assertEquals(
             $expected,
             $anotherSocket->getConfig(),
-            'Reset should cause config to return the defaults defined in _defaultConfig'
+            'Reset should cause config to return the defaults defined in _defaultConfig',
         );
     }
 

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -209,7 +209,7 @@ class BelongsToTest extends TestCase
         $this->assertSame(
             'integer',
             $query->getTypeMap()->type('Companies__id'),
-            'Associations should map types.'
+            'Associations should map types.',
         );
     }
 

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -310,7 +310,7 @@ class HasManyTest extends TestCase
 
         $expected = new QueryExpression(
             ['Articles.published' => 'Y', 'Articles.author_id IN' => $keys],
-            $this->articlesTypeMap
+            $this->articlesTypeMap,
         );
         $this->assertWhereClause($expected, $query);
 
@@ -364,7 +364,7 @@ class HasManyTest extends TestCase
                 'Articles.id !=' => 3,
                 'Articles.author_id IN' => $keys,
             ],
-            $query->getTypeMap()
+            $query->getTypeMap(),
         );
         $this->assertWhereClause($expected, $query);
 
@@ -444,7 +444,7 @@ class HasManyTest extends TestCase
                 'Articles.author_id IN' => $keys,
                 'comments.id' => 1,
             ],
-            $query->getTypeMap()
+            $query->getTypeMap(),
         );
         $this->assertWhereClause($expected, $query);
     }
@@ -485,7 +485,7 @@ class HasManyTest extends TestCase
             ['Articles.author_id', 'Articles.site_id'],
             $keys,
             ['integer'],
-            'IN'
+            'IN',
         );
         $query->expects($this->once())->method('andWhere')
             ->with($tuple)
@@ -564,7 +564,7 @@ class HasManyTest extends TestCase
         // Exclude one record from the association finder
         $articles->updateAll(
             ['published' => 'N'],
-            ['author_id' => 1, 'title' => 'First Article']
+            ['author_id' => 1, 'title' => 'First Article'],
         );
         $association = new HasMany('Articles', $config);
 
@@ -896,7 +896,7 @@ class HasManyTest extends TestCase
         $listenerAfterSave = function ($e, $entity, $options) use ($articles): void {
             $this->assertTrue(
                 $articles->getConnection()->inTransaction(),
-                'Multiple transactions used to save associated models.'
+                'Multiple transactions used to save associated models.',
             );
         };
         $articles->getEventManager()->on('Model.afterSave', $listenerAfterSave);
@@ -1360,7 +1360,7 @@ class HasManyTest extends TestCase
         // No additional records in db.
         $this->assertCount(
             1,
-            $authors->Articles->find()->where(['author_id' => 1])->toArray()
+            $authors->Articles->find()->where(['author_id' => 1])->toArray(),
         );
 
         $others = $articles->find('all')
@@ -1370,7 +1370,7 @@ class HasManyTest extends TestCase
         $this->assertCount(
             1,
             $others,
-            'Record not matching association condition should stay'
+            'Record not matching association condition should stay',
         );
         $this->assertSame('Third Article', $others[0]->title);
     }

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -318,7 +318,7 @@ class HasOneTest extends TestCase
                 $this->assertInstanceOf(Query::class, $query);
                 $this->assertEquals($options, $opts);
                 $this->assertFalse($primary);
-            }
+            },
         );
         $association = new HasOne('Profiles', $config);
         $query = $this->user->find();

--- a/tests/TestCase/ORM/AssociationCollectionTest.php
+++ b/tests/TestCase/ORM/AssociationCollectionTest.php
@@ -286,7 +286,7 @@ class AssociationCollectionTest extends TestCase
             $table,
             $entity,
             ['Parent', 'Child'],
-            $options
+            $options,
         );
         $this->assertTrue($result, 'Save should work.');
     }
@@ -333,7 +333,7 @@ class AssociationCollectionTest extends TestCase
             $table,
             $entity,
             ['Parents' => ['associated' => ['Others']]],
-            $options
+            $options,
         );
         $this->assertTrue($result, 'Save should work.');
     }
@@ -380,7 +380,7 @@ class AssociationCollectionTest extends TestCase
             $table,
             $entity,
             ['Comments' => ['associated' => ['Other']]],
-            $options
+            $options,
         );
         $this->assertTrue($result, 'Should succeed.');
     }
@@ -404,7 +404,7 @@ class AssociationCollectionTest extends TestCase
             $table,
             $entity,
             ['Profiles'],
-            ['atomic' => true]
+            ['atomic' => true],
         );
     }
 

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -336,7 +336,7 @@ class AssociationTest extends TestCase
 
         $this->assertTrue(
             $this->getTableLocator()->exists('TestPlugin.ThisAssociationName'),
-            'The association class will use this registry key'
+            'The association class will use this registry key',
         );
         $this->assertFalse($this->getTableLocator()->exists('TestPlugin.Comments'), 'The association class will NOT use this key');
         $this->assertFalse($this->getTableLocator()->exists('Comments'), 'Should also not be set');
@@ -483,15 +483,15 @@ class AssociationTest extends TestCase
         $this->association->setFinder('publishedWithArgOnly');
         $this->assertEquals(
             ['custom', 'this' => 'custom'],
-            $this->association->find(null, 'custom')->getOptions()
+            $this->association->find(null, 'custom')->getOptions(),
         );
         $this->assertEquals(
             ['what' => 'custom', 'this' => 'custom'],
-            $this->association->find(null, what: 'custom')->getOptions()
+            $this->association->find(null, what: 'custom')->getOptions(),
         );
         $this->assertEquals(
             ['what' => 'custom', 'this' => 'custom'],
-            $this->association->find(what: 'custom')->getOptions()
+            $this->association->find(what: 'custom')->getOptions(),
         );
     }
 
@@ -503,12 +503,12 @@ class AssociationTest extends TestCase
         $this->deprecated(function (): void {
             $this->assertEquals(
                 ['this' => 'worked'],
-                $this->association->find(null)->getOptions()
+                $this->association->find(null)->getOptions(),
             );
 
             $this->assertEquals(
                 ['that' => 'custom', 'this' => 'worked'],
-                $this->association->find(null, ['that' => 'custom'])->getOptions()
+                $this->association->find(null, ['that' => 'custom'])->getOptions(),
             );
         });
     }

--- a/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
+++ b/tests/TestCase/ORM/Behavior/BehaviorRegressionTest.php
@@ -47,7 +47,7 @@ class BehaviorRegressionTest extends TestCase
         $connection = ConnectionManager::get('test');
         $this->skipIf(
             $connection->getDriver() instanceof Sqlserver,
-            'This test fails sporadically in SQLServer'
+            'This test fails sporadically in SQLServer',
         );
 
         $table = $this->getTableLocator()->get('NumberTrees');

--- a/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/CounterCacheBehaviorTest.php
@@ -127,7 +127,7 @@ class CounterCacheBehaviorTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
-            'This test fails sporadically in SQLServer'
+            'This test fails sporadically in SQLServer',
         );
 
         $this->post->belongsTo('Users');

--- a/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TimestampBehaviorTest.php
@@ -269,7 +269,7 @@ class TimestampBehaviorTest extends TestCase
         $this->assertInstanceOf(
             DateTime::class,
             $return,
-            'Should return a timestamp object'
+            'Should return a timestamp object',
         );
 
         $now = DateTime::now();
@@ -290,7 +290,7 @@ class TimestampBehaviorTest extends TestCase
         $this->assertSame(
             $initialValue,
             $postValue,
-            'The timestamp should be exactly the same object'
+            'The timestamp should be exactly the same object',
         );
     }
 
@@ -308,7 +308,7 @@ class TimestampBehaviorTest extends TestCase
         $this->assertNotSame(
             $initialValue,
             $postValue,
-            'The timestamp should be a different object if refreshTimestamp is truthy'
+            'The timestamp should be a different object if refreshTimestamp is truthy',
         );
     }
 
@@ -327,7 +327,7 @@ class TimestampBehaviorTest extends TestCase
         $this->assertSame(
             $ts->format('c'),
             $return->format('c'),
-            'Should return the same value as initially set'
+            'Should return the same value as initially set',
         );
     }
 
@@ -347,7 +347,7 @@ class TimestampBehaviorTest extends TestCase
         $this->assertSame(
             $ts->format('Y-m-d H:i:s'),
             $entity->modified->format('Y-m-d H:i:s'),
-            'Modified field is expected to be updated'
+            'Modified field is expected to be updated',
         );
         $this->assertNull($entity->created, 'Created field is NOT expected to change');
     }
@@ -394,7 +394,7 @@ class TimestampBehaviorTest extends TestCase
         $this->assertSame(
             $ts->format('Y-m-d H:i:s'),
             $entity->date_specialed->format('Y-m-d H:i:s'),
-            'Modified field is expected to be updated'
+            'Modified field is expected to be updated',
         );
         $this->assertNull($entity->created, 'Created field is NOT expected to change');
     }

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorEavTest.php
@@ -632,7 +632,7 @@ class TranslateBehaviorEavTest extends TestCase
         $driver = ConnectionManager::get('test')->getDriver();
         $this->skipIf(
             $driver instanceof Mysql &&
-            version_compare($driver->version(), '8.0.0', '>=')
+            version_compare($driver->version(), '8.0.0', '>='),
         );
 
         $table = $this->getTableLocator()->get('Articles');
@@ -1272,7 +1272,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->hasMany('OtherComments', ['className' => 'Comments']);
         $table->OtherComments->addBehavior(
             'Translate',
-            ['fields' => ['comment']]
+            ['fields' => ['comment']],
         );
 
         $items = $table->OtherComments->associations();
@@ -1300,7 +1300,7 @@ class TranslateBehaviorEavTest extends TestCase
         $table->setAlias('FavoritePost');
         $table->addBehavior(
             'Translate',
-            ['fields' => ['body'], 'referenceName' => 'Posts']
+            ['fields' => ['body'], 'referenceName' => 'Posts'],
         );
 
         $items = $table->associations();
@@ -1424,7 +1424,7 @@ class TranslateBehaviorEavTest extends TestCase
         );
         $this->assertSame(
             ['notBlank' => 'The provided value is invalid'],
-            $article->getError('title')
+            $article->getError('title'),
         );
 
         $data = [
@@ -1528,7 +1528,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertNotFalse($table->save($article));
 
         $results = $this->_extractTranslations(
-            $table->find('translations')->where(['id' => 1])
+            $table->find('translations')->where(['id' => 1]),
         )->first();
 
         $this->assertArrayHasKey('es', $results, 'New translation added');
@@ -1566,7 +1566,7 @@ class TranslateBehaviorEavTest extends TestCase
         $this->assertNotFalse($table->save($article));
 
         $results = $this->_extractTranslations(
-            $table->find('translations')->where(['id' => 1])
+            $table->find('translations')->where(['id' => 1]),
         )->first();
 
         $this->assertSame('Mi nuevo titulo', $results['spa']['title']);

--- a/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
+++ b/tests/TestCase/ORM/Behavior/TranslateBehaviorShadowTableTest.php
@@ -130,7 +130,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertSame(
             'SomeRandomPlugin.ArticlesTranslations',
             $translationTable->getRegistryAlias(),
-            'It should be a different object to the one in the no-plugin prefix'
+            'It should be a different object to the one in the no-plugin prefix',
         );
 
         $this->_testFind('SomeRandomPlugin.Articles');
@@ -178,7 +178,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $table->getTable();
         $table->addBehavior(
             'Translate',
-            ['referenceName' => 'Posts']
+            ['referenceName' => 'Posts'],
         );
 
         $config = $table->behaviors()->get('Translate')->getStrategy()->getConfig();
@@ -215,7 +215,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertSame(
             $expected,
             $result,
-            'If no fields are specified, they should be derived from the schema'
+            'If no fields are specified, they should be derived from the schema',
         );
     }
 
@@ -251,7 +251,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringNotContainsString(
             'articles_translations',
             $query->sql(),
-            "The default locale doesn't need a join"
+            "The default locale doesn't need a join",
         );
 
         $table->setLocale('eng');
@@ -260,14 +260,14 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringNotContainsString(
             'articles_translations',
             $query->sql(),
-            'No translated fields, nothing to do'
+            'No translated fields, nothing to do',
         );
 
         $query = $table->find()->select(['Other.title']);
         $this->assertStringNotContainsString(
             'articles_translations',
             $query->sql(),
-            "Other isn't the table class with the translate behavior, nothing to do"
+            "Other isn't the table class with the translate behavior, nothing to do",
         );
     }
 
@@ -284,21 +284,21 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'No fields specified, means select all fields - translated included'
+            'No fields specified, means select all fields - translated included',
         );
 
         $query = $table->find()->select(['title']);
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'Selecting a translated field should join the translations table'
+            'Selecting a translated field should join the translations table',
         );
 
         $query = $table->find()->select(['Articles.title']);
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'Selecting an aliased translated field should join the translations table'
+            'Selecting an aliased translated field should join the translations table',
         );
     }
 
@@ -315,7 +315,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'If the where clause includes a translated field - a join is required'
+            'If the where clause includes a translated field - a join is required',
         );
     }
 
@@ -335,7 +335,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'Enabling `onlyTranslated` should join the translations table'
+            'Enabling `onlyTranslated` should join the translations table',
         );
 
         $table
@@ -347,7 +347,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'Enabling `filterByCurrentLocale` should join the translations table'
+            'Enabling `filterByCurrentLocale` should join the translations table',
         );
     }
 
@@ -367,7 +367,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'Do not try to use non string fields when traversing "where" clause'
+            'Do not try to use non string fields when traversing "where" clause',
         );
     }
 
@@ -384,14 +384,14 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'If the order clause includes a translated field - a join is required'
+            'If the order clause includes a translated field - a join is required',
         );
 
         $query = $table->find();
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'No fields means auto-fields - a join is required'
+            'No fields means auto-fields - a join is required',
         );
     }
 
@@ -436,7 +436,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertEquals(
             $expected,
             $result,
-            'The copy record should also be translated'
+            'The copy record should also be translated',
         );
     }
 
@@ -579,7 +579,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertStringContainsString(
             'articles_translations',
             $query->sql(),
-            'There should be a join to the translations table'
+            'There should be a join to the translations table',
         );
 
         $result = $query->firstOrFail();
@@ -733,7 +733,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
     {
         $this->skipIf(
             ConnectionManager::get('test')->getDriver() instanceof Postgres,
-            'Test needs to be adjusted to not fail on Postgres'
+            'Test needs to be adjusted to not fail on Postgres',
         );
 
         $table = $this->getTableLocator()->get('Articles');
@@ -748,7 +748,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         ]);
         $result = array_intersect_key(
             $query->first()->toArray(),
-            array_flip(['title', 'function_expression', 'body', '_locale'])
+            array_flip(['title', 'function_expression', 'body', '_locale']),
         );
 
         $expected = [
@@ -760,7 +760,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertSame(
             $expected,
             $result,
-            'Including a function expression should work but requires referencing the used table aliases'
+            'Including a function expression should work but requires referencing the used table aliases',
         );
     }
 
@@ -864,7 +864,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertNotFalse($table->save($article));
 
         $results = $this->_extractTranslations(
-            $table->find('translations')->where(['id' => 1])
+            $table->find('translations')->where(['id' => 1]),
         )->first();
 
         $this->assertSame('Mi nuevo titulo', $results['spa']['title']);
@@ -894,7 +894,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         );
         $this->assertSame(
             ['notBlank' => 'The provided value is invalid'],
-            $article->getError('title')
+            $article->getError('title'),
         );
 
         $data = [
@@ -1116,7 +1116,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $query = $table->find()->select();
         $result = array_intersect_key(
             $query->first()->toArray(),
-            array_flip(['title', 'body', '_locale'])
+            array_flip(['title', 'body', '_locale']),
         );
         $expected = [
             'title' => 'Title #1',
@@ -1126,7 +1126,7 @@ class TranslateBehaviorShadowTableTest extends TranslateBehaviorEavTest
         $this->assertSame(
             $expected,
             $result,
-            "Title and body are translated values, but don't match"
+            "Title and body are translated values, but don't match",
         );
     }
 

--- a/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/ORM/Behavior/TreeBehaviorTest.php
@@ -734,7 +734,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->table;
         $entity = new Entity(
             ['name' => 'New Orphan', 'parent_id' => null, 'level' => null],
-            ['markNew' => true]
+            ['markNew' => true],
         );
         $this->assertSame($entity, $table->save($entity));
         $this->assertSame(23, $entity->lft);
@@ -765,7 +765,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->table;
         $entity = new Entity(
             ['name' => 'laptops', 'parent_id' => 1],
-            ['markNew' => true]
+            ['markNew' => true],
         );
         $this->assertSame($entity, $table->save($entity));
         $this->assertSame(20, $entity->lft);
@@ -796,7 +796,7 @@ class TreeBehaviorTest extends TestCase
         $table = $this->table;
         $entity = new Entity(
             ['name' => 'laptops', 'parent_id' => 2],
-            ['markNew' => true]
+            ['markNew' => true],
         );
         $this->assertSame($entity, $table->save($entity));
         $this->assertSame(9, $entity->lft);
@@ -1455,7 +1455,7 @@ class TreeBehaviorTest extends TestCase
                     str_pad((string)$item->lft, 2, ' ', STR_PAD_LEFT),
                     str_pad((string)$item->rght, 2, ' ', STR_PAD_LEFT),
                     str_pad((string)$item->$primaryKey, 2, ' ', STR_PAD_LEFT),
-                    $item->{$displayField}
+                    $item->{$displayField},
                 );
             },
         ];

--- a/tests/TestCase/ORM/BindingKeyTest.php
+++ b/tests/TestCase/ORM/BindingKeyTest.php
@@ -75,13 +75,13 @@ class BindingKeyTest extends TestCase
         $expected = array_combine($expected, $expected);
         $this->assertEquals(
             $expected,
-            $result->all()->combine('username', 'auth_user.username')->toArray()
+            $result->all()->combine('username', 'auth_user.username')->toArray(),
         );
 
         $expected = [1 => 1, 2 => 5, 3 => 2, 4 => 4];
         $this->assertEquals(
             $expected,
-            $result->all()->combine('id', 'auth_user.id')->toArray()
+            $result->all()->combine('id', 'auth_user.id')->toArray(),
         );
     }
 

--- a/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
+++ b/tests/TestCase/ORM/ColumnSchemaAwareTypeIntegrationTest.php
@@ -75,7 +75,7 @@ class ColumnSchemaAwareTypeIntegrationTest extends TestCase
                         'precision',
                         'scale',
                     ],
-                    array_keys($definition)
+                    array_keys($definition),
                 );
 
                 return null;

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -262,8 +262,8 @@ class EagerLoaderTest extends TestCase
                             ['categories.id' => new IdentifierExpression('companies.category_id')],
                         ], $this->categoriesTypeMap),
                     ]],
-                    ]
-                )
+                    ],
+                ),
             )
             ->willReturn($query);
 
@@ -528,11 +528,11 @@ class EagerLoaderTest extends TestCase
         $assocs = $assocs['stuff']->associations();
         $this->assertSame(
             'clients.orders.stuff.stuffTypes',
-            $assocs['stuffTypes']->aliasPath()
+            $assocs['stuffTypes']->aliasPath(),
         );
         $this->assertSame(
             'client.order.stuff.stuff_type',
-            $assocs['stuffTypes']->propertyPath()
+            $assocs['stuffTypes']->propertyPath(),
         );
     }
 
@@ -620,7 +620,7 @@ class EagerLoaderTest extends TestCase
 
             return array_combine(
                 array_map($quoter, array_keys($elements)),
-                array_map($quoter, array_values($elements))
+                array_map($quoter, array_values($elements)),
             );
         }
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -87,7 +87,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(
             ['false' => false, 'null' => null, 'zero' => 0, 'empty' => ''],
-            ['markNew' => true]
+            ['markNew' => true],
         );
         $this->assertNull($entity->getOriginal('null'));
         $this->assertFalse($entity->getOriginal('false'));
@@ -109,7 +109,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(
             ['foo' => 'foo', 'bar' => 'bar'],
-            ['markNew' => true]
+            ['markNew' => true],
         );
         $this->assertNull($entity->getOriginal('baz', true));
         $this->expectException(InvalidArgumentException::class);
@@ -256,8 +256,8 @@ class EntityTest extends TestCase
                     [
                     ['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false],
                     ],
-                    [['foo' => 'bar'], ['setter' => false, 'guard' => false]]
-                )
+                    [['foo' => 'bar'], ['setter' => false, 'guard' => false]],
+                ),
             );
 
         $entity->__construct(['a' => 'b', 'c' => 'd']);
@@ -574,7 +574,7 @@ class EntityTest extends TestCase
         $entity->expects($this->exactly(2))
             ->method('get')
             ->with(
-                ...self::withConsecutive(['foo'], ['bar'])
+                ...self::withConsecutive(['foo'], ['bar']),
             )
             ->willReturn('worked', 'worked too');
 
@@ -595,7 +595,7 @@ class EntityTest extends TestCase
         $entity->expects($this->exactly(2))
             ->method('set')
             ->with(
-                ...self::withConsecutive(['foo', 1], ['bar', 2])
+                ...self::withConsecutive(['foo', 1], ['bar', 2]),
             )
             ->willReturnSelf();
 
@@ -1511,7 +1511,7 @@ class EntityTest extends TestCase
     {
         $entity = new Entity(
             ['a' => 1, 'b' => 2],
-            ['markNew' => false, 'markClean' => true]
+            ['markNew' => false, 'markClean' => true],
         );
 
         $this->assertFalse($entity->isNew());

--- a/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
+++ b/tests/TestCase/ORM/Locator/LocatorAwareTraitTest.php
@@ -85,7 +85,7 @@ class LocatorAwareTraitTest extends TestCase
     {
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage(
-            'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
+            'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.',
         );
 
         $stub = new LocatorAwareStub();
@@ -96,7 +96,7 @@ class LocatorAwareTraitTest extends TestCase
     {
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage(
-            'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.'
+            'You must provide an `$alias` or set the `$defaultTable` property to a non empty string.',
         );
 
         $stub = new LocatorAwareStub('');

--- a/tests/TestCase/ORM/Locator/TableLocatorTest.php
+++ b/tests/TestCase/ORM/Locator/TableLocatorTest.php
@@ -331,11 +331,11 @@ class TableLocatorTest extends TestCase
         $this->assertInstanceOf(TestPluginCommentsTable::class, $table);
         $this->assertFalse(
             $this->_locator->exists('TestPluginComments'),
-            'Short form should NOT exist'
+            'Short form should NOT exist',
         );
         $this->assertTrue(
             $this->_locator->exists('TestPlugin.TestPluginComments'),
-            'Long form should exist'
+            'Long form should exist',
         );
 
         $second = $this->_locator->get('TestPlugin.TestPluginComments');

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -533,12 +533,12 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf(
             Entity::class,
             $result->tags[0]->_joinData,
-            '_joinData should be an entity.'
+            '_joinData should be an entity.',
         );
         $this->assertSame(
             $data['tags'][0]['_joinData']['active'],
             $result->tags[0]->_joinData->active,
-            '_joinData should be an entity.'
+            '_joinData should be an entity.',
         );
     }
 
@@ -619,13 +619,13 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf(
             Entity::class,
             $result->tags[0]->_joinData->user,
-            'joinData should contain a user entity.'
+            'joinData should contain a user entity.',
         );
         $this->assertSame('Bill', $result->tags[0]->_joinData->user->username);
         $this->assertInstanceOf(
             Entity::class,
             $result->tags[1]->_joinData->user,
-            'joinData should contain a user entity.'
+            'joinData should contain a user entity.',
         );
         $this->assertSame('Mark', $result->tags[1]->_joinData->user->username);
     }
@@ -667,21 +667,21 @@ class MarshallerTest extends TestCase
         $result = $marshall->one($data, ['associated' => ['Tags._joinData.Users']]);
         $this->assertInstanceOf(
             Entity::class,
-            $result->tags[0]
+            $result->tags[0],
         );
         $this->assertInstanceOf(
             Entity::class,
-            $result->tags[1]
-        );
-
-        $this->assertInstanceOf(
-            Entity::class,
-            $result->tags[0]->_joinData->user
+            $result->tags[1],
         );
 
         $this->assertInstanceOf(
             Entity::class,
-            $result->tags[1]->_joinData->user
+            $result->tags[0]->_joinData->user,
+        );
+
+        $this->assertInstanceOf(
+            Entity::class,
+            $result->tags[1]->_joinData->user,
         );
         $this->assertFalse($result->tags[0]->isNew(), 'Should not be new, as id is in db.');
         $this->assertFalse($result->tags[1]->isNew(), 'Should not be new, as id is in db.');
@@ -1121,11 +1121,11 @@ class MarshallerTest extends TestCase
 
         $this->assertSame(
             $data['article']['title'],
-            $result->article->title
+            $result->article->title,
         );
         $this->assertSame(
             $data['article']['user']['username'],
-            $result->article->user->username
+            $result->article->user->username,
         );
     }
 
@@ -1193,11 +1193,11 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf(Entity::class, $result[1]);
         $this->assertSame(
             $data[0]['user']['username'],
-            $result[0]->user->username
+            $result[0]->user->username,
         );
         $this->assertSame(
             $data[1]['user']['username'],
-            $result[1]->user->username
+            $result[1]->user->username,
         );
     }
 
@@ -1680,7 +1680,7 @@ class MarshallerTest extends TestCase
 
         $this->assertEquals(
             ['comment' => 'Extra comment 3'] + $thirdComment,
-            $entity->comments[2]->toArray()
+            $entity->comments[2]->toArray(),
         );
 
         $forthComment = $this->articles->Comments
@@ -1691,16 +1691,16 @@ class MarshallerTest extends TestCase
 
         $this->assertEquals(
             ['comment' => 'Extra comment 4'] + $forthComment,
-            $entity->comments[3]->toArray()
+            $entity->comments[3]->toArray(),
         );
 
         $this->assertEquals(
             ['comment' => 'Extra comment 1'],
-            $entity->comments[4]->toArray()
+            $entity->comments[4]->toArray(),
         );
         $this->assertEquals(
             ['comment' => 'Extra comment 2'],
-            $entity->comments[5]->toArray()
+            $entity->comments[5]->toArray(),
         );
     }
 
@@ -2141,11 +2141,11 @@ class MarshallerTest extends TestCase
 
         $this->assertSame(
             $data['tags'][0]['_joinData']['user']['username'],
-            $result->tags[0]->_joinData->user->username
+            $result->tags[0]->_joinData->user->username,
         );
         $this->assertSame(
             $data['tags'][1]['_joinData']['user']['username'],
-            $result->tags[1]->_joinData->user->username
+            $result->tags[1]->_joinData->user->username,
         );
     }
 
@@ -2205,11 +2205,11 @@ class MarshallerTest extends TestCase
 
         $this->assertSame(
             $data['tags'][0]['_joinData']['user']['username'],
-            $result->tags[0]->_joinData->user->username
+            $result->tags[0]->_joinData->user->username,
         );
         $this->assertSame(
             $data['tags'][1]['_joinData']['user']['username'],
-            $result->tags[1]->_joinData->user->username
+            $result->tags[1]->_joinData->user->username,
         );
     }
 
@@ -2262,11 +2262,11 @@ class MarshallerTest extends TestCase
         $this->assertSame($tag1->_joinData, $entity->tags[0]->_joinData);
         $this->assertSame(
             ['active' => 0, 'foo' => 'bar'],
-            $entity->tags[0]->_joinData->toArray()
+            $entity->tags[0]->_joinData->toArray(),
         );
         $this->assertSame(
             ['active' => 1, 'foo' => 'baz'],
-            $entity->tags[1]->_joinData->toArray()
+            $entity->tags[1]->_joinData->toArray(),
         );
         $this->assertSame('new tag', $entity->tags[1]->tag);
         $this->assertTrue($entity->tags[0]->isDirty('_joinData'));
@@ -2541,7 +2541,7 @@ class MarshallerTest extends TestCase
     {
         $entity = new Entity(
             ['comment' => 'My Comment text'],
-            ['markNew' => false, 'markClean' => true]
+            ['markNew' => false, 'markClean' => true],
         );
         $data = [
             'created' => [
@@ -2807,13 +2807,13 @@ class MarshallerTest extends TestCase
         $this->assertInstanceOf(
             Entity::class,
             $result->tags[0]->_joinData->user,
-            'joinData should contain a user entity.'
+            'joinData should contain a user entity.',
         );
         $this->assertSame('Bill', $result->tags[0]->_joinData->user->username);
         $this->assertInstanceOf(
             Entity::class,
             $result->tags[1]->_joinData->user,
-            'joinData should contain a user entity.'
+            'joinData should contain a user entity.',
         );
         $this->assertSame('Mark', $result->tags[1]->_joinData->user->username);
 
@@ -2872,11 +2872,11 @@ class MarshallerTest extends TestCase
         $this->assertSame($tag1->_joinData, $entity->tags[0]->_joinData);
         $this->assertSame(
             ['active' => 0, 'foo' => 'bar'],
-            $entity->tags[0]->_joinData->toArray()
+            $entity->tags[0]->_joinData->toArray(),
         );
         $this->assertSame(
             ['foo' => 'baz'],
-            $entity->tags[1]->_joinData->toArray()
+            $entity->tags[1]->_joinData->toArray(),
         );
         $this->assertSame('new tag', $entity->tags[1]->tag);
         $this->assertTrue($entity->tags[0]->isDirty('_joinData'));
@@ -2984,7 +2984,7 @@ class MarshallerTest extends TestCase
         ];
         $this->articles->setValidator(
             'custom',
-            (new Validator())->add('number', 'numeric', ['rule' => 'numeric'])
+            (new Validator())->add('number', 'numeric', ['rule' => 'numeric']),
         );
         $marshall = new Marshaller($this->articles);
         $entity = $marshall->one($data, ['validate' => 'custom']);
@@ -3137,7 +3137,7 @@ class MarshallerTest extends TestCase
                 $data['user']['username'] = 'robert';
 
                 $options['associated'] = ['Users'];
-            }
+            },
         );
 
         $entity = $marshall->one($data);
@@ -3185,35 +3185,35 @@ class MarshallerTest extends TestCase
 
                 $this->assertArrayHasKey('association', $options);
                 $this->assertInstanceOf(Association::class, $options['association']);
-            }
+            },
         );
 
         $this->articles->Users->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data, $options): void {
                 $data['secret'] = 'h45h3d';
-            }
+            },
         );
 
         $this->articles->Comments->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data): void {
                 $data['comment'] .= ' (modified)';
-            }
+            },
         );
 
         $this->articles->Tags->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data): void {
                 $data['tag'] .= ' (modified)';
-            }
+            },
         );
 
         $this->articles->Tags->junction()->getEventManager()->on(
             'Model.beforeMarshal',
             function ($e, $data): void {
                 $data['modified_by'] = 1;
-            }
+            },
         );
 
         $entity = $marshall->one($data, [
@@ -3257,7 +3257,7 @@ class MarshallerTest extends TestCase
                 $options['associated'] = ['Users'];
 
                 $entity->body = 'Modified body';
-            }
+            },
         );
 
         $entity = $marshall->one($data);
@@ -3302,7 +3302,7 @@ class MarshallerTest extends TestCase
                 if (isset($options['fields'])) {
                     $entity->body = 'options[fields] is set';
                 }
-            }
+            },
         );
 
         //test when $options['fields'] is empty

--- a/tests/TestCase/ORM/Query/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/Query/CompositeKeysTest.php
@@ -748,7 +748,7 @@ class CompositeKeysTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlite,
-            'SQLite does not support the requirements of this test.'
+            'SQLite does not support the requirements of this test.',
         );
     }
 }

--- a/tests/TestCase/ORM/Query/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/Query/QueryRegressionTest.php
@@ -456,7 +456,7 @@ class QueryRegressionTest extends TestCase
         $this->assertSame('Second top article', $highlights->top_articles[1]->title);
         $this->assertEquals(
             new DateTime('2014-06-01 10:10:00'),
-            $highlights->_joinData->highlighted_time
+            $highlights->_joinData->highlighted_time,
         );
     }
 
@@ -478,11 +478,11 @@ class QueryRegressionTest extends TestCase
 
         $this->assertNotEmpty(
             $result->comments[0]->id,
-            'No SQL error and comment exists.'
+            'No SQL error and comment exists.',
         );
         $this->assertNotEmpty(
             $result->author->id,
-            'No SQL error and author exists.'
+            'No SQL error and author exists.',
         );
         $this->clearPlugins();
     }
@@ -552,7 +552,7 @@ class QueryRegressionTest extends TestCase
 
         $this->assertEquals(
             ['tag1', 'tag3'],
-            collection($result[2]->articles[0]->tags)->sortBy('name')->extract('name')->toArray()
+            collection($result[2]->articles[0]->tags)->sortBy('name')->extract('name')->toArray(),
         );
     }
 
@@ -579,7 +579,7 @@ class QueryRegressionTest extends TestCase
             ->toArray();
         $this->assertEquals(
             ['tag1', 'tag2'],
-            collection($result[0]->author->tags)->extract('name')->toArray()
+            collection($result[0]->author->tags)->extract('name')->toArray(),
         );
         $this->assertSame(3, $result[0]->author->id);
     }
@@ -596,7 +596,7 @@ class QueryRegressionTest extends TestCase
 
         $this->skipIf(
             $tags->getConnection()->getDriver() instanceof Sqlserver,
-            'SQL server is temporarily weird in this test, will investigate later'
+            'SQL server is temporarily weird in this test, will investigate later',
         );
         $tags = $this->getTableLocator()->get('Tags');
         $featuredTags = $this->getTableLocator()->get('FeaturedTags');
@@ -1117,14 +1117,14 @@ class QueryRegressionTest extends TestCase
             'id',
             'coalesced' => $query->func()->coalesce(
                 ['published' => 'identifier', -1],
-                ['integer']
+                ['integer'],
             ),
         ]);
         $result = $query->all()->first();
         $this->assertSame(
             -1,
             $result['coalesced'],
-            'Output values for functions should be casted'
+            'Output values for functions should be casted',
         );
     }
 
@@ -1457,7 +1457,7 @@ class QueryRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
         $query->orderByDesc(
-            $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0)
+            $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0),
         );
         $query->orderBy(['title' => 'desc']);
         // Executing the normal query before getting the count
@@ -1467,7 +1467,7 @@ class QueryRegressionTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $query = $table->find();
         $query->orderByDesc(
-            $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0)
+            $query->newExpr()->case()->when(['id' => 3])->then(1)->else(0),
         );
         $query->orderByDesc($query->newExpr()->add(['id' => 3]));
         // Not executing the query first, just getting the count
@@ -1617,7 +1617,7 @@ class QueryRegressionTest extends TestCase
                                     ->selectQuery(1.23456),
                                 2,
                             ],
-                            [null, 'integer']
+                            [null, 'integer'],
                         )
                         ->setReturnType('float'),
                 ];
@@ -1637,7 +1637,7 @@ class QueryRegressionTest extends TestCase
 
         $this->assertSame(
             1,
-            $table->getAssociation('Authors')->updateAll(['name' => null], ['id' => 3])
+            $table->getAssociation('Authors')->updateAll(['name' => null], ['id' => 3]),
         );
 
         $query = $table

--- a/tests/TestCase/ORM/Query/SelectQueryTest.php
+++ b/tests/TestCase/ORM/Query/SelectQueryTest.php
@@ -181,7 +181,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             ['extra' => 2, 'id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
-            $results
+            $results,
         );
 
         $query = new SelectQuery($table);
@@ -194,7 +194,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             ['id' => 2, 'extra' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
-            $results
+            $results,
         );
 
         $query = new SelectQuery($table);
@@ -207,7 +207,7 @@ class SelectQueryTest extends TestCase
 
         $this->assertSame(
             ['extra' => 2, 'id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
-            $results
+            $results,
         );
     }
 
@@ -1088,7 +1088,7 @@ class SelectQueryTest extends TestCase
         $this->assertSame($query, $query->mapReduce($mapper1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => null]],
-            $query->getMapReducers()
+            $query->getMapReducers(),
         );
 
         $this->assertEquals($query, $query->mapReduce($mapper2));
@@ -1098,7 +1098,7 @@ class SelectQueryTest extends TestCase
                 ['mapper' => $mapper1, 'reducer' => null],
                 ['mapper' => $mapper2, 'reducer' => null],
             ],
-            $result
+            $result,
         );
     }
 
@@ -1119,7 +1119,7 @@ class SelectQueryTest extends TestCase
         $this->assertSame($query, $query->mapReduce($mapper1, $reducer1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => $reducer1]],
-            $query->getMapReducers()
+            $query->getMapReducers(),
         );
 
         $this->assertSame($query, $query->mapReduce($mapper2, $reducer2));
@@ -1128,7 +1128,7 @@ class SelectQueryTest extends TestCase
                 ['mapper' => $mapper1, 'reducer' => $reducer1],
                 ['mapper' => $mapper2, 'reducer' => $reducer2],
             ],
-            $query->getMapReducers()
+            $query->getMapReducers(),
         );
     }
 
@@ -1149,13 +1149,13 @@ class SelectQueryTest extends TestCase
         $this->assertEquals($query, $query->mapReduce($mapper1, $reducer1));
         $this->assertEquals(
             [['mapper' => $mapper1, 'reducer' => $reducer1]],
-            $query->getMapReducers()
+            $query->getMapReducers(),
         );
 
         $this->assertEquals($query, $query->mapReduce($mapper2, $reducer2, true));
         $this->assertEquals(
             [['mapper' => $mapper2, 'reducer' => $reducer2]],
-            $query->getMapReducers()
+            $query->getMapReducers(),
         );
     }
 
@@ -1176,7 +1176,7 @@ class SelectQueryTest extends TestCase
             },
             function ($v, $k, $mr): void {
                 $mr->emit($v[0] + 1);
-            }
+            },
         );
 
         $this->assertEquals([2, 3], iterator_to_array($query->all()));
@@ -1669,7 +1669,7 @@ class SelectQueryTest extends TestCase
         $query->select([
             'title' => $query->func()->concat(
                 ['title' => 'identifier', 'test'],
-                ['string']
+                ['string'],
             ),
         ]);
         $query->where(['id' => 1]);
@@ -1906,7 +1906,7 @@ class SelectQueryTest extends TestCase
             ->method('set')
             ->with(
                 'my_key',
-                $this->isInstanceOf(ResultSetInterface::class)
+                $this->isInstanceOf(ResultSetInterface::class),
             );
 
         $query->cache('my_key', $cacher)
@@ -2167,7 +2167,7 @@ class SelectQueryTest extends TestCase
 
                     return $results;
                 });
-            }
+            },
         );
 
         $sourceQuery = $articles
@@ -2198,7 +2198,7 @@ class SelectQueryTest extends TestCase
             ->find()
             ->contain('Authors', function (SelectQuery $targetQuery) use (
                 &$resultFormatterTargetQuery,
-                &$resultFormatterSourceQuery
+                &$resultFormatterSourceQuery,
             ) {
                 $resultFormatterTargetQuery = $targetQuery;
 
@@ -2239,7 +2239,7 @@ class SelectQueryTest extends TestCase
 
                     return $results;
                 });
-            }
+            },
         );
 
         $sourceQuery = $articles
@@ -2270,7 +2270,7 @@ class SelectQueryTest extends TestCase
             ->find()
             ->contain('Tags', function (SelectQuery $targetQuery) use (
                 &$resultFormatterTargetQuery,
-                &$resultFormatterSourceQuery
+                &$resultFormatterSourceQuery,
             ) {
                 $resultFormatterTargetQuery = $targetQuery;
 
@@ -2471,7 +2471,7 @@ class SelectQueryTest extends TestCase
                     '%s - %s - %s',
                     $row->tag_id,
                     $row->article->idCopy,
-                    $row->article->author->idCopy
+                    $row->article->author->idCopy,
                 );
             });
         });
@@ -2792,7 +2792,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $this->assertEquals(
             json_encode($table->find()),
-            json_encode($table->find()->toArray())
+            json_encode($table->find()->toArray()),
         );
     }
 
@@ -2904,7 +2904,7 @@ class SelectQueryTest extends TestCase
         $this->assertNotSame(
             $reflect->getValue($copyLoader),
             $reflect->getValue($loader),
-            'should be clones'
+            'should be clones',
         );
         $this->assertNull($copy->clause('offset'));
         $this->assertNull($copy->clause('limit'));
@@ -2964,7 +2964,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('Articles');
         $table->belongsTo(
             'Authors',
-            ['className' => AuthorsTable::class]
+            ['className' => AuthorsTable::class],
         );
         $authorId = 1;
 
@@ -2996,7 +2996,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany(
             'Articles',
-            ['className' => ArticlesTable::class]
+            ['className' => ArticlesTable::class],
         );
 
         $newArticle = $table->newEntity([
@@ -3065,7 +3065,7 @@ class SelectQueryTest extends TestCase
         $this->assertCount(1, $resultWithArticlesArrayOptions->first()->articles);
         $this->assertSame(
             'First Article',
-            $resultWithArticlesArrayOptions->first()->articles[0]->title
+            $resultWithArticlesArrayOptions->first()->articles[0]->title,
         );
 
         $this->assertCount(0, $resultWithoutArticles->first()->articles);
@@ -3081,7 +3081,7 @@ class SelectQueryTest extends TestCase
         $table = $this->getTableLocator()->get('Authors');
         $table->hasMany(
             'Articles',
-            ['className' => ArticlesTable::class]
+            ['className' => ArticlesTable::class],
         );
 
         $newArticle = $table->newEntity([
@@ -3403,11 +3403,11 @@ class SelectQueryTest extends TestCase
         $expected = ['id' => 2, 'title' => 'Second Article'];
         $this->assertEquals(
             $expected,
-            $results->first()->_matchingData['articles']->toArray()
+            $results->first()->_matchingData['articles']->toArray(),
         );
         $this->assertEquals(
             ['name' => 'tag3'],
-            $results->first()->_matchingData['tags']->toArray()
+            $results->first()->_matchingData['tags']->toArray(),
         );
     }
 
@@ -3868,7 +3868,7 @@ class SelectQueryTest extends TestCase
     {
         $this->skipIf(
             !$this->connection->getDriver()->supports(DriverFeatureEnum::CTE),
-            'The current driver does not support common table expressions.'
+            'The current driver does not support common table expressions.',
         );
         $this->skipIf(
             (
@@ -3876,7 +3876,7 @@ class SelectQueryTest extends TestCase
                 $this->connection->getDriver() instanceof Sqlite
             ) &&
             !$this->connection->getDriver()->supports(DriverFeatureEnum::WINDOW),
-            'The current driver does not support window functions.'
+            'The current driver does not support window functions.',
         );
 
         $table = $this->getTableLocator()->get('Articles');
@@ -3995,7 +3995,7 @@ class SelectQueryTest extends TestCase
         $function = new FunctionExpression('MyFunction', [$query]);
         $this->assertSame(
             'MyFunction((SELECT Articles.column AS Articles__column FROM articles Articles))',
-            preg_replace('/[`"\[\]]/', '', $function->sql($binder))
+            preg_replace('/[`"\[\]]/', '', $function->sql($binder)),
         );
     }
 }

--- a/tests/TestCase/ORM/Rule/LinkConstraintTest.php
+++ b/tests/TestCase/ORM/Rule/LinkConstraintTest.php
@@ -99,7 +99,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('NonExistent', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('NonExistent', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get(1);
@@ -114,7 +114,7 @@ class LinkConstraintTest extends TestCase
         $this->expectException(DatabaseException::class);
         $this->expectExceptionMessage(
             'LinkConstraint rule on `Articles` requires all primary key values for building the counting ' .
-            'conditions, expected values for `(id, nonexistent)`, got `(1, )`.'
+            'conditions, expected values for `(id, nonexistent)`, got `(1, )`.',
         );
 
         $Articles = $this->getTableLocator()->get('Articles');
@@ -126,7 +126,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get(1);
@@ -141,7 +141,7 @@ class LinkConstraintTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'The number of fields is expected to match the number of values, got 0 field(s) and 1 value(s).'
+            'The number of fields is expected to match the number of values, got 0 field(s) and 1 value(s).',
         );
 
         $Articles = $this->getTableLocator()->get('Articles');
@@ -196,7 +196,7 @@ class LinkConstraintTest extends TestCase
         $Articles->expects($this->atLeastOnce())->method('buildRules')->willReturn($rulesChecker);
 
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
         $Articles->buildRules($rulesChecker);
 
@@ -214,7 +214,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            new LinkConstraint('Articles', LinkConstraint::STATUS_LINKED)
+            new LinkConstraint('Articles', LinkConstraint::STATUS_LINKED),
         );
 
         $comment = $Comments->get(1);
@@ -243,7 +243,7 @@ class LinkConstraintTest extends TestCase
             '_isLinkedTo',
             [
                 'errorField' => 'article',
-            ]
+            ],
         );
 
         $comment = $Comments->get(7);
@@ -267,7 +267,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Tags->rulesChecker();
         $rulesChecker->addUpdate(
-            new LinkConstraint('Articles', LinkConstraint::STATUS_LINKED)
+            new LinkConstraint('Articles', LinkConstraint::STATUS_LINKED),
         );
 
         $tag = $Tags->get(1);
@@ -293,7 +293,7 @@ class LinkConstraintTest extends TestCase
             '_isLinkedTo',
             [
                 'errorField' => 'articles',
-            ]
+            ],
         );
 
         $tag = $Tags->get(4);
@@ -318,7 +318,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addUpdate(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_LINKED),
         );
 
         $article = $Articles->get(1);
@@ -341,7 +341,7 @@ class LinkConstraintTest extends TestCase
             '_isLinkedTo',
             [
                 'errorField' => 'comments',
-            ]
+            ],
         );
 
         $article = $Articles->get(3);
@@ -366,7 +366,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addUpdate(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_LINKED),
         );
 
         $article = $Articles->get(1);
@@ -389,7 +389,7 @@ class LinkConstraintTest extends TestCase
             '_isLinkedTo',
             [
                 'errorField' => 'comment',
-            ]
+            ],
         );
 
         $article = $Articles->get(3);
@@ -420,7 +420,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Articles', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Articles', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $comment = $Comments->get(7);
@@ -442,7 +442,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'article',
-            ]
+            ],
         );
 
         $comment = $Comments->get(1);
@@ -469,7 +469,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Tags->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Articles', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Articles', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $tag = $Tags->get(4);
@@ -490,7 +490,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'articles',
-            ]
+            ],
         );
 
         $tag = $Tags->get(1);
@@ -514,7 +514,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get(3);
@@ -536,7 +536,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'comments',
-            ]
+            ],
         );
 
         $article = $Articles->get(1);
@@ -560,7 +560,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get(3);
@@ -582,7 +582,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'comment',
-            ]
+            ],
         );
 
         $article = $Articles->get(1);
@@ -612,7 +612,7 @@ class LinkConstraintTest extends TestCase
                     ->where(function (QueryExpression $exp) {
                         return $exp->eq(
                             new IdentifierExpression('Articles.id'),
-                            new IdentifierExpression('RecentComments.article_id')
+                            new IdentifierExpression('RecentComments.article_id'),
                         );
                     })
                     ->orderBy(['RecentComments.created' => 'DESC'])
@@ -624,7 +624,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get(3);
@@ -648,7 +648,7 @@ class LinkConstraintTest extends TestCase
                     ->where(function (QueryExpression $exp) {
                         return $exp->eq(
                             new IdentifierExpression('Articles.id'),
-                            new IdentifierExpression('RecentComments.article_id')
+                            new IdentifierExpression('RecentComments.article_id'),
                         );
                     })
                     ->orderBy(['RecentComments.created' => 'DESC'])
@@ -664,7 +664,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'comment',
-            ]
+            ],
         );
 
         $article = $Articles->get(1);
@@ -692,7 +692,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get(2);
@@ -718,7 +718,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'comments',
-            ]
+            ],
         );
 
         $article = $Articles->get(2);
@@ -742,7 +742,7 @@ class LinkConstraintTest extends TestCase
             'conditions' => function (QueryExpression $exp) {
                 return $exp->notEq(
                     new IdentifierExpression('Comments.published'),
-                    new IdentifierExpression('Articles.published')
+                    new IdentifierExpression('Articles.published'),
                 );
             },
         ]);
@@ -760,7 +760,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Comments', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $article = $Articles->get($article->id);
@@ -778,7 +778,7 @@ class LinkConstraintTest extends TestCase
             'conditions' => function (QueryExpression $exp) {
                 return $exp->eq(
                     new IdentifierExpression('Comments.published'),
-                    new IdentifierExpression('Articles.published')
+                    new IdentifierExpression('Articles.published'),
                 );
             },
         ]);
@@ -789,7 +789,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'comment',
-            ]
+            ],
         );
 
         $article = $Articles->get(1);
@@ -826,7 +826,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addDelete(
-            new LinkConstraint('Articles', LinkConstraint::STATUS_NOT_LINKED)
+            new LinkConstraint('Articles', LinkConstraint::STATUS_NOT_LINKED),
         );
 
         $comment = $Comments->get($comment->id);
@@ -850,7 +850,7 @@ class LinkConstraintTest extends TestCase
             '_isLinkedTo',
             [
                 'errorField' => 'article',
-            ]
+            ],
         );
 
         $comment = $Comments->get(1);
@@ -874,7 +874,7 @@ class LinkConstraintTest extends TestCase
 
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            new LinkConstraint($Comments->getAssociation('Articles'), LinkConstraint::STATUS_LINKED)
+            new LinkConstraint($Comments->getAssociation('Articles'), LinkConstraint::STATUS_LINKED),
         );
 
         $comment = $Comments->get(1);
@@ -903,7 +903,7 @@ class LinkConstraintTest extends TestCase
             '_isLinkedTo',
             [
                 'errorField' => 'article',
-            ]
+            ],
         );
 
         $comment = $Comments->get(7);
@@ -939,7 +939,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'attachments',
-            ]
+            ],
         );
 
         $article = $Articles->get(2);
@@ -953,7 +953,7 @@ class LinkConstraintTest extends TestCase
         $this->assertFalse($Articles->save($article));
         $this->assertEmpty(
             $article->getErrors(),
-            'This should not be empty, but currently is because unlink errors are not being returned.'
+            'This should not be empty, but currently is because unlink errors are not being returned.',
         );
 
         $this->markTestIncomplete('This test is incomplete because currently unlink errors are not being returned.');
@@ -972,7 +972,7 @@ class LinkConstraintTest extends TestCase
             '_isNotLinkedTo',
             [
                 'errorField' => 'articles',
-            ]
+            ],
         );
 
         $article = $Articles->get(1);
@@ -986,11 +986,11 @@ class LinkConstraintTest extends TestCase
         $this->assertFalse($Articles->save($article));
         $this->assertEmpty(
             $article->getErrors(),
-            'This should not be empty, but currently is because junction delete errors are not being returned.'
+            'This should not be empty, but currently is because junction delete errors are not being returned.',
         );
 
         $this->markTestIncomplete(
-            'This test is incomplete because currently junction delete errors are not returned.'
+            'This test is incomplete because currently junction delete errors are not returned.',
         );
     }
 }

--- a/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
+++ b/tests/TestCase/ORM/RulesCheckerIntegrationTest.php
@@ -70,7 +70,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
                     return false;
                 },
-                ['errorField' => 'name', 'message' => 'This is an error']
+                ['errorField' => 'name', 'message' => 'This is an error'],
             );
 
         $this->assertFalse($table->save($entity));
@@ -104,7 +104,7 @@ class RulesCheckerIntegrationTest extends TestCase
                 function (EntityInterface $entity) {
                     return false;
                 },
-                ['errorField' => 'title', 'message' => 'This is an error']
+                ['errorField' => 'title', 'message' => 'This is an error'],
             );
 
         $this->assertFalse($table->save($entity));
@@ -149,7 +149,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
                     return $entity->title === '1';
                 },
-                ['errorField' => 'title', 'message' => 'This is an error']
+                ['errorField' => 'title', 'message' => 'This is an error'],
             );
 
         $this->assertFalse($table->save($entity));
@@ -194,7 +194,7 @@ class RulesCheckerIntegrationTest extends TestCase
                 function (Entity $article) {
                     return is_numeric($article->title);
                 },
-                ['errorField' => 'title', 'message' => 'This is an error']
+                ['errorField' => 'title', 'message' => 'This is an error'],
             );
 
         $result = $table->save($entity, ['atomic' => false]);
@@ -297,7 +297,7 @@ class RulesCheckerIntegrationTest extends TestCase
                 return false;
             },
             'ruleName',
-            ['errorField' => 'name']
+            ['errorField' => 'name'],
         );
 
         $this->assertFalse($table->save($entity));
@@ -321,7 +321,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $this->assertEquals(
             ['_isUnique' => 'This value is already in use'],
             $entity->getError('title'),
-            'Provided field should have errors'
+            'Provided field should have errors',
         );
         $this->assertEmpty($entity->getError('name'), 'Errors should not apply to original field.');
     }
@@ -381,7 +381,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rules = $table->rulesChecker();
         $rules->add($rules->isUnique(
             ['first_author_id', 'second_author_id'],
-            ['allowMultipleNulls' => false]
+            ['allowMultipleNulls' => false],
         ));
 
         $entity = new Entity([
@@ -402,7 +402,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $table = $this->getTableLocator()->get('UniqueAuthors');
         $rules = $table->rulesChecker();
         $rules->add($rules->isUnique(
-            ['first_author_id', 'second_author_id']
+            ['first_author_id', 'second_author_id'],
         ));
 
         $entity = new Entity([
@@ -460,7 +460,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $this->assertEquals(
             ['_existsIn' => 'This value does not exist'],
             $entity->getError('other'),
-            'Provided field should have errors'
+            'Provided field should have errors',
         );
         $this->assertEmpty($entity->getError('author_id'), 'Errors should not apply to original field.');
     }
@@ -668,13 +668,13 @@ class RulesCheckerIntegrationTest extends TestCase
                         '_primary' => true,
                         '_cleanOnSuccess' => true,
                     ],
-                    $options->getArrayCopy()
+                    $options->getArrayCopy(),
                 );
                 $this->assertSame('create', $operation);
                 $event->stopPropagation();
 
                 return true;
-            }
+            },
         );
 
         $this->assertSame($entity, $table->save($entity));
@@ -706,14 +706,14 @@ class RulesCheckerIntegrationTest extends TestCase
                         '_primary' => true,
                         '_cleanOnSuccess' => true,
                     ],
-                    $options->getArrayCopy()
+                    $options->getArrayCopy(),
                 );
                 $this->assertSame('create', $operation);
                 $this->assertFalse($result);
                 $event->stopPropagation();
 
                 return true;
-            }
+            },
         );
 
         $this->assertSame($entity, $table->save($entity));
@@ -1301,7 +1301,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo('Articles')
+            $rulesChecker->isLinkedTo('Articles'),
         );
 
         $comment->setDirty('comment', true);
@@ -1326,7 +1326,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            $rulesChecker->isNotLinkedTo('Comments')
+            $rulesChecker->isNotLinkedTo('Comments'),
         );
 
         $article = $Articles->get(1);
@@ -1365,7 +1365,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $rulesChecker->addUpdate(
             $rulesChecker->isLinkedTo('Articles'),
-            ['repository' => $Comments]
+            ['repository' => $Comments],
         );
 
         $comment->setDirty('comment', true);
@@ -1398,7 +1398,7 @@ class RulesCheckerIntegrationTest extends TestCase
 
         $rulesChecker->addDelete(
             $rulesChecker->isNotLinkedTo('Comments'),
-            ['repository' => $Articles]
+            ['repository' => $Articles],
         );
 
         $article = $Articles->get(1);
@@ -1429,7 +1429,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo($Comments->getAssociation('Articles'))
+            $rulesChecker->isLinkedTo($Comments->getAssociation('Articles')),
         );
 
         $comment->setDirty('comment', true);
@@ -1454,7 +1454,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            $rulesChecker->isNotLinkedTo($Articles->getAssociation('Comments'))
+            $rulesChecker->isNotLinkedTo($Articles->getAssociation('Comments')),
         );
 
         $article = $Articles->get(1);
@@ -1485,7 +1485,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo('Articles', 'custom')
+            $rulesChecker->isLinkedTo('Articles', 'custom'),
         );
 
         $comment->setDirty('comment', true);
@@ -1510,7 +1510,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            $rulesChecker->isNotLinkedTo('Comments', 'custom')
+            $rulesChecker->isNotLinkedTo('Comments', 'custom'),
         );
 
         $article = $Articles->get(1);
@@ -1541,7 +1541,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo('Articles', 'article', 'custom')
+            $rulesChecker->isLinkedTo('Articles', 'article', 'custom'),
         );
 
         $comment->setDirty('comment', true);
@@ -1566,7 +1566,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            $rulesChecker->isNotLinkedTo('Comments', 'comments', 'custom')
+            $rulesChecker->isNotLinkedTo('Comments', 'comments', 'custom'),
         );
 
         $article = $Articles->get(1);
@@ -1591,7 +1591,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $messageId = 'Cannot modify row: a constraint for the `{0}` association fails.';
         $translator->getPackage()->addMessage(
             $messageId,
-            'Zeile kann nicht geändert werden: Eine Einschränkung für die "{0}" Beziehung schlägt fehl.'
+            'Zeile kann nicht geändert werden: Eine Einschränkung für die "{0}" Beziehung schlägt fehl.',
         );
 
         $Comments = $this->getTableLocator()->get('Comments');
@@ -1607,7 +1607,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo('Articles', 'article')
+            $rulesChecker->isLinkedTo('Articles', 'article'),
         );
 
         $comment->setDirty('comment', true);
@@ -1634,7 +1634,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $messageId = 'Cannot modify row: a constraint for the `{0}` association fails.';
         $translator->getPackage()->addMessage(
             $messageId,
-            'Zeile kann nicht geändert werden: Eine Einschränkung für die "{0}" Beziehung schlägt fehl.'
+            'Zeile kann nicht geändert werden: Eine Einschränkung für die "{0}" Beziehung schlägt fehl.',
         );
 
         $Comments = $this->getTableLocator()->get('Comments');
@@ -1644,7 +1644,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $rulesChecker = $Comments->rulesChecker();
 
         $rulesChecker->addUpdate(
-            $rulesChecker->isNotLinkedTo('Articles', 'articles')
+            $rulesChecker->isNotLinkedTo('Articles', 'articles'),
         );
 
         $comment = $Comments->get(1);
@@ -1672,7 +1672,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $messageId = 'Cannot modify row: a constraint for the `{0}` association fails.';
         $translator->getPackage()->addMessage(
             $messageId,
-            'translated'
+            'translated',
         );
 
         $Comments = $this->getTableLocator()->get('Comments');
@@ -1692,11 +1692,11 @@ class RulesCheckerIntegrationTest extends TestCase
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,
-            RulesChecker::class
+            RulesChecker::class,
         )();
 
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo('Articles', 'article')
+            $rulesChecker->isLinkedTo('Articles', 'article'),
         );
 
         $comment->setDirty('comment', true);
@@ -1723,7 +1723,7 @@ class RulesCheckerIntegrationTest extends TestCase
         $messageId = 'Cannot modify row: a constraint for the `{0}` association fails.';
         $translator->getPackage()->addMessage(
             $messageId,
-            'translated'
+            'translated',
         );
 
         $Comments = $this->getTableLocator()->get('Comments');
@@ -1737,11 +1737,11 @@ class RulesCheckerIntegrationTest extends TestCase
                 $rulesChecker->{'_useI18n'} = false;
             },
             null,
-            RulesChecker::class
+            RulesChecker::class,
         )();
 
         $rulesChecker->addUpdate(
-            $rulesChecker->isNotLinkedTo('Articles', 'articles')
+            $rulesChecker->isNotLinkedTo('Articles', 'articles'),
         );
 
         $comment = $Comments->get(1);
@@ -1769,7 +1769,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Comments->rulesChecker();
         $rulesChecker->addUpdate(
-            $rulesChecker->isLinkedTo('Articles', 'articles')
+            $rulesChecker->isLinkedTo('Articles', 'articles'),
         );
 
         $comment = $Comments->get(1);
@@ -1788,7 +1788,7 @@ class RulesCheckerIntegrationTest extends TestCase
         /** @var \Cake\ORM\RulesChecker $rulesChecker */
         $rulesChecker = $Articles->rulesChecker();
         $rulesChecker->addDelete(
-            $rulesChecker->isNotLinkedTo('Comments', 'comments')
+            $rulesChecker->isNotLinkedTo('Comments', 'comments'),
         );
 
         $article = $Articles->get(3);

--- a/tests/TestCase/ORM/TableRegressionTest.php
+++ b/tests/TestCase/ORM/TableRegressionTest.php
@@ -48,7 +48,7 @@ class TableRegressionTest extends TestCase
             'Model.afterSave',
             function () use ($table): void {
                 $table->getConnection()->rollback();
-            }
+            },
         );
         $entity = $table->newEntity(['name' => 'Jon']);
         $table->save($entity);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -231,7 +231,7 @@ class TableTest extends TestCase
         $this->assertRegExpSql(
             'SELECT <username> FROM <users> <users>',
             $sql,
-            !$this->connection->getDriver()->isAutoQuotingEnabled()
+            !$this->connection->getDriver()->isAutoQuotingEnabled(),
         );
     }
 
@@ -247,7 +247,7 @@ class TableTest extends TestCase
         $this->assertRegExpSql(
             'SELECT <Articles>.<field1> FROM <articles> <Articles>',
             $subquery->sql(),
-            !$this->connection->getDriver()->isAutoQuotingEnabled()
+            !$this->connection->getDriver()->isAutoQuotingEnabled(),
         );
 
         $subquery->select($articles, true);
@@ -573,7 +573,7 @@ class TableTest extends TestCase
         $table->setSchema($schema);
         $this->assertEquals(
             new TableSchema('another', $schema),
-            $table->getSchema()
+            $table->getSchema(),
         );
     }
 
@@ -600,7 +600,7 @@ class TableTest extends TestCase
                 'ORM queries generate field aliases using the table name/alias and column name. ' .
                 "The table alias `very_long_alias_name` and column `this_is_invalid_because_it_is_very_very_very_long` create an alias longer than ({$nameLength}). " .
                 'You must change the table schema in the database and shorten either the table or column ' .
-                'identifier so they fit within the database alias limits.'
+                'identifier so they fit within the database alias limits.',
             );
         }
         $this->assertNotNull($table->setSchema($schema));
@@ -759,7 +759,7 @@ class TableTest extends TestCase
             'Model.beforeFind',
             function (EventInterface $event, $query, $options): void {
                 $query->limit(1);
-            }
+            },
         );
 
         $result = $table->find('all')->all();
@@ -782,7 +782,7 @@ class TableTest extends TestCase
             function (EventInterface $event, $query, $options) use ($expected): void {
                 $query->setResult($expected);
                 $event->stopPropagation();
-            }
+            },
         );
 
         $query = $table->find('all')
@@ -811,7 +811,7 @@ class TableTest extends TestCase
         $this->assertInstanceOf(BelongsToMany::class, $association);
         $this->assertSame(
             $sections->getAssociation('SectionsMembers')->getAssociation('Members')->getAssociation('Sections'),
-            $association
+            $association,
         );
     }
 
@@ -820,7 +820,7 @@ class TableTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             "The `authors` association is not defined on `Articles`.\n"
-            . 'Valid associations are: Authors, Tags, ArticlesTags'
+            . 'Valid associations are: Authors, Tags, ArticlesTags',
         );
 
         $articles = $this->getTableLocator()->get('Articles', ['className' => ArticlesTable::class]);
@@ -1773,7 +1773,7 @@ class TableTest extends TestCase
         $this->assertSame($table, $table->setEntityClass('MyPlugin.SuperUser'));
         $this->assertSame(
             'MyPlugin\Model\Entity\SuperUser',
-            $table->getEntityClass()
+            $table->getEntityClass(),
         );
     }
 
@@ -1852,7 +1852,7 @@ class TableTest extends TestCase
         $this->assertInstanceOf(Tag::class, $result->tags[0]);
         $this->assertInstanceOf(
             ArticlesTag::class,
-            $result->tags[0]->_joinData
+            $result->tags[0]->_joinData,
         );
     }
 
@@ -2020,7 +2020,7 @@ class TableTest extends TestCase
         $this->assertTrue($table->behaviors()->has('Timestamp'));
         $this->assertSame(
             $behaviors['Timestamp']['events'],
-            $table->behaviors()->get('Timestamp')->getConfig('events')
+            $table->behaviors()->get('Timestamp')->getConfig('events'),
         );
     }
 
@@ -3282,8 +3282,8 @@ class TableTest extends TestCase
                     [$this->callback(function (EventInterface $event) use ($entity, $options) {
                         return $event->getName() === 'Model.afterDeleteCommit' &&
                         $event->getData() == ['entity' => $entity, 'options' => $options];
-                    })]
-                )
+                    })],
+                ),
             );
 
         $table = $this->getTableLocator()->get('users', ['eventManager' => $mock]);
@@ -3637,7 +3637,7 @@ class TableTest extends TestCase
                     'Users.username' => 'garrett',
                     'Users.id' => 4,
                 ],
-            ]
+            ],
         );
         $this->assertEquals($expected, $result->clause('where'));
     }
@@ -3669,7 +3669,7 @@ class TableTest extends TestCase
         $this->assertNull($result->clause('limit'));
         $expected = new QueryExpression(
             ['Users.author_id' => 1, 'Users.published' => 'Y'],
-            $this->usersTypeMap
+            $this->usersTypeMap,
         );
         $this->assertEquals($expected, $result->clause('where'));
     }
@@ -3687,7 +3687,7 @@ class TableTest extends TestCase
         $expected = new QueryExpression();
         $expected->getTypeMap()->setDefaults($this->usersTypeMap->toArray());
         $expected->add(
-            ['or' => ['Users.author_id' => 1, 'Users.published' => 'Y']]
+            ['or' => ['Users.author_id' => 1, 'Users.published' => 'Y']],
         );
         $this->assertEquals($expected, $result->clause('where'));
         $this->assertNull($result->clause('order'));
@@ -4038,7 +4038,7 @@ class TableTest extends TestCase
             ->getMock();
         $entity = new Entity(
             ['id' => 'foo'],
-            ['markNew' => false, 'markClean' => true]
+            ['markNew' => false, 'markClean' => true],
         );
         $table->expects($this->never())->method('_processSave');
         $this->assertSame($entity, $table->save($entity));
@@ -4302,7 +4302,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $sizeArticles = count($newArticles);
@@ -4337,7 +4337,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $this->assertTrue($authors->Articles->link($author, $newArticles));
@@ -4350,7 +4350,7 @@ class TableTest extends TestCase
                     'title' => 'Nothing but the cake',
                     'body' => 'It is all that we need',
                 ],
-            ]
+            ],
         );
         $this->assertTrue($authors->Articles->link($author, $newArticles));
 
@@ -4384,7 +4384,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $this->assertTrue($authors->Articles->link($author, $newArticles));
@@ -4399,8 +4399,8 @@ class TableTest extends TestCase
                         'title' => 'Nothing but the cake',
                         'body' => 'It is all that we need',
                     ],
-                ]
-            )
+                ],
+            ),
         );
         $this->assertTrue($authors->Articles->link($author, $newArticles));
 
@@ -4438,7 +4438,7 @@ class TableTest extends TestCase
                     'title' => 'Creamy cake recipe',
                     'body' => 'chocolate and cream',
                 ],
-            ]
+            ],
         );
 
         $this->assertTrue($authors->Articles->link($author, $newArticles));
@@ -4481,7 +4481,7 @@ class TableTest extends TestCase
                     'title' => 'Creamy cake recipe',
                     'body' => 'chocolate and cream',
                 ],
-            ]
+            ],
         );
 
         $this->assertTrue($authors->Articles->link($author, $newArticles));
@@ -4568,7 +4568,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $sizeArticles = count($newArticles);
@@ -4589,8 +4589,8 @@ class TableTest extends TestCase
                         'title' => 'Not another piece of cake',
                         'body' => 'This is the best',
                     ],
-                ]
-            )
+                ],
+            ),
         );
         unset($newArticles[0]);
 
@@ -4623,7 +4623,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $sizeArticles = count($newArticles);
@@ -4664,7 +4664,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $authors->Articles->deleteAll(['1=1']);
@@ -4699,7 +4699,7 @@ class TableTest extends TestCase
                     'title' => 'Spicy cake recipe',
                     'body' => 'chocolate and peppers',
                 ],
-            ]
+            ],
         );
 
         $sizeArticles = count($newArticles);
@@ -4721,8 +4721,8 @@ class TableTest extends TestCase
                         'title' => 'Not another piece of cake',
                         'body' => 'This is the best',
                     ],
-                ]
-            )
+                ],
+            ),
         );
         unset($newArticles[0]);
 
@@ -4875,7 +4875,7 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $article = $articles->get(1);
@@ -4909,7 +4909,7 @@ class TableTest extends TestCase
             'Model.beforeSave',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $article = $articles->get(1);
@@ -4945,7 +4945,7 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $article = $articles->get(1);
@@ -4976,13 +4976,13 @@ class TableTest extends TestCase
             'Model.beforeSave',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
                 $actualSaveOptions = $options->getArrayCopy();
-            }
+            },
         );
         $tags->junction()->getEventManager()->on(
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
                 $actualDeleteOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $article = $articles->get(1);
@@ -4993,7 +4993,7 @@ class TableTest extends TestCase
                 $tags->getTarget()->newEntity(['name' => 'new']),
                 $tags->getTarget()->get(2),
             ],
-            ['foo' => 'bar']
+            ['foo' => 'bar'],
         );
         $this->assertTrue($result);
 
@@ -5034,7 +5034,7 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $author = $authors->get(1);
@@ -5069,7 +5069,7 @@ class TableTest extends TestCase
             'Model.beforeSave',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $author = $authors->get(1);
@@ -5111,7 +5111,7 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $author = $authors->get(1);
@@ -5146,13 +5146,13 @@ class TableTest extends TestCase
             'Model.beforeSave',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualSaveOptions): void {
                 $actualSaveOptions = $options->getArrayCopy();
-            }
+            },
         );
         $articles->getTarget()->getEventManager()->on(
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualDeleteOptions): void {
                 $actualDeleteOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $author = $authors->get(1);
@@ -5163,7 +5163,7 @@ class TableTest extends TestCase
                 $articles->getTarget()->newEntity(['title' => 'new', 'body' => 'new']),
                 $articles->getTarget()->get(1),
             ],
-            ['foo' => 'bar']
+            ['foo' => 'bar'],
         );
         $this->assertTrue($result);
 
@@ -5206,7 +5206,7 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $article = $articles->get(1);
@@ -5236,7 +5236,7 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$actualOptions): void {
                 $actualOptions = $options->getArrayCopy();
-            }
+            },
         );
 
         $author = $authors->get(1);
@@ -5630,7 +5630,7 @@ class TableTest extends TestCase
                 $this->assertInstanceOf(EntityInterface::class, $article);
                 $article->set(['published' => 'N', 'body' => 'New body']);
                 $callbackExecuted = true;
-            }
+            },
         );
         $this->assertTrue($callbackExecuted);
         $this->assertFalse($article->isNew());
@@ -5757,7 +5757,7 @@ class TableTest extends TestCase
         $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage(
             'Entity findOrCreate failure. ' .
-            'Found the following errors (title._empty: "This field cannot be left empty").'
+            'Found the following errors (title._empty: "This field cannot be left empty").',
         );
 
         $articles = $this->getTableLocator()->get('Articles');
@@ -5799,7 +5799,7 @@ class TableTest extends TestCase
         $this->expectException(PersistenceFailedException::class);
         $this->expectExceptionMessage(
             'Entity findOrCreate failure. ' .
-            'Found the following errors (title._required: "This field is required").'
+            'Found the following errors (title._required: "This field is required").',
         );
 
         $articles->findOrCreate(['body' => 'test']);
@@ -5959,7 +5959,7 @@ class TableTest extends TestCase
             function (EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary) use (&$associationBeforeFindCount): void {
                 $this->assertIsBool($primary);
                 $associationBeforeFindCount++;
-            }
+            },
         );
 
         $beforeFindCount = 0;
@@ -5968,7 +5968,7 @@ class TableTest extends TestCase
             function (EventInterface $event, SelectQuery $query, ArrayObject $options, bool $primary) use (&$beforeFindCount): void {
                 $this->assertIsBool($primary);
                 $beforeFindCount++;
-            }
+            },
         );
         $table->find()->contain('authors')->first();
         $this->assertSame(1, $associationBeforeFindCount);
@@ -5980,7 +5980,7 @@ class TableTest extends TestCase
             $callback = function (EventInterface $event, Validator $validator, $name) use (&$buildValidatorCount): void {
                 $this->assertIsString($name);
                 $buildValidatorCount++;
-            }
+            },
         );
         $table->getValidator();
         $this->assertSame(1, $buildValidatorCount);
@@ -5993,14 +5993,14 @@ class TableTest extends TestCase
             'Model.buildRules',
             function (EventInterface $event, RulesChecker $rules) use (&$buildRulesCount): void {
                 $buildRulesCount++;
-            }
+            },
         );
         $eventManager->on(
             'Model.beforeRules',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options, $operation) use (&$beforeRulesCount): void {
                 $this->assertIsString($operation);
                 $beforeRulesCount++;
-            }
+            },
         );
         $eventManager->on(
             'Model.afterRules',
@@ -6008,19 +6008,19 @@ class TableTest extends TestCase
                 $this->assertIsBool($result);
                 $this->assertIsString($operation);
                 $afterRulesCount++;
-            }
+            },
         );
         $eventManager->on(
             'Model.beforeSave',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeSaveCount): void {
                 $beforeSaveCount++;
-            }
+            },
         );
         $eventManager->on(
             'Model.afterSave',
             $afterSaveCallback = function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterSaveCount): void {
                 $afterSaveCount++;
-            }
+            },
         );
         $entity = new Entity(['title' => 'Title']);
         $this->assertNotFalse($table->save($entity));
@@ -6035,13 +6035,13 @@ class TableTest extends TestCase
             'Model.beforeDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$beforeDeleteCount): void {
                 $beforeDeleteCount++;
-            }
+            },
         );
         $eventManager->on(
             'Model.afterDelete',
             function (EventInterface $event, EntityInterface $entity, ArrayObject $options) use (&$afterDeleteCount): void {
                 $afterDeleteCount++;
-            }
+            },
         );
         $this->assertTrue($table->delete($entity, ['checkRules' => false]));
         $this->assertSame(1, $beforeDeleteCount);
@@ -6076,7 +6076,7 @@ class TableTest extends TestCase
         $this->assertSame($cloned, $table->save($cloned));
         $this->assertEquals(
             $article->extract(['title', 'author_id']),
-            $cloned->extract(['title', 'author_id'])
+            $cloned->extract(['title', 'author_id']),
         );
         $this->assertSame(4, $cloned->id);
     }
@@ -6407,7 +6407,7 @@ class TableTest extends TestCase
     {
         $this->skipIf(
             $this->connection->getDriver() instanceof Sqlserver,
-            'SQLServer does not support the requirements of this test.'
+            'SQLServer does not support the requirements of this test.',
         );
     }
 }

--- a/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
+++ b/tests/TestCase/ORM/TableValidationWithBadDefinerTest.php
@@ -29,7 +29,7 @@ class TableValidationWithBadDefinerTest extends TestCase
         $this->expectException(AssertionError::class);
         $this->expectExceptionMessage(sprintf(
             'The `%s::validationBad()` validation method must return an instance of `Cake\Validation\Validator`.',
-            $table::class
+            $table::class,
         ));
 
         $table->getValidator('bad');

--- a/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/AssetMiddlewareTest.php
@@ -144,23 +144,23 @@ class AssetMiddlewareTest extends TestCase
 
         $this->assertSame(
             'application/javascript',
-            $res->getHeaderLine('Content-Type')
+            $res->getHeaderLine('Content-Type'),
         );
         $this->assertSame(
             gmdate(DATE_RFC7231, $time),
-            $res->getHeaderLine('Date')
+            $res->getHeaderLine('Date'),
         );
         $this->assertSame(
             'public,max-age=' . ($expires - $time),
-            $res->getHeaderLine('Cache-Control')
+            $res->getHeaderLine('Cache-Control'),
         );
         $this->assertSame(
             gmdate(DATE_RFC7231, $modified),
-            $res->getHeaderLine('Last-Modified')
+            $res->getHeaderLine('Last-Modified'),
         );
         $this->assertSame(
             gmdate(DATE_RFC7231, $expires),
-            $res->getHeaderLine('Expires')
+            $res->getHeaderLine('Expires'),
         );
     }
 

--- a/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
+++ b/tests/TestCase/Routing/Middleware/RoutingMiddlewareTest.php
@@ -263,7 +263,7 @@ class RoutingMiddlewareTest extends TestCase
                 'REQUEST_URI' => '/articles-patch',
             ],
             null,
-            ['_method' => 'PATCH']
+            ['_method' => 'PATCH'],
         );
         $handler = new TestRequestHandler(function ($req) {
             $expected = [

--- a/tests/TestCase/Routing/Route/DashedRouteTest.php
+++ b/tests/TestCase/Routing/Route/DashedRouteTest.php
@@ -164,7 +164,7 @@ class DashedRouteTest extends TestCase
 
         $route = new DashedRoute(
             '/admin/{controller}',
-            ['prefix' => 'Admin', 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index'],
         );
         $route->compile();
         $result = $route->parse('/admin/', 'GET');
@@ -176,7 +176,7 @@ class DashedRouteTest extends TestCase
 
         $route = new DashedRoute(
             '/media/search/*',
-            ['controller' => 'Media', 'action' => 'searchIt']
+            ['controller' => 'Media', 'action' => 'searchIt'],
         );
         $result = $route->parse('/media/search', 'GET');
         $this->assertSame('Media', $result['controller']);

--- a/tests/TestCase/Routing/Route/EntityRouteTest.php
+++ b/tests/TestCase/Routing/Route/EntityRouteTest.php
@@ -40,7 +40,7 @@ class EntityRouteTest extends TestCase
             '/articles/{category_id}/{slug}',
             [
                 '_name' => 'articlesView',
-            ]
+            ],
         );
 
         $result = $route->match([
@@ -66,7 +66,7 @@ class EntityRouteTest extends TestCase
             '/articles/{category_id}/{slug}',
             [
                 '_name' => 'articlesView',
-            ]
+            ],
         );
 
         $result = $route->match([
@@ -91,7 +91,7 @@ class EntityRouteTest extends TestCase
             '/articles/{category_id}_{slug}',
             [
                 '_name' => 'articlesView',
-            ]
+            ],
         );
 
         $result = $route->match([
@@ -117,7 +117,7 @@ class EntityRouteTest extends TestCase
             [
                 '_name' => 'articlesView',
                 '_entity' => $entity,
-            ]
+            ],
         );
 
         $result = $route->match([

--- a/tests/TestCase/Routing/Route/InflectedRouteTest.php
+++ b/tests/TestCase/Routing/Route/InflectedRouteTest.php
@@ -164,7 +164,7 @@ class InflectedRouteTest extends TestCase
 
         $route = new InflectedRoute(
             '/admin/{controller}',
-            ['prefix' => 'Admin', 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index'],
         );
         $route->compile();
         $result = $route->parse('/admin/', 'GET');
@@ -176,7 +176,7 @@ class InflectedRouteTest extends TestCase
 
         $route = new InflectedRoute(
             '/media/search/*',
-            ['controller' => 'Media', 'action' => 'search_it']
+            ['controller' => 'Media', 'action' => 'search_it'],
         );
         $result = $route->parse('/media/search', 'GET');
         $this->assertSame('Media', $result['controller']);

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -115,7 +115,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/fighters/{id}/move/{x}/{y}',
             ['controller' => 'Fighters', 'action' => 'move'],
-            ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']]
+            ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']],
         );
         $pattern = $route->compile();
         $this->assertMatchesRegularExpression($pattern, '/fighters/123/move/8/42');
@@ -138,7 +138,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/fighters/{id}/move/{x}/{y}',
             ['controller' => 'Fighters', 'action' => 'move'],
-            ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']]
+            ['id' => '\d+', 'x' => '\d+', 'y' => '\d+', 'pass' => ['id', 'x', 'y']],
         );
         $this->assertMatchesRegularExpression($route->compile(), '/fighters/123/move/8/42');
 
@@ -153,7 +153,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/images/{id}/{x}x{y}',
-            ['controller' => 'Images', 'action' => 'view']
+            ['controller' => 'Images', 'action' => 'view'],
         );
         $this->assertMatchesRegularExpression($route->compile(), '/images/123/640x480');
 
@@ -174,7 +174,7 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/fighters/{0id}',
-            ['controller' => 'Fighters', 'action' => 'move']
+            ['controller' => 'Fighters', 'action' => 'move'],
         );
         $this->assertDoesNotMatchRegularExpression($route->compile(), '/fighters/123', 'Placeholders must start with letter');
 
@@ -195,13 +195,13 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/fighters/{ id }',
-            ['controller' => 'Fighters', 'action' => 'move']
+            ['controller' => 'Fighters', 'action' => 'move'],
         );
         $this->assertDoesNotMatchRegularExpression($route->compile(), '/fighters/123', 'no spaces in placeholder');
 
         $route = new Route(
             '/fighters/{i d}',
-            ['controller' => 'Fighters', 'action' => 'move']
+            ['controller' => 'Fighters', 'action' => 'move'],
         );
         $this->assertDoesNotMatchRegularExpression($route->compile(), '/fighters/123', 'no spaces in placeholder');
     }
@@ -213,7 +213,7 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/images/{open/{id}',
-            ['controller' => 'Images', 'action' => 'open']
+            ['controller' => 'Images', 'action' => 'open'],
         );
         $pattern = $route->compile();
         $this->assertMatchesRegularExpression($pattern, '/images/{open/9', 'Need both {} to enable brace mode');
@@ -227,7 +227,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/fighters/{id}/move/{x}/:y',
             ['controller' => 'Fighters', 'action' => 'move'],
-            ['id' => '\d+', 'x' => '\d+', 'pass' => ['id', 'x']]
+            ['id' => '\d+', 'x' => '\d+', 'pass' => ['id', 'x']],
         );
         $pattern = $route->compile();
         $this->assertMatchesRegularExpression($pattern, '/fighters/123/move/8/:y');
@@ -250,7 +250,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{controller}/{action}/*',
             [],
-            ['_ext' => ['json', 'xml']]
+            ['_ext' => ['json', 'xml']],
         );
 
         $result = $route->parse('/posts/index', 'GET');
@@ -390,7 +390,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{controller}/{action}/{id}',
             [],
-            ['id' => Router::ID]
+            ['id' => Router::ID],
         );
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/posts/edit/1');
@@ -402,7 +402,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{lang}/{controller}/{action}/{id}',
             ['controller' => 'Testing4'],
-            ['id' => Router::ID, 'lang' => '[a-z]{3}']
+            ['id' => Router::ID, 'lang' => '[a-z]{3}'],
         );
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/eng/posts/edit/1');
@@ -426,7 +426,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/posts/{id}:{title}/{year}',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['id' => Router::ID, 'year' => Router::YEAR, 'title' => '[a-z-_]+']
+            ['id' => Router::ID, 'year' => Router::YEAR, 'title' => '[a-z-_]+'],
         );
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/posts/1:name-of-article/2009/');
@@ -439,7 +439,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/posts/{url_title}-(uuid:{id})',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['pass' => ['id', 'url_title'], 'id' => Router::ID]
+            ['pass' => ['id', 'url_title'], 'id' => Router::ID],
         );
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/posts/some_title_for_article-(uuid:12534)/');
@@ -458,7 +458,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/test/{slug}',
             ['controller' => 'Pages', 'action' => 'display'],
-            ['pass' => ['slug'], 'multibytePattern' => false, 'slug' => '[A-zА-я\-\ ]+']
+            ['pass' => ['slug'], 'multibytePattern' => false, 'slug' => '[A-zА-я\-\ ]+'],
         );
         $result = $route->compile();
         $this->assertDoesNotMatchRegularExpression($result, '/test/bla-blan-тест');
@@ -466,7 +466,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/test/{slug}',
             ['controller' => 'Pages', 'action' => 'display'],
-            ['pass' => ['slug'], 'multibytePattern' => true, 'slug' => '[A-zА-я\-\ ]+']
+            ['pass' => ['slug'], 'multibytePattern' => true, 'slug' => '[A-zА-я\-\ ]+'],
         );
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/test/bla-blan-тест');
@@ -481,7 +481,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/posts/{month}/{day}/{year}/*',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['year' => Router::YEAR, 'month' => Router::MONTH, 'day' => Router::DAY]
+            ['year' => Router::YEAR, 'month' => Router::MONTH, 'day' => Router::DAY],
         );
         $result = $route->compile();
         $this->assertMatchesRegularExpression($result, '/posts/08/01/2007/title-of-post');
@@ -500,7 +500,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{extra}/page/{slug}/*',
             ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
-            ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view']
+            ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view'],
         );
         $result = $route->compile();
 
@@ -520,7 +520,7 @@ class RouteTest extends TestCase
             [
                 'controller' => 'source|wiki|commits|tickets|comments|view',
                 'action' => 'branches|history|branch|logs|view|start|add|edit|modify',
-            ]
+            ],
         );
         $this->assertNull($route->parse('/chaw_test/wiki', 'GET'));
 
@@ -622,7 +622,7 @@ class RouteTest extends TestCase
         $route = new Route('/{lang}/{controller}/{action}', [], ['persist' => ['lang']]);
         $result = $route->match(
             ['controller' => 'Tasks', 'action' => 'add'],
-            $context
+            $context,
         );
         $this->assertSame('/en/Tasks/add', $result);
     }
@@ -641,27 +641,27 @@ class RouteTest extends TestCase
         $route = new Route('/{controller}/{action}');
         $result = $route->match(
             ['controller' => 'Posts', 'action' => 'index', '_host' => 'example.com'],
-            $context
+            $context,
         );
         // Http has port 80 as default, do not include it in the url
         $this->assertSame('http://example.com/Posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'Posts', 'action' => 'index', '_scheme' => 'webcal'],
-            $context
+            $context,
         );
         // Webcal is not on port 80 by default, include it in url
         $this->assertSame('webcal://foo.com:80/Posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'Posts', 'action' => 'index', '_port' => '8080'],
-            $context
+            $context,
         );
         $this->assertSame('http://foo.com:8080/Posts/index', $result);
 
         $result = $route->match(
             ['controller' => 'Posts', 'action' => 'index', '_base' => '/dir'],
-            $context
+            $context,
         );
         $this->assertSame('/dir/Posts/index', $result);
 
@@ -674,7 +674,7 @@ class RouteTest extends TestCase
                 '_scheme' => 'https',
                 '_base' => '/dir',
             ],
-            $context
+            $context,
         );
         $this->assertSame('https://example.com:8080/dir/Posts/index', $result);
 
@@ -693,7 +693,7 @@ class RouteTest extends TestCase
                 '_scheme' => 'https',
                 '_base' => '/dir',
             ],
-            $context
+            $context,
         );
         // Https scheme is not on port 8080 by default, include the port
         $this->assertSame('https://example.com:8080/dir/Posts/index', $result);
@@ -707,7 +707,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/fallback',
             ['controller' => 'Articles', 'action' => 'index'],
-            ['_host' => 'www.example.com']
+            ['_host' => 'www.example.com'],
         );
         $result = $route->match([
             'controller' => 'Articles',
@@ -724,7 +724,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/fallback',
             ['controller' => 'Articles', 'action' => 'index'],
-            ['_host' => '*.example.com']
+            ['_host' => '*.example.com'],
         );
         $result = $route->match([
             'controller' => 'Articles',
@@ -837,7 +837,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/blog/{id}-{slug}',
             ['controller' => 'Blog', 'action' => 'view'],
-            ['pass' => ['id', 'slug']]
+            ['pass' => ['id', 'slug']],
         );
         $result = $route->match([
             'controller' => 'Blog',
@@ -881,7 +881,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/blog/{id}-{slug}/*',
             ['controller' => 'Blog', 'action' => 'view'],
-            ['pass' => ['id', 'slug']]
+            ['pass' => ['id', 'slug']],
         );
         $result = $route->match([
             'controller' => 'Blog',
@@ -982,7 +982,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/articles/{action}/{id}',
             ['controller' => 'Articles'],
-            ['multibytePattern' => true, 'id' => '\pL+']
+            ['multibytePattern' => true, 'id' => '\pL+'],
         );
         $result = $route->match([
             'controller' => 'Articles',
@@ -999,7 +999,7 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/anything',
-            ['controller' => 'Articles', 'action' => 'foo', '_method' => 'GET']
+            ['controller' => 'Articles', 'action' => 'foo', '_method' => 'GET'],
         );
         $result = $route->match([
             'controller' => 'Articles',
@@ -1063,7 +1063,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/fallback',
             ['controller' => 'Articles', 'action' => 'index'],
-            ['_host' => '*.example.com']
+            ['_host' => '*.example.com'],
         );
 
         $request = new ServerRequest([
@@ -1108,7 +1108,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/{controller}/{action}/{id}',
             ['controller' => 'Testing4', 'id' => null],
-            ['id' => Router::ID]
+            ['id' => Router::ID],
         );
         $route->compile();
         $result = $route->parse('/Posts/view/1', 'GET');
@@ -1118,7 +1118,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/admin/{controller}',
-            ['prefix' => 'Admin', 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index'],
         );
         $route->compile();
         $result = $route->parse('/admin/', 'GET');
@@ -1130,7 +1130,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/media/search/*',
-            ['controller' => 'Media', 'action' => 'search']
+            ['controller' => 'Media', 'action' => 'search'],
         );
         $result = $route->parse('/media/search', 'GET');
         $this->assertSame('Media', $result['controller']);
@@ -1156,7 +1156,7 @@ class RouteTest extends TestCase
 
         $route = new Route(
             '/{controller}',
-            ['prefix' => 'Admin', 'action' => 'index']
+            ['prefix' => 'Admin', 'action' => 'index'],
         );
         $route->parse('/posts', 'NOPE');
     }
@@ -1168,7 +1168,7 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/{controller}/{slug}',
-            ['action' => 'view']
+            ['action' => 'view'],
         );
         $route->compile();
         $result = $route->parse('/posts/%E2%88%82%E2%88%82', 'GET');
@@ -1314,7 +1314,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
-            ['action' => 'other|actions']
+            ['action' => 'other|actions'],
         );
         $result = $route->match(['controller' => 'BlogPosts', 'action' => 'foo']);
         $this->assertNull($result);
@@ -1511,19 +1511,19 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/a/{controller}/{action}',
-            ['plugin' => 'Asset']
+            ['plugin' => 'Asset'],
         );
         $this->assertSame('asset._controller:_action', $route->getName());
 
         $route = new Route(
             '/a/assets/{action}',
-            ['plugin' => 'Asset', 'controller' => 'Assets']
+            ['plugin' => 'Asset', 'controller' => 'Assets'],
         );
         $this->assertSame('asset.assets:_action', $route->getName());
 
         $route = new Route(
             '/assets/get',
-            ['plugin' => 'Asset', 'controller' => 'Assets', 'action' => 'get']
+            ['plugin' => 'Asset', 'controller' => 'Assets', 'action' => 'get'],
         );
         $this->assertSame('asset.assets:get', $route->getName());
     }
@@ -1535,25 +1535,25 @@ class RouteTest extends TestCase
     {
         $route = new Route(
             '/admin/{controller}/{action}',
-            ['prefix' => 'Admin']
+            ['prefix' => 'Admin'],
         );
         $this->assertSame('admin:_controller:_action', $route->getName());
 
         $route = new Route(
             '/{prefix}/assets/{action}',
-            ['controller' => 'Assets']
+            ['controller' => 'Assets'],
         );
         $this->assertSame('_prefix:assets:_action', $route->getName());
 
         $route = new Route(
             '/admin/assets/get',
-            ['prefix' => 'Admin', 'plugin' => 'Asset', 'controller' => 'Assets', 'action' => 'get']
+            ['prefix' => 'Admin', 'plugin' => 'Asset', 'controller' => 'Assets', 'action' => 'get'],
         );
         $this->assertSame('admin:asset.assets:get', $route->getName());
 
         $route = new Route(
             '/{prefix}/{plugin}/{controller}/{action}/*',
-            []
+            [],
         );
         $this->assertSame('_prefix:_plugin._controller:_action', $route->getName());
     }
@@ -1569,7 +1569,7 @@ class RouteTest extends TestCase
             [
                 'persist' => ['section'],
                 'section' => 'آموزش|weblog',
-            ]
+            ],
         );
 
         $result = $route->parse('/%D8%A2%D9%85%D9%88%D8%B2%D8%B4', 'GET');
@@ -1602,7 +1602,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/products/tests/*',
             ['controller' => 'Products', 'action' => 'test'],
-            ['_urldecode' => false]
+            ['_urldecode' => false],
         );
 
         $result = $route->parse('/products/tests/xx%2Fyy', 'GET');
@@ -1618,7 +1618,7 @@ class RouteTest extends TestCase
         $route = new Route(
             '/products/view/{slug}',
             ['controller' => 'Products', 'action' => 'view'],
-            ['_urldecode' => false]
+            ['_urldecode' => false],
         );
 
         $result = $route->parse('/products/view/xx%2Fyy', 'GET');

--- a/tests/TestCase/Routing/RouteBuilderTest.php
+++ b/tests/TestCase/Routing/RouteBuilderTest.php
@@ -110,7 +110,7 @@ class RouteBuilderTest extends TestCase
             $this->collection,
             '/l',
             [],
-            ['routeClass' => 'InflectedRoute']
+            ['routeClass' => 'InflectedRoute'],
         );
         $routes->connect('/{controller}', ['action' => 'index']);
         $routes->connect('/{controller}/{action}/*');
@@ -318,7 +318,7 @@ class RouteBuilderTest extends TestCase
             $this->collection,
             '/l',
             [],
-            ['extensions' => ['json']]
+            ['extensions' => ['json']],
         );
         $this->assertEquals(['json'], $routes->getExtensions());
 
@@ -343,7 +343,7 @@ class RouteBuilderTest extends TestCase
             $this->collection,
             '/l',
             [],
-            ['extensions' => ['json']]
+            ['extensions' => ['json']],
         );
         $this->assertEquals(['json'], $routes->getExtensions());
 
@@ -488,7 +488,7 @@ class RouteBuilderTest extends TestCase
             $route = $this->collection->routes()[0];
             $this->assertEquals(
                 ['key' => 'value', 'plugin' => 'Contacts', 'action' => 'index'],
-                $route->defaults
+                $route->defaults,
             );
         });
         $this->assertSame($routes, $res);
@@ -537,7 +537,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/api/articles', $all[4]->template);
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
-            array_keys($all[0]->defaults)
+            array_keys($all[0]->defaults),
         );
         $this->assertSame('json', $all[0]->options['_ext']);
         $this->assertSame('Articles', $all[0]->defaults['controller']);
@@ -559,7 +559,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame(
             '/api/posts/{article_id}/comments',
             $all[4]->template,
-            'parameter name should reflect resource name'
+            'parameter name should reflect resource name',
         );
     }
 
@@ -606,7 +606,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/api/blog-posts', $all[4]->template);
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
-            array_keys($all[0]->defaults)
+            array_keys($all[0]->defaults),
         );
         $this->assertSame('BlogPosts', $all[0]->defaults['controller']);
     }
@@ -622,7 +622,7 @@ class RouteBuilderTest extends TestCase
             ['inflect' => 'dasherize'],
             function (RouteBuilder $routes): void {
                 $routes->resources('Attributes');
-            }
+            },
         );
 
         $all = $this->collection->routes();
@@ -653,7 +653,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/api/articles/delete_all', $all[1]->template, 'Path defaults to key name.');
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
-            array_keys($all[5]->defaults)
+            array_keys($all[5]->defaults),
         );
         $this->assertSame('Articles', $all[5]->defaults['controller']);
         $this->assertSame('deleteAll', $all[1]->defaults['action']);
@@ -661,7 +661,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/api/articles/updateAll', $all[0]->template, 'Explicit path option');
         $this->assertEquals(
             ['controller', 'action', '_method', 'prefix', 'plugin'],
-            array_keys($all[6]->defaults)
+            array_keys($all[6]->defaults),
         );
         $this->assertSame('Articles', $all[6]->defaults['controller']);
         $this->assertSame('updateAll', $all[0]->defaults['action']);
@@ -945,7 +945,7 @@ class RouteBuilderTest extends TestCase
             $this->collection,
             '/api',
             ['prefix' => 'Api'],
-            ['middleware' => ['auth']]
+            ['middleware' => ['auth']],
         );
         $routes->scope('/v1', function (RouteBuilder $routes): void {
             $this->assertSame(['auth'], $routes->getMiddleware(), 'Should inherit middleware');
@@ -1128,7 +1128,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/bookmarks/{id}', $route->template);
         $this->assertEquals(
             ['plugin' => null, 'controller' => 'Bookmarks', 'action' => 'view', '_method' => $method],
-            $route->defaults
+            $route->defaults,
         );
     }
 
@@ -1150,7 +1150,7 @@ class RouteBuilderTest extends TestCase
         $this->assertSame('/bookmarks/{id}', $route->template);
         $this->assertEquals(
             ['plugin' => null, 'controller' => 'Bookmarks', 'action' => 'view', '_method' => $method],
-            $route->defaults
+            $route->defaults,
         );
     }
 

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -353,7 +353,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect(
             '/fallback',
             ['controller' => 'Articles', 'action' => 'index'],
-            ['_host' => '*.example.com']
+            ['_host' => '*.example.com'],
         );
 
         $request = new ServerRequest([
@@ -423,7 +423,7 @@ class RouteCollectionTest extends TestCase
         $routes->connect(
             '/fallback',
             ['controller' => 'Articles', 'action' => 'index'],
-            ['_host' => '*.example.com']
+            ['_host' => '*.example.com'],
         );
 
         $request = new ServerRequest([
@@ -594,7 +594,7 @@ class RouteCollectionTest extends TestCase
 
         $result = $this->collection->match(
             ['id' => 'thing', 'plugin' => null, 'controller' => 'Articles', 'action' => 'view'],
-            $context
+            $context,
         );
         $this->assertSame('b/thing', $result);
     }

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -606,19 +606,19 @@ class RouterTest extends TestCase
         $routes->connect(
             '{language}/galleries',
             ['controller' => 'Galleries', 'action' => 'index'],
-            ['language' => '[a-z]{3}']
+            ['language' => '[a-z]{3}'],
         );
 
         $routes->connect(
             '/{language}/{admin}/{controller}/{action}/*',
             ['admin' => 'admin'],
-            ['language' => '[a-z]{3}', 'admin' => 'admin']
+            ['language' => '[a-z]{3}', 'admin' => 'admin'],
         );
 
         $routes->connect(
             '/{language}/{controller}/{action}/*',
             [],
-            ['language' => '[a-z]{3}']
+            ['language' => '[a-z]{3}'],
         );
 
         $result = Router::url(['admin' => false, 'language' => 'dan', 'action' => 'index', 'controller' => 'Galleries']);
@@ -634,7 +634,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/{language}/pages',
             ['controller' => 'Pages', 'action' => 'index'],
-            ['language' => '[a-z]{3}']
+            ['language' => '[a-z]{3}'],
         );
         $routes->connect('/{language}/{controller}/{action}/*', [], ['language' => '[a-z]{3}']);
 
@@ -654,7 +654,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/forestillinger/{month}/{year}/*',
             ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
-            ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
+            ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}'],
         );
 
         $result = Router::url([
@@ -673,7 +673,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/kalender/{month}/{year}/*',
             ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
-            ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
+            ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}'],
         );
         $routes->connect('/kalender/*', ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar']);
 
@@ -1007,17 +1007,17 @@ class RouterTest extends TestCase
         $routes->connect(
             '/users',
             ['controller' => 'Users', 'action' => 'index'],
-            ['_name' => 'users-index']
+            ['_name' => 'users-index'],
         );
         $routes->connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
-            ['_name' => 'test']
+            ['_name' => 'test'],
         );
         $routes->connect(
             '/view/*',
             ['action' => 'view'],
-            ['_name' => 'Articles::view']
+            ['_name' => 'Articles::view'],
         );
 
         $url = Router::url(['_name' => 'test', 'name' => 'mark']);
@@ -1052,7 +1052,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
-            ['_name' => 'test']
+            ['_name' => 'test'],
         );
         Router::url(['_name' => 'junk', 'name' => 'mark']);
     }
@@ -1067,17 +1067,17 @@ class RouterTest extends TestCase
         $routes->connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
-            ['_name' => 'test']
+            ['_name' => 'test'],
         );
         $routes->connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
-            ['_name' => 'otherName']
+            ['_name' => 'otherName'],
         );
         $routes->connect(
             '/users/{name}',
             ['controller' => 'Users', 'action' => 'view'],
-            ['_name' => 'test']
+            ['_name' => 'test'],
         );
     }
 
@@ -1124,7 +1124,7 @@ class RouterTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessageMatches(
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
-            ' The filter failed with: nope/'
+            ' The filter failed with: nope/',
         );
         $routes = Router::createRouteBuilder('/');
         $routes->connect('/{lang}/{controller}/{action}/*');
@@ -1152,7 +1152,7 @@ class RouterTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessageMatches(
             '/URL filter defined in .*RouterTest\.php on line \d+ could not be applied\.' .
-            ' The filter failed with: /'
+            ' The filter failed with: /',
         );
         $routes = Router::createRouteBuilder('/');
         $routes->connect('/{lang}/{controller}/{action}/*');
@@ -1264,7 +1264,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/posts/{value}/{somevalue}/{othervalue}/*',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['value', 'somevalue', 'othervalue']
+            ['value', 'somevalue', 'othervalue'],
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
         unset($result['_route']);
@@ -1285,7 +1285,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/posts/{year}/{month}/{day}/*',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['year' => $Year, 'month' => $Month, 'day' => $Day]
+            ['year' => $Year, 'month' => $Month, 'day' => $Day],
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
         unset($result['_route']);
@@ -1306,7 +1306,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/posts/{day}/{year}/{month}/*',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['year' => $Year, 'month' => $Month, 'day' => $Day]
+            ['year' => $Year, 'month' => $Month, 'day' => $Day],
         );
         $result = Router::parseRequest($this->makeRequest('/posts/01/2007/08/title-of-post-here', 'GET'));
         unset($result['_route']);
@@ -1327,7 +1327,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/posts/{month}/{day}/{year}/*',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['year' => $Year, 'month' => $Month, 'day' => $Day]
+            ['year' => $Year, 'month' => $Month, 'day' => $Day],
         );
         $result = Router::parseRequest($this->makeRequest('/posts/08/01/2007/title-of-post-here', 'GET'));
         unset($result['_route']);
@@ -1347,7 +1347,7 @@ class RouterTest extends TestCase
         $routes = Router::createRouteBuilder('/');
         $routes->connect(
             '/posts/{year}/{month}/{day}/*',
-            ['controller' => 'Posts', 'action' => 'view']
+            ['controller' => 'Posts', 'action' => 'view'],
         );
         $result = Router::parseRequest($this->makeRequest('/posts/2007/08/01/title-of-post-here', 'GET'));
         unset($result['_route']);
@@ -1403,7 +1403,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/{language}/contact',
             ['language' => 'eng', 'plugin' => 'Contact', 'controller' => 'Contact', 'action' => 'index'],
-            ['language' => '[a-z]{3}']
+            ['language' => '[a-z]{3}'],
         );
         $result = Router::parseRequest($this->makeRequest('/eng/contact', 'GET'));
         unset($result['_route']);
@@ -1422,7 +1422,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/forestillinger/{month}/{year}/*',
             ['plugin' => 'Shows', 'controller' => 'Shows', 'action' => 'calendar'],
-            ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}']
+            ['month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}'],
         );
 
         $result = Router::parseRequest($this->makeRequest('/forestillinger/10/2007/min-forestilling', 'GET'));
@@ -1469,7 +1469,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/Posts/{id}:{url_title}',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
+            ['pass' => ['id', 'url_title'], 'id' => '[\d]+'],
         );
         $result = Router::parseRequest($this->makeRequest('/Posts/5:sample-post-title', 'GET'));
         unset($result['_route']);
@@ -1489,7 +1489,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/Posts/{id}:{url_title}/*',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['pass' => ['id', 'url_title'], 'id' => '[\d]+']
+            ['pass' => ['id', 'url_title'], 'id' => '[\d]+'],
         );
         $result = Router::parseRequest($this->makeRequest('/Posts/5:sample-post-title/other/params/4', 'GET'));
         unset($result['_route']);
@@ -1524,7 +1524,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/posts/{url_title}-(uuid:{id})',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['pass' => ['id', 'url_title'], 'id' => $UUID]
+            ['pass' => ['id', 'url_title'], 'id' => $UUID],
         );
         $result = Router::parseRequest($this->makeRequest('/posts/sample-post-title-(uuid:47fc97a9-019c-41d1-a058-1fa3cbdd56cb)', 'GET'));
         unset($result['_route']);
@@ -1583,7 +1583,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/subjects/add/{category_id}',
             ['controller' => 'Subjects', 'action' => 'add'],
-            ['category_id' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}']
+            ['category_id' => '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}'],
         );
         $result = Router::parseRequest($this->makeRequest('/subjects/add/4795d601-19c8-49a6-930e-06a8b01d17b7', 'GET'));
         unset($result['_route']);
@@ -1607,7 +1607,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/{extra}/page/{slug}/*',
             ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
-            ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view']
+            ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view'],
         );
 
         $result = Router::parseRequest($this->makeRequest('/some_extra/page/this_is_the_slug', 'GET'));
@@ -1641,7 +1641,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/{extra}/page/{slug}/*',
             ['controller' => 'Pages', 'action' => 'view', 'extra' => null],
-            ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+']
+            ['extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+'],
         );
 
         $result = Router::url([
@@ -2095,7 +2095,7 @@ class RouterTest extends TestCase
     {
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage(
-            'Value for `plugin` in $defaults when connecting routes must be of type `string` or `null`'
+            'Value for `plugin` in $defaults when connecting routes must be of type `string` or `null`',
         );
 
         $routes = Router::createRouteBuilder('/');
@@ -2230,7 +2230,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
-            ['action' => 'other|actions']
+            ['action' => 'other|actions'],
         );
 
         $result = Router::parseRequest($this->makeRequest('/blog/other', 'GET'));
@@ -2492,7 +2492,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
-            ['action' => 'other|actions']
+            ['action' => 'other|actions'],
         );
 
         $result = Router::url(['controller' => 'BlogPosts', 'action' => 'actions']);
@@ -2608,7 +2608,7 @@ class RouterTest extends TestCase
         $routes = Router::createRouteBuilder('/');
         $routes->connect(
             '/admin/login',
-            ['controller' => 'Users', 'action' => 'login', 'prefix' => 'Admin']
+            ['controller' => 'Users', 'action' => 'login', 'prefix' => 'Admin'],
         );
         $request = new ServerRequest([
             'url' => '/',
@@ -2712,7 +2712,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/{slug}',
             ['plugin' => 'TestPlugin', 'action' => 'index'],
-            ['routeClass' => 'PluginShortRoute', 'slug' => '[a-z_-]+']
+            ['routeClass' => 'PluginShortRoute', 'slug' => '[a-z_-]+'],
         );
         $result = Router::parseRequest($this->makeRequest('/the-best', 'GET'));
         unset($result['_route']);
@@ -2737,7 +2737,7 @@ class RouterTest extends TestCase
         $routes->connect(
             '/{slug}',
             ['controller' => 'Posts', 'action' => 'view'],
-            ['routeClass' => 'TestPlugin.TestRoute', 'slug' => '[a-z_-]+']
+            ['routeClass' => 'TestPlugin.TestRoute', 'slug' => '[a-z_-]+'],
         );
         $this->assertTrue(true); // Just to make sure the connect do not throw exception
         $this->removePlugins(['TestPlugin']);
@@ -3061,7 +3061,7 @@ class RouterTest extends TestCase
         $route = new Route(
             '/blog/{action}/*',
             ['controller' => 'BlogPosts'],
-            ['action' => 'other|actions']
+            ['action' => 'other|actions'],
         );
         $result = $route->match(['controller' => 'BlogPosts', 'action' => 'foo']);
         $this->assertNull($result);
@@ -3113,7 +3113,7 @@ class RouterTest extends TestCase
             $this->assertEquals(
                 ['rss'],
                 $routes->getExtensions(),
-                'Should include new extensions.'
+                'Should include new extensions.',
             );
             $routes->connect('/home', []);
         });

--- a/tests/TestCase/TestSuite/AssertHtmlTest.php
+++ b/tests/TestCase/TestSuite/AssertHtmlTest.php
@@ -239,7 +239,7 @@ HTML;
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
                 'Attribute did not match. Was expecting Attribute `clAss` == `active`',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
     }
@@ -260,7 +260,7 @@ HTML;
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString(
                 'Item #1 / regex #0 failed: Open <a tag',
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
     }

--- a/tests/TestCase/TestSuite/ConnectionHelperTest.php
+++ b/tests/TestCase/TestSuite/ConnectionHelperTest.php
@@ -41,7 +41,7 @@ class ConnectionHelperTest extends TestCase
 
         $this->assertSame(
             ConnectionManager::get('test'),
-            ConnectionManager::get('default')
+            ConnectionManager::get('default'),
         );
     }
 
@@ -56,7 +56,7 @@ class ConnectionHelperTest extends TestCase
         // connection for simpler CI configuration
         $this->assertSame(
             ConnectionManager::get('test_something'),
-            ConnectionManager::get('something')
+            ConnectionManager::get('something'),
         );
     }
 

--- a/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
+++ b/tests/TestCase/TestSuite/IntegrationTestTraitTest.php
@@ -226,17 +226,17 @@ class IntegrationTestTraitTest extends TestCase
         $this->assertSame(
             $first['cookies']['csrfToken'],
             $second['post']['_csrfToken'],
-            'Csrf token should match cookie'
+            'Csrf token should match cookie',
         );
         $this->assertSame(
             $first['session']->read('csrfToken'),
             $second['post']['_csrfToken'],
-            'Csrf token should match session'
+            'Csrf token should match session',
         );
         $this->assertSame(
             $first['post']['_csrfToken'],
             $second['post']['_csrfToken'],
-            'Tokens should be consistent per test method'
+            'Tokens should be consistent per test method',
         );
     }
 
@@ -1045,7 +1045,7 @@ class IntegrationTestTraitTest extends TestCase
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                     [
                         'cookieName' => 'customCsrfToken',
-                    ]
+                    ],
                 ));
                 $routes->applyMiddleware('cookieCsrf');
                 $routes->connect('/posts/{action}', ['controller' => 'Posts']);
@@ -1071,7 +1071,7 @@ class IntegrationTestTraitTest extends TestCase
                 $routes->registerMiddleware('cookieCsrf', new CsrfProtectionMiddleware(
                     [
                         'cookieName' => 'customCsrfToken',
-                    ]
+                    ],
                 ));
                 $routes->applyMiddleware('cookieCsrf');
                 $routes->connect('/posts/{action}', ['controller' => 'Posts']);

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -460,7 +460,7 @@ class TestCaseTest extends TestCase
         $Mock = $this->getMockForModel(
             'Table',
             ['save'],
-            ['alias' => 'Comments', 'className' => Table::class]
+            ['alias' => 'Comments', 'className' => Table::class],
         );
 
         $result = $this->getTableLocator()->get('Comments');
@@ -477,7 +477,7 @@ class TestCaseTest extends TestCase
         $allMethodsStubs = $this->getMockForModel(
             'Table',
             [],
-            ['alias' => 'Comments', 'className' => Table::class]
+            ['alias' => 'Comments', 'className' => Table::class],
         );
         $result = $this->getTableLocator()->get('Comments');
         $this->assertInstanceOf(Table::class, $result);

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -86,7 +86,7 @@ class TestFixtureTest extends TestCase
         $this->expectExceptionMessage(
             sprintf(
                 'Cannot describe schema for table `letters` for fixture `%s`. The table does not exist.',
-                LettersFixture::class
+                LettersFixture::class,
             ),
         );
 
@@ -198,8 +198,8 @@ class TestFixtureTest extends TestCase
                 ...self::withConsecutive(
                     [$expected[0]],
                     [$expected[1]],
-                    [$expected[2]]
-                )
+                    [$expected[2]],
+                ),
             )
             ->willReturnSelf();
 

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -702,7 +702,7 @@ class HashTest extends TestCase
     {
         $result = Hash::merge(
             ['hkuc' => ['lion']],
-            ['hkuc' => 'lion']
+            ['hkuc' => 'lion'],
         );
         $expected = ['hkuc' => 'lion'];
         $this->assertSame($expected, $result);
@@ -710,7 +710,7 @@ class HashTest extends TestCase
         $result = Hash::merge(
             ['hkuc' => ['lion']],
             ['hkuc' => ['lion']],
-            ['hkuc' => 'lion']
+            ['hkuc' => 'lion'],
         );
         $this->assertSame($expected, $result);
 
@@ -1405,11 +1405,11 @@ class HashTest extends TestCase
         ];
         $this->assertSame(
             ['test1', 'test2'],
-            Hash::extract($data, 'Level1.Level2')
+            Hash::extract($data, 'Level1.Level2'),
         );
         $this->assertSame(
             ['test3', 'test4'],
-            Hash::extract($data, 'Level1.Level2bis')
+            Hash::extract($data, 'Level1.Level2bis'),
         );
 
         $data = new ArrayObject([
@@ -1420,11 +1420,11 @@ class HashTest extends TestCase
         ]);
         $this->assertSame(
             ['test1', 'test2'],
-            Hash::extract($data, 'Level1.Level2')
+            Hash::extract($data, 'Level1.Level2'),
         );
         $this->assertSame(
             ['test3', 'test4'],
-            Hash::extract($data, 'Level1.Level2bis')
+            Hash::extract($data, 'Level1.Level2bis'),
         );
 
         $data = [
@@ -2517,7 +2517,7 @@ class HashTest extends TestCase
             $a,
             '{n}.User.id',
             ['%1$s: %2$s', '{n}.User.Data.user', '{n}.User.Data.name'],
-            '{n}.User.group_id'
+            '{n}.User.group_id',
         );
         $expected = [
             1 => [
@@ -2534,7 +2534,7 @@ class HashTest extends TestCase
             $a,
             null,
             ['%1$s: %2$s', '{n}.User.Data.user', '{n}.User.Data.name'],
-            '{n}.User.group_id'
+            '{n}.User.group_id',
         );
         $expected = [
             1 => [
@@ -2554,7 +2554,7 @@ class HashTest extends TestCase
                 '{n}.User.Data.user',
                 '{n}.User.Data.name',
             ],
-            '{n}.User.id'
+            '{n}.User.id',
         );
         $expected = [
             'mariano.iglesias: Mariano Iglesias' => 2,
@@ -2566,7 +2566,7 @@ class HashTest extends TestCase
         $result = Hash::combine(
             $a,
             ['%1$s: %2$d', '{n}.User.Data.user', '{n}.User.id'],
-            '{n}.User.Data.name'
+            '{n}.User.Data.name',
         );
         $expected = [
             'mariano.iglesias: 2' => 'Mariano Iglesias',
@@ -2578,7 +2578,7 @@ class HashTest extends TestCase
         $result = Hash::combine(
             $a,
             ['%2$d: %1$s', '{n}.User.Data.user', '{n}.User.id'],
-            '{n}.User.Data.name'
+            '{n}.User.Data.name',
         );
         $expected = [
             '2: mariano.iglesias' => 'Mariano Iglesias',
@@ -2598,7 +2598,7 @@ class HashTest extends TestCase
         $result = Hash::format(
             $data,
             ['{n}.User.Data.user', '{n}.User.id'],
-            '%s, %s'
+            '%s, %s',
         );
         $expected = [
             'mariano.iglesias, 2',
@@ -2610,7 +2610,7 @@ class HashTest extends TestCase
         $result = Hash::format(
             $data,
             ['{n}.User.Data.user', '{n}.User.id'],
-            '%2$s, %1$s'
+            '%2$s, %1$s',
         );
         $expected = [
             '2, mariano.iglesias',

--- a/tests/TestCase/Utility/InflectorTest.php
+++ b/tests/TestCase/Utility/InflectorTest.php
@@ -211,11 +211,11 @@ class InflectorTest extends TestCase
         $this->assertSame('pregunta_frecuente', Inflector::singularize('preguntas_frecuentes'));
         $this->assertSame(
             'categoria_pregunta_frecuente',
-            Inflector::singularize('categorias_preguntas_frecuentes')
+            Inflector::singularize('categorias_preguntas_frecuentes'),
         );
         $this->assertSame(
             'faq_categoria_pregunta_frecuente',
-            Inflector::singularize('faq_categorias_preguntas_frecuentes')
+            Inflector::singularize('faq_categorias_preguntas_frecuentes'),
         );
     }
 
@@ -327,11 +327,11 @@ class InflectorTest extends TestCase
         $this->assertSame('preguntas_frecuentes', Inflector::pluralize('pregunta_frecuente'));
         $this->assertSame(
             'categorias_preguntas_frecuentes',
-            Inflector::pluralize('categoria_pregunta_frecuente')
+            Inflector::pluralize('categoria_pregunta_frecuente'),
         );
         $this->assertSame(
             'faq_categorias_preguntas_frecuentes',
-            Inflector::pluralize('faq_categoria_pregunta_frecuente')
+            Inflector::pluralize('faq_categoria_pregunta_frecuente'),
         );
     }
 

--- a/tests/TestCase/Utility/TextTest.php
+++ b/tests/TestCase/Utility/TextTest.php
@@ -203,7 +203,7 @@ class TextTest extends TestCase
         $result = Text::insert(
             ':I.am: :not.yet: passing.',
             ['I.am' => 'We are'],
-            ['before' => ':', 'after' => ':', 'clean' => true]
+            ['before' => ':', 'after' => ':', 'clean' => true],
         );
         $expected = 'We are passing.';
         $this->assertSame($expected, $result);
@@ -256,7 +256,7 @@ class TextTest extends TestCase
             ':incomplete',
             [
             'clean' => ['method' => 'text', 'replacement' => 'complete'],
-            'before' => ':', 'after' => '']
+            'before' => ':', 'after' => ''],
         );
         $this->assertSame('complete', $result);
 
@@ -268,7 +268,7 @@ class TextTest extends TestCase
         $result = Text::cleanInsert(
             ':in.complete and',
             [
-            'clean' => true, 'before' => ':', 'after' => '']
+            'clean' => true, 'before' => ':', 'after' => ''],
         );
         $this->assertSame('', $result);
 
@@ -279,7 +279,7 @@ class TextTest extends TestCase
 
         $result = Text::cleanInsert(
             '<p class=":missing" id=":missing">Text here</p>',
-            ['clean' => 'html', 'before' => ':', 'after' => '']
+            ['clean' => 'html', 'before' => ':', 'after' => ''],
         );
         $this->assertSame('<p>Text here</p>', $result);
     }

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -86,7 +86,7 @@ class XmlTest extends TestCase
 
         $this->assertEquals(
             Xml::build($xml, ['readFile' => true]),
-            Xml::build(file_get_contents($xml))
+            Xml::build(file_get_contents($xml)),
         );
 
         $obj = Xml::build($xml, ['return' => 'domdocument', 'readFile' => true]);
@@ -94,7 +94,7 @@ class XmlTest extends TestCase
 
         $this->assertEquals(
             Xml::build($xml, ['return' => 'domdocument', 'readFile' => true]),
-            Xml::build(file_get_contents($xml), ['return' => 'domdocument'])
+            Xml::build(file_get_contents($xml), ['return' => 'domdocument']),
         );
 
         $xml = ['tag' => 'value'];

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2361,14 +2361,14 @@ class ValidationTest extends TestCase
                 'file1' => ['name' => 'file.jpg'],
                 'file2' => ['name' => 'file.gif'],
             ],
-            ['gif']
+            ['gif'],
         ), 'Only the first element should be checked');
         $this->assertTrue(Validation::extension(
             [
                 'file1' => ['name' => 'file.gif'],
                 'file2' => ['name' => 'file.jpg'],
             ],
-            ['gif']
+            ['gif'],
         ), 'Only the first element should be checked');
 
         $file = [

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -687,7 +687,7 @@ class ValidatorTest extends TestCase
             'picture' => new UploadedFile(
                 '',
                 0,
-                UPLOAD_ERR_NO_FILE
+                UPLOAD_ERR_NO_FILE,
             ),
         ];
         $result = $validator->validate($data);
@@ -747,7 +747,7 @@ class ValidatorTest extends TestCase
             'very required',
             function ($context) {
                 return $context['data']['otherField'] === true;
-            }
+            },
         )
             ->scalar('title');
 
@@ -2771,7 +2771,7 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => [1, 2, 3]]));
         $this->assertSame(
             ['username' => ['array' => 'The provided value must be an array']],
-            $validator->validate(['username' => 'is not an array'])
+            $validator->validate(['username' => 'is not an array']),
         );
 
         $fieldName = 'field_name';
@@ -2790,7 +2790,7 @@ class ValidatorTest extends TestCase
         $this->assertEmpty($validator->validate(['username' => 'scalar']));
         $this->assertSame(
             ['username' => ['scalar' => 'The provided value must be scalar']],
-            $validator->validate(['username' => ['array']])
+            $validator->validate(['username' => ['array']]),
         );
 
         $fieldName = 'field_name';
@@ -2826,7 +2826,7 @@ class ValidatorTest extends TestCase
             'multipleOptions',
             ['min' => 1, 'caseInsensitive' => true],
             [['min' => 1], true],
-            'multiple'
+            'multiple',
         );
 
         $this->assertProxyMethod(
@@ -2834,7 +2834,7 @@ class ValidatorTest extends TestCase
             'multipleOptions',
             ['min' => 1, 'caseInsensitive' => false],
             [['min' => 1], false],
-            'multiple'
+            'multiple',
         );
 
         $this->assertNotEmpty($validator->validate(['username' => '']));
@@ -3000,7 +3000,7 @@ class ValidatorTest extends TestCase
         string $fieldName,
         string $rule,
         string $expectedMessage,
-        mixed $additional = null
+        mixed $additional = null,
     ): void {
         $validator = new Validator();
         if ($additional !== null) {
@@ -3011,7 +3011,7 @@ class ValidatorTest extends TestCase
 
         $this->assertSame(
             $expectedMessage,
-            $validator->field($fieldName)->rule($rule)->get('message')
+            $validator->field($fieldName)->rule($rule)->get('message'),
         );
 
         $noI18nValidator = new NoI18nValidator();
@@ -3023,7 +3023,7 @@ class ValidatorTest extends TestCase
 
         $this->assertSame(
             $expectedMessage,
-            $noI18nValidator->field($fieldName)->rule($rule)->get('message')
+            $noI18nValidator->field($fieldName)->rule($rule)->get('message'),
         );
     }
 }

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -206,7 +206,7 @@ class CellTest extends TestCase
         $message = $e->getMessage();
         $this->assertStringContainsString(
             str_replace('/', DS, 'Cell template file `cell/Articles/foo_bar.php` could not be found.'),
-            $message
+            $message,
         );
         $this->assertStringContainsString('The following paths', $message);
         $this->assertStringContainsString(ROOT . DS . 'templates', $message);
@@ -233,14 +233,14 @@ class CellTest extends TestCase
         $cell = $this->View->cell('Articles');
         $this->assertStringContainsString(
             'TestPlugin Articles/display',
-            $cell->render('TestPlugin.display')
+            $cell->render('TestPlugin.display'),
         );
 
         $cell = $this->View->cell('Articles');
         $cell->viewBuilder()->setPlugin('TestPlugin');
         $this->assertStringContainsString(
             'TestPlugin Articles/display',
-            $cell->render('display')
+            $cell->render('display'),
         );
     }
 

--- a/tests/TestCase/View/Form/ContextFactoryTest.php
+++ b/tests/TestCase/View/Form/ContextFactoryTest.php
@@ -31,7 +31,7 @@ class ContextFactoryTest extends TestCase
         $this->expectException(CakeException::class);
         $this->expectExceptionMessage(
             'No context provider found for value of type `bool`.'
-            . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.'
+            . ' Use `null` as 1st argument of FormHelper::create() to create a context-less form.',
         );
 
         $factory = new ContextFactory();

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -861,11 +861,11 @@ class EntityContextTest extends TestCase
 
         $this->assertTrue(
             $context->isRequired('comments.0.comment'),
-            'comment is required as object is not new'
+            'comment is required as object is not new',
         );
         $this->assertFalse(
             $context->isRequired('comments.1.comment'),
-            'comment is not required as missing object is "new"'
+            'comment is not required as missing object is "new"',
         );
     }
 
@@ -1244,7 +1244,7 @@ class EntityContextTest extends TestCase
         $tagTwo = new Tag(['name' => 'second-post']);
         $tagOne->setError(
             'metadata',
-            ['description' => ['_empty' => 'required value']]
+            ['description' => ['_empty' => 'required value']],
         );
         $row = new Article([
             'title' => 'My title',

--- a/tests/TestCase/View/Form/FormContextTest.php
+++ b/tests/TestCase/View/Form/FormContextTest.php
@@ -224,11 +224,11 @@ class FormContextTest extends TestCase
         $this->assertEquals([], $context->attributes('id'));
         $this->assertEquals(
             ['length' => 10, 'precision' => null, 'default' => null],
-            $context->attributes('email')
+            $context->attributes('email'),
         );
         $this->assertEquals(
             ['precision' => 2, 'length' => 5, 'default' => null],
-            $context->attributes('amount')
+            $context->attributes('amount'),
         );
     }
 
@@ -271,7 +271,7 @@ class FormContextTest extends TestCase
         $this->assertEquals(
             ['_required' => 'should be an array, not a string'],
             $context->error('key'),
-            'This test should not produce a PHP warning from array_values().'
+            'This test should not produce a PHP warning from array_values().',
         );
     }
 

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -395,7 +395,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->breadcrumbs->render(
             ['data-stuff' => 'foo and bar'],
-            ['separator' => '<i class="fa fa-angle-right"></i>', 'class' => 'separator']
+            ['separator' => '<i class="fa fa-angle-right"></i>', 'class' => 'separator'],
         );
         $expected = [
             ['ul' => ['data-stuff' => 'foo and bar']],
@@ -449,7 +449,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->breadcrumbs->render(
             ['data-stuff' => 'foo and bar'],
-            ['separator' => ' > ', 'class' => 'separator']
+            ['separator' => ' > ', 'class' => 'separator'],
         );
         $expected = [
             ['ol' => ['itemtype' => 'http://schema.org/BreadcrumbList', 'data-stuff' => 'foo and bar']],
@@ -488,7 +488,7 @@ class BreadcrumbsHelperTest extends TestCase
 
         $result = $this->breadcrumbs->render(
             ['data-stuff' => 'foo and bar', 'templateVars' => ['thing' => 'somestuff']],
-            ['separator' => ' > ', 'class' => 'separator']
+            ['separator' => ' > ', 'class' => 'separator'],
         );
         $expected = [
             'somestuff',

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -793,7 +793,7 @@ class FormHelperTest extends TestCase
         $builder->connect(
             '/new-article',
             ['controller' => 'Articles', 'action' => 'myAction'],
-            ['_name' => 'my-route']
+            ['_name' => 'my-route'],
         );
         $result = $this->Form->create(null, ['url' => ['_name' => 'my-route']]);
         $expected = [
@@ -814,7 +814,7 @@ class FormHelperTest extends TestCase
             $this->article,
             [
                 'type' => 'post', 'url' => ['action' => 'index'], 'encoding' => 'iso-8859-1',
-            ]
+            ],
         );
         $expected = [
             'form' => [
@@ -1622,7 +1622,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getFormProtector()->__debugInfo()['unlockedFields'];
         $this->assertEquals(
             $this->View->getRequest()->getAttribute('formTokenData'),
-            ['unlockedFields' => $result]
+            ['unlockedFields' => $result],
         );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -1696,7 +1696,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getFormProtector()->__debugInfo()['unlockedFields'];
         $this->assertEquals(
             $this->View->getRequest()->getAttribute('formTokenData'),
-            ['unlockedFields' => $result]
+            ['unlockedFields' => $result],
         );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -1769,7 +1769,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getFormProtector()->__debugInfo()['unlockedFields'];
         $this->assertEquals(
             $this->View->getRequest()->getAttribute('formTokenData'),
-            ['unlockedFields' => $result]
+            ['unlockedFields' => $result],
         );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -1823,7 +1823,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->getFormProtector()->__debugInfo()['unlockedFields'];
         $this->assertEquals(
             $this->View->getRequest()->getAttribute('formTokenData'),
-            ['unlockedFields' => $result]
+            ['unlockedFields' => $result],
         );
 
         $this->Form->hidden('Addresses.id', ['value' => '123456']);
@@ -2935,7 +2935,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('Model.0.OtherModel.field', 'My value')
+            $this->View->getRequest()->withData('Model.0.OtherModel.field', 'My value'),
         );
         $this->Form->create();
         $result = $this->Form->control('Model.0.OtherModel.field', ['id' => 'myId']);
@@ -3167,7 +3167,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['first'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
         $expected = [
             'input' => [
@@ -3520,7 +3520,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control(
             'email',
             [
-            'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true]
+            'options' => ['è' => 'Firést', 'é' => 'Secoènd'], 'empty' => true],
         );
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3544,7 +3544,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->control(
             'email',
             [
-            'options' => ['First', 'Second'], 'empty' => true]
+            'options' => ['First', 'Second'], 'empty' => true],
         );
         $expected = [
             'div' => ['class' => 'input select'],
@@ -3574,7 +3574,7 @@ class FormHelperTest extends TestCase
 
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $this->View->setRequest(
-            $this->View->getRequest()->withData('Model', ['user_id' => 'value'])
+            $this->View->getRequest()->withData('Model', ['user_id' => 'value']),
         );
         $this->Form->create();
         $result = $this->Form->control('Model.user_id', ['empty' => true]);
@@ -3599,7 +3599,7 @@ class FormHelperTest extends TestCase
 
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $this->View->setRequest(
-            $this->View->getRequest()->withData('Thing', ['user_id' => null])
+            $this->View->getRequest()->withData('Thing', ['user_id' => null]),
         );
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
         $expected = [
@@ -3624,7 +3624,7 @@ class FormHelperTest extends TestCase
 
         $this->View->set('users', ['value' => 'good', 'other' => 'bad']);
         $this->View->setRequest(
-            $this->View->getRequest()->withData('Thing', ['user_id' => 'value'])
+            $this->View->getRequest()->withData('Thing', ['user_id' => 'value']),
         );
         $this->Form->create();
         $result = $this->Form->control('Thing.user_id', ['empty' => 'Some Empty']);
@@ -3679,7 +3679,7 @@ class FormHelperTest extends TestCase
         $articlesTable = $this->getTableLocator()->get('Articles');
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatus::class)
+            EnumType::from(ArticleStatus::class),
         );
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published');
@@ -3702,7 +3702,7 @@ class FormHelperTest extends TestCase
 
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatusLabel::class)
+            EnumType::from(ArticleStatusLabel::class),
         );
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published');
@@ -3725,7 +3725,7 @@ class FormHelperTest extends TestCase
 
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatusLabelInterface::class)
+            EnumType::from(ArticleStatusLabelInterface::class),
         );
 
         $this->Form->create($articlesTable->newEmptyEntity());
@@ -3735,7 +3735,7 @@ class FormHelperTest extends TestCase
         $articlePriosTable = $this->getTableLocator()->get('ArticlePrios');
         $articlePriosTable->getSchema()->setColumnType(
             'priority',
-            EnumType::from(Priority::class)
+            EnumType::from(Priority::class),
         );
 
         $this->Form->create($articlePriosTable->newEmptyEntity());
@@ -4121,7 +4121,7 @@ class FormHelperTest extends TestCase
         ];
         $result = $this->Form->allControls(
             ['foo' => ['type' => 'text']],
-            ['legend' => false]
+            ['legend' => false],
         );
         $this->assertHtml($expected, $result);
     }
@@ -4181,7 +4181,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['first', 'second', 'third'],
-            ['multiple' => 'checkbox', 'value' => [0, 1]]
+            ['multiple' => 'checkbox', 'value' => [0, 1]],
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'model-multi-field'],
@@ -4209,7 +4209,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['1/2' => 'half'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'model-multi-field'],
@@ -4365,7 +4365,7 @@ class FormHelperTest extends TestCase
         $title = $Articles->getSchema()->getColumn('title');
         $Articles->getSchema()->addColumn(
             'title',
-            ['default' => 'default title', 'length' => 255] + $title
+            ['default' => 'default title', 'length' => 255] + $title,
         );
 
         $entity = $Articles->newEmptyEntity();
@@ -4583,7 +4583,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->radio(
             'Employee.vegetarian',
             ['yes' => 'Yes', 'no' => 'No'],
-            ['form' => 'my-form', 'id' => 'id-veg']
+            ['form' => 'my-form', 'id' => 'id-veg'],
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Employee[vegetarian]', 'value' => '', 'form' => 'my-form', 'id' => 'id-veg'],
@@ -4617,7 +4617,7 @@ class FormHelperTest extends TestCase
             [
                 ['value' => 'male', 'text' => 'Male', 'style' => 'width:20px'],
                 ['value' => 'female', 'text' => 'Female', 'style' => 'width:20px'],
-            ]
+            ],
         );
         $expected = [
             'input' => ['type' => 'hidden', 'name' => 'Employee[gender]', 'value' => '', 'id' => 'employee-gender'],
@@ -4693,7 +4693,7 @@ class FormHelperTest extends TestCase
         $title = $Articles->getSchema()->getColumn('title');
         $Articles->getSchema()->addColumn(
             'title',
-            ['default' => '1'] + $title
+            ['default' => '1'] + $title,
         );
 
         $this->Form->create($Articles->newEmptyEntity());
@@ -4847,7 +4847,7 @@ class FormHelperTest extends TestCase
         $articlesTable = $this->getTableLocator()->get('Articles');
         $articlesTable->getSchema()->setColumnType(
             'published',
-            EnumType::from(ArticleStatus::class)
+            EnumType::from(ArticleStatus::class),
         );
         $this->Form->create($articlesTable->newEmptyEntity());
         $result = $this->Form->control('published', ['type' => 'radio', 'label' => false,]);
@@ -5016,7 +5016,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.field',
             $options,
-            ['escape' => false, 'empty' => false]
+            ['escape' => false, 'empty' => false],
         );
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -5035,7 +5035,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.contact_id',
             ['228' => '228 value', '228-1' => '228-1 value', '228-2' => '228-2 value'],
-            ['escape' => false, 'empty' => 'pick something']
+            ['escape' => false, 'empty' => 'pick something'],
         );
 
         $expected = [
@@ -5083,7 +5083,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.field',
             ['first' => 'first "html" <chars>', 'second' => 'value'],
-            ['empty' => false]
+            ['empty' => false],
         );
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -5100,7 +5100,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.field',
             ['first' => 'first "html" <chars>', 'second' => 'value'],
-            ['escape' => false, 'empty' => false]
+            ['escape' => false, 'empty' => false],
         );
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -5182,7 +5182,7 @@ class FormHelperTest extends TestCase
             [1 => 'One', 2 => 'Two', 'Three' => [
                 3 => 'Three', 4 => 'Four', 5 => 'Five',
             ]],
-            ['empty' => false]
+            ['empty' => false],
         );
         $expected = [
             'select' => ['name' => 'Model[field]'],
@@ -5219,7 +5219,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             $options,
-            ['form' => 'my-form', 'multiple' => true]
+            ['form' => 'my-form', 'multiple' => true],
         );
         $expected = [
             'input' => [
@@ -5249,14 +5249,14 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             $options,
-            ['multiple' => 'multiple', 'form' => 'my-form']
+            ['multiple' => 'multiple', 'form' => 'my-form'],
         );
         $this->assertHtml($expected, $result);
 
         $result = $this->Form->select(
             'Model.multi_field',
             $options,
-            ['form' => 'my-form', 'multiple' => false]
+            ['form' => 'my-form', 'multiple' => false],
         );
         $this->assertStringNotContainsString('multiple', $result);
     }
@@ -5478,7 +5478,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['first', 'second', 'third'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
 
         $expected = [
@@ -5518,7 +5518,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['a+' => 'first', 'a++' => 'second', 'a+++' => 'third'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
         $expected = [
             'input' => [
@@ -5557,7 +5557,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['a>b' => 'first', 'a<b' => 'second', 'a"b' => 'third'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
         $expected = [
             'input' => [
@@ -5605,7 +5605,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.tags',
             ['1' => 'first', 'Array' => 'Array'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
         $expected = [
             'input' => [
@@ -5647,7 +5647,7 @@ class FormHelperTest extends TestCase
         $this->Form->select(
             'Model.multi_field',
             ['1' => 'first', '2' => 'second', '3' => 'third'],
-            ['multiple' => 'checkbox']
+            ['multiple' => 'checkbox'],
         );
         $fields = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals(['Model.multi_field'], $fields);
@@ -5672,7 +5672,7 @@ class FormHelperTest extends TestCase
         $this->Form->select(
             'Model.select',
             [],
-            ['multiple' => true]
+            ['multiple' => true],
         );
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals(['Model.select'], $result);
@@ -5691,7 +5691,7 @@ class FormHelperTest extends TestCase
 
         $this->Form->select(
             'Model.select',
-            []
+            [],
         );
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals([], $result);
@@ -5699,7 +5699,7 @@ class FormHelperTest extends TestCase
         $this->Form->select(
             'Model.user_id',
             [],
-            ['empty' => true]
+            ['empty' => true],
         );
         $result = $this->Form->getFormProtector()->__debugInfo()['fields'];
         $this->assertEquals(['Model.user_id'], $result);
@@ -5787,7 +5787,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'Model.multi_field',
             ['first', 'second'],
-            ['multiple' => 'checkbox', 'hiddenField' => false, 'value' => null]
+            ['multiple' => 'checkbox', 'hiddenField' => false, 'value' => null],
         );
         $this->assertStringNotContainsString('type="hidden"', $result);
     }
@@ -5823,7 +5823,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->multiCheckbox(
             'category',
             new Collection(['1', '2']),
-            ['name' => 'fish']
+            ['name' => 'fish'],
         );
         $this->assertHtml($expected, $result);
 
@@ -5864,7 +5864,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->multiCheckbox(
             'category',
             ['1', '2'],
-            ['id' => 'cat']
+            ['id' => 'cat'],
         );
         $this->assertHtml($expected, $result);
     }
@@ -5966,7 +5966,7 @@ class FormHelperTest extends TestCase
         $Articles = $this->getTableLocator()->get('Articles');
         $Articles->getSchema()->addColumn(
             'published',
-            ['type' => 'boolean', 'null' => false, 'default' => true]
+            ['type' => 'boolean', 'null' => false, 'default' => true],
         );
 
         $this->Form->create($Articles->newEmptyEntity());
@@ -6168,7 +6168,7 @@ class FormHelperTest extends TestCase
     public function testDateTimeSecured(): void
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withAttribute('formTokenData', ['unlockedFields' => []])
+            $this->View->getRequest()->withAttribute('formTokenData', ['unlockedFields' => []]),
         );
         $this->Form->create();
 
@@ -6191,7 +6191,7 @@ class FormHelperTest extends TestCase
     public function testDateTimeSecuredDisabled(): void
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withAttribute('formTokenData', ['unlockedFields' => []])
+            $this->View->getRequest()->withAttribute('formTokenData', ['unlockedFields' => []]),
         );
         $this->Form->create();
 
@@ -6256,7 +6256,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('release', '2050-02-10')
+            $this->View->getRequest()->withData('release', '2050-02-10'),
         );
         $this->Form->create();
         $result = $this->Form->month('release');
@@ -6271,7 +6271,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('release', '2050-03')
+            $this->View->getRequest()->withData('release', '2050-03'),
         );
         $this->Form->create();
         $result = $this->Form->month('release');
@@ -6293,7 +6293,7 @@ class FormHelperTest extends TestCase
     public function testYear(): void
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withData('published', '2006')
+            $this->View->getRequest()->withData('published', '2006'),
         );
 
         $result = $this->Form->year('field', ['value' => '', 'min' => 2006, 'max' => 2007]);
@@ -6406,7 +6406,7 @@ class FormHelperTest extends TestCase
         ]);
         $this->assertStringContainsString(
             '<input type="date" name="birthday" required="required"',
-            $result
+            $result,
         );
     }
 
@@ -6541,7 +6541,7 @@ class FormHelperTest extends TestCase
 
         $this->View->setRequest($this->View->getRequest()->withData(
             'Model.field',
-            'some <strong>test</strong> data with <a href="#">HTML</a> chars'
+            'some <strong>test</strong> data with <a href="#">HTML</a> chars',
         ));
         $this->Form->create();
         $result = $this->Form->textarea('Model.field', ['escape' => false]);
@@ -6696,7 +6696,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('Model.upload', 'no data should be set in value')
+            $this->View->getRequest()->withData('Model.upload', 'no data should be set in value'),
         );
         $result = $this->Form->file('Model.upload');
         $this->assertHtml($expected, $result);
@@ -6942,7 +6942,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postLink(
             'Delete',
             '/posts/delete/1',
-            ['target' => '_blank', 'class' => 'btn btn-danger']
+            ['target' => '_blank', 'class' => 'btn btn-danger'],
         );
         $expected = [
             'form' => [
@@ -6986,7 +6986,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postLink(
             'Delete',
             '/posts/delete/1',
-            ['confirm' => "'Confirm'\nthis \"deletion\"?"]
+            ['confirm' => "'Confirm'\nthis \"deletion\"?"],
         );
         $expected = [
             'form' => [
@@ -7009,7 +7009,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postLink(
             'Delete',
             '/posts/delete/1',
-            ['escape' => false, 'confirm' => 'Confirm this deletion?']
+            ['escape' => false, 'confirm' => 'Confirm this deletion?'],
         );
         $expected = [
             'form' => [
@@ -7039,7 +7039,7 @@ class FormHelperTest extends TestCase
     {
         $result = $this->Form->postLink(
             'Delete',
-            ['controller' => 'Posts', 'action' => 'delete', 1, '?' => ['a' => 'b', 'c' => 'd']]
+            ['controller' => 'Posts', 'action' => 'delete', 1, '?' => ['a' => 'b', 'c' => 'd']],
         );
         $expected = [
             'form' => [
@@ -7072,7 +7072,7 @@ class FormHelperTest extends TestCase
         $this->assertStringContainsString(
             '<input type="hidden" name="name" value="show"',
             $result,
-            'should not contain entity data.'
+            'should not contain entity data.',
         );
     }
 
@@ -7090,7 +7090,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postLink(
             'Delete',
             '/posts/delete/1',
-            ['data' => ['id' => 1]]
+            ['data' => ['id' => 1]],
         );
         $tokenDebug = urlencode(json_encode([
             '/posts/delete/1',
@@ -7165,7 +7165,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postLink(
             'Delete',
             '/posts/delete/1',
-            ['data' => ['id' => 1]]
+            ['data' => ['id' => 1]],
         );
         $expected = [
             'form' => [
@@ -7278,7 +7278,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->postLink(
             'Delete',
             '/posts/delete/2',
-            ['block' => true, 'method' => 'DELETE']
+            ['block' => true, 'method' => 'DELETE'],
         );
         $expected = [
             'a' => ['href' => '#', 'onclick' => 'preg:/document\.post_\w+\.submit\(\); event\.returnValue = false; return false;/'],
@@ -7590,7 +7590,7 @@ class FormHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('nonexistent_not_validated', 'CakePHP magic')
+            $this->View->getRequest()->withData('nonexistent_not_validated', 'CakePHP magic'),
         );
         $this->Form->create($this->article);
         $result = $this->Form->control('nonexistent_not_validated');
@@ -8303,7 +8303,7 @@ class FormHelperTest extends TestCase
         $result = $this->Form->select(
             'multi_field',
             ['first', 'second'],
-            ['multiple' => 'checkbox', 'id' => true]
+            ['multiple' => 'checkbox', 'id' => true],
         );
         $expected = [
             'input' => [
@@ -8483,7 +8483,7 @@ class FormHelperTest extends TestCase
         $articles->patchEntity($article, ['id' => '3']);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('id', '4')->withQueryParams(['id' => '5'])
+            $this->View->getRequest()->withData('id', '4')->withQueryParams(['id' => '5']),
         );
 
         $this->Form->create($article, ['valueSources' => 'query']);
@@ -8537,7 +8537,7 @@ class FormHelperTest extends TestCase
         $articles->patchEntity($article, ['id' => '3']);
 
         $this->View->setRequest(
-            $this->View->getRequest()->withData('id', '10')->withQueryParams(['id' => '11'])
+            $this->View->getRequest()->withData('id', '10')->withQueryParams(['id' => '11']),
         );
 
         $this->Form->setValueSources(['context'])
@@ -8592,7 +8592,7 @@ class FormHelperTest extends TestCase
     public function testFormValueSourcesDefaults(): void
     {
         $this->View->setRequest(
-            $this->View->getRequest()->withQueryParams(['password' => 'open Sesame'])
+            $this->View->getRequest()->withQueryParams(['password' => 'open Sesame']),
         );
         $this->Form->create();
 
@@ -8982,7 +8982,7 @@ class FormHelperTest extends TestCase
                     'schema' => $this->article['schema'],
                     'validator' => $validator,
                 ]),
-            ]
+            ],
         );
 
         $this->Form->create($article);
@@ -9018,7 +9018,7 @@ class FormHelperTest extends TestCase
                     'alias' => 'Articles',
                 ]),
 
-            ]
+            ],
         );
 
         $this->Form->create($article);
@@ -9054,7 +9054,7 @@ class FormHelperTest extends TestCase
                     'alias' => 'Articles',
                 ]),
 
-            ]
+            ],
         );
 
         $this->Form->create($article);
@@ -9096,7 +9096,7 @@ class FormHelperTest extends TestCase
                     'schema' => $this->article['schema'],
                     'validator' => $validator,
                 ]),
-            ]
+            ],
         );
 
         $this->Form->create($article);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -643,8 +643,8 @@ class HtmlHelperTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['css', $this->matchesRegularExpression('/css_in_head.css/')],
-                    ['css', $this->matchesRegularExpression('/more_css_in_head.css/')]
-                )
+                    ['css', $this->matchesRegularExpression('/more_css_in_head.css/')],
+                ),
             );
 
         $result = $this->Html->css('css_in_head', ['block' => true]);
@@ -741,7 +741,7 @@ class HtmlHelperTest extends TestCase
 
         $result = explode("\n", trim($this->Html->css(
             ['TestPlugin.test_plugin_asset', 'TestPlugin.vendor.generic'],
-            ['once' => false]
+            ['once' => false],
         )));
         $expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css/';
         $this->assertHtml($expected, $result[0]);
@@ -852,8 +852,8 @@ class HtmlHelperTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['css', $this->stringContains('test.min.css')],
-                    ['script', $this->stringContains('test.min.js')]
-                )
+                    ['script', $this->stringContains('test.min.js')],
+                ),
             );
         $this->Html->css('test.min', ['block' => true]);
         $this->Html->script('test.min', ['block' => true]);
@@ -1123,8 +1123,8 @@ class HtmlHelperTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['script', $this->matchesRegularExpression('/script_in_head.js/')],
-                    ['headScripts', $this->matchesRegularExpression('/second_script.js/')]
-                )
+                    ['headScripts', $this->matchesRegularExpression('/second_script.js/')],
+                ),
             );
 
         $result = $this->Html->script('script_in_head', ['block' => true]);
@@ -1215,8 +1215,8 @@ class HtmlHelperTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['script', $this->matchesRegularExpression('/window\.foo\s\=\s2;/')],
-                    ['scriptTop', $this->stringContains('alert(')]
-                )
+                    ['scriptTop', $this->stringContains('alert(')],
+                ),
             );
 
         $result = $this->Html->scriptBlock('window.foo = 2;', ['block' => true]);
@@ -1720,8 +1720,8 @@ class HtmlHelperTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['meta', $this->stringContains('robots')],
-                    ['metaTags', $this->stringContains('favicon.ico')]
-                )
+                    ['metaTags', $this->stringContains('favicon.ico')],
+                ),
             );
 
         $result = $this->Html->meta('robots', 'ALL', ['block' => true]);
@@ -1741,8 +1741,8 @@ class HtmlHelperTest extends TestCase
             ->with(
                 ...self::withConsecutive(
                     ['meta', $this->stringContains('og:site_name')],
-                    ['meta', $this->stringContains('og:description')]
-                )
+                    ['meta', $this->stringContains('og:description')],
+                ),
             );
         $result = $this->Html->meta(['property' => 'og:site_name', 'content' => 'CakePHP', 'block' => true]);
         $this->assertNull($result, 'compact style should work');
@@ -1997,7 +1997,7 @@ class HtmlHelperTest extends TestCase
 
         $result = $this->Html->media(
             ['video.webm', ['src' => 'video.ogv', 'type' => "video/ogg; codecs='theora, vorbis'"]],
-            ['pathPrefix' => 'videos/', 'poster' => 'poster.jpg', 'text' => 'Your browser does not support the HTML5 Video element.']
+            ['pathPrefix' => 'videos/', 'poster' => 'poster.jpg', 'text' => 'Your browser does not support the HTML5 Video element.'],
         );
         $expected = [
             'video' => ['poster' => Configure::read('App.imageBaseUrl') . 'poster.jpg'],
@@ -2017,7 +2017,7 @@ class HtmlHelperTest extends TestCase
         $this->assertHtml($expected, $result);
 
         $result = $this->Html->media(
-            [['src' => 'video.mov', 'type' => 'video/mp4'], 'video.webm']
+            [['src' => 'video.mov', 'type' => 'video/mp4'], 'video.webm'],
         );
         $expected = [
             '<video',

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -123,7 +123,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertSame(
             $this->Paginator,
             $result,
-            'Setting should return the same object'
+            'Setting should return the same object',
         );
 
         $result = $this->Paginator->getTemplates();
@@ -540,7 +540,7 @@ class PaginatorHelperTest extends TestCase
                 'direction' => 'asc',
                 'page' => 1,
                 'scope' => 'tags',
-            ]
+            ],
         ));
 
         $result = $this->Paginator->sort('tag', 'Tag', ['model' => 'Tags']);
@@ -1812,7 +1812,7 @@ class PaginatorHelperTest extends TestCase
         $this->assertStringContainsString(
             '<li',
             $this->Paginator->templater()->get('current'),
-            'Templates were not restored.'
+            'Templates were not restored.',
         );
     }
 

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -102,7 +102,7 @@ class TimeHelperTest extends TestCase
         $timestamp = strtotime('+2 weeks');
         $result = $Time->timeAgoInWords(
             $timestamp,
-            ['end' => '1 years', 'element' => 'div']
+            ['end' => '1 years', 'element' => 'div'],
         );
         $expected = [
             'div' => [
@@ -559,7 +559,7 @@ class TimeHelperTest extends TestCase
     {
         $this->assertSame(
             str_replace([',', '(', ')', ' at', ' à'], '', $expected),
-            str_replace([',', '(', ')', ' at', ' à'], '', $result)
+            str_replace([',', '(', ')', ' at', ' à'], '', $result),
         );
     }
 

--- a/tests/TestCase/View/Helper/UrlHelperTest.php
+++ b/tests/TestCase/View/Helper/UrlHelperTest.php
@@ -137,7 +137,7 @@ class UrlHelperTest extends TestCase
         $this->assertSame('/magazine/subscribe', $this->Helper->build());
         $this->assertSame(
             '/magazine/articles/add',
-            $this->Helper->build(['controller' => 'Articles', 'action' => 'add'])
+            $this->Helper->build(['controller' => 'Articles', 'action' => 'add']),
         );
     }
 
@@ -355,7 +355,7 @@ class UrlHelperTest extends TestCase
     {
         $result = $this->Helper->script(
             'post.js',
-            ['fullBase' => true]
+            ['fullBase' => true],
         );
         $this->assertSame(Router::fullBaseUrl() . '/js/post.js', $result);
     }
@@ -472,7 +472,7 @@ class UrlHelperTest extends TestCase
     {
         $request = $this->View->getRequest()->withAttribute('webroot', '/');
         $this->View->setRequest(
-            $request
+            $request,
         );
         Router::setRequest($request);
         $result = $this->Helper->webroot('/img/cake.power.gif');

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -194,7 +194,7 @@ class HelperRegistryTest extends TestCase
         $this->assertInstanceOf(
             OtherHelperHelper::class,
             $this->Helpers->get('thing.helper'),
-            'Class is wrong'
+            'Class is wrong',
         );
         $this->assertTrue($this->Helpers->has('thing.helper'));
         $this->assertFalse($this->Helpers->has('thing'));
@@ -215,7 +215,7 @@ class HelperRegistryTest extends TestCase
         $this->assertSame(
             $instance,
             $this->Helpers->EventListenerTest,
-            'Instance in registry should be the same as previously loaded'
+            'Instance in registry should be the same as previously loaded',
         );
         $this->assertCount(1, $this->Events->listeners('View.beforeRender'));
 
@@ -236,7 +236,7 @@ class HelperRegistryTest extends TestCase
         $this->assertSame(
             $instance,
             $this->Helpers->EventListenerTest,
-            'Instance in registry should be the same as previously loaded'
+            'Instance in registry should be the same as previously loaded',
         );
         $this->assertCount(1, $this->Events->listeners('View.beforeRender'));
 

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -62,7 +62,7 @@ class StringTemplateTest extends TestCase
         $this->assertSame(
             $this->template,
             $result,
-            'The same instance should be returned'
+            'The same instance should be returned',
         );
 
         $this->assertSame($templates['link'], $this->template->get('link'));
@@ -218,14 +218,14 @@ class StringTemplateTest extends TestCase
         $result = $this->template->formatAttributes($attrs);
         $this->assertSame(
             ' disabled="disabled" selected="selected" checked="checked" multiple="multiple"',
-            $result
+            $result,
         );
 
         $attrs = ['disabled' => false, 'selected' => 0, 'checked' => '0', 'multiple' => null];
         $result = $this->template->formatAttributes($attrs);
         $this->assertSame(
             '',
-            $result
+            $result,
         );
     }
 
@@ -238,28 +238,28 @@ class StringTemplateTest extends TestCase
         $result = $this->template->formatAttributes($attrs);
         $this->assertSame(
             ' name="bruce" data-hero="&lt;batman&gt;" spellcheck="true"',
-            $result
+            $result,
         );
 
         $attrs = ['escape' => false, 'name' => 'bruce', 'data-hero' => '<batman>'];
         $result = $this->template->formatAttributes($attrs);
         $this->assertSame(
             ' name="bruce" data-hero="<batman>"',
-            $result
+            $result,
         );
 
         $attrs = ['name' => 'bruce', 'data-hero' => '<batman>'];
         $result = $this->template->formatAttributes($attrs, ['name']);
         $this->assertSame(
             ' data-hero="&lt;batman&gt;"',
-            $result
+            $result,
         );
 
         $attrs = ['name' => 'bruce', 'data-hero' => '<batman>', 'templateVars' => ['foo' => 'bar']];
         $result = $this->template->formatAttributes($attrs, ['name']);
         $this->assertSame(
             ' data-hero="&lt;batman&gt;"',
-            $result
+            $result,
         );
 
         $evilKey = '><script>alert(1)</script>';
@@ -268,7 +268,7 @@ class StringTemplateTest extends TestCase
         $result = $this->template->formatAttributes($attrs);
         $this->assertSame(
             ' &gt;&lt;script&gt;alert(1)&lt;/script&gt;="some value"',
-            $result
+            $result,
         );
     }
 
@@ -281,7 +281,7 @@ class StringTemplateTest extends TestCase
         $result = $this->template->formatAttributes($attrs);
         $this->assertSame(
             ' name="bruce wayne"',
-            $result
+            $result,
         );
     }
 
@@ -381,7 +381,7 @@ class StringTemplateTest extends TestCase
                 'type' => 'text',
             ],
             'new_class',
-            'class'
+            'class',
         );
         $this->assertEquals($result, [
             'class' => ['current_class', 'new_class'],
@@ -396,7 +396,7 @@ class StringTemplateTest extends TestCase
                 'type' => 'text',
             ],
             'new_class',
-            'my_class'
+            'my_class',
         );
         $this->assertEquals($result, [
             'other_index1' => false,
@@ -412,7 +412,7 @@ class StringTemplateTest extends TestCase
                 ],
             ],
             'new_class',
-            'nonexistent'
+            'nonexistent',
         );
         $this->assertEquals($result, [
             'class' => [

--- a/tests/TestCase/View/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/StringTemplateTraitTest.php
@@ -54,7 +54,7 @@ class StringTemplateTraitTest extends TestCase
                 'text' => '<p>{{text}}</p>',
             ],
             $this->Template->getTemplates(),
-            'newly added template should be included in template list'
+            'newly added template should be included in template list',
         );
     }
 
@@ -65,7 +65,7 @@ class StringTemplateTraitTest extends TestCase
     {
         $this->Template->setConfig(
             'templates.text',
-            '<p>{{text}}</p>'
+            '<p>{{text}}</p>',
         );
 
         $this->assertEquals(
@@ -73,7 +73,7 @@ class StringTemplateTraitTest extends TestCase
                 'text' => '<p>{{text}}</p>',
             ],
             $this->Template->getTemplates(),
-            'Configured templates should be included in template list'
+            'Configured templates should be included in template list',
         );
     }
 
@@ -91,7 +91,7 @@ class StringTemplateTraitTest extends TestCase
         ]);
         $this->assertSame(
             '<p>CakePHP</p>',
-            $result
+            $result,
         );
     }
 

--- a/tests/TestCase/View/ViewBuilderTest.php
+++ b/tests/TestCase/View/ViewBuilderTest.php
@@ -55,14 +55,14 @@ class ViewBuilderTest extends TestCase
         $builder->setVars($update);
         $this->assertEquals(
             ['foo' => 'bar', 'test' => 'updated'],
-            $builder->getVars()
+            $builder->getVars(),
         );
 
         $update = ['overwrite' => 'yes'];
         $builder->setVars($update, false);
         $this->assertEquals(
             ['overwrite' => 'yes'],
-            $builder->getVars()
+            $builder->getVars(),
         );
     }
 
@@ -230,7 +230,7 @@ class ViewBuilderTest extends TestCase
         $view = $builder->build(
             $request,
             $response,
-            $events
+            $events,
         );
         $this->assertInstanceOf(AjaxView::class, $view);
         $this->assertSame('edit', $view->getTemplate());

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -974,8 +974,8 @@ class ViewTest extends TestCase
                     })],
                     [$this->callback(function (EventInterface $event) {
                         return $event->getName() === 'View.afterLayout';
-                    })]
-                )
+                    })],
+                ),
             );
 
         $View->render('index');
@@ -1033,7 +1033,7 @@ class ViewTest extends TestCase
         $this->assertEquals(['Form', 'Number', 'Html'], $attached);
 
         $this->PostsController->viewBuilder()->addHelpers(
-            ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper']
+            ['Html', 'Form', 'Number', 'TestPlugin.PluggedHelper'],
         );
         $View = $this->PostsController->createView(TestView::class);
         $View->setTemplatePath($this->PostsController->getName());
@@ -1061,7 +1061,7 @@ class ViewTest extends TestCase
 
         $this->PostsController->viewBuilder()->addHelpers(['Html']);
         $this->PostsController->setRequest(
-            $this->PostsController->getRequest()->withParam('action', 'index')
+            $this->PostsController->getRequest()->withParam('action', 'index'),
         );
         Configure::write('Cache.check', true);
 
@@ -1332,7 +1332,7 @@ class ViewTest extends TestCase
     public function testBlockSetObjectWithoutToString(): void
     {
         $this->checkException(
-            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
+            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string',
         );
 
         $objectWithToString = new TestObjectWithoutToString();
@@ -1384,7 +1384,7 @@ class ViewTest extends TestCase
     public function testBlockAppendObjectWithoutToString(): void
     {
         $this->checkException(
-            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
+            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string',
         );
 
         $object = new TestObjectWithoutToString();
@@ -1414,7 +1414,7 @@ class ViewTest extends TestCase
     public function testBlockPrependObjectWithoutToString(): void
     {
         $this->checkException(
-            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string'
+            'Object of class ' . TestObjectWithoutToString::class . ' could not be converted to string',
         );
 
         $object = new TestObjectWithoutToString();

--- a/tests/TestCase/View/Widget/FileWidgetTest.php
+++ b/tests/TestCase/View/Widget/FileWidgetTest.php
@@ -112,7 +112,7 @@ class FileWidgetTest extends TestCase
 
         $this->assertEquals(
             ['image'],
-            $input->secureFields($data)
+            $input->secureFields($data),
         );
     }
 }

--- a/tests/TestCase/View/Widget/RadioWidgetTest.php
+++ b/tests/TestCase/View/Widget/RadioWidgetTest.php
@@ -716,11 +716,11 @@ class RadioWidgetTest extends TestCase
         $result = $radio->render($data, $this->context);
         $this->assertStringContainsString(
             '<div class="radio"><input type="radio"',
-            $result
+            $result,
         );
         $this->assertStringContainsString(
             '</label></div>',
-            $result
+            $result,
         );
     }
 

--- a/tests/TestCase/View/Widget/WidgetLocatorTest.php
+++ b/tests/TestCase/View/Widget/WidgetLocatorTest.php
@@ -77,7 +77,7 @@ class WidgetLocatorTest extends TestCase
         $inputs = new WidgetLocator(
             $this->templates,
             $this->view,
-            ['test' => [TestUsingViewWidget::class, '_view']]
+            ['test' => [TestUsingViewWidget::class, '_view']],
         );
 
         /** @var \TestApp\View\Widget\TestUsingViewWidget $widget */

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -326,7 +326,7 @@ class XmlViewTest extends TestCase
         $this->assertSame(
             '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
             . '<response><authors><id>1</id><name>mariano</name></authors></response>' . "\n",
-            $output
+            $output,
         );
         $this->assertSame('application/xml', $View->getResponse()->getType());
     }

--- a/tests/test_app/Plugin/TestPlugin/config/routes.php
+++ b/tests/test_app/Plugin/TestPlugin/config/routes.php
@@ -9,6 +9,6 @@ return function (RouteBuilder $routes): void {
     $routes->get(
         '/test_plugin',
         ['controller' => 'TestPlugin', 'plugin' => 'TestPlugin', 'action' => 'index'],
-        'test_plugin:index'
+        'test_plugin:index',
     );
 };

--- a/tests/test_app/TestApp/Controller/DependenciesController.php
+++ b/tests/test_app/TestApp/Controller/DependenciesController.php
@@ -20,7 +20,7 @@ class DependenciesController extends Controller
         ?ServerRequest $request = null,
         ?string $name = null,
         ?EventManagerInterface $eventManager = null,
-        ?stdClass $inject = null
+        ?stdClass $inject = null,
     ) {
         parent::__construct($request, $name, $eventManager);
         $this->inject = $inject;
@@ -46,7 +46,7 @@ class DependenciesController extends Controller
     {
         return $this->response->withStringBody(json_encode(
             compact('one', 'two', 'three', 'four'),
-            JSON_PRESERVE_ZERO_FRACTION
+            JSON_PRESERVE_ZERO_FRACTION,
         ));
     }
 

--- a/tests/test_app/TestApp/Controller/UnionDependenciesController.php
+++ b/tests/test_app/TestApp/Controller/UnionDependenciesController.php
@@ -23,7 +23,7 @@ class UnionDependenciesController extends Controller
         ?string $name = null,
         ?EventManagerInterface $eventManager = null,
         ?ComponentRegistry $components = null,
-        ?stdClass $inject = null
+        ?stdClass $inject = null,
     ) {
         parent::__construct($request, $response, $name, $eventManager, $components);
         $this->inject = $inject;

--- a/tests/test_app/TestApp/Database/Type/ColumnSchemaAwareType.php
+++ b/tests/test_app/TestApp/Database/Type/ColumnSchemaAwareType.php
@@ -56,14 +56,14 @@ class ColumnSchemaAwareType extends BaseType implements ExpressionTypeInterface,
                     new FunctionExpression('LOWER', [$value]),
                     'should be',
                     'has been',
-                ]
+                ],
             );
         }
 
         throw new InvalidArgumentException(sprintf(
             'The `$value` argument must be an instance of `\%s`, or a string, `%s` given.',
             ColumnSchemaAwareTypeValueObject::class,
-            get_debug_type($value)
+            get_debug_type($value),
         ));
     }
 

--- a/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
+++ b/tests/test_app/TestApp/Database/Type/OrderedUuidType.php
@@ -34,13 +34,13 @@ class OrderedUuidType extends BaseType implements ExpressionTypeInterface
             return new FunctionExpression(
                 'SUBSTR',
                 $length === null ? [$value, $start] : [$value, $start, $length],
-                ['string', 'integer', 'integer']
+                ['string', 'integer', 'integer'],
             );
         };
 
         return new FunctionExpression(
             'CONCAT',
-            [$substr(15, 4), $substr(10, 4), $substr(1, 8), $substr(20, 4), $substr(25)]
+            [$substr(15, 4), $substr(10, 4), $substr(1, 8), $substr(20, 4), $substr(25)],
         );
     }
 

--- a/tests/test_app/TestApp/Datasource/StubFactory.php
+++ b/tests/test_app/TestApp/Datasource/StubFactory.php
@@ -19,7 +19,7 @@ class StubFactory implements LocatorInterface
         if (!isset($this->instances[$alias])) {
             throw new MissingModelException(sprintf(
                 'Model class "%s" of type "Test" could not be found.',
-                $alias
+                $alias,
             ));
         }
 

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -27,7 +27,7 @@ return function (RouteBuilder $routes): void {
             [
                 '_name' => 'some_alias',
                 'routeClass' => 'InflectedRoute',
-            ]
+            ],
         );
         $routes->fallbacks();
     });


### PR DESCRIPTION
This would make CI green for
https://github.com/cakephp/cakephp-codesniffer/pull/369
update

and allows less merge conflicts in the future, and to be in sync with
https://www.php-fig.org/per/coding-style/#26-trailing-commas

I checked and these changes and additional rules are additive.
That means the old standard would not complain about it, all stays green.
And so we can apply them to 5.x and merge upstream.
We can also apply them to 5.next directly, but then we lose some of the usefulness of less merge conflicts in the future.
The current conflicts are about ~13 files, so managable.