### PR TITLE
5.x: hide skipped tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,9 @@ jobs:
 
         if [[ ${{ matrix.php-version }} == '8.1' ]]; then
           export CODECOVERAGE=1
-          vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --display-skipped --coverage-clover=coverage.xml
-          CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --display-skipped --testsuite=database
-          vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --display-skipped --testsuite=globalfunctions --coverage-clover=coverage-functions.xml
+          vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --coverage-clover=coverage.xml
+          CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --testsuite=database
+          vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --testsuite=globalfunctions --coverage-clover=coverage-functions.xml
         else
           vendor/bin/phpunit --display-deprecations --display-warnings
           CAKE_TEST_AUTOQUOTE=1 vendor/bin/phpunit --display-deprecations --display-warnings --testsuite=database
@@ -172,14 +172,14 @@ jobs:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
           set CAKE_DISABLE_GLOBAL_FUNCS=1
-          vendor/bin/phpunit --display-incomplete --display-skipped
+          vendor/bin/phpunit --display-incomplete
 
     - name: Run PHPUnit (autoquote enabled)
       env:
         DB_URL: 'sqlserver://@(localdb)\MSSQLLocalDB/cakephp'
       run: |
           set CAKE_TEST_AUTOQUOTE=1
-          vendor/bin/phpunit --display-incomplete --display-skipped --testsuite=database
+          vendor/bin/phpunit --display-incomplete --testsuite=database
 
   cs-stan:
     name: Coding Standard & Static Analysis


### PR DESCRIPTION
displaying 100's of skipped tests for each PHP 8.1 version (and Windows) seems a bit unnecessary to me