### PR TITLE
Fix `Client\Request` mangling the `Content-Type` header.

### DIFF
--- a/src/Http/Client/Request.php
+++ b/src/Http/Client/Request.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Http\Client;
 
+use Cake\Utility\Xml;
 use Laminas\Diactoros\RequestTrait;
 use Laminas\Diactoros\Stream;
 use Psr\Http\Message\RequestInterface;
@@ -90,12 +91,21 @@ class Request extends Message implements RequestInterface
     protected function setContent(array|string $content)
     {
         if (is_array($content)) {
-            $formData = new FormData();
-            $formData->addMany($content);
-            /** @phpstan-var array<non-empty-string, non-empty-string> $headers */
-            $headers = ['Content-Type' => $formData->contentType()];
-            $this->addHeaders($headers);
-            $content = (string)$formData;
+            $contentType = $this->getHeaderLine('content-type');
+
+            if (str_contains($contentType, 'application/json')) {
+                $content = json_encode($content, JSON_THROW_ON_ERROR);
+            } elseif (str_contains($contentType, 'application/xml')) {
+                /** @phpstan-ignore-next-line */
+                $content = (string)Xml::fromArray($content);
+            } else {
+                $formData = new FormData();
+                $formData->addMany($content);
+                /** @phpstan-var array<non-empty-string, non-empty-string> $headers */
+                $headers = ['Content-Type' => $formData->contentType()];
+                $this->addHeaders($headers);
+                $content = (string)$formData;
+            }
         }
 
         $stream = new Stream('php://memory', 'rw');

--- a/tests/TestCase/Http/Client/Adapter/StreamTest.php
+++ b/tests/TestCase/Http/Client/Adapter/StreamTest.php
@@ -174,18 +174,16 @@ class StreamTest extends TestCase
         $request = new Request(
             'http://localhost',
             'GET',
-            [
-                'Content-Type' => 'application/json',
-            ],
+            [],
             ['a' => 'my value'],
         );
 
         $this->stream->send($request, []);
         $result = $this->stream->contextOptions();
         $expected = [
-            'Content-Type: application/x-www-form-urlencoded',
             'Connection: close',
             'User-Agent: CakePHP',
+            'Content-Type: application/x-www-form-urlencoded',
         ];
         $this->assertStringStartsWith(implode("\r\n", $expected), $result['header']);
         $this->assertStringContainsString('a=my+value', $result['content']);
@@ -200,7 +198,7 @@ class StreamTest extends TestCase
         $request = new Request(
             'http://localhost',
             'GET',
-            ['Content-Type' => 'application/json'],
+            [],
             ['upload' => fopen(CORE_PATH . 'VERSION.txt', 'r')],
         );
 

--- a/tests/TestCase/Http/Client/RequestTest.php
+++ b/tests/TestCase/Http/Client/RequestTest.php
@@ -50,7 +50,7 @@ class RequestTest extends TestCase
     #[DataProvider('additionProvider')]
     public function testMethods(array $headers, $data, $method): void
     {
-        $request = new Request('http://example.com', $method, $headers, json_encode($data));
+        $request = new Request('http://example.com', $method, $headers, $data);
 
         $this->assertSame($request->getMethod(), $method);
         $this->assertSame('http://example.com', (string)$request->getUri());
@@ -58,7 +58,6 @@ class RequestTest extends TestCase
         $this->assertSame(json_encode($data), $request->getBody()->__toString());
     }
 
-    #[DataProvider('additionProvider')]
     public static function additionProvider(): array
     {
         $headers = [
@@ -81,7 +80,6 @@ class RequestTest extends TestCase
     public function testConstructorArrayData(): void
     {
         $headers = [
-            'Content-Type' => 'application/json',
             'Authorization' => 'Bearer valid-token',
         ];
         $data = ['a' => 'b', 'c' => 'd'];
@@ -91,6 +89,15 @@ class RequestTest extends TestCase
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
         $this->assertSame('a=b&c=d', $request->getBody()->__toString());
+
+        $headers = [
+            'Content-Type' => 'application/xml',
+        ];
+        $data = ['tag' => 'value'];
+        $request = new Request('http://example.com', 'POST', $headers, $data);
+
+        $this->assertSame('application/xml', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('value', $request->getBody()->__toString());
     }
 
     /**
@@ -99,7 +106,6 @@ class RequestTest extends TestCase
     public function testConstructorArrayNestedData(): void
     {
         $headers = [
-            'Content-Type' => 'application/json',
             'Authorization' => 'Bearer valid-token',
         ];
         $data = ['a' => 'b', 'c' => ['foo', 'bar']];


### PR DESCRIPTION
It now correctly handles serializing data array to JSON or XML based on the `Content-Type` header.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
