### PR TITLE
Try reenabling Redis tests for PHP 8.4

### DIFF
--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -40,7 +40,6 @@ class RedisEngineTest extends TestCase
     {
         parent::setUp();
         $this->skipIf(!class_exists('Redis'), 'Redis extension is not installed or configured properly.');
-        $this->skipIf(PHP_VERSION_ID >= 80400, 'redis.io currrently generates an error on PHP 8.4');
 
         $this->port = env('REDIS_PORT', $this->port);
 


### PR DESCRIPTION
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
