### PR TITLE
Add console out/err to assertion messages

### DIFF
--- a/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
+++ b/src/Console/TestSuite/ConsoleIntegrationTestTrait.php
@@ -136,7 +136,11 @@ trait ConsoleIntegrationTestTrait
      */
     public function assertExitCode(int $expected, string $message = ''): void
     {
-        $this->assertThat($expected, new ExitCode($this->_exitCode), $message);
+        $this->assertThat(
+            $expected,
+            new ExitCode($this->_exitCode, $this->_out->messages(), $this->_err->messages()),
+            $message
+        );
     }
 
     /**
@@ -147,7 +151,11 @@ trait ConsoleIntegrationTestTrait
      */
     public function assertExitSuccess(string $message = ''): void
     {
-        $this->assertThat(Command::CODE_SUCCESS, new ExitCode($this->_exitCode), $message);
+        $this->assertThat(
+            Command::CODE_SUCCESS,
+            new ExitCode($this->_exitCode, $this->_out->messages(), $this->_err->messages()),
+            $message
+        );
     }
 
     /**
@@ -158,7 +166,11 @@ trait ConsoleIntegrationTestTrait
      */
     public function assertExitError(string $message = ''): void
     {
-        $this->assertThat(Command::CODE_ERROR, new ExitCode($this->_exitCode), $message);
+        $this->assertThat(
+            Command::CODE_ERROR,
+            new ExitCode($this->_exitCode, $this->_out->messages(), $this->_err->messages()),
+            $message
+        );
     }
 
     /**

--- a/src/Console/TestSuite/Constraint/ContentsContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsContain.php
@@ -40,7 +40,15 @@ class ContentsContain extends ContentsBase
      */
     public function toString(): string
     {
-        return sprintf('is in %s,' . PHP_EOL . 'actual result:' . PHP_EOL . '`%s`', $this->output, $this->contents);
+        return sprintf('is in %s.', $this->output);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function additionalFailureDescription(mixed $other): string
+    {
+        return sprintf("actual result:\n%s", $this->contents);
     }
 }
 

--- a/src/Console/TestSuite/Constraint/ContentsEmpty.php
+++ b/src/Console/TestSuite/Constraint/ContentsEmpty.php
@@ -40,7 +40,7 @@ class ContentsEmpty extends ContentsBase
      */
     public function toString(): string
     {
-        return sprintf('%s is empty', $this->output);
+        return sprintf('%s is empty.', $this->output);
     }
 
     /**
@@ -52,6 +52,14 @@ class ContentsEmpty extends ContentsBase
     protected function failureDescription(mixed $other): string
     {
         return $this->toString();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function additionalFailureDescription(mixed $other): string
+    {
+        return sprintf("actual result:\n%s", $this->contents);
     }
 }
 

--- a/src/Console/TestSuite/Constraint/ContentsNotContain.php
+++ b/src/Console/TestSuite/Constraint/ContentsNotContain.php
@@ -40,7 +40,15 @@ class ContentsNotContain extends ContentsBase
      */
     public function toString(): string
     {
-        return sprintf('is not in %s', $this->output);
+        return sprintf('is not in %s.', $this->output);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function additionalFailureDescription(mixed $other): string
+    {
+        return sprintf("actual result:\n%s", $this->contents);
     }
 }
 

--- a/src/Console/TestSuite/Constraint/ContentsRegExp.php
+++ b/src/Console/TestSuite/Constraint/ContentsRegExp.php
@@ -51,6 +51,14 @@ class ContentsRegExp extends ContentsBase
     {
         return '`' . $other . '` ' . $this->toString();
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function additionalFailureDescription(mixed $other): string
+    {
+        return sprintf("actual result:\n%s", $this->contents);
+    }
 }
 
 // phpcs:disable

--- a/src/Console/TestSuite/Constraint/ExitCode.php
+++ b/src/Console/TestSuite/Constraint/ExitCode.php
@@ -30,13 +30,27 @@ class ExitCode extends Constraint
     private ?int $exitCode = null;
 
     /**
+     * @var array $out
+     */
+    private array $out;
+
+    /**
+     * @var array $err
+     */
+    private array $err;
+
+    /**
      * Constructor
      *
      * @param int|null $exitCode Exit code
+     * @param array $out stdout stream
+     * @param array $err stderr stream
      */
