### PR TITLE
4.x: fix ORM querys not being able to set read role

### DIFF
--- a/src/ORM/Query/SelectQuery.php
+++ b/src/ORM/Query/SelectQuery.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\ORM\Query;
 
+use Cake\Database\Connection;
 use Cake\ORM\Query;
 
 /**
@@ -88,5 +89,39 @@ class SelectQuery extends Query
         $this->_deprecatedMethod('set()');
 
         return parent::set($key, $value, $types);
+    }
+
+    /**
+     * Sets the connection role.
+     *
+     * @param string $role Connection role ('read' or 'write')
+     * @return $this
+     */
+    public function setConnectionRole(string $role)
+    {
+        assert($role === Connection::ROLE_READ || $role === Connection::ROLE_WRITE);
+        $this->connectionRole = $role;
+
+        return $this;
+    }
+
+    /**
+     * Sets the connection role to read.
+     *
+     * @return $this
+     */
+    public function useReadRole()
+    {
+        return $this->setConnectionRole(Connection::ROLE_READ);
+    }
+
+    /**
+     * Sets the connection role to write.
+     *
+     * @return $this
+     */
+    public function useWriteRole()
+    {
+        return $this->setConnectionRole(Connection::ROLE_WRITE);
     }
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Cache\Engine\FileEngine;
 use Cake\Collection\Collection;
 use Cake\Collection\Iterator\BufferedIterator;
+use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Database\Driver\Sqlite;
 use Cake\Database\DriverInterface;
@@ -4111,5 +4112,18 @@ class QueryTest extends TestCase
             ->disableHydration()
             ->disableResultsCasting()
             ->firstOrFail();
+    }
+
+    public function testORMQueryUseReadRoleWorks(): void
+    {
+        $articles = $this->getTableLocator()->get('Articles');
+
+        // Make sure it defaults to the write role
+        $query = $articles->find();
+        $this->assertEquals(Connection::ROLE_WRITE, $query->getConnectionRole());
+
+        // Make sure it can be changed to the read role
+        $query = $articles->find()->useReadRole();
+        $this->assertEquals(Connection::ROLE_READ, $query->getConnectionRole());
     }
 }


### PR DESCRIPTION
jojomartius in Slack reported, that its currently not possible to mark a ORM query as `useReadRole()`

As it seems, the `Cake\ORM\Query\SelectQuery` Shim introduced in this refactoring was missing the methods which were added to the `Cake\Database\Query\SelectQuery`