### PR TITLE
Deprecate the `errorClass` config for FormHelper.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -76,7 +76,8 @@ class FormHelper extends Helper
      */
     protected array $_defaultConfig = [
         'idPrefix' => null,
-        'errorClass' => 'form-error',
+        // Deprecated option, use templates.errorClass intead.
+        'errorClass' => null,
         'typeMap' => [
             'string' => 'text',
             'text' => 'textarea',
@@ -164,6 +165,8 @@ class FormHelper extends Helper
             'selectedClass' => 'selected',
             // required class
             'requiredClass' => 'required',
+            // CSS class added to the input when the field has validation errors
+            'errorClass' => 'form-error',
         ],
         // set HTML5 validation message to custom required/empty messages
         'autoSetCustomValidity' => true,
@@ -2400,7 +2403,17 @@ class FormHelper extends Helper
         }
 
         if ($context->hasError($field)) {
-            $options = $this->addClass($options, $this->_config['errorClass']);
+            $errorClass = $this->getConfig('errorClass');
+            if ($errorClass !== null) {
+                deprecationWarning(
+                    '5.2.0',
+                    'The `errorClass` config is deprecated. Use the `templates.errorClass` template variable instead.',
+                );
+            } else {
+                $errorClass = $this->templater()->get('errorClass');
+            }
+
+            $options = $this->addClass($options, $errorClass);
         }
         $isDisabled = $this->_isDisabled($options);
         if ($isDisabled) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -45,6 +45,7 @@ use Cake\View\Widget\WidgetLocator;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use ReflectionProperty;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Enum\ArticleStatus;
@@ -2402,6 +2403,27 @@ class FormHelperTest extends TestCase
         ];
         $this->assertHtml($expected, $result);
 
+        $result = $this->Form->control('Article.title', ['templates' => ['errorClass' => 'danger']]);
+        $expected = [
+            'div' => ['class' => 'input text error'],
+            'label' => ['for' => 'article-title'],
+            'Title',
+            '/label',
+            'input' => [
+                'type' => 'text',
+                'name' => 'Article[title]',
+                'id' => 'article-title',
+                'class' => 'danger',
+                'aria-invalid' => 'true',
+                'aria-describedby' => 'article-title-error',
+            ],
+            ['div' => ['class' => 'error-message', 'id' => 'article-title-error']],
+            'error message',
+            '/div',
+            '/div',
+        ];
+        $this->assertHtml($expected, $result);
+
         $result = $this->Form->control('Article.user_id', [
             'type' => 'select',
             'options' => ['1' => 'One', '2' => 'Two'],
@@ -2517,6 +2539,44 @@ class FormHelperTest extends TestCase
             '/div',
         ];
         $this->assertHtml($expected, $result);
+    }
+
+    /**
+     * @deprecated
+     */
+    #[WithoutErrorHandler]
+    public function testWarningForDeprecatedErrorClassConfig(): void
+    {
+        $this->Form->setConfig('errorClass', 'danger');
+        $this->article['errors'] = [
+            'Article' => [
+                'title' => 'error message',
+            ],
+        ];
+        $this->Form->create($this->article);
+
+        $this->deprecated(function (): void {
+            $result = $this->Form->control('Article.title');
+            $expected = [
+                'div' => ['class' => 'input text error'],
+                'label' => ['for' => 'article-title'],
+                'Title',
+                '/label',
+                'input' => [
+                    'type' => 'text',
+                    'name' => 'Article[title]',
+                    'id' => 'article-title',
+                    'class' => 'danger',
+                    'aria-invalid' => 'true',
+                    'aria-describedby' => 'article-title-error',
+                ],
+                ['div' => ['class' => 'error-message', 'id' => 'article-title-error']],
+                'error message',
+                '/div',
+                '/div',
+            ];
+            $this->assertHtml($expected, $result);
+        });
     }
 
     /**


### PR DESCRIPTION
Use a template variable of the same name instead. This makes is it consistent with other template vars used for CSS classes.

Closes #18068.
<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
