### PR TITLE
Add JsonType::setDecodingOptions().

### DIFF
--- a/src/Database/Type/JsonType.php
+++ b/src/Database/Type/JsonType.php
@@ -23,7 +23,7 @@ use PDO;
 /**
  * JSON type converter.
  *
- * Use to convert JSON data between PHP and the database types.
+ * Used to convert JSON data between PHP and the database types.
  */
 class JsonType extends BaseType implements BatchCastingInterface
 {
@@ -31,6 +31,13 @@ class JsonType extends BaseType implements BatchCastingInterface
      * @var int
      */
     protected int $_encodingOptions = 0;
+
+    /**
+     * Flags for json_decode()
+     *
+     * @var int
+     */
+    protected int $_decodingOptions = JSON_OBJECT_AS_ARRAY;
 
     /**
      * Convert a value data into a JSON string
@@ -67,7 +74,7 @@ class JsonType extends BaseType implements BatchCastingInterface
             return null;
         }
 
-        return json_decode($value, true);
+        return json_decode($value, flags: $this->_decodingOptions);
     }
 
     /**
@@ -80,7 +87,7 @@ class JsonType extends BaseType implements BatchCastingInterface
                 continue;
             }
 
-            $values[$field] = json_decode($values[$field], true);
+            $values[$field] = json_decode($values[$field], flags: $this->_decodingOptions);
         }
 
         return $values;
@@ -115,6 +122,21 @@ class JsonType extends BaseType implements BatchCastingInterface
     public function setEncodingOptions(int $options)
     {
         $this->_encodingOptions = $options;
+
+        return $this;
+    }
+
+    /**
+     * Set json_decode() options.
+     *
+     * By default, the value is `JSON_OBJECT_AS_ARRAY`.
+     *
+     * @param int $options Decoding flags. Use JSON_* flags. Set `0` to reset.
+     * @return $this
+     */
+    public function setDecodingOptions(int $options)
+    {
+        $this->_decodingOptions = $options;
 
         return $this;
     }

--- a/tests/TestCase/Database/Type/JsonTypeTest.php
+++ b/tests/TestCase/Database/Type/JsonTypeTest.php
@@ -22,6 +22,7 @@ use Cake\Database\TypeFactory;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
 use PDO;
+use stdClass;
 
 /**
  * Test for the String type.
@@ -136,5 +137,22 @@ class JsonTypeTest extends TestCase
 
         $result = $instance->toDatabase(['é', 'https://cakephp.org/'], $this->driver);
         $this->assertSame('["é","https://cakephp.org/"]', $result);
+    }
+
+    /**
+     * Test decoding options
+     *
+     * @return void
+     */
+    public function testDecodingOptions(): void
+    {
+        // New instance to prevent others tests breaking
+        $instance = new JsonType();
+        $instance->setDecodingOptions(0);
+
+        $result = $instance->toPHP('{"foo":"bar"}', $this->driver);
+        $expected = new stdClass();
+        $expected->foo = 'bar';
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
The allows setting the `flags` argument for json_decode() calls.

<!---

Please describe the reason for the changes you're proposing. If it is a large change, please open an issue to discuss first.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.

-->
