### PR TITLE
Fix up strack trace for ErrorTrap handleError()

### DIFF
--- a/src/Error/ErrorTrap.php
+++ b/src/Error/ErrorTrap.php
@@ -121,7 +121,7 @@ class ErrorTrap
             throw new FatalErrorException($description, $code, $file, $line);
         }
 
-        $trace = (array)Debugger::trace(['start' => 1, 'format' => 'points']);
+        $trace = (array)Debugger::trace(['start' => 0, 'format' => 'points']);
         $error = new PhpError($code, $description, $file, $line, $trace);
 
         $ignoredPaths = (array)Configure::read('Error.ignoredDeprecationPaths');


### PR DESCRIPTION
for me the stack trace on latest 5.x is off on prod for some reason
PHP 8.3.12
```
Trying to access array offset on null
Request URL: /members/view/c81af5b8-a9de-4756-b8ec-1d6c21337c4
Client IP: 2003:fc:870d:3205:ede7:6c79:b679:c59
Trace:
/var/www/app/vendor/cakephp/cakephp/src/View/View.php /var/www/app/vendor/cakephp/cakephp/src/View/View.php, line 1188
Cake\View\View->_evaluate() /var/www/app/vendor/cakephp/cakephp/src/View/View.php, line 1145
```
If I change start 1 back to start 0 it works again and shows the actual template line.

Was this maybe forgotten to be fixed up with https://github.com/cakephp/cakephp/pull/16771 ?

Could there be other cases where we might need adjusting it?
And could it be depending on the PHP version?