### PR TITLE
Use REQUEST_URI instead of PATH_INFO (#18050)

### DIFF
--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -247,14 +247,7 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
         $uri = marshalUriFromSapi($server, $headers);
         [$base, $webroot] = static::getBase($uri, $server);
 
-        // Look in PATH_INFO first, as this is the exact value we need prepared
-        // by PHP.
-        $pathInfo = Hash::get($server, 'PATH_INFO');
-        if ($pathInfo) {
-            $uri = $uri->withPath($pathInfo);
-        } else {
-            $uri = static::updatePath($base, $uri);
-        }
+        $uri = static::updatePath($base, $uri);
 
         if (!$uri->getHost()) {
             $uri = $uri->withHost('localhost');
@@ -282,12 +275,18 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
         if (empty($path) || $path === '/' || $path === '//' || $path === '/index.php') {
             $path = '/';
         }
-        $endsWithIndex = '/' . (Configure::read('App.webroot') ?: 'webroot') . '/index.php';
-        $endsWithLength = strlen($endsWithIndex);
-        if (
-            strlen($path) >= $endsWithLength &&
-            substr($path, -$endsWithLength) === $endsWithIndex
-        ) {
+        // Check for $webroot/index.php at the start and end of the path.
+        $search = '';
+        if ($path[0] === '/') {
+            $search .= '/';
+        }
+        $search .= (Configure::read('App.webroot') ?: 'webroot') . '/index.php';
+        if (str_starts_with($path, $search)) {
+            $path = substr($path, strlen($search));
+        } elseif (str_ends_with($path, $search)) {
+            $path = '/';
+        }
+        if (!$path) {
             $path = '/';
         }
 
@@ -321,9 +320,9 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             // Clean up additional / which cause following code to fail..
             $base = preg_replace('#/+#', '/', $base);
 
-            $indexPos = strpos($base, '/' . $webroot . '/index.php');
+            $indexPos = strpos($base, '/index.php');
             if ($indexPos !== false) {
-                $base = substr($base, 0, $indexPos) . '/' . $webroot;
+                $base = substr($base, 0, $indexPos);
             }
             if ($webroot === basename($base)) {
                 $base = dirname($base);

--- a/src/Http/ServerRequestFactory.php
+++ b/src/Http/ServerRequestFactory.php
@@ -281,9 +281,9 @@ abstract class ServerRequestFactory implements ServerRequestFactoryInterface
             $search .= '/';
         }
         $search .= (Configure::read('App.webroot') ?: 'webroot') . '/index.php';
-        if (str_starts_with($path, $search)) {
+        if (strpos($path, $search) === 0) {
             $path = substr($path, strlen($search));
-        } elseif (str_ends_with($path, $search)) {
+        } elseif (substr($path, -strlen($search)) === $search) {
             $path = '/';
         }
         if (!$path) {

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -204,11 +204,19 @@ class RouteCollection
     public function parseRequest(ServerRequestInterface $request): array
     {
         $uri = $request->getUri();
-        $urlPath = urldecode($uri->getPath());
+        $urlPath = $uri->getPath();
+        if (strpos($urlPath, '%') !== false) {
+            // decode urlencoded segments, but don't decode %2f aka /
+            $parts = explode('/', $urlPath);
+            $parts = array_map(
+                fn (string $part) => str_replace('/', '%2f', urldecode($part)),
+                $parts
+            );
+            $urlPath = implode('/', $parts);
+        }
         if ($urlPath !== '/') {
             $urlPath = rtrim($urlPath, '/');
         }
-
         if (isset($this->staticPaths[$urlPath])) {
             foreach ($this->staticPaths[$urlPath] as $route) {
                 $r = $route->parseRequest($request);

--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -121,6 +121,23 @@ class ServerRequestFactoryTest extends TestCase
     }
 
     /**
+     * Test fromGlobals with urlencoded path separators
+     */
+    public function testFromGlobalsUrlEncoded(): void
+    {
+        $server = [
+            'DOCUMENT_ROOT' => '/cake/repo/branches/webroot',
+            'PHP_SELF' => '/index.php',
+            'REQUEST_URI' => '/posts%2fadd',
+        ];
+        $res = ServerRequestFactory::fromGlobals($server);
+
+        $this->assertSame('', $res->getAttribute('base'));
+        $this->assertSame('/', $res->getAttribute('webroot'));
+        $this->assertSame('/posts%2fadd', $res->getUri()->getPath());
+    }
+
+    /**
      * Test fromGlobals with mod-rewrite server configuration.
      */
     public function testFromGlobalsUrlModRewrite(): void
@@ -141,7 +158,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = ServerRequestFactory::fromGlobals([
             'DOCUMENT_ROOT' => '/cake/repo/branches',
             'PHP_SELF' => '/1.2.x.x/webroot/index.php',
-            'PATH_INFO' => '/posts/view/1',
+            'REQUEST_URI' => '/posts/view/1',
         ]);
         $this->assertSame('/1.2.x.x', $request->getAttribute('base'));
         $this->assertSame('/1.2.x.x/', $request->getAttribute('webroot'));
@@ -273,23 +290,6 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame('/cakephp', $request->getAttribute('base'));
         $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
         $this->assertSame('/bananas/eat/tasty_banana', $request->getRequestTarget());
-    }
-
-    /**
-     * Test that even if mod_rewrite is on, and the url contains index.php
-     * and there are numerous //s that the base/webroot is calculated correctly.
-     */
-    public function testBaseUrlWithModRewriteAndExtraSlashes(): void
-    {
-        $request = ServerRequestFactory::fromGlobals([
-            'REQUEST_URI' => '/cakephp/webroot///index.php/bananas/eat',
-            'PHP_SELF' => '/cakephp/webroot///index.php/bananas/eat',
-            'PATH_INFO' => '/bananas/eat',
-        ]);
-
-        $this->assertSame('/cakephp', $request->getAttribute('base'));
-        $this->assertSame('/cakephp/', $request->getAttribute('webroot'));
-        $this->assertSame('/bananas/eat', $request->getRequestTarget());
     }
 
     /**

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -1062,7 +1062,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'REQUEST_METHOD' => 'GET',
-                'PATH_INFO' => '/forward',
+                'REQUEST_URI' => '/forward',
             ],
         ]);
         $result = $route->parseRequest($request);
@@ -1083,7 +1083,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'a.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $route->parseRequest($request);
@@ -1099,7 +1099,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'foo.bar.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $route->parseRequest($request);
@@ -1791,7 +1791,7 @@ class RouteTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'a.example.com',
-                'PATH_INFO' => '/reviews',
+                'REQUEST_URI' => '/reviews',
             ],
         ]);
         $this->assertNull($route->parseRequest($request));

--- a/tests/TestCase/Routing/RouteCollectionTest.php
+++ b/tests/TestCase/Routing/RouteCollectionTest.php
@@ -367,7 +367,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'a.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $this->collection->parseRequest($request);
@@ -384,7 +384,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'foo.bar.example.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $result = $this->collection->parseRequest($request);
@@ -394,7 +394,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => 'example.test.com',
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         try {
@@ -438,7 +438,7 @@ class RouteCollectionTest extends TestCase
         $request = new ServerRequest([
             'environment' => [
                 'HTTP_HOST' => $host,
-                'PATH_INFO' => '/fallback',
+                'REQUEST_URI' => '/fallback',
             ],
         ]);
         $this->collection->parseRequest($request);
@@ -564,6 +564,20 @@ class RouteCollectionTest extends TestCase
         $result = $this->collection->parseRequest($request);
         unset($result['_route']);
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test parsing routes that match non-ascii urls
+     */
+    public function testParseRequestNoDecode2f(): void
+    {
+        $routes = new RouteBuilder($this->collection, '/b', []);
+        $routes->connect('/media/confirm', ['controller' => 'Media', 'action' => 'confirm']);
+
+        $request = new ServerRequest(['url' => '/b/media%2fconfirm']);
+
+        $this->expectException(MissingRouteException::class);
+        $this->collection->parseRequest($request);
     }
 
     /**


### PR DESCRIPTION
Switch to using REQUEST_URI (via diactoros/Uri) instead of reading from PATH_INFO. The PATH_INFO value includes URL decoding which can allow encoded URLs to match routes when they shouldn't.

Remove urldecode in RouteCollection

This was contributing to %2f getting through routing. We have to retain backwards compatibility with urlencoded path segements as users expect those to be exposed to application code in a decoded state.

Backport of #18050 to 4.x
