### PR TITLE
Remove test for defunct option

### DIFF
--- a/tests/TestCase/Http/ServerRequestFactoryTest.php
+++ b/tests/TestCase/Http/ServerRequestFactoryTest.php
@@ -1046,8 +1046,6 @@ class ServerRequestFactoryTest extends TestCase
      */
     public function testFromGlobalsWithFiles(): void
     {
-        $this->assertNull(Configure::read('App.uploadedFilesAsObjects'));
-
         $files = [
             'file' => [
                 'name' => 'file.txt',


### PR DESCRIPTION
`App.uploadedFilesAsObjects` config no longer exits.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
