### PR TITLE
5.next: port over `thephpleague/container`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "cakephp/cache": "self.version",
         "cakephp/collection": "self.version",
         "cakephp/console": "self.version",
+        "cakephp/container": "self.version",
         "cakephp/core": "self.version",
         "cakephp/database": "self.version",
         "cakephp/datasource": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,10 @@
             "Named\\": "tests/test_app/Plugin/Named/src/",
             "TestTheme\\": "tests/test_app/Plugin/TestTheme/src/",
             "PluginJs\\": "tests/test_app/Plugin/PluginJs/src/"
-        }
+        },
+        "files": [
+            "tests/TestCase/Container/Asset/function.php"
+        ]
     },
     "scripts": {
         "check": [

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,7 @@ parameters:
 		- identifier: method.internalClass
 		- identifier: new.internalClass
 		- identifier: trait.unused
+		- identifier: method.templateTypeNotInParameter
 		-
 			message: '#^Call to an undefined method PHPUnit\\Framework\\MockObject\\MockBuilder\<Cake\\ORM\\Table\>\:\:addMethods\(\)\.$#'
 			reportUnmatched: false

--- a/src/Container/Argument/ArgumentInterface.php
+++ b/src/Container/Argument/ArgumentInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+interface ArgumentInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getValue(): mixed;
+}

--- a/src/Container/Argument/ArgumentResolverInterface.php
+++ b/src/Container/Argument/ArgumentResolverInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+use Cake\Container\ContainerAwareInterface;
+use ReflectionFunctionAbstract;
+
+interface ArgumentResolverInterface extends ContainerAwareInterface
+{
+    /**
+     * @param array $arguments
+     * @return array
+     */
+    public function resolveArguments(array $arguments): array;
+
+    /**
+     * @param \ReflectionFunctionAbstract $method
+     * @param array $args
+     * @return array
+     */
+    public function reflectArguments(ReflectionFunctionAbstract $method, array $args = []): array;
+}

--- a/src/Container/Argument/ArgumentResolverInterface.php
+++ b/src/Container/Argument/ArgumentResolverInterface.php
@@ -9,7 +9,7 @@ use ReflectionFunctionAbstract;
 interface ArgumentResolverInterface extends ContainerAwareInterface
 {
     /**
-     * @param array $arguments
+     * @param array<\Cake\Container\Argument\LiteralArgument|\Cake\Container\Argument\ResolvableArgument> $arguments
      * @return array
      */
     public function resolveArguments(array $arguments): array;

--- a/src/Container/Argument/ArgumentResolverTrait.php
+++ b/src/Container/Argument/ArgumentResolverTrait.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+use Cake\Container\DefinitionContainerInterface;
+use Cake\Container\Exception\ContainerException;
+use Cake\Container\Exception\NotFoundException;
+use Cake\Container\ReflectionContainer;
+use Psr\Container\ContainerInterface;
+use ReflectionFunctionAbstract;
+use ReflectionNamedType;
+
+trait ArgumentResolverTrait
+{
+    /**
+     * @inheritDoc
+     */
+    public function resolveArguments(array $arguments): array
+    {
+        try {
+            $container = $this->getContainer();
+        } catch (ContainerException $e) {
+            $container = $this instanceof ReflectionContainer ? $this : null;
+        }
+
+        foreach ($arguments as &$arg) {
+            // if we have a literal, we don't want to do anything more with it
+            if ($arg instanceof LiteralArgumentInterface) {
+                $arg = $arg->getValue();
+                continue;
+            }
+
+            if ($arg instanceof ArgumentInterface) {
+                $argValue = $arg->getValue();
+            } else {
+                $argValue = $arg;
+            }
+
+            if (!is_string($argValue)) {
+                 continue;
+            }
+
+            // resolve the argument from the container, if it happens to be another
+            // argument wrapper, use that value
+            if ($container instanceof ContainerInterface && $container->has($argValue)) {
+                try {
+                    $arg = $container->get($argValue);
+
+                    if ($arg instanceof ArgumentInterface) {
+                        $arg = $arg->getValue();
+                    }
+
+                    continue;
+                } catch (NotFoundException $e) {
+                }
+            }
+
+            // if we have a default value, we use that, no more resolution as
+            // we expect a default/optional argument value to be literal
+            if ($arg instanceof DefaultValueInterface) {
+                $arg = $arg->getDefaultValue();
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reflectArguments(ReflectionFunctionAbstract $method, array $args = []): array
+    {
+        $params = $method->getParameters();
+        $arguments = [];
+
+        foreach ($params as $param) {
+            $name = $param->getName();
+
+            // if we've been given a value for the argument, treat as literal
+            if (array_key_exists($name, $args)) {
+                $arguments[] = new LiteralArgument($args[$name]);
+                continue;
+            }
+
+            $type = $param->getType();
+
+            if ($type instanceof ReflectionNamedType) {
+                // in PHP 8, nullable arguments have "?" prefix
+                $typeHint = ltrim($type->getName(), '?');
+
+                if ($param->isDefaultValueAvailable()) {
+                    $arguments[] = new DefaultValueArgument($typeHint, $param->getDefaultValue());
+                    continue;
+                }
+
+                $arguments[] = new ResolvableArgument($typeHint);
+                continue;
+            }
+
+            if ($param->isDefaultValueAvailable()) {
+                $arguments[] = new LiteralArgument($param->getDefaultValue());
+                continue;
+            }
+
+            throw new NotFoundException(sprintf(
+                'Unable to resolve a value for parameter (%s) in the function/method (%s)',
+                $name,
+                $method->getName()
+            ));
+        }
+
+        return $this->resolveArguments($arguments);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    abstract public function getContainer(): DefinitionContainerInterface;
+}

--- a/src/Container/Argument/ArgumentResolverTrait.php
+++ b/src/Container/Argument/ArgumentResolverTrait.php
@@ -20,7 +20,7 @@ trait ArgumentResolverTrait
     {
         try {
             $container = $this->getContainer();
-        } catch (ContainerException $e) {
+        } catch (ContainerException) {
             $container = $this instanceof ReflectionContainer ? $this : null;
         }
 
@@ -52,7 +52,7 @@ trait ArgumentResolverTrait
                     }
 
                     continue;
-                } catch (NotFoundException $e) {
+                } catch (NotFoundException) {
                 }
             }
 
@@ -106,7 +106,7 @@ trait ArgumentResolverTrait
             throw new NotFoundException(sprintf(
                 'Unable to resolve a value for parameter (%s) in the function/method (%s)',
                 $name,
-                $method->getName()
+                $method->getName(),
             ));
         }
 

--- a/src/Container/Argument/DefaultValueArgument.php
+++ b/src/Container/Argument/DefaultValueArgument.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+class DefaultValueArgument extends ResolvableArgument implements DefaultValueInterface
+{
+    protected mixed $defaultValue;
+
+    /**
+     * @param string $value
+     * @param mixed|null $defaultValue
+     */
+    public function __construct(string $value, mixed $defaultValue = null)
+    {
+        $this->defaultValue = $defaultValue;
+        parent::__construct($value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefaultValue(): mixed
+    {
+        return $this->defaultValue;
+    }
+}

--- a/src/Container/Argument/DefaultValueInterface.php
+++ b/src/Container/Argument/DefaultValueInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+interface DefaultValueInterface extends ArgumentInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getDefaultValue(): mixed;
+}

--- a/src/Container/Argument/Literal/ArrayArgument.php
+++ b/src/Container/Argument/Literal/ArrayArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class ArrayArgument extends LiteralArgument
+{
+    /**
+     * @param array $value
+     */
+    public function __construct(array $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_ARRAY);
+    }
+}

--- a/src/Container/Argument/Literal/BooleanArgument.php
+++ b/src/Container/Argument/Literal/BooleanArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class BooleanArgument extends LiteralArgument
+{
+    /**
+     * @param bool $value
+     */
+    public function __construct(bool $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_BOOL);
+    }
+}

--- a/src/Container/Argument/Literal/CallableArgument.php
+++ b/src/Container/Argument/Literal/CallableArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class CallableArgument extends LiteralArgument
+{
+    /**
+     * @param callable $value
+     */
+    public function __construct(callable $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_CALLABLE);
+    }
+}

--- a/src/Container/Argument/Literal/FloatArgument.php
+++ b/src/Container/Argument/Literal/FloatArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class FloatArgument extends LiteralArgument
+{
+    /**
+     * @param float $value
+     */
+    public function __construct(float $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_FLOAT);
+    }
+}

--- a/src/Container/Argument/Literal/IntegerArgument.php
+++ b/src/Container/Argument/Literal/IntegerArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class IntegerArgument extends LiteralArgument
+{
+    /**
+     * @param int $value
+     */
+    public function __construct(int $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_INT);
+    }
+}

--- a/src/Container/Argument/Literal/ObjectArgument.php
+++ b/src/Container/Argument/Literal/ObjectArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class ObjectArgument extends LiteralArgument
+{
+    /**
+     * @param object $value
+     */
+    public function __construct(object $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_OBJECT);
+    }
+}

