### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,6 @@
     "suggest": {
         "ext-curl": "To enable more efficient network calls in Http\\Client.",
         "ext-openssl": "To use Security::encrypt() or have secure CSRF token generation.",
-        "lib-ICU": "To use locale-aware features in the I18n and Database packages",
         "paragonie/csp-builder": "CSP builder, to use the CSP Middleware"
     },
     "provide": {


### PR DESCRIPTION
Drop `lib-ICU` from `suggest` section. It's already a dependency to the `intl` module.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
