### PR TITLE
adjust ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         mysql root password: 'root'
 
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -129,6 +131,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Get date part for cache key
       id: key-date
@@ -191,6 +195,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
I ran https://github.com/woodruffw/zizmor on the current CI config and got the following output:
```
🌈 completed ci.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/kevin/Documents/CakePHP/Org/cakephp/.github/workflows/ci.yml:70:7
   |
70 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/kevin/Documents/CakePHP/Org/cakephp/.github/workflows/ci.yml:131:7
    |
131 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> /Users/kevin/Documents/CakePHP/Org/cakephp/.github/workflows/ci.yml:193:9
    |
193 |       - uses: actions/checkout@v4
    |         ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> /Users/kevin/Documents/CakePHP/Org/cakephp/.github/workflows/ci.yml:91:7
   |
91 |     - name: Setup problem matchers for PHPUnit
   |       ---------------------------------------- info: this step
92 |       if: matrix.php-version == '8.1' && matrix.db-type == 'mysql'
93 |       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
   |       ---------------------------------------------------------------- info: runner.tool_cache may expand into attacker-controllable code
   |
   = note: audit confidence → Low

17 findings (13 suppressed): 0 unknown, 1 informational, 0 low, 3 medium, 0 high
```

Don't know what to do with the last one, but its just a `informational` warning