--- a/src/Container/Argument/Literal/StringArgument.php
+++ b/src/Container/Argument/Literal/StringArgument.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument\Literal;
+
+use Cake\Container\Argument\LiteralArgument;
+
+class StringArgument extends LiteralArgument
+{
+    /**
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        parent::__construct($value, LiteralArgument::TYPE_STRING);
+    }
+}

--- a/src/Container/Argument/LiteralArgument.php
+++ b/src/Container/Argument/LiteralArgument.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+use InvalidArgumentException;
+
+class LiteralArgument implements LiteralArgumentInterface
+{
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_BOOL = 'boolean';
+    public const TYPE_BOOLEAN = 'boolean';
+    public const TYPE_CALLABLE = 'callable';
+    public const TYPE_DOUBLE = 'double';
+    public const TYPE_FLOAT = 'double';
+    public const TYPE_INT = 'integer';
+    public const TYPE_INTEGER = 'integer';
+    public const TYPE_OBJECT = 'object';
+    public const TYPE_STRING = 'string';
+
+    /**
+     * @var mixed
+     */
+    protected mixed $value;
+
+    /**
+     * @param mixed $value
+     * @param string|null $type
+     */
+    public function __construct(mixed $value, ?string $type = null)
+    {
+        if (
+            $type === null
+            || ($type === self::TYPE_CALLABLE && is_callable($value))
+            || ($type === self::TYPE_OBJECT && is_object($value))
+            || gettype($value) === $type
+        ) {
+            $this->value = $value;
+        } else {
+            throw new InvalidArgumentException('Incorrect type for value.');
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/src/Container/Argument/LiteralArgumentInterface.php
+++ b/src/Container/Argument/LiteralArgumentInterface.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+interface LiteralArgumentInterface extends ArgumentInterface
+{
+}

--- a/src/Container/Argument/ResolvableArgument.php
+++ b/src/Container/Argument/ResolvableArgument.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+class ResolvableArgument implements ResolvableArgumentInterface
+{
+    protected string $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Container/Argument/ResolvableArgumentInterface.php
+++ b/src/Container/Argument/ResolvableArgumentInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Argument;
+
+interface ResolvableArgumentInterface extends ArgumentInterface
+{
+    /**
+     * @return string
+     */
+    public function getValue(): string;
+}

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -60,6 +60,8 @@ class Container implements DefinitionContainerInterface
         $this->definitions->setContainer($this);
         $this->providers->setContainer($this);
         $this->inflectors->setContainer($this);
+
+        $this->enableAutoWiring();
     }
 
     /**
@@ -193,6 +195,23 @@ class Container implements DefinitionContainerInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @param bool $cache
+     * @return void
+     */
+    public function enableAutoWiring(bool $cache = true): void
+    {
+        $this->delegate(new ReflectionContainer($cache));
+    }
+
+    /**
+     * @return void
+     */
+    public function disableAutoWiring(): void
+    {
+        $this->delegates = [];
     }
 
     /**

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -132,6 +132,8 @@ class Container implements DefinitionContainerInterface
      * @template RequestedType
      * @param class-string<RequestedType>|string $id
      * @return RequestedType|mixed
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
      */
     public function get(string $id)
     {
@@ -142,6 +144,8 @@ class Container implements DefinitionContainerInterface
      * @template RequestedType
      * @param class-string<RequestedType>|string $id
      * @return RequestedType|mixed
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
      */
     public function getNew(mixed $id): mixed
     {

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -1,0 +1,245 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container;
+
+use Cake\Container\Definition\DefinitionAggregate;
+use Cake\Container\Definition\DefinitionAggregateInterface;
+use Cake\Container\Definition\DefinitionInterface;
+use Cake\Container\Exception\ContainerException;
+use Cake\Container\Exception\NotFoundException;
+use Cake\Container\Inflector\InflectorAggregate;
+use Cake\Container\Inflector\InflectorAggregateInterface;
+use Cake\Container\Inflector\InflectorInterface;
+use Cake\Container\ServiceProvider\ServiceProviderAggregate;
+use Cake\Container\ServiceProvider\ServiceProviderAggregateInterface;
+use Cake\Container\ServiceProvider\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+class Container implements DefinitionContainerInterface
+{
+    /**
+     * @var bool
+     */
+    protected bool $defaultToShared = false;
+
+    /**
+     * @var \Cake\Container\Definition\DefinitionAggregateInterface
+     */
+    protected DefinitionAggregateInterface $definitions;
+
+    /**
+     * @var \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface
+     */
+    protected ServiceProviderAggregateInterface $providers;
+
+    /**
+     * @var \Cake\Container\Inflector\InflectorAggregateInterface
+     */
+    protected InflectorAggregateInterface $inflectors;
+
+    /**
+     * @var array<\Psr\Container\ContainerInterface>
+     */
+    protected array $delegates = [];
+
+    /**
+     * @param \Cake\Container\Definition\DefinitionAggregateInterface|null $definitions
+     * @param \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
+     * @param \Cake\Container\Inflector\InflectorAggregateInterface|null $inflectors
+     */
+    public function __construct(
+        ?DefinitionAggregateInterface $definitions = null,
+        ?ServiceProviderAggregateInterface $providers = null,
+        ?InflectorAggregateInterface $inflectors = null
+    ) {
+        $this->definitions = $definitions ?? new DefinitionAggregate();
+        $this->providers = $providers ?? new ServiceProviderAggregate();
+        $this->inflectors = $inflectors ?? new InflectorAggregate();
+
+        $this->definitions->setContainer($this);
+        $this->providers->setContainer($this);
+        $this->inflectors->setContainer($this);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(string $id, $concrete = null): DefinitionInterface
+    {
+        $concrete = $concrete ?? $id;
+
+        if ($this->defaultToShared === true) {
+            return $this->addShared($id, $concrete);
+        }
+
+        return $this->definitions->add($id, $concrete);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addShared(string $id, $concrete = null): DefinitionInterface
+    {
+        $concrete = $concrete ?? $id;
+
+        return $this->definitions->addShared($id, $concrete);
+    }
+
+    /**
+     * @param bool $shared
+     * @return \Psr\Container\ContainerInterface
+     */
+    public function defaultToShared(bool $shared = true): ContainerInterface
+    {
+        $this->defaultToShared = $shared;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function extend(string $id): DefinitionInterface
+    {
+        if ($this->providers->provides($id)) {
+            $this->providers->register($id);
+        }
+
+        if ($this->definitions->has($id)) {
+            return $this->definitions->getDefinition($id);
+        }
+
+        throw new NotFoundException(sprintf(
+            'Unable to extend alias (%s) as it is not being managed as a definition',
+            $id
+        ));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addServiceProvider(ServiceProviderInterface $provider): DefinitionContainerInterface
+    {
+        $this->providers->add($provider);
+
+        return $this;
+    }
+
+    /**
+     * @template RequestedType
+     * @param class-string<RequestedType>|string $id
+     * @return RequestedType|mixed
+     */
+    public function get(string $id)
+    {
+        return $this->resolve($id);
+    }
+
+    /**
+     * @template RequestedType
+     * @param class-string<RequestedType>|string $id
+     * @return RequestedType|mixed
+     */
+    public function getNew(mixed $id): mixed
+    {
+        return $this->resolve($id, true);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id): bool
+    {
+        if ($this->definitions->has($id)) {
+            return true;
+        }
+
+        if ($this->definitions->hasTag($id)) {
+            return true;
+        }
+
+        if ($this->providers->provides($id)) {
+            return true;
+        }
+
+        foreach ($this->delegates as $delegate) {
+            if ($delegate->has($id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inflector(string $type, ?callable $callback = null): InflectorInterface
+    {
+        return $this->inflectors->add($type, $callback);
+    }
+
+    /**
+     * @param \Psr\Container\ContainerInterface $container
+     * @return $this
+     */
+    public function delegate(ContainerInterface $container)
+    {
+        $this->delegates[] = $container;
+
+        if ($container instanceof ContainerAwareInterface) {
+            $container->setContainer($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $id
+     * @param bool $new
+     * @return mixed|object|array|null|void
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    protected function resolve(mixed $id, bool $new = false): mixed
+    {
+        if ($this->definitions->has($id)) {
+            $resolved = $new === true ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
+
+            return $this->inflectors->inflect($resolved);
+        }
+
+        if ($this->definitions->hasTag($id)) {
+            $arrayOf = $new === true
+                ? $this->definitions->resolveTaggedNew($id)
+                : $this->definitions->resolveTagged($id);
+
+            array_walk($arrayOf, function (object &$resolved): void {
+                $resolved = $this->inflectors->inflect($resolved);
+            });
+
+            return $arrayOf;
+        }
+
+        if ($this->providers->provides($id)) {
+            $this->providers->register($id);
+
+            if (!$this->definitions->has($id) && !$this->definitions->hasTag($id)) {
+                throw new ContainerException(sprintf('Service provider lied about providing (%s) service', $id));
+            }
+
+            return $this->resolve($id, $new);
+        }
+
+        foreach ($this->delegates as $delegate) {
+            if ($delegate->has($id)) {
+                $resolved = $delegate->get($id);
+
+                return $this->inflectors->inflect($resolved);
+            }
+        }
+
+        throw new NotFoundException(sprintf('Alias (%s) is not being managed by the container or delegates', $id));
+    }
+}

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -24,39 +24,20 @@ class Container implements DefinitionContainerInterface
     protected bool $defaultToShared = false;
 
     /**
-     * @var \Cake\Container\Definition\DefinitionAggregateInterface
-     */
-    protected DefinitionAggregateInterface $definitions;
-
-    /**
-     * @var \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface
-     */
-    protected ServiceProviderAggregateInterface $providers;
-
-    /**
-     * @var \Cake\Container\Inflector\InflectorAggregateInterface
-     */
-    protected InflectorAggregateInterface $inflectors;
-
-    /**
      * @var array<\Psr\Container\ContainerInterface>
      */
     protected array $delegates = [];
 
     /**
-     * @param \Cake\Container\Definition\DefinitionAggregateInterface|null $definitions
-     * @param \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface|null $providers
-     * @param \Cake\Container\Inflector\InflectorAggregateInterface|null $inflectors
+     * @param \Cake\Container\Definition\DefinitionAggregateInterface $definitions
+     * @param \Cake\Container\ServiceProvider\ServiceProviderAggregateInterface $providers
+     * @param \Cake\Container\Inflector\InflectorAggregateInterface $inflectors
      */
     public function __construct(
-        ?DefinitionAggregateInterface $definitions = null,
-        ?ServiceProviderAggregateInterface $providers = null,
-        ?InflectorAggregateInterface $inflectors = null
+        protected DefinitionAggregateInterface $definitions = new DefinitionAggregate(),
+        protected ServiceProviderAggregateInterface $providers = new ServiceProviderAggregate(),
+        protected InflectorAggregateInterface $inflectors = new InflectorAggregate(),
     ) {
-        $this->definitions = $definitions ?? new DefinitionAggregate();
-        $this->providers = $providers ?? new ServiceProviderAggregate();
-        $this->inflectors = $inflectors ?? new InflectorAggregate();
-
         $this->definitions->setContainer($this);
         $this->providers->setContainer($this);
         $this->inflectors->setContainer($this);
@@ -69,9 +50,9 @@ class Container implements DefinitionContainerInterface
      */
     public function add(string $id, $concrete = null): DefinitionInterface
     {
-        $concrete = $concrete ?? $id;
+        $concrete ??= $id;
 
-        if ($this->defaultToShared === true) {
+        if ($this->defaultToShared) {
             return $this->addShared($id, $concrete);
         }
 
@@ -83,7 +64,7 @@ class Container implements DefinitionContainerInterface
      */
     public function addShared(string $id, $concrete = null): DefinitionInterface
     {
-        $concrete = $concrete ?? $id;
+        $concrete ??= $id;
 
         return $this->definitions->addShared($id, $concrete);
     }
@@ -159,7 +140,7 @@ class Container implements DefinitionContainerInterface
 
         throw new NotFoundException(sprintf(
             'Unable to extend alias (%s) as it is not being managed as a definition',
-            $id
+            $id,
         ));
     }
 
@@ -198,6 +179,29 @@ class Container implements DefinitionContainerInterface
     }
 
     /**
+     * Resolve an entry with specific constructor arguments.
+     *
+     * Unlike `get()`, this method allows passing specific constructor arguments
+     * that will be used during autowiring. Arguments can be passed by name.
+     *
+     * Example:
+     * ```
+     * $container->make(MyService::class, ['configValue' => 'foo']);
+     * ```
+     *
+     * @template RequestedType
+     * @param class-string<RequestedType>|string $id
+     * @param array<string, mixed> $args Named arguments to pass to the constructor
+     * @return RequestedType|mixed
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    public function make(string $id, array $args = []): mixed
+    {
+        return $this->resolve($id, true, $args);
+    }
+
+    /**
      * @inheritDoc
      */
     public function has($id): bool
@@ -221,6 +225,14 @@ class Container implements DefinitionContainerInterface
         }
 
         return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasDefinition(string $id): bool
+    {
+        return $this->definitions->has($id);
     }
 
     /**
@@ -266,20 +278,21 @@ class Container implements DefinitionContainerInterface
     /**
      * @param mixed $id
      * @param bool $new
+     * @param array<string, mixed> $args
      * @return mixed|object|array|null|void
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    protected function resolve(mixed $id, bool $new = false): mixed
+    protected function resolve(mixed $id, bool $new = false, array $args = []): mixed
     {
         if ($this->definitions->has($id)) {
-            $resolved = $new === true ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
+            $resolved = $new ? $this->definitions->resolveNew($id) : $this->definitions->resolve($id);
 
             return $this->inflectors->inflect($resolved);
         }
 
         if ($this->definitions->hasTag($id)) {
-            $arrayOf = $new === true
+            $arrayOf = $new
                 ? $this->definitions->resolveTaggedNew($id)
                 : $this->definitions->resolveTagged($id);
 
@@ -297,12 +310,19 @@ class Container implements DefinitionContainerInterface
                 throw new ContainerException(sprintf('Service provider lied about providing (%s) service', $id));
             }
 
-            return $this->resolve($id, $new);
+            return $this->resolve($id, $new, $args);
         }
 
         foreach ($this->delegates as $delegate) {
             if ($delegate->has($id)) {
-                $resolved = $delegate->get($id);
+                // Use getNew() for ReflectionContainer when $new is true or args are provided
+                if ($delegate instanceof ReflectionContainer) {
+                    $resolved = $new || $args !== []
+                        ? $delegate->getNew($id, $args)
+                        : $delegate->get($id, $args);
+                } else {
+                    $resolved = $delegate->get($id);
+                }
 
                 return $this->inflectors->inflect($resolved);
             }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -89,6 +89,51 @@ class Container implements DefinitionContainerInterface
     }
 
     /**
+     * Add multiple definitions at once.
+     *
+     * Examples:
+     *
+     * ```
+     * $container->addDefinitions([
+     *     Foo::class,
+     *     Bar::class
+     * ]);
+     * ```
+     *
+     * ```
+     * $container->addDefinitions([
+     *     Foo::class => [Bar::class],
+     *     Bar::class
+     * ]);
+     * ```
+     *
+     * ```
+     * $container->addDefinitions([
+     *    'foo' => Foo::class,
+     *    'bar' => Bar::class
+     * ]);
+     * ```
+     *
+     * @param array<int|string, array<class-string>|class-string> $definitions
+     * @return \Cake\Container\DefinitionContainerInterface
+     */
+    public function addDefinitions(array $definitions): DefinitionContainerInterface
+    {
+        foreach ($definitions as $id => $definition) {
+            if (is_int($id) && is_string($definition)) {
+                $this->add($definition);
+            } elseif (is_string($id) && is_string($definition)) {
+                $this->add($id, $definition);
+            } elseif (is_string($id) && is_array($definition)) {
+                $this->add($id)
+                    ->addArguments($definition);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @param bool $shared
      * @return \Psr\Container\ContainerInterface
      */

--- a/src/Container/ContainerAwareInterface.php
+++ b/src/Container/ContainerAwareInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container;
+
+interface ContainerAwareInterface
+{
+    /**
+     * @return \Cake\Container\DefinitionContainerInterface
+     */
+    public function getContainer(): DefinitionContainerInterface;
+
+    /**
+     * @param \Cake\Container\DefinitionContainerInterface $container
+     * @return $this
+     */
+    public function setContainer(DefinitionContainerInterface $container): ContainerAwareInterface;
+}

--- a/src/Container/ContainerAwareTrait.php
+++ b/src/Container/ContainerAwareTrait.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container;
+
+use BadMethodCallException;
+use Cake\Container\Exception\ContainerException;
+
+trait ContainerAwareTrait
+{
+    /**
+     * @var \Cake\Container\DefinitionContainerInterface|null
+     */
+    protected ?DefinitionContainerInterface $container = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function setContainer(DefinitionContainerInterface $container): ContainerAwareInterface
+    {
+        $this->container = $container;
+
+        if ($this instanceof ContainerAwareInterface) {
+            return $this;
+        }
+
+        throw new BadMethodCallException(sprintf(
+            'Attempt to use (%s) while not implementing (%s)',
+            ContainerAwareTrait::class,
+            ContainerAwareInterface::class
+        ));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getContainer(): DefinitionContainerInterface
+    {
+        if ($this->container instanceof DefinitionContainerInterface) {
+            return $this->container;
+        }
+
+        throw new ContainerException('No container implementation has been set.');
+    }
+}

--- a/src/Container/ContainerAwareTrait.php
+++ b/src/Container/ContainerAwareTrait.php
@@ -27,7 +27,7 @@ trait ContainerAwareTrait
         throw new BadMethodCallException(sprintf(
             'Attempt to use (%s) while not implementing (%s)',
             ContainerAwareTrait::class,
-            ContainerAwareInterface::class
+            ContainerAwareInterface::class,
         ));
     }
 

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -1,0 +1,312 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Definition;
+
+use Cake\Container\Argument\ArgumentInterface;
+use Cake\Container\Argument\ArgumentResolverInterface;
+use Cake\Container\Argument\ArgumentResolverTrait;
+use Cake\Container\Argument\LiteralArgumentInterface;
+use Cake\Container\ContainerAwareTrait;
+use Cake\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+
+class Definition implements ArgumentResolverInterface, DefinitionInterface
+{
+    use ArgumentResolverTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var string
+     */
+    protected string $alias;
+
+    /**
+     * @var mixed
+     */
+    protected mixed $concrete;
+
+    /**
+     * @var bool
+     */
+    protected bool $shared = false;
+
+    /**
+     * @var array
+     */
+    protected array $tags = [];
+
+    /**
+     * @var array
+     */
+    protected array $arguments = [];
+
+    /**
+     * @var array
+     */
+    protected array $methods = [];
+
+    /**
+     * @var mixed
+     */
+    protected mixed $resolved = null;
+
+    /**
+     * @var array
+     */
+    protected array $recursiveCheck = [];
+
+    /**
+     * @param string     $id
+     * @param mixed|null $concrete
+     */
+    public function __construct(string $id, mixed $concrete = null)
+    {
+        $id = static::normaliseAlias($id);
+
+        $concrete = $concrete ?? $id;
+        $this->alias = $id;
+        $this->concrete = $concrete;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addTag(string $tag): DefinitionInterface
+    {
+        $this->tags[$tag] = true;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTag(string $tag): bool
+    {
+        return isset($this->tags[$tag]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setAlias(string $id): DefinitionInterface
+    {
+        $id = static::normaliseAlias($id);
+
+        $this->alias = $id;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setShared(bool $shared = true): DefinitionInterface
+    {
+        $this->shared = $shared;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isShared(): bool
+    {
+        return $this->shared;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConcrete(): mixed
+    {
+        return $this->concrete;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setConcrete($concrete): DefinitionInterface
+    {
+        $this->concrete = $concrete;
+        $this->resolved = null;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addArgument($arg): DefinitionInterface
+    {
+        $this->arguments[] = $arg;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addArguments(array $args): DefinitionInterface
+    {
+        foreach ($args as $arg) {
+            $this->addArgument($arg);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addMethodCall(string $method, array $args = []): DefinitionInterface
+    {
+        $this->methods[] = [
+            'method' => $method,
+            'arguments' => $args,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addMethodCalls(array $methods = []): DefinitionInterface
+    {
+        foreach ($methods as $method => $args) {
+            $this->addMethodCall($method, $args);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(): mixed
+    {
+        if ($this->resolved !== null && $this->isShared()) {
+            return $this->resolved;
+        }
+
+        return $this->resolveNew();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveNew(): mixed
+    {
+        $concrete = $this->concrete;
+
+        if (is_callable($concrete)) {
+            $concrete = $this->resolveCallable($concrete);
+        }
+
+        if ($concrete instanceof LiteralArgumentInterface) {
+            $this->resolved = $concrete->getValue();
+
+            return $concrete->getValue();
+        }
+
+        if ($concrete instanceof ArgumentInterface) {
+            $concrete = $concrete->getValue();
+        }
+
+        if (is_string($concrete) && class_exists($concrete)) {
+            $concrete = $this->resolveClass($concrete);
+        }
+
+        if (is_object($concrete)) {
+            $concrete = $this->invokeMethods($concrete);
+        }
+
+        try {
+            $container = $this->getContainer();
+        } catch (ContainerException $e) {
+            $container = null;
+        }
+
+        // stop recursive resolving
+        if (is_string($concrete) && in_array($concrete, $this->recursiveCheck)) {
+            $this->resolved = $concrete;
+
+            return $concrete;
+        }
+
+        // if we still have a string, try to pull it from the container
+        // this allows for `alias -> alias -> ... -> concrete
+        if (is_string($concrete) && $container instanceof ContainerInterface && $container->has($concrete)) {
+            $this->recursiveCheck[] = $concrete;
+            $concrete = $container->get($concrete);
+        }
+
+        $this->resolved = $concrete;
+
+        return $concrete;
+    }
+
+    /**
+     * @param callable $concrete
+     * @return mixed
+     */
+    protected function resolveCallable(callable $concrete): mixed
+    {
+        $resolved = $this->resolveArguments($this->arguments);
+
+        return call_user_func_array($concrete, $resolved);
+    }
+
+    /**
+     * @param string $concrete
+     * @return object
+     * @throws \ReflectionException
+     */
+    protected function resolveClass(string $concrete): object
+    {
+        $resolved = $this->resolveArguments($this->arguments);
+        $reflection = new ReflectionClass($concrete);
+
+        return $reflection->newInstanceArgs($resolved);
+    }
+
+    /**
+     * @param object $instance
+     * @return object
+     */
+    protected function invokeMethods(object $instance): object
+    {
+        foreach ($this->methods as $method) {
+            $args = $this->resolveArguments($method['arguments']);
+            $callable = [$instance, $method['method']];
+            call_user_func_array($callable, $args);
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @param string $alias
+     * @return string
+     */
+    public static function normaliseAlias(string $alias): string
+    {
+        if (str_starts_with($alias, '\\')) {
+            return substr($alias, 1);
+        }
+
+        return $alias;
+    }
+}

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -9,7 +9,6 @@ use Cake\Container\Argument\ArgumentResolverTrait;
 use Cake\Container\Argument\LiteralArgumentInterface;
 use Cake\Container\ContainerAwareTrait;
 use Cake\Container\Exception\ContainerException;
-use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
 class Definition implements ArgumentResolverInterface, DefinitionInterface
@@ -65,7 +64,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     {
         $id = static::normaliseAlias($id);
 
-        $concrete = $concrete ?? $id;
+        $concrete ??= $id;
         $this->alias = $id;
         $this->concrete = $concrete;
     }
@@ -233,18 +232,34 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
             $concrete = $concrete->getValue();
         }
 
+        // Check if the container has a registered definition for this concrete class
+        // before attempting to instantiate it directly. This ensures interface -> concrete
+        // bindings respect existing definitions for the concrete class (fixes #275, #278).
+        try {
+            $container = $this->getContainer();
+        } catch (ContainerException) {
+            $container = null;
+        }
+
+        if (
+            is_string($concrete)
+            && $concrete !== $this->alias
+            && $container !== null
+            && $container->hasDefinition($concrete)
+        ) {
+            $this->recursiveCheck[] = $concrete;
+            $concrete = $container->get($concrete);
+            $this->resolved = $concrete;
+
+            return $concrete;
+        }
+
         if (is_string($concrete) && class_exists($concrete)) {
             $concrete = $this->resolveClass($concrete);
         }
 
         if (is_object($concrete)) {
             $concrete = $this->invokeMethods($concrete);
-        }
-
-        try {
-            $container = $this->getContainer();
-        } catch (ContainerException $e) {
-            $container = null;
         }
 
         // stop recursive resolving
@@ -256,7 +271,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
 
         // if we still have a string, try to pull it from the container
         // this allows for `alias -> alias -> ... -> concrete
-        if (is_string($concrete) && $container instanceof ContainerInterface && $container->has($concrete)) {
+        if (is_string($concrete) && $container !== null && $container->has($concrete)) {
             $this->recursiveCheck[] = $concrete;
             $concrete = $container->get($concrete);
         }
@@ -278,28 +293,12 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     }
 
     /**
-     * @param string $concrete
+     * @param class-string $concrete
      * @return object
      * @throws \ReflectionException
      */
     protected function resolveClass(string $concrete): object
     {
-//        $reflector = new ReflectionClass($concrete);
-//        $construct = $reflector->getConstructor();
-//        $params = $construct->getParameters();
-//        if (count($params) !== count($this->arguments)) {
-//            // This indicates, that certain arguments need to be auto wired
-//            $tmpArgs = $this->arguments;
-//            $this->arguments = [];
-//            foreach($params as $param) {
-//                if (!array_key_exists($param->getName(), $tmpArgs)) {
-//                    $this->addArgument($param->getType()->getName(), $param->getName());
-//                } else {
-//                    $this->addArgument($tmpArgs[$param->getName()], $param->getName());
-//                }
-//            }
-//        }
-
         $resolved = $this->resolveArguments($this->arguments);
         $reflection = new ReflectionClass($concrete);
 
@@ -314,6 +313,7 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     {
         foreach ($this->methods as $method) {
             $args = $this->resolveArguments($method['arguments']);
+            /** @var callable $callable */
             $callable = [$instance, $method['method']];
             call_user_func_array($callable, $args);
         }

--- a/src/Container/Definition/Definition.php
+++ b/src/Container/Definition/Definition.php
@@ -148,9 +148,13 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
     /**
      * @inheritDoc
      */
-    public function addArgument($arg): DefinitionInterface
+    public function addArgument($arg, ?string $name = null): DefinitionInterface
     {
-        $this->arguments[] = $arg;
+        if ($name) {
+            $this->arguments[$name] = $arg;
+        } else {
+            $this->arguments[] = $arg;
+        }
 
         return $this;
     }
@@ -160,8 +164,12 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
      */
     public function addArguments(array $args): DefinitionInterface
     {
-        foreach ($args as $arg) {
-            $this->addArgument($arg);
+        foreach ($args as $argName => $arg) {
+            if (is_string($argName)) {
+                $this->addArgument($arg, $argName);
+            } else {
+                $this->addArgument($arg);
+            }
         }
 
         return $this;
@@ -276,6 +284,22 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
      */
     protected function resolveClass(string $concrete): object
     {
+//        $reflector = new ReflectionClass($concrete);
+//        $construct = $reflector->getConstructor();
+//        $params = $construct->getParameters();
+//        if (count($params) !== count($this->arguments)) {
+//            // This indicates, that certain arguments need to be auto wired
+//            $tmpArgs = $this->arguments;
+//            $this->arguments = [];
+//            foreach($params as $param) {
+//                if (!array_key_exists($param->getName(), $tmpArgs)) {
+//                    $this->addArgument($param->getType()->getName(), $param->getName());
+//                } else {
+//                    $this->addArgument($tmpArgs[$param->getName()], $param->getName());
+//                }
+//            }
+//        }
+
         $resolved = $this->resolveArguments($this->arguments);
         $reflection = new ReflectionClass($concrete);
 

--- a/src/Container/Definition/DefinitionAggregate.php
+++ b/src/Container/Definition/DefinitionAggregate.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Definition;
+
+use Cake\Container\ContainerAwareTrait;
+use Cake\Container\Exception\NotFoundException;
+use Generator;
+
+class DefinitionAggregate implements DefinitionAggregateInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var array<\Cake\Container\Definition\DefinitionInterface>
+     */
+    protected array $definitions = [];
+
+    /**
+     * @param array $definitions
+     */
+    public function __construct(array $definitions = [])
+    {
+        $this->definitions = array_filter($definitions, static function ($definition) {
+            return $definition instanceof DefinitionInterface;
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(string $id, $definition): DefinitionInterface
+    {
+        if (!($definition instanceof DefinitionInterface)) {
+            $definition = new Definition($id, $definition);
+        }
+
+        $this->definitions[] = $definition->setAlias($id);
+
+        return $definition;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addShared(string $id, $definition): DefinitionInterface
+    {
+        $definition = $this->add($id, $definition);
+
+        return $definition->setShared(true);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has(string $id): bool
+    {
+        $id = Definition::normaliseAlias($id);
+
+        foreach ($this->getIterator() as $definition) {
+            if ($id === $definition->getAlias()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasTag(string $tag): bool
+    {
+        foreach ($this->getIterator() as $definition) {
+            if ($definition->hasTag($tag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefinition(string $id): DefinitionInterface
+    {
+        $id = Definition::normaliseAlias($id);
+
+        foreach ($this->getIterator() as $definition) {
+            if ($id === $definition->getAlias()) {
+                return $definition->setContainer($this->getContainer());
+            }
+        }
+
+        throw new NotFoundException(sprintf('Alias (%s) is not being handled as a definition.', $id));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(string $id): mixed
+    {
+        return $this->getDefinition($id)->resolve();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveNew(string $id): mixed
+    {
+        return $this->getDefinition($id)->resolveNew();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveTagged(string $tag): array
+    {
+        $arrayOf = [];
+
+        foreach ($this->getIterator() as $definition) {
+            if ($definition->hasTag($tag)) {
+                $arrayOf[] = $definition->setContainer($this->getContainer())->resolve();
+            }
+        }
+
+        return $arrayOf;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveTaggedNew(string $tag): array
+    {
+        $arrayOf = [];
+
+        foreach ($this->getIterator() as $definition) {
+            if ($definition->hasTag($tag)) {
+                $arrayOf[] = $definition->setContainer($this->getContainer())->resolveNew();
+            }
+        }
+
+        return $arrayOf;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator(): Generator
+    {
+        yield from $this->definitions;
+    }
+}

--- a/src/Container/Definition/DefinitionAggregateInterface.php
+++ b/src/Container/Definition/DefinitionAggregateInterface.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Definition;
+
+use Cake\Container\ContainerAwareInterface;
+use IteratorAggregate;
+
+/**
+ * @template-extends \IteratorAggregate<string, \Cake\Container\Definition\DefinitionInterface>
+ */
+interface DefinitionAggregateInterface extends ContainerAwareInterface, IteratorAggregate
+{
+    /**
+     * @param string $id
+     * @param mixed $definition
+     * @return \Cake\Container\Definition\DefinitionInterface
+     */
+    public function add(string $id, mixed $definition): DefinitionInterface;
+
+    /**
+     * @param string $id
+     * @param mixed $definition
+     * @return \Cake\Container\Definition\DefinitionInterface
+     */
+    public function addShared(string $id, mixed $definition): DefinitionInterface;
+
+    /**
+     * @param string $id
+     * @return \Cake\Container\Definition\DefinitionInterface
+     */
+    public function getDefinition(string $id): DefinitionInterface;
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function has(string $id): bool;
+
+    /**
+     * @param string $tag
+     * @return bool
+     */
+    public function hasTag(string $tag): bool;
+
+    /**
+     * @param string $id
+     * @return mixed
+     */
+    public function resolve(string $id): mixed;
+
+    /**
+     * @param string $id
+     * @return mixed
+     */
+    public function resolveNew(string $id): mixed;
+
+    /**
+     * @param string $tag
+     * @return array
+     */
+    public function resolveTagged(string $tag): array;
+
+    /**
+     * @param string $tag
+     * @return array
+     */
+    public function resolveTaggedNew(string $tag): array;
+}

--- a/src/Container/Definition/DefinitionInterface.php
+++ b/src/Container/Definition/DefinitionInterface.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Definition;
+
+use Cake\Container\ContainerAwareInterface;
+
+interface DefinitionInterface extends ContainerAwareInterface
+{
+    /**
+     * @param mixed $arg
+     * @return $this
+     */
+    public function addArgument(mixed $arg): DefinitionInterface;
+
+    /**
+     * @param array $args
+     * @return $this
+     */
+    public function addArguments(array $args): DefinitionInterface;
+
+    /**
+     * @param string $method
+     * @param array $args
+     * @return $this
+     */
+    public function addMethodCall(string $method, array $args = []): DefinitionInterface;
+
+    /**
+     * @param array $methods
+     * @return $this
+     */
+    public function addMethodCalls(array $methods = []): DefinitionInterface;
+
+    /**
+     * @param string $tag
+     * @return $this
+     */
+    public function addTag(string $tag): DefinitionInterface;
+
+    /**
+     * @return string
+     */
+    public function getAlias(): string;
+
+    /**
+     * @return mixed
+     */
+    public function getConcrete(): mixed;
+
+    /**
+     * @param string $tag
+     * @return bool
+     */
+    public function hasTag(string $tag): bool;
+
+    /**
+     * @return bool
+     */
+    public function isShared(): bool;
+
+    /**
+     * @return mixed
+     */
+    public function resolve(): mixed;
+
+    /**
+     * @return mixed
+     */
+    public function resolveNew(): mixed;
+
+    /**
+     * @param string $id
+     * @return $this
+     */
+    public function setAlias(string $id): DefinitionInterface;
+
+    /**
+     * @param mixed $concrete
+     * @return $this
+     */
+    public function setConcrete(mixed $concrete): DefinitionInterface;
+
+    /**
+     * @param bool $shared
+     * @return $this
+     */
+    public function setShared(bool $shared): DefinitionInterface;
+}

--- a/src/Container/Definition/DefinitionInterface.php
+++ b/src/Container/Definition/DefinitionInterface.php
@@ -9,9 +9,10 @@ interface DefinitionInterface extends ContainerAwareInterface
 {
     /**
      * @param mixed $arg
+     * @param string|null $name
      * @return $this
      */
-    public function addArgument(mixed $arg): DefinitionInterface;
+    public function addArgument(mixed $arg, ?string $name = null): DefinitionInterface;
 
     /**
      * @param array $args

--- a/src/Container/DefinitionContainerInterface.php
+++ b/src/Container/DefinitionContainerInterface.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container;
+
+use Cake\Container\Definition\DefinitionInterface;
+use Cake\Container\Inflector\InflectorInterface;
+use Cake\Container\ServiceProvider\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+interface DefinitionContainerInterface extends ContainerInterface
+{
+    /**
+     * @param string $id
+     * @param mixed $concrete
+     * @return \Cake\Container\Definition\DefinitionInterface
+     */
+    public function add(string $id, mixed $concrete = null): DefinitionInterface;
+
+    /**
+     * @param \Cake\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @return self
+     */
+    public function addServiceProvider(ServiceProviderInterface $provider): self;
+
+    /**
+     * @param string $id
+     * @param mixed $concrete
+     * @return \Cake\Container\Definition\DefinitionInterface
+     */
+    public function addShared(string $id, mixed $concrete = null): DefinitionInterface;
+
+    /**
+     * @param string $id
+     * @return \Cake\Container\Definition\DefinitionInterface
+     */
+    public function extend(string $id): DefinitionInterface;
+
+    /**
+     * @param mixed $id
+     * @return mixed
+     */
+    public function getNew(mixed $id): mixed;
+
+    /**
+     * @param string $type
+     * @param callable|null $callback
+     * @return \Cake\Container\Inflector\InflectorInterface
+     */
+    public function inflector(string $type, ?callable $callback = null): InflectorInterface;
+}

--- a/src/Container/DefinitionContainerInterface.php
+++ b/src/Container/DefinitionContainerInterface.php
@@ -18,6 +18,19 @@ interface DefinitionContainerInterface extends ContainerInterface
     public function add(string $id, mixed $concrete = null): DefinitionInterface;
 
     /**
+     * Add multiple definitions at once.
+     *
+     * Supports multiple formats:
+     * - `[Foo::class]` - class name as value, registers as itself
+     * - `['alias' => Foo::class]` - alias as key, class as value
+     * - `[Foo::class => [Bar::class]]` - class with constructor arguments
+     *
+     * @param array<int|string, array<class-string>|class-string> $definitions
+     * @return self
+     */
+    public function addDefinitions(array $definitions): self;
+
+    /**
      * @param \Cake\Container\ServiceProvider\ServiceProviderInterface $provider
      * @return self
      */

--- a/src/Container/DefinitionContainerInterface.php
+++ b/src/Container/DefinitionContainerInterface.php
@@ -43,6 +43,17 @@ interface DefinitionContainerInterface extends ContainerInterface
     public function getNew(mixed $id): mixed;
 
     /**
+     * Check if the container has a registered definition for the given id.
+     *
+     * Unlike `has()`, this only checks explicit definitions, not service providers
+     * or delegate containers.
+     *
+     * @param string $id
+     * @return bool
+     */
+    public function hasDefinition(string $id): bool;
+
+    /**
      * @param string $type
      * @param callable|null $callback
      * @return \Cake\Container\Inflector\InflectorInterface

--- a/src/Container/Exception/ContainerException.php
+++ b/src/Container/Exception/ContainerException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Exception;
+
+use Psr\Container\ContainerExceptionInterface;
+use RuntimeException;
+
+class ContainerException extends RuntimeException implements ContainerExceptionInterface
+{
+}

--- a/src/Container/Exception/NotFoundException.php
+++ b/src/Container/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Exception;
+
+use InvalidArgumentException;
+use Psr\Container\NotFoundExceptionInterface;
+
+class NotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface
+{
+}

--- a/src/Container/Inflector/Inflector.php
+++ b/src/Container/Inflector/Inflector.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Inflector;
+
+use Cake\Container\Argument\ArgumentResolverInterface;
+use Cake\Container\Argument\ArgumentResolverTrait;
+use Cake\Container\ContainerAwareTrait;
+
+class Inflector implements ArgumentResolverInterface, InflectorInterface
+{
+    use ArgumentResolverTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var string
+     */
+    protected string $type;
+
+    /**
+     * @var callable|null
+     */
+    protected $callback;
+
+    /**
+     * @var array
+     */
+    protected array $methods = [];
+
+    /**
+     * @var array
+     */
+    protected array $properties = [];
+
+    /**
+     * @param string $type
+     * @param callable|null $callback
+     */
+    public function __construct(string $type, ?callable $callback = null)
+    {
+        $this->type = $type;
+        $this->callback = $callback;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invokeMethod(string $name, array $args): InflectorInterface
+    {
+        $this->methods[$name] = $args;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invokeMethods(array $methods): InflectorInterface
+    {
+        foreach ($methods as $name => $args) {
+            $this->invokeMethod($name, $args);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setProperty(string $property, $value): InflectorInterface
+    {
+        $this->properties[$property] = $this->resolveArguments([$value])[0];
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setProperties(array $properties): InflectorInterface
+    {
+        foreach ($properties as $property => $value) {
+            $this->setProperty($property, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inflect(object $object): void
+    {
+        $properties = $this->resolveArguments(array_values($this->properties));
+        $properties = array_combine(array_keys($this->properties), $properties);
+
+        // array_combine() can technically return false
+        foreach ($properties ?: [] as $property => $value) {
+            $object->{$property} = $value;
+        }
+
+        foreach ($this->methods as $method => $args) {
+            $args = $this->resolveArguments($args);
+            $callable = [$object, $method];
+            call_user_func_array($callable, $args);
+        }
+
+        if ($this->callback !== null) {
+            call_user_func($this->callback, $object);
+        }
+    }
+}

--- a/src/Container/Inflector/Inflector.php
+++ b/src/Container/Inflector/Inflector.php
@@ -109,6 +109,7 @@ class Inflector implements ArgumentResolverInterface, InflectorInterface
 
         foreach ($this->methods as $method => $args) {
             $args = $this->resolveArguments($args);
+            /** @var callable $callable */
             $callable = [$object, $method];
             call_user_func_array($callable, $args);
         }

--- a/src/Container/Inflector/InflectorAggregate.php
+++ b/src/Container/Inflector/InflectorAggregate.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Inflector;
+
+use Cake\Container\ContainerAwareTrait;
+use Generator;
+
+class InflectorAggregate implements InflectorAggregateInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var array<\Cake\Container\Inflector\Inflector>
+     */
+    protected array $inflectors = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function add(string $type, ?callable $callback = null): Inflector
+    {
+        $inflector = new Inflector($type, $callback);
+        $this->inflectors[] = $inflector;
+
+        return $inflector;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inflect($object): mixed
+    {
+        foreach ($this->getIterator() as $inflector) {
+            $type = $inflector->getType();
+
+            if ($object instanceof $type) {
+                $inflector->setContainer($this->getContainer());
+                $inflector->inflect($object);
+            }
+        }
+
+        return $object;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator(): Generator
+    {
+        yield from $this->inflectors;
+    }
+}

--- a/src/Container/Inflector/InflectorAggregateInterface.php
+++ b/src/Container/Inflector/InflectorAggregateInterface.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Inflector;
+
+use Cake\Container\ContainerAwareInterface;
+use IteratorAggregate;
+
+/**
+ * @template-extends \IteratorAggregate<string, \Cake\Container\Inflector\Inflector>
+ */
+interface InflectorAggregateInterface extends ContainerAwareInterface, IteratorAggregate
+{
+    /**
+     * @param string $type
+     * @param callable|null $callback
+     * @return \Cake\Container\Inflector\Inflector
+     */
+    public function add(string $type, ?callable $callback = null): Inflector;
+
+    /**
+     * @param object $object
+     * @return mixed
+     */
+    public function inflect(object $object): mixed;
+}

--- a/src/Container/Inflector/InflectorInterface.php
+++ b/src/Container/Inflector/InflectorInterface.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\Inflector;
+
+interface InflectorInterface
+{
+    /**
+     * @return string
+     */
+    public function getType(): string;
+
+    /**
+     * @param object $object
+     * @return void
+     */
+    public function inflect(object $object): void;
+
+    /**
+     * @param string $name
+     * @param array $args
+     * @return $this
+     */
+    public function invokeMethod(string $name, array $args): InflectorInterface;
+
+    /**
+     * @param array $methods
+     * @return $this
+     */
+    public function invokeMethods(array $methods): InflectorInterface;
+
+    /**
+     * @param array $properties
+     * @return $this
+     */
+    public function setProperties(array $properties): InflectorInterface;
+
+    /**
+     * @param string $property
+     * @param mixed $value
+     * @return $this
+     */
+    public function setProperty(string $property, mixed $value): InflectorInterface;
+}

--- a/src/Container/LICENSE.txt
+++ b/src/Container/LICENSE.txt
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) 2021 Phil Bennett <philipobenito@gmail.com>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/src/Container/README.md
+++ b/src/Container/README.md
@@ -1,0 +1,19 @@
+# CakePHP Container Library
+
+TBD
+
+# Installation
+
+```
+composer require cakephp/container
+```
+
+# Getting Started
+
+TBD
+
+## Credits
+
+- [Phil Bennett](https://github.com/philipobenito)
+- [thephpleague/container](https://github.com/thephpleague/container)
+- `Orno\Di` contributors

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -7,7 +7,6 @@ use Cake\Container\Argument\ArgumentResolverInterface;
 use Cake\Container\Argument\ArgumentResolverTrait;
 use Cake\Container\Exception\ContainerException;
 use Cake\Container\Exception\NotFoundException;
-use Closure;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionFunction;
@@ -80,16 +79,16 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     }
 
     /**
-     * @param callable $callable
+     * @param callable|string $callable
      * @param array $args
      * @return mixed
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \ReflectionException
      */
-    public function call(callable $callable, array $args = []): mixed
+    public function call(callable|string $callable, array $args = []): mixed
     {
-        if (is_string($callable) && strpos($callable, '::') !== false) {
+        if (is_string($callable) && str_contains($callable, '::')) {
             $callable = explode('::', $callable);
         }
 
@@ -118,8 +117,15 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
             return $reflection->invokeArgs($callable, $this->reflectArguments($reflection, $args));
         }
 
-        $reflection = new ReflectionFunction(Closure::fromCallable($callable));
+        if (is_callable($callable)) {
+            $reflection = new ReflectionFunction($callable(...));
 
-        return $reflection->invokeArgs($this->reflectArguments($reflection, $args));
+            return $reflection->invokeArgs($this->reflectArguments($reflection, $args));
+        }
+
+        throw new NotFoundException(sprintf(
+            'Callable (%s) is not a valid callable',
+            $callable
+        ));
     }
 }

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container;
+
+use Cake\Container\Argument\ArgumentResolverInterface;
+use Cake\Container\Argument\ArgumentResolverTrait;
+use Cake\Container\Exception\ContainerException;
+use Cake\Container\Exception\NotFoundException;
+use Closure;
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionMethod;
+
+class ReflectionContainer implements ArgumentResolverInterface, ContainerInterface
+{
+    use ArgumentResolverTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var bool
+     */
+    protected bool $cacheResolutions;
+
+    /**
+     * @var array
+     */
+    protected array $cache = [];
+
+    /**
+     * @param bool $cacheResolutions
+     */
+    public function __construct(bool $cacheResolutions = false)
+    {
+        $this->cacheResolutions = $cacheResolutions;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $id, array $args = [])
+    {
+        if ($this->cacheResolutions === true && array_key_exists($id, $this->cache)) {
+            return $this->cache[$id];
+        }
+
+        if (!$this->has($id)) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id)
+            );
+        }
+
+        $reflector = new ReflectionClass($id);
+        $construct = $reflector->getConstructor();
+
+        if ($construct && !$construct->isPublic()) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id)
+            );
+        }
+
+        $resolution = $construct === null
+            ? new $id()
+            : $reflector->newInstanceArgs($this->reflectArguments($construct, $args));
+
+        if ($this->cacheResolutions === true) {
+            $this->cache[$id] = $resolution;
+        }
+
+        return $resolution;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id): bool
+    {
+        return class_exists($id);
+    }
+
+    /**
+     * @param callable $callable
+     * @param array $args
+     * @return mixed
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     * @throws \ReflectionException
+     */
+    public function call(callable $callable, array $args = []): mixed
+    {
+        if (is_string($callable) && strpos($callable, '::') !== false) {
+            $callable = explode('::', $callable);
+        }
+
+        if (is_array($callable)) {
+            if (is_string($callable[0])) {
+                // if we have a definition container, try that first, otherwise, reflect
+                try {
+                    $callable[0] = $this->getContainer()->get($callable[0]);
+                } catch (ContainerException $e) {
+                    $callable[0] = $this->get($callable[0]);
+                }
+            }
+
+            $reflection = new ReflectionMethod($callable[0], $callable[1]);
+
+            if ($reflection->isStatic()) {
+                $callable[0] = null;
+            }
+
+            return $reflection->invokeArgs($callable[0], $this->reflectArguments($reflection, $args));
+        }
+
+        if (is_object($callable)) {
+            $reflection = new ReflectionMethod($callable, '__invoke');
+
+            return $reflection->invokeArgs($callable, $this->reflectArguments($reflection, $args));
+        }
+
+        $reflection = new ReflectionFunction(Closure::fromCallable($callable));
+
+        return $reflection->invokeArgs($this->reflectArguments($reflection, $args));
+    }
+}

--- a/src/Container/ReflectionContainer.php
+++ b/src/Container/ReflectionContainer.php
@@ -40,22 +40,24 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
      */
     public function get(string $id, array $args = [])
     {
-        if ($this->cacheResolutions === true && array_key_exists($id, $this->cache)) {
+        // Only use cache when no custom args are provided
+        if ($this->cacheResolutions && $args === [] && array_key_exists($id, $this->cache)) {
             return $this->cache[$id];
         }
 
         if (!$this->has($id)) {
             throw new NotFoundException(
-                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id)
+                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id),
             );
         }
 
+        /** @var class-string $id */
         $reflector = new ReflectionClass($id);
         $construct = $reflector->getConstructor();
 
         if ($construct && !$construct->isPublic()) {
             throw new NotFoundException(
-                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id)
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id),
             );
         }
 
@@ -63,7 +65,8 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
             ? new $id()
             : $reflector->newInstanceArgs($this->reflectArguments($construct, $args));
 
-        if ($this->cacheResolutions === true) {
+        // Only cache when no custom args are provided
+        if ($this->cacheResolutions && $args === []) {
             $this->cache[$id] = $resolution;
         }
 
@@ -76,6 +79,36 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
     public function has($id): bool
     {
         return class_exists($id);
+    }
+
+    /**
+     * Get a new instance, bypassing the cache.
+     *
+     * @param string $id
+     * @param array<string, mixed> $args
+     * @return mixed
+     */
+    public function getNew(string $id, array $args = []): mixed
+    {
+        if (!$this->has($id)) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) is not an existing class and therefore cannot be resolved', $id),
+            );
+        }
+
+        /** @var class-string $id */
+        $reflector = new ReflectionClass($id);
+        $construct = $reflector->getConstructor();
+
+        if ($construct && !$construct->isPublic()) {
+            throw new NotFoundException(
+                sprintf('Alias (%s) has a non-public constructor and therefore cannot be instantiated', $id),
+            );
+        }
+
+        return $construct === null
+            ? new $id()
+            : $reflector->newInstanceArgs($this->reflectArguments($construct, $args));
     }
 
     /**
@@ -97,7 +130,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
                 // if we have a definition container, try that first, otherwise, reflect
                 try {
                     $callable[0] = $this->getContainer()->get($callable[0]);
-                } catch (ContainerException $e) {
+                } catch (ContainerException) {
                     $callable[0] = $this->get($callable[0]);
                 }
             }
@@ -125,7 +158,7 @@ class ReflectionContainer implements ArgumentResolverInterface, ContainerInterfa
 
         throw new NotFoundException(sprintf(
             'Callable (%s) is not a valid callable',
-            $callable
+            $callable,
         ));
     }
 }

--- a/src/Container/ServiceProvider/AbstractServiceProvider.php
+++ b/src/Container/ServiceProvider/AbstractServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\ServiceProvider;
+
+use Cake\Container\ContainerAwareTrait;
+
+abstract class AbstractServiceProvider implements ServiceProviderInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $identifier = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function getIdentifier(): string
+    {
+        return $this->identifier ?? static::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setIdentifier(string $id): ServiceProviderInterface
+    {
+        $this->identifier = $id;
+
+        return $this;
+    }
+}

--- a/src/Container/ServiceProvider/BootableServiceProviderInterface.php
+++ b/src/Container/ServiceProvider/BootableServiceProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\ServiceProvider;
+
+interface BootableServiceProviderInterface extends ServiceProviderInterface
+{
+    /**
+     * Method will be invoked on registration of a service provider implementing
+     * this interface. Provides ability for eager loading of Service Providers.
+     *
+     * @return void
+     */
+    public function boot(): void;
+}

--- a/src/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\ServiceProvider;
+
+use Cake\Container\ContainerAwareTrait;
+use Cake\Container\Exception\ContainerException;
+use Generator;
+
+class ServiceProviderAggregate implements ServiceProviderAggregateInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var array<\Cake\Container\ServiceProvider\ServiceProviderInterface>
+     */
+    protected array $providers = [];
+
+    /**
+     * @var array
+     */
+    protected array $registered = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function add(ServiceProviderInterface $provider): ServiceProviderAggregateInterface
+    {
+        if (in_array($provider, $this->providers, true)) {
+            return $this;
+        }
+
+        $provider->setContainer($this->getContainer());
+
+        if ($provider instanceof BootableServiceProviderInterface) {
+            $provider->boot();
+        }
+
+        $this->providers[] = $provider;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function provides(string $id): bool
+    {
+        foreach ($this->getIterator() as $provider) {
+            if ($provider->provides($id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator(): Generator
+    {
+        yield from $this->providers;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function register(string $service): void
+    {
+        if ($this->provides($service) === false) {
+            throw new ContainerException(
+                sprintf('(%s) is not provided by a service provider', $service)
+            );
+        }
+
+        foreach ($this->getIterator() as $provider) {
+            if (in_array($provider->getIdentifier(), $this->registered, true)) {
+                continue;
+            }
+
+            if ($provider->provides($service)) {
+                $provider->register();
+                $this->registered[] = $provider->getIdentifier();
+            }
+        }
+    }
+}

--- a/src/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/src/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -70,7 +70,7 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
     {
         if ($this->provides($service) === false) {
             throw new ContainerException(
-                sprintf('(%s) is not provided by a service provider', $service)
+                sprintf('(%s) is not provided by a service provider', $service),
             );
         }
 

--- a/src/Container/ServiceProvider/ServiceProviderAggregateInterface.php
+++ b/src/Container/ServiceProvider/ServiceProviderAggregateInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\ServiceProvider;
+
+use Cake\Container\ContainerAwareInterface;
+use IteratorAggregate;
+
+/**
+ * @template-extends \IteratorAggregate<string, \Cake\Container\ServiceProvider\ServiceProviderInterface>
+ */
+interface ServiceProviderAggregateInterface extends ContainerAwareInterface, IteratorAggregate
+{
+    /**
+     * @param \Cake\Container\ServiceProvider\ServiceProviderInterface $provider
+     * @return $this
+     */
+    public function add(ServiceProviderInterface $provider): ServiceProviderAggregateInterface;
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function provides(string $id): bool;
+
+    /**
+     * @param string $service
+     * @return void
+     */
+    public function register(string $service): void;
+}

--- a/src/Container/ServiceProvider/ServiceProviderInterface.php
+++ b/src/Container/ServiceProvider/ServiceProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Container\ServiceProvider;
+
+use Cake\Container\ContainerAwareInterface;
+
+interface ServiceProviderInterface extends ContainerAwareInterface
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * @param string $id
+     * @return bool
+     */
+    public function provides(string $id): bool;
+
+    /**
+     * @return void
+     */
+    public function register(): void;
+
+    /**
+     * @param string $id
+     * @return $this
+     */
+    public function setIdentifier(string $id): ServiceProviderInterface;
+}

--- a/src/Container/composer.json
+++ b/src/Container/composer.json
@@ -1,0 +1,48 @@
+{
+    "name": "cakephp/container",
+    "description": "A fast and intuitive dependency injection container.",
+    "type": "library",
+    "keywords": [
+        "cakephp",
+        "container",
+        "dependency",
+        "injection",
+        "di",
+        "service",
+        "provider"
+    ],
+    "homepage": "https://cakephp.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Phil Bennett",
+            "email": "mail@philbennett.co.uk",
+            "role": "Developer"
+        },
+        {
+            "name": "CakePHP Community",
+            "homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/cakephp/cakephp/issues",
+        "forum": "https://stackoverflow.com/tags/cakephp",
+        "irc": "irc://irc.freenode.org/cakephp",
+        "source": "https://github.com/cakephp/console"
+    },
+    "require": {
+        "php": ">=8.1",
+        "psr/container": "^1.1 || ^2.0"
+    },
+    "provide": {
+        "psr/container-implementation": "^1.0"
+    },
+    "replace": {
+        "orno/di": "~2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Cake\\Container\\": "."
+        }
+    }
+}

--- a/src/Container/composer.json
+++ b/src/Container/composer.json
@@ -37,9 +37,6 @@
     "provide": {
         "psr/container-implementation": "^1.0"
     },
-    "replace": {
-        "orno/di": "~2.0"
-    },
     "autoload": {
         "psr-4": {
             "Cake\\Container\\": "."

--- a/src/Container/composer.json
+++ b/src/Container/composer.json
@@ -28,10 +28,10 @@
         "issues": "https://github.com/cakephp/cakephp/issues",
         "forum": "https://stackoverflow.com/tags/cakephp",
         "irc": "irc://irc.freenode.org/cakephp",
-        "source": "https://github.com/cakephp/console"
+        "source": "https://github.com/cakephp/container"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "psr/container": "^1.1 || ^2.0"
     },
     "provide": {

--- a/tests/TestCase/Container/Argument/ArgumentResolverTest.php
+++ b/tests/TestCase/Container/Argument/ArgumentResolverTest.php
@@ -1,0 +1,157 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Argument;
+
+use Cake\Container\Argument\ArgumentResolverInterface;
+use Cake\Container\Argument\ArgumentResolverTrait;
+use Cake\Container\Argument\Literal;
+use Cake\Container\Container;
+use Cake\Container\ContainerAwareTrait;
+use Cake\Test\TestCase\Container\Asset\Baz;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
+use ReflectionClass;
+use ReflectionFunctionAbstract;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+class ArgumentResolverTest extends TestCase
+{
+    public function testResolverResolvesFromContainer(): void
+    {
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        $container = Mockery::mock(Container::class);
+
+        $container
+            ->shouldReceive('has')
+            ->with('alias1')
+            ->andReturn(true);
+
+        $container
+            ->shouldReceive('get')
+            ->with('alias1')
+            ->andReturn($resolver);
+
+        $container
+            ->shouldReceive('has')
+            ->with('alias2')
+            ->andReturn(false);
+
+        /** @var Container $container */
+        $resolver->setContainer($container);
+
+        $args = $resolver->resolveArguments(['alias1', 'alias2']);
+
+        $this->assertSame($resolver, $args[0]);
+        $this->assertSame('alias2', $args[1]);
+    }
+
+    public function testResolverResolvesLiteralArguments(): void
+    {
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with(self::equalTo('alias1'))
+            ->willReturn(true);
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(self::equalTo('alias1'))
+            ->willReturn(new Literal\StringArgument('value1'));
+
+        /** @var Container $container */
+        $resolver->setContainer($container);
+
+        $args = $resolver->resolveArguments(['alias1', new Literal\StringArgument('value2')]);
+
+        self::assertSame('value1', $args[0]);
+        self::assertSame('value2', $args[1]);
+    }
+
+    public function testResolverResolvesArgumentsViaReflection(): void
+    {
+        $method = $this->getMockBuilder(ReflectionFunctionAbstract::class)->getMock();
+        $param1 = $this->getMockBuilder(ReflectionParameter::class)->disableOriginalConstructor()->getMock();
+        $param2 = $this->getMockBuilder(ReflectionParameter::class)->disableOriginalConstructor()->getMock();
+        $param3 = $this->getMockBuilder(ReflectionParameter::class)->disableOriginalConstructor()->getMock();
+        $class = $this->getMockBuilder(ReflectionNamedType::class)->disableOriginalConstructor()->getMock();
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $class->expects(self::once())->method('getName')->willReturn('Class');
+        $param1->expects(self::once())->method('getName')->willReturn('param1');
+        $param1->expects(self::once())->method('getType')->willReturn($class);
+
+        $param2->expects(self::once())->method('getName')->willReturn('param2');
+        $param2->expects(self::once())->method('getType')->willReturn(null);
+        $param2->expects(self::once())->method('isDefaultValueAvailable')->willReturn(true);
+        $param2->expects(self::once())->method('getDefaultValue')->willReturn('value2');
+
+        $param3->expects(self::once())->method('getName')->willReturn('param3');
+
+        $method->expects(self::once())->method('getParameters')->willReturn([$param1, $param2, $param3]);
+
+        $container->expects(self::once())->method('has')->with($this->equalTo('Class'))->willReturn(true);
+        $container->expects(self::once())->method('get')->with($this->equalTo('Class'))->willReturn('classObject');
+
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        /** @var Container $container */
+        $resolver->setContainer($container);
+
+        $args = $resolver->reflectArguments($method, ['param3' => 'value3']);
+
+        self::assertSame('classObject', $args[0]);
+        self::assertSame('value2', $args[1]);
+        self::assertSame('value3', $args[2]);
+    }
+
+    public function testResolvesDefaultValueArgument(): void
+    {
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        $result = $resolver->reflectArguments((new ReflectionClass(Baz::class))->getConstructor());
+        self::assertSame([null], $result);
+    }
+
+    public function testResolverThrowsExceptionWhenReflectionDoesNotResolve(): void
+    {
+        $this->expectException(NotFoundExceptionInterface::class);
+
+        $method = $this->getMockBuilder(ReflectionFunctionAbstract::class)->getMock();
+        $param = $this->getMockBuilder(ReflectionParameter::class)->disableOriginalConstructor()->getMock();
+
+        $param->expects(self::once())->method('getName')->willReturn('param1');
+        $param->expects(self::once())->method('getType')->willReturn(null);
+        $param->expects(self::once())->method('isDefaultValueAvailable')->willReturn(false);
+
+        $method->expects(self::once())->method('getParameters')->willReturn([$param]);
+
+        $resolver = new class implements ArgumentResolverInterface {
+            use ArgumentResolverTrait;
+            use ContainerAwareTrait;
+        };
+
+        /** @var ReflectionFunctionAbstract $method */
+        $resolver->reflectArguments($method);
+    }
+}

--- a/tests/TestCase/Container/Argument/TypedArgumentTest.php
+++ b/tests/TestCase/Container/Argument/TypedArgumentTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Argument;
+
+use Cake\Container\Argument\Literal;
+use Cake\Container\Argument\LiteralArgument;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class TypedArgumentTest extends TestCase
+{
+    public function testLiteralArgumentSetsAndGetsArgument(): void
+    {
+        $arguments = [
+            Literal\ArrayArgument::class => [],
+            Literal\BooleanArgument::class => true,
+            Literal\CallableArgument::class => function () {
+            },
+            Literal\FloatArgument::class => 1.23,
+            Literal\IntegerArgument::class => 1,
+            Literal\ObjectArgument::class => new class {
+            },
+            Literal\StringArgument::class => 'string',
+        ];
+
+        foreach ($arguments as $type => $expected) {
+            $argument = new $type($expected);
+            self::assertSame($expected, $argument->getValue());
+        }
+    }
+
+    public function testLiteralArgumentThrowsWithWrongArgumentType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new LiteralArgument(LiteralArgument::TYPE_BOOL, 'blah');
+    }
+}

--- a/tests/TestCase/Container/Argument/TypedArgumentTest.php
+++ b/tests/TestCase/Container/Argument/TypedArgumentTest.php
@@ -15,7 +15,7 @@ class TypedArgumentTest extends TestCase
         $arguments = [
             Literal\ArrayArgument::class => [],
             Literal\BooleanArgument::class => true,
-            Literal\CallableArgument::class => function () {
+            Literal\CallableArgument::class => function (): void {
             },
             Literal\FloatArgument::class => 1.23,
             Literal\IntegerArgument::class => 1,

--- a/tests/TestCase/Container/Asset/Bar.php
+++ b/tests/TestCase/Container/Asset/Bar.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+class Bar implements BarInterface
+{
+    protected $something;
+
+    public function setSomething($something): void
+    {
+        $this->something = $something;
+    }
+}

--- a/tests/TestCase/Container/Asset/BarInterface.php
+++ b/tests/TestCase/Container/Asset/BarInterface.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+interface BarInterface
+{
+}

--- a/tests/TestCase/Container/Asset/Baz.php
+++ b/tests/TestCase/Container/Asset/Baz.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+class Baz
+{
+    public function __construct(?BarInterface $bar = null)
+    {
+    }
+}

--- a/tests/TestCase/Container/Asset/Baz.php
+++ b/tests/TestCase/Container/Asset/Baz.php
@@ -5,7 +5,10 @@ namespace Cake\Test\TestCase\Container\Asset;
 
 class Baz
 {
+    public ?BarInterface $bar;
+
     public function __construct(?BarInterface $bar = null)
     {
+        $this->bar = $bar;
     }
 }

--- a/tests/TestCase/Container/Asset/Foo.php
+++ b/tests/TestCase/Container/Asset/Foo.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+class Foo
+{
+    public $bar;
+
+    public static $staticBar;
+
+    public static $staticHello;
+
+    public function __construct(?Bar $bar = null)
+    {
+        $this->bar = $bar;
+    }
+
+    public function setBar(Bar $bar): void
+    {
+        $this->bar = $bar;
+    }
+
+    public static function staticSetBar(Bar $bar, $hello = 'hello world'): void
+    {
+        self::$staticHello = $hello;
+        self::$staticBar = $bar;
+    }
+}

--- a/tests/TestCase/Container/Asset/Foo.php
+++ b/tests/TestCase/Container/Asset/Foo.php
@@ -7,13 +7,16 @@ class Foo
 {
     public $bar;
 
+    public $myString;
+
     public static $staticBar;
 
     public static $staticHello;
 
-    public function __construct(?Bar $bar = null)
+    public function __construct(?Bar $bar = null, ?string $myString = null)
     {
         $this->bar = $bar;
+        $this->myString = $myString;
     }
 
     public function setBar(Bar $bar): void

--- a/tests/TestCase/Container/Asset/FooCallable.php
+++ b/tests/TestCase/Container/Asset/FooCallable.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+class FooCallable
+{
+    public function __invoke(Bar $bar)
+    {
+        return new Foo($bar);
+    }
+}

--- a/tests/TestCase/Container/Asset/FooCallable.php
+++ b/tests/TestCase/Container/Asset/FooCallable.php
@@ -5,7 +5,7 @@ namespace Cake\Test\TestCase\Container\Asset;
 
 class FooCallable
 {
-    public function __invoke(Bar $bar)
+    public function __invoke(Bar $bar): Foo
     {
         return new Foo($bar);
     }

--- a/tests/TestCase/Container/Asset/ProBar.php
+++ b/tests/TestCase/Container/Asset/ProBar.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+class ProBar implements BarInterface
+{
+    protected function __construct()
+    {
+    }
+
+    public static function factory(): ProBar
+    {
+        return new self();
+    }
+}

--- a/tests/TestCase/Container/Asset/ProFoo.php
+++ b/tests/TestCase/Container/Asset/ProFoo.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+class ProFoo
+{
+    public $bar;
+
+    public function __construct(?ProBar $bar = null)
+    {
+        $this->bar = $bar;
+    }
+}

--- a/tests/TestCase/Container/Asset/function.php
+++ b/tests/TestCase/Container/Asset/function.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Asset;
+
+function test(Bar $bar): Foo
+{
+    return new Foo($bar);
+}

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -1,0 +1,235 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container;
+
+use BadMethodCallException;
+use Cake\Container\Container;
+use Cake\Container\ContainerAwareTrait;
+use Cake\Container\Exception\ContainerException;
+use Cake\Container\Exception\NotFoundException;
+use Cake\Container\ReflectionContainer;
+use Cake\Container\ServiceProvider\AbstractServiceProvider;
+use Cake\Test\TestCase\Container\Asset\Bar;
+use Cake\Test\TestCase\Container\Asset\Foo;
+use PHPUnit\Framework\TestCase;
+
+class ContainerTest extends TestCase
+{
+    public function testContainerAddsAndGets(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class);
+        self::assertTrue($container->has(Foo::class));
+        $foo = $container->get(Foo::class);
+        self::assertInstanceOf(Foo::class, $foo);
+    }
+
+    public function testContainerAddsAndGetsRecursively(): void
+    {
+        $container = new Container();
+        $container->add(Bar::class, Foo::class);
+        $container->add(Foo::class);
+        self::assertTrue($container->has(Foo::class));
+        $foo = $container->get(Bar::class);
+        self::assertInstanceOf(Foo::class, $foo);
+    }
+
+    public function testContainerAddsAndGetsShared(): void
+    {
+        $container = new Container();
+        $container->addShared(Foo::class);
+        self::assertTrue($container->has(Foo::class));
+
+        $fooOne = $container->get(Foo::class);
+        $fooTwo = $container->get(Foo::class);
+
+        self::assertInstanceOf(Foo::class, $fooOne);
+        self::assertInstanceOf(Foo::class, $fooTwo);
+        self::assertSame($fooOne, $fooTwo);
+    }
+
+    public function testContainerAddsAndGetsSharedByDefault(): void
+    {
+        $container = (new Container())->defaultToShared();
+        $container->add(Foo::class);
+        self::assertTrue($container->has(Foo::class));
+
+        $fooOne = $container->get(Foo::class);
+        $fooTwo = $container->get(Foo::class);
+
+        self::assertInstanceOf(Foo::class, $fooOne);
+        self::assertInstanceOf(Foo::class, $fooTwo);
+        self::assertSame($fooOne, $fooTwo);
+    }
+
+    public function testContainerAddsAndGetsFromTag(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class)->addTag('foobar');
+        $container->add(Bar::class)->addTag('foobar');
+        self::assertTrue($container->has(Foo::class));
+
+        $arrayOf = $container->get('foobar');
+
+        self::assertTrue($container->has('foobar'));
+        self::assertIsArray($arrayOf);
+        self::assertCount(2, $arrayOf);
+        self::assertInstanceOf(Foo::class, $arrayOf[0]);
+        self::assertInstanceOf(Bar::class, $arrayOf[1]);
+    }
+
+    public function testContainerAddsAndGetsNewFromTag(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class)->addTag('foobar');
+        $container->add(Bar::class)->addTag('foobar');
+        self::assertTrue($container->has(Foo::class));
+
+        $arrayOf = $container->get('foobar');
+
+        self::assertTrue($container->has('foobar'));
+        self::assertIsArray($arrayOf);
+        self::assertCount(2, $arrayOf);
+        self::assertInstanceOf(Foo::class, $arrayOf[0]);
+        self::assertInstanceOf(Bar::class, $arrayOf[1]);
+
+        $arrayOfTwo = $container->getNew('foobar');
+        self::assertNotSame($arrayOfTwo, $arrayOf);
+    }
+
+    public function testContainerAddsAndGetsWithServiceProvider(): void
+    {
+        $provider = new class extends AbstractServiceProvider
+        {
+            public function provides(string $id): bool
+            {
+                return $id === Foo::class;
+            }
+
+            public function register(): void
+            {
+                $this->getContainer()->add(Foo::class);
+            }
+        };
+
+        $container = new Container();
+
+        $container->addServiceProvider($provider);
+        self::assertTrue($container->has(Foo::class));
+
+        $foo = $container->get(Foo::class);
+        self::assertInstanceOf(Foo::class, $foo);
+    }
+
+    public function testThrowsWhenServiceProviderLies(): void
+    {
+        $liar = new class extends AbstractServiceProvider
+        {
+            public function provides(string $id): bool
+            {
+                return true;
+            }
+
+            public function register(): void
+            {
+            }
+        };
+
+        $container = new Container();
+
+        $container->addServiceProvider($liar);
+        self::assertTrue($container->has('lie'));
+
+        $this->expectException(ContainerException::class);
+        $container->get('lie');
+    }
+
+    public function testContainerAddsAndGetsFromDelegate(): void
+    {
+        $delegate = new ReflectionContainer();
+        $container = new Container();
+        $container->delegate($delegate);
+        $foo = $container->get(Foo::class);
+        self::assertInstanceOf(Foo::class, $foo);
+    }
+
+    public function testContainerThrowsWhenCannotGetService(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $container = new Container();
+        self::assertFalse($container->has(Foo::class));
+        $container->get(Foo::class);
+    }
+
+    public function testContainerCanExtendDefinition(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class);
+        $definition = $container->extend(Foo::class);
+        self::assertSame(Foo::class, $definition->getAlias());
+        self::assertSame(Foo::class, $definition->getConcrete());
+    }
+
+    public function testContainerCanExtendDefinitionFromServiceProvider(): void
+    {
+        $provider = new class extends AbstractServiceProvider
+        {
+            public function provides(string $id): bool
+            {
+                return $id === Foo::class;
+            }
+
+            public function register(): void
+            {
+                $this->getContainer()->add(Foo::class);
+            }
+        };
+
+        $container = new Container();
+        $container->addServiceProvider($provider);
+        $definition = $container->extend(Foo::class);
+        self::assertSame(Foo::class, $definition->getAlias());
+        self::assertSame(Foo::class, $definition->getConcrete());
+    }
+
+    public function testContainerThrowsWhenCannotGetDefinitionToExtend(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $container = new Container();
+        self::assertFalse($container->has(Foo::class));
+        $container->extend(Foo::class);
+    }
+
+    public function testContainerAddsAndInvokesInflector(): void
+    {
+        $container = new Container();
+        $container->inflector(Foo::class)->setProperty('bar', Bar::class);
+        $container->add(Foo::class);
+        $container->add(Bar::class);
+        $foo = $container->get(Foo::class);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testContainerAwareCannotBeUsedWithoutImplementingInterface(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $class = new class {
+            use ContainerAwareTrait;
+        };
+
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $class->setContainer($container);
+    }
+
+    public function testNonExistentClassCausesException(): void
+    {
+        $container = new Container();
+        $container->add(NonExistent::class);
+
+        self::assertTrue($container->has(NonExistent::class));
+        self::assertSame(NonExistent::class, $container->get(NonExistent::class));
+    }
+}

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -158,6 +158,7 @@ class ContainerTest extends TestCase
     {
         $this->expectException(NotFoundException::class);
         $container = new Container();
+        $container->disableAutoWiring();
         self::assertFalse($container->has(Foo::class));
         $container->get(Foo::class);
     }
@@ -197,6 +198,7 @@ class ContainerTest extends TestCase
     {
         $this->expectException(NotFoundException::class);
         $container = new Container();
+        $container->disableAutoWiring();
         self::assertFalse($container->has(Foo::class));
         $container->extend(Foo::class);
     }

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -11,6 +11,7 @@ use Cake\Container\Exception\NotFoundException;
 use Cake\Container\ReflectionContainer;
 use Cake\Container\ServiceProvider\AbstractServiceProvider;
 use Cake\Test\TestCase\Container\Asset\Bar;
+use Cake\Test\TestCase\Container\Asset\BarInterface;
 use Cake\Test\TestCase\Container\Asset\Foo;
 use PHPUnit\Framework\TestCase;
 
@@ -275,21 +276,79 @@ class ContainerTest extends TestCase
     public function testNonExistentClassCausesException(): void
     {
         $container = new Container();
-        $container->add(NonExistent::class);
+        $nonExistent = 'Cake\Test\TestCase\Container\NonExistent';
+        $container->add($nonExistent);
 
-        self::assertTrue($container->has(NonExistent::class));
-        self::assertSame(NonExistent::class, $container->get(NonExistent::class));
+        self::assertTrue($container->has($nonExistent));
+        self::assertSame($nonExistent, $container->get($nonExistent));
     }
 
-//    public function testContainerResolvesWithNamedArgument(): void
-//    {
-//        $container = new Container();
-//        $container->add(Foo::class)
-//            ->addArgument('something', 'myString');
-//        self::assertTrue($container->has(Foo::class));
-//        $foo = $container->get(Foo::class);
-//        self::assertInstanceOf(Foo::class, $foo);
-//        self::assertInstanceOf(Bar::class, $foo->bar);
-//        self::assertSame('something', $foo->myString);
-//    }
+    /**
+     * Test that named arguments work when all required arguments are provided.
+     *
+     * Note: Partial autowiring (where some args are named and others are auto-wired)
+     * is not yet supported in Definition. For that use case, use Container::make().
+     */
+    public function testContainerResolvesWithNamedArgument(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class)
+            ->addArgument(Bar::class, 'bar')
+            ->addArgument('something', 'myString');
+        self::assertTrue($container->has(Foo::class));
+        $foo = $container->get(Foo::class);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+        self::assertSame('something', $foo->myString);
+    }
+
+    public function testContainerMakeWithArgs(): void
+    {
+        $container = new Container();
+        $foo = $container->make(Foo::class, ['myString' => 'hello world']);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+        self::assertSame('hello world', $foo->myString);
+    }
+
+    public function testContainerMakeAlwaysReturnsNewInstance(): void
+    {
+        $container = new Container();
+        $fooOne = $container->make(Foo::class);
+        $fooTwo = $container->make(Foo::class);
+        self::assertNotSame($fooOne, $fooTwo);
+    }
+
+    public function testInterfaceToImplementationUsesExistingDefinition(): void
+    {
+        $container = new Container();
+        // Register Bar with specific configuration
+        $container->addShared(Bar::class);
+
+        // Map interface to the concrete class
+        $container->add(BarInterface::class, Bar::class);
+
+        // Get via interface should use the existing Bar definition
+        $barFromInterface = $container->get(BarInterface::class);
+        $barDirect = $container->get(Bar::class);
+
+        self::assertInstanceOf(Bar::class, $barFromInterface);
+        // Should be the same instance because Bar is shared
+        self::assertSame($barDirect, $barFromInterface);
+    }
+
+    public function testHasDefinitionOnlyChecksExplicitDefinitions(): void
+    {
+        $container = new Container();
+        $container->add(Foo::class);
+
+        // hasDefinition should return true for explicitly added definitions
+        self::assertTrue($container->hasDefinition(Foo::class));
+
+        // hasDefinition should return false for autowirable classes not explicitly added
+        self::assertFalse($container->hasDefinition(Bar::class));
+
+        // but has() should return true because autowiring can resolve it
+        self::assertTrue($container->has(Bar::class));
+    }
 }

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -35,6 +35,52 @@ class ContainerTest extends TestCase
         self::assertInstanceOf(Foo::class, $foo);
     }
 
+    public function testContainerAddsMultipleAndGets(): void
+    {
+        $container = new Container();
+        $container->addDefinitions([
+            Foo::class,
+            Bar::class,
+        ]);
+        self::assertTrue($container->has(Foo::class));
+        self::assertTrue($container->has(Bar::class));
+        $foo = $container->get(Foo::class);
+        $bar = $container->get(Bar::class);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $bar);
+    }
+
+    public function testContainerAddsMultipleWithArgsAndGets(): void
+    {
+        $container = new Container();
+        $container->addDefinitions([
+            Foo::class => [Bar::class],
+            Bar::class,
+        ]);
+        self::assertTrue($container->has(Foo::class));
+        self::assertTrue($container->has(Bar::class));
+        $foo = $container->get(Foo::class);
+        $bar = $container->get(Bar::class);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $bar);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testContainerAddsMultipleWithCustomNamesAndGets(): void
+    {
+        $container = new Container();
+        $container->addDefinitions([
+            'foo' => Foo::class,
+            'bar' => Bar::class,
+        ]);
+        self::assertTrue($container->has('foo'));
+        self::assertTrue($container->has('bar'));
+        $foo = $container->get('foo');
+        $bar = $container->get('bar');
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $bar);
+    }
+
     public function testContainerAddsAndGetsShared(): void
     {
         $container = new Container();

--- a/tests/TestCase/Container/ContainerTest.php
+++ b/tests/TestCase/Container/ContainerTest.php
@@ -280,4 +280,16 @@ class ContainerTest extends TestCase
         self::assertTrue($container->has(NonExistent::class));
         self::assertSame(NonExistent::class, $container->get(NonExistent::class));
     }
+
+//    public function testContainerResolvesWithNamedArgument(): void
+//    {
+//        $container = new Container();
+//        $container->add(Foo::class)
+//            ->addArgument('something', 'myString');
+//        self::assertTrue($container->has(Foo::class));
+//        $foo = $container->get(Foo::class);
+//        self::assertInstanceOf(Foo::class, $foo);
+//        self::assertInstanceOf(Bar::class, $foo->bar);
+//        self::assertSame('something', $foo->myString);
+//    }
 }

--- a/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
@@ -1,0 +1,269 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Definition;
+
+use Cake\Container\Container;
+use Cake\Container\Definition\Definition;
+use Cake\Container\Definition\DefinitionAggregate;
+use Cake\Container\Definition\DefinitionInterface;
+use Cake\Container\Exception\NotFoundException;
+use Cake\Test\TestCase\Container\Asset\Foo;
+use PHPUnit\Framework\TestCase;
+
+class DefinitionAggregateTest extends TestCase
+{
+    public function testAggregateAddsDefinition(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $definition = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+
+        $definition
+            ->expects(self::once())
+            ->method('setAlias')
+            ->with(self::equalTo('alias'))
+            ->will(self::returnSelf());
+
+        $aggregate = (new DefinitionAggregate())->setContainer($container);
+        $definition = $aggregate->add('alias', $definition);
+
+        self::assertInstanceOf(DefinitionInterface::class, $definition);
+    }
+
+    public function testAggregateCreatesDefinition(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new DefinitionAggregate())->setContainer($container);
+        $definition = $aggregate->add('alias', Foo::class);
+        self::assertSame('alias', $definition->getAlias());
+    }
+
+    public function testAggregateHasDefinition(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new DefinitionAggregate())->setContainer($container);
+        $aggregate->add('alias', Foo::class);
+        self::assertTrue($aggregate->has('alias'));
+        self::assertFalse($aggregate->has('nope'));
+    }
+
+    public function testAggregateAddsAndIteratesMultipleDefinitions(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new DefinitionAggregate())->setContainer($container);
+
+        $definitions = [];
+
+        for ($i = 0; $i < 10; $i++) {
+            $definitions[] = $aggregate->add('alias' . $i, Foo::class);
+        }
+
+        foreach ($aggregate->getIterator() as $key => $definition) {
+            self::assertSame($definitions[$key], $definition);
+        }
+    }
+
+    public function testAggregateIteratesAndResolvesDefinition(): void
+    {
+        $aggregate = new DefinitionAggregate();
+        $definition1 = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+        $definition2 = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $definition1
+            ->expects(self::once())
+            ->method('getAlias')
+            ->willReturn('alias1');
+
+        $definition1
+            ->expects(self::once())
+            ->method('setAlias')
+            ->with(self::equalTo('alias1'))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('getAlias')
+            ->willReturn('alias2');
+
+        $definition2
+            ->expects(self::once())
+            ->method('setContainer')
+            ->with(self::equalTo($container))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('setShared')
+            ->with(self::equalTo(true))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('setAlias')
+            ->with(self::equalTo('alias2'))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('resolve')
+            ->will(self::returnSelf());
+
+        $aggregate->setContainer($container);
+
+        $aggregate->add('alias1', $definition1);
+        $aggregate->addShared('alias2', $definition2);
+
+        $resolved = $aggregate->resolve('alias2');
+        self::assertSame($definition2, $resolved);
+    }
+
+    public function testAggregateCanResolveArrayOfTaggedDefinitions(): void
+    {
+        $definition1 = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+        $definition2 = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $definition1
+            ->expects(self::once())
+            ->method('setContainer')
+            ->with(self::equalTo($container))
+            ->will(self::returnSelf());
+
+        $definition1
+            ->expects(self::exactly(2))
+            ->method('hasTag')
+            ->with(self::equalTo('tag'))
+            ->willReturn(true);
+
+        $definition1
+            ->expects(self::once())
+            ->method('resolve')
+            ->willReturn('definition1');
+
+        $definition2
+            ->expects(self::once())
+            ->method('setContainer')
+            ->with(self::equalTo($container))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('hasTag')
+            ->with(self::equalTo('tag'))
+            ->willReturn(true);
+
+        $definition2
+            ->expects(self::once())
+            ->method('resolve')
+            ->willReturn('definition2');
+
+        $aggregate = new DefinitionAggregate([$definition1, $definition2]);
+
+        $aggregate->setContainer($container);
+        self::assertTrue($aggregate->hasTag('tag'));
+        $resolved = $aggregate->resolveTagged('tag');
+        self::assertSame(['definition1', 'definition2'], $resolved);
+    }
+
+    public function testAggregateThrowsExceptionWhenCannotResolve(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $aggregate = new DefinitionAggregate();
+        $definition1 = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+        $definition2 = $this->getMockBuilder(DefinitionInterface::class)->getMock();
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $definition1
+            ->expects(self::once())
+            ->method('getAlias')
+            ->willReturn('alias1');
+
+        $definition1
+            ->expects(self::once())
+            ->method('setAlias')
+            ->with(self::equalTo('alias1'))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('getAlias')
+            ->willReturn('alias2');
+
+        $definition2
+            ->expects(self::once())
+            ->method('setShared')
+            ->with(self::equalTo(true))
+            ->will(self::returnSelf());
+
+        $definition2
+            ->expects(self::once())
+            ->method('setAlias')
+            ->with(self::equalTo('alias2'))
+            ->will(self::returnSelf());
+
+        $aggregate->setContainer($container);
+
+        $aggregate->add('alias1', $definition1);
+        $aggregate->addShared('alias2', $definition2);
+
+        $aggregate->resolveNew('alias');
+    }
+
+    public function testDefinitionPrecedingSlash(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = new DefinitionAggregate();
+        $aggregate->setContainer($container);
+
+        $some_class = '\\Cake\\Test\\TestCase\\Container\\Asset\\Foo';
+        $aggregate->add($some_class, null);
+
+        $definition = $aggregate->getDefinition(Foo::class);
+
+        self::assertInstanceOf(Definition::class, $definition);
+    }
+
+    public function testGetPrecedingSlash(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = new DefinitionAggregate();
+        $aggregate->setContainer($container);
+
+        $some_class = Foo::class;
+        $aggregate->add($some_class, null);
+
+        $definition = $aggregate->getDefinition('\\Cake\\Test\\TestCase\\Container\\Asset\\Foo');
+
+        self::assertInstanceOf(Definition::class, $definition);
+    }
+
+    public function testDefinitionPrecedingSlashSingularQuotes(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = new DefinitionAggregate();
+        $aggregate->setContainer($container);
+
+        $some_class = '\\Cake\\Test\\TestCase\\Container\\Asset\\Foo';
+        $aggregate->add($some_class, null);
+
+        $definition = $aggregate->getDefinition(Foo::class);
+
+        self::assertInstanceOf(Definition::class, $definition);
+    }
+
+    public function testGetPrecedingSlashSingularQuote(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = new DefinitionAggregate();
+        $aggregate->setContainer($container);
+
+        $some_class = Foo::class;
+        $aggregate->add($some_class, null);
+
+        $definition = $aggregate->getDefinition('\\Cake\\Test\\TestCase\\Container\\Asset\\Foo');
+
+        self::assertInstanceOf(Definition::class, $definition);
+    }
+}

--- a/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionAggregateTest.php
@@ -22,7 +22,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $aggregate = (new DefinitionAggregate())->setContainer($container);
         $definition = $aggregate->add('alias', $definition);
@@ -79,7 +79,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias1'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
@@ -90,24 +90,24 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setContainer')
             ->with(self::equalTo($container))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('setShared')
             ->with(self::equalTo(true))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias2'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('resolve')
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $aggregate->setContainer($container);
 
@@ -128,7 +128,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setContainer')
             ->with(self::equalTo($container))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition1
             ->expects(self::exactly(2))
@@ -145,7 +145,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setContainer')
             ->with(self::equalTo($container))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
@@ -184,7 +184,7 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias1'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
@@ -195,13 +195,13 @@ class DefinitionAggregateTest extends TestCase
             ->expects(self::once())
             ->method('setShared')
             ->with(self::equalTo(true))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $definition2
             ->expects(self::once())
             ->method('setAlias')
             ->with(self::equalTo('alias2'))
-            ->will(self::returnSelf());
+            ->willReturnSelf();
 
         $aggregate->setContainer($container);
 

--- a/tests/TestCase/Container/Definition/DefinitionTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionTest.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Definition;
+
+use Cake\Container\Argument\Literal;
+use Cake\Container\Argument\ResolvableArgument;
+use Cake\Container\Container;
+use Cake\Container\Definition\Definition;
+use Cake\Test\TestCase\Container\Asset\Bar;
+use Cake\Test\TestCase\Container\Asset\Foo;
+use Cake\Test\TestCase\Container\Asset\FooCallable;
+use PHPUnit\Framework\TestCase;
+
+class DefinitionTest extends TestCase
+{
+    public function testDefinitionResolvesClosureWithDefinedArgs(): void
+    {
+        $definition = new Definition('callable', function (...$args) {
+            return implode(' ', $args);
+        });
+
+        $definition->addArguments(['hello', 'world']);
+        $actual = $definition->resolve();
+        self::assertSame('hello world', $actual);
+    }
+
+    public function testDefinitionResolvesClosureReturningRawArgument(): void
+    {
+        $definition = new Definition('callable', function () {
+            return new Literal\StringArgument('hello world');
+        });
+
+        $actual = $definition->resolve();
+        self::assertSame('hello world', $actual);
+    }
+
+    public function testDefinitionResolvesCallableClass(): void
+    {
+        $definition = new Definition('callable', new FooCallable());
+        $definition->addArgument(new Bar());
+        $actual = $definition->resolve();
+        self::assertInstanceOf(Foo::class, $actual);
+    }
+
+    public function testDefinitionResolvesArrayCallable(): void
+    {
+        $definition = new Definition('callable', [new FooCallable(), '__invoke']);
+        $definition->addArgument(new Bar());
+        $actual = $definition->resolve();
+        self::assertInstanceOf(Foo::class, $actual);
+    }
+
+    public function testDefinitionResolvesClassWithMethodCalls(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $bar = new Bar();
+
+        $container->expects(self::once())->method('has')->with(self::equalTo(Bar::class))->willReturn(true);
+        $container->expects(self::once())->method('get')->with(self::equalTo(Bar::class))->willReturn($bar);
+
+        $definition = new Definition('callable', Foo::class);
+
+        $definition->setContainer($container);
+        $definition->addMethodCalls(['setBar' => [Bar::class]]);
+
+        $actual = $definition->resolve();
+        self::assertInstanceOf(Foo::class, $actual);
+        self::assertInstanceOf(Bar::class, $actual->bar);
+    }
+
+    public function testDefinitionResolvesClassWithDefinedArgs(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $bar = new Bar();
+
+        $container->expects(self::once())->method('has')->with(self::equalTo(Bar::class))->willReturn(true);
+        $container->expects(self::once())->method('get')->with(self::equalTo(Bar::class))->willReturn($bar);
+
+        $definition = new Definition('callable', Foo::class);
+
+        $definition->setContainer($container);
+        $definition->addArgument(Bar::class);
+
+        $actual = $definition->resolve();
+        self::assertInstanceOf(Foo::class, $actual);
+        self::assertInstanceOf(Bar::class, $actual->bar);
+    }
+
+    public function testDefinitionResolvesSharedItemOnlyOnce(): void
+    {
+        $definition = new Definition('class', Foo::class);
+        $definition->setShared(true);
+        $actual1 = $definition->resolve();
+        $actual2 = $definition->resolve();
+        $actual3 = $definition->resolveNew();
+        self::assertSame($actual1, $actual2);
+        self::assertNotSame($actual1, $actual3);
+    }
+
+    public function testDefinitionResolvesNestedAlias(): void
+    {
+        $aliasDefinition = new Definition('alias', new ResolvableArgument('class'));
+        $definition = new Definition('class', Foo::class);
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $expected = $definition->resolve();
+
+        $container->expects(self::once())->method('has')->with(self::equalTo('class'))->willReturn(true);
+        $container->expects(self::once())->method('get')->with(self::equalTo('class'))->willReturn($expected);
+
+        $aliasDefinition->setContainer($container);
+        $actual = $aliasDefinition->resolve();
+        self::assertSame($expected, $actual);
+    }
+
+    public function testDefinitionCanAddTags(): void
+    {
+        $definition = new Definition('class', Foo::class);
+        $definition->addTag('tag1')->addTag('tag2');
+        self::assertTrue($definition->hasTag('tag1'));
+        self::assertTrue($definition->hasTag('tag2'));
+        self::assertFalse($definition->hasTag('tag3'));
+    }
+
+    public function testDefinitionCanGetConcrete(): void
+    {
+        $concrete = new Literal\StringArgument(Foo::class);
+        $definition = new Definition('class', $concrete);
+        self::assertSame($concrete, $definition->getConcrete());
+    }
+
+    public function testDefinitionCanSetConcrete(): void
+    {
+        $definition = new Definition('class', null);
+        $concrete = new Literal\StringArgument(Foo::class);
+        $definition->setConcrete($concrete);
+        self::assertSame($concrete, $definition->getConcrete());
+    }
+}

--- a/tests/TestCase/Container/Definition/DefinitionTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionTest.php
@@ -151,7 +151,7 @@ class DefinitionTest extends TestCase
 
     public function testDefinitionCanSetConcrete(): void
     {
-        $definition = new Definition('class', null);
+        $definition = new Definition('class');
         $concrete = new Literal\StringArgument(Foo::class);
         $definition->setConcrete($concrete);
         self::assertSame($concrete, $definition->getConcrete());

--- a/tests/TestCase/Container/Definition/DefinitionTest.php
+++ b/tests/TestCase/Container/Definition/DefinitionTest.php
@@ -10,6 +10,7 @@ use Cake\Container\Definition\Definition;
 use Cake\Test\TestCase\Container\Asset\Bar;
 use Cake\Test\TestCase\Container\Asset\Foo;
 use Cake\Test\TestCase\Container\Asset\FooCallable;
+use Error;
 use PHPUnit\Framework\TestCase;
 
 class DefinitionTest extends TestCase
@@ -49,6 +50,24 @@ class DefinitionTest extends TestCase
         $definition->addArgument(new Bar());
         $actual = $definition->resolve();
         self::assertInstanceOf(Foo::class, $actual);
+    }
+
+    public function testDefinitionAddsArgumentWithName(): void
+    {
+        $definition = new Definition('class', Foo::class);
+        $definition->addArgument('something', 'myString');
+        $actual = $definition->resolve();
+        self::assertInstanceOf(Foo::class, $actual);
+        self::assertSame('something', $actual->myString);
+    }
+
+    public function testDefinitionAddsArgumentWithUnknownNameThrows(): void
+    {
+        $definition = new Definition('class', Foo::class);
+        $definition->addArgument('something', 'unknown');
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Unknown named parameter $unknown');
+        $definition->resolve();
     }
 
     public function testDefinitionResolvesClassWithMethodCalls(): void

--- a/tests/TestCase/Container/Inflector/InflectorAggregateTest.php
+++ b/tests/TestCase/Container/Inflector/InflectorAggregateTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Inflector;
+
+use Cake\Container\Container;
+use Cake\Container\ContainerAwareInterface;
+use Cake\Container\Inflector\InflectorAggregate;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+
+class InflectorAggregateTest extends TestCase
+{
+    public function testAggregateAddsInflector(): void
+    {
+        $aggregate = new InflectorAggregate();
+        $inflector = $aggregate->add('Some\Type');
+        self::assertSame('Some\Type', $inflector->getType());
+    }
+
+    public function testAggregateAddsAndIteratesMultipleInflectors(): void
+    {
+        $aggregate = new InflectorAggregate();
+        $inflectors = [];
+
+        for ($i = 0; $i < 10; $i++) {
+            $inflectors[] = $aggregate->add('Some\Type' . $i);
+        }
+
+        foreach ($aggregate->getIterator() as $key => $inflector) {
+            self::assertSame($inflectors[$key], $inflector);
+        }
+    }
+
+    public function testAggregateIteratesAndInflectsOnObject(): void
+    {
+        $aggregate = new InflectorAggregate();
+        $containerAware = $this->getMockBuilder(ContainerAwareInterface::class)->getMock();
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $containerAware->expects(self::once())->method('setContainer')->with(self::equalTo($container));
+        $aggregate->add(ContainerAwareInterface::class)->invokeMethod('setContainer', [$container]);
+        $aggregate->add('Ignored\Type');
+        $aggregate->setContainer($container);
+        $aggregate->inflect($containerAware);
+    }
+
+    public function testNoInflectionIsAttemptedOnNonObjects(): void
+    {
+        $container = new Container();
+
+        $types = [
+            'my-array' => [1, 2, 3],
+            'my-number' => 123,
+            'my-string' => 'foo bar',
+            'my-generated-array' => [DateTimeZone::class, 'listIdentifiers'],
+            'my-generated-number' => 'time',
+            'my-generated-string' => function (): string {
+                return 'blahblahblah';
+            },
+        ];
+
+        foreach ($types as $alias => $concrete) {
+            $container->add($alias, $concrete);
+
+            if (is_callable($concrete)) {
+                $concrete = $concrete();
+            }
+
+            self::assertSame($container->get($alias), $concrete);
+        }
+    }
+}

--- a/tests/TestCase/Container/Inflector/InflectorTest.php
+++ b/tests/TestCase/Container/Inflector/InflectorTest.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\Inflector;
+
+use Cake\Container\Container;
+use Cake\Container\Inflector\Inflector;
+use Cake\Test\TestCase\Container\Asset\Bar;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class InflectorTest extends TestCase
+{
+    public function testInflectorSetsExpectedMethodCalls(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $inflector = (new Inflector('Type'))->setContainer($container);
+
+        $inflector->invokeMethod('method1', ['arg1']);
+
+        $inflector->invokeMethods([
+            'method2' => ['arg1'],
+            'method3' => ['arg1'],
+        ]);
+
+        $methods = (new ReflectionClass($inflector))->getProperty('methods');
+        $methods->setAccessible(true);
+
+        self::assertSame($methods->getValue($inflector), [
+            'method1' => ['arg1'],
+            'method2' => ['arg1'],
+            'method3' => ['arg1'],
+        ]);
+    }
+
+    public function testInflectorSetsExpectedProperties(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $inflector = (new Inflector('Type'))->setContainer($container);
+
+        $inflector->setProperty('property1', 'value');
+
+        $inflector->setProperties([
+            'property2' => 'value',
+            'property3' => 'value',
+        ]);
+
+        $properties = (new ReflectionClass($inflector))->getProperty('properties');
+        $properties->setAccessible(true);
+
+        self::assertSame($properties->getValue($inflector), [
+            'property1' => 'value',
+            'property2' => 'value',
+            'property3' => 'value',
+        ]);
+    }
+
+    public function testInflectorInflectsWithProperties(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $bar = new class {
+        };
+
+        $container
+            ->expects(self::once())
+            ->method('has')
+            ->with(self::equalTo(Bar::class))
+            ->willReturn(true);
+
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with(self::equalTo(Bar::class))
+            ->willReturn($bar);
+
+        $inflector = (new Inflector('Type'))
+            ->setContainer($container)
+            ->setProperty('bar', Bar::class);
+
+        $foo = new class {
+            public $bar;
+        };
+
+        $inflector->inflect($foo);
+
+        self::assertSame($bar, $foo->bar);
+    }
+
+    public function testInflectorInflectsWithMethodCall(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $bar = new class {
+        };
+
+        $container
+            ->expects(self::once())
+            ->method('has')
+            ->with(self::equalTo(Bar::class))
+            ->willReturn(true);
+
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with(self::equalTo(Bar::class))
+            ->willReturn($bar);
+
+        $inflector = (new Inflector('Type'))
+            ->setContainer($container)
+            ->invokeMethod('setBar', [Bar::class]);
+
+        $foo = new class {
+            public $bar;
+            public function setBar($bar): void
+            {
+                $this->bar = $bar;
+            }
+        };
+
+        $inflector->inflect($foo);
+        self::assertSame($bar, $foo->bar);
+    }
+
+    public function testInflectorInflectsWithCallback(): void
+    {
+        $foo = new class {
+            public $bar;
+            public function setBar($bar): void
+            {
+                $this->bar = $bar;
+            }
+        };
+
+        $bar = new class {
+        };
+
+        $inflector = new Inflector('Type', function ($object) use ($bar) {
+            $object->setBar($bar);
+        });
+
+        $inflector->inflect($foo);
+        self::assertSame($bar, $foo->bar);
+    }
+}

--- a/tests/TestCase/Container/Inflector/InflectorTest.php
+++ b/tests/TestCase/Container/Inflector/InflectorTest.php
@@ -24,7 +24,6 @@ class InflectorTest extends TestCase
         ]);
 
         $methods = (new ReflectionClass($inflector))->getProperty('methods');
-        $methods->setAccessible(true);
 
         self::assertSame($methods->getValue($inflector), [
             'method1' => ['arg1'],
@@ -46,7 +45,6 @@ class InflectorTest extends TestCase
         ]);
 
         $properties = (new ReflectionClass($inflector))->getProperty('properties');
-        $properties->setAccessible(true);
 
         self::assertSame($properties->getValue($inflector), [
             'property1' => 'value',
@@ -135,7 +133,7 @@ class InflectorTest extends TestCase
         $bar = new class {
         };
 
-        $inflector = new Inflector('Type', function ($object) use ($bar) {
+        $inflector = new Inflector('Type', function ($object) use ($bar): void {
             $object->setBar($bar);
         });
 

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -188,11 +188,18 @@ class ReflectionContainerTest extends TestCase
 
     public function testCallResolvesFunction(): void
     {
-        require CORE_TEST_CASES . DS . 'Container' . DS . 'Asset' . DS . 'function.php';
         $container = new ReflectionContainer();
-        $foo = $container->call(Asset\test::class, [new Bar()]);
+        $foo = $container->call('\Cake\Test\TestCase\Container\Asset\test', [new Bar()]);
         self::assertInstanceOf(Foo::class, $foo);
         self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testCallThrowsOnUnknownString(): void
+    {
+        $container = new ReflectionContainer();
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage('Callable (Unknown) is not a valid callable');
+        $container->call('Unknown', [new Bar()]);
     }
 
     public function testGetInstantiatesClassWithConstructorAndSkipsProtectedConstructor(): void

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -1,0 +1,226 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container;
+
+use Cake\Container\Container;
+use Cake\Container\Exception\NotFoundException;
+use Cake\Container\ReflectionContainer;
+use Cake\Test\TestCase\Container\Asset\Bar;
+use Cake\Test\TestCase\Container\Asset\Foo;
+use Cake\Test\TestCase\Container\Asset\FooCallable;
+use Cake\Test\TestCase\Container\Asset\ProBar;
+use Cake\Test\TestCase\Container\Asset\ProFoo;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class ReflectionContainerTest extends TestCase
+{
+    private function getContainerMock(array $items = []): Container
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+
+        $container
+            ->method('has')
+            ->willReturnCallback(function ($alias) use ($items) {
+                return array_key_exists($alias, $items);
+            });
+
+        $container
+            ->method('get')
+            ->willReturnCallback(function ($alias) use ($items) {
+                if (array_key_exists($alias, $items)) {
+                    return $items[$alias];
+                }
+            });
+
+        return $container;
+    }
+
+    public function testHasReturnsTrueIfClassExists(): void
+    {
+        $container = new ReflectionContainer();
+        self::assertTrue($container->has(ReflectionContainer::class));
+    }
+
+    public function testHasReturnsFalseIfClassDoesNotExist(): void
+    {
+        $container = new ReflectionContainer();
+        self::assertFalse($container->has('blah'));
+    }
+
+    public function testContainerInstantiatesClassWithoutConstructor(): void
+    {
+        $classWithoutConstructor = stdClass::class;
+        $container = new ReflectionContainer();
+        self::assertInstanceOf($classWithoutConstructor, $container->get($classWithoutConstructor));
+    }
+
+    public function testContainerInstantiatesAndCachesClassWithoutConstructor(): void
+    {
+        $classWithoutConstructor = stdClass::class;
+        $container = new ReflectionContainer(true);
+
+        $classWithoutConstructorOne = $container->get($classWithoutConstructor);
+        $classWithoutConstructorTwo = $container->get($classWithoutConstructor);
+
+        self::assertInstanceOf($classWithoutConstructor, $classWithoutConstructorOne);
+        self::assertInstanceOf($classWithoutConstructor, $classWithoutConstructorTwo);
+        self::assertSame($classWithoutConstructorOne, $classWithoutConstructorTwo);
+    }
+
+    public function testGetInstantiatesClassWithConstructor(): void
+    {
+        $classWithConstructor = Foo::class;
+        $dependencyClass = Bar::class;
+
+        $container = new ReflectionContainer();
+        $item = $container->get($classWithConstructor);
+
+        self::assertInstanceOf($classWithConstructor, $item);
+        self::assertInstanceOf($dependencyClass, $item->bar);
+    }
+
+    public function testGetInstantiatesAndCachedClassWithConstructor(): void
+    {
+        $classWithConstructor = Foo::class;
+        $dependencyClass = Bar::class;
+
+        $container = new ReflectionContainer(true);
+
+        $itemOne = $container->get($classWithConstructor);
+        $itemTwo = $container->get($classWithConstructor);
+
+        self::assertInstanceOf($classWithConstructor, $itemOne);
+        self::assertInstanceOf($dependencyClass, $itemOne->bar);
+
+        self::assertInstanceOf($classWithConstructor, $itemTwo);
+        self::assertInstanceOf($dependencyClass, $itemTwo->bar);
+
+        self::assertSame($itemOne, $itemTwo);
+        self::assertSame($itemOne->bar, $itemTwo->bar);
+    }
+
+    public function testGetInstantiatesClassWithConstructorAndUsesContainer(): void
+    {
+        $classWithConstructor = Foo::class;
+        $dependencyClass = Bar::class;
+
+        $dependency = new $dependencyClass();
+        $container = new ReflectionContainer();
+
+        $container->setContainer($this->getContainerMock([
+            $dependencyClass => $dependency,
+        ]));
+
+        $item = $container->get($classWithConstructor);
+
+        self::assertInstanceOf($classWithConstructor, $item);
+        self::assertSame($dependency, $item->bar);
+    }
+
+    public function testGetInstantiatesClassWithConstructorAndUsesArguments(): void
+    {
+        $classWithConstructor = Foo::class;
+        $dependencyClass = Bar::class;
+
+        $dependency = new $dependencyClass();
+        $container = new ReflectionContainer();
+
+        $item = $container->get($classWithConstructor, [
+            'bar' => $dependency,
+        ]);
+
+        self::assertInstanceOf($classWithConstructor, $item);
+        self::assertSame($dependency, $item->bar);
+    }
+
+    public function testThrowsWhenGettingNonExistentClass(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $container = new ReflectionContainer();
+        $container->get('Whoooo');
+    }
+
+    public function testCallReflectsOnClosureArguments(): void
+    {
+        $container = new ReflectionContainer();
+
+        $foo = $container->call(function (Foo $foo) {
+            return $foo;
+        });
+
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testCallReflectsOnInstanceMethodArguments(): void
+    {
+        $container = new ReflectionContainer();
+        $foo = new Foo();
+        $container->call([$foo, 'setBar']);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testCallReflectsOnStaticMethodArguments(): void
+    {
+        $container = new ReflectionContainer();
+        $container->call('Cake\Test\TestCase\Container\Asset\Foo::staticSetBar');
+        self::assertInstanceOf(Bar::class, Asset\Foo::$staticBar);
+        self::assertEquals('hello world', Asset\Foo::$staticHello);
+    }
+
+    public function testCallThrowsWhenArgumentCannotBeResolved(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $container = new ReflectionContainer();
+        $container->call([new Bar(), 'setSomething']);
+    }
+
+    public function testCallResolvesInvokableClass(): void
+    {
+        $container = new ReflectionContainer();
+        $foo = $container->call(new FooCallable(), [new Bar()]);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testCallResolvesFunction(): void
+    {
+        require CORE_TEST_CASES . DS . 'Container' . DS . 'Asset' . DS . 'function.php';
+        $container = new ReflectionContainer();
+        $foo = $container->call(Asset\test::class, [new Bar()]);
+        self::assertInstanceOf(Foo::class, $foo);
+        self::assertInstanceOf(Bar::class, $foo->bar);
+    }
+
+    public function testGetInstantiatesClassWithConstructorAndSkipsProtectedConstructor(): void
+    {
+        $classWithConstructor = ProFoo::class;
+
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+
+        $item = $container->get($classWithConstructor);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertNull($item->bar);
+    }
+
+    public function testGetInstantiatesClassWithConstructorAndUsesFactory(): void
+    {
+        $classWithConstructor = ProFoo::class;
+        $dependencyClass = ProBar::class;
+
+        $container = new Container();
+        $container->delegate(new ReflectionContainer());
+
+        $container->add($dependencyClass, [$dependencyClass, 'factory']);
+
+        $item = $container->get($classWithConstructor);
+
+        $this->assertInstanceOf($classWithConstructor, $item);
+        $this->assertInstanceOf($dependencyClass, $item->bar);
+    }
+}

--- a/tests/TestCase/Container/ReflectionContainerTest.php
+++ b/tests/TestCase/Container/ReflectionContainerTest.php
@@ -158,7 +158,7 @@ class ReflectionContainerTest extends TestCase
     {
         $container = new ReflectionContainer();
         $foo = new Foo();
-        $container->call([$foo, 'setBar']);
+        $container->call($foo->setBar(...));
         self::assertInstanceOf(Foo::class, $foo);
         self::assertInstanceOf(Bar::class, $foo->bar);
     }

--- a/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
+++ b/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\ServiceProvider;
+
+use Cake\Container\Container;
+use Cake\Container\Exception\ContainerException;
+use Cake\Container\ServiceProvider\AbstractServiceProvider;
+use Cake\Container\ServiceProvider\BootableServiceProviderInterface;
+use Cake\Container\ServiceProvider\ServiceProviderAggregate;
+use Cake\Container\ServiceProvider\ServiceProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class ServiceProviderAggregateTest extends TestCase
+{
+    protected function getServiceProvider(): ServiceProviderInterface
+    {
+        return new class extends AbstractServiceProvider implements BootableServiceProviderInterface {
+            public $booted = 0;
+            public $registered = 0;
+
+            public function provides(string $id): bool
+            {
+                return in_array($id, [
+                    'SomeService',
+                    'AnotherService',
+                ], true);
+            }
+
+            public function boot(): void
+            {
+                $this->booted++;
+            }
+
+            public function register(): void
+            {
+                $this->registered++;
+
+                $this->getContainer()->add('SomeService', function ($arg) {
+                    return $arg;
+                });
+            }
+        };
+    }
+
+    public function testAggregateAddsClassNameServiceProvider(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = new ServiceProviderAggregate();
+        $aggregate->setContainer($container);
+        $aggregate->add($this->getServiceProvider());
+        self::assertTrue($aggregate->provides('SomeService'));
+        self::assertTrue($aggregate->provides('AnotherService'));
+    }
+
+    public function testAggregateThrowsWhenRegisteringForServiceThatIsNotAdded(): void
+    {
+        $this->expectException(ContainerException::class);
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new ServiceProviderAggregate())->setContainer($container);
+        $aggregate->register('SomeService');
+    }
+
+    public function testAggregateInvokesCorrectRegisterMethodOnlyOnce(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new ServiceProviderAggregate())->setContainer($container);
+        $provider = $this->getServiceProvider();
+        $aggregate->add($provider);
+        $aggregate->register('SomeService');
+        $aggregate->register('AnotherService');
+        self::assertSame(1, $provider->registered);
+    }
+
+    public function testAggregateSkipsExistingProviders(): void
+    {
+        $container = $this->getMockBuilder(Container::class)->getMock();
+        $aggregate = (new ServiceProviderAggregate())->setContainer($container);
+        $provider = $this->getServiceProvider();
+        $aggregate->add($provider);
+        $aggregate->add($provider);
+
+        // assert after adding provider multiple times, that it
+        // was only aggregated and booted once
+        self::assertSame(
+            [$provider],
+            iterator_to_array($aggregate->getIterator())
+        );
+
+        self::assertSame(1, $provider->booted);
+    }
+}

--- a/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
+++ b/tests/TestCase/Container/ServiceProvider/ServiceProviderAggregateTest.php
@@ -84,7 +84,7 @@ class ServiceProviderAggregateTest extends TestCase
         // was only aggregated and booted once
         self::assertSame(
             [$provider],
-            iterator_to_array($aggregate->getIterator())
+            iterator_to_array($aggregate->getIterator()),
         );
 
         self::assertSame(1, $provider->booted);

--- a/tests/TestCase/Container/ServiceProvider/ServiceProviderTest.php
+++ b/tests/TestCase/Container/ServiceProvider/ServiceProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Test\TestCase\Container\ServiceProvider;
+
+use Cake\Container\ServiceProvider\AbstractServiceProvider;
+use Cake\Container\ServiceProvider\BootableServiceProviderInterface;
+use Cake\Container\ServiceProvider\ServiceProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    protected function getServiceProvider(): ServiceProviderInterface
+    {
+        return new class extends AbstractServiceProvider implements BootableServiceProviderInterface
+        {
+            public function provides(string $id): bool
+            {
+                return in_array($id, [
+                    'SomeService',
+                    'AnotherService',
+                ], true);
+            }
+
+            public function boot(): void
+            {
+            }
+
+            public function register(): void
+            {
+                $this->getContainer()->add('SomeService', function ($arg) {
+                    return $arg;
+                });
+            }
+        };
+    }
+
+    public function testServiceProviderCorrectlyDeterminesWhatIsProvided(): void
+    {
+        $provider = $this->getServiceProvider()->setIdentifier('something');
+        self::assertTrue($provider->provides('SomeService'));
+        self::assertTrue($provider->provides('AnotherService'));
+        self::assertFalse($provider->provides('NonService'));
+    }
+}


### PR DESCRIPTION
Due to our code style some BC changes had to be done (mostly return types for interface methods) to this lib to get it all green, therefore it is NOT a 1:1 replacement of `thephpleague/container`

I added it to `5.next` and not `6.x` since it can be seen as an opt-in feature to use the built-in container instead of the already existing container implementation. If not suited for a minor update this can still be easily rebased onto `6.x`

It of course needs to be connected to the rest of the framework (e.g. the Testsuite).