### PR TITLE
Use REQUEST_URI instead of PATH_INFO

### DIFF
--- a/src/Http/UriFactory.php
+++ b/src/Http/UriFactory.php
@@ -55,14 +55,7 @@ class UriFactory implements UriFactoryInterface
         $uri = DiactorosUriFactory::createFromSapi($server, $headers);
         ['base' => $base, 'webroot' => $webroot] = static::getBase($uri, $server);
 
-        // Look in PATH_INFO first, as this is the exact value we need prepared
-        // by PHP.
-        $pathInfo = $server['PATH_INFO'] ?? null;
-        if ($pathInfo) {
-            $uri = $uri->withPath($pathInfo);
-        } else {
-            $uri = static::updatePath($base, $uri);
-        }
+        $uri = static::updatePath($base, $uri);
 
         if (!$uri->getHost()) {
             $uri = $uri->withHost('localhost');
@@ -90,12 +83,19 @@ class UriFactory implements UriFactoryInterface
         if (!$path || $path === '/' || $path === '//' || $path === '/index.php') {
             $path = '/';
         }
-        $endsWithIndex = '/' . (Configure::read('App.webroot') ?: 'webroot') . '/index.php';
-        $endsWithLength = strlen($endsWithIndex);
-        if (
-            strlen($path) >= $endsWithLength &&
-            substr($path, -$endsWithLength) === $endsWithIndex
-        ) {
+
+        // Check for $webroot/index.php at the start and end of the path.
+        $search = '';
+        if ($path[0] === '/') {
+            $search .= '/';
+        }
+        $search .= (Configure::read('App.webroot') ?: 'webroot') . '/index.php';
+        if (str_starts_with($path, $search)) {
+            $path = substr($path, strlen($search));
+        } elseif (str_ends_with($path, $search)) {
+            $path = '/';
+        }
+        if (!$path) {
             $path = '/';
         }
 
@@ -135,9 +135,9 @@ class UriFactory implements UriFactoryInterface
             // Clean up additional / which cause following code to fail..
             $base = (string)preg_replace('#/+#', '/', $base);
 
-            $indexPos = strpos($base, '/' . $webroot . '/index.php');
+            $indexPos = strpos($base, '/index.php');
             if ($indexPos !== false) {
-                $base = substr($base, 0, $indexPos) . '/' . $webroot;
+                $base = substr($base, 0, $indexPos);
             }
             if ($webroot === basename($base)) {
                 $base = dirname($base);

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -136,11 +136,19 @@ class RouteCollection
     public function parseRequest(ServerRequestInterface $request): array
     {
         $uri = $request->getUri();
-        $urlPath = urldecode($uri->getPath());
+        $urlPath = $uri->getPath();
+        if (strpos($urlPath, '%') !== false) {
+            // decode urlencoded segments, but don't decode %2f aka /
+            $parts = explode('/', $urlPath);
+            $parts = array_map(
+                fn (string $part) => str_replace('/', '%2f', urldecode($part)),
+                $parts
+            );
+            $urlPath = implode('/', $parts);
+        }
         if ($urlPath !== '/') {
             $urlPath = rtrim($urlPath, '/');
         }
-
         if (isset($this->staticPaths[$urlPath])) {
             foreach ($this->staticPaths[$urlPath] as $route) {
                 $r = $route->parseRequest($request);

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -124,6 +124,23 @@ class ServerRequestFactoryTest extends TestCase
     }
 
     /**
+     * Test fromGlobals with urlencoded path separators
+     */
+    public function testFromGlobalsUrlEncoded(): void
+    {
+        $server = [
+            'DOCUMENT_ROOT' => '/cake/repo/branches/webroot',
+            'PHP_SELF' => '/index.php',
+            'REQUEST_URI' => '/posts%2fadd',
+        ];
+        $res = ServerRequestFactory::fromGlobals($server);
+
+        $this->assertSame('', $res->getAttribute('base'));
+        $this->assertSame('/', $res->getAttribute('webroot'));
+        $this->assertSame('/posts%2fadd', $res->getUri()->getPath());
+    }
+
+    /**
      * Test fromGlobals with mod-rewrite server configuration.
      */
     public function testFromGlobalsUrlModRewrite(): void
@@ -144,7 +161,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = ServerRequestFactory::fromGlobals([
             'DOCUMENT_ROOT' => '/cake/repo/branches',
             'PHP_SELF' => '/1.2.x.x/webroot/index.php',
-            'PATH_INFO' => '/posts/view/1',
+            'REQUEST_URI' => '/posts/view/1',
         ]);
         $this->assertSame('/1.2.x.x', $request->getAttribute('base'));
         $this->assertSame('/1.2.x.x/', $request->getAttribute('webroot'));
@@ -276,23 +293,6 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame('/cakephp', $request->getAttribute('base'));
         $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
         $this->assertSame('/bananas/eat/tasty_banana', $request->getRequestTarget());
-    }
-
-    /**
-     * Test that even if mod_rewrite is on, and the url contains index.php
-     * and there are numerous //s that the base/webroot is calculated correctly.
-     */
-    public function testBaseUrlWithModRewriteAndExtraSlashes(): void
-    {
-        $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/cakephp/webroot///index.php/bananas/eat',
-            'PHP_SELF' => '/cakephp/webroot///index.php/bananas/eat',
-            'PATH_INFO' => '/bananas/eat',
-        ]);
-
-        $this->assertSame('/cakephp', $request->getAttribute('base'));
-        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertSame('/bananas/eat', $request->getRequestTarget());
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1048,7 +1048,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
-                'PATH_INFO' => '/forward',
+                'REQUEST_URI' => '/forward',
             ],
         ]);
         $result = $route->parseRequest($request);
@@ -1069,7 +1069,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'a.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $route->parseRequest($request);
@@ -1085,7 +1085,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'foo.bar.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $route->parseRequest($request);
@@ -1760,7 +1760,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'a.example.com',
-                'PATH_INFO' => '/reviews',
+                'REQUEST_URI' => '/reviews',
             ],
         ]);
         $this->assertNull($route->parseRequest($request));

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -359,7 +359,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'a.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $this->collection->parseRequest($request);
@@ -376,7 +376,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'foo.bar.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $this->collection->parseRequest($request);
@@ -386,7 +386,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'example.test.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         try {
@@ -429,7 +429,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => $host,
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $this->collection->parseRequest($request);
@@ -555,6 +555,20 @@ class RouteCollectionTest extends TestCase
         $result = $this->collection->parseRequest($request);
         unset($result['_route']);
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test parsing routes that match non-ascii urls
+     */
+    public function testParseRequestNoDecode2f(): void
+    {
+        $routes = new RouteBuilder($this->collection, '/b', []);
+        $routes->connect('/media/confirm', ['controller' => 'Media', 'action' => 'confirm']);
+
+        $request = new ServerRequest(['url' => '/b/media%2fconfirm']);
+
+        $this->expectException(MissingRouteException::class);
+        $this->collection->parseRequest($request);
     }
 
     /**


### PR DESCRIPTION
Switch to using REQUEST_URI (via diactoros/Uri) instead of reading from PATH_INFO. The PATH_INFO value includes URL decoding which can allow encoded URLs to match routes when they shouldn't.

I'll back port this to 4.x once we're happy with it.

