### PR TITLE
Drop ORM.mapJsonTypeForSqlite config.

### DIFF
--- a/src/Database/Schema/SqliteSchemaDialect.php
+++ b/src/Database/Schema/SqliteSchemaDialect.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Database\Schema;
 
-use Cake\Core\Configure;
 use Cake\Database\Exception\DatabaseException;
 
 /**
@@ -143,10 +142,8 @@ class SqliteSchemaDialect extends SchemaDialect
             return ['type' => $col, 'length' => null];
         }
 
-        if (Configure::read('ORM.mapJsonTypeForSqlite') === true) {
-            if (str_contains($col, TableSchemaInterface::TYPE_JSON) && !str_contains($col, 'jsonb')) {
-                return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
-            }
+        if (str_contains($col, TableSchemaInterface::TYPE_JSON) && !str_contains($col, 'jsonb')) {
+            return ['type' => TableSchemaInterface::TYPE_JSON, 'length' => null];
         }
 
         if (in_array($col, TableSchemaInterface::GEOSPATIAL_TYPES)) {

--- a/tests/TestCase/Database/Driver/SqliteTest.php
+++ b/tests/TestCase/Database/Driver/SqliteTest.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Test\TestCase\Database\Driver;
 
-use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\DriverFeatureEnum;
@@ -231,7 +230,6 @@ class SqliteTest extends TestCase
 
     public function testJSON(): void
     {
-        Configure::write('ORM.mapJsonTypeForSqlite', true);
         $connection = ConnectionManager::get('test');
         $this->skipIf(!($connection->getDriver() instanceof Sqlite));
         assert($connection instanceof Connection);
@@ -244,7 +242,6 @@ class SqliteTest extends TestCase
         $table->save($entity);
         $result = $table->find()->first();
         $this->assertEquals($data, $result->data);
-        Configure::write('ORM.mapJsonTypeForSqlite', false);
     }
 
     /**


### PR DESCRIPTION
Columns with the string "json" in their names are now mapped to `JsonType` by default.

Closes #17972

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