-    public function __construct(?int $exitCode)
+    public function __construct(?int $exitCode, array $out, array $err)
     {
         $this->exitCode = $exitCode;
+        $this->out = $out;
+        $this->err = $err;
     }
 
     /**
@@ -69,6 +83,18 @@ class ExitCode extends Constraint
     public function failureDescription(mixed $other): string
     {
         return '`' . $other . '` ' . $this->toString();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function additionalFailureDescription(mixed $other): string
+    {
+        return sprintf(
+            "STDOUT\n%s\n\nSTDERR\n%s\n",
+            implode("\n", $this->out),
+            implode("\n", $this->err),
+        );
     }
 }
 

--- a/src/ORM/phpstan.neon.dist
+++ b/src/ORM/phpstan.neon.dist
@@ -18,9 +18,3 @@ parameters:
 		- "#^PHPDoc tag @return with type Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\> is not subtype of native type static\\(Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\)\\.$#"
 		- "#^Method Cake\\\\ORM\\\\Query\\\\SelectQuery\\:\\:find\\(\\) should return static\\(Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\) but returns Cake\\\\ORM\\\\Query\\\\SelectQuery\\<TSubject of array\\|Cake\\\\Datasource\\\\EntityInterface\\>\\.$#"
 		- '#^PHPDoc tag @var with type callable\(\): mixed is not subtype of native type Closure\(string\): string\.$#'
-		- '#^Parameter \#1 \$fields of method Cake\\ORM\\Entity::extract\(\) expects list<string>, non-empty-array given\.$#'
-		- '#^Parameter \#1 \$fields of method Cake\\ORM\\Entity::extract\(\) expects list<string>, array<string> given\.$#'
-		- '#^Parameter \#1 \$fields of method Cake\\Datasource\\EntityInterface::.*\(\) expects list<string>, non-empty-array<string> given\.$#'
-		- '#^Parameter \#1 \$fields of method Cake\\Datasource\\EntityInterface::.*\(\) expects list<string>, array<string> given\.$#'
-		- '#^Parameter \#1 \$field of method Cake\\Datasource\\EntityInterface::has\(\) expects list<string>\|string, .+<string> given\.$#'
-		- '#^Parameter \#1 \$field of method Cake\\Datasource\\EntityInterface::unset\(\) expects list<string>\|string, array<string>\|string given\.$#'

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -229,7 +229,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     public function testAssertionFailureMessages($assertion, $message, $command, ...$rest): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageMatches('#' . $message . '.?#');
+        $this->expectExceptionMessageMatches('#' . $message . '.?#sm');
 
         $this->exec($command);
 
@@ -245,6 +245,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     {
         return [
             'assertExitCode' => ['assertExitCode', 'Failed asserting that `1` matches exit code `0`', 'routes', CommandInterface::CODE_ERROR],
+            'assertExitCodeOutput' => ['assertExitCode', "STDOUT.*Route name.*STDERR", 'routes', CommandInterface::CODE_ERROR],
             'assertOutputEmpty' => ['assertOutputEmpty', 'Failed asserting that output is empty', 'routes'],
             'assertOutputContains' => ['assertOutputContains', "Failed asserting that 'missing' is in output", 'routes', 'missing'],
             'assertOutputNotContains' => ['assertOutputNotContains', "Failed asserting that 'controller' is not in output", 'routes', 'controller'],

--- a/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
+++ b/tests/TestCase/Console/TestSuite/ConsoleIntegrationTestTraitTest.php
@@ -245,7 +245,7 @@ class ConsoleIntegrationTestTraitTest extends TestCase
     {
         return [
             'assertExitCode' => ['assertExitCode', 'Failed asserting that `1` matches exit code `0`', 'routes', CommandInterface::CODE_ERROR],
-            'assertExitCodeOutput' => ['assertExitCode', "STDOUT.*Route name.*STDERR", 'routes', CommandInterface::CODE_ERROR],
+            'assertExitCodeOutput' => ['assertExitCode', 'STDOUT.*Route name.*STDERR', 'routes', CommandInterface::CODE_ERROR],
             'assertOutputEmpty' => ['assertOutputEmpty', 'Failed asserting that output is empty', 'routes'],
             'assertOutputContains' => ['assertOutputContains', "Failed asserting that 'missing' is in output", 'routes', 'missing'],
             'assertOutputNotContains' => ['assertOutputNotContains', "Failed asserting that 'controller' is not in output", 'routes', 'controller'],


### PR DESCRIPTION
When console assertions fail it can be tedious to find out *why*. By exposing the stdout/err on exit codes, and on output assertions we can provide more context to developers.